### PR TITLE
feat(agent-core): add Grok app server contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist-electron/
 out/
 playwright-report/
 test-results/
+packages/agent-core/.env.local
 .env.local

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Thread-centric coding agent desktop app.
 When you are ready to run live xAI-backed smoke coverage, put credentials in
 `packages/agent-core/.env.local`. The tracked template lives at
 `packages/agent-core/.env.local.example`.
+
+Live smoke coverage:
+
+- `pnpm --filter @pwragnt/agent-core test:live`

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Thread-centric coding agent desktop app.
 
 - `pnpm test`
 - `pnpm typecheck`
+
+`packages/agent-core` now includes the first Grok app-server contract and provider tests.
+When you are ready to run live xAI-backed smoke coverage, put credentials in
+`packages/agent-core/.env.local`. The tracked template lives at
+`packages/agent-core/.env.local.example`.

--- a/docs/plans/2026-04-16-002-feat-grok-app-server-tests-plan.md
+++ b/docs/plans/2026-04-16-002-feat-grok-app-server-tests-plan.md
@@ -113,7 +113,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Wire `packages/agent-core` into the workspace test runner**
+- [x] **Unit 1: Wire `packages/agent-core` into the workspace test runner**
 
 **Goal:** Establish the package-local test harness, fixture helpers, and env-loading conventions so later contract and adapter tests have one stable home.
 
@@ -150,7 +150,7 @@ flowchart TB
 **Verification:**
 - Running the root workspace tests includes a new `agent-core` project, and all non-live tests pass without any local xAI configuration.
 
-- [ ] **Unit 2: Lock the Codex app-server contract from the consumer side**
+- [x] **Unit 2: Lock the Codex app-server contract from the consumer side**
 
 **Goal:** Capture the minimal Codex app-server method and notification contract that the Grok server must satisfy for current consumers.
 
@@ -190,7 +190,7 @@ flowchart TB
 **Verification:**
 - The server harness can satisfy the method lifecycle currently assumed by the OpenClaw client without fallback-specific hacks in the client.
 
-- [ ] **Unit 3: Add Grok Responses adapter and normalization tests**
+- [x] **Unit 3: Add Grok Responses adapter and normalization tests**
 
 **Goal:** Prove that Grok Responses requests and responses can be translated into the Codex app-server contract without Grok-specific leakage.
 

--- a/docs/plans/2026-04-16-002-feat-grok-app-server-tests-plan.md
+++ b/docs/plans/2026-04-16-002-feat-grok-app-server-tests-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Grok app-server contract test suite
 type: feat
-status: active
+status: completed
 date: 2026-04-16
 origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
 ---
@@ -231,7 +231,7 @@ flowchart TB
 **Verification:**
 - The Grok adapter can satisfy the contract suite using only normalized app-server structures, with no test that depends on raw xAI response envelopes outside the provider boundary.
 
-- [ ] **Unit 4: Add opt-in live smoke coverage and local secret handling**
+- [x] **Unit 4: Add opt-in live smoke coverage and local secret handling**
 
 **Goal:** Add the smallest live test path that proves the in-memory server can talk to xAI for real, while keeping secrets local and default runs deterministic.
 

--- a/packages/agent-core/.env.local.example
+++ b/packages/agent-core/.env.local.example
@@ -1,0 +1,3 @@
+XAI_API_KEY=
+XAI_BASE_URL=https://api.x.ai/v1
+GROK_MODEL=grok-4.20-reasoning

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "vitest run --project agent-core --config ../../vitest.workspace.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "vitest run --project agent-core --config ../../vitest.workspace.ts",
+    "test:live": "pnpm --dir ../.. exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/grok-live.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
+
+describe("Codex app-server contract", () => {
+  it("returns server info and supported methods from initialize", async () => {
+    const { server } = createTestHarness();
+
+    const result = await server.request("initialize", {
+      protocolVersion: "1.0",
+      clientInfo: { name: "test-client", version: "0.0.0" },
+      capabilities: { experimentalApi: true },
+    });
+
+    expect(result).toEqual({
+      protocolVersion: "1.0",
+      serverInfo: {
+        name: "@pwragnt/grok-app-server",
+        version: "0.1.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+      methods: [
+        "initialize",
+        "thread/start",
+        "thread/new",
+        "thread/resume",
+        "thread/read",
+        "turn/start",
+        "turn/steer",
+        "turn/interrupt",
+      ],
+    });
+  });
+
+  it("creates and resumes a thread without requiring cwd on resume", async () => {
+    const { server } = createTestHarness();
+
+    const created = await server.request("thread/start", {
+      cwd: "/repo/workspace",
+      model: "grok-4.20-reasoning",
+    });
+
+    expect(created).toEqual({
+      threadId: "thread-1",
+      cwd: "/repo/workspace",
+      model: "grok-4.20-reasoning",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      serviceTier: undefined,
+      reasoningEffort: undefined,
+    });
+
+    const resumed = await server.request("thread/resume", {
+      threadId: "thread-1",
+      model: "grok-4.20-fast",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+
+    expect(resumed).toEqual({
+      threadId: "thread-1",
+      cwd: "/repo/workspace",
+      model: "grok-4.20-fast",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+      serviceTier: undefined,
+      reasoningEffort: undefined,
+    });
+  });
+
+  it("returns thread replay state after user and assistant messages are recorded", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    const turn = await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Ship it" }],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "Done.",
+      providerResponseId: "resp_1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const replay = await server.request("thread/read", { threadId: "thread-1" });
+
+    expect(turn).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(replay).toEqual({
+      threadId: "thread-1",
+      messages: [
+        { role: "user", text: "Ship it" },
+        { role: "assistant", text: "Done." },
+      ],
+      lastUserMessage: "Ship it",
+      lastAssistantMessage: "Done.",
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
+
+describe("Codex turn lifecycle", () => {
+  it("starts a turn, preserves mixed input, and emits a completion notification", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace", model: "grok-4.20-reasoning" });
+
+    const started = await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [
+        { type: "text", text: "Describe this image" },
+        { type: "localImage", path: "/tmp/screenshot.png" },
+      ],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "It is a screenshot.",
+      providerResponseId: "resp_2",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(started).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(provider.runs[0]?.input).toEqual([
+      { type: "text", text: "Describe this image" },
+      { type: "localImage", path: "/tmp/screenshot.png" },
+    ]);
+    expect(notifications).toEqual([
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "It is a screenshot." }],
+          },
+        },
+      },
+    ]);
+  });
+
+  it("reuses the prior provider response id on follow-up turns", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "First turn" }],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "First answer",
+      providerResponseId: "resp_first",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Follow up" }],
+    });
+
+    expect(provider.runs[1]?.previousResponseId).toBe("resp_first");
+  });
+
+  it("steers an active turn with the expected turn id", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Initial prompt" }],
+    });
+
+    const steered = await server.request("turn/steer", {
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "Continue with more detail" }],
+    });
+
+    expect(steered).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(provider.runs[0]?.steerCalls).toEqual([
+      {
+        thread: {
+          threadId: "thread-1",
+          cwd: "/repo/workspace",
+          model: undefined,
+          approvalPolicy: "on-request",
+          sandbox: "workspace-write",
+          serviceTier: undefined,
+          reasoningEffort: undefined,
+        },
+        runId: "turn-1",
+        input: [{ type: "text", text: "Continue with more detail" }],
+      },
+    ]);
+  });
+
+  it("rejects steering a stale turn id", async () => {
+    const { server } = createTestHarness({ provider: new FakeProvider() });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Initial prompt" }],
+    });
+
+    await expect(
+      server.request("turn/steer", {
+        threadId: "thread-1",
+        expectedTurnId: "turn-999",
+        input: [{ type: "text", text: "Continue" }],
+      }),
+    ).rejects.toThrow("Cannot steer inactive turn: turn-999");
+  });
+
+  it("interrupts an active turn and emits cancellation", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Long running" }],
+    });
+
+    const interrupted = await server.request("turn/interrupt", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    expect(interrupted).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(provider.runs[0]?.interrupted).toBe(true);
+    expect(notifications).toEqual([
+      {
+        method: "turn/cancelled",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "cancelled",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("emits a failed notification when the provider rejects", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Cause failure" }],
+    });
+    provider.runs[0]?.deferred.reject(new Error("Unauthorized"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notifications).toEqual([
+      {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error: {
+              message: "Unauthorized",
+            },
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { CodexAppServer } from "../app-server/codex-app-server.js";
+import type { AppServerNotification } from "../app-server/protocol.js";
+import { GrokProvider } from "../providers/grok-provider.js";
+import { loadLocalEnv } from "../testing/load-local-env.js";
+
+const envResult = loadLocalEnv({ override: true });
+const xaiApiKey = process.env.XAI_API_KEY?.trim();
+const xaiBaseUrl = process.env.XAI_BASE_URL?.trim() || "https://api.x.ai/v1";
+const grokModel = process.env.GROK_MODEL?.trim() || "grok-4.20-reasoning";
+const liveSkipReason = !envResult.loaded
+  ? `missing local env file at ${envResult.path}`
+  : !xaiApiKey
+    ? "XAI_API_KEY is missing from the local env file"
+    : undefined;
+
+const itLive = liveSkipReason ? it.skip : it;
+
+function completedOutput(notification: AppServerNotification): string {
+  if (notification.method !== "turn/completed") {
+    throw new Error(`Expected a completed notification, received ${notification.method}`);
+  }
+  return notification.params.turn.output[0]?.text ?? "";
+}
+
+async function waitForNotification(
+  notifications: AppServerNotification[],
+  method: AppServerNotification["method"],
+  runId: string,
+): Promise<AppServerNotification> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    const match = notifications.find(
+      (notification) =>
+        notification.method === method &&
+        notification.params.runId === runId,
+    );
+    if (match) {
+      return match;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${method} for run ${runId}`);
+}
+
+describe("Grok live smoke", () => {
+  itLive(
+    "runs two real Grok-backed turns through the public app-server harness",
+    { timeout: 45_000 },
+    async () => {
+      const notifications: AppServerNotification[] = [];
+      const provider = new GrokProvider({
+        apiKey: xaiApiKey!,
+        baseUrl: xaiBaseUrl,
+        model: grokModel,
+      });
+      const server = new CodexAppServer({
+        provider,
+        threadIdGenerator: () => "thread-live",
+        runIdGenerator: (() => {
+          let index = 0;
+          return () => `turn-live-${++index}`;
+        })(),
+      });
+      server.onNotification(async (notification) => {
+        notifications.push(notification);
+      });
+
+      const marker = `smoke-${Date.now().toString(36)}`;
+      const created = await server.request("thread/start", {
+        cwd: "/tmp/live-smoke",
+        model: grokModel,
+      });
+      expect(created).toMatchObject({
+        threadId: "thread-live",
+        model: grokModel,
+      });
+
+      const firstTurn = (await server.request("turn/start", {
+        threadId: "thread-live",
+        input: [
+          {
+            type: "text",
+            text: `Reply with this token and no explanation: ${marker}`,
+          },
+        ],
+      })) as { threadId: string; runId: string };
+      const firstCompleted = await waitForNotification(
+        notifications,
+        "turn/completed",
+        firstTurn.runId,
+      );
+      const firstOutput = completedOutput(firstCompleted);
+
+      expect(firstOutput).toContain(marker);
+
+      const secondTurn = (await server.request("turn/start", {
+        threadId: "thread-live",
+        input: [
+          {
+            type: "text",
+            text: "What token did you just return? Reply with the token only.",
+          },
+        ],
+      })) as { threadId: string; runId: string };
+      const secondCompleted = await waitForNotification(
+        notifications,
+        "turn/completed",
+        secondTurn.runId,
+      );
+      const secondOutput = completedOutput(secondCompleted);
+
+      expect(secondOutput).toContain(marker);
+
+      const replay = await server.request("thread/read", { threadId: "thread-live" });
+      expect(replay).toMatchObject({
+        threadId: "thread-live",
+        lastUserMessage: "What token did you just return? Reply with the token only.",
+      });
+      expect((replay as { lastAssistantMessage?: string }).lastAssistantMessage).toContain(marker);
+    },
+  );
+});

--- a/packages/agent-core/src/__tests__/grok-provider.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { GrokProvider } from "../providers/grok-provider.js";
+import { XaiResponsesClient, buildXaiInput } from "../providers/xai-responses-client.js";
+import { makeXaiResponse } from "../testing/xai-fixtures.js";
+
+describe("buildXaiInput", () => {
+  it("maps text and image items to xAI input content", () => {
+    expect(
+      buildXaiInput([
+        { type: "text", text: "Describe this screenshot" },
+        { type: "localImage", path: "/tmp/screenshot.png" },
+      ]),
+    ).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "Describe this screenshot" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "input_image", image_url: "file:///tmp/screenshot.png" }],
+      },
+    ]);
+  });
+});
+
+describe("XaiResponsesClient", () => {
+  it("builds a create payload without unsupported instructions", () => {
+    const client = new XaiResponsesClient({
+      apiKey: "test-key",
+      model: "grok-4.20-reasoning",
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    });
+
+    expect(
+      client.buildCreatePayload({
+        input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
+        previousResponseId: "resp_prev",
+      }),
+    ).toEqual({
+      model: "grok-4.20-reasoning",
+      input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
+      previous_response_id: "resp_prev",
+      stream: false,
+    });
+  });
+
+  it("raises a clear auth error when xAI responds with a failure", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    }));
+    const client = new XaiResponsesClient({
+      apiKey: "bad-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.createResponse({
+        input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
+      }),
+    ).rejects.toThrow("xAI Responses API request failed (401): Unauthorized");
+  });
+});
+
+describe("GrokProvider", () => {
+  it("uses the thread model and previous response id when starting a turn", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => makeXaiResponse({ id: "resp_next", text: "Shipped." }),
+    }));
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Ship it" }],
+      previousResponseId: "resp_prev",
+    });
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Shipped.",
+      providerResponseId: "resp_next",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.x.ai/v1/responses",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+        }),
+        body: JSON.stringify({
+          model: "grok-4.20-reasoning",
+          input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
+          previous_response_id: "resp_prev",
+          stream: false,
+        }),
+      }),
+    );
+  });
+
+  it("surfaces transport failures as provider errors", async () => {
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: vi.fn(async () => {
+        throw new Error("network down");
+      }) as unknown as typeof fetch,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: { threadId: "thread-123", model: "grok-4.20-reasoning" },
+      input: [{ type: "text", text: "Ship it" }],
+    });
+
+    await expect(activeTurn.result).rejects.toThrow("network down");
+  });
+});

--- a/packages/agent-core/src/__tests__/test-harness.test.ts
+++ b/packages/agent-core/src/__tests__/test-harness.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+import { loadLocalEnv } from "../testing/load-local-env.js";
+
+const tempEnvKeys = ["XAI_API_KEY", "GROK_MODEL"];
+
+afterEach(() => {
+  for (const key of tempEnvKeys) {
+    delete process.env[key];
+  }
+});
+
+describe("test harness helpers", () => {
+  it("creates and removes a temporary test directory", async () => {
+    const temp = await createTemporaryTestDirectory();
+    await fs.writeFile(path.join(temp.path, "marker.txt"), "ok");
+    await expect(fs.stat(path.join(temp.path, "marker.txt"))).resolves.toBeDefined();
+
+    await temp.cleanup();
+
+    await expect(fs.stat(temp.path)).rejects.toThrow();
+  });
+
+  it("skips local env loading when the file is missing", () => {
+    const result = loadLocalEnv({
+      envPath: "/tmp/does-not-exist-agent-core.env",
+    });
+
+    expect(result.loaded).toBe(false);
+    expect(result.skippedReason).toBe("missing");
+    expect(result.entries).toEqual([]);
+  });
+
+  it("loads values from a local env file", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const envPath = path.join(temp.path, ".env.local");
+    await fs.writeFile(envPath, "XAI_API_KEY=test-key\nGROK_MODEL=grok-4.20-reasoning\n");
+
+    const result = loadLocalEnv({ envPath });
+
+    expect(result.loaded).toBe(true);
+    expect(result.entries).toEqual(["XAI_API_KEY", "GROK_MODEL"]);
+    expect(process.env.XAI_API_KEY).toBe("test-key");
+    expect(process.env.GROK_MODEL).toBe("grok-4.20-reasoning");
+
+    await temp.cleanup();
+  });
+
+  it("throws a helpful error for malformed env lines", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const envPath = path.join(temp.path, ".env.local");
+    await fs.writeFile(envPath, "XAI_API_KEY\n");
+
+    expect(() => loadLocalEnv({ envPath })).toThrow(`Invalid env line 1 in ${envPath}`);
+
+    await temp.cleanup();
+  });
+});

--- a/packages/agent-core/src/__tests__/xai-response-normalizer.test.ts
+++ b/packages/agent-core/src/__tests__/xai-response-normalizer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeXaiResponse } from "../providers/response-normalizer.js";
+import { makeDirectOutputResponse, makeXaiResponse } from "../testing/xai-fixtures.js";
+
+describe("normalizeXaiResponse", () => {
+  it("prefers direct output_text when present", () => {
+    expect(normalizeXaiResponse(makeDirectOutputResponse())).toEqual({
+      assistantText: "Direct output",
+      providerResponseId: "resp_direct",
+    });
+  });
+
+  it("collects text from message content when output_text is absent", () => {
+    expect(normalizeXaiResponse(makeXaiResponse())).toEqual({
+      assistantText: "All green.",
+      providerResponseId: "resp_123",
+    });
+  });
+
+  it("returns an empty assistant string when no text is present", () => {
+    expect(
+      normalizeXaiResponse({
+        id: "resp_empty",
+        output: [{ type: "message", content: [] }],
+      }),
+    ).toEqual({
+      assistantText: "",
+      providerResponseId: "resp_empty",
+    });
+  });
+});

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -1,0 +1,311 @@
+import {
+  APP_SERVER_PROTOCOL_VERSION,
+  AppServerProtocolError,
+  type AppServerInitializeResult,
+  type AppServerNotification,
+  type AppServerTurnInput,
+  type AppServerTurnInputItem,
+  type AppServerTurnResult,
+  type ThreadReplay,
+  type ThreadState,
+} from "./protocol.js";
+import { AppServerSessionState } from "./session-state.js";
+import type { AppServerProvider } from "../providers/provider-contract.js";
+
+type NotificationHandler = (
+  notification: AppServerNotification,
+) => void | Promise<void>;
+
+type ServerOptions = {
+  provider: AppServerProvider;
+  threadIdGenerator?: () => string;
+  runIdGenerator?: () => string;
+};
+
+const SUPPORTED_METHODS = [
+  "initialize",
+  "thread/start",
+  "thread/new",
+  "thread/resume",
+  "thread/read",
+  "turn/start",
+  "turn/steer",
+  "turn/interrupt",
+] as const;
+
+function createId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export class CodexAppServer {
+  private readonly provider: AppServerProvider;
+  private readonly state = new AppServerSessionState();
+  private readonly notificationHandlers = new Set<NotificationHandler>();
+  private readonly createThreadId: () => string;
+  private readonly createRunId: () => string;
+
+  constructor(options: ServerOptions) {
+    this.provider = options.provider;
+    this.createThreadId = options.threadIdGenerator ?? (() => createId("thread"));
+    this.createRunId = options.runIdGenerator ?? (() => createId("turn"));
+  }
+
+  onNotification(handler: NotificationHandler): () => void {
+    this.notificationHandlers.add(handler);
+    return () => {
+      this.notificationHandlers.delete(handler);
+    };
+  }
+
+  async notify(method: string, _params?: unknown): Promise<void> {
+    if (method === "initialized") {
+      return;
+    }
+    throw new AppServerProtocolError(`Unsupported notification: ${method}`);
+  }
+
+  async request(method: string, params?: unknown): Promise<unknown> {
+    switch (method) {
+      case "initialize":
+        return this.initialize();
+      case "thread/start":
+      case "thread/new":
+        return this.startThread((params ?? {}) as Record<string, unknown>);
+      case "thread/resume":
+        return this.resumeThread((params ?? {}) as Record<string, unknown>);
+      case "thread/read":
+        return this.readThread((params ?? {}) as Record<string, unknown>);
+      case "turn/start":
+        return this.startTurn((params ?? {}) as AppServerTurnInput);
+      case "turn/steer":
+        return this.steerTurn((params ?? {}) as Record<string, unknown>);
+      case "turn/interrupt":
+        return this.interruptTurn((params ?? {}) as Record<string, unknown>);
+      default:
+        throw new AppServerProtocolError(`Unsupported method: ${method}`);
+    }
+  }
+
+  private initialize(): AppServerInitializeResult {
+    return {
+      protocolVersion: APP_SERVER_PROTOCOL_VERSION,
+      serverInfo: {
+        name: "@pwragnt/grok-app-server",
+        version: "0.1.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+      methods: [...SUPPORTED_METHODS],
+    };
+  }
+
+  private startThread(params: Record<string, unknown>): ThreadState {
+    const threadId = this.createThreadId();
+    return this.state.createThread({
+      threadId,
+      cwd: asOptionalString(params.cwd),
+      model: asOptionalString(params.model),
+      approvalPolicy: asOptionalString(params.approvalPolicy),
+      sandbox: asOptionalString(params.sandbox),
+      serviceTier: asOptionalString(params.serviceTier),
+      reasoningEffort: asOptionalString(params.reasoningEffort),
+    });
+  }
+
+  private resumeThread(params: Record<string, unknown>): ThreadState {
+    const threadId = asRequiredString(params.threadId, "thread/resume requires threadId");
+    const thread = this.state.updateThread(threadId, {
+      cwd: asOptionalString(params.cwd),
+      model: asOptionalString(params.model),
+      approvalPolicy: asOptionalString(params.approvalPolicy),
+      sandbox: asOptionalString(params.sandbox),
+      serviceTier: asOptionalString(params.serviceTier),
+      reasoningEffort: asOptionalString(params.reasoningEffort),
+    });
+    if (!thread) {
+      throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
+    }
+    return thread;
+  }
+
+  private readThread(params: Record<string, unknown>): ThreadReplay {
+    const threadId = asRequiredString(params.threadId, "thread/read requires threadId");
+    const thread = this.state.getThread(threadId);
+    if (!thread) {
+      throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
+    }
+    return this.state.readThread(threadId);
+  }
+
+  private async startTurn(params: AppServerTurnInput): Promise<AppServerTurnResult> {
+    const threadId = asRequiredString(params.threadId, "turn/start requires threadId");
+    const thread = this.state.getThread(threadId);
+    if (!thread) {
+      throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
+    }
+    const normalizedInput = normalizeTurnInput(params.input);
+    const handle = await this.provider.startTurn({
+      thread,
+      input: normalizedInput,
+      previousResponseId: this.state.getPreviousResponseId(threadId),
+    });
+    const runId = this.createRunId();
+    this.state.appendInput(threadId, normalizedInput);
+    this.state.createRun({ runId, threadId, handle });
+    void this.completeTurn({ thread, runId, handle });
+    return { threadId, runId };
+  }
+
+  private async completeTurn(params: {
+    thread: ThreadState;
+    runId: string;
+    handle: Awaited<ReturnType<AppServerProvider["startTurn"]>>;
+  }): Promise<void> {
+    try {
+      const result = await params.handle.result;
+      const run = this.state.getRun(params.runId);
+      if (!run || run.status !== "active") {
+        return;
+      }
+      this.state.completeRun(params.runId);
+      this.state.appendAssistant(params.thread.threadId, result.assistantText ?? "");
+      this.state.setPreviousResponseId(params.thread.threadId, result.providerResponseId);
+      await this.emit({
+        method: "turn/completed",
+        params: {
+          threadId: params.thread.threadId,
+          runId: params.runId,
+          turn: {
+            id: params.runId,
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: result.assistantText ?? "",
+              },
+            ],
+          },
+        },
+      });
+    } catch (error) {
+      const run = this.state.getRun(params.runId);
+      if (!run || run.status !== "active") {
+        return;
+      }
+      this.state.failRun(params.runId);
+      await this.emit({
+        method: "turn/failed",
+        params: {
+          threadId: params.thread.threadId,
+          runId: params.runId,
+          turn: {
+            id: params.runId,
+            status: "failed",
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+            },
+          },
+        },
+      });
+    }
+  }
+
+  private async steerTurn(params: Record<string, unknown>): Promise<AppServerTurnResult> {
+    const threadId = asRequiredString(params.threadId, "turn/steer requires threadId");
+    const runId = asRequiredString(
+      params.expectedTurnId ?? params.turnId,
+      "turn/steer requires expectedTurnId",
+    );
+    const run = this.state.getRun(runId);
+    if (!run || run.threadId !== threadId || run.status !== "active") {
+      throw new AppServerProtocolError(`Cannot steer inactive turn: ${runId}`);
+    }
+    if (!run.handle.steer) {
+      throw new AppServerProtocolError(`Turn does not support steering: ${runId}`);
+    }
+    const thread = this.state.getThread(threadId);
+    if (!thread) {
+      throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
+    }
+    const input = normalizeTurnInput(params.input);
+    this.state.appendInput(threadId, input);
+    await run.handle.steer({ thread, runId, input });
+    return { threadId, runId };
+  }
+
+  private async interruptTurn(params: Record<string, unknown>): Promise<AppServerTurnResult> {
+    const threadId = asRequiredString(params.threadId, "turn/interrupt requires threadId");
+    const runId = asRequiredString(
+      params.turnId ?? params.expectedTurnId,
+      "turn/interrupt requires turnId",
+    );
+    const run = this.state.getRun(runId);
+    if (!run || run.threadId !== threadId || run.status !== "active") {
+      throw new AppServerProtocolError(`Cannot interrupt inactive turn: ${runId}`);
+    }
+    await run.handle.interrupt?.();
+    this.state.cancelRun(runId);
+    await this.emit({
+      method: "turn/cancelled",
+      params: {
+        threadId,
+        runId,
+        turn: {
+          id: runId,
+          status: "cancelled",
+        },
+      },
+    });
+    return { threadId, runId };
+  }
+
+  private async emit(notification: AppServerNotification): Promise<void> {
+    for (const handler of this.notificationHandlers) {
+      await handler(notification);
+    }
+  }
+}
+
+function asRequiredString(value: unknown, message: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new AppServerProtocolError(message);
+  }
+  return value.trim();
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeTurnInput(value: unknown): AppServerTurnInputItem[] {
+  if (!Array.isArray(value)) {
+    throw new AppServerProtocolError("turn input must be an array");
+  }
+  return value.map((item) => {
+    if (!item || typeof item !== "object") {
+      throw new AppServerProtocolError("turn input items must be objects");
+    }
+    const record = item as Record<string, unknown>;
+    const type = asRequiredString(record.type, "turn input items require type");
+    if (type === "text") {
+      return {
+        type: "text",
+        text: asRequiredString(record.text, "text input requires text"),
+      };
+    }
+    if (type === "image") {
+      return {
+        type: "image",
+        url: asRequiredString(record.url, "image input requires url"),
+      };
+    }
+    if (type === "localImage") {
+      return {
+        type: "localImage",
+        path: asRequiredString(record.path, "localImage input requires path"),
+      };
+    }
+    throw new AppServerProtocolError(`Unsupported input type: ${type}`);
+  });
+}

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -1,0 +1,115 @@
+export const APP_SERVER_PROTOCOL_VERSION = "1.0" as const;
+
+export type AppServerRole = "user" | "assistant";
+
+export type AppServerTextInputItem = {
+  type: "text";
+  text: string;
+};
+
+export type AppServerImageInputItem = {
+  type: "image";
+  url: string;
+};
+
+export type AppServerLocalImageInputItem = {
+  type: "localImage";
+  path: string;
+};
+
+export type AppServerTurnInputItem =
+  | AppServerTextInputItem
+  | AppServerImageInputItem
+  | AppServerLocalImageInputItem;
+
+export type AppServerTurnInput = {
+  threadId: string;
+  input: AppServerTurnInputItem[];
+  model?: string;
+};
+
+export type ThreadState = {
+  threadId: string;
+  cwd?: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+};
+
+export type ThreadReplay = {
+  threadId: string;
+  messages: Array<{
+    role: AppServerRole;
+    text: string;
+  }>;
+  lastUserMessage?: string;
+  lastAssistantMessage?: string;
+};
+
+export type AppServerInitializeResult = {
+  protocolVersion: typeof APP_SERVER_PROTOCOL_VERSION;
+  serverInfo: {
+    name: string;
+    version: string;
+  };
+  capabilities: {
+    experimentalApi: boolean;
+  };
+  methods: string[];
+};
+
+export type AppServerTurnResult = {
+  threadId: string;
+  runId: string;
+};
+
+export type AppServerNotification =
+  | {
+      method: "turn/completed";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "completed";
+          output: Array<{
+            type: "text";
+            text: string;
+          }>;
+        };
+      };
+    }
+  | {
+      method: "turn/failed";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "failed";
+          error: {
+            message: string;
+          };
+        };
+      };
+    }
+  | {
+      method: "turn/cancelled";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "cancelled";
+        };
+      };
+    };
+
+export class AppServerProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AppServerProtocolError";
+  }
+}

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -1,0 +1,170 @@
+import type { AppServerRole, AppServerTurnInputItem, ThreadReplay, ThreadState } from "./protocol.js";
+import type { ProviderActiveTurn } from "../providers/provider-contract.js";
+
+type StoredMessage = {
+  role: AppServerRole;
+  text: string;
+};
+
+type ActiveRunRecord = {
+  runId: string;
+  threadId: string;
+  status: "active" | "completed" | "failed" | "cancelled";
+  handle: ProviderActiveTurn;
+};
+
+type CreateThreadParams = {
+  threadId: string;
+  cwd?: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+};
+
+export class AppServerSessionState {
+  private readonly threads = new Map<string, ThreadState>();
+  private readonly messages = new Map<string, StoredMessage[]>();
+  private readonly responseIds = new Map<string, string>();
+  private readonly runs = new Map<string, ActiveRunRecord>();
+
+  createThread(params: CreateThreadParams): ThreadState {
+    const thread: ThreadState = {
+      threadId: params.threadId,
+      cwd: params.cwd,
+      model: params.model,
+      approvalPolicy: params.approvalPolicy ?? "on-request",
+      sandbox: params.sandbox ?? "workspace-write",
+      serviceTier: params.serviceTier,
+      reasoningEffort: params.reasoningEffort,
+    };
+    this.threads.set(thread.threadId, thread);
+    this.messages.set(thread.threadId, []);
+    return thread;
+  }
+
+  getThread(threadId: string): ThreadState | undefined {
+    return this.threads.get(threadId);
+  }
+
+  updateThread(
+    threadId: string,
+    patch: Partial<Omit<ThreadState, "threadId">>,
+  ): ThreadState | undefined {
+    const thread = this.threads.get(threadId);
+    if (!thread) {
+      return undefined;
+    }
+    const next = {
+      ...thread,
+      ...Object.fromEntries(
+        Object.entries(patch).filter(([, value]) => value !== undefined),
+      ),
+    };
+    this.threads.set(threadId, next);
+    return next;
+  }
+
+  appendInput(threadId: string, input: AppServerTurnInputItem[]): void {
+    const text = input
+      .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
+      .map((item) => item.text.trim())
+      .filter(Boolean)
+      .join("\n");
+    if (!text) {
+      return;
+    }
+    this.appendMessage(threadId, { role: "user", text });
+  }
+
+  appendAssistant(threadId: string, text: string): void {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.appendMessage(threadId, { role: "assistant", text: trimmed });
+  }
+
+  private appendMessage(threadId: string, message: StoredMessage): void {
+    const messages = this.messages.get(threadId) ?? [];
+    messages.push(message);
+    this.messages.set(threadId, messages);
+  }
+
+  readThread(threadId: string): ThreadReplay {
+    const messages = [...(this.messages.get(threadId) ?? [])];
+    let lastUserMessage: string | undefined;
+    let lastAssistantMessage: string | undefined;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!lastUserMessage && message?.role === "user") {
+        lastUserMessage = message.text;
+      }
+      if (!lastAssistantMessage && message?.role === "assistant") {
+        lastAssistantMessage = message.text;
+      }
+      if (lastUserMessage && lastAssistantMessage) {
+        break;
+      }
+    }
+    return { threadId, messages, lastUserMessage, lastAssistantMessage };
+  }
+
+  setPreviousResponseId(threadId: string, responseId: string | undefined): void {
+    if (!responseId?.trim()) {
+      return;
+    }
+    this.responseIds.set(threadId, responseId.trim());
+  }
+
+  getPreviousResponseId(threadId: string): string | undefined {
+    return this.responseIds.get(threadId);
+  }
+
+  createRun(params: {
+    runId: string;
+    threadId: string;
+    handle: ProviderActiveTurn;
+  }): ActiveRunRecord {
+    const run: ActiveRunRecord = {
+      runId: params.runId,
+      threadId: params.threadId,
+      status: "active",
+      handle: params.handle,
+    };
+    this.runs.set(run.runId, run);
+    return run;
+  }
+
+  getRun(runId: string): ActiveRunRecord | undefined {
+    return this.runs.get(runId);
+  }
+
+  completeRun(runId: string): ActiveRunRecord | undefined {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return undefined;
+    }
+    run.status = "completed";
+    return run;
+  }
+
+  failRun(runId: string): ActiveRunRecord | undefined {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return undefined;
+    }
+    run.status = "failed";
+    return run;
+  }
+
+  cancelRun(runId: string): ActiveRunRecord | undefined {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return undefined;
+    }
+    run.status = "cancelled";
+    return run;
+  }
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,1 +1,29 @@
-export const agentCoreScaffoldReady = true;
+export { CodexAppServer } from "./app-server/codex-app-server.js";
+export type {
+  AppServerInitializeResult,
+  AppServerNotification,
+  AppServerTurnInput,
+  AppServerTurnInputItem,
+  AppServerTurnResult,
+  ThreadReplay,
+  ThreadState,
+} from "./app-server/protocol.js";
+export { GrokProvider } from "./providers/grok-provider.js";
+export type { GrokProviderOptions } from "./providers/grok-provider.js";
+export { XaiResponsesClient } from "./providers/xai-responses-client.js";
+export {
+  normalizeXaiResponse,
+  type NormalizedResponseOutput,
+} from "./providers/response-normalizer.js";
+export {
+  createTestHarness,
+  createTemporaryTestDirectory,
+  Deferred,
+  FakeProvider,
+  type FakeProviderRun,
+} from "./testing/test-harness.js";
+export {
+  defaultLocalEnvPath,
+  loadLocalEnv,
+  type LocalEnvLoadResult,
+} from "./testing/load-local-env.js";

--- a/packages/agent-core/src/providers/grok-provider.ts
+++ b/packages/agent-core/src/providers/grok-provider.ts
@@ -1,0 +1,39 @@
+import type { AppServerProvider, ProviderActiveTurn, ProviderTurnParams } from "./provider-contract.js";
+import { normalizeXaiResponse } from "./response-normalizer.js";
+import { buildXaiInput, XaiResponsesClient, type XaiResponsesClientOptions } from "./xai-responses-client.js";
+
+export type GrokProviderOptions = XaiResponsesClientOptions;
+
+export class GrokProvider implements AppServerProvider {
+  private readonly client: XaiResponsesClient;
+
+  constructor(options: GrokProviderOptions) {
+    this.client = new XaiResponsesClient(options);
+  }
+
+  startTurn(params: ProviderTurnParams): ProviderActiveTurn {
+    const result = this.client
+      .createResponse({
+        model: params.thread.model,
+        input: buildXaiInput(params.input),
+        previousResponseId: params.previousResponseId,
+      })
+      .then((response) => {
+        const normalized = normalizeXaiResponse(response);
+        return {
+          assistantText: normalized.assistantText,
+          providerResponseId: normalized.providerResponseId,
+        };
+      });
+
+    return {
+      result,
+      steer: async () => {
+        throw new Error("GrokProvider does not support steering active turns yet");
+      },
+      interrupt: async () => {
+        return;
+      },
+    };
+  }
+}

--- a/packages/agent-core/src/providers/provider-contract.ts
+++ b/packages/agent-core/src/providers/provider-contract.ts
@@ -1,0 +1,28 @@
+import type { AppServerTurnInputItem, ThreadState } from "../app-server/protocol.js";
+
+export type ProviderTurnParams = {
+  thread: ThreadState;
+  input: AppServerTurnInputItem[];
+  previousResponseId?: string;
+};
+
+export type ProviderSteerParams = {
+  thread: ThreadState;
+  runId: string;
+  input: AppServerTurnInputItem[];
+};
+
+export type ProviderTurnResult = {
+  assistantText?: string;
+  providerResponseId?: string;
+};
+
+export type ProviderActiveTurn = {
+  result: Promise<ProviderTurnResult>;
+  steer?: (params: ProviderSteerParams) => Promise<void>;
+  interrupt?: () => Promise<void>;
+};
+
+export interface AppServerProvider {
+  startTurn(params: ProviderTurnParams): Promise<ProviderActiveTurn> | ProviderActiveTurn;
+}

--- a/packages/agent-core/src/providers/response-normalizer.ts
+++ b/packages/agent-core/src/providers/response-normalizer.ts
@@ -1,0 +1,54 @@
+export type NormalizedResponseOutput = {
+  assistantText: string;
+  providerResponseId?: string;
+};
+
+export function normalizeXaiResponse(response: unknown): NormalizedResponseOutput {
+  const record = asRecord(response);
+  const providerResponseId = readString(record, ["id"]);
+  const directOutputText = readString(record, ["output_text"]);
+  if (directOutputText) {
+    return {
+      assistantText: directOutputText,
+      providerResponseId,
+    };
+  }
+
+  const output = Array.isArray(record.output) ? record.output : [];
+  const chunks: string[] = [];
+  for (const item of output) {
+    const itemRecord = asRecord(item);
+    const content = Array.isArray(itemRecord.content) ? itemRecord.content : [];
+    for (const contentItem of content) {
+      const contentRecord = asRecord(contentItem);
+      const text = readString(contentRecord, ["text"]);
+      if (text) {
+        chunks.push(text);
+      }
+    }
+  }
+
+  return {
+    assistantText: chunks.join("\n").trim(),
+    providerResponseId,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}

--- a/packages/agent-core/src/providers/xai-responses-client.ts
+++ b/packages/agent-core/src/providers/xai-responses-client.ts
@@ -1,0 +1,79 @@
+import type { AppServerTurnInputItem } from "../app-server/protocol.js";
+
+export type XaiResponsesClientOptions = {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  model?: string;
+};
+
+export type XaiResponseCreateRequest = {
+  model?: string;
+  input: Array<Record<string, unknown>>;
+  previousResponseId?: string;
+};
+
+export class XaiResponsesClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly defaultModel?: string;
+
+  constructor(options: XaiResponsesClientOptions) {
+    this.apiKey = options.apiKey.trim();
+    this.baseUrl = (options.baseUrl ?? "https://api.x.ai/v1").replace(/\/$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultModel = options.model?.trim() || undefined;
+  }
+
+  buildCreatePayload(params: XaiResponseCreateRequest): Record<string, unknown> {
+    if (params.input.length === 0) {
+      throw new Error("xAI responses require at least one input item");
+    }
+    return {
+      model: params.model ?? this.defaultModel ?? "grok-4.20-reasoning",
+      input: params.input,
+      ...(params.previousResponseId
+        ? { previous_response_id: params.previousResponseId }
+        : {}),
+      stream: false,
+    };
+  }
+
+  async createResponse(params: XaiResponseCreateRequest): Promise<unknown> {
+    const response = await this.fetchImpl(`${this.baseUrl}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(this.buildCreatePayload(params)),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`xAI Responses API request failed (${response.status}): ${body.trim()}`);
+    }
+    return await response.json();
+  }
+}
+
+export function buildXaiInput(items: AppServerTurnInputItem[]): Array<Record<string, unknown>> {
+  return items.map((item) => {
+    if (item.type === "text") {
+      return {
+        role: "user",
+        content: [{ type: "input_text", text: item.text }],
+      };
+    }
+    if (item.type === "image") {
+      return {
+        role: "user",
+        content: [{ type: "input_image", image_url: item.url }],
+      };
+    }
+    return {
+      role: "user",
+      content: [{ type: "input_image", image_url: `file://${item.path}` }],
+    };
+  });
+}

--- a/packages/agent-core/src/testing/load-local-env.ts
+++ b/packages/agent-core/src/testing/load-local-env.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type LocalEnvLoadResult = {
+  path: string;
+  loaded: boolean;
+  entries: string[];
+  skippedReason?: string;
+};
+
+export function defaultLocalEnvPath(): string {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(currentDir, "../../.env.local");
+}
+
+export function loadLocalEnv(options?: {
+  envPath?: string;
+  override?: boolean;
+}): LocalEnvLoadResult {
+  const envPath = options?.envPath ?? defaultLocalEnvPath();
+  if (!fs.existsSync(envPath)) {
+    return {
+      path: envPath,
+      loaded: false,
+      entries: [],
+      skippedReason: "missing",
+    };
+  }
+
+  const entries: string[] = [];
+  const contents = fs.readFileSync(envPath, "utf8");
+  for (const [index, rawLine] of contents.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex < 1) {
+      throw new Error(`Invalid env line ${index + 1} in ${envPath}`);
+    }
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!key) {
+      throw new Error(`Invalid env key on line ${index + 1} in ${envPath}`);
+    }
+    if (options?.override || process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+    entries.push(key);
+  }
+
+  return {
+    path: envPath,
+    loaded: true,
+    entries,
+  };
+}

--- a/packages/agent-core/src/testing/test-harness.ts
+++ b/packages/agent-core/src/testing/test-harness.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AppServerNotification, AppServerTurnInputItem, ThreadState } from "../app-server/protocol.js";
+import { CodexAppServer } from "../app-server/codex-app-server.js";
+import type {
+  AppServerProvider,
+  ProviderActiveTurn,
+  ProviderSteerParams,
+  ProviderTurnParams,
+  ProviderTurnResult,
+} from "../providers/provider-contract.js";
+
+export class Deferred<T> {
+  promise: Promise<T>;
+  resolve!: (value: T | PromiseLike<T>) => void;
+  reject!: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+export type FakeProviderRun = {
+  thread: ThreadState;
+  input: AppServerTurnInputItem[];
+  previousResponseId?: string;
+  deferred: Deferred<ProviderTurnResult>;
+  steerCalls: ProviderSteerParams[];
+  interrupted: boolean;
+};
+
+export class FakeProvider implements AppServerProvider {
+  readonly runs: FakeProviderRun[] = [];
+
+  startTurn(params: ProviderTurnParams): ProviderActiveTurn {
+    const deferred = new Deferred<ProviderTurnResult>();
+    const run: FakeProviderRun = {
+      thread: params.thread,
+      input: params.input,
+      previousResponseId: params.previousResponseId,
+      deferred,
+      steerCalls: [],
+      interrupted: false,
+    };
+    this.runs.push(run);
+    return {
+      result: deferred.promise,
+      steer: async (steerParams) => {
+        run.steerCalls.push(steerParams);
+      },
+      interrupt: async () => {
+        run.interrupted = true;
+      },
+    };
+  }
+}
+
+export function createTestHarness(options?: {
+  provider?: AppServerProvider;
+}) {
+  const provider = options?.provider ?? new FakeProvider();
+  const notifications: AppServerNotification[] = [];
+  const server = new CodexAppServer({
+    provider,
+    threadIdGenerator: (() => {
+      let index = 0;
+      return () => `thread-${++index}`;
+    })(),
+    runIdGenerator: (() => {
+      let index = 0;
+      return () => `turn-${++index}`;
+    })(),
+  });
+  server.onNotification(async (notification) => {
+    notifications.push(notification);
+  });
+  return { server, provider, notifications };
+}
+
+export async function createTemporaryTestDirectory(): Promise<{
+  path: string;
+  cleanup: () => Promise<void>;
+}> {
+  const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), "pwragnt-agent-core-"));
+  return {
+    path: tempPath,
+    cleanup: async () => {
+      await fs.rm(tempPath, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/agent-core/src/testing/xai-fixtures.ts
+++ b/packages/agent-core/src/testing/xai-fixtures.ts
@@ -1,0 +1,29 @@
+export function makeXaiResponse(params?: {
+  id?: string;
+  text?: string;
+}): Record<string, unknown> {
+  return {
+    id: params?.id ?? "resp_123",
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "output_text",
+            text: params?.text ?? "All green.",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function makeDirectOutputResponse(params?: {
+  id?: string;
+  text?: string;
+}): Record<string, unknown> {
+  return {
+    id: params?.id ?? "resp_direct",
+    output_text: params?.text ?? "Direct output",
+  };
+}

--- a/packages/agent-core/tsconfig.json
+++ b/packages/agent-core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2023"]
+    "lib": ["ES2023"],
+    "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,6 +5,14 @@ export default defineConfig({
     projects: [
       {
         test: {
+          name: "agent-core",
+          globals: true,
+          environment: "node",
+          include: ["packages/agent-core/src/__tests__/**/*.test.ts"]
+        }
+      },
+      {
+        test: {
           name: "desktop-main",
           globals: true,
           environment: "node",


### PR DESCRIPTION
## Summary
- add `agent-core` workspace test coverage and reusable harness utilities
- add an in-memory Codex app-server surface with contract tests for initialize, thread lifecycle, and turn lifecycle
- add the Grok Responses client/provider and normalization tests
- add a real xAI-backed live smoke test and a package-local `test:live` command

## Testing
- `pnpm test -- --project agent-core`
- `pnpm typecheck`
- `pnpm --filter @pwragnt/agent-core test:live`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this work adds package-local runtime and test coverage, and it does not introduce a deployed production path.

## Notes
- live xAI coverage loads credentials from `packages/agent-core/.env.local`
- the implementation plan at `docs/plans/2026-04-16-002-feat-grok-app-server-tests-plan.md` is now completed