### PR TITLE
feat(desktop): build inbox-first Codex thread navigation shell

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     ]
   },
   preload: {
+    build: {
+      rollupOptions: {
+        output: {
+          format: "cjs"
+        }
+      }
+    },
     plugins: [
       externalizeDepsPlugin({
         exclude: ["@pwragnt/shared"]

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   main: {
     plugins: [
       externalizeDepsPlugin({
-        exclude: ["@pwragnt/shared"]
+        exclude: ["@pwragnt/shared", "@pwragnt/agent-core"]
       })
     ]
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@pwragnt/agent-core": "workspace:*",
     "@pwragnt/shared": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -5,6 +5,8 @@ const browserWindowState: {
   options?: BrowserWindowConstructorOptions;
   loadFile?: ReturnType<typeof vi.fn>;
   loadURL?: ReturnType<typeof vi.fn>;
+  on?: ReturnType<typeof vi.fn>;
+  send?: ReturnType<typeof vi.fn>;
   setWindowOpenHandler?: ReturnType<typeof vi.fn>;
   show?: ReturnType<typeof vi.fn>;
 } = {};
@@ -16,15 +18,19 @@ const BrowserWindowMock = vi.fn(function BrowserWindow(
   browserWindowState.options = options;
   browserWindowState.loadFile = vi.fn();
   browserWindowState.loadURL = vi.fn();
+  browserWindowState.on = vi.fn();
+  browserWindowState.send = vi.fn();
   browserWindowState.setWindowOpenHandler = vi.fn();
   browserWindowState.show = vi.fn();
 
   return {
     loadFile: browserWindowState.loadFile,
     loadURL: browserWindowState.loadURL,
+    on: browserWindowState.on,
     once: (_event: string, handler: () => void) => handler(),
     show: browserWindowState.show,
     webContents: {
+      send: browserWindowState.send,
       setWindowOpenHandler: browserWindowState.setWindowOpenHandler
     }
   };

--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -56,7 +56,7 @@ describe("createMainWindow", () => {
 
     expect(BrowserWindowMock).toHaveBeenCalledTimes(1);
     expect(browserWindowState.options?.webPreferences?.preload).toContain(
-      "preload/index.js"
+      "preload/index.cjs"
     );
     expect(browserWindowState.options?.webPreferences?.contextIsolation).toBe(
       true

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -118,7 +118,18 @@ describe("CodexAppServerClient", () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
-      command: "codex"
+      command: "codex",
+      directoryResolver: async (projectKey) =>
+        projectKey
+          ? [
+              {
+                id: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                label: "PwrAgnt",
+                path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                kind: "worktree"
+              }
+            ]
+          : []
     });
 
     const threads = await client.listThreads();
@@ -132,7 +143,8 @@ describe("CodexAppServerClient", () => {
         {
           id: "/Users/huntharo/pwrdrvr/PwrAgnt",
           label: "PwrAgnt",
-          path: "/Users/huntharo/pwrdrvr/PwrAgnt"
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          kind: "worktree"
         }
       ]
     });
@@ -145,7 +157,8 @@ describe("CodexAppServerClient", () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
-      command: "codex"
+      command: "codex",
+      directoryResolver: async () => []
     });
 
     const threads = await client.listThreads();
@@ -159,7 +172,8 @@ describe("CodexAppServerClient", () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
-      command: "codex"
+      command: "codex",
+      directoryResolver: async () => []
     });
 
     const replay = await client.readThread({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -66,6 +66,28 @@ class MockTransport implements JsonRpcTransport {
           }
         })
       );
+      return;
+    }
+
+    if (payload.method === "thread/read") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {
+            messages: [
+              {
+                role: "user",
+                text: "Show me the current desktop thread shell"
+              },
+              {
+                role: "assistant",
+                text: "The desktop shell is live and listing Codex threads."
+              }
+            ]
+          }
+        })
+      );
     }
   }
 
@@ -114,6 +136,25 @@ describe("CodexAppServerClient", () => {
       ]
     });
     expect(threads[1]?.title).toBe("Plan Codex compatibility");
+
+    await client.close();
+  });
+
+  it("extracts last user and assistant messages from thread/read", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex"
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-2"
+    });
+
+    expect(replay).toEqual({
+      lastUserMessage: "Show me the current desktop thread shell",
+      lastAssistantMessage: "The desktop shell is live and listing Codex threads."
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -57,6 +57,7 @@ class MockTransport implements JsonRpcTransport {
               {
                 id: "thread-1",
                 title: "Plan Codex compatibility",
+                text: "Do not leak this planning prompt into the thread browser",
                 updatedAt: 1_763_400_000,
                 session: {
                   cwd: "/Users/huntharo/pwrdrvr/openclaw-codex-app-server"
@@ -136,6 +137,20 @@ describe("CodexAppServerClient", () => {
       ]
     });
     expect(threads[1]?.title).toBe("Plan Codex compatibility");
+
+    await client.close();
+  });
+
+  it("does not synthesize summaries from raw conversation text", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex"
+    });
+
+    const threads = await client.listThreads();
+
+    expect(threads[1]?.summary).toBeUndefined();
 
     await client.close();
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,4 +1,6 @@
+import { execFile as execFileCallback } from "node:child_process";
 import path from "node:path";
+import { promisify } from "node:util";
 import type {
   AppServerThreadReplay,
   AppServerThreadSummary,
@@ -9,15 +11,24 @@ import { StdioJsonRpcTransport } from "./stdio-transport";
 
 const DEFAULT_PROTOCOL_VERSION = "1.0";
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+const execFile = promisify(execFileCallback);
 
 type CodexClientOptions = {
   command?: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
+  directoryResolver?: (
+    projectKey?: string
+  ) => Promise<LinkedDirectorySummary[]>;
   requestTimeoutMs?: number;
 };
 
-type CodexThreadSummary = Omit<AppServerThreadSummary, "source">;
+type RawCodexThreadSummary = Omit<
+  AppServerThreadSummary,
+  "source" | "linkedDirectories"
+> & {
+  projectKey?: string;
+};
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -274,7 +285,24 @@ function isAlreadyInitializedError(error: unknown): boolean {
   return text.toLowerCase().includes("already initialized");
 }
 
-function deriveLinkedDirectories(projectKey?: string): LinkedDirectorySummary[] {
+async function runGit(projectKey: string, args: string[]): Promise<string> {
+  const result = await execFile("git", ["-C", projectKey, ...args], {
+    env: process.env
+  });
+  return result.stdout.trim();
+}
+
+function parseGitWorktrees(output: string): string[] {
+  return output
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim())
+    .filter(Boolean);
+}
+
+async function resolveLinkedDirectories(
+  projectKey?: string
+): Promise<LinkedDirectorySummary[]> {
   if (!projectKey) {
     return [];
   }
@@ -284,18 +312,38 @@ function deriveLinkedDirectories(projectKey?: string): LinkedDirectorySummary[] 
     return [];
   }
 
-  return [
-    {
-      id: normalizedPath,
-      path: normalizedPath,
-      label: path.basename(normalizedPath) || normalizedPath
-    }
-  ];
+  try {
+    const repoRoot = await runGit(normalizedPath, ["rev-parse", "--show-toplevel"]);
+    const worktreeList = await runGit(normalizedPath, ["worktree", "list", "--porcelain"]);
+    const worktreePaths = parseGitWorktrees(worktreeList);
+    const primaryPath = worktreePaths[0] || repoRoot;
+    const currentPath = path.resolve(repoRoot);
+    const resolvedPrimaryPath = path.resolve(primaryPath);
+
+    return [
+      {
+        id: resolvedPrimaryPath,
+        path: resolvedPrimaryPath,
+        label: path.basename(resolvedPrimaryPath) || resolvedPrimaryPath,
+        kind: currentPath === resolvedPrimaryPath ? "local" : "worktree"
+      }
+    ];
+  } catch {
+    const fallbackPath = path.resolve(normalizedPath);
+    return [
+      {
+        id: fallbackPath,
+        path: fallbackPath,
+        label: path.basename(fallbackPath) || fallbackPath,
+        kind: "local"
+      }
+    ];
+  }
 }
 
-function extractThreadsFromValue(value: unknown): CodexThreadSummary[] {
+function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
   const items = extractThreadRecords(value);
-  const summaries = new Map<string, CodexThreadSummary>();
+  const summaries = new Map<string, RawCodexThreadSummary>();
 
   for (const record of items) {
     const threadId =
@@ -321,7 +369,7 @@ function extractThreadsFromValue(value: unknown): CodexThreadSummary[] {
         pickString(record, ["summary", "preview", "snippet"]) ??
           pickString(sessionRecord ?? {}, ["summary", "preview", "snippet"])
       ),
-      linkedDirectories: deriveLinkedDirectories(projectKey),
+      projectKey,
       createdAt: normalizeEpochTimestamp(
         pickNumber(record, ["createdAt", "created_at"]) ??
           pickNumber(sessionRecord ?? {}, ["createdAt", "created_at"])
@@ -383,6 +431,9 @@ async function requestWithFallbacks(params: {
 
 export class CodexAppServerClient {
   private readonly connection: JsonRpcConnection;
+  private readonly directoryResolver: (
+    projectKey?: string
+  ) => Promise<LinkedDirectorySummary[]>;
   private initialized = false;
   private initializationPromise: Promise<void> | null = null;
 
@@ -395,6 +446,7 @@ export class CodexAppServerClient {
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     );
+    this.directoryResolver = options.directoryResolver ?? resolveLinkedDirectories;
   }
 
   async close(): Promise<void> {
@@ -413,10 +465,13 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     });
 
-    return extractThreadsFromValue(result).map((thread) => ({
-      ...thread,
-      source: "codex"
-    }));
+    return await Promise.all(
+      extractThreadsFromValue(result).map(async (thread) => ({
+        ...thread,
+        linkedDirectories: await this.directoryResolver(thread.projectKey),
+        source: "codex"
+      }))
+    );
   }
 
   async readThread(params: { threadId: string }): Promise<AppServerThreadReplay> {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -107,6 +107,24 @@ function dedupeJoinedText(parts: string[]): string | undefined {
   return unique.join("\n\n");
 }
 
+function normalizeThreadSummary(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (
+    trimmed.length > 160 ||
+    trimmed.startsWith("[$") ||
+    trimmed.includes("](/") ||
+    trimmed.includes("/Users/")
+  ) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
 function normalizeConversationRole(
   value: string | undefined
 ): "user" | "assistant" | undefined {
@@ -299,9 +317,10 @@ function extractThreadsFromValue(value: unknown): CodexThreadSummary[] {
         pickString(record, ["title", "name", "headline"]) ??
         pickString(sessionRecord ?? {}, ["title", "name"]) ??
         "Untitled thread",
-      summary:
-        pickString(record, ["summary", "preview", "snippet", "text"]) ??
-        dedupeJoinedText(collectText(record.messages ?? record.lastMessage ?? record.content)),
+      summary: normalizeThreadSummary(
+        pickString(record, ["summary", "preview", "snippet"]) ??
+          pickString(sessionRecord ?? {}, ["summary", "preview", "snippet"])
+      ),
       linkedDirectories: deriveLinkedDirectories(projectKey),
       createdAt: normalizeEpochTimestamp(
         pickNumber(record, ["createdAt", "created_at"]) ??

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type {
+  AppServerThreadReplay,
   AppServerThreadSummary,
   LinkedDirectorySummary
 } from "@pwragnt/shared";
@@ -106,6 +107,106 @@ function dedupeJoinedText(parts: string[]): string | undefined {
   return unique.join("\n\n");
 }
 
+function normalizeConversationRole(
+  value: string | undefined
+): "user" | "assistant" | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "user" || normalized === "usermessage") {
+    return "user";
+  }
+  if (
+    normalized === "assistant" ||
+    normalized === "agentmessage" ||
+    normalized === "assistantmessage"
+  ) {
+    return "assistant";
+  }
+  return undefined;
+}
+
+function collectMessageText(record: Record<string, unknown>): string {
+  return (
+    dedupeJoinedText([
+      ...collectText(record.content),
+      ...collectText(record.text),
+      ...collectText(record.message),
+      ...collectText(record.messages),
+      ...collectText(record.input),
+      ...collectText(record.output),
+      ...collectText(record.parts)
+    ]) ?? ""
+  );
+}
+
+function extractConversationMessages(
+  value: unknown
+): Array<{ role: "user" | "assistant"; text: string }> {
+  const output: Array<{ role: "user" | "assistant"; text: string }> = [];
+
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach((entry) => visit(entry));
+      return;
+    }
+
+    const record = asRecord(node);
+    if (!record) {
+      return;
+    }
+
+    const role = normalizeConversationRole(
+      pickString(record, ["role", "author", "speaker", "source", "type"])
+    );
+    const text = collectMessageText(record);
+    if (role && text) {
+      output.push({ role, text });
+    }
+
+    for (const key of [
+      "items",
+      "messages",
+      "content",
+      "parts",
+      "entries",
+      "data",
+      "results",
+      "turns",
+      "events",
+      "item",
+      "message",
+      "thread",
+      "response",
+      "result"
+    ]) {
+      visit(record[key]);
+    }
+  };
+
+  visit(value);
+  return output;
+}
+
+function extractThreadReplayFromReadResult(value: unknown): AppServerThreadReplay {
+  const messages = extractConversationMessages(value);
+  let lastUserMessage: string | undefined;
+  let lastAssistantMessage: string | undefined;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!lastAssistantMessage && message?.role === "assistant") {
+      lastAssistantMessage = message.text;
+    }
+    if (!lastUserMessage && message?.role === "user") {
+      lastUserMessage = message.text;
+    }
+    if (lastUserMessage && lastAssistantMessage) {
+      break;
+    }
+  }
+
+  return { lastUserMessage, lastAssistantMessage };
+}
+
 function extractThreadRecords(value: unknown): Record<string, unknown>[] {
   if (Array.isArray(value)) {
     return value.flatMap((entry) => extractThreadRecords(entry));
@@ -148,6 +249,11 @@ function isMethodUnavailableError(error: unknown, method?: string): boolean {
   }
 
   return normalized.includes(`unknown variant \`${method.toLowerCase()}\``);
+}
+
+function isAlreadyInitializedError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.toLowerCase().includes("already initialized");
 }
 
 function deriveLinkedDirectories(projectKey?: string): LinkedDirectorySummary[] {
@@ -259,6 +365,7 @@ async function requestWithFallbacks(params: {
 export class CodexAppServerClient {
   private readonly connection: JsonRpcConnection;
   private initialized = false;
+  private initializationPromise: Promise<void> | null = null;
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -273,6 +380,7 @@ export class CodexAppServerClient {
 
   async close(): Promise<void> {
     this.initialized = false;
+    this.initializationPromise = null;
     await this.connection.close();
   }
 
@@ -292,18 +400,54 @@ export class CodexAppServerClient {
     }));
   }
 
+  async readThread(params: { threadId: string }): Promise<AppServerThreadReplay> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/read"],
+      payloads: [{ threadId: params.threadId, includeTurns: true }],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    });
+
+    return extractThreadReplayFromReadResult(result);
+  }
+
   private async ensureInitialized(): Promise<void> {
     if (this.initialized) {
       return;
     }
 
-    await this.connection.connect();
-    await this.connection.request("initialize", {
-      protocolVersion: DEFAULT_PROTOCOL_VERSION,
-      clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
-      capabilities: { experimentalApi: true }
-    });
-    await this.connection.notify("initialized", {});
-    this.initialized = true;
+    if (this.initializationPromise) {
+      await this.initializationPromise;
+      return;
+    }
+
+    this.initializationPromise = (async () => {
+      await this.connection.connect();
+
+      try {
+        await this.connection.request("initialize", {
+          protocolVersion: DEFAULT_PROTOCOL_VERSION,
+          clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
+          capabilities: { experimentalApi: true }
+        });
+      } catch (error) {
+        if (!isAlreadyInitializedError(error)) {
+          throw error;
+        }
+      }
+
+      await this.connection.notify("initialized", {});
+      this.initialized = true;
+    })();
+
+    try {
+      await this.initializationPromise;
+    } finally {
+      if (!this.initialized) {
+        this.initializationPromise = null;
+      }
+    }
   }
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,14 +1,22 @@
-import { ipcMain } from "electron";
+import { app, ipcMain } from "electron";
+import path from "node:path";
+import { OverlayStore } from "@pwragnt/agent-core";
 import type {
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
-  AppServerReadThreadResponse
+  AppServerReadThreadResponse,
+  GetNavigationSnapshotRequest,
+  MarkThreadSeenRequest,
+  MarkThreadSeenResponse,
+  NavigationSnapshot,
 } from "@pwragnt/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import {
   APP_SERVER_LIST_THREADS_CHANNEL,
-  APP_SERVER_READ_THREAD_CHANNEL
+  APP_SERVER_READ_THREAD_CHANNEL,
+  NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_SNAPSHOT_CHANNEL,
 } from "../../shared/ipc";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -34,6 +42,7 @@ function parseEnvArgs(rawArgs: string | undefined): string[] {
 
 class DesktopAppServerService {
   private codexClient: CodexAppServerClient | null = null;
+  private overlayStore: OverlayStore | null = null;
 
   async listThreads(
     request: AppServerListThreadsRequest = {}
@@ -91,6 +100,60 @@ class DesktopAppServerService {
     };
   }
 
+  async getNavigationSnapshot(
+    request: GetNavigationSnapshotRequest = {},
+  ): Promise<NavigationSnapshot> {
+    const backend = request.backend ?? "codex";
+
+    if (backend !== "codex") {
+      throw new Error(`${backend} app server is not wired yet`);
+    }
+
+    const client = this.getCodexClient();
+    const threads = await client.listThreads({
+      filter: request.filter,
+    });
+    const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
+      backend,
+      fetchedAt: Date.now(),
+      threads,
+    });
+
+    logDebug("getNavigationSnapshot", {
+      backend,
+      count: snapshot.threads.length,
+      inboxCount: snapshot.inboxThreadIds.length,
+      unchanged: snapshot.unchanged,
+    });
+
+    return snapshot;
+  }
+
+  async markThreadSeen(
+    request: MarkThreadSeenRequest,
+  ): Promise<MarkThreadSeenResponse> {
+    const backend = request.backend ?? "codex";
+
+    if (backend !== "codex") {
+      throw new Error(`${backend} app server is not wired yet`);
+    }
+
+    const response = await this.getOverlayStore().markThreadSeen({
+      backend,
+      seenAt: request.seenAt,
+      seenUpdatedAt: request.seenUpdatedAt,
+      threadId: request.threadId,
+    });
+
+    logDebug("markThreadSeen", {
+      backend,
+      threadId: request.threadId,
+      seenUpdatedAt: request.seenUpdatedAt ?? null,
+    });
+
+    return response;
+  }
+
   async close(): Promise<void> {
     await this.codexClient?.close();
     this.codexClient = null;
@@ -108,6 +171,18 @@ class DesktopAppServerService {
     });
 
     return this.codexClient;
+  }
+
+  private getOverlayStore(): OverlayStore {
+    if (this.overlayStore) {
+      return this.overlayStore;
+    }
+
+    this.overlayStore = new OverlayStore(
+      path.join(app.getPath("userData"), "overlay-state.json"),
+    );
+
+    return this.overlayStore;
   }
 }
 
@@ -134,11 +209,33 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.readThread(request);
     }
   );
+  ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SNAPSHOT_CHANNEL,
+    async (
+      _event,
+      request?: GetNavigationSnapshotRequest,
+    ): Promise<NavigationSnapshot> => {
+      return await appServerService.getNavigationSnapshot(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+    async (
+      _event,
+      request: MarkThreadSeenRequest,
+    ): Promise<MarkThreadSeenResponse> => {
+      return await appServerService.markThreadSeen(request);
+    },
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   await appServerService.close();
 }
 export { APP_SERVER_LIST_THREADS_CHANNEL };

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,10 +1,25 @@
 import { ipcMain } from "electron";
 import type {
   AppServerListThreadsRequest,
-  AppServerListThreadsResponse
+  AppServerListThreadsResponse,
+  AppServerReadThreadRequest,
+  AppServerReadThreadResponse
 } from "@pwragnt/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
-import { APP_SERVER_LIST_THREADS_CHANNEL } from "../../shared/ipc";
+import {
+  APP_SERVER_LIST_THREADS_CHANNEL,
+  APP_SERVER_READ_THREAD_CHANNEL
+} from "../../shared/ipc";
+
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+function logDebug(event: string, payload: Record<string, unknown>): void {
+  if (!isDevelopment) {
+    return;
+  }
+
+  console.info(`[pwragnt:app-server] ${event}`, payload);
+}
 
 function parseEnvArgs(rawArgs: string | undefined): string[] {
   if (!rawArgs?.trim()) {
@@ -34,10 +49,45 @@ class DesktopAppServerService {
       filter: request.filter
     });
 
+    logDebug("listThreads", {
+      backend,
+      count: threads.length,
+      threadIds: threads.slice(0, 5).map((thread) => thread.id)
+    });
+
     return {
       backend,
       fetchedAt: Date.now(),
       threads
+    };
+  }
+
+  async readThread(
+    request: AppServerReadThreadRequest
+  ): Promise<AppServerReadThreadResponse> {
+    const backend = request.backend ?? "codex";
+
+    if (backend !== "codex") {
+      throw new Error(`${backend} app server is not wired yet`);
+    }
+
+    const client = this.getCodexClient();
+    const replay = await client.readThread({
+      threadId: request.threadId
+    });
+
+    logDebug("readThread", {
+      backend,
+      threadId: request.threadId,
+      hasLastUserMessage: Boolean(replay.lastUserMessage),
+      hasLastAssistantMessage: Boolean(replay.lastAssistantMessage)
+    });
+
+    return {
+      backend,
+      fetchedAt: Date.now(),
+      threadId: request.threadId,
+      replay
     };
   }
 
@@ -74,10 +124,21 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.listThreads(request);
     }
   );
+  ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_READ_THREAD_CHANNEL,
+    async (
+      _event,
+      request: AppServerReadThreadRequest
+    ): Promise<AppServerReadThreadResponse> => {
+      return await appServerService.readThread(request);
+    }
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
+  ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
   await appServerService.close();
 }
 export { APP_SERVER_LIST_THREADS_CHANNEL };

--- a/apps/desktop/src/main/window-focus-sync.ts
+++ b/apps/desktop/src/main/window-focus-sync.ts
@@ -1,0 +1,25 @@
+import type { BrowserWindow } from "electron";
+import { WINDOW_FOCUS_SYNC_CHANNEL } from "../shared/ipc";
+
+export function attachWindowFocusSync(window: BrowserWindow): void {
+  if (typeof window.on !== "function") {
+    return;
+  }
+
+  window.on("focus", () => {
+    if (
+      typeof window.isDestroyed === "function" &&
+      window.isDestroyed()
+    ) {
+      return;
+    }
+
+    if (typeof window.webContents.send !== "function") {
+      return;
+    }
+
+    window.webContents.send(WINDOW_FOCUS_SYNC_CHANNEL, {
+      focusedAt: Date.now(),
+    });
+  });
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, shell } from "electron";
 import { join } from "node:path";
+import { attachWindowFocusSync } from "./window-focus-sync";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 
@@ -55,6 +56,7 @@ export function createMainWindow(): BrowserWindow {
   });
 
   const { webContents } = window;
+  attachWindowFocusSync(window);
 
   if (typeof webContents.on === "function") {
     webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedUrl) => {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,8 +1,10 @@
 import { BrowserWindow, shell } from "electron";
 import { join } from "node:path";
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+
 export function getPreloadPath(): string {
-  return join(__dirname, "../preload/index.js");
+  return join(__dirname, "../preload/index.cjs");
 }
 
 export function getRendererEntry(): { kind: "url" | "file"; value: string } {
@@ -17,6 +19,7 @@ export function getRendererEntry(): { kind: "url" | "file"; value: string } {
 }
 
 export function createMainWindow(): BrowserWindow {
+  const preloadPath = getPreloadPath();
   const window = new BrowserWindow({
     width: 1440,
     height: 960,
@@ -26,12 +29,19 @@ export function createMainWindow(): BrowserWindow {
     title: "PwrAgnt",
     backgroundColor: "#10151f",
     webPreferences: {
-      preload: getPreloadPath(),
+      preload: preloadPath,
       contextIsolation: true,
       sandbox: true,
       nodeIntegration: false
     }
   });
+
+  if (isDevelopment) {
+    console.info("[pwragnt:main] creating window", {
+      preloadPath,
+      rendererUrl: process.env.ELECTRON_RENDERER_URL ?? null
+    });
+  }
 
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {
@@ -44,7 +54,52 @@ export function createMainWindow(): BrowserWindow {
     window.show();
   });
 
-  window.webContents.setWindowOpenHandler(({ url }) => {
+  const { webContents } = window;
+
+  if (typeof webContents.on === "function") {
+    webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedUrl) => {
+      console.error("[pwragnt:main] renderer load failed", {
+        errorCode,
+        errorDescription,
+        validatedUrl
+      });
+    });
+
+    webContents.on("render-process-gone", (_event, details) => {
+      console.error("[pwragnt:main] renderer process gone", details);
+    });
+  }
+
+  if (isDevelopment && typeof webContents.on === "function") {
+    webContents.on("console-message", (_event, level, message, line, sourceId) => {
+      console.info("[pwragnt:renderer:console]", {
+        level,
+        message,
+        line,
+        sourceId
+      });
+    });
+
+    webContents.on("did-finish-load", () => {
+      void webContents
+        .executeJavaScript(
+          `({
+            hasPwragnt: typeof window.pwragnt !== "undefined",
+            pwragntKeys: typeof window.pwragnt !== "undefined" ? Object.keys(window.pwragnt) : [],
+            locationHref: window.location.href
+          })`,
+          true
+        )
+        .then((result) => {
+          console.info("[pwragnt:main] renderer globals", result);
+        })
+        .catch((error: unknown) => {
+          console.error("[pwragnt:main] failed to inspect renderer globals", error);
+        });
+    });
+  }
+
+  webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: "deny" };
   });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,9 +1,20 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type {
   AppServerListThreadsRequest,
-  AppServerListThreadsResponse
+  AppServerListThreadsResponse,
+  AppServerReadThreadRequest,
+  AppServerReadThreadResponse
 } from "@pwragnt/shared";
-import { APP_SERVER_LIST_THREADS_CHANNEL } from "../shared/ipc";
+import {
+  APP_SERVER_LIST_THREADS_CHANNEL,
+  APP_SERVER_READ_THREAD_CHANNEL
+} from "../shared/ipc";
+
+console.info("[pwragnt:preload] start", {
+  contextIsolated: process.contextIsolated,
+  platform: process.platform,
+  electron: process.versions.electron
+});
 
 const desktopApi = Object.freeze({
   ping: () => "pong",
@@ -11,6 +22,10 @@ const desktopApi = Object.freeze({
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>
     await ipcRenderer.invoke(APP_SERVER_LIST_THREADS_CHANNEL, request),
+  readThread: async (
+    request: AppServerReadThreadRequest
+  ): Promise<AppServerReadThreadResponse> =>
+    await ipcRenderer.invoke(APP_SERVER_READ_THREAD_CHANNEL, request),
   platform: process.platform,
   versions: {
     chrome: process.versions.chrome,
@@ -21,4 +36,9 @@ const desktopApi = Object.freeze({
 
 if (process.contextIsolated) {
   contextBridge.exposeInMainWorld("pwragnt", desktopApi);
+  console.info("[pwragnt:preload] exposed context bridge", {
+    keys: Object.keys(desktopApi)
+  });
+} else {
+  console.warn("[pwragnt:preload] context isolation disabled; bridge not exposed");
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,11 +3,18 @@ import type {
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
-  AppServerReadThreadResponse
+  AppServerReadThreadResponse,
+  GetNavigationSnapshotRequest,
+  MarkThreadSeenRequest,
+  MarkThreadSeenResponse,
+  NavigationSnapshot,
 } from "@pwragnt/shared";
 import {
   APP_SERVER_LIST_THREADS_CHANNEL,
-  APP_SERVER_READ_THREAD_CHANNEL
+  APP_SERVER_READ_THREAD_CHANNEL,
+  NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_SNAPSHOT_CHANNEL,
+  WINDOW_FOCUS_SYNC_CHANNEL,
 } from "../shared/ipc";
 
 console.info("[pwragnt:preload] start", {
@@ -26,6 +33,21 @@ const desktopApi = Object.freeze({
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> =>
     await ipcRenderer.invoke(APP_SERVER_READ_THREAD_CHANNEL, request),
+  getNavigationSnapshot: async (
+    request?: GetNavigationSnapshotRequest,
+  ): Promise<NavigationSnapshot> =>
+    await ipcRenderer.invoke(NAVIGATION_SNAPSHOT_CHANNEL, request),
+  markThreadSeen: async (
+    request: MarkThreadSeenRequest,
+  ): Promise<MarkThreadSeenResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_MARK_THREAD_SEEN_CHANNEL, request),
+  onWindowFocus: (callback: () => void): (() => void) => {
+    const listener = () => callback();
+    ipcRenderer.on(WINDOW_FOCUS_SYNC_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(WINDOW_FOCUS_SYNC_CHANNEL, listener);
+    };
+  },
   platform: process.platform,
   versions: {
     chrome: process.versions.chrome,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -90,25 +90,27 @@ function formatLinkedDirectoryCount(thread: AppServerThreadSummary): string {
   }`;
 }
 
-function getDirectoryLabelSummary(thread: AppServerThreadSummary): string {
-  if (thread.linkedDirectories.length === 0) {
-    return "No linked directories yet";
+function getThreadMetadataPills(
+  thread: AppServerThreadSummary
+): Array<{ key: string; icon: string; label: string }> {
+  const projectPills = thread.linkedDirectories.map((directory) => ({
+    key: directory.id,
+    icon: "📁",
+    label: directory.label
+  }));
+
+  if (!thread.gitBranch) {
+    return projectPills;
   }
 
-  const labels = thread.linkedDirectories.map((directory) => directory.label);
-  if (labels.length <= 2) {
-    return labels.join(" • ");
-  }
-
-  return `${labels.slice(0, 2).join(" • ")} +${labels.length - 2}`;
-}
-
-function getThreadListSubtitle(thread: AppServerThreadSummary): string {
-  const parts = [getDirectoryLabelSummary(thread)];
-  if (thread.gitBranch) {
-    parts.push(thread.gitBranch);
-  }
-  return parts.join(" • ");
+  return [
+    ...projectPills,
+    {
+      key: `branch:${thread.gitBranch}`,
+      icon: "🌿",
+      label: thread.gitBranch
+    }
+  ];
 }
 
 function getInspectorSummary(thread: AppServerThreadSummary): string {
@@ -206,6 +208,7 @@ function ThreadList(props: {
     >
       {props.threads.map((thread) => {
         const isSelected = thread.id === props.selectedThreadId;
+        const metadataPills = getThreadMetadataPills(thread);
 
         return (
           <button
@@ -256,28 +259,14 @@ function ThreadList(props: {
               </span>
             </div>
 
-            <p
-              style={{
-                margin: 0,
-                color: colors.muted,
-                fontSize: "0.88rem",
-                lineHeight: 1.35,
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-                overflow: "hidden"
-              }}
-            >
-              {getThreadListSubtitle(thread)}
-            </p>
-
             <div style={{ display: "flex", gap: "0.45rem", flexWrap: "wrap" }}>
-              {thread.linkedDirectories.map((directory) => (
+              {metadataPills.map((pill) => (
                 <span
-                  key={directory.id}
+                  key={pill.key}
                   style={{
                     display: "inline-flex",
                     alignItems: "center",
+                    gap: "0.35rem",
                     minHeight: "1.65rem",
                     padding: "0 0.55rem",
                     borderRadius: "999px",
@@ -286,7 +275,8 @@ function ThreadList(props: {
                     fontSize: "0.78rem"
                   }}
                 >
-                  {directory.label}
+                  <span aria-hidden="true">{pill.icon}</span>
+                  {pill.label}
                 </span>
               ))}
             </div>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -95,7 +95,7 @@ function getThreadMetadataPills(
 ): Array<{ key: string; icon: string; label: string }> {
   const projectPills = thread.linkedDirectories.map((directory) => ({
     key: directory.id,
-    icon: "📁",
+    icon: directory.kind === "worktree" ? "🔀" : "📁",
     label: directory.label
   }));
 
@@ -924,6 +924,7 @@ export function App(): React.ReactElement {
                         display: "inline-flex",
                         minHeight: "1.8rem",
                         alignItems: "center",
+                        gap: "0.35rem",
                         padding: "0 0.65rem",
                         borderRadius: "999px",
                         background: colors.accentMuted,
@@ -931,6 +932,9 @@ export function App(): React.ReactElement {
                         fontSize: "0.84rem"
                       }}
                     >
+                      <span aria-hidden="true">
+                        {directory.kind === "worktree" ? "🔀" : "📁"}
+                      </span>
                       {directory.label}
                     </span>
                   ))

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -84,13 +84,57 @@ function formatTimestamp(timestamp: number | undefined): string {
   }).format(timestamp);
 }
 
-function getPrimarySummary(thread: AppServerThreadSummary): string {
-  return (
-    thread.summary?.trim() ||
-    `${thread.linkedDirectories.length || 0} linked director${
-      thread.linkedDirectories.length === 1 ? "y" : "ies"
-    }`
-  );
+function formatLinkedDirectoryCount(thread: AppServerThreadSummary): string {
+  return `${thread.linkedDirectories.length || 0} linked director${
+    thread.linkedDirectories.length === 1 ? "y" : "ies"
+  }`;
+}
+
+function getDirectoryLabelSummary(thread: AppServerThreadSummary): string {
+  if (thread.linkedDirectories.length === 0) {
+    return "No linked directories yet";
+  }
+
+  const labels = thread.linkedDirectories.map((directory) => directory.label);
+  if (labels.length <= 2) {
+    return labels.join(" • ");
+  }
+
+  return `${labels.slice(0, 2).join(" • ")} +${labels.length - 2}`;
+}
+
+function getThreadListSubtitle(thread: AppServerThreadSummary): string {
+  const parts = [getDirectoryLabelSummary(thread)];
+  if (thread.gitBranch) {
+    parts.push(thread.gitBranch);
+  }
+  return parts.join(" • ");
+}
+
+function getInspectorSummary(thread: AppServerThreadSummary): string {
+  const lines = [formatLinkedDirectoryCount(thread)];
+
+  if (thread.linkedDirectories.length > 0) {
+    lines.push(
+      `Projects: ${thread.linkedDirectories
+        .map((directory) => directory.label)
+        .join(", ")}`
+    );
+  }
+
+  if (thread.gitBranch) {
+    lines.push(`Branch: ${thread.gitBranch}`);
+  }
+
+  if (thread.updatedAt) {
+    lines.push(`Last activity: ${formatTimestamp(thread.updatedAt)}`);
+  }
+
+  if (thread.summary) {
+    lines.push(thread.summary);
+  }
+
+  return lines.join("\n");
 }
 
 function sectionLabelStyle(): React.CSSProperties {
@@ -217,10 +261,14 @@ function ThreadList(props: {
                 margin: 0,
                 color: colors.muted,
                 fontSize: "0.88rem",
-                lineHeight: 1.35
+                lineHeight: 1.35,
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden"
               }}
             >
-              {getPrimarySummary(thread)}
+              {getThreadListSubtitle(thread)}
             </p>
 
             <div style={{ display: "flex", gap: "0.45rem", flexWrap: "wrap" }}>
@@ -819,7 +867,7 @@ export function App(): React.ReactElement {
                 }}
               >
                 {selectedThread
-                  ? getPrimarySummary(selectedThread)
+                  ? getInspectorSummary(selectedThread)
                   : "Select a thread to inspect it."}
               </p>
             </div>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
+  AppServerReadThreadRequest,
+  AppServerReadThreadResponse,
   AppServerThreadSummary
 } from "@pwragnt/shared";
 
@@ -10,6 +12,9 @@ type DesktopApi = {
   listThreads?: (
     request?: AppServerListThreadsRequest
   ) => Promise<AppServerListThreadsResponse>;
+  readThread?: (
+    request: AppServerReadThreadRequest
+  ) => Promise<AppServerReadThreadResponse>;
   platform?: string;
   versions?: {
     chrome?: string;
@@ -29,7 +34,8 @@ const colors = {
   text: "#f2f1ea",
   muted: "#a5ab9b",
   accent: "#cbff45",
-  accentMuted: "rgba(203, 255, 69, 0.16)"
+  accentMuted: "rgba(203, 255, 69, 0.16)",
+  danger: "#ff9d8b"
 } as const;
 
 function formatRelativeTime(timestamp: number | undefined): string {
@@ -65,7 +71,7 @@ function formatRelativeTime(timestamp: number | undefined): string {
   }).format(timestamp);
 }
 
-function formatUpdatedAt(timestamp: number | undefined): string {
+function formatTimestamp(timestamp: number | undefined): string {
   if (!timestamp) {
     return "Unknown";
   }
@@ -84,6 +90,57 @@ function getPrimarySummary(thread: AppServerThreadSummary): string {
     `${thread.linkedDirectories.length || 0} linked director${
       thread.linkedDirectories.length === 1 ? "y" : "ies"
     }`
+  );
+}
+
+function sectionLabelStyle(): React.CSSProperties {
+  return {
+    margin: 0,
+    color: colors.muted,
+    fontSize: "0.82rem",
+    textTransform: "uppercase",
+    fontWeight: 700
+  };
+}
+
+function actionButtonStyle(active = false): React.CSSProperties {
+  return {
+    minWidth: "2.4rem",
+    height: "2rem",
+    padding: "0 0.8rem",
+    border: `1px solid ${active ? colors.accent : colors.border}`,
+    borderRadius: "8px",
+    background: active ? colors.accent : colors.panel,
+    color: active ? "#0f1300" : colors.text,
+    cursor: "pointer",
+    fontSize: "0.84rem",
+    fontWeight: 600
+  };
+}
+
+function ErrorBlock(props: { title: string; message: string }): React.ReactElement {
+  return (
+    <div
+      style={{
+        marginTop: "0.85rem",
+        padding: "0.85rem 0.95rem",
+        borderRadius: "8px",
+        border: `1px solid rgba(255, 157, 139, 0.32)`,
+        background: "rgba(88, 26, 18, 0.25)"
+      }}
+    >
+      <p style={{ margin: 0, color: colors.danger, fontWeight: 700 }}>{props.title}</p>
+      <p
+        style={{
+          margin: "0.45rem 0 0",
+          color: colors.text,
+          fontSize: "0.9rem",
+          lineHeight: 1.45
+        }}
+      >
+        {props.message}
+      </p>
+    </div>
   );
 }
 
@@ -302,57 +359,166 @@ function DirectoryList(props: {
   );
 }
 
+function MessagePreview(props: {
+  label: string;
+  text?: string;
+  emptyText: string;
+}): React.ReactElement {
+  return (
+    <div
+      style={{
+        padding: "1rem",
+        borderRadius: "8px",
+        background: colors.panelAlt,
+        border: `1px solid ${colors.border}`
+      }}
+    >
+      <p style={sectionLabelStyle()}>{props.label}</p>
+      <p
+        style={{
+          margin: "0.65rem 0 0",
+          color: props.text ? colors.text : colors.muted,
+          fontSize: "0.95rem",
+          lineHeight: 1.5,
+          whiteSpace: "pre-wrap"
+        }}
+      >
+        {props.text ?? props.emptyText}
+      </p>
+    </div>
+  );
+}
+
 export function App(): React.ReactElement {
   const shellApi = (window as Window & { pwragnt?: DesktopApi }).pwragnt;
   const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
   const [threadState, setThreadState] = useState<{
     loading: boolean;
+    refreshing: boolean;
     error?: string;
     response?: AppServerListThreadsResponse;
   }>({
-    loading: true
+    loading: true,
+    refreshing: false
   });
   const [selectedThreadId, setSelectedThreadId] = useState<string>();
+  const [detailState, setDetailState] = useState<{
+    loading: boolean;
+    error?: string;
+    response?: AppServerReadThreadResponse;
+  }>({
+    loading: false
+  });
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadThreads(): Promise<void> {
-      try {
-        const response = await shellApi?.listThreads?.({ backend: "codex" });
-        if (cancelled) {
-          return;
-        }
-
-        setThreadState({
-          loading: false,
-          response
-        });
-        setSelectedThreadId((current) => current ?? response?.threads[0]?.id);
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
-        setThreadState({
-          loading: false,
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
+  const loadThreads = useCallback(async (): Promise<void> => {
+    if (!shellApi?.listThreads) {
+      setThreadState({
+        loading: false,
+        refreshing: false,
+        error: "Desktop bridge is missing listThreads().",
+        response: undefined
+      });
+      return;
     }
 
-    void loadThreads();
+    setThreadState((current) => ({
+      ...current,
+      loading: !current.response,
+      refreshing: Boolean(current.response),
+      error: undefined
+    }));
 
-    return () => {
-      cancelled = true;
-    };
+    try {
+      const response = await shellApi.listThreads({ backend: "codex" });
+      setThreadState({
+        loading: false,
+        refreshing: false,
+        response
+      });
+      setSelectedThreadId((current) => {
+        if (current && response.threads.some((thread) => thread.id === current)) {
+          return current;
+        }
+        return response.threads[0]?.id;
+      });
+    } catch (error) {
+      setThreadState((current) => ({
+        loading: false,
+        refreshing: false,
+        response: current.response,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
   }, [shellApi]);
+
+  useEffect(() => {
+    void loadThreads();
+  }, [loadThreads]);
 
   const threads = threadState.response?.threads ?? [];
   const selectedThread = useMemo(
     () => threads.find((thread) => thread.id === selectedThreadId) ?? threads[0],
     [selectedThreadId, threads]
   );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSelectedThread(): Promise<void> {
+      if (!selectedThread?.id) {
+        setDetailState({
+          loading: false,
+          response: undefined,
+          error: undefined
+        });
+        return;
+      }
+
+      if (!shellApi?.readThread) {
+        setDetailState({
+          loading: false,
+          response: undefined,
+          error: "Desktop bridge is missing readThread()."
+        });
+        return;
+      }
+
+      setDetailState((current) => ({
+        ...current,
+        loading: true,
+        error: undefined
+      }));
+
+      try {
+        const response = await shellApi.readThread({
+          backend: "codex",
+          threadId: selectedThread.id
+        });
+        if (cancelled) {
+          return;
+        }
+        setDetailState({
+          loading: false,
+          response
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setDetailState({
+          loading: false,
+          response: undefined,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    void loadSelectedThread();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedThread?.id, shellApi]);
 
   return (
     <div
@@ -410,19 +576,13 @@ export function App(): React.ReactElement {
 
           <button
             type="button"
-            style={{
-              width: "2.1rem",
-              height: "2.1rem",
-              borderRadius: "8px",
-              border: `1px solid ${colors.border}`,
-              background: colors.panel,
-              color: colors.text,
-              fontSize: "1.2rem",
-              cursor: "pointer"
+            style={actionButtonStyle()}
+            aria-label="Refresh threads"
+            onClick={() => {
+              void loadThreads();
             }}
-            aria-label="New thread"
           >
-            +
+            {threadState.refreshing ? "..." : "Refresh"}
           </button>
         </div>
 
@@ -491,7 +651,21 @@ export function App(): React.ReactElement {
               gap: "0.75rem"
             }}
           >
-            <h2 style={{ margin: 0, fontSize: "1.08rem" }}>Browse</h2>
+            <div>
+              <h2 style={{ margin: 0, fontSize: "1.08rem" }}>Browse</h2>
+              <p
+                style={{
+                  margin: "0.25rem 0 0",
+                  color: colors.muted,
+                  fontSize: "0.8rem"
+                }}
+              >
+                {threads.length} threads •{" "}
+                {threadState.response
+                  ? formatTimestamp(threadState.response.fetchedAt)
+                  : "waiting"}
+              </p>
+            </div>
             <div
               style={{
                 display: "inline-flex",
@@ -534,8 +708,16 @@ export function App(): React.ReactElement {
               Loading Codex threads...
             </p>
           ) : threadState.error ? (
-            <p style={{ margin: "1rem 0 0", color: "#ff9d8b", lineHeight: 1.4 }}>
-              {threadState.error}
+            <ErrorBlock title="Thread list failed" message={threadState.error} />
+          ) : threads.length === 0 ? (
+            <p
+              style={{
+                margin: "1rem 0 0",
+                color: colors.muted,
+                lineHeight: 1.45
+              }}
+            >
+              Codex returned zero threads for this account.
             </p>
           ) : browseMode === "directories" ? (
             <DirectoryList
@@ -572,16 +754,7 @@ export function App(): React.ReactElement {
           }}
         >
           <div>
-            <div
-              style={{
-                color: colors.muted,
-                fontSize: "0.82rem",
-                textTransform: "uppercase",
-                fontWeight: 700
-              }}
-            >
-              Recent view
-            </div>
+            <div style={sectionLabelStyle()}>Recent view</div>
             <h2 style={{ margin: "0.3rem 0 0", fontSize: "1.85rem" }}>
               {selectedThread?.title ?? "No thread selected"}
             </h2>
@@ -623,35 +796,62 @@ export function App(): React.ReactElement {
         >
           <div
             style={{
-              padding: "1.2rem",
-              borderRadius: "8px",
-              background: colors.panel,
-              border: `1px solid ${colors.border}`
+              display: "flex",
+              flexDirection: "column",
+              gap: "1rem"
             }}
           >
-            <p
+            <div
               style={{
-                margin: 0,
-                color: colors.muted,
-                fontSize: "0.84rem",
-                textTransform: "uppercase",
-                fontWeight: 700
+                padding: "1.2rem",
+                borderRadius: "8px",
+                background: colors.panel,
+                border: `1px solid ${colors.border}`
               }}
             >
-              Summary
-            </p>
-            <p
-              style={{
-                margin: "0.85rem 0 0",
-                fontSize: "1.05rem",
-                lineHeight: 1.55,
-                color: selectedThread ? colors.text : colors.muted
-              }}
-            >
-              {selectedThread
-                ? getPrimarySummary(selectedThread)
-                : "Start a thread or pick one from Recents."}
-            </p>
+              <p style={sectionLabelStyle()}>Summary</p>
+              <p
+                style={{
+                  margin: "0.85rem 0 0",
+                  fontSize: "1.05rem",
+                  lineHeight: 1.55,
+                  color: selectedThread ? colors.text : colors.muted
+                }}
+              >
+                {selectedThread
+                  ? getPrimarySummary(selectedThread)
+                  : "Select a thread to inspect it."}
+              </p>
+            </div>
+
+            {detailState.error ? (
+              <ErrorBlock title="Thread read failed" message={detailState.error} />
+            ) : detailState.loading ? (
+              <div
+                style={{
+                  padding: "1.2rem",
+                  borderRadius: "8px",
+                  background: colors.panel,
+                  border: `1px solid ${colors.border}`,
+                  color: colors.muted
+                }}
+              >
+                Loading thread context...
+              </div>
+            ) : (
+              <>
+                <MessagePreview
+                  label="Last user message"
+                  text={detailState.response?.replay.lastUserMessage}
+                  emptyText="No user message was extracted from this thread."
+                />
+                <MessagePreview
+                  label="Last assistant message"
+                  text={detailState.response?.replay.lastAssistantMessage}
+                  emptyText="No assistant message was extracted from this thread."
+                />
+              </>
+            )}
           </div>
 
           <div
@@ -669,17 +869,7 @@ export function App(): React.ReactElement {
                 border: `1px solid ${colors.border}`
               }}
             >
-              <p
-                style={{
-                  margin: 0,
-                  color: colors.muted,
-                  fontSize: "0.84rem",
-                  textTransform: "uppercase",
-                  fontWeight: 700
-                }}
-              >
-                Linked directories
-              </p>
+              <p style={sectionLabelStyle()}>Linked directories</p>
               <div
                 style={{
                   display: "flex",
@@ -722,17 +912,7 @@ export function App(): React.ReactElement {
                 border: `1px solid ${colors.border}`
               }}
             >
-              <p
-                style={{
-                  margin: 0,
-                  color: colors.muted,
-                  fontSize: "0.84rem",
-                  textTransform: "uppercase",
-                  fontWeight: 700
-                }}
-              >
-                Runtime
-              </p>
+              <p style={sectionLabelStyle()}>Runtime</p>
               <dl
                 style={{
                   margin: "0.85rem 0 0",
@@ -743,10 +923,18 @@ export function App(): React.ReactElement {
                   fontSize: "0.9rem"
                 }}
               >
+                <dt style={{ color: colors.muted }}>Fetched</dt>
+                <dd style={{ margin: 0 }}>
+                  {threadState.response
+                    ? formatTimestamp(threadState.response.fetchedAt)
+                    : "Unknown"}
+                </dd>
                 <dt style={{ color: colors.muted }}>Updated</dt>
                 <dd style={{ margin: 0 }}>
-                  {selectedThread ? formatUpdatedAt(selectedThread.updatedAt) : "Unknown"}
+                  {selectedThread ? formatTimestamp(selectedThread.updatedAt) : "Unknown"}
                 </dd>
+                <dt style={{ color: colors.muted }}>Threads</dt>
+                <dd style={{ margin: 0 }}>{threads.length}</dd>
                 <dt style={{ color: colors.muted }}>Platform</dt>
                 <dd style={{ margin: 0 }}>{shellApi?.platform ?? "unknown"}</dd>
                 <dt style={{ color: colors.muted }}>Electron</dt>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,20 +1,26 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
-  AppServerListThreadsRequest,
-  AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
-  AppServerThreadSummary
+  AppServerThreadSummary,
+  GetNavigationSnapshotRequest,
+  MarkThreadSeenRequest,
+  NavigationSnapshot,
+  NavigationThreadSummary,
 } from "@pwragnt/shared";
 
 type DesktopApi = {
   ping?: () => string;
-  listThreads?: (
-    request?: AppServerListThreadsRequest
-  ) => Promise<AppServerListThreadsResponse>;
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;
+  getNavigationSnapshot?: (
+    request?: GetNavigationSnapshotRequest,
+  ) => Promise<NavigationSnapshot>;
+  markThreadSeen?: (
+    request: MarkThreadSeenRequest,
+  ) => Promise<unknown>;
+  onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {
     chrome?: string;
@@ -191,9 +197,9 @@ function ErrorBlock(props: { title: string; message: string }): React.ReactEleme
 }
 
 function ThreadList(props: {
-  threads: AppServerThreadSummary[];
+  threads: NavigationThreadSummary[];
   selectedThreadId?: string;
-  onSelectThread: (thread: AppServerThreadSummary) => void;
+  onSelectThread: (thread: NavigationThreadSummary) => void;
 }): React.ReactElement {
   return (
     <div
@@ -288,13 +294,13 @@ function ThreadList(props: {
 }
 
 function DirectoryList(props: {
-  threads: AppServerThreadSummary[];
+  threads: NavigationThreadSummary[];
   selectedThreadId?: string;
-  onSelectThread: (thread: AppServerThreadSummary) => void;
+  onSelectThread: (thread: NavigationThreadSummary) => void;
 }): React.ReactElement {
   const groupedDirectories = new Map<
     string,
-    { label: string; path: string; threads: AppServerThreadSummary[] }
+    { label: string; path: string; threads: NavigationThreadSummary[] }
   >();
 
   for (const thread of props.threads) {
@@ -397,6 +403,77 @@ function DirectoryList(props: {
   );
 }
 
+function InboxList(props: {
+  threads: NavigationThreadSummary[];
+  selectedThreadId?: string;
+  onSelectThread: (thread: NavigationThreadSummary) => void;
+}): React.ReactElement {
+  if (props.threads.length === 0) {
+    return (
+      <p
+        style={{
+          margin: "0.65rem 0 0",
+          color: colors.muted,
+          fontSize: "0.9rem",
+          lineHeight: 1.35,
+        }}
+      >
+        Nothing is waiting on you yet.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.5rem",
+        marginTop: "0.75rem",
+      }}
+    >
+      {props.threads.slice(0, 4).map((thread) => {
+        const isSelected = props.selectedThreadId === thread.id;
+        return (
+          <button
+            key={thread.id}
+            type="button"
+            onClick={() => props.onSelectThread(thread)}
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              gap: "0.75rem",
+              padding: "0.7rem 0.75rem",
+              borderRadius: "8px",
+              border: `1px solid ${
+                isSelected ? colors.accent : "rgba(228, 232, 220, 0.08)"
+              }`,
+              background: isSelected ? colors.panel : "transparent",
+              color: colors.text,
+              textAlign: "left",
+              cursor: "pointer",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "0.9rem",
+                fontWeight: 600,
+                lineHeight: 1.25,
+              }}
+            >
+              {thread.title}
+            </span>
+            <span style={{ color: colors.muted, fontSize: "0.78rem" }}>
+              {formatRelativeTime(thread.updatedAt)}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function MessagePreview(props: {
   label: string;
   text?: string;
@@ -434,12 +511,13 @@ export function App(): React.ReactElement {
     loading: boolean;
     refreshing: boolean;
     error?: string;
-    response?: AppServerListThreadsResponse;
+    response?: NavigationSnapshot;
   }>({
     loading: true,
     refreshing: false
   });
   const [selectedThreadId, setSelectedThreadId] = useState<string>();
+  const [shouldMarkSelectionSeen, setShouldMarkSelectionSeen] = useState(false);
   const [detailState, setDetailState] = useState<{
     loading: boolean;
     error?: string;
@@ -448,12 +526,12 @@ export function App(): React.ReactElement {
     loading: false
   });
 
-  const loadThreads = useCallback(async (): Promise<void> => {
-    if (!shellApi?.listThreads) {
+  const loadNavigationSnapshot = useCallback(async (): Promise<void> => {
+    if (!shellApi?.getNavigationSnapshot) {
       setThreadState({
         loading: false,
         refreshing: false,
-        error: "Desktop bridge is missing listThreads().",
+        error: "Desktop bridge is missing getNavigationSnapshot().",
         response: undefined
       });
       return;
@@ -467,18 +545,33 @@ export function App(): React.ReactElement {
     }));
 
     try {
-      const response = await shellApi.listThreads({ backend: "codex" });
-      setThreadState({
-        loading: false,
-        refreshing: false,
-        response
-      });
-      setSelectedThreadId((current) => {
-        if (current && response.threads.some((thread) => thread.id === current)) {
-          return current;
+      const response = await shellApi.getNavigationSnapshot({ backend: "codex" });
+      setThreadState((current) => {
+        if (current.response && response.unchanged) {
+          return {
+            ...current,
+            loading: false,
+            refreshing: false,
+            error: undefined,
+          };
         }
-        return response.threads[0]?.id;
+
+        return {
+          loading: false,
+          refreshing: false,
+          error: undefined,
+          response,
+        };
       });
+
+      if (!response.unchanged) {
+        setSelectedThreadId((current) => {
+          if (current && response.threads.some((thread) => thread.id === current)) {
+            return current;
+          }
+          return response.threads[0]?.id;
+        });
+      }
     } catch (error) {
       setThreadState((current) => ({
         loading: false,
@@ -490,14 +583,59 @@ export function App(): React.ReactElement {
   }, [shellApi]);
 
   useEffect(() => {
-    void loadThreads();
-  }, [loadThreads]);
+    void loadNavigationSnapshot();
+  }, [loadNavigationSnapshot]);
+
+  useEffect(() => {
+    if (!shellApi?.onWindowFocus) {
+      return;
+    }
+
+    return shellApi.onWindowFocus(() => {
+      void loadNavigationSnapshot();
+    });
+  }, [loadNavigationSnapshot, shellApi]);
 
   const threads = threadState.response?.threads ?? [];
+  const inboxThreads = useMemo(() => {
+    const inboxIds = new Set(threadState.response?.inboxThreadIds ?? []);
+    return threads.filter((thread) => inboxIds.has(thread.id));
+  }, [threadState.response?.inboxThreadIds, threads]);
   const selectedThread = useMemo(
     () => threads.find((thread) => thread.id === selectedThreadId) ?? threads[0],
     [selectedThreadId, threads]
   );
+
+  const markThreadSeen = useCallback(
+    async (thread: NavigationThreadSummary): Promise<void> => {
+      if (!shellApi?.markThreadSeen) {
+        return;
+      }
+
+      await shellApi.markThreadSeen({
+        backend: "codex",
+        threadId: thread.id,
+        seenUpdatedAt: thread.updatedAt,
+      });
+
+      await loadNavigationSnapshot();
+    },
+    [loadNavigationSnapshot, shellApi],
+  );
+
+  useEffect(() => {
+    if (!selectedThread || !shouldMarkSelectionSeen) {
+      return;
+    }
+
+    void markThreadSeen(selectedThread);
+    setShouldMarkSelectionSeen(false);
+  }, [markThreadSeen, selectedThread, shouldMarkSelectionSeen]);
+
+  const handleSelectThread = useCallback((thread: NavigationThreadSummary): void => {
+    setSelectedThreadId(thread.id);
+    setShouldMarkSelectionSeen(true);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -617,7 +755,7 @@ export function App(): React.ReactElement {
             style={actionButtonStyle()}
             aria-label="Refresh threads"
             onClick={() => {
-              void loadThreads();
+              void loadNavigationSnapshot();
             }}
           >
             {threadState.refreshing ? "..." : "Refresh"}
@@ -654,19 +792,14 @@ export function App(): React.ReactElement {
                 fontSize: "0.82rem"
               }}
             >
-              0
+              {inboxThreads.length}
             </span>
           </div>
-          <p
-            style={{
-              margin: "0.65rem 0 0",
-              color: colors.muted,
-              fontSize: "0.9rem",
-              lineHeight: 1.35
-            }}
-          >
-            Nothing is waiting on you yet.
-          </p>
+          <InboxList
+            threads={inboxThreads}
+            selectedThreadId={selectedThread?.id}
+            onSelectThread={handleSelectThread}
+          />
         </section>
 
         <section
@@ -761,13 +894,13 @@ export function App(): React.ReactElement {
             <DirectoryList
               threads={threads}
               selectedThreadId={selectedThread?.id}
-              onSelectThread={(thread) => setSelectedThreadId(thread.id)}
+              onSelectThread={handleSelectThread}
             />
           ) : (
             <ThreadList
               threads={threads}
               selectedThreadId={selectedThread?.id}
-              onSelectThread={(thread) => setSelectedThreadId(thread.id)}
+              onSelectThread={handleSelectThread}
             />
           )}
         </section>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { App } from "../App";
 
 describe("App", () => {
@@ -8,9 +8,11 @@ describe("App", () => {
       configurable: true,
       value: {
         ping: () => "pong",
-        listThreads: async () => ({
+        getNavigationSnapshot: async () => ({
           backend: "codex",
           fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadIds: ["thread-1"],
           threads: [
             {
               id: "thread-1",
@@ -26,10 +28,20 @@ describe("App", () => {
                   kind: "worktree"
                 }
               ],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread",
+              },
               updatedAt: Date.now()
             }
           ]
         }),
+        markThreadSeen: async () => ({
+          backend: "codex",
+          threadId: "thread-1",
+          seenAt: Date.now(),
+        }),
+        onWindowFocus: () => () => undefined,
         readThread: async () => ({
           backend: "codex",
           fetchedAt: Date.now(),
@@ -67,6 +79,10 @@ describe("App", () => {
         name: "Build Codex client"
       })
     ).toBeInTheDocument();
+    const inboxHeading = screen.getByRole("heading", { level: 2, name: "Inbox" });
+    const inboxSection = inboxHeading.closest("section");
+    expect(inboxSection).not.toBeNull();
+    expect(within(inboxSection as HTMLElement).getByText("1")).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
     expect(screen.getByText("codex/build-codex-client")).toBeInTheDocument();
     expect(screen.getByText(/1 linked directory/i)).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -65,9 +65,8 @@ describe("App", () => {
         name: "Build Codex client"
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByText("Wire the app-server transport and list threads")
-    ).toHaveLength(2);
+    expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
+    expect(screen.getByText(/1 linked directory/i)).toBeInTheDocument();
     expect(
       await screen.findByText("Open the desktop plan and build the Codex client.")
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -17,6 +17,7 @@ describe("App", () => {
               title: "Build Codex client",
               summary: "Wire the app-server transport and list threads",
               source: "codex",
+              gitBranch: "codex/build-codex-client",
               linkedDirectories: [
                 {
                   id: "/Users/huntharo/pwrdrvr/PwrAgnt",
@@ -66,6 +67,7 @@ describe("App", () => {
       })
     ).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
+    expect(screen.getByText("codex/build-codex-client")).toBeInTheDocument();
     expect(screen.getByText(/1 linked directory/i)).toBeInTheDocument();
     expect(
       await screen.findByText("Open the desktop plan and build the Codex client.")

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -28,6 +28,16 @@ describe("App", () => {
             }
           ]
         }),
+        readThread: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          threadId: "thread-1",
+          replay: {
+            lastUserMessage: "Open the desktop plan and build the Codex client.",
+            lastAssistantMessage:
+              "The Codex client is wired and the thread browser is live."
+          }
+        }),
         platform: "darwin",
         versions: {
           electron: "41.2.1"
@@ -47,6 +57,9 @@ describe("App", () => {
       screen.getByRole("button", { name: "recents" })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "Refresh threads" })
+    ).toBeInTheDocument();
+    expect(
       await screen.findByRole("heading", {
         level: 2,
         name: "Build Codex client"
@@ -55,6 +68,12 @@ describe("App", () => {
     expect(
       screen.getAllByText("Wire the app-server transport and list threads")
     ).toHaveLength(2);
+    expect(
+      await screen.findByText("Open the desktop plan and build the Codex client.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The Codex client is wired and the thread browser is live.")
+    ).toBeInTheDocument();
     expect(screen.getByText("darwin")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -22,7 +22,8 @@ describe("App", () => {
                 {
                   id: "/Users/huntharo/pwrdrvr/PwrAgnt",
                   label: "PwrAgnt",
-                  path: "/Users/huntharo/pwrdrvr/PwrAgnt"
+                  path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                  kind: "worktree"
                 }
               ],
               updatedAt: Date.now()

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,1 +1,2 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
+export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,2 +1,5 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
+export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
+export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";

--- a/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
+++ b/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
@@ -10,11 +10,11 @@ origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
 
 ## Overview
 
-Build the first real version of a desktop coding agent whose differentiator is thread navigation rather than repo-first attachment. The milestone should ship a runnable Electron app with a real provider/harness path, thread persistence, Inbox plus Recents plus Directories navigation, multi-directory thread associations, and enough plugin/wiki infrastructure that the product already feels accumulative instead of stateless.
+Build the first real version of a desktop coding agent whose differentiator is thread navigation rather than repo-first attachment. The milestone should ship a runnable Electron app with a real provider/harness path, desktop-owned overlay state, Inbox plus Recents plus Directories navigation, multi-directory thread associations, and enough plugin/wiki infrastructure that the product already feels accumulative instead of stateless.
 
 ## Problem Frame
 
-The origin requirements define a thread-first product surface where users can start from a blank thread, attach repos later, and find important work from Inbox before drilling into Recents or Directories (see origin: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`). The technical plan must preserve that product behavior while creating the repo structure, local persistence, IPC boundaries, and provider abstraction needed for a credible interview-ready demo.
+The origin requirements define a thread-first product surface where users can start from a blank thread, attach repos later, and find important work from Inbox before drilling into Recents or Directories (see origin: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`). The technical plan must preserve that product behavior while creating the repo structure, desktop-owned overlay state, IPC boundaries, and provider abstraction needed for a credible interview-ready demo.
 
 ## Requirements Trace
 
@@ -167,44 +167,44 @@ flowchart TB
 **Verification:**
 - A developer can install dependencies and launch a blank but running desktop shell with passing baseline tests.
 
-- [ ] **Unit 2: Model thread, directory, and inbox persistence**
+- [ ] **Unit 2: Add desktop overlay state, inbox state, and refresh reconciliation**
 
-**Goal:** Create the persisted domain model for threads, linked Git directories, working directories, inbox state, execution mode, and thread events/messages.
+**Goal:** Create the desktop-owned persistence layer for inbox state, extra directory associations, lightweight selection/view state, and refresh reconciliation without duplicating canonical thread or transcript state already owned by the app server.
 
-**Requirements:** R1-R6, R12-R19
+**Requirements:** R1-R6, R5-R11, R12-R15
 
 **Dependencies:** Unit 1
 
 **Files:**
-- Create: `packages/agent-core/src/domain/thread.ts`
-- Create: `packages/agent-core/src/domain/project.ts`
 - Create: `packages/agent-core/src/domain/inbox.ts`
-- Create: `packages/agent-core/src/persistence/store.ts`
+- Create: `packages/agent-core/src/domain/navigation-state.ts`
+- Create: `packages/agent-core/src/persistence/overlay-store.ts`
 - Create: `packages/agent-core/src/persistence/migrations.ts`
-- Create: `packages/shared/src/contracts/threading.ts`
 - Create: `packages/shared/src/contracts/navigation.ts`
-- Test: `packages/agent-core/src/__tests__/thread-store.test.ts`
-- Test: `packages/agent-core/src/__tests__/directory-linking.test.ts`
+- Create: `apps/desktop/src/main/window-focus-sync.ts`
+- Test: `packages/agent-core/src/__tests__/overlay-store.test.ts`
+- Test: `packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
 - Test: `packages/agent-core/src/__tests__/inbox-ranking.test.ts`
 
 **Approach:**
-- Represent threads, Git directories, and working directories as separate entities with explicit join records so one thread can surface under multiple directories without inventing a fake primary owner.
-- Persist execution mode on the thread and inbox membership/ranking as derived-but-stored state so Inbox queries remain fast and explainable.
-- Store thread events/messages in the same persistence boundary as navigation metadata so the UI can correlate status, approvals, and results.
+- Treat the app server as the source of truth for thread identity, transcript history, and run state; persist only the desktop overlay state the app server does not model.
+- Persist inbox signals, dismiss/snooze state, last-seen timestamps, material-change hashes, and any extra linked Git directories needed to make basic single-directory app servers behave like multi-project threads in the desktop UI.
+- Add refresh-on-focus behavior that re-fetches thread lists in the background, compares them against the last known snapshot, and avoids visible UI churn when nothing material changed.
+- Keep transcript scrollback out of this persistence unit; real thread history remains an app-server read concern and should surface in the renderer through richer `thread/read` contracts rather than a duplicated local transcript store.
 
 **Patterns to follow:**
 - Follow the type and package boundaries established in Unit 1.
 
 **Test scenarios:**
-- Happy path: creating a thread without a directory persists successfully and remains queryable in Recents.
-- Happy path: attaching two Git directories to one thread makes the thread queryable under both directories.
-- Edge case: local-mode thread stores identical Git and working directory identifiers without duplicate-link corruption.
-- Edge case: worktree-mode thread stores distinct Git-root and working-directory records and resolves both correctly.
-- Error path: linking a missing or moved directory marks the association degraded without deleting the thread.
-- Integration: inbox query returns active, blocked, and newly completed threads in rank order from persisted state.
+- Happy path: inbox dismiss/snooze state persists locally and survives app restart without modifying the app-server-owned thread.
+- Happy path: a Codex-backed thread can carry additional linked Git directories in desktop overlay state and surface under all relevant directory views.
+- Happy path: focus-triggered refresh detects a changed thread snapshot and updates inbox membership and recents ordering.
+- Edge case: focus-triggered refresh sees no material change and does not clear selection, reorder rows, or show blocking loading state.
+- Edge case: overlay directory link points at a missing path and is marked degraded without deleting the thread from the UI.
+- Integration: inbox query returns active, blocked, and newly completed threads in rank order from overlay state plus the latest app-server snapshot.
 
 **Verification:**
-- Main-process services can create, update, and query threads and directory links entirely from the local store without renderer-specific logic.
+- Main-process services can store desktop-only inbox/navigation metadata, reconcile fresh app-server thread snapshots on focus, and preserve a stable UI when nothing materially changed.
 
 - [ ] **Unit 3: Build the provider contract and agent harness**
 
@@ -252,7 +252,7 @@ flowchart TB
 
 - [ ] **Unit 4: Ship Inbox, Recents, Directories, and thread detail UI**
 
-**Goal:** Build the renderer experience that makes thread navigation visibly better than repo-first tools.
+**Goal:** Build the renderer experience that makes thread navigation visibly better than repo-first tools, including a real transcript view with thread history scrollback instead of the current last-user/last-assistant placeholder cards.
 
 **Requirements:** R5-R13, R20-R22
 
@@ -266,17 +266,23 @@ flowchart TB
 - Create: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
 - Create: `apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx`
 - Create: `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx`
 - Create: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
 - Create: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Create: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
 - Create: `apps/desktop/src/renderer/src/styles/app.css`
 - Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
 - Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
 - Test: `apps/desktop/e2e/thread-navigation.spec.ts`
 
 **Approach:**
 - Make Inbox the top section of the sidebar, with Recents and Directories presented as alternate browsing lenses below it.
 - Ensure thread rows can display linked-directory summary text without requiring users to open the thread first.
-- In thread detail, surface linked Git directories, working directories, branches, and PR/stacked-PR context in one place so multi-repo work is legible.
+- Replace the current Telegram-era stopgap of “Last user message” and “Last assistant message” with a real transcript surface that renders normalized messages returned by `thread/read`.
+- Support scrollable thread history and incremental scrollback/pagination whenever the backing app server can provide it, while still degrading to a complete one-shot read when pagination is unavailable.
+- In thread detail, surface linked Git directories, working directories, branches, and PR/stacked-PR context alongside the transcript so multi-repo work is legible.
 
 **Patterns to follow:**
 - Renderer feature-folder pattern established in Unit 1.
@@ -285,12 +291,15 @@ flowchart TB
 - Happy path: sidebar opens with Inbox first and Recents as the default lens beneath it.
 - Happy path: a cross-project thread appears under both linked directories in directory mode.
 - Happy path: a thread can appear in Inbox and still appear in Recents without duplication bugs in thread identity.
+- Happy path: selecting a thread renders a real transcript history rather than only the latest request/response pair.
+- Happy path: scrolling upward loads additional transcript history when the provider/app server supports incremental pagination.
 - Edge case: a directory-less thread still renders meaningfully in Recents and thread detail.
 - Edge case: long linked-directory labels truncate safely without hiding the fact that multiple repos are attached.
+- Edge case: transcript pagination unavailable falls back to a non-paginated thread read without breaking the thread detail surface.
 - Integration: clicking a thread from Inbox preserves selected thread state while switching the underlying browse lens.
 
 **Verification:**
-- A demo user can understand the app's thread-first model from the sidebar and thread detail alone.
+- A demo user can understand the app's thread-first model from the sidebar and can scroll through real thread history from thread detail alone.
 
 - [ ] **Unit 5: Add project attachment, worktree awareness, and repo-status enrichment**
 
@@ -413,7 +422,7 @@ flowchart TB
 
 - **Interaction graph:** renderer -> preload -> main IPC -> agent core services -> local store/provider/git/plugin/wiki services.
 - **Error propagation:** provider, git, search, or plugin failures should surface as thread or feature-level state without crashing the renderer or corrupting persisted thread state.
-- **State lifecycle risks:** thread runs, approvals, and directory attachments can race with navigation updates; the store must remain the source of truth for derived Inbox and directory views.
+- **State lifecycle risks:** thread runs, approvals, and directory attachments can race with navigation updates; the overlay store must remain the source of truth for desktop-only inbox and refresh state, while the app server remains the source of truth for transcript and run history.
 - **API surface parity:** provider adapters, plugin manifests, wiki search interfaces, and thread IPC payloads all depend on stable shared contracts in `packages/shared`.
 - **Integration coverage:** cross-layer tests are required for provider event flow, project attachment flow, and wiki edit/search flow because unit tests alone will not prove IPC and persistence behavior.
 - **Unchanged invariants:** credential mediation stays out of scope; thread-first navigation remains the hero even as plugins and wiki memory are added.

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -6,6 +6,9 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "dependencies": {
+    "@pwragnt/shared": "workspace:*"
+  },
   "scripts": {
     "test": "pnpm --dir ../.. exec vitest run --config vitest.workspace.ts --project agent-core",
     "test:live": "pnpm --dir ../.. exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/grok-live.test.ts",

--- a/packages/agent-core/src/__tests__/inbox-ranking.test.ts
+++ b/packages/agent-core/src/__tests__/inbox-ranking.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { rankInboxThreadIds } from "../domain/inbox";
+
+describe("rankInboxThreadIds", () => {
+  it("ranks new threads ahead of updated threads and sorts by recency within each bucket", () => {
+    const ranked = rankInboxThreadIds([
+      {
+        id: "updated-old",
+        inbox: { inInbox: true, reason: "updated-since-seen" },
+        updatedAt: 1000,
+      },
+      {
+        id: "new-thread",
+        inbox: { inInbox: true, reason: "new-thread" },
+        updatedAt: 500,
+      },
+      {
+        id: "updated-newer",
+        inbox: { inInbox: true, reason: "updated-since-seen" },
+        updatedAt: 2000,
+      },
+    ]);
+
+    expect(ranked).toEqual(["new-thread", "updated-newer", "updated-old"]);
+  });
+});

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AppServerThreadSummary } from "@pwragnt/shared";
+import { OverlayStore } from "../persistence/overlay-store";
+
+const tempDirs: string[] = [];
+
+async function createStore(): Promise<OverlayStore> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-overlay-store-"));
+  tempDirs.push(tempDir);
+  return new OverlayStore(path.join(tempDir, "overlay-state.json"));
+}
+
+function buildThread(overrides: Partial<AppServerThreadSummary> = {}): AppServerThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Desktop App",
+    source: "codex",
+    linkedDirectories: [],
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (tempDir) => {
+      await import("node:fs/promises").then(({ rm }) =>
+        rm(tempDir, { recursive: true, force: true }),
+      );
+    }),
+  );
+});
+
+describe("OverlayStore", () => {
+  it("persists seen state without mutating app-server-owned thread data", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread()],
+    });
+
+    await store.markThreadSeen({
+      backend: "codex",
+      threadId: "thread-1",
+      seenAt: 2000,
+      seenUpdatedAt: 1000,
+    });
+
+    const raw = JSON.parse(
+      await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
+    ) as {
+      threads: Record<string, { lastSeenAt?: number; lastSeenUpdatedAt?: number }>;
+    };
+
+    expect(raw.threads["thread-1"]).toMatchObject({
+      lastSeenAt: 2000,
+      lastSeenUpdatedAt: 1000,
+    });
+  });
+
+  it("stores extra linked directories for desktop-only multi-project overlays", async () => {
+    const store = await createStore();
+
+    await store.addLinkedDirectory({
+      threadId: "thread-2",
+      directory: {
+        id: "/Users/huntharo/pwrdrvr/openclaw",
+        kind: "local",
+        label: "openclaw",
+        path: "/Users/huntharo/pwrdrvr/openclaw",
+      },
+    });
+
+    const raw = JSON.parse(
+      await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
+    ) as {
+      threads: Record<string, { extraLinkedDirectories: Array<{ label: string }> }>;
+    };
+
+    expect(raw.threads["thread-2"]?.extraLinkedDirectories).toEqual([
+      expect.objectContaining({ label: "openclaw" }),
+    ]);
+  });
+});

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AppServerThreadSummary } from "@pwragnt/shared";
+import { OverlayStore } from "../persistence/overlay-store";
+
+const tempDirs: string[] = [];
+
+async function createStore(): Promise<OverlayStore> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-refresh-reconcile-"));
+  tempDirs.push(tempDir);
+  return new OverlayStore(path.join(tempDir, "overlay-state.json"));
+}
+
+function buildThread(overrides: Partial<AppServerThreadSummary> = {}): AppServerThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Desktop App",
+    source: "codex",
+    linkedDirectories: [],
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (tempDir) => {
+      await import("node:fs/promises").then(({ rm }) =>
+        rm(tempDir, { recursive: true, force: true }),
+      );
+    }),
+  );
+});
+
+describe("refresh reconciliation", () => {
+  it("treats the first snapshot as a baseline instead of flooding inbox", async () => {
+    const store = await createStore();
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread()],
+    });
+
+    expect(snapshot.unchanged).toBe(false);
+    expect(snapshot.inboxThreadIds).toEqual([]);
+    expect(snapshot.threads[0]?.inbox.inInbox).toBe(false);
+  });
+
+  it("marks later thread updates as changed and inbox-worthy", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread()],
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [buildThread({ updatedAt: 3000 })],
+    });
+
+    expect(snapshot.unchanged).toBe(false);
+    expect(snapshot.inboxThreadIds).toEqual(["thread-1"]);
+    expect(snapshot.threads[0]?.inbox.reason).toBe("updated-since-seen");
+  });
+
+  it("returns unchanged when the material thread snapshot did not move", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread()],
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [buildThread()],
+    });
+
+    expect(snapshot.unchanged).toBe(true);
+  });
+});

--- a/packages/agent-core/src/domain/inbox.ts
+++ b/packages/agent-core/src/domain/inbox.ts
@@ -1,0 +1,101 @@
+import type {
+  AppServerThreadSummary,
+  ThreadIdentifier,
+} from "@pwragnt/shared";
+import type { InboxReason, ThreadInboxState, ThreadOverlayState } from "@pwragnt/shared";
+
+function isSuppressed(
+  overlay: ThreadOverlayState | undefined,
+  thread: AppServerThreadSummary,
+  now: number,
+): boolean {
+  if (!overlay) {
+    return false;
+  }
+
+  if (overlay.snoozedUntil && overlay.snoozedUntil > now) {
+    return true;
+  }
+
+  if (!overlay.dismissedAt) {
+    return false;
+  }
+
+  return (thread.updatedAt ?? 0) <= overlay.dismissedAt;
+}
+
+export function deriveInboxState(params: {
+  firstSnapshot: boolean;
+  isNewThread: boolean;
+  now?: number;
+  overlay?: ThreadOverlayState;
+  thread: AppServerThreadSummary;
+}): ThreadInboxState {
+  const now = params.now ?? Date.now();
+
+  if (isSuppressed(params.overlay, params.thread, now)) {
+    return {
+      inInbox: false,
+      lastSeenAt: params.overlay?.lastSeenAt,
+      lastSeenUpdatedAt: params.overlay?.lastSeenUpdatedAt,
+    };
+  }
+
+  if (params.firstSnapshot) {
+    return {
+      inInbox: false,
+      lastSeenAt: params.overlay?.lastSeenAt,
+      lastSeenUpdatedAt: params.overlay?.lastSeenUpdatedAt,
+    };
+  }
+
+  if (params.isNewThread) {
+    return {
+      inInbox: true,
+      reason: "new-thread",
+      lastSeenAt: params.overlay?.lastSeenAt,
+      lastSeenUpdatedAt: params.overlay?.lastSeenUpdatedAt,
+    };
+  }
+
+  const updatedAt = params.thread.updatedAt ?? 0;
+  const lastSeenUpdatedAt = params.overlay?.lastSeenUpdatedAt ?? 0;
+  const reason: InboxReason | undefined =
+    updatedAt > lastSeenUpdatedAt ? "updated-since-seen" : undefined;
+
+  return {
+    inInbox: Boolean(reason),
+    reason,
+    lastSeenAt: params.overlay?.lastSeenAt,
+    lastSeenUpdatedAt: params.overlay?.lastSeenUpdatedAt,
+  };
+}
+
+export function rankInboxThreadIds(threads: Array<{
+  id: ThreadIdentifier;
+  inbox: ThreadInboxState;
+  updatedAt?: number;
+}>): ThreadIdentifier[] {
+  return threads
+    .filter((thread) => thread.inbox.inInbox)
+    .sort((left, right) => {
+      const reasonWeight = (reason?: InboxReason): number => {
+        if (reason === "new-thread") {
+          return 2;
+        }
+        if (reason === "updated-since-seen") {
+          return 1;
+        }
+        return 0;
+      };
+
+      const reasonDelta =
+        reasonWeight(right.inbox.reason) - reasonWeight(left.inbox.reason);
+      if (reasonDelta !== 0) {
+        return reasonDelta;
+      }
+
+      return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
+    })
+    .map((thread) => thread.id);
+}

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -1,0 +1,104 @@
+import type {
+  AppServerBackendKind,
+  AppServerThreadSummary,
+  LinkedDirectorySummary,
+  NavigationSnapshot,
+  NavigationThreadSummary,
+  ThreadOverlayState,
+} from "@pwragnt/shared";
+import { deriveInboxState, rankInboxThreadIds } from "./inbox";
+
+function dedupeLinkedDirectories(
+  directories: LinkedDirectorySummary[],
+): LinkedDirectorySummary[] {
+  const byId = new Map<string, LinkedDirectorySummary>();
+
+  for (const directory of directories) {
+    byId.set(directory.id, directory);
+  }
+
+  return [...byId.values()].sort((left, right) =>
+    left.label.localeCompare(right.label),
+  );
+}
+
+export function materializeNavigationThreads(params: {
+  firstSnapshot: boolean;
+  now?: number;
+  overlayByThreadId: Record<string, ThreadOverlayState | undefined>;
+  previousKnownThreadIds: string[];
+  threads: AppServerThreadSummary[];
+}): NavigationThreadSummary[] {
+  const previousKnownThreadIds = new Set(params.previousKnownThreadIds);
+
+  return params.threads.map((thread) => {
+    const overlay = params.overlayByThreadId[thread.id];
+    const linkedDirectories = dedupeLinkedDirectories([
+      ...thread.linkedDirectories,
+      ...(overlay?.extraLinkedDirectories ?? []),
+    ]);
+
+    return {
+      ...thread,
+      linkedDirectories,
+      inbox: deriveInboxState({
+        firstSnapshot: params.firstSnapshot,
+        isNewThread: !previousKnownThreadIds.has(thread.id),
+        now: params.now,
+        overlay,
+        thread,
+      }),
+    };
+  });
+}
+
+export function buildNavigationSnapshot(params: {
+  backend: AppServerBackendKind;
+  fetchedAt: number;
+  firstSnapshot: boolean;
+  now?: number;
+  overlayByThreadId: Record<string, ThreadOverlayState | undefined>;
+  previousKnownThreadIds: string[];
+  threads: AppServerThreadSummary[];
+  unchanged: boolean;
+}): NavigationSnapshot {
+  const threads = materializeNavigationThreads({
+    firstSnapshot: params.firstSnapshot,
+    now: params.now,
+    overlayByThreadId: params.overlayByThreadId,
+    previousKnownThreadIds: params.previousKnownThreadIds,
+    threads: params.threads,
+  });
+
+  return {
+    backend: params.backend,
+    fetchedAt: params.fetchedAt,
+    unchanged: params.unchanged,
+    threads,
+    inboxThreadIds: rankInboxThreadIds(threads),
+  };
+}
+
+export function buildNavigationSnapshotHash(params: {
+  backend: AppServerBackendKind;
+  threads: NavigationThreadSummary[];
+}): string {
+  return JSON.stringify({
+    backend: params.backend,
+    threads: params.threads.map((thread) => ({
+      id: thread.id,
+      updatedAt: thread.updatedAt ?? null,
+      gitBranch: thread.gitBranch ?? null,
+      linkedDirectories: thread.linkedDirectories.map((directory) => ({
+        id: directory.id,
+        kind: directory.kind,
+        path: directory.path,
+      })),
+      inbox: {
+        inInbox: thread.inbox.inInbox,
+        reason: thread.inbox.reason ?? null,
+        lastSeenUpdatedAt: thread.inbox.lastSeenUpdatedAt ?? null,
+      },
+    })),
+  });
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -34,3 +34,4 @@ export {
   loadLocalEnv,
   type LocalEnvLoadResult,
 } from "./testing/load-local-env.js";
+export { OverlayStore } from "./persistence/overlay-store.js";

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -1,0 +1,101 @@
+import type { AppServerBackendKind, ThreadOverlayState } from "@pwragnt/shared";
+
+export const CURRENT_OVERLAY_STORE_VERSION = 1;
+
+export type OverlayStoreData = {
+  version: number;
+  backends: Partial<
+    Record<
+      AppServerBackendKind,
+      {
+        knownThreadIds: string[];
+        lastSnapshotHash?: string;
+      }
+    >
+  >;
+  threads: Record<string, ThreadOverlayState>;
+};
+
+const EMPTY_OVERLAY_STORE_DATA: OverlayStoreData = {
+  version: CURRENT_OVERLAY_STORE_VERSION,
+  backends: {},
+  threads: {},
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
+  const record = asRecord(raw);
+  if (!record) {
+    return structuredClone(EMPTY_OVERLAY_STORE_DATA);
+  }
+
+  const version =
+    typeof record.version === "number" ? record.version : CURRENT_OVERLAY_STORE_VERSION;
+  const backendsRecord = asRecord(record.backends) ?? {};
+  const threadsRecord = asRecord(record.threads) ?? {};
+
+  return {
+    version,
+    backends: {
+      codex: asRecord(backendsRecord.codex)
+        ? {
+            knownThreadIds: Array.isArray(asRecord(backendsRecord.codex)?.knownThreadIds)
+              ? (asRecord(backendsRecord.codex)?.knownThreadIds as string[])
+              : [],
+            lastSnapshotHash:
+              typeof asRecord(backendsRecord.codex)?.lastSnapshotHash === "string"
+                ? (asRecord(backendsRecord.codex)?.lastSnapshotHash as string)
+                : undefined,
+          }
+        : undefined,
+      grok: asRecord(backendsRecord.grok)
+        ? {
+            knownThreadIds: Array.isArray(asRecord(backendsRecord.grok)?.knownThreadIds)
+              ? (asRecord(backendsRecord.grok)?.knownThreadIds as string[])
+              : [],
+            lastSnapshotHash:
+              typeof asRecord(backendsRecord.grok)?.lastSnapshotHash === "string"
+                ? (asRecord(backendsRecord.grok)?.lastSnapshotHash as string)
+                : undefined,
+          }
+        : undefined,
+    },
+    threads: Object.fromEntries(
+      Object.entries(threadsRecord).map(([threadId, value]) => {
+        const threadRecord = asRecord(value) ?? {};
+        return [
+          threadId,
+          {
+            threadId,
+            lastSeenAt:
+              typeof threadRecord.lastSeenAt === "number"
+                ? threadRecord.lastSeenAt
+                : undefined,
+            lastSeenUpdatedAt:
+              typeof threadRecord.lastSeenUpdatedAt === "number"
+                ? threadRecord.lastSeenUpdatedAt
+                : undefined,
+            dismissedAt:
+              typeof threadRecord.dismissedAt === "number"
+                ? threadRecord.dismissedAt
+                : undefined,
+            snoozedUntil:
+              typeof threadRecord.snoozedUntil === "number"
+                ? threadRecord.snoozedUntil
+                : undefined,
+            extraLinkedDirectories: Array.isArray(threadRecord.extraLinkedDirectories)
+              ? (threadRecord.extraLinkedDirectories as ThreadOverlayState["extraLinkedDirectories"])
+              : [],
+          } satisfies ThreadOverlayState,
+        ];
+      }),
+    ),
+  };
+}

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -1,0 +1,175 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  AppServerBackendKind,
+  AppServerThreadSummary,
+  LinkedDirectorySummary,
+  MarkThreadSeenResponse,
+  NavigationSnapshot,
+  ThreadOverlayState,
+} from "@pwragnt/shared";
+import {
+  buildNavigationSnapshot,
+  buildNavigationSnapshotHash,
+} from "../domain/navigation-state";
+import {
+  CURRENT_OVERLAY_STORE_VERSION,
+  migrateOverlayStoreData,
+  type OverlayStoreData,
+} from "./migrations";
+
+export class OverlayStore {
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly filePath: string) {}
+
+  async reconcileNavigationSnapshot(params: {
+    backend: AppServerBackendKind;
+    fetchedAt: number;
+    threads: AppServerThreadSummary[];
+  }): Promise<NavigationSnapshot> {
+    return await this.withData(async (data) => {
+      const backendState = data.backends[params.backend];
+      const firstSnapshot = !backendState?.lastSnapshotHash;
+      const overlayByThreadId = Object.fromEntries(
+        params.threads.map((thread) => [thread.id, data.threads[thread.id]]),
+      );
+
+      if (firstSnapshot) {
+        for (const thread of params.threads) {
+          data.threads[thread.id] = {
+            threadId: thread.id,
+            lastSeenAt: params.fetchedAt,
+            lastSeenUpdatedAt: thread.updatedAt,
+            extraLinkedDirectories:
+              data.threads[thread.id]?.extraLinkedDirectories ?? [],
+          };
+        }
+      }
+
+      const snapshot = buildNavigationSnapshot({
+        backend: params.backend,
+        fetchedAt: params.fetchedAt,
+        firstSnapshot,
+        overlayByThreadId: Object.fromEntries(
+          params.threads.map((thread) => [thread.id, data.threads[thread.id]]),
+        ),
+        previousKnownThreadIds: backendState?.knownThreadIds ?? [],
+        threads: params.threads,
+        unchanged: false,
+      });
+
+      const nextHash = buildNavigationSnapshotHash({
+        backend: params.backend,
+        threads: snapshot.threads,
+      });
+      const unchanged = backendState?.lastSnapshotHash === nextHash;
+
+      data.backends[params.backend] = {
+        knownThreadIds: params.threads.map((thread) => thread.id),
+        lastSnapshotHash: nextHash,
+      };
+
+      return {
+        ...snapshot,
+        unchanged,
+      };
+    });
+  }
+
+  async markThreadSeen(params: {
+    backend: AppServerBackendKind;
+    seenAt?: number;
+    seenUpdatedAt?: number;
+    threadId: string;
+  }): Promise<MarkThreadSeenResponse> {
+    return await this.withData(async (data) => {
+      const current = data.threads[params.threadId];
+      const seenAt = params.seenAt ?? Date.now();
+
+      data.threads[params.threadId] = {
+        threadId: params.threadId,
+        dismissedAt: current?.dismissedAt,
+        snoozedUntil: current?.snoozedUntil,
+        lastSeenAt: seenAt,
+        lastSeenUpdatedAt: params.seenUpdatedAt ?? current?.lastSeenUpdatedAt,
+        extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
+      };
+
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        seenAt,
+        seenUpdatedAt: params.seenUpdatedAt,
+      };
+    });
+  }
+
+  async addLinkedDirectory(params: {
+    directory: LinkedDirectorySummary;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const current = data.threads[params.threadId] ?? {
+        threadId: params.threadId,
+        extraLinkedDirectories: [],
+      };
+
+      const nextDirectories = [
+        ...current.extraLinkedDirectories.filter(
+          (directory) => directory.id !== params.directory.id,
+        ),
+        params.directory,
+      ];
+
+      const nextState: ThreadOverlayState = {
+        ...current,
+        extraLinkedDirectories: nextDirectories,
+      };
+      data.threads[params.threadId] = nextState;
+      return nextState;
+    });
+  }
+
+  private async withData<T>(
+    operation: (data: OverlayStoreData) => Promise<T> | T,
+  ): Promise<T> {
+    const next = this.queue.then(async () => {
+      const data = await this.readData();
+      const result = await operation(data);
+      await this.writeData(data);
+      return result;
+    });
+
+    this.queue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return (await next) as T;
+  }
+
+  private async readData(): Promise<OverlayStoreData> {
+    try {
+      const contents = await readFile(this.filePath, "utf8");
+      return migrateOverlayStoreData(JSON.parse(contents));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return migrateOverlayStoreData({
+          version: CURRENT_OVERLAY_STORE_VERSION,
+          backends: {},
+          threads: {},
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  private async writeData(data: OverlayStoreData): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    const tempPath = `${this.filePath}.tmp`;
+    await writeFile(tempPath, JSON.stringify(data, null, 2), "utf8");
+    await rename(tempPath, this.filePath);
+  }
+}

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -19,6 +19,11 @@ export type AppServerThreadSummary = {
   source: AppServerBackendKind;
 };
 
+export type AppServerThreadReplay = {
+  lastUserMessage?: string;
+  lastAssistantMessage?: string;
+};
+
 export type AppServerListThreadsRequest = {
   backend?: AppServerBackendKind;
   filter?: string;
@@ -28,4 +33,16 @@ export type AppServerListThreadsResponse = {
   backend: AppServerBackendKind;
   fetchedAt: number;
   threads: AppServerThreadSummary[];
+};
+
+export type AppServerReadThreadRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type AppServerReadThreadResponse = {
+  backend: AppServerBackendKind;
+  fetchedAt: number;
+  threadId: ThreadIdentifier;
+  replay: AppServerThreadReplay;
 };

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -6,6 +6,7 @@ export type LinkedDirectorySummary = {
   id: string;
   label: string;
   path: string;
+  kind: "local" | "worktree";
 };
 
 export type AppServerThreadSummary = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1,0 +1,55 @@
+import type {
+  AppServerBackendKind,
+  AppServerThreadSummary,
+  LinkedDirectorySummary,
+  ThreadIdentifier,
+} from "./app-server";
+
+export type InboxReason = "new-thread" | "updated-since-seen";
+
+export type ThreadInboxState = {
+  inInbox: boolean;
+  reason?: InboxReason;
+  lastSeenAt?: number;
+  lastSeenUpdatedAt?: number;
+};
+
+export type NavigationThreadSummary = AppServerThreadSummary & {
+  inbox: ThreadInboxState;
+};
+
+export type NavigationSnapshot = {
+  backend: AppServerBackendKind;
+  fetchedAt: number;
+  unchanged: boolean;
+  threads: NavigationThreadSummary[];
+  inboxThreadIds: ThreadIdentifier[];
+};
+
+export type GetNavigationSnapshotRequest = {
+  backend?: AppServerBackendKind;
+  filter?: string;
+};
+
+export type MarkThreadSeenRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  seenAt?: number;
+  seenUpdatedAt?: number;
+};
+
+export type MarkThreadSeenResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  seenAt: number;
+  seenUpdatedAt?: number;
+};
+
+export type ThreadOverlayState = {
+  threadId: ThreadIdentifier;
+  lastSeenAt?: number;
+  lastSeenUpdatedAt?: number;
+  dismissedAt?: number;
+  snoozedUntil?: number;
+  extraLinkedDirectories: LinkedDirectorySummary[];
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./contracts/app-server";
+export * from "./contracts/navigation";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@pwragnt/agent-core':
+        specifier: workspace:*
+        version: link:../../packages/agent-core
       '@pwragnt/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -58,7 +61,11 @@ importers:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@25.6.0)(lightningcss@1.32.0)
 
-  packages/agent-core: {}
+  packages/agent-core:
+    dependencies:
+      '@pwragnt/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/shared: {}
 


### PR DESCRIPTION
## Summary
- build the first real Codex App Server-backed desktop thread browser instead of the blank Electron shell
- tighten the recent thread list so rows show compact titles plus linked project and branch pills, including worktree vs local directory distinction
- add desktop-owned overlay navigation state for inbox membership, last-seen tracking, and no-churn refresh reconciliation on app focus

## What changed
- wired the desktop main process to launch and talk to Codex App Server, list threads, and read thread replay details
- upgraded the renderer into an Inbox / Recents / Directories thread browser with compact cards and linked directory metadata
- added shared navigation contracts plus an `agent-core` overlay store for inbox derivation, snapshot hashing, and extra linked-directory support
- added focus refresh plumbing so the renderer re-queries thread state when the window regains focus without reshuffling the UI when nothing changed
- updated the active plan doc to narrow Unit 2 around desktop-owned overlay state and move transcript scrollback explicitly into Unit 4

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`

## Follow-up
- replace the current last-user / last-assistant detail cards with real transcript scrollback
- add UI flows for mutating overlay state such as extra linked directories and inbox actions
- continue the desktop client work for the Grok app server path
