### PR TITLE
docs(plan): desktop unit 3 - add grok app server start

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AgentEvent,
+  InterruptTurnRequest,
+  ListBackendsRequest,
+  StartThreadRequest,
+  StartTurnRequest,
+} from "@pwragnt/shared";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const send = vi.fn();
+let registryListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
+
+const registry = {
+  listBackends: vi.fn(async (_request?: ListBackendsRequest) => ({
+    fetchedAt: 1,
+    backends: [],
+  })),
+  onEvent: vi.fn((listener: (event: AgentEvent) => void | Promise<void>) => {
+    registryListener = listener;
+    return () => {
+      registryListener = undefined;
+    };
+  }),
+  startThread: vi.fn(async (request: StartThreadRequest) => ({
+    backend: request.backend,
+    threadId: "thread-1",
+  })),
+  startTurn: vi.fn(async (request: StartTurnRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    runId: "turn-1",
+  })),
+  interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    runId: request.runId,
+  })),
+};
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        isDestroyed: () => false,
+        webContents: { send },
+      },
+    ],
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("../app-server/backend-registry", () => ({
+  getDesktopBackendRegistry: () => registry,
+}));
+
+describe("agent ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    send.mockReset();
+    registry.listBackends.mockClear();
+    registry.onEvent.mockClear();
+    registry.startThread.mockClear();
+    registry.startTurn.mockClear();
+    registry.interruptTurn.mockClear();
+    registryListener = undefined;
+  });
+
+  it("registers backend and agent handlers and broadcasts backend-tagged events", async () => {
+    const {
+      registerAgentIpcHandlers,
+      disposeAgentIpcHandlers,
+    } = await import("../ipc/agent-ipc");
+    const {
+      AGENT_EVENT_CHANNEL,
+      AGENT_INTERRUPT_TURN_CHANNEL,
+      AGENT_START_THREAD_CHANNEL,
+      AGENT_START_TURN_CHANNEL,
+      BACKEND_LIST_CHANNEL,
+    } = await import("../../shared/ipc");
+
+    registerAgentIpcHandlers();
+
+    expect(await handlers.get(BACKEND_LIST_CHANNEL)?.({}, {})).toEqual({
+      fetchedAt: 1,
+      backends: [],
+    });
+    expect(
+      await handlers.get(AGENT_START_THREAD_CHANNEL)?.({}, { backend: "grok" }),
+    ).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+    });
+    expect(
+      await handlers.get(AGENT_START_TURN_CHANNEL)?.({}, {
+        backend: "grok",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Ship it" }],
+      }),
+    ).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+      runId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_INTERRUPT_TURN_CHANNEL)?.({}, {
+        backend: "grok",
+        threadId: "thread-1",
+        runId: "turn-1",
+      }),
+    ).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+      runId: "turn-1",
+    });
+
+    await registryListener?.({
+      backend: "grok",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Done." }],
+          },
+        },
+      },
+    });
+
+    expect(send).toHaveBeenCalledWith(AGENT_EVENT_CHANNEL, {
+      backend: "grok",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Done." }],
+          },
+        },
+      },
+    });
+
+    disposeAgentIpcHandlers();
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentEvent,
+  AppServerNotification,
+  AppServerThreadReplay,
+  AppServerThreadSummary,
+  AppServerTurnInputItem,
+} from "@pwragnt/shared";
+import { DesktopBackendRegistry } from "../app-server/backend-registry";
+
+class MockBackendClient {
+  private readonly listeners = new Set<
+    (notification: AppServerNotification) => void | Promise<void>
+  >();
+
+  constructor(
+    private readonly options: {
+      initializeResult?: {
+        serverInfo?: {
+          name?: string;
+          version?: string;
+        };
+        methods?: string[];
+      };
+      initializeError?: Error;
+      threads?: AppServerThreadSummary[];
+      replay?: AppServerThreadReplay;
+    }
+  ) {}
+
+  async close(): Promise<void> {
+    return;
+  }
+
+  async getInitializeResult() {
+    if (this.options.initializeError) {
+      throw this.options.initializeError;
+    }
+
+    return this.options.initializeResult ?? {};
+  }
+
+  async listThreads(): Promise<AppServerThreadSummary[]> {
+    return this.options.threads ?? [];
+  }
+
+  onNotification(
+    listener: (notification: AppServerNotification) => void | Promise<void>
+  ): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async readThread(): Promise<AppServerThreadReplay> {
+    return this.options.replay ?? {};
+  }
+
+  async startThread(): Promise<{ threadId: string }> {
+    return { threadId: "thread-1" };
+  }
+
+  async startTurn(): Promise<{ threadId: string; runId: string }> {
+    return { threadId: "thread-1", runId: "turn-1" };
+  }
+
+  async interruptTurn(): Promise<{ threadId: string; runId: string }> {
+    return { threadId: "thread-1", runId: "turn-1" };
+  }
+
+  async emit(notification: AppServerNotification): Promise<void> {
+    for (const listener of this.listeners) {
+      await listener(notification);
+    }
+  }
+}
+
+describe("DesktopBackendRegistry", () => {
+  it("reports backend availability and capabilities", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: {
+          serverInfo: { name: "Codex App Server", version: "1.0.0" },
+          methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+        },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+    });
+
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(response.backends).toEqual([
+      {
+        kind: "codex",
+        label: "Codex app server",
+        available: true,
+        serverName: "Codex App Server",
+        serverVersion: "1.0.0",
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: false,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: false,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: false,
+          approvalRequests: false,
+          multiDirectoryThreads: true,
+        },
+      },
+      {
+        kind: "grok",
+        label: "Grok app server",
+        available: false,
+        methods: [],
+        capabilities: {
+          listThreads: false,
+          createThread: false,
+          resumeThread: false,
+          readThread: false,
+          startTurn: false,
+          interruptTurn: false,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: false,
+          approvalRequests: false,
+          multiDirectoryThreads: false,
+        },
+        unavailableReason: "grok app server unavailable: XAI_API_KEY is not set",
+      },
+    ]);
+
+    await registry.close();
+  });
+
+  it("normalizes backend notifications with backend identity", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      grokClient,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await grokClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        runId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [{ type: "text", text: "Done." }],
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        backend: "grok",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            runId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      },
+    ]);
+
+    unsubscribe();
+    await registry.close();
+  });
+});

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { CodexAppServer, FakeProvider } from "@pwragnt/agent-core";
+import { GrokAppServerClient } from "../grok-app-server/client";
+
+describe("GrokAppServerClient", () => {
+  it("lists threads, reads replay, and forwards turn notifications", async () => {
+    const provider = new FakeProvider();
+    const server = new CodexAppServer({
+      provider,
+      threadIdGenerator: () => "thread-1",
+      runIdGenerator: () => "turn-1",
+    });
+
+    const client = new GrokAppServerClient({
+      server,
+      directoryResolver: async (projectKey) =>
+        projectKey
+          ? [
+              {
+                id: "/repo/workspace",
+                label: "workspace",
+                path: "/repo/workspace",
+                kind: "local",
+              },
+            ]
+          : [],
+    });
+
+    const notifications: string[] = [];
+    const unsubscribe = client.onNotification((notification) => {
+      notifications.push(notification.method);
+    });
+
+    const initialize = await client.getInitializeResult();
+    expect(initialize.serverInfo?.name).toBe("@pwragnt/grok-app-server");
+    expect(initialize.methods).toContain("thread/list");
+    expect(initialize.methods).toContain("turn/start");
+
+    const created = await client.startThread({
+      cwd: "/repo/workspace",
+      model: "grok-4.20-reasoning",
+    });
+    expect(created).toEqual({ threadId: "thread-1" });
+
+    const threads = await client.listThreads();
+    expect(threads).toEqual([
+      {
+        id: "thread-1",
+        title: "Untitled thread",
+        summary: undefined,
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+        linkedDirectories: [
+          {
+            id: "/repo/workspace",
+            label: "workspace",
+            path: "/repo/workspace",
+            kind: "local",
+          },
+        ],
+        source: "grok",
+      },
+    ]);
+
+    const startedTurn = await client.startTurn({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Ship Unit 3" }],
+    });
+    expect(startedTurn).toEqual({ threadId: "thread-1", runId: "turn-1" });
+
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "Done.",
+      providerResponseId: "resp_1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const replay = await client.readThread({ threadId: "thread-1" });
+    expect(replay).toEqual({
+      lastUserMessage: "Ship Unit 3",
+      lastAssistantMessage: "Done.",
+    });
+    expect(notifications).toContain("turn/completed");
+
+    unsubscribe();
+    await client.close();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,0 +1,275 @@
+import type {
+  AgentEvent,
+  BackendCapabilities,
+  BackendSummary,
+  ListBackendsRequest,
+  ListBackendsResponse,
+  AppServerBackendKind,
+  AppServerNotification,
+  AppServerReadThreadRequest,
+  AppServerReadThreadResponse,
+  AppServerThreadSummary,
+  AppServerTurnInputItem,
+} from "@pwragnt/shared";
+import { CodexAppServerClient } from "../codex-app-server/client";
+import { GrokAppServerClient } from "../grok-app-server/client";
+
+type BackendClient = {
+  close(): Promise<void>;
+  getInitializeResult(): Promise<{
+    serverInfo?: {
+      name?: string;
+      version?: string;
+    };
+    methods?: string[];
+  }>;
+  listThreads(params?: { filter?: string }): Promise<AppServerThreadSummary[]>;
+  onNotification(
+    listener: (notification: AppServerNotification) => void | Promise<void>
+  ): () => void;
+  readThread(params: { threadId: string }): Promise<AppServerReadThreadResponse["replay"]>;
+  startThread(params: {
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }>;
+  startTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    model?: string;
+  }): Promise<{ threadId: string; runId: string }>;
+  interruptTurn(params: {
+    threadId: string;
+    runId: string;
+  }): Promise<{ threadId: string; runId: string }>;
+};
+
+const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
+  codex: "Codex app server",
+  grok: "Grok app server",
+};
+
+function buildCapabilities(methods: string[], backend: AppServerBackendKind): BackendCapabilities {
+  const supported = new Set(methods);
+
+  return {
+    listThreads:
+      supported.has("thread/list") || supported.has("thread/loaded/list"),
+    createThread: supported.has("thread/start") || supported.has("thread/new"),
+    resumeThread: supported.has("thread/resume"),
+    readThread: supported.has("thread/read"),
+    startTurn: supported.has("turn/start"),
+    interruptTurn: supported.has("turn/interrupt"),
+    steerTurn: supported.has("turn/steer"),
+    transcriptPagination: false,
+    toolUse: false,
+    approvalRequests: false,
+    multiDirectoryThreads: backend === "codex",
+  };
+}
+
+export class DesktopBackendRegistry {
+  private readonly codexClient: BackendClient;
+  private readonly grokClient: BackendClient;
+  private readonly eventListeners = new Set<
+    (event: AgentEvent) => void | Promise<void>
+  >();
+  private readonly unsubscribers: Array<() => void> = [];
+
+  constructor(options?: {
+    codexClient?: BackendClient;
+    grokClient?: BackendClient;
+  }) {
+    this.codexClient = options?.codexClient ?? new CodexAppServerClient();
+    this.grokClient = options?.grokClient ?? new GrokAppServerClient();
+
+    this.unsubscribers.push(
+      this.codexClient.onNotification(async (notification) => {
+        await this.emit({ backend: "codex", notification });
+      }),
+    );
+    this.unsubscribers.push(
+      this.grokClient.onNotification(async (notification) => {
+        await this.emit({ backend: "grok", notification });
+      }),
+    );
+  }
+
+  onEvent(listener: (event: AgentEvent) => void | Promise<void>): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
+    };
+  }
+
+  async listBackends(
+    request: ListBackendsRequest = {}
+  ): Promise<ListBackendsResponse> {
+    const summaries = await Promise.all([
+      this.describeBackend("codex", this.codexClient),
+      this.describeBackend("grok", this.grokClient),
+    ]);
+
+    return {
+      fetchedAt: Date.now(),
+      backends: request.includeUnavailable
+        ? summaries
+        : summaries.filter((backend) => backend.available),
+    };
+  }
+
+  async listThreads(params: {
+    backend?: AppServerBackendKind;
+    filter?: string;
+  } = {}): Promise<AppServerThreadSummary[]> {
+    if (params.backend) {
+      return await this.getClient(params.backend).listThreads({
+        filter: params.filter,
+      });
+    }
+
+    const availableBackends = (await this.listBackends()).backends.map(
+      (backend) => backend.kind,
+    );
+    const threadLists = await Promise.all(
+      availableBackends.map(async (backend) =>
+        await this.getClient(backend).listThreads({ filter: params.filter }),
+      ),
+    );
+
+    return threadLists
+      .flat()
+      .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  }
+
+  async readThread(
+    request: AppServerReadThreadRequest
+  ): Promise<AppServerReadThreadResponse> {
+    const backend = request.backend ?? "codex";
+    const replay = await this.getClient(backend).readThread({
+      threadId: request.threadId,
+    });
+
+    return {
+      backend,
+      fetchedAt: Date.now(),
+      threadId: request.threadId,
+      replay,
+    };
+  }
+
+  async startThread(params: {
+    backend: AppServerBackendKind;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ backend: AppServerBackendKind; threadId: string }> {
+    const result = await this.getClient(params.backend).startThread(params);
+    return {
+      backend: params.backend,
+      threadId: result.threadId,
+    };
+  }
+
+  async startTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    model?: string;
+  }): Promise<{ backend: AppServerBackendKind; threadId: string; runId: string }> {
+    const result = await this.getClient(params.backend).startTurn(params);
+    return {
+      backend: params.backend,
+      threadId: result.threadId,
+      runId: result.runId,
+    };
+  }
+
+  async interruptTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    runId: string;
+  }): Promise<{ backend: AppServerBackendKind; threadId: string; runId: string }> {
+    const result = await this.getClient(params.backend).interruptTurn(params);
+    return {
+      backend: params.backend,
+      threadId: result.threadId,
+      runId: result.runId,
+    };
+  }
+
+  async close(): Promise<void> {
+    for (const unsubscribe of this.unsubscribers.splice(0)) {
+      unsubscribe();
+    }
+    await this.codexClient.close();
+    await this.grokClient.close();
+  }
+
+  private getClient(backend: AppServerBackendKind): BackendClient {
+    return backend === "grok" ? this.grokClient : this.codexClient;
+  }
+
+  private async describeBackend(
+    kind: AppServerBackendKind,
+    client: BackendClient
+  ): Promise<BackendSummary> {
+    try {
+      const initialize = await client.getInitializeResult();
+      const methods = Array.isArray(initialize.methods)
+        ? initialize.methods.filter((method): method is string => typeof method === "string")
+        : [];
+
+      return {
+        kind,
+        label: BACKEND_LABELS[kind],
+        available: true,
+        serverName: initialize.serverInfo?.name,
+        serverVersion: initialize.serverInfo?.version,
+        methods,
+        capabilities: buildCapabilities(methods, kind),
+      };
+    } catch (error) {
+      return {
+        kind,
+        label: BACKEND_LABELS[kind],
+        available: false,
+        methods: [],
+        capabilities: buildCapabilities([], kind),
+        unavailableReason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async emit(event: AgentEvent): Promise<void> {
+    for (const listener of this.eventListeners) {
+      await listener(event);
+    }
+  }
+}
+
+let registry: DesktopBackendRegistry | null = null;
+
+export function getDesktopBackendRegistry(): DesktopBackendRegistry {
+  if (!registry) {
+    registry = new DesktopBackendRegistry();
+  }
+
+  return registry;
+}
+
+export async function disposeDesktopBackendRegistry(): Promise<void> {
+  if (!registry) {
+    return;
+  }
+
+  const current = registry;
+  registry = null;
+  await current.close();
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2,8 +2,10 @@ import { execFile as execFileCallback } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
 import type {
+  AppServerNotification,
   AppServerThreadReplay,
   AppServerThreadSummary,
+  AppServerTurnInputItem,
   LinkedDirectorySummary
 } from "@pwragnt/shared";
 import { JsonRpcConnection } from "./json-rpc";
@@ -21,6 +23,14 @@ type CodexClientOptions = {
     projectKey?: string
   ) => Promise<LinkedDirectorySummary[]>;
   requestTimeoutMs?: number;
+};
+
+type InitializeResult = {
+  serverInfo?: {
+    name?: string;
+    version?: string;
+  };
+  methods?: string[];
 };
 
 type RawCodexThreadSummary = Omit<
@@ -236,6 +246,24 @@ function extractThreadReplayFromReadResult(value: unknown): AppServerThreadRepla
   return { lastUserMessage, lastAssistantMessage };
 }
 
+function extractThreadIdFromValue(value: unknown): string | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  return pickString(record, ["threadId", "thread_id", "id"]);
+}
+
+function extractRunIdFromValue(value: unknown): string | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  return pickString(record, ["runId", "run_id", "id"]);
+}
+
 function extractThreadRecords(value: unknown): Record<string, unknown>[] {
   if (Array.isArray(value)) {
     return value.flatMap((entry) => extractThreadRecords(entry));
@@ -436,6 +464,10 @@ export class CodexAppServerClient {
   ) => Promise<LinkedDirectorySummary[]>;
   private initialized = false;
   private initializationPromise: Promise<void> | null = null;
+  private initializeResult: InitializeResult | null = null;
+  private readonly notificationListeners = new Set<
+    (notification: AppServerNotification) => void | Promise<void>
+  >();
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -447,12 +479,35 @@ export class CodexAppServerClient {
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     );
     this.directoryResolver = options.directoryResolver ?? resolveLinkedDirectories;
+    this.connection.setNotificationHandler(async (method, params) => {
+      for (const listener of this.notificationListeners) {
+        await listener({
+          method: method as AppServerNotification["method"],
+          params: (params ?? {}) as AppServerNotification["params"],
+        } as AppServerNotification);
+      }
+    });
   }
 
   async close(): Promise<void> {
     this.initialized = false;
     this.initializationPromise = null;
+    this.initializeResult = null;
     await this.connection.close();
+  }
+
+  onNotification(
+    listener: (notification: AppServerNotification) => void | Promise<void>
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => {
+      this.notificationListeners.delete(listener);
+    };
+  }
+
+  async getInitializeResult(): Promise<InitializeResult> {
+    await this.ensureInitialized();
+    return this.initializeResult ?? {};
   }
 
   async listThreads(params?: { filter?: string }): Promise<AppServerThreadSummary[]> {
@@ -487,6 +542,76 @@ export class CodexAppServerClient {
     return extractThreadReplayFromReadResult(result);
   }
 
+  async startThread(params: {
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/start", "thread/new"],
+      payloads: [params],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    const threadId = extractThreadIdFromValue(result);
+    if (!threadId) {
+      throw new Error("codex app server thread/start did not return threadId");
+    }
+
+    return { threadId };
+  }
+
+  async startTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    model?: string;
+  }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["turn/start"],
+      payloads: [params],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    const threadId = extractThreadIdFromValue(result);
+    const runId = extractRunIdFromValue(result);
+    if (!threadId || !runId) {
+      throw new Error("codex app server turn/start did not return threadId and runId");
+    }
+
+    return { threadId, runId };
+  }
+
+  async interruptTurn(params: {
+    threadId: string;
+    runId: string;
+  }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["turn/interrupt"],
+      payloads: [{ threadId: params.threadId, turnId: params.runId }],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    const threadId = extractThreadIdFromValue(result);
+    const runId = extractRunIdFromValue(result);
+    if (!threadId || !runId) {
+      throw new Error("codex app server turn/interrupt did not return threadId and runId");
+    }
+
+    return { threadId, runId };
+  }
+
   private async ensureInitialized(): Promise<void> {
     if (this.initialized) {
       return;
@@ -501,11 +626,12 @@ export class CodexAppServerClient {
       await this.connection.connect();
 
       try {
-        await this.connection.request("initialize", {
+        const result = await this.connection.request("initialize", {
           protocolVersion: DEFAULT_PROTOCOL_VERSION,
           clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
           capabilities: { experimentalApi: true }
         });
+        this.initializeResult = (asRecord(result) ?? {}) as InitializeResult;
       } catch (error) {
         if (!isAlreadyInitializedError(error)) {
           throw error;

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1,0 +1,377 @@
+import path from "node:path";
+import { CodexAppServer, GrokProvider, loadLocalEnv } from "@pwragnt/agent-core";
+import type {
+  AppServerNotification,
+  AppServerThreadReplay,
+  AppServerThreadSummary,
+  AppServerTurnInputItem,
+  LinkedDirectorySummary,
+} from "@pwragnt/shared";
+
+const DEFAULT_PROTOCOL_VERSION = "1.0";
+
+type InitializeResult = {
+  serverInfo?: {
+    name?: string;
+    version?: string;
+  };
+  methods?: string[];
+};
+
+type GrokServerLike = {
+  request(method: string, params?: unknown): Promise<unknown>;
+  notify?(method: string, params?: unknown): Promise<void>;
+  onNotification(
+    handler: (notification: AppServerNotification) => void | Promise<void>
+  ): () => void;
+};
+
+type GrokClientOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  directoryResolver?: (
+    projectKey?: string
+  ) => Promise<LinkedDirectorySummary[]>;
+  server?: GrokServerLike;
+  threadIdGenerator?: () => string;
+  runIdGenerator?: () => string;
+};
+
+type RawThreadSummary = {
+  threadId: string;
+  title?: string;
+  summary?: string;
+  projectKey?: string;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+function normalizeThreadSummary(thread: RawThreadSummary): RawThreadSummary {
+  return {
+    ...thread,
+    title: thread.title?.trim() || "Untitled thread",
+    summary: thread.summary?.trim() || undefined,
+  };
+}
+
+async function resolveLinkedDirectories(
+  projectKey?: string
+): Promise<LinkedDirectorySummary[]> {
+  if (!projectKey?.trim()) {
+    return [];
+  }
+
+  const resolvedPath = path.resolve(projectKey);
+  return [
+    {
+      id: resolvedPath,
+      label: path.basename(resolvedPath) || resolvedPath,
+      path: resolvedPath,
+      kind: "local",
+    },
+  ];
+}
+
+function extractThreadSummaryList(value: unknown): RawThreadSummary[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const record = value as { threads?: unknown };
+  if (!Array.isArray(record.threads)) {
+    return [];
+  }
+
+  return record.threads
+    .flatMap((thread): RawThreadSummary[] => {
+      if (!thread || typeof thread !== "object" || Array.isArray(thread)) {
+        return [];
+      }
+
+      const record = thread as Record<string, unknown>;
+      const threadId =
+        typeof record.threadId === "string"
+          ? record.threadId.trim()
+          : typeof record.id === "string"
+            ? record.id.trim()
+            : "";
+
+      if (!threadId) {
+        return [];
+      }
+
+      return [
+        {
+          threadId,
+          title: typeof record.title === "string" ? record.title : undefined,
+          summary: typeof record.summary === "string" ? record.summary : undefined,
+          projectKey:
+            typeof record.projectKey === "string"
+              ? record.projectKey
+              : typeof record.cwd === "string"
+                ? record.cwd
+                : undefined,
+          createdAt:
+            typeof record.createdAt === "number" ? record.createdAt : undefined,
+          updatedAt:
+            typeof record.updatedAt === "number" ? record.updatedAt : undefined,
+        },
+      ];
+    })
+    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+}
+
+function extractThreadReplay(value: unknown): AppServerThreadReplay {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as {
+    lastUserMessage?: unknown;
+    lastAssistantMessage?: unknown;
+    messages?: Array<{ role?: unknown; text?: unknown }>;
+  };
+
+  if (
+    typeof record.lastUserMessage === "string" ||
+    typeof record.lastAssistantMessage === "string"
+  ) {
+    return {
+      lastUserMessage:
+        typeof record.lastUserMessage === "string"
+          ? record.lastUserMessage
+          : undefined,
+      lastAssistantMessage:
+        typeof record.lastAssistantMessage === "string"
+          ? record.lastAssistantMessage
+          : undefined,
+    };
+  }
+
+  const messages = Array.isArray(record.messages) ? record.messages : [];
+  let lastUserMessage: string | undefined;
+  let lastAssistantMessage: string | undefined;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!lastUserMessage && message?.role === "user" && typeof message.text === "string") {
+      lastUserMessage = message.text;
+    }
+    if (
+      !lastAssistantMessage &&
+      message?.role === "assistant" &&
+      typeof message.text === "string"
+    ) {
+      lastAssistantMessage = message.text;
+    }
+    if (lastUserMessage && lastAssistantMessage) {
+      break;
+    }
+  }
+
+  return { lastUserMessage, lastAssistantMessage };
+}
+
+function extractThreadId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.threadId === "string"
+    ? record.threadId
+    : typeof record.id === "string"
+      ? record.id
+      : undefined;
+}
+
+function extractRunId(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  return typeof record.runId === "string"
+    ? record.runId
+    : typeof record.id === "string"
+      ? record.id
+      : undefined;
+}
+
+export class GrokAppServerClient {
+  private readonly directoryResolver: (
+    projectKey?: string
+  ) => Promise<LinkedDirectorySummary[]>;
+  private server: GrokServerLike | null;
+  private initialized = false;
+  private initializeResult: InitializeResult | null = null;
+  private readonly notificationListeners = new Set<
+    (notification: AppServerNotification) => void | Promise<void>
+  >();
+  private unsubscribeNotification?: () => void;
+
+  constructor(private readonly options: GrokClientOptions = {}) {
+    this.directoryResolver = options.directoryResolver ?? resolveLinkedDirectories;
+    this.server = options.server ?? null;
+    if (this.server) {
+      this.subscribeToServerNotifications(this.server);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.unsubscribeNotification?.();
+    this.unsubscribeNotification = undefined;
+    this.initialized = false;
+    this.initializeResult = null;
+  }
+
+  onNotification(
+    listener: (notification: AppServerNotification) => void | Promise<void>
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => {
+      this.notificationListeners.delete(listener);
+    };
+  }
+
+  async getInitializeResult(): Promise<InitializeResult> {
+    await this.ensureInitialized();
+    return this.initializeResult ?? {};
+  }
+
+  async listThreads(_params?: { filter?: string }): Promise<AppServerThreadSummary[]> {
+    await this.ensureInitialized();
+
+    const result = await this.getServer().request("thread/list", {});
+    return await Promise.all(
+      extractThreadSummaryList(result).map(async (thread) => ({
+        id: thread.threadId,
+        title: normalizeThreadSummary(thread).title ?? "Untitled thread",
+        summary: normalizeThreadSummary(thread).summary,
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        linkedDirectories: await this.directoryResolver(thread.projectKey),
+        source: "grok" as const,
+      }))
+    );
+  }
+
+  async readThread(params: { threadId: string }): Promise<AppServerThreadReplay> {
+    await this.ensureInitialized();
+
+    const result = await this.getServer().request("thread/read", {
+      threadId: params.threadId,
+      includeTurns: true,
+    });
+
+    return extractThreadReplay(result);
+  }
+
+  async startThread(params: {
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+
+    const result = await this.getServer().request("thread/start", params);
+    const threadId = extractThreadId(result);
+    if (!threadId) {
+      throw new Error("grok app server thread/start did not return threadId");
+    }
+
+    return { threadId };
+  }
+
+  async startTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    model?: string;
+  }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
+
+    const result = await this.getServer().request("turn/start", params);
+    const threadId = extractThreadId(result);
+    const runId = extractRunId(result);
+    if (!threadId || !runId) {
+      throw new Error("grok app server turn/start did not return threadId and runId");
+    }
+
+    return { threadId, runId };
+  }
+
+  async interruptTurn(params: {
+    threadId: string;
+    runId: string;
+  }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
+
+    const result = await this.getServer().request("turn/interrupt", {
+      threadId: params.threadId,
+      turnId: params.runId,
+    });
+    const threadId = extractThreadId(result);
+    const runId = extractRunId(result);
+    if (!threadId || !runId) {
+      throw new Error("grok app server turn/interrupt did not return threadId and runId");
+    }
+
+    return { threadId, runId };
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    const server = this.getServer();
+    const result = await server.request("initialize", {
+      protocolVersion: DEFAULT_PROTOCOL_VERSION,
+      clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
+      capabilities: { experimentalApi: true },
+    });
+
+    this.initializeResult = (result ?? {}) as InitializeResult;
+    await server.notify?.("initialized", {});
+    this.initialized = true;
+  }
+
+  private getServer(): GrokServerLike {
+    if (this.server) {
+      return this.server;
+    }
+
+    loadLocalEnv({ override: false });
+    const apiKey = this.options.apiKey?.trim() || process.env.XAI_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error("grok app server unavailable: XAI_API_KEY is not set");
+    }
+
+    const provider = new GrokProvider({
+      apiKey,
+      baseUrl: this.options.baseUrl?.trim() || process.env.XAI_BASE_URL?.trim(),
+      model: this.options.model?.trim() || process.env.GROK_MODEL?.trim(),
+    });
+
+    this.server = new CodexAppServer({
+      provider,
+      threadIdGenerator: this.options.threadIdGenerator,
+      runIdGenerator: this.options.runIdGenerator,
+    });
+    this.subscribeToServerNotifications(this.server);
+    return this.server;
+  }
+
+  private subscribeToServerNotifications(server: GrokServerLike): void {
+    this.unsubscribeNotification?.();
+    this.unsubscribeNotification = server.onNotification(async (notification) => {
+      for (const listener of this.notificationListeners) {
+        await listener(notification);
+      }
+    });
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu, shell } from "electron";
+import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import { disposeAppServerIpcHandlers, registerAppServerIpcHandlers } from "./ipc/app-server";
 import { createMainWindow } from "./window";
 
@@ -34,6 +35,7 @@ export function bootstrapApp(): void {
   app.whenReady().then(() => {
     installApplicationMenu();
     registerAppServerIpcHandlers();
+    registerAgentIpcHandlers();
     createMainWindow();
 
     app.on("activate", () => {
@@ -50,6 +52,7 @@ export function bootstrapApp(): void {
   });
 
   app.on("before-quit", () => {
+    disposeAgentIpcHandlers();
     void disposeAppServerIpcHandlers();
   });
 }

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,0 +1,98 @@
+import { BrowserWindow, ipcMain } from "electron";
+import type {
+  AgentEvent,
+  InterruptTurnRequest,
+  InterruptTurnResponse,
+  ListBackendsRequest,
+  ListBackendsResponse,
+  StartThreadRequest,
+  StartThreadResponse,
+  StartTurnRequest,
+  StartTurnResponse,
+} from "@pwragnt/shared";
+import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import {
+  AGENT_EVENT_CHANNEL,
+  AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_START_THREAD_CHANNEL,
+  AGENT_START_TURN_CHANNEL,
+  BACKEND_LIST_CHANNEL,
+} from "../../shared/ipc";
+
+let unsubscribeRegistryEvents: (() => void) | undefined;
+
+function broadcastAgentEvent(event: AgentEvent): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+      continue;
+    }
+
+    if (typeof window.webContents.send !== "function") {
+      continue;
+    }
+
+    window.webContents.send(AGENT_EVENT_CHANNEL, event);
+  }
+}
+
+export function registerAgentIpcHandlers(): void {
+  const registry = getDesktopBackendRegistry();
+
+  unsubscribeRegistryEvents?.();
+  unsubscribeRegistryEvents = registry.onEvent((event) => {
+    broadcastAgentEvent(event);
+  });
+
+  ipcMain.removeHandler(BACKEND_LIST_CHANNEL);
+  ipcMain.handle(
+    BACKEND_LIST_CHANNEL,
+    async (
+      _event,
+      request?: ListBackendsRequest
+    ): Promise<ListBackendsResponse> => {
+      return await registry.listBackends(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_START_THREAD_CHANNEL);
+  ipcMain.handle(
+    AGENT_START_THREAD_CHANNEL,
+    async (
+      _event,
+      request: StartThreadRequest
+    ): Promise<StartThreadResponse> => {
+      return await registry.startThread(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
+  ipcMain.handle(
+    AGENT_START_TURN_CHANNEL,
+    async (
+      _event,
+      request: StartTurnRequest
+    ): Promise<StartTurnResponse> => {
+      return await registry.startTurn(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
+  ipcMain.handle(
+    AGENT_INTERRUPT_TURN_CHANNEL,
+    async (
+      _event,
+      request: InterruptTurnRequest
+    ): Promise<InterruptTurnResponse> => {
+      return await registry.interruptTurn(request);
+    },
+  );
+}
+
+export function disposeAgentIpcHandlers(): void {
+  unsubscribeRegistryEvents?.();
+  unsubscribeRegistryEvents = undefined;
+  ipcMain.removeHandler(BACKEND_LIST_CHANNEL);
+  ipcMain.removeHandler(AGENT_START_THREAD_CHANNEL);
+  ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
+  ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
+}

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -11,7 +11,10 @@ import type {
   MarkThreadSeenResponse,
   NavigationSnapshot,
 } from "@pwragnt/shared";
-import { CodexAppServerClient } from "../codex-app-server/client";
+import {
+  disposeDesktopBackendRegistry,
+  getDesktopBackendRegistry,
+} from "../app-server/backend-registry";
 import {
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
@@ -29,43 +32,26 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
   console.info(`[pwragnt:app-server] ${event}`, payload);
 }
 
-function parseEnvArgs(rawArgs: string | undefined): string[] {
-  if (!rawArgs?.trim()) {
-    return [];
-  }
-
-  return rawArgs
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-}
-
 class DesktopAppServerService {
-  private codexClient: CodexAppServerClient | null = null;
   private overlayStore: OverlayStore | null = null;
 
   async listThreads(
     request: AppServerListThreadsRequest = {}
   ): Promise<AppServerListThreadsResponse> {
-    const backend = request.backend ?? "codex";
-
-    if (backend !== "codex") {
-      throw new Error(`${backend} app server is not wired yet`);
-    }
-
-    const client = this.getCodexClient();
-    const threads = await client.listThreads({
-      filter: request.filter
+    const backend = request.backend;
+    const threads = await getDesktopBackendRegistry().listThreads({
+      backend,
+      filter: request.filter,
     });
 
     logDebug("listThreads", {
-      backend,
+      backend: backend ?? "all",
       count: threads.length,
       threadIds: threads.slice(0, 5).map((thread) => thread.id)
     });
 
     return {
-      backend,
+      backend: backend ?? "codex",
       fetchedAt: Date.now(),
       threads
     };
@@ -75,42 +61,27 @@ class DesktopAppServerService {
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {
     const backend = request.backend ?? "codex";
-
-    if (backend !== "codex") {
-      throw new Error(`${backend} app server is not wired yet`);
-    }
-
-    const client = this.getCodexClient();
-    const replay = await client.readThread({
-      threadId: request.threadId
+    const response = await getDesktopBackendRegistry().readThread({
+      backend,
+      threadId: request.threadId,
     });
 
     logDebug("readThread", {
       backend,
       threadId: request.threadId,
-      hasLastUserMessage: Boolean(replay.lastUserMessage),
-      hasLastAssistantMessage: Boolean(replay.lastAssistantMessage)
+      hasLastUserMessage: Boolean(response.replay.lastUserMessage),
+      hasLastAssistantMessage: Boolean(response.replay.lastAssistantMessage)
     });
 
-    return {
-      backend,
-      fetchedAt: Date.now(),
-      threadId: request.threadId,
-      replay
-    };
+    return response;
   }
 
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
   ): Promise<NavigationSnapshot> {
     const backend = request.backend ?? "codex";
-
-    if (backend !== "codex") {
-      throw new Error(`${backend} app server is not wired yet`);
-    }
-
-    const client = this.getCodexClient();
-    const threads = await client.listThreads({
+    const threads = await getDesktopBackendRegistry().listThreads({
+      backend,
       filter: request.filter,
     });
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
@@ -155,22 +126,7 @@ class DesktopAppServerService {
   }
 
   async close(): Promise<void> {
-    await this.codexClient?.close();
-    this.codexClient = null;
-  }
-
-  private getCodexClient(): CodexAppServerClient {
-    if (this.codexClient) {
-      return this.codexClient;
-    }
-
-    this.codexClient = new CodexAppServerClient({
-      command: process.env.PWRAGNT_CODEX_COMMAND?.trim() || "codex",
-      args: parseEnvArgs(process.env.PWRAGNT_CODEX_ARGS),
-      requestTimeoutMs: 20_000
-    });
-
-    return this.codexClient;
+    await disposeDesktopBackendRegistry();
   }
 
   private getOverlayStore(): OverlayStore {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,10 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type {
+  AgentEvent,
+  InterruptTurnRequest,
+  InterruptTurnResponse,
+  ListBackendsRequest,
+  ListBackendsResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
@@ -8,10 +13,19 @@ import type {
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   NavigationSnapshot,
+  StartThreadRequest,
+  StartThreadResponse,
+  StartTurnRequest,
+  StartTurnResponse,
 } from "@pwragnt/shared";
 import {
+  AGENT_EVENT_CHANNEL,
+  AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_START_THREAD_CHANNEL,
+  AGENT_START_TURN_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  BACKEND_LIST_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
@@ -29,10 +43,26 @@ const desktopApi = Object.freeze({
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>
     await ipcRenderer.invoke(APP_SERVER_LIST_THREADS_CHANNEL, request),
+  listBackends: async (
+    request?: ListBackendsRequest
+  ): Promise<ListBackendsResponse> =>
+    await ipcRenderer.invoke(BACKEND_LIST_CHANNEL, request),
   readThread: async (
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> =>
     await ipcRenderer.invoke(APP_SERVER_READ_THREAD_CHANNEL, request),
+  startThread: async (
+    request: StartThreadRequest
+  ): Promise<StartThreadResponse> =>
+    await ipcRenderer.invoke(AGENT_START_THREAD_CHANNEL, request),
+  startTurn: async (
+    request: StartTurnRequest
+  ): Promise<StartTurnResponse> =>
+    await ipcRenderer.invoke(AGENT_START_TURN_CHANNEL, request),
+  interruptTurn: async (
+    request: InterruptTurnRequest
+  ): Promise<InterruptTurnResponse> =>
+    await ipcRenderer.invoke(AGENT_INTERRUPT_TURN_CHANNEL, request),
   getNavigationSnapshot: async (
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> =>
@@ -46,6 +76,14 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(WINDOW_FOCUS_SYNC_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_FOCUS_SYNC_CHANNEL, listener);
+    };
+  },
+  onAgentEvent: (callback: (event: AgentEvent) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: AgentEvent) =>
+      callback(payload);
+    ipcRenderer.on(AGENT_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(AGENT_EVENT_CHANNEL, listener);
     };
   },
   platform: process.platform,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,5 +1,10 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const BACKEND_LIST_CHANNEL = "backend:list";
+export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
+export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
+export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
+export const AGENT_EVENT_CHANNEL = "agent:event";
 export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";

--- a/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
+++ b/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
@@ -206,49 +206,51 @@ flowchart TB
 **Verification:**
 - Main-process services can store desktop-only inbox/navigation metadata, reconcile fresh app-server thread snapshots on focus, and preserve a stable UI when nothing materially changed.
 
-- [ ] **Unit 3: Build the provider contract and agent harness**
+- [ ] **Unit 3: Integrate the Grok app server and normalize backend thread loading**
 
-**Goal:** Deliver the first real agent runtime with a Grok-first adapter, a generic responses-style provider contract, command execution hooks, and thread event emission.
+**Goal:** Wire the existing Grok app server into the desktop beside Codex App Server, normalize the minimum thread-loading and run-lifecycle contracts across both backends, and expose capability-aware IPC without rebuilding `agent-core` abstractions that already exist.
 
 **Requirements:** R16-R22
 
 **Dependencies:** Unit 2
 
 **Files:**
-- Create: `packages/shared/src/contracts/provider.ts`
+- Create: `packages/shared/src/contracts/backend.ts`
 - Create: `packages/shared/src/contracts/agent.ts`
-- Create: `packages/agent-core/src/providers/provider-registry.ts`
-- Create: `packages/agent-core/src/providers/grok-provider.ts`
-- Create: `packages/agent-core/src/providers/responses-provider.ts`
-- Create: `packages/agent-core/src/runtime/agent-harness.ts`
-- Create: `packages/agent-core/src/runtime/command-runner.ts`
-- Create: `packages/agent-core/src/runtime/approval-policy.ts`
+- Create: `apps/desktop/src/main/grok-app-server/client.ts`
+- Create: `apps/desktop/src/main/app-server/backend-registry.ts`
 - Create: `apps/desktop/src/main/ipc/agent-ipc.ts`
-- Test: `packages/agent-core/src/__tests__/agent-harness.test.ts`
-- Test: `packages/agent-core/src/__tests__/approval-policy.test.ts`
+- Update: `apps/desktop/src/main/ipc/app-server.ts`
+- Update: `apps/desktop/src/preload/index.ts`
+- Update: `apps/desktop/src/shared/ipc.ts`
+- Test: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
 - Test: `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
 
 **Approach:**
-- Define one provider interface that covers request submission, streaming responses/events, tool or command intents, cancellation, and structured error reporting.
-- Implement Grok first behind that interface, then add a second generic responses-style adapter to prove the abstraction is not fake.
-- Keep command execution and approval checks in the harness boundary so thread events, logs, and user prompts share one source of truth.
+- Treat `packages/agent-core` as the existing Grok app server implementation rather than re-planning a new provider or harness layer.
+- Add a desktop main-process client for the Grok app server that mirrors the role of the Codex App Server client while respecting the Grok server's current limitations.
+- Normalize the desktop-facing contract around the backend operations the UI actually needs now: initialize, list threads, create/resume threads, read threads, start turns, observe notifications, and cancel when supported.
+- Introduce backend capability metadata so the renderer can tell the difference between "not implemented yet" and "unsupported by this backend" for tools, approvals, transcript pagination, steering, and interruption.
+- Keep tool execution, code search, and richer command/approval behavior out of this unit unless they are already available from the backing app server; the desktop should integrate real capability, not invent fake parity.
 
-**Execution note:** Start with failing tests around provider event translation and approval decisions before wiring the live adapter.
+**Execution note:** Start with failing tests around backend capability reporting, Grok thread loading, and notification normalization before wiring the live desktop integration.
 
 **Patterns to follow:**
 - Typed IPC and domain contracts from Units 1 and 2.
+- Reuse the existing `agent-core` app-server protocol and runners instead of creating parallel runtime abstractions in the desktop layer.
 
 **Test scenarios:**
-- Happy path: harness starts a thread run, streams provider output, and persists thread events.
-- Happy path: Grok adapter satisfies the shared provider contract and emits normalized events.
-- Happy path: generic responses-style adapter can be registered beside Grok without changing harness code.
-- Edge case: user cancels an in-flight run and the thread returns to a non-running state with a persisted cancellation event.
-- Error path: provider error surfaces as a thread event and does not corrupt prior transcript state.
-- Error path: guarded-mode destructive command request triggers approval-needed status instead of executing immediately.
-- Integration: IPC call from renderer starts a harness run and returns normalized state updates to the UI.
+- Happy path: desktop can initialize both Codex and Grok backends and read capability metadata for each.
+- Happy path: Grok-backed threads can be listed, started, read, and surfaced through the same navigation pipeline as Codex-backed threads.
+- Happy path: starting a Grok run through desktop IPC yields normalized lifecycle updates that the renderer can consume without backend-specific branching everywhere.
+- Edge case: a backend lacking transcript pagination reports that capability clearly and still supports one-shot `thread/read`.
+- Edge case: a backend lacking interruption, steering, tool use, or approvals reports those gaps without breaking thread loading or run start.
+- Error path: backend request failure surfaces as normalized desktop state instead of wedging the selected thread or navigation model.
+- Integration: renderer-to-main IPC can choose a backend, start a thread/run, and receive normalized updates from either Codex or Grok.
 
 **Verification:**
-- The app can run a real provider-backed thread and produce persisted messages/events with guarded/full-access behavior.
+- The desktop can load and run threads from both Codex and Grok backends, while accurately representing each backend's current feature envelope instead of assuming parity.
 
 - [ ] **Unit 4: Ship Inbox, Recents, Directories, and thread detail UI**
 
@@ -279,6 +281,7 @@ flowchart TB
 
 **Approach:**
 - Make Inbox the top section of the sidebar, with Recents and Directories presented as alternate browsing lenses below it.
+- Treat Unit 3's backend integration as the data boundary for this renderer work: the UI should consume normalized thread loading, run lifecycle, capability metadata, and `thread/read` responses without embedding backend-specific protocol logic.
 - Ensure thread rows can display linked-directory summary text without requiring users to open the thread first.
 - Replace the current Telegram-era stopgap of “Last user message” and “Last assistant message” with a real transcript surface that renders normalized messages returned by `thread/read`.
 - Support scrollable thread history and incremental scrollback/pagination whenever the backing app server can provide it, while still degrading to a complete one-shot read when pagination is unavailable.

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -1,0 +1,51 @@
+import type {
+  AppServerBackendKind,
+  AppServerNotification,
+  AppServerTurnInputItem,
+  ThreadIdentifier,
+} from "./app-server";
+
+export type StartThreadRequest = {
+  backend: AppServerBackendKind;
+  cwd?: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+};
+
+export type StartThreadResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type StartTurnRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  input: AppServerTurnInputItem[];
+  model?: string;
+};
+
+export type StartTurnResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  runId: string;
+};
+
+export type InterruptTurnRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  runId: string;
+};
+
+export type InterruptTurnResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  runId: string;
+};
+
+export type AgentEvent = {
+  backend: AppServerBackendKind;
+  notification: AppServerNotification;
+};

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -2,6 +2,26 @@ export type AppServerBackendKind = "codex" | "grok";
 
 export type ThreadIdentifier = string;
 
+export type AppServerTextInputItem = {
+  type: "text";
+  text: string;
+};
+
+export type AppServerImageInputItem = {
+  type: "image";
+  url: string;
+};
+
+export type AppServerLocalImageInputItem = {
+  type: "localImage";
+  path: string;
+};
+
+export type AppServerTurnInputItem =
+  | AppServerTextInputItem
+  | AppServerImageInputItem
+  | AppServerLocalImageInputItem;
+
 export type LinkedDirectorySummary = {
   id: string;
   label: string;
@@ -47,3 +67,99 @@ export type AppServerReadThreadResponse = {
   threadId: ThreadIdentifier;
   replay: AppServerThreadReplay;
 };
+
+export type AppServerNotification =
+  | {
+      method: "turn/completed";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "completed";
+          output: Array<{
+            type: "text";
+            text: string;
+          }>;
+        };
+      };
+    }
+  | {
+      method: "turn/failed";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "failed";
+          error: {
+            message: string;
+          };
+        };
+      };
+    }
+  | {
+      method: "turn/cancelled";
+      params: {
+        threadId: string;
+        runId: string;
+        turn: {
+          id: string;
+          status: "cancelled";
+        };
+      };
+    }
+  | {
+      method: "item/started" | "item/completed";
+      params: {
+        threadId: string;
+        runId?: string;
+        item: {
+          id: string;
+          type: string;
+          text?: string;
+          review?: string;
+        };
+      };
+    }
+  | {
+      method: "item/plan/delta";
+      params: {
+        threadId: string;
+        runId?: string;
+        item: {
+          id: string;
+          type: "plan";
+        };
+        delta: string;
+      };
+    }
+  | {
+      method: "turn/plan/updated";
+      params: {
+        threadId: string;
+        runId: string;
+        plan: {
+          explanation?: string;
+          steps: Array<{
+            step: string;
+            status: "pending" | "in_progress" | "completed";
+          }>;
+        };
+      };
+    }
+  | {
+      method: "serverRequest/resolved";
+      params: {
+        threadId: string;
+        runId?: string;
+        requestId: string;
+      };
+    }
+  | {
+      method: "thread/compacted";
+      params: {
+        threadId: string;
+        itemId?: string;
+      };
+    };

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -1,0 +1,35 @@
+import type { AppServerBackendKind } from "./app-server";
+
+export type BackendCapabilities = {
+  listThreads: boolean;
+  createThread: boolean;
+  resumeThread: boolean;
+  readThread: boolean;
+  startTurn: boolean;
+  interruptTurn: boolean;
+  steerTurn: boolean;
+  transcriptPagination: boolean;
+  toolUse: boolean;
+  approvalRequests: boolean;
+  multiDirectoryThreads: boolean;
+};
+
+export type BackendSummary = {
+  kind: AppServerBackendKind;
+  label: string;
+  available: boolean;
+  serverName?: string;
+  serverVersion?: string;
+  methods: string[];
+  capabilities: BackendCapabilities;
+  unavailableReason?: string;
+};
+
+export type ListBackendsRequest = {
+  includeUnavailable?: boolean;
+};
+
+export type ListBackendsResponse = {
+  fetchedAt: number;
+  backends: BackendSummary[];
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./contracts/app-server";
+export * from "./contracts/backend";
+export * from "./contracts/agent";
 export * from "./contracts/navigation";


### PR DESCRIPTION
## Summary
- rewrite Unit 3 around integrating the existing Grok app server into the desktop instead of re-planning provider and harness abstractions that already exist in `agent-core`
- clarify that Unit 3 owns normalized backend thread loading, run lifecycle plumbing, and capability reporting across Codex and Grok
- tighten Unit 4 so the renderer consumes Unit 3's normalized backend surface rather than embedding backend-specific protocol logic

## Why
`main` now includes the initial Grok app server implementation, so the old Unit 3 plan was stale. This update makes the next execution unit match the actual architecture and keeps transcript and thread-detail UI work clearly in Unit 4.

## Testing
- not run; docs-only change
