### PR TITLE
feat: add Grok app-server repository tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
 
-      - name: Live agent-core smoke
+      - name: Live agent-core smoke and tool coverage
         env:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           XAI_BASE_URL: https://api.x.ai/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Test
         run: pnpm run test
 
@@ -81,6 +84,9 @@ jobs:
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Live agent-core smoke and tool coverage
         env:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ When you are ready to run live xAI-backed smoke coverage, put credentials in
 `packages/agent-core/.env.local`. The tracked template lives at
 `packages/agent-core/.env.local.example`.
 
+CI uses the existing `live-agent-core` workflow job with the `XAI_API_KEY`
+repository secret. No separate tool-test secret is required.
+
 Live smoke coverage:
 
 - `pnpm --filter @pwragnt/agent-core test:live`
 - Covers live thread continuation via `thread/resume`
 - Covers live context compaction via `thread/compact/start`
+- Covers live repository-tool usage against a temporary workspace

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -236,7 +236,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 **Verification:**
 - `thread/read` reflects the tool-bearing turn history needed by later phases.
 
-- [ ] **Unit 2: Add a local tool contract and registry**
+- [x] **Unit 2: Add a local tool contract and registry**
 
 **Goal:** Create one internal place where model-visible tools are declared, validated, executed, and mapped back into provider and app-server events.
 
@@ -270,7 +270,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 **Verification:**
 - Provider code can request a tool by name without importing the tool implementation directly.
 
-- [ ] **Unit 3: Implement read-only repository tools with ripgrep-first search**
+- [x] **Unit 3: Implement read-only repository tools with ripgrep-first search**
 
 **Goal:** Give the model stable, high-signal tools for reading files, listing files, and searching repository contents without forcing it to synthesize shell every time.
 

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -308,7 +308,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 **Verification:**
 - The model has dedicated repository exploration tools and no longer needs shell for every read-only operation.
 
-- [ ] **Unit 4: Add mutation tools and shell safety with approval policy**
+- [x] **Unit 4: Add mutation tools and shell safety with approval policy**
 
 **Goal:** Support durable edits and shell execution while preserving guarded behavior and transparent approvals.
 

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -1,0 +1,455 @@
+---
+title: feat: Add Grok tool usage and ripgrep-backed code search
+type: feat
+status: active
+date: 2026-04-16
+origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
+---
+
+# feat: Add Grok tool usage and ripgrep-backed code search
+
+## Overview
+
+Turn the initial Grok-backed app-server implementation in `packages/agent-core` into a usable coding runtime by adding model-callable tools, ripgrep-backed code search, safe shell execution, and structured tool notifications that match the Codex app-server style already consumed by downstream clients. The implementation target is this repository, but the reference contracts come from `/Users/huntharo/github/grok-cli` and `/Users/huntharo/github/codex`.
+
+## Problem Frame
+
+The merged Grok app-server baseline proves that `packages/agent-core` can start threads, run turns, and talk to the xAI Responses API, but it is still text-only:
+
+- `packages/agent-core/src/providers/grok-provider.ts` issues one synchronous xAI response request and returns only final assistant text
+- `packages/agent-core/src/providers/response-normalizer.ts` only extracts text, not tool calls, tool results, or iterative tool rounds
+- `packages/agent-core/src/app-server/protocol.ts` and `turn-runner.ts` can emit progress and pending-input events, but there is no tool runtime feeding those events
+- `thread/read`, `review/start`, and `thread/compact/start` currently operate on replay state that contains user and assistant text, not durable tool activity
+
+That leaves the Grok app server well short of the coding workflow expected from the surrounding product direction. The user explicitly wants tool usage and code search, especially ripgrep-style search. The two local reference implementations point toward the right shape:
+
+- `/Users/huntharo/github/grok-cli` exposes explicit tools such as `bash`, `read_file`, `write_file`, and `edit_file`, then loops tool calls back through the model runtime
+- `/Users/huntharo/github/codex` treats shell activity and tool calls as first-class app-server items, classifies command actions like `read`, `listFiles`, and `search`, and applies approval policy around unsafe commands
+
+The plan here is not to clone either codebase. It is to implement the smallest durable subset in `packages/agent-core` that makes the Grok app server useful for repository work and keeps the app-server contract moving toward the Codex/OpenClaw shape already in use.
+
+## Requirements Trace
+
+- R16-R19. Guarded versus full-access execution settings, approvals, and interruption must remain observable and controllable through the app-server contract.
+- R20. The server must stay backed by a real provider path, not a fake compatibility shell.
+- R21. Grok remains the first real provider, but the server surface should continue converging on the Codex app-server interface already known by clients.
+- R22. The core coding loop must include thread start or resume, thread readback, turn start, steer, interrupt, review, and compaction.
+- User requirement: evaluate tool usage patterns in both `/Users/huntharo/github/grok-cli` and `/Users/huntharo/github/codex`.
+- User requirement: implement code-search behavior centered on ripgrep rather than hand-rolled scanning alone.
+- Compatibility requirement: preserve the OpenClaw-relevant app-server surface while adding tool-bearing behavior instead of inventing a separate Grok-only dialect.
+
+## Scope Boundaries
+
+- In scope: tool usage and code-search implementation inside `packages/agent-core`.
+- In scope: model-facing tools for repository work, especially file reading, file listing, content search, file edits, and shell execution.
+- In scope: structured tool notifications and replay persistence so turns, reviews, and compaction can observe tool activity.
+- In scope: approval and interruption behavior for tool execution, using the existing app-server request flow.
+- In scope: deterministic tests plus narrow live-gated coverage using the existing `live-agent-core` CI job.
+- Out of scope: modifying `/Users/huntharo/github/grok-cli` or `/Users/huntharo/github/codex` directly as part of this plan.
+- Out of scope: full Codex App Server v2 parity, full MCP runtime parity, browser or computer-use tools, media tools, or sub-agent orchestration.
+- Out of scope: fuzzy file-name search UI parity with Codex in this first pass. The immediate target is repository search and coding tools, not composer popups.
+
+## Context & Research
+
+### Current `agent-core` state
+
+- `packages/agent-core/src/providers/grok-provider.ts` currently has no tool loop, no subscription-backed provider events, and no iterative response chaining beyond `previousResponseId`.
+- `packages/agent-core/src/providers/xai-responses-client.ts` sends `stream: false` requests and does not yet send any tool definitions or tool outputs.
+- `packages/agent-core/src/providers/response-normalizer.ts` only collects assistant text from `output_text` and `output[].content[].text`.
+- `packages/agent-core/src/app-server/turn-runner.ts` already knows how to turn provider events into `item/started`, `item/completed`, `item/plan/delta`, `turn/plan/updated`, and `serverRequest/resolved`, which is a good fit for tool progress once the provider can emit those events.
+- `packages/agent-core/src/testing/test-harness.ts` already provides a fake provider with event subscriptions, so the new tool-bearing provider paths can be tested without spinning up a real server process.
+
+### Grok CLI reference
+
+Relevant files:
+
+- `/Users/huntharo/github/grok-cli/src/grok/tools.ts`
+- `/Users/huntharo/github/grok-cli/src/tools/bash.ts`
+- `/Users/huntharo/github/grok-cli/src/tools/file.ts`
+- `/Users/huntharo/github/grok-cli/src/agent/agent.ts`
+- `/Users/huntharo/github/grok-cli/src/types/index.ts`
+
+Useful patterns:
+
+- Grok CLI separates tool definition from execution. `createTools(...)` builds a registry, while the agent loop executes tool calls and feeds tool results back into later model rounds.
+- File tools are explicit and durable: `read_file`, `write_file`, and `edit_file` are distinct from `bash`.
+- Shell is still important, but Grok CLI pushes the model toward dedicated file tools for durable edits and uses `bash` for search, git inspection, builds, and tests.
+- The runtime emits `tool_calls`, `tool_result`, and `tool_approval_request` events, which maps well onto the provider-event mechanism already present in `agent-core`.
+
+### Codex reference
+
+Relevant files:
+
+- `/Users/huntharo/github/codex/codex-rs/app-server-protocol/src/protocol/v2.rs`
+- `/Users/huntharo/github/codex/codex-rs/shell-command/src/command_safety/is_safe_command.rs`
+- `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs`
+- `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs`
+- `/Users/huntharo/github/codex/codex-rs/file-search/src/lib.rs`
+
+Useful patterns:
+
+- Codex distinguishes shell activity from generic tool calls. `ThreadItem::CommandExecution` carries shell semantics, while `ThreadItem::DynamicToolCall` carries explicit tool/function calls.
+- Codex classifies shell commands into semantic actions via `CommandAction::{Read,ListFiles,Search,Unknown}`. That is a useful lightweight contract for app-server notifications and replay, even if the underlying runtime stays much smaller.
+- Codex auto-approves a constrained read-only shell subset and explicitly treats unsafe ripgrep flags such as `--pre` and `--search-zip` as non-safe.
+- Codex persists structured thread items rather than flattening everything into assistant text, which matters for `thread/read`, review, and compaction consistency.
+
+### Local comparison and implications
+
+| Concern | Grok CLI | Codex | Implication for `agent-core` |
+|---|---|---|---|
+| Model-facing tool surface | Explicit built-in tools in `src/grok/tools.ts` | Dynamic tools plus shell commands | Use an explicit local tool registry and keep shell separate from dedicated file/search tools |
+| Code search | Mostly via `bash` and repository tools | Shell commands plus semantic `search` classification | Add a first-class `search_code` tool and classify shell `rg` invocations for notifications and approvals |
+| File IO | Dedicated file tools | File change items plus shell/file approvals | Add explicit file tools so durable edits do not depend solely on shell side effects |
+| Approval flow | Tool approval events in the streaming runtime | Structured command and file-change approvals | Reuse `PendingInputCoordinator` and app-server request handling for risky tool actions |
+| Replay model | Chat entries with `tool_call` and `tool_result` | Persisted structured `ThreadItem`s | Extend session replay beyond plain user/assistant messages |
+
+### Institutional learnings
+
+- No relevant `docs/solutions/` artifacts exist yet in this repository.
+
+### External research decision
+
+Skipped. The codebases already contain direct local examples for tool registries, ripgrep safety, command classification, and app-server eventing. External documentation would add little planning value relative to the local references.
+
+## Key Technical Decisions
+
+- Implement the tool runtime in `packages/agent-core`; treat `grok-cli` and `codex` as design references, not code-copy targets.
+- Keep shell and explicit tools separate. Shell execution should produce command-style items and approval semantics; file and search helpers should be explicit tools with stable arguments and outputs.
+- Make ripgrep a first-class path, not a prompt convention. The server should provide a dedicated search tool that uses `rg` directly when available, with bounded output and semantic parameters.
+- Preserve a small, opinionated initial tool subset:
+  - `read_file`
+  - `list_files`
+  - `search_code`
+  - `write_file`
+  - `edit_file`
+  - `shell_command`
+- Treat `read_file`, `list_files`, and `search_code` as read-only by default and auto-approvable under guarded settings; require approval for mutation tools and non-safe shell commands.
+- Model explicit tools as dynamic tool calls and shell as command execution. That gives `agent-core` a clean line between stable high-signal tools and arbitrary shell commands while staying compatible with Codex-style semantics.
+- Persist structured tool items into thread state and replay so `thread/read`, `review/start`, and `thread/compact/start` operate on the same observable history the provider already advanced through.
+- Extend the existing live xAI path rather than creating a second integration mechanism. The current `live-agent-core` CI job is the right home for tool-loop smoke coverage.
+
+## Open Questions
+
+### Resolved during planning
+
+- Should the implementation target be `codex`, `grok-cli`, or this repo? This repo. The other two are references.
+- Should ripgrep be exposed only through shell? No. It should also exist as a dedicated search tool so the model has a stable, obvious path for code search.
+- Should shell safety be all-or-nothing? No. A read-only safe subset should auto-approve, with approval requests for risky invocations.
+- Should fuzzy file-name search ship in the same pass? No. The first milestone should focus on coding tools and content search.
+
+### Deferred to implementation
+
+- Whether `list_files` should always rely on `rg --files` or use a hybrid `rg` plus Node walker approach when `rg` is unavailable.
+- Whether `write_file` should emit file diffs immediately in tool results or leave diff rendering solely to replay items.
+- How much command output should be stored in replay versus only emitted live, especially for long-running shell commands.
+- Whether the first xAI tool loop should stay synchronous round-by-round or move directly to streamed Responses support.
+
+## High-Level Technical Design
+
+> *This is directional guidance for review, not implementation specification.*
+
+```mermaid
+flowchart TB
+    CLIENT["Desktop / OpenClaw-style client"]
+    SERVER["CodexAppServer"]
+    TURN["TurnRunner / ReviewRunner / CompactionRunner"]
+    STATE["AppServerSessionState\nthreads / runs / replay / items"]
+    PROVIDER["GrokProvider"]
+    XAI["xAI Responses API"]
+    REGISTRY["ToolRegistry"]
+    SAFE["Shell safety + approval classifier"]
+    READ["read_file / list_files"]
+    SEARCH["search_code (rg-first)"]
+    EDIT["write_file / edit_file"]
+    SHELL["shell_command"]
+    INPUT["PendingInputCoordinator"]
+
+    CLIENT --> SERVER
+    SERVER --> TURN
+    TURN --> STATE
+    TURN --> PROVIDER
+    PROVIDER --> XAI
+    PROVIDER --> REGISTRY
+    REGISTRY --> READ
+    REGISTRY --> SEARCH
+    REGISTRY --> EDIT
+    REGISTRY --> SHELL
+    SHELL --> SAFE
+    SAFE --> INPUT
+    INPUT --> CLIENT
+    TURN --> CLIENT
+```
+
+## Phased Delivery
+
+### Phase 1
+
+Extend protocol and session state to represent tool-bearing replay and notifications without breaking the existing app-server surface.
+
+### Phase 2
+
+Implement the local tool registry and the read-only repository tools, centered on ripgrep-backed search.
+
+### Phase 3
+
+Add mutation tools and shell safety, then wire the full Grok Responses tool loop.
+
+### Phase 4
+
+Lock the behavior down with deterministic contract tests and a live-gated tool-loop smoke test.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend protocol and replay state for tool-bearing turns**
+
+**Goal:** Make `agent-core` capable of representing shell commands and explicit tool calls as durable app-server items instead of flattening everything into assistant text.
+
+**Requirements:** R16-R22
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/agent-core/src/app-server/protocol.ts`
+- Modify: `packages/agent-core/src/app-server/session-state.ts`
+- Modify: `packages/agent-core/src/app-server/turn-runner.ts`
+- Modify: `packages/agent-core/src/app-server/review-runner.ts`
+- Modify: `packages/agent-core/src/app-server/compaction-runner.ts`
+- Test: `packages/agent-core/src/__tests__/session-state.test.ts`
+- Test: `packages/agent-core/src/__tests__/codex-tool-progress.test.ts`
+
+**Approach:**
+- Add structured item types for command execution and dynamic tool calls, keeping the current lightweight app-server protocol rather than importing Codex v2 wholesale.
+- Extend thread replay to preserve structured items alongside user and assistant text so later prompts, review, and compaction can see the same local history.
+- Make specialized runners persist their output the same way ordinary turns do, so replay does not diverge from provider chaining.
+
+**Patterns to follow:**
+- `packages/agent-core/src/app-server/turn-runner.ts`
+- `/Users/huntharo/github/codex/codex-rs/app-server-protocol/src/protocol/v2.rs`
+
+**Test scenarios:**
+- Happy path: a completed dynamic tool call is visible in `thread/read` after the turn completes.
+- Happy path: a completed shell command is visible in `thread/read` with its status and summarized output.
+- Edge case: cancelled tool-bearing turns do not leave orphaned active-run state.
+- Edge case: `review/start` and `thread/compact/start` append their final output to replay just like ordinary turns.
+- Error path: failed tool calls emit failed items and preserve enough replay state for debugging without marking the whole thread unreadable.
+
+**Verification:**
+- `thread/read` reflects the tool-bearing turn history needed by later phases.
+
+- [ ] **Unit 2: Add a local tool contract and registry**
+
+**Goal:** Create one internal place where model-visible tools are declared, validated, executed, and mapped back into provider and app-server events.
+
+**Requirements:** R20-R22
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `packages/agent-core/src/tools/tool-contract.ts`
+- Create: `packages/agent-core/src/tools/tool-registry.ts`
+- Create: `packages/agent-core/src/tools/tool-execution.ts`
+- Create: `packages/agent-core/src/tools/tool-errors.ts`
+- Modify: `packages/agent-core/src/providers/provider-contract.ts`
+- Test: `packages/agent-core/src/__tests__/tool-registry.test.ts`
+
+**Approach:**
+- Define a normalized tool spec format that can describe input schema, read-only versus mutating behavior, approval requirements, and result rendering.
+- Keep the registry small and explicit so the initial Grok tool loop remains predictable.
+- Extend the provider contract so a provider can emit started and completed tool items without knowing the underlying tool implementation details.
+
+**Patterns to follow:**
+- `/Users/huntharo/github/grok-cli/src/grok/tools.ts`
+- `packages/agent-core/src/providers/provider-contract.ts`
+
+**Test scenarios:**
+- Happy path: the registry exposes the expected initial tool names and schemas.
+- Happy path: a valid tool invocation returns normalized output and metadata suitable for provider/app-server events.
+- Edge case: invalid arguments fail before execution with stable error text.
+- Error path: requesting an unknown tool returns a deterministic error and does not crash the turn loop.
+
+**Verification:**
+- Provider code can request a tool by name without importing the tool implementation directly.
+
+- [ ] **Unit 3: Implement read-only repository tools with ripgrep-first search**
+
+**Goal:** Give the model stable, high-signal tools for reading files, listing files, and searching repository contents without forcing it to synthesize shell every time.
+
+**Requirements:** R20-R22
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `packages/agent-core/src/tools/read-file-tool.ts`
+- Create: `packages/agent-core/src/tools/list-files-tool.ts`
+- Create: `packages/agent-core/src/tools/search-code-tool.ts`
+- Modify: `packages/agent-core/src/tools/tool-registry.ts`
+- Test: `packages/agent-core/src/__tests__/read-file-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/list-files-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/search-code-tool.test.ts`
+
+**Approach:**
+- Implement `read_file` with stable line-numbered output and path resolution relative to thread `cwd`.
+- Implement `list_files` with `rg --files` when available and a deterministic filesystem fallback when it is not.
+- Implement `search_code` as a ripgrep-first content search tool with bounded output, file paths, line numbers, and a clear distinction between no matches and execution failure.
+- Respect ignore files by default and keep output size bounded so tool results remain useful as model context.
+
+**Patterns to follow:**
+- `/Users/huntharo/github/grok-cli/src/tools/file.ts`
+- `/Users/huntharo/github/codex/codex-rs/shell-command/src/command_safety/is_safe_command.rs`
+
+**Test scenarios:**
+- Happy path: `read_file` returns numbered lines for a requested range.
+- Happy path: `list_files` returns repository-relative paths for a nested workspace.
+- Happy path: `search_code` returns filename, line number, and matched text for a unique identifier found via `rg`.
+- Edge case: searching with no matches returns a successful empty result instead of a thrown error.
+- Edge case: binary files and unreadable paths are skipped or reported cleanly.
+- Error path: a missing target file or unreadable path returns actionable tool output.
+
+**Verification:**
+- The model has dedicated repository exploration tools and no longer needs shell for every read-only operation.
+
+- [ ] **Unit 4: Add mutation tools and shell safety with approval policy**
+
+**Goal:** Support durable edits and shell execution while preserving guarded behavior and transparent approvals.
+
+**Requirements:** R16-R19, R20-R22
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Create: `packages/agent-core/src/tools/write-file-tool.ts`
+- Create: `packages/agent-core/src/tools/edit-file-tool.ts`
+- Create: `packages/agent-core/src/tools/shell-command-tool.ts`
+- Create: `packages/agent-core/src/tools/shell-safety.ts`
+- Modify: `packages/agent-core/src/tools/tool-registry.ts`
+- Modify: `packages/agent-core/src/app-server/pending-input.ts`
+- Modify: `packages/agent-core/src/app-server/turn-runner.ts`
+- Test: `packages/agent-core/src/__tests__/write-file-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/edit-file-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/shell-safety.test.ts`
+- Test: `packages/agent-core/src/__tests__/shell-command-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/pending-input.test.ts`
+
+**Approach:**
+- Add durable file mutation tools for the common edit cases Grok CLI already handles explicitly.
+- Implement a right-sized shell safety classifier based on the Codex allowlist: safe read-only commands auto-run, while mutating or ambiguous commands go through approval.
+- Explicitly treat unsafe ripgrep flags like `--pre`, `--hostname-bin`, `--search-zip`, and `-z` as non-safe.
+- Ensure cancellation clears queued pending-input work so stale approval requests cannot outlive a cancelled turn.
+
+**Patterns to follow:**
+- `/Users/huntharo/github/grok-cli/src/tools/bash.ts`
+- `/Users/huntharo/github/grok-cli/src/tools/file.ts`
+- `/Users/huntharo/github/codex/codex-rs/shell-command/src/command_safety/is_safe_command.rs`
+
+**Test scenarios:**
+- Happy path: `write_file` creates a new file and returns a concise success result.
+- Happy path: `edit_file` rejects non-unique edit anchors and succeeds on a unique replacement.
+- Happy path: a safe shell read command such as `rg foo src` or `git status` runs without approval.
+- Edge case: a shell command with unsafe ripgrep flags requests approval instead of auto-running.
+- Edge case: cancellation while approvals are queued leaves no stray pending-input requests behind.
+- Error path: a declined approval produces a completed tool item with a clear decline outcome and no side effects.
+
+**Verification:**
+- Guarded tool execution is observable, cancellable, and aligned with the current app-server approval flow.
+
+- [ ] **Unit 5: Wire the Grok Responses tool loop**
+
+**Goal:** Teach the Grok provider to advertise tools to xAI, execute tool calls locally, and continue the conversation until the provider reaches a terminal assistant response.
+
+**Requirements:** R20-R22
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `packages/agent-core/src/providers/grok-provider.ts`
+- Modify: `packages/agent-core/src/providers/xai-responses-client.ts`
+- Modify: `packages/agent-core/src/providers/response-normalizer.ts`
+- Modify: `packages/agent-core/src/providers/provider-contract.ts`
+- Create: `packages/agent-core/src/providers/responses-tool-loop.ts`
+- Modify: `packages/agent-core/src/testing/xai-fixtures.ts`
+- Test: `packages/agent-core/src/__tests__/grok-provider-tools.test.ts`
+- Test: `packages/agent-core/src/__tests__/xai-response-normalizer.test.ts`
+
+**Approach:**
+- Extend xAI request shaping so tool definitions are included in the Responses payload.
+- Parse tool-call responses from xAI, execute the matching local tool, and submit tool outputs back into the next response round using `previous_response_id`.
+- Emit provider events for tool start, tool completion, approvals, and final assistant output through the existing subscription interface.
+- Keep a round limit so malformed tool loops fail deterministically instead of spinning forever.
+
+**Patterns to follow:**
+- `/Users/huntharo/github/grok-cli/src/agent/agent.ts`
+- `packages/agent-core/src/providers/grok-provider.ts`
+
+**Test scenarios:**
+- Happy path: a single tool call followed by a final assistant response completes in two provider rounds.
+- Happy path: multiple tool calls in one turn produce ordered started and completed events.
+- Edge case: tool output is chained through `previousResponseId` rather than replaying the full transcript every round.
+- Edge case: tool schema and argument parsing errors become failed tool items rather than crashing the provider.
+- Error path: hitting the max tool round limit yields a failed turn with clear error text.
+
+**Verification:**
+- A Grok turn can perform at least one real repository tool call before producing final assistant text.
+
+- [ ] **Unit 6: Lock down app-server compatibility and live coverage for tool-bearing turns**
+
+**Goal:** Prove that the new tool runtime works through the public app-server surface and in the real xAI-backed live path.
+
+**Requirements:** R16-R22
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts`
+- Modify: `packages/agent-core/src/__tests__/review-start.test.ts`
+- Modify: `packages/agent-core/src/__tests__/thread-compaction.test.ts`
+- Modify: `packages/agent-core/src/__tests__/grok-live.test.ts`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `README.md`
+
+**Approach:**
+- Expand deterministic compatibility sequences so they assert tool-bearing notifications and replay behavior, not just plain text turns.
+- Add a narrow live smoke that creates a temporary workspace, asks the model to find a unique string via repository tools, and asserts that the final answer reflects the search result.
+- Reuse the existing `live-agent-core` job and `XAI_API_KEY` secret instead of creating a second live-test path.
+- Document the local expectations so contributors know that `packages/agent-core/.env.local` remains the local override and CI uses the existing secret-backed job.
+
+**Patterns to follow:**
+- `packages/agent-core/src/__tests__/grok-live.test.ts`
+- `.github/workflows/ci.yml`
+
+**Test scenarios:**
+- Happy path: a public app-server turn emits `item/started` and `item/completed` for a repository search before `turn/completed`.
+- Happy path: `thread/read` after a tool-bearing turn shows both replay text and structured tool history.
+- Edge case: review and compaction over a tool-bearing thread see the updated local replay rather than stale pre-tool state.
+- Edge case: live smoke skips cleanly when no xAI credentials are available locally.
+- Error path: live tool smoke fails loudly when the model never uses the provided repository tools or returns an inconsistent result.
+
+**Verification:**
+- The feature is covered end to end through both deterministic tests and the existing secret-backed live CI lane.
+
+## System-Wide Impact
+
+- `packages/agent-core` moves from a text-only provider shell toward an actual coding runtime.
+- `thread/read`, review, and compaction become more trustworthy because local replay will include tool-bearing state, not just assistant prose.
+- Approval behavior becomes meaningfully observable through the existing app-server request flow instead of being deferred until later.
+- The live xAI coverage becomes more valuable because it will exercise tool usage, not just plain prompt-response turns.
+
+## Risks and Mitigations
+
+- **Risk:** xAI tool-call payloads differ from the assumptions borrowed from Grok CLI.
+  **Mitigation:** isolate parsing in `response-normalizer.ts` and fixture it heavily before live testing.
+
+- **Risk:** unbounded search or shell output bloats model context and replay.
+  **Mitigation:** enforce output limits and truncate with explicit markers.
+
+- **Risk:** approvals and cancellation race each other, leaving stale queued requests.
+  **Mitigation:** clear queued pending-input requests on cancel and test that path directly.
+
+- **Risk:** shell safety rules become either too loose or too strict.
+  **Mitigation:** start with a narrow, Codex-inspired allowlist and widen only when concrete use cases demand it.
+
+- **Risk:** replay changes break current OpenClaw-style consumers.
+  **Mitigation:** extend the existing compatibility tests rather than relying on internal-only unit coverage.
+
+## Recommended Execution Posture
+
+Characterization-first for the provider and replay layers, then test-first for each new tool and approval rule. The tricky part here is not code volume; it is making sure tool calls, replay state, and app-server notifications all describe the same turn consistently.

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -352,7 +352,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 **Verification:**
 - Guarded tool execution is observable, cancellable, and aligned with the current app-server approval flow.
 
-- [ ] **Unit 5: Wire the Grok Responses tool loop**
+- [x] **Unit 5: Wire the Grok Responses tool loop**
 
 **Goal:** Teach the Grok provider to advertise tools to xAI, execute tool calls locally, and continue the conversation until the provider reaches a terminal assistant response.
 

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -200,7 +200,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend protocol and replay state for tool-bearing turns**
+- [x] **Unit 1: Extend protocol and replay state for tool-bearing turns**
 
 **Goal:** Make `agent-core` capable of representing shell commands and explicit tool calls as durable app-server items instead of flattening everything into assistant text.
 

--- a/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
+++ b/docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md
@@ -390,7 +390,7 @@ Lock the behavior down with deterministic contract tests and a live-gated tool-l
 **Verification:**
 - A Grok turn can perform at least one real repository tool call before producing final assistant text.
 
-- [ ] **Unit 6: Lock down app-server compatibility and live coverage for tool-bearing turns**
+- [x] **Unit 6: Lock down app-server compatibility and live coverage for tool-bearing turns**
 
 **Goal:** Prove that the new tool runtime works through the public app-server surface and in the real xAI-backed live path.
 

--- a/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
@@ -162,6 +162,22 @@ describe("Codex app-server contract", () => {
         { role: "user", text: "Ship it" },
         { role: "assistant", text: "Done." },
       ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Ship it",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Done.",
+        },
+      ],
       lastUserMessage: "Ship it",
       lastAssistantMessage: "Done.",
     });

--- a/packages/agent-core/src/__tests__/codex-tool-progress.test.ts
+++ b/packages/agent-core/src/__tests__/codex-tool-progress.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
+
+async function flushAsync(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("Codex tool-bearing replay", () => {
+  it("persists provider item progress into thread replay", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Search the repository." }],
+    });
+
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "search_code",
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_completed",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "Found 3 matches",
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "I found the references.",
+      providerResponseId: "resp_tool_1",
+    });
+    await flushAsync();
+
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+
+    expect(replay).toEqual({
+      threadId: "thread-1",
+      thread: expect.objectContaining({
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+      }),
+      messages: [
+        { role: "user", text: "Search the repository." },
+        { role: "assistant", text: "I found the references." },
+      ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Search the repository.",
+        },
+        {
+          id: "tool-1",
+          type: "dynamicToolCall",
+          status: "completed",
+          text: "Found 3 matches",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "I found the references.",
+        },
+      ],
+      lastUserMessage: "Search the repository.",
+      lastAssistantMessage: "I found the references.",
+    });
+  });
+
+  it("accumulates plan deltas into replay items before completion", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Plan the update." }],
+    });
+
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "plan-1",
+        type: "plan",
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_plan_delta",
+      itemId: "plan-1",
+      delta: "- inspect code\n",
+    });
+    await provider.runs[0]?.emit({
+      type: "item_plan_delta",
+      itemId: "plan-1",
+      delta: "- update tests\n",
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "Plan ready.",
+      providerResponseId: "resp_plan_1",
+    });
+    await flushAsync();
+
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+
+    expect(replay).toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            id: "plan-1",
+            type: "plan",
+            status: "in_progress",
+            text: "- inspect code\n- update tests\n",
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/packages/agent-core/src/__tests__/edit-file-tool.test.ts
+++ b/packages/agent-core/src/__tests__/edit-file-tool.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEditFileTool } from "../tools/edit-file-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("edit_file tool", () => {
+  it("rejects non-unique edit anchors", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "demo.ts"),
+      "const value = 1;\nconst value = 2;\n",
+      "utf8",
+    );
+    const tool = createEditFileTool();
+
+    await expect(
+      tool.execute(
+        tool.parseArguments({
+          path: "src/demo.ts",
+          oldString: "const value",
+          newString: "const answer",
+        }),
+        { cwd: workspace.path, approvalPolicy: "never" },
+      ),
+    ).rejects.toThrow(/oldString is not unique/);
+  });
+
+  it("edits a unique anchor after approval", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "demo.ts"),
+      "const value = 1;\n",
+      "utf8",
+    );
+    const tool = createEditFileTool();
+    const requestApproval = vi.fn(async () => ({ decision: "approve" }));
+
+    const result = await tool.execute(
+      tool.parseArguments({
+        path: "src/demo.ts",
+        oldString: "const value = 1;",
+        newString: "",
+      }),
+      {
+        cwd: workspace.path,
+        approvalPolicy: "on-request",
+        requestApproval,
+      },
+    );
+
+    expect(await fs.readFile(path.join(workspace.path, "src", "demo.ts"), "utf8")).toBe("\n");
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "fileChange",
+        path: "src/demo.ts",
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      output: "Edited src/demo.ts.",
+      data: {
+        path: "src/demo.ts",
+        replacements: 1,
+      },
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { CodexAppServer } from "../app-server/codex-app-server.js";
 import type { AppServerNotification } from "../app-server/protocol.js";
 import { GrokProvider } from "../providers/grok-provider.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
 import { loadLocalEnv } from "../testing/load-local-env.js";
 
 const envResult = loadLocalEnv({ override: true });
@@ -243,6 +246,90 @@ describe("Grok live smoke", () => {
           itemId: compaction.itemId,
         },
       });
+    },
+  );
+
+  itLive(
+    "uses repository tools against a temporary workspace and reports the discovered marker",
+    { timeout: 90_000 },
+    async () => {
+      const workspace = await createTemporaryTestDirectory();
+      try {
+        await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+        const marker = `tool-${Date.now().toString(36)}`;
+        await fs.writeFile(
+          path.join(workspace.path, "src", "marker.ts"),
+          `export const TOOL_TARGET = "${marker}";\n`,
+          "utf8",
+        );
+
+        const { notifications, server } = createLiveServer();
+        await server.request("thread/start", {
+          cwd: workspace.path,
+          model: grokModel,
+        });
+
+        const turn = (await server.request("turn/start", {
+          threadId: "thread-live",
+          input: [
+            {
+              type: "text",
+              text:
+                "Use the repository tools to inspect this workspace and find the exact string value assigned to TOOL_TARGET in src/marker.ts. Reply with the value only.",
+            },
+          ],
+        })) as { threadId: string; runId: string };
+
+        const startedTool = await waitForNotification(
+          notifications,
+          (notification) =>
+            notification.method === "item/started" &&
+            notification.params.runId === turn.runId &&
+            notification.params.item.type === "dynamicToolCall" &&
+            ["read_file", "search_code", "list_files"].includes(
+              notification.params.item.toolName ?? "",
+            ),
+          `tool item/started for ${turn.runId}`,
+        );
+        const completedTool = await waitForNotification(
+          notifications,
+          (notification) =>
+            notification.method === "item/completed" &&
+            notification.params.runId === turn.runId &&
+            notification.params.item.type === "dynamicToolCall" &&
+            notification.params.item.success === true &&
+            ["read_file", "search_code", "list_files"].includes(
+              notification.params.item.toolName ?? "",
+            ),
+          `tool item/completed for ${turn.runId}`,
+        );
+        const completedTurn = await waitForNotification(
+          notifications,
+          (notification) =>
+            notification.method === "turn/completed" &&
+            notification.params.runId === turn.runId,
+          `turn/completed for ${turn.runId}`,
+        );
+
+        expect(startedTool.method).toBe("item/started");
+        expect(completedTool.method).toBe("item/completed");
+        expect(completedOutput(completedTurn)).toContain(marker);
+
+        const replay = await server.request("thread/read", { threadId: "thread-live" });
+        expect((replay as { lastAssistantMessage?: string }).lastAssistantMessage).toContain(
+          marker,
+        );
+        expect((replay as { items?: Array<{ toolName?: string; success?: boolean }> }).items).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              toolName: expect.stringMatching(/^(read_file|search_code|list_files)$/),
+              success: true,
+            }),
+          ]),
+        );
+      } finally {
+        await workspace.cleanup();
+      }
     },
   );
 });

--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -38,6 +38,14 @@ async function waitForNotification(
 ): Promise<AppServerNotification> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < liveNotificationTimeoutMs) {
+    const failed = notifications.find(
+      (notification) => notification.method === "turn/failed",
+    );
+    if (failed?.method === "turn/failed") {
+      throw new Error(
+        `Received turn/failed while waiting for ${description}: ${failed.params.turn.error?.message ?? "unknown error"}`,
+      );
+    }
     const match = notifications.find((notification) => predicate(notification));
     if (match) {
       return match;
@@ -93,7 +101,7 @@ describe("Grok live smoke", () => {
         input: [
           {
             type: "text",
-            text: `Reply with this token and no explanation: ${marker}`,
+            text: `Reply with this token exactly. Do not use any tools or inspect the workspace. No explanation: ${marker}`,
           },
         ],
       })) as { threadId: string; runId: string };
@@ -127,7 +135,7 @@ describe("Grok live smoke", () => {
         input: [
           {
             type: "text",
-            text: "What token did you just return? Reply with the token only.",
+            text: "What token did you just return? Reply with the token only. Do not use any tools.",
           },
         ],
       })) as { threadId: string; runId: string };
@@ -145,7 +153,8 @@ describe("Grok live smoke", () => {
       const replay = await server.request("thread/read", { threadId: "thread-live" });
       expect(replay).toMatchObject({
         threadId: "thread-live",
-        lastUserMessage: "What token did you just return? Reply with the token only.",
+        lastUserMessage:
+          "What token did you just return? Reply with the token only. Do not use any tools.",
       });
       expect((replay as { lastAssistantMessage?: string }).lastAssistantMessage).toContain(marker);
     },

--- a/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it, vi } from "vitest";
+import { GrokProvider } from "../providers/grok-provider.js";
+import type {
+  ProviderTurnEvent,
+  ProviderTurnEventListener,
+} from "../providers/provider-contract.js";
+import { createShellCommandTool } from "../tools/shell-command-tool.js";
+import { LocalToolExecutor } from "../tools/tool-execution.js";
+import type {
+  ToolDescriptor,
+  ToolExecutionContext,
+  ToolExecutor,
+  ToolInvocation,
+} from "../tools/tool-contract.js";
+import { ToolRegistry } from "../tools/tool-registry.js";
+import {
+  makeXaiFunctionCallResponse,
+  makeXaiResponse,
+} from "../testing/xai-fixtures.js";
+
+function createFetchSequence(responses: unknown[]) {
+  let index = 0;
+  return vi.fn(async (_url: string, init?: RequestInit) => ({
+    ok: true,
+    json: async () => responses[index++],
+    text: async () => JSON.stringify({ body: init?.body ?? null }),
+  }));
+}
+
+function parseRequestBodies(fetchImpl: ReturnType<typeof createFetchSequence>) {
+  return fetchImpl.mock.calls.map(([, init]) =>
+    JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+  );
+}
+
+function collectSubscribedEvents(
+  subscribe: ProviderActiveTurnLike["subscribe"],
+  onRequestInput?: (event: Extract<ProviderTurnEvent, { type: "request_input" }>) => void,
+) {
+  const events: ProviderTurnEvent[] = [];
+  const unsubscribe = subscribe?.(async (event) => {
+    events.push(event);
+    if (event.type === "request_input") {
+      onRequestInput?.(event);
+    }
+  });
+  return { events, unsubscribe };
+}
+
+type ProviderActiveTurnLike = {
+  subscribe?: (listener: ProviderTurnEventListener) => () => void;
+};
+
+function createStubToolExecutor(): {
+  executor: ToolExecutor;
+  calls: Array<{ invocation: ToolInvocation; context: ToolExecutionContext }>;
+} {
+  const calls: Array<{ invocation: ToolInvocation; context: ToolExecutionContext }> = [];
+  const tools: ToolDescriptor[] = [
+    {
+      name: "search_code",
+      description: "Search the repository for code matches.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          query: {
+            type: "string" as const,
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      readOnly: true,
+    },
+    {
+      name: "list_files",
+      description: "List files in the repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: {
+            type: "string" as const,
+          },
+        },
+        additionalProperties: false,
+      },
+      readOnly: true,
+    },
+  ];
+
+  return {
+    calls,
+    executor: {
+      listTools: () => tools,
+      getTool: (name) => tools.find((tool) => tool.name === name),
+      executeTool: async (invocation, context) => {
+        calls.push({ invocation, context });
+        if (invocation.name === "search_code") {
+          return {
+            toolName: "search_code",
+            arguments: invocation.arguments ?? {},
+            success: true,
+            output: `Found ${(invocation.arguments?.query as string) ?? "query"}.`,
+            data: { matches: 1 },
+            commandAction: "search",
+            item: {
+              type: "dynamicToolCall",
+              text: `Found ${(invocation.arguments?.query as string) ?? "query"}.`,
+              toolName: "search_code",
+              success: true,
+              arguments: invocation.arguments ?? {},
+              commandAction: "search",
+            },
+          };
+        }
+        return {
+          toolName: "list_files",
+          arguments: invocation.arguments ?? {},
+          success: true,
+          output: "Listed files.",
+          data: { count: 2 },
+          commandAction: "listFiles",
+          item: {
+            type: "dynamicToolCall",
+            text: "Listed files.",
+            toolName: "list_files",
+            success: true,
+            arguments: invocation.arguments ?? {},
+            commandAction: "listFiles",
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("GrokProvider tool loop", () => {
+  it("continues with function_call_output and previous_response_id after a tool call", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_tool_1",
+        calls: [
+          {
+            callId: "call_search",
+            name: "search_code",
+            argumentsText: JSON.stringify({ query: "needle" }),
+          },
+        ],
+      }),
+      makeXaiResponse({ id: "resp_final_1", text: "Needle located." }),
+    ]);
+    const { executor, calls } = createStubToolExecutor();
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+        approvalPolicy: "never",
+        sandbox: "workspace-write",
+      },
+      input: [{ type: "text", text: "Find the needle." }],
+      tools: executor,
+    });
+    const { events } = collectSubscribedEvents(activeTurn.subscribe);
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Needle located.",
+      providerResponseId: "resp_final_1",
+    });
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        invocation: {
+          name: "search_code",
+          arguments: { query: "needle" },
+        },
+      }),
+    ]);
+    expect(events).toEqual([
+      {
+        type: "item_started",
+        item: {
+          id: "call_search",
+          type: "dynamicToolCall",
+          text: "search_code",
+          toolName: "search_code",
+          arguments: { query: "needle" },
+          command: undefined,
+        },
+      },
+      {
+        type: "item_completed",
+        item: {
+          id: "call_search",
+          type: "dynamicToolCall",
+          text: "Found needle.",
+          toolName: "search_code",
+          success: true,
+          arguments: { query: "needle" },
+          commandAction: "search",
+          command: undefined,
+        },
+      },
+    ]);
+
+    expect(parseRequestBodies(fetchImpl)).toEqual([
+      {
+        model: "grok-4.20-reasoning",
+        input: [{ role: "user", content: [{ type: "input_text", text: "Find the needle." }] }],
+        tools: [
+          {
+            type: "function",
+            name: "search_code",
+            description: "Search the repository for code matches.",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+              required: ["query"],
+              additionalProperties: false,
+            },
+          },
+          {
+            type: "function",
+            name: "list_files",
+            description: "List files in the repository.",
+            parameters: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+              },
+              additionalProperties: false,
+            },
+          },
+        ],
+        stream: false,
+      },
+      {
+        model: "grok-4.20-reasoning",
+        input: [
+          {
+            type: "function_call_output",
+            call_id: "call_search",
+            output:
+              "{\"toolName\":\"search_code\",\"success\":true,\"output\":\"Found needle.\",\"data\":{\"matches\":1},\"errorCode\":null}",
+          },
+        ],
+        previous_response_id: "resp_tool_1",
+        tools: [
+          {
+            type: "function",
+            name: "search_code",
+            description: "Search the repository for code matches.",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+              required: ["query"],
+              additionalProperties: false,
+            },
+          },
+          {
+            type: "function",
+            name: "list_files",
+            description: "List files in the repository.",
+            parameters: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+              },
+              additionalProperties: false,
+            },
+          },
+        ],
+        stream: false,
+      },
+    ]);
+  });
+
+  it("emits multiple tool calls in order before producing the final assistant output", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_tool_batch",
+        calls: [
+          {
+            callId: "call_search",
+            name: "search_code",
+            argumentsText: JSON.stringify({ query: "alpha" }),
+          },
+          {
+            callId: "call_list",
+            name: "list_files",
+            argumentsText: JSON.stringify({ path: "src" }),
+          },
+        ],
+      }),
+      makeXaiResponse({ id: "resp_final_batch", text: "Done." }),
+    ]);
+    const { executor } = createStubToolExecutor();
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Inspect the repo." }],
+      tools: executor,
+    });
+    const { events } = collectSubscribedEvents(activeTurn.subscribe);
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Done.",
+      providerResponseId: "resp_final_batch",
+    });
+
+    expect(
+      events.map((event) => {
+        if (event.type === "request_input") {
+          return `${event.type}:${event.requestId}`;
+        }
+        if (event.type === "item_started" || event.type === "item_completed") {
+          return `${event.type}:${event.item.id}`;
+        }
+        return event.type;
+      }),
+    ).toEqual([
+      "item_started:call_search",
+      "item_completed:call_search",
+      "item_started:call_list",
+      "item_completed:call_list",
+    ]);
+  });
+
+  it("routes approval requests through provider events before completing the tool call", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_shell_1",
+        calls: [
+          {
+            callId: "call_shell",
+            name: "shell_command",
+            argumentsText: JSON.stringify({ command: "touch created.txt" }),
+          },
+        ],
+      }),
+      makeXaiResponse({ id: "resp_shell_final", text: "Shell step complete." }),
+    ]);
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const executor = new LocalToolExecutor(new ToolRegistry([createShellCommandTool()]));
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+      },
+      input: [{ type: "text", text: "Touch a file." }],
+      tools: executor,
+    });
+    const { events } = collectSubscribedEvents(activeTurn.subscribe, (event) => {
+      void event.respond({ decision: "decline" });
+    });
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Shell step complete.",
+      providerResponseId: "resp_shell_final",
+    });
+
+    expect(events).toEqual([
+      {
+        type: "item_started",
+        item: {
+          id: "call_shell",
+          type: "commandExecution",
+          text: "shell_command",
+          toolName: "shell_command",
+          arguments: { command: "touch created.txt" },
+          command: "touch created.txt",
+        },
+      },
+      {
+        type: "request_input",
+        requestId: expect.stringMatching(/^shell_command-/),
+        method: "turn/requestApproval",
+        params: {
+          kind: "commandExecution",
+          reason: "command requires approval: touch",
+          path: undefined,
+          command: "touch created.txt",
+          commandAction: "unknown",
+        },
+        respond: expect.any(Function),
+      },
+      {
+        type: "item_completed",
+        item: {
+          id: "call_shell",
+          type: "commandExecution",
+          text: "Approval declined for shell_command: touch created.txt",
+          toolName: "shell_command",
+          success: false,
+          arguments: { command: "touch created.txt" },
+          commandAction: "unknown",
+          command: "touch created.txt",
+        },
+      },
+    ]);
+  });
+
+  it("turns malformed tool arguments into a failed tool item instead of crashing", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_bad_args",
+        calls: [
+          {
+            callId: "call_bad",
+            name: "search_code",
+            argumentsText: "{",
+          },
+        ],
+      }),
+      makeXaiResponse({ id: "resp_bad_args_final", text: "Recovered." }),
+    ]);
+    const { executor, calls } = createStubToolExecutor();
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Run the tool." }],
+      tools: executor,
+    });
+    const { events } = collectSubscribedEvents(activeTurn.subscribe);
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Recovered.",
+      providerResponseId: "resp_bad_args_final",
+    });
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([
+      {
+        type: "item_started",
+        item: {
+          id: "call_bad",
+          type: "dynamicToolCall",
+          text: "search_code",
+          toolName: "search_code",
+          arguments: undefined,
+          command: undefined,
+        },
+      },
+      {
+        type: "item_completed",
+        item: {
+          id: "call_bad",
+          type: "dynamicToolCall",
+          text: expect.stringMatching(/arguments must be valid JSON/),
+          toolName: "search_code",
+          success: false,
+          arguments: {},
+          command: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("fails deterministically when the tool loop exceeds the configured round limit", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_round_1",
+        calls: [
+          {
+            callId: "call_1",
+            name: "search_code",
+            argumentsText: JSON.stringify({ query: "first" }),
+          },
+        ],
+      }),
+      makeXaiFunctionCallResponse({
+        id: "resp_round_2",
+        calls: [
+          {
+            callId: "call_2",
+            name: "search_code",
+            argumentsText: JSON.stringify({ query: "second" }),
+          },
+        ],
+      }),
+    ]);
+    const { executor } = createStubToolExecutor();
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      maxToolRounds: 1,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Loop forever." }],
+      tools: executor,
+    });
+
+    await expect(activeTurn.result).rejects.toThrow(
+      "Grok tool loop exceeded the maximum round limit (1)",
+    );
+  });
+});

--- a/packages/agent-core/src/__tests__/list-files-tool.test.ts
+++ b/packages/agent-core/src/__tests__/list-files-tool.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createListFilesTool } from "../tools/list-files-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("list_files tool", () => {
+  it("returns repository-relative paths for a nested workspace scope", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src", "nested"), { recursive: true });
+    await fs.writeFile(path.join(workspace.path, "src", "app.ts"), "export {};\n", "utf8");
+    await fs.writeFile(path.join(workspace.path, "src", "nested", "util.ts"), "export {};\n", "utf8");
+    const tool = createListFilesTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ path: "src", limit: 10 }),
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output: "src/app.ts\nsrc/nested/util.ts",
+      data: {
+        path: "src",
+        files: ["src/app.ts", "src/nested/util.ts"],
+        truncated: false,
+      },
+      commandAction: "listFiles",
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
+++ b/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
@@ -79,6 +79,148 @@ function buildThreadStartPayloads(workspaceDir: string, model?: string): unknown
 }
 
 describe("OpenClaw compatibility sequences", () => {
+  it("emits tool-bearing notifications and replay through the public turn surface", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    const client = createTransport(server);
+
+    await server.request("thread/start", {
+      cwd: "/repo/workspace",
+      model: "grok-4.20-reasoning",
+    });
+
+    const startedTurn = await requestWithFallbacks({
+      client,
+      methods: ["turn/start"],
+      payloads: [
+        {
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Find the Grok tool usage plan." }],
+        },
+      ],
+    });
+
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "search_code",
+        toolName: "search_code",
+        arguments: { query: "tool usage" },
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_completed",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "Found docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md.",
+        toolName: "search_code",
+        success: true,
+        arguments: { query: "tool usage" },
+        commandAction: "search",
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "I found the plan document.",
+      providerResponseId: "resp_tool_turn_1",
+    });
+    await flushAsync();
+
+    const replay = await requestWithFallbacks({
+      client,
+      methods: ["thread/read"],
+      payloads: [{ threadId: "thread-1", includeTurns: true }],
+    });
+
+    expect(startedTurn).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(notifications).toEqual([
+      {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "dynamicToolCall",
+            text: "search_code",
+            toolName: "search_code",
+            arguments: { query: "tool usage" },
+          },
+        },
+      },
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "dynamicToolCall",
+            text: "Found docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md.",
+            toolName: "search_code",
+            success: true,
+            arguments: { query: "tool usage" },
+            commandAction: "search",
+          },
+        },
+      },
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "I found the plan document." }],
+          },
+        },
+      },
+    ]);
+    expect(replay).toEqual({
+      threadId: "thread-1",
+      thread: expect.objectContaining({
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      }),
+      messages: [
+        { role: "user", text: "Find the Grok tool usage plan." },
+        { role: "assistant", text: "I found the plan document." },
+      ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Find the Grok tool usage plan.",
+        },
+        {
+          id: "tool-1",
+          type: "dynamicToolCall",
+          status: "completed",
+          text: "Found docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md.",
+          toolName: "search_code",
+          success: true,
+          arguments: { query: "tool usage" },
+          commandAction: "search",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "I found the plan document.",
+        },
+      ],
+      lastUserMessage: "Find the Grok tool usage plan.",
+      lastAssistantMessage: "I found the plan document.",
+    });
+  });
+
   it("supports OpenClaw-style startup, turn start, and thread replay", async () => {
     const provider = new FakeProvider();
     const { server, notifications } = createTestHarness({ provider });

--- a/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
+++ b/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
@@ -10,6 +10,7 @@ async function flushAsync(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function createTransport(
@@ -177,6 +178,22 @@ describe("OpenClaw compatibility sequences", () => {
       messages: [
         { role: "user", text: "Ship the Grok app server." },
         { role: "assistant", text: "Shipped." },
+      ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Ship the Grok app server.",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Shipped.",
+        },
       ],
       lastUserMessage: "Ship the Grok app server.",
       lastAssistantMessage: "Shipped.",

--- a/packages/agent-core/src/__tests__/pending-input.test.ts
+++ b/packages/agent-core/src/__tests__/pending-input.test.ts
@@ -202,4 +202,83 @@ describe("Codex pending input", () => {
       },
     ]);
   });
+
+  it("cancels queued interactive requests when interruption happens mid-flight", async () => {
+    const provider = new FakeProvider();
+    const neverResolve = new Deferred<unknown>();
+    const { server, notifications } = createTestHarness({
+      provider,
+      requestHandler: async () => await neverResolve.promise,
+    });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Queue multiple approvals" }],
+    });
+
+    await provider.runs[0]?.emit({
+      type: "request_input",
+      requestId: "req-4",
+      method: "turn/requestApproval",
+      params: {
+        prompt: "Approve the first action?",
+      },
+      respond: async () => {
+        return;
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "request_input",
+      requestId: "req-5",
+      method: "turn/requestApproval",
+      params: {
+        prompt: "Approve the second action?",
+      },
+      respond: async () => {
+        return;
+      },
+    });
+    await flushAsync();
+
+    await server.request("turn/interrupt", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await flushAsync();
+
+    expect(provider.runs[0]?.eventResponses).toEqual([
+      { decision: "cancel" },
+      { decision: "cancel" },
+    ]);
+    expect(notifications).toEqual([
+      {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          requestId: "req-4",
+        },
+      },
+      {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          requestId: "req-5",
+        },
+      },
+      {
+        method: "turn/cancelled",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "cancelled",
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/packages/agent-core/src/__tests__/read-file-tool.test.ts
+++ b/packages/agent-core/src/__tests__/read-file-tool.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createReadFileTool } from "../tools/read-file-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("read_file tool", () => {
+  it("returns numbered lines for a requested range", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "demo.ts"),
+      ["alpha", "beta", "gamma", "delta"].join("\n"),
+      "utf8",
+    );
+    const tool = createReadFileTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ path: "src/demo.ts", startLine: 2, endLine: 3 }),
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output: "src/demo.ts\n2: beta\n3: gamma",
+      data: {
+        path: "src/demo.ts",
+        startLine: 2,
+        endLine: 3,
+        totalLines: 4,
+        truncated: true,
+      },
+      commandAction: "read",
+    });
+  });
+
+  it("returns actionable output for missing files", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createReadFileTool();
+
+    await expect(
+      tool.execute(tool.parseArguments({ path: "src/missing.ts" }), {
+        cwd: workspace.path,
+      }),
+    ).rejects.toThrow(
+      /read_file failed: unable to read src\/missing\.ts:/,
+    );
+  });
+});

--- a/packages/agent-core/src/__tests__/review-start.test.ts
+++ b/packages/agent-core/src/__tests__/review-start.test.ts
@@ -5,6 +5,7 @@ async function flushAsync(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("Codex review start", () => {
@@ -68,6 +69,11 @@ describe("Codex review start", () => {
     });
     await flushAsync();
 
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+
     expect(notifications).toEqual([
       {
         method: "item/completed",
@@ -90,6 +96,117 @@ describe("Codex review start", () => {
             id: "turn-2",
             status: "completed",
             output: [{ type: "text", text: "Looks good overall." }],
+          },
+        },
+      },
+    ]);
+    expect(replay).toEqual({
+      threadId: "thread-1",
+      thread: expect.objectContaining({
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+      }),
+      messages: [
+        { role: "user", text: "Please review the current diff." },
+        { role: "assistant", text: "Ready to review." },
+        { role: "assistant", text: "Looks good overall." },
+      ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Please review the current diff.",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Ready to review.",
+        },
+        {
+          id: "turn-2-item",
+          type: "exitedReviewMode",
+          status: "completed",
+          review: "Looks good overall.",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Looks good overall.",
+        },
+      ],
+      lastUserMessage: "Please review the current diff.",
+      lastAssistantMessage: "Looks good overall.",
+    });
+  });
+
+  it("routes interactive review requests through the client before completing", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({
+      provider,
+      requestHandler: async () => ({ decision: "approve" }),
+    });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("review/start", {
+      threadId: "thread-1",
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+    });
+
+    await provider.runs[0]?.emit({
+      type: "request_input",
+      requestId: "review-req-1",
+      method: "review/requestApproval",
+      params: {
+        prompt: "Approve this review check?",
+      },
+      respond: async () => {
+        return;
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "Review complete.",
+      providerResponseId: "resp_review_approval",
+    });
+    await flushAsync();
+
+    expect(provider.runs[0]?.eventResponses).toEqual([{ decision: "approve" }]);
+    expect(notifications).toEqual([
+      {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          requestId: "review-req-1",
+        },
+      },
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          item: {
+            id: "turn-1-item",
+            type: "exitedReviewMode",
+            review: "Review complete.",
+          },
+        },
+      },
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Review complete." }],
           },
         },
       },
@@ -137,6 +254,7 @@ describe("Codex review start", () => {
         cwd: "/repo/workspace",
       }),
       messages: [],
+      items: [],
       lastUserMessage: undefined,
       lastAssistantMessage: undefined,
     });

--- a/packages/agent-core/src/__tests__/review-start.test.ts
+++ b/packages/agent-core/src/__tests__/review-start.test.ts
@@ -213,6 +213,87 @@ describe("Codex review start", () => {
     ]);
   });
 
+  it("builds review context from a prior tool-bearing turn replay", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", {
+      cwd: "/repo/workspace",
+      model: "grok-4.20-reasoning",
+    });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Search for the Grok tool usage plan." }],
+    });
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "search_code",
+        toolName: "search_code",
+        arguments: { query: "tool usage plan" },
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_completed",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "Found docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md.",
+        toolName: "search_code",
+        success: true,
+        arguments: { query: "tool usage plan" },
+        commandAction: "search",
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "I found the tool usage plan.",
+      providerResponseId: "resp_turn_1",
+    });
+    await flushAsync();
+
+    await server.request("review/start", {
+      threadId: "thread-1",
+      target: {
+        type: "uncommittedChanges",
+      },
+      delivery: "inline",
+    });
+
+    expect(provider.runs[1]?.previousResponseId).toBe("resp_turn_1");
+    expect(provider.runs[1]?.input).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("USER: Search for the Grok tool usage plan."),
+      },
+    ]);
+    expect(provider.runs[1]?.input[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("ASSISTANT: I found the tool usage plan."),
+    });
+
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+    expect(replay).toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            id: "tool-1",
+            type: "dynamicToolCall",
+            status: "completed",
+            toolName: "search_code",
+            success: true,
+            commandAction: "search",
+          }),
+        ]),
+        lastAssistantMessage: "I found the tool usage plan.",
+      }),
+    );
+  });
+
   it("emits a failed turn when the provider review run rejects", async () => {
     const provider = new FakeProvider();
     const { server, notifications } = createTestHarness({ provider });

--- a/packages/agent-core/src/__tests__/search-code-tool.test.ts
+++ b/packages/agent-core/src/__tests__/search-code-tool.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSearchCodeTool } from "../tools/search-code-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("search_code tool", () => {
+  it("returns filename, line number, and matching text for a unique identifier", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "app.ts"),
+      "const UNIQUE_MARKER_42 = true;\nexport { UNIQUE_MARKER_42 };\n",
+      "utf8",
+    );
+    const tool = createSearchCodeTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ query: "UNIQUE_MARKER_42", fixedStrings: true }),
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output: "src/app.ts:1: const UNIQUE_MARKER_42 = true;\nsrc/app.ts:2: export { UNIQUE_MARKER_42 };",
+      data: {
+        query: "UNIQUE_MARKER_42",
+        path: ".",
+        matches: [
+          {
+            path: "src/app.ts",
+            line: 1,
+            text: "const UNIQUE_MARKER_42 = true;",
+          },
+          {
+            path: "src/app.ts",
+            line: 2,
+            text: "export { UNIQUE_MARKER_42 };",
+          },
+        ],
+        truncated: false,
+      },
+      commandAction: "search",
+    });
+  });
+
+  it("returns a successful empty result when there are no matches", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(path.join(workspace.path, "src", "app.ts"), "export const hello = true;\n", "utf8");
+    const tool = createSearchCodeTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ query: "NO_SUCH_MARKER", fixedStrings: true }),
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output: 'No matches found for "NO_SUCH_MARKER" in workspace.',
+      data: {
+        query: "NO_SUCH_MARKER",
+        path: ".",
+        matches: [],
+      },
+      commandAction: "search",
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/session-state.test.ts
+++ b/packages/agent-core/src/__tests__/session-state.test.ts
@@ -68,6 +68,22 @@ describe("AppServerSessionState", () => {
         { role: "user", text: "Ship it" },
         { role: "assistant", text: "Done." },
       ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Ship it",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Done.",
+        },
+      ],
       lastUserMessage: "Ship it",
       lastAssistantMessage: "Done.",
     });

--- a/packages/agent-core/src/__tests__/shell-command-tool.test.ts
+++ b/packages/agent-core/src/__tests__/shell-command-tool.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createShellCommandTool } from "../tools/shell-command-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("shell_command tool", () => {
+  it("runs a safe shell read command without approval", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.writeFile(path.join(workspace.path, "needle.txt"), "SAFE_NEEDLE\n", "utf8");
+    const tool = createShellCommandTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ command: "rg -n SAFE_NEEDLE ." }),
+      { cwd: workspace.path, approvalPolicy: "on-request" },
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        commandAction: "search",
+        itemType: "commandExecution",
+        command: "rg -n SAFE_NEEDLE .",
+      }),
+    );
+    expect(result.output).toContain("needle.txt:1:SAFE_NEEDLE");
+  });
+
+  it("requests approval for unsafe commands and does not run when declined", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createShellCommandTool();
+    const requestApproval = vi.fn(async () => ({ decision: "decline" }));
+
+    const result = await tool.execute(
+      tool.parseArguments({ command: "touch created.txt" }),
+      {
+        cwd: workspace.path,
+        approvalPolicy: "on-request",
+        requestApproval,
+      },
+    );
+
+    await expect(fs.stat(path.join(workspace.path, "created.txt"))).rejects.toThrow();
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "commandExecution",
+        command: "touch created.txt",
+      }),
+    );
+    expect(result).toEqual({
+      success: false,
+      output: "Approval declined for shell_command: touch created.txt",
+      commandAction: "unknown",
+      itemType: "commandExecution",
+      command: "touch created.txt",
+    });
+  });
+
+  it("runs an approved unsafe command and applies the side effect", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createShellCommandTool();
+    const requestApproval = vi.fn(async () => ({ decision: "approve" }));
+
+    const result = await tool.execute(
+      tool.parseArguments({ command: "touch created.txt" }),
+      {
+        cwd: workspace.path,
+        approvalPolicy: "on-request",
+        requestApproval,
+      },
+    );
+
+    await expect(fs.stat(path.join(workspace.path, "created.txt"))).resolves.toBeTruthy();
+    expect(result).toEqual({
+      success: true,
+      output: "Command executed successfully (no output).",
+      data: {
+        exitCode: 0,
+      },
+      commandAction: "unknown",
+      itemType: "commandExecution",
+      command: "touch created.txt",
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/shell-safety.test.ts
+++ b/packages/agent-core/src/__tests__/shell-safety.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { classifyShellCommand, splitShellWords } from "../tools/shell-safety.js";
+
+describe("shell safety", () => {
+  it("classifies safe read-only commands", () => {
+    expect(classifyShellCommand("rg UNIQUE src")).toEqual({
+      safe: true,
+      commandAction: "search",
+    });
+    expect(classifyShellCommand("git status --short")).toEqual({
+      safe: true,
+      commandAction: "unknown",
+    });
+  });
+
+  it("requires approval for unsafe ripgrep flags and mutating git commands", () => {
+    expect(classifyShellCommand("rg --search-zip UNIQUE src")).toEqual({
+      safe: false,
+      commandAction: "search",
+      reason: "ripgrep flag requires approval: --search-zip",
+    });
+    expect(classifyShellCommand("rg --pre cat UNIQUE src")).toEqual({
+      safe: false,
+      commandAction: "search",
+      reason: "ripgrep flag requires approval: --pre",
+    });
+    expect(classifyShellCommand("git push")).toEqual({
+      safe: false,
+      commandAction: "unknown",
+      reason: "mutating or unknown git commands require approval",
+    });
+  });
+
+  it("treats shell metacharacters as requiring approval", () => {
+    expect(classifyShellCommand("git status | wc -l")).toEqual({
+      safe: false,
+      commandAction: "unknown",
+      reason: "shell metacharacters require approval",
+    });
+  });
+
+  it("splits shell words while respecting quoted segments", () => {
+    expect(splitShellWords('rg "hello world" src')).toEqual([
+      "rg",
+      "hello world",
+      "src",
+    ]);
+  });
+});

--- a/packages/agent-core/src/__tests__/thread-compaction.test.ts
+++ b/packages/agent-core/src/__tests__/thread-compaction.test.ts
@@ -5,6 +5,7 @@ async function flushAsync(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("Codex thread compaction", () => {
@@ -69,6 +70,11 @@ describe("Codex thread compaction", () => {
     });
     await flushAsync();
 
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+
     expect(notifications).toEqual([
       {
         method: "item/started",
@@ -101,6 +107,49 @@ describe("Codex thread compaction", () => {
         },
       },
     ]);
+    expect(replay).toEqual({
+      threadId: "thread-1",
+      thread: expect.objectContaining({
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+      }),
+      messages: [
+        { role: "user", text: "Investigate the Grok app server." },
+        { role: "assistant", text: "I investigated the Grok app server." },
+        { role: "assistant", text: "Compact summary" },
+      ],
+      items: [
+        {
+          id: expect.any(String),
+          type: "userMessage",
+          status: "completed",
+          role: "user",
+          text: "Investigate the Grok app server.",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "I investigated the Grok app server.",
+        },
+        {
+          id: "turn-2-item",
+          type: "contextCompaction",
+          status: "completed",
+          text: "Compact summary",
+        },
+        {
+          id: expect.any(String),
+          type: "agentMessage",
+          status: "completed",
+          role: "assistant",
+          text: "Compact summary",
+        },
+      ],
+      lastUserMessage: "Investigate the Grok app server.",
+      lastAssistantMessage: "Compact summary",
+    });
   });
 
   it("compacts an otherwise empty thread deterministically", async () => {
@@ -214,8 +263,87 @@ describe("Codex thread compaction", () => {
         cwd: "/repo/workspace",
       }),
       messages: [],
+      items: [
+        {
+          id: "turn-1-item",
+          type: "contextCompaction",
+          status: "failed",
+        },
+      ],
       lastUserMessage: undefined,
       lastAssistantMessage: undefined,
     });
+  });
+
+  it("routes interactive compaction requests through the client before finishing", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({
+      provider,
+      requestHandler: async () => ({ decision: "approve" }),
+    });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("thread/compact/start", {
+      threadId: "thread-1",
+    });
+
+    await provider.runs[0]?.emit({
+      type: "request_input",
+      requestId: "compact-req-1",
+      method: "thread/requestCompactionApproval",
+      params: {
+        prompt: "Approve this compaction step?",
+      },
+      respond: async () => {
+        return;
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "Compaction approved.",
+      providerResponseId: "resp_compact_approval",
+    });
+    await flushAsync();
+
+    expect(provider.runs[0]?.eventResponses).toEqual([{ decision: "approve" }]);
+    expect(notifications).toEqual([
+      {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          item: {
+            id: "turn-1-item",
+            type: "contextCompaction",
+          },
+        },
+      },
+      {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          requestId: "compact-req-1",
+        },
+      },
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          item: {
+            id: "turn-1-item",
+            type: "contextCompaction",
+            text: "Compaction approved.",
+          },
+        },
+      },
+      {
+        method: "thread/compacted",
+        params: {
+          threadId: "thread-1",
+          itemId: "turn-1-item",
+        },
+      },
+    ]);
   });
 });

--- a/packages/agent-core/src/__tests__/thread-compaction.test.ts
+++ b/packages/agent-core/src/__tests__/thread-compaction.test.ts
@@ -346,4 +346,78 @@ describe("Codex thread compaction", () => {
       },
     ]);
   });
+
+  it("compacts a tool-bearing thread using the updated local replay", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Find the Grok tool usage plan." }],
+    });
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "search_code",
+        toolName: "search_code",
+        arguments: { query: "tool usage plan" },
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_completed",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "Found docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md.",
+        toolName: "search_code",
+        success: true,
+        arguments: { query: "tool usage plan" },
+        commandAction: "search",
+      },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "I found the tool usage plan.",
+      providerResponseId: "resp_turn_1",
+    });
+    await flushAsync();
+
+    await server.request("thread/compact/start", {
+      threadId: "thread-1",
+    });
+
+    expect(provider.runs[1]?.previousResponseId).toBe("resp_turn_1");
+    expect(provider.runs[1]?.input).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("USER: Find the Grok tool usage plan."),
+      },
+    ]);
+    expect(provider.runs[1]?.input[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("ASSISTANT: I found the tool usage plan."),
+    });
+
+    const replay = await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+    });
+    expect(replay).toEqual(
+      expect.objectContaining({
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            id: "tool-1",
+            type: "dynamicToolCall",
+            status: "completed",
+            toolName: "search_code",
+            success: true,
+            commandAction: "search",
+          }),
+        ]),
+        lastAssistantMessage: "I found the tool usage plan.",
+      }),
+    );
+  });
 });

--- a/packages/agent-core/src/__tests__/tool-registry.test.ts
+++ b/packages/agent-core/src/__tests__/tool-registry.test.ts
@@ -28,6 +28,18 @@ describe("tool registry", () => {
         name: "search_code",
         readOnly: true,
       }),
+      expect.objectContaining({
+        name: "write_file",
+        readOnly: false,
+      }),
+      expect.objectContaining({
+        name: "edit_file",
+        readOnly: false,
+      }),
+      expect.objectContaining({
+        name: "shell_command",
+        readOnly: false,
+      }),
     ]);
   });
 

--- a/packages/agent-core/src/__tests__/tool-registry.test.ts
+++ b/packages/agent-core/src/__tests__/tool-registry.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocalToolExecutor } from "../tools/tool-execution.js";
+import { createDefaultToolRegistry } from "../tools/tool-registry.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("tool registry", () => {
+  it("exposes the initial read-only tool set", () => {
+    const executor = new LocalToolExecutor(createDefaultToolRegistry());
+
+    expect(executor.listTools()).toEqual([
+      expect.objectContaining({
+        name: "read_file",
+        readOnly: true,
+      }),
+      expect.objectContaining({
+        name: "list_files",
+        readOnly: true,
+      }),
+      expect.objectContaining({
+        name: "search_code",
+        readOnly: true,
+      }),
+    ]);
+  });
+
+  it("returns normalized execution metadata for valid tool invocations", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(path.join(workspace.path, "src", "app.ts"), "export const marker = 1;\n", "utf8");
+    const executor = new LocalToolExecutor(createDefaultToolRegistry());
+
+    const result = await executor.executeTool(
+      {
+        name: "list_files",
+        arguments: { path: "src" },
+      },
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      toolName: "list_files",
+      arguments: { path: "src" },
+      success: true,
+      output: "src/app.ts",
+      data: {
+        path: "src",
+        files: ["src/app.ts"],
+        truncated: false,
+      },
+      commandAction: "listFiles",
+      item: {
+        type: "dynamicToolCall",
+        text: "src/app.ts",
+        toolName: "list_files",
+        success: true,
+        arguments: { path: "src" },
+        commandAction: "listFiles",
+      },
+    });
+  });
+
+  it("fails validation before execution with stable error text", async () => {
+    const executor = new LocalToolExecutor(createDefaultToolRegistry());
+
+    const result = await executor.executeTool(
+      {
+        name: "read_file",
+        arguments: { path: 42 },
+      },
+      { cwd: "/repo" },
+    );
+
+    expect(result).toEqual({
+      toolName: "read_file",
+      arguments: { path: 42 },
+      success: false,
+      output: 'Invalid arguments for read_file: "path" must be a non-empty string',
+      errorCode: "invalid_arguments",
+      item: {
+        type: "dynamicToolCall",
+        text: 'Invalid arguments for read_file: "path" must be a non-empty string',
+        toolName: "read_file",
+        success: false,
+        arguments: { path: 42 },
+      },
+    });
+  });
+
+  it("returns a deterministic error for unknown tools", async () => {
+    const executor = new LocalToolExecutor(createDefaultToolRegistry());
+
+    const result = await executor.executeTool(
+      {
+        name: "missing_tool",
+        arguments: { query: "x" },
+      },
+      { cwd: "/repo" },
+    );
+
+    expect(result).toEqual({
+      toolName: "missing_tool",
+      arguments: { query: "x" },
+      success: false,
+      output: "Unknown tool: missing_tool",
+      errorCode: "unknown_tool",
+      item: {
+        type: "dynamicToolCall",
+        text: "Unknown tool: missing_tool",
+        toolName: "missing_tool",
+        success: false,
+        arguments: { query: "x" },
+      },
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/write-file-tool.test.ts
+++ b/packages/agent-core/src/__tests__/write-file-tool.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWriteFileTool } from "../tools/write-file-tool.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe("write_file tool", () => {
+  it("creates a new file and returns a concise success result", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createWriteFileTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ path: "src/new-file.ts", content: "export const value = 1;\n" }),
+      { cwd: workspace.path, approvalPolicy: "never" },
+    );
+
+    expect(await fs.readFile(path.join(workspace.path, "src", "new-file.ts"), "utf8")).toBe(
+      "export const value = 1;\n",
+    );
+    expect(result).toEqual({
+      success: true,
+      output: "Created src/new-file.ts.",
+      data: {
+        path: "src/new-file.ts",
+        created: true,
+        bytes: Buffer.byteLength("export const value = 1;\n", "utf8"),
+      },
+    });
+  });
+
+  it("requests approval before mutating when policy is guarded", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createWriteFileTool();
+    const requestApproval = vi.fn(async () => ({ decision: "decline" }));
+
+    const result = await tool.execute(
+      tool.parseArguments({ path: "src/new-file.ts", content: "" }),
+      {
+        cwd: workspace.path,
+        approvalPolicy: "on-request",
+        requestApproval,
+      },
+    );
+
+    await expect(fs.stat(path.join(workspace.path, "src", "new-file.ts"))).rejects.toThrow();
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "fileChange",
+        path: "src/new-file.ts",
+      }),
+    );
+    expect(result).toEqual({
+      success: false,
+      output: "Approval declined for write_file: src/new-file.ts",
+    });
+  });
+});

--- a/packages/agent-core/src/__tests__/xai-response-normalizer.test.ts
+++ b/packages/agent-core/src/__tests__/xai-response-normalizer.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { normalizeXaiResponse } from "../providers/response-normalizer.js";
-import { makeDirectOutputResponse, makeXaiResponse } from "../testing/xai-fixtures.js";
+import {
+  normalizeXaiResponse,
+  parseNormalizedFunctionArguments,
+} from "../providers/response-normalizer.js";
+import {
+  makeDirectOutputResponse,
+  makeXaiFunctionCallResponse,
+  makeXaiResponse,
+} from "../testing/xai-fixtures.js";
 
 describe("normalizeXaiResponse", () => {
   it("prefers direct output_text when present", () => {
     expect(normalizeXaiResponse(makeDirectOutputResponse())).toEqual({
       assistantText: "Direct output",
       providerResponseId: "resp_direct",
+      functionCalls: [],
     });
   });
 
@@ -14,6 +22,7 @@ describe("normalizeXaiResponse", () => {
     expect(normalizeXaiResponse(makeXaiResponse())).toEqual({
       assistantText: "All green.",
       providerResponseId: "resp_123",
+      functionCalls: [],
     });
   });
 
@@ -26,6 +35,48 @@ describe("normalizeXaiResponse", () => {
     ).toEqual({
       assistantText: "",
       providerResponseId: "resp_empty",
+      functionCalls: [],
     });
+  });
+
+  it("collects function calls from the response output", () => {
+    expect(
+      normalizeXaiResponse(
+        makeXaiFunctionCallResponse({
+          id: "resp_tool",
+          calls: [
+            {
+              callId: "call_1",
+              name: "search_code",
+              argumentsText: JSON.stringify({ query: "needle" }),
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      assistantText: "",
+      providerResponseId: "resp_tool",
+      functionCalls: [
+        {
+          callId: "call_1",
+          name: "search_code",
+          argumentsText: "{\"query\":\"needle\"}",
+        },
+      ],
+    });
+  });
+});
+
+describe("parseNormalizedFunctionArguments", () => {
+  it("decodes object arguments", () => {
+    expect(
+      parseNormalizedFunctionArguments("search_code", "{\"query\":\"needle\"}"),
+    ).toEqual({ query: "needle" });
+  });
+
+  it("rejects malformed arguments", () => {
+    expect(() =>
+      parseNormalizedFunctionArguments("search_code", "{"),
+    ).toThrow(/arguments must be valid JSON/);
   });
 });

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -15,6 +15,8 @@ import { TurnRunner } from "./turn-runner.js";
 import { CompactionRunner } from "./compaction-runner.js";
 import { ReviewRunner } from "./review-runner.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
+import { createDefaultToolRegistry } from "../tools/tool-registry.js";
+import { LocalToolExecutor } from "../tools/tool-execution.js";
 
 type NotificationHandler = (
   notification: AppServerNotification,
@@ -66,11 +68,13 @@ export class CodexAppServer {
   private readonly turnRunner: TurnRunner;
   private readonly compactionRunner: CompactionRunner;
   private readonly reviewRunner: ReviewRunner;
+  private readonly toolExecutor: LocalToolExecutor;
   private readonly createThreadId: () => string;
   private readonly createRunId: () => string;
 
   constructor(options: ServerOptions) {
     this.provider = options.provider;
+    this.toolExecutor = new LocalToolExecutor(createDefaultToolRegistry());
     this.createThreadId = options.threadIdGenerator ?? (() => createId("thread"));
     this.createRunId = options.runIdGenerator ?? (() => createId("turn"));
     this.turnRunner = new TurnRunner({
@@ -87,6 +91,7 @@ export class CodexAppServer {
         await this.emit(notification);
       },
       turnRunner: this.turnRunner,
+      tools: this.toolExecutor,
     });
     this.reviewRunner = new ReviewRunner({
       provider: this.provider,
@@ -95,6 +100,7 @@ export class CodexAppServer {
         await this.emit(notification);
       },
       turnRunner: this.turnRunner,
+      tools: this.toolExecutor,
     });
   }
 
@@ -284,6 +290,7 @@ export class CodexAppServer {
       thread,
       input: normalizedInput,
       previousResponseId: this.state.getPreviousResponseId(threadId),
+      tools: this.toolExecutor,
     });
     const runId = this.createRunId();
     this.state.appendInput(threadId, normalizedInput);

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -86,6 +86,7 @@ export class CodexAppServer {
       emit: async (notification) => {
         await this.emit(notification);
       },
+      turnRunner: this.turnRunner,
     });
     this.reviewRunner = new ReviewRunner({
       provider: this.provider,
@@ -93,6 +94,7 @@ export class CodexAppServer {
       emit: async (notification) => {
         await this.emit(notification);
       },
+      turnRunner: this.turnRunner,
     });
   }
 

--- a/packages/agent-core/src/app-server/compaction-runner.ts
+++ b/packages/agent-core/src/app-server/compaction-runner.ts
@@ -1,22 +1,26 @@
 import type { AppServerNotification, ThreadState } from "./protocol.js";
 import { AppServerSessionState } from "./session-state.js";
+import { TurnRunner } from "./turn-runner.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
 
 type CompactionRunnerOptions = {
   provider: AppServerProvider;
   state: AppServerSessionState;
   emit: (notification: AppServerNotification) => Promise<void>;
+  turnRunner: TurnRunner;
 };
 
 export class CompactionRunner {
   private readonly provider: AppServerProvider;
   private readonly state: AppServerSessionState;
   private readonly emit: (notification: AppServerNotification) => Promise<void>;
+  private readonly turnRunner: TurnRunner;
 
   constructor(options: CompactionRunnerOptions) {
     this.provider = options.provider;
     this.state = options.state;
     this.emit = options.emit;
+    this.turnRunner = options.turnRunner;
   }
 
   async start(params: {
@@ -39,6 +43,11 @@ export class CompactionRunner {
       threadId: params.thread.threadId,
       handle,
     });
+    this.state.upsertItem(params.thread.threadId, {
+      id: params.itemId,
+      type: "contextCompaction",
+      status: "in_progress",
+    });
     await this.emit({
       method: "item/started",
       params: {
@@ -50,70 +59,71 @@ export class CompactionRunner {
         },
       },
     });
-    void this.complete(params, handle);
+    this.turnRunner.attach({
+      threadId: params.thread.threadId,
+      runId: params.runId,
+      handle,
+      onSuccess: async (result) => {
+        this.state.completeRun(params.runId);
+        this.state.upsertItem(params.thread.threadId, {
+          id: params.itemId,
+          type: "contextCompaction",
+          status: "completed",
+          text: result.assistantText,
+        });
+        this.state.appendAssistant(params.thread.threadId, result.assistantText ?? "");
+        this.state.setPreviousResponseId(
+          params.thread.threadId,
+          result.providerResponseId,
+        );
+        await this.emit({
+          method: "item/completed",
+          params: {
+            threadId: params.thread.threadId,
+            runId: params.runId,
+            item: {
+              id: params.itemId,
+              type: "contextCompaction",
+              text: result.assistantText,
+            },
+          },
+        });
+        await this.emit({
+          method: "thread/compacted",
+          params: {
+            threadId: params.thread.threadId,
+            itemId: params.itemId,
+          },
+        });
+      },
+      onError: async (error) => {
+        this.state.failRun(params.runId);
+        this.state.upsertItem(params.thread.threadId, {
+          id: params.itemId,
+          type: "contextCompaction",
+          status: "failed",
+        });
+        await this.emit({
+          method: "turn/failed",
+          params: {
+            threadId: params.thread.threadId,
+            runId: params.runId,
+            turn: {
+              id: params.runId,
+              status: "failed",
+              error: {
+                message: error instanceof Error ? error.message : String(error),
+              },
+            },
+          },
+        });
+      },
+    });
     return {
       threadId: params.thread.threadId,
       runId: params.runId,
       itemId: params.itemId,
     };
-  }
-
-  private async complete(
-    params: {
-      thread: ThreadState;
-      runId: string;
-      itemId: string;
-    },
-    handle: Awaited<ReturnType<AppServerProvider["startTurn"]>>,
-  ): Promise<void> {
-    try {
-      const result = await handle.result;
-      const run = this.state.getRun(params.runId);
-      if (!run || run.status !== "active") {
-        return;
-      }
-      this.state.completeRun(params.runId);
-      this.state.setPreviousResponseId(params.thread.threadId, result.providerResponseId);
-      await this.emit({
-        method: "item/completed",
-        params: {
-          threadId: params.thread.threadId,
-          runId: params.runId,
-          item: {
-            id: params.itemId,
-            type: "contextCompaction",
-            text: result.assistantText,
-          },
-        },
-      });
-      await this.emit({
-        method: "thread/compacted",
-        params: {
-          threadId: params.thread.threadId,
-          itemId: params.itemId,
-        },
-      });
-    } catch (error) {
-      const run = this.state.getRun(params.runId);
-      if (!run || run.status !== "active") {
-        return;
-      }
-      this.state.failRun(params.runId);
-      await this.emit({
-        method: "turn/failed",
-        params: {
-          threadId: params.thread.threadId,
-          runId: params.runId,
-          turn: {
-            id: params.runId,
-            status: "failed",
-            error: {
-              message: error instanceof Error ? error.message : String(error),
-            },
-          },
-        },
-      });
-    }
   }
 }
 

--- a/packages/agent-core/src/app-server/compaction-runner.ts
+++ b/packages/agent-core/src/app-server/compaction-runner.ts
@@ -2,12 +2,14 @@ import type { AppServerNotification, ThreadState } from "./protocol.js";
 import { AppServerSessionState } from "./session-state.js";
 import { TurnRunner } from "./turn-runner.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
+import type { ToolExecutor } from "../tools/tool-contract.js";
 
 type CompactionRunnerOptions = {
   provider: AppServerProvider;
   state: AppServerSessionState;
   emit: (notification: AppServerNotification) => Promise<void>;
   turnRunner: TurnRunner;
+  tools: ToolExecutor;
 };
 
 export class CompactionRunner {
@@ -15,12 +17,14 @@ export class CompactionRunner {
   private readonly state: AppServerSessionState;
   private readonly emit: (notification: AppServerNotification) => Promise<void>;
   private readonly turnRunner: TurnRunner;
+  private readonly tools: ToolExecutor;
 
   constructor(options: CompactionRunnerOptions) {
     this.provider = options.provider;
     this.state = options.state;
     this.emit = options.emit;
     this.turnRunner = options.turnRunner;
+    this.tools = options.tools;
   }
 
   async start(params: {
@@ -37,6 +41,7 @@ export class CompactionRunner {
         },
       ],
       previousResponseId: this.state.getPreviousResponseId(params.thread.threadId),
+      tools: this.tools,
     });
     this.state.createRun({
       runId: params.runId,

--- a/packages/agent-core/src/app-server/pending-input.ts
+++ b/packages/agent-core/src/app-server/pending-input.ts
@@ -38,15 +38,23 @@ export class PendingInputCoordinator {
   }
 
   async cancelPending(response: unknown = { decision: "cancel" }): Promise<void> {
+    const pending: PendingInputRequest[] = [];
     const active = this.currentRequest;
-    if (!active || active.settled) {
-      this.resolveIdleIfPossible();
-      return;
+    if (active && !active.settled) {
+      active.settled = true;
+      pending.push(active.request);
     }
-    active.settled = true;
-    await active.request.respond(response);
-    await this.onResolved?.(active.request.requestId);
     this.currentRequest = null;
+    while (this.queue.length > 0) {
+      const queued = this.queue.shift();
+      if (queued) {
+        pending.push(queued);
+      }
+    }
+    for (const request of pending) {
+      await request.respond(response);
+      await this.onResolved?.(request.requestId);
+    }
     this.resolveIdleIfPossible();
   }
 

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -213,6 +213,11 @@ export type AppServerNotification =
           type: string;
           text?: string;
           review?: string;
+          command?: string;
+          commandAction?: AppServerCommandAction;
+          toolName?: string;
+          success?: boolean;
+          arguments?: Record<string, unknown>;
         };
       };
     }

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -59,8 +59,35 @@ export type ThreadReplay = {
     role: AppServerRole;
     text: string;
   }>;
+  items: ThreadReplayItem[];
   lastUserMessage?: string;
   lastAssistantMessage?: string;
+};
+
+export type AppServerItemStatus =
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type AppServerCommandAction =
+  | "read"
+  | "listFiles"
+  | "search"
+  | "unknown";
+
+export type ThreadReplayItem = {
+  id: string;
+  type: string;
+  status?: AppServerItemStatus;
+  role?: AppServerRole;
+  text?: string;
+  review?: string;
+  command?: string;
+  commandAction?: AppServerCommandAction;
+  toolName?: string;
+  success?: boolean;
+  arguments?: Record<string, unknown>;
 };
 
 export type ModelSummary = {

--- a/packages/agent-core/src/app-server/review-runner.ts
+++ b/packages/agent-core/src/app-server/review-runner.ts
@@ -2,12 +2,14 @@ import type { AppServerNotification, ThreadState } from "./protocol.js";
 import { AppServerSessionState } from "./session-state.js";
 import { TurnRunner } from "./turn-runner.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
+import type { ToolExecutor } from "../tools/tool-contract.js";
 
 type ReviewRunnerOptions = {
   provider: AppServerProvider;
   state: AppServerSessionState;
   emit: (notification: AppServerNotification) => Promise<void>;
   turnRunner: TurnRunner;
+  tools: ToolExecutor;
 };
 
 export class ReviewRunner {
@@ -15,12 +17,14 @@ export class ReviewRunner {
   private readonly state: AppServerSessionState;
   private readonly emit: (notification: AppServerNotification) => Promise<void>;
   private readonly turnRunner: TurnRunner;
+  private readonly tools: ToolExecutor;
 
   constructor(options: ReviewRunnerOptions) {
     this.provider = options.provider;
     this.state = options.state;
     this.emit = options.emit;
     this.turnRunner = options.turnRunner;
+    this.tools = options.tools;
   }
 
   async start(params: {
@@ -41,6 +45,7 @@ export class ReviewRunner {
         },
       ],
       previousResponseId: this.state.getPreviousResponseId(params.thread.threadId),
+      tools: this.tools,
     });
     this.state.createRun({
       runId: params.runId,

--- a/packages/agent-core/src/app-server/review-runner.ts
+++ b/packages/agent-core/src/app-server/review-runner.ts
@@ -1,22 +1,26 @@
 import type { AppServerNotification, ThreadState } from "./protocol.js";
 import { AppServerSessionState } from "./session-state.js";
+import { TurnRunner } from "./turn-runner.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
 
 type ReviewRunnerOptions = {
   provider: AppServerProvider;
   state: AppServerSessionState;
   emit: (notification: AppServerNotification) => Promise<void>;
+  turnRunner: TurnRunner;
 };
 
 export class ReviewRunner {
   private readonly provider: AppServerProvider;
   private readonly state: AppServerSessionState;
   private readonly emit: (notification: AppServerNotification) => Promise<void>;
+  private readonly turnRunner: TurnRunner;
 
   constructor(options: ReviewRunnerOptions) {
     this.provider = options.provider;
     this.state = options.state;
     this.emit = options.emit;
+    this.turnRunner = options.turnRunner;
   }
 
   async start(params: {
@@ -43,80 +47,58 @@ export class ReviewRunner {
       threadId: params.thread.threadId,
       handle,
     });
-    void this.complete(params, handle);
+    this.turnRunner.attach({
+      threadId: params.thread.threadId,
+      runId: params.runId,
+      handle,
+      onSuccess: async (result) => {
+        this.state.completeRun(params.runId);
+        this.state.upsertItem(params.thread.threadId, {
+          id: params.itemId,
+          type: "exitedReviewMode",
+          status: "completed",
+          review: result.assistantText,
+        });
+        this.state.appendAssistant(params.thread.threadId, result.assistantText ?? "");
+        this.state.setPreviousResponseId(
+          params.thread.threadId,
+          result.providerResponseId,
+        );
+        await this.emit({
+          method: "item/completed",
+          params: {
+            threadId: params.thread.threadId,
+            runId: params.runId,
+            item: {
+              id: params.itemId,
+              type: "exitedReviewMode",
+              review: result.assistantText,
+            },
+          },
+        });
+        await this.emit({
+          method: "turn/completed",
+          params: {
+            threadId: params.thread.threadId,
+            runId: params.runId,
+            turn: {
+              id: params.runId,
+              status: "completed",
+              output: [
+                {
+                  type: "text",
+                  text: result.assistantText ?? "",
+                },
+              ],
+            },
+          },
+        });
+      },
+    });
     return {
       reviewThreadId: params.thread.threadId,
       runId: params.runId,
     };
-  }
-
-  private async complete(
-    params: {
-      thread: ThreadState;
-      runId: string;
-      itemId: string;
-      target: unknown;
-    },
-    handle: Awaited<ReturnType<AppServerProvider["startTurn"]>>,
-  ): Promise<void> {
-    try {
-      const result = await handle.result;
-      const run = this.state.getRun(params.runId);
-      if (!run || run.status !== "active") {
-        return;
-      }
-      this.state.completeRun(params.runId);
-      this.state.setPreviousResponseId(params.thread.threadId, result.providerResponseId);
-      await this.emit({
-        method: "item/completed",
-        params: {
-          threadId: params.thread.threadId,
-          runId: params.runId,
-          item: {
-            id: params.itemId,
-            type: "exitedReviewMode",
-            review: result.assistantText,
-          },
-        },
-      });
-      await this.emit({
-        method: "turn/completed",
-        params: {
-          threadId: params.thread.threadId,
-          runId: params.runId,
-          turn: {
-            id: params.runId,
-            status: "completed",
-            output: [
-              {
-                type: "text",
-                text: result.assistantText ?? "",
-              },
-            ],
-          },
-        },
-      });
-    } catch (error) {
-      const run = this.state.getRun(params.runId);
-      if (!run || run.status !== "active") {
-        return;
-      }
-      this.state.failRun(params.runId);
-      await this.emit({
-        method: "turn/failed",
-        params: {
-          threadId: params.thread.threadId,
-          runId: params.runId,
-          turn: {
-            id: params.runId,
-            status: "failed",
-            error: {
-              message: error instanceof Error ? error.message : String(error),
-            },
-          },
-        },
-      });
-    }
   }
 }
 

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -1,7 +1,9 @@
 import type {
+  AppServerItemStatus,
   AppServerRole,
   AppServerTurnInputItem,
   ThreadReplay,
+  ThreadReplayItem,
   ThreadState,
   ThreadSummary,
 } from "./protocol.js";
@@ -11,7 +13,6 @@ type StoredMessage = {
   role: AppServerRole;
   text: string;
 };
-
 type ActiveRunRecord = {
   runId: string;
   threadId: string;
@@ -35,9 +36,11 @@ type ThreadMutation = Partial<Omit<ThreadState, "threadId" | "createdAt">>;
 export class AppServerSessionState {
   private readonly threads = new Map<string, ThreadState>();
   private readonly messages = new Map<string, StoredMessage[]>();
+  private readonly items = new Map<string, ThreadReplayItem[]>();
   private readonly responseIds = new Map<string, string>();
   private readonly runs = new Map<string, ActiveRunRecord>();
   private lastTimestamp = 0;
+  private itemSequence = 0;
 
   createThread(params: CreateThreadParams): ThreadState {
     const timestamp = this.nextTimestamp();
@@ -56,6 +59,7 @@ export class AppServerSessionState {
     };
     this.threads.set(thread.threadId, thread);
     this.messages.set(thread.threadId, []);
+    this.items.set(thread.threadId, []);
     return thread;
   }
 
@@ -111,7 +115,13 @@ export class AppServerSessionState {
       this.touchThread(threadId);
       return;
     }
-    this.appendMessage(threadId, { role: "user", text });
+    this.appendMessage(threadId, { role: "user", text }, {
+      id: this.nextItemId("user"),
+      type: "userMessage",
+      status: "completed",
+      role: "user",
+      text,
+    });
   }
 
   appendAssistant(threadId: string, text: string): void {
@@ -120,13 +130,66 @@ export class AppServerSessionState {
       this.touchThread(threadId);
       return;
     }
-    this.appendMessage(threadId, { role: "assistant", text: trimmed });
+    this.appendMessage(threadId, { role: "assistant", text: trimmed }, {
+      id: this.nextItemId("assistant"),
+      type: "agentMessage",
+      status: "completed",
+      role: "assistant",
+      text: trimmed,
+    });
   }
 
-  private appendMessage(threadId: string, message: StoredMessage): void {
+  upsertItem(threadId: string, item: ThreadReplayItem): ThreadReplayItem {
+    const items = this.items.get(threadId) ?? [];
+    const normalized = normalizeReplayItem(item);
+    const index = items.findIndex((entry) => entry.id === normalized.id);
+    if (index >= 0) {
+      items[index] = {
+        ...items[index],
+        ...normalized,
+      };
+    } else {
+      items.push(normalized);
+    }
+    this.items.set(threadId, items);
+    this.touchThread(threadId);
+    return normalized;
+  }
+
+  appendItemTextDelta(
+    threadId: string,
+    itemId: string,
+    delta: string,
+    type = "plan",
+    status: AppServerItemStatus = "in_progress",
+  ): ThreadReplayItem {
+    const existing = (this.items.get(threadId) ?? []).find((item) => item.id === itemId);
+    return this.upsertItem(threadId, {
+      id: itemId,
+      type: existing?.type ?? type,
+      status: existing?.status ?? status,
+      text: `${existing?.text ?? ""}${delta}`,
+      review: existing?.review,
+      role: existing?.role,
+      command: existing?.command,
+      commandAction: existing?.commandAction,
+      toolName: existing?.toolName,
+      success: existing?.success,
+      arguments: existing?.arguments,
+    });
+  }
+
+  private appendMessage(
+    threadId: string,
+    message: StoredMessage,
+    item: ThreadReplayItem,
+  ): void {
     const messages = this.messages.get(threadId) ?? [];
     messages.push(message);
     this.messages.set(threadId, messages);
+    const items = this.items.get(threadId) ?? [];
+    items.push(item);
+    this.items.set(threadId, items);
     this.touchThread(threadId);
   }
 
@@ -136,6 +199,7 @@ export class AppServerSessionState {
       throw new Error(`Unknown thread: ${threadId}`);
     }
     const messages = [...(this.messages.get(threadId) ?? [])];
+    const items = [...(this.items.get(threadId) ?? [])];
     let lastUserMessage: string | undefined;
     let lastAssistantMessage: string | undefined;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -150,7 +214,14 @@ export class AppServerSessionState {
         break;
       }
     }
-    return { threadId, thread, messages, lastUserMessage, lastAssistantMessage };
+    return {
+      threadId,
+      thread,
+      messages,
+      items,
+      lastUserMessage,
+      lastAssistantMessage,
+    };
   }
 
   setPreviousResponseId(threadId: string, responseId: string | undefined): void {
@@ -238,4 +309,15 @@ export class AppServerSessionState {
     this.lastTimestamp = Math.max(Date.now(), this.lastTimestamp + 1);
     return this.lastTimestamp;
   }
+
+  private nextItemId(prefix: string): string {
+    this.itemSequence += 1;
+    return `${prefix}-${this.itemSequence}`;
+  }
+}
+
+function normalizeReplayItem(item: ThreadReplayItem): ThreadReplayItem {
+  return Object.fromEntries(
+    Object.entries(item).filter(([, value]) => value !== undefined),
+  ) as ThreadReplayItem;
 }

--- a/packages/agent-core/src/app-server/turn-runner.ts
+++ b/packages/agent-core/src/app-server/turn-runner.ts
@@ -1,7 +1,11 @@
 import type { AppServerNotification } from "./protocol.js";
 import { AppServerSessionState } from "./session-state.js";
 import { PendingInputCoordinator } from "./pending-input.js";
-import type { ProviderActiveTurn, ProviderTurnEvent } from "../providers/provider-contract.js";
+import type {
+  ProviderActiveTurn,
+  ProviderTurnEvent,
+  ProviderTurnResult,
+} from "../providers/provider-contract.js";
 
 type TurnRunnerOptions = {
   state: AppServerSessionState;
@@ -14,6 +18,11 @@ type ActiveExecution = {
   runId: string;
   pendingInput: PendingInputCoordinator;
   unsubscribe?: () => void;
+};
+
+type TurnRunnerCallbacks = {
+  onSuccess?: (result: ProviderTurnResult) => Promise<void>;
+  onError?: (error: unknown) => Promise<void>;
 };
 
 export class TurnRunner {
@@ -32,7 +41,7 @@ export class TurnRunner {
     threadId: string;
     runId: string;
     handle: ProviderActiveTurn;
-  }): void {
+  } & TurnRunnerCallbacks): void {
     const pendingInput = new PendingInputCoordinator({
       requestClient: this.requestClient,
       onResolved: async (requestId) => {
@@ -73,6 +82,13 @@ export class TurnRunner {
     switch (event.type) {
       case "item_started":
       case "item_completed":
+        this.state.upsertItem(execution.threadId, {
+          id: event.item.id,
+          type: event.item.type,
+          status: event.type === "item_started" ? "in_progress" : "completed",
+          text: event.item.text,
+          review: event.item.review,
+        });
         await this.emit({
           method: event.type === "item_started" ? "item/started" : "item/completed",
           params: {
@@ -88,6 +104,12 @@ export class TurnRunner {
         });
         return;
       case "item_plan_delta":
+        this.state.appendItemTextDelta(
+          execution.threadId,
+          event.itemId,
+          event.delta,
+          "plan",
+        );
         await this.emit({
           method: "item/plan/delta",
           params: {
@@ -135,7 +157,7 @@ export class TurnRunner {
       threadId: string;
       runId: string;
       handle: ProviderActiveTurn;
-    },
+    } & TurnRunnerCallbacks,
     execution: ActiveExecution,
   ): Promise<void> {
     try {
@@ -145,49 +167,73 @@ export class TurnRunner {
         return;
       }
       await execution.pendingInput.waitForIdle();
-      this.state.completeRun(params.runId);
-      this.state.appendAssistant(params.threadId, result.assistantText ?? "");
-      this.state.setPreviousResponseId(params.threadId, result.providerResponseId);
-      await this.emit({
-        method: "turn/completed",
-        params: {
-          threadId: params.threadId,
-          runId: params.runId,
-          turn: {
-            id: params.runId,
-            status: "completed",
-            output: [
-              {
-                type: "text",
-                text: result.assistantText ?? "",
-              },
-            ],
-          },
-        },
-      });
+      if (params.onSuccess) {
+        await params.onSuccess(result);
+      } else {
+        await this.completeDefaultTurn(params.threadId, params.runId, result);
+      }
     } catch (error) {
       const run = this.state.getRun(params.runId);
       if (!run || run.status !== "active") {
         return;
       }
-      this.state.failRun(params.runId);
-      await this.emit({
-        method: "turn/failed",
-        params: {
-          threadId: params.threadId,
-          runId: params.runId,
-          turn: {
-            id: params.runId,
-            status: "failed",
-            error: {
-              message: error instanceof Error ? error.message : String(error),
-            },
-          },
-        },
-      });
+      if (params.onError) {
+        await params.onError(error);
+      } else {
+        await this.failDefaultTurn(params.threadId, params.runId, error);
+      }
     } finally {
       execution.unsubscribe?.();
       this.executions.delete(params.runId);
     }
+  }
+
+  private async completeDefaultTurn(
+    threadId: string,
+    runId: string,
+    result: ProviderTurnResult,
+  ): Promise<void> {
+    this.state.completeRun(runId);
+    this.state.appendAssistant(threadId, result.assistantText ?? "");
+    this.state.setPreviousResponseId(threadId, result.providerResponseId);
+    await this.emit({
+      method: "turn/completed",
+      params: {
+        threadId,
+        runId,
+        turn: {
+          id: runId,
+          status: "completed",
+          output: [
+            {
+              type: "text",
+              text: result.assistantText ?? "",
+            },
+          ],
+        },
+      },
+    });
+  }
+
+  private async failDefaultTurn(
+    threadId: string,
+    runId: string,
+    error: unknown,
+  ): Promise<void> {
+    this.state.failRun(runId);
+    await this.emit({
+      method: "turn/failed",
+      params: {
+        threadId,
+        runId,
+        turn: {
+          id: runId,
+          status: "failed",
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+      },
+    });
   }
 }

--- a/packages/agent-core/src/app-server/turn-runner.ts
+++ b/packages/agent-core/src/app-server/turn-runner.ts
@@ -88,6 +88,11 @@ export class TurnRunner {
           status: event.type === "item_started" ? "in_progress" : "completed",
           text: event.item.text,
           review: event.item.review,
+          command: event.item.command,
+          commandAction: event.item.commandAction,
+          toolName: event.item.toolName,
+          success: event.item.success,
+          arguments: event.item.arguments,
         });
         await this.emit({
           method: event.type === "item_started" ? "item/started" : "item/completed",
@@ -99,6 +104,11 @@ export class TurnRunner {
               type: event.item.type,
               text: event.item.text,
               review: event.item.review,
+              command: event.item.command,
+              commandAction: event.item.commandAction,
+              toolName: event.item.toolName,
+              success: event.item.success,
+              arguments: event.item.arguments,
             },
           },
         });

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -17,9 +17,18 @@ export type {
 } from "./app-server/protocol.js";
 export { GrokProvider } from "./providers/grok-provider.js";
 export type { GrokProviderOptions } from "./providers/grok-provider.js";
+export { startResponsesToolLoop } from "./providers/responses-tool-loop.js";
 export { XaiResponsesClient } from "./providers/xai-responses-client.js";
 export {
+  buildFunctionCallOutputInput,
+  buildXaiFunctionTools,
+  buildXaiInput,
+  type XaiFunctionTool,
+} from "./providers/xai-responses-client.js";
+export {
   normalizeXaiResponse,
+  parseNormalizedFunctionArguments,
+  type NormalizedFunctionCall,
   type NormalizedResponseOutput,
 } from "./providers/response-normalizer.js";
 export {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -41,7 +41,12 @@ export {
   readOptionalPositiveInteger,
   readOptionalString,
   readRequiredString,
+  normalizeApprovalDecision,
+  requestToolApproval,
   type ToolDefinition,
+  type ToolApprovalDecision,
+  type ToolApprovalKind,
+  type ToolApprovalRequest,
   type ToolDescriptor,
   type ToolExecutionContext,
   type ToolExecutionOutput,
@@ -57,7 +62,11 @@ export {
   UnknownToolError,
 } from "./tools/tool-errors.js";
 export { LocalToolExecutor } from "./tools/tool-execution.js";
+export { createEditFileTool } from "./tools/edit-file-tool.js";
 export { createListFilesTool } from "./tools/list-files-tool.js";
 export { createReadFileTool } from "./tools/read-file-tool.js";
 export { createSearchCodeTool } from "./tools/search-code-tool.js";
+export { classifyShellCommand, splitShellWords, type ShellSafetyClassification } from "./tools/shell-safety.js";
+export { createShellCommandTool } from "./tools/shell-command-tool.js";
 export { createDefaultToolRegistry, ToolRegistry } from "./tools/tool-registry.js";
+export { createWriteFileTool } from "./tools/write-file-tool.js";

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -35,3 +35,29 @@ export {
   type LocalEnvLoadResult,
 } from "./testing/load-local-env.js";
 export { OverlayStore } from "./persistence/overlay-store.js";
+export {
+  asObjectArguments,
+  readOptionalBoolean,
+  readOptionalPositiveInteger,
+  readOptionalString,
+  readRequiredString,
+  type ToolDefinition,
+  type ToolDescriptor,
+  type ToolExecutionContext,
+  type ToolExecutionOutput,
+  type ToolExecutor,
+  type ToolInputSchema,
+  type ToolInputSchemaProperty,
+  type ToolInvocation,
+} from "./tools/tool-contract.js";
+export {
+  InvalidToolArgumentsError,
+  ToolError,
+  ToolExecutionFailure,
+  UnknownToolError,
+} from "./tools/tool-errors.js";
+export { LocalToolExecutor } from "./tools/tool-execution.js";
+export { createListFilesTool } from "./tools/list-files-tool.js";
+export { createReadFileTool } from "./tools/read-file-tool.js";
+export { createSearchCodeTool } from "./tools/search-code-tool.js";
+export { createDefaultToolRegistry, ToolRegistry } from "./tools/tool-registry.js";

--- a/packages/agent-core/src/providers/grok-provider.ts
+++ b/packages/agent-core/src/providers/grok-provider.ts
@@ -1,39 +1,25 @@
 import type { AppServerProvider, ProviderActiveTurn, ProviderTurnParams } from "./provider-contract.js";
-import { normalizeXaiResponse } from "./response-normalizer.js";
-import { buildXaiInput, XaiResponsesClient, type XaiResponsesClientOptions } from "./xai-responses-client.js";
+import { startResponsesToolLoop } from "./responses-tool-loop.js";
+import { XaiResponsesClient, type XaiResponsesClientOptions } from "./xai-responses-client.js";
 
-export type GrokProviderOptions = XaiResponsesClientOptions;
+export type GrokProviderOptions = XaiResponsesClientOptions & {
+  maxToolRounds?: number;
+};
 
 export class GrokProvider implements AppServerProvider {
   private readonly client: XaiResponsesClient;
+  private readonly maxToolRounds?: number;
 
   constructor(options: GrokProviderOptions) {
     this.client = new XaiResponsesClient(options);
+    this.maxToolRounds = options.maxToolRounds;
   }
 
   startTurn(params: ProviderTurnParams): ProviderActiveTurn {
-    const result = this.client
-      .createResponse({
-        model: params.thread.model,
-        input: buildXaiInput(params.input),
-        previousResponseId: params.previousResponseId,
-      })
-      .then((response) => {
-        const normalized = normalizeXaiResponse(response);
-        return {
-          assistantText: normalized.assistantText,
-          providerResponseId: normalized.providerResponseId,
-        };
-      });
-
-    return {
-      result,
-      steer: async () => {
-        throw new Error("GrokProvider does not support steering active turns yet");
-      },
-      interrupt: async () => {
-        return;
-      },
-    };
+    return startResponsesToolLoop({
+      client: this.client,
+      params,
+      maxToolRounds: this.maxToolRounds,
+    });
   }
 }

--- a/packages/agent-core/src/providers/provider-contract.ts
+++ b/packages/agent-core/src/providers/provider-contract.ts
@@ -1,9 +1,15 @@
-import type { AppServerTurnInputItem, ThreadState } from "../app-server/protocol.js";
+import type {
+  AppServerCommandAction,
+  AppServerTurnInputItem,
+  ThreadState,
+} from "../app-server/protocol.js";
+import type { ToolExecutor } from "../tools/tool-contract.js";
 
 export type ProviderTurnParams = {
   thread: ThreadState;
   input: AppServerTurnInputItem[];
   previousResponseId?: string;
+  tools?: ToolExecutor;
 };
 
 export type ProviderSteerParams = {
@@ -30,6 +36,11 @@ export type ProviderTurnEvent =
         type: string;
         text?: string;
         review?: string;
+        command?: string;
+        commandAction?: AppServerCommandAction;
+        toolName?: string;
+        success?: boolean;
+        arguments?: Record<string, unknown>;
       };
     }
   | {

--- a/packages/agent-core/src/providers/response-normalizer.ts
+++ b/packages/agent-core/src/providers/response-normalizer.ts
@@ -1,6 +1,15 @@
+import { InvalidToolArgumentsError } from "../tools/tool-errors.js";
+
+export type NormalizedFunctionCall = {
+  callId: string;
+  name: string;
+  argumentsText: string;
+};
+
 export type NormalizedResponseOutput = {
   assistantText: string;
   providerResponseId?: string;
+  functionCalls: NormalizedFunctionCall[];
 };
 
 export function normalizeXaiResponse(response: unknown): NormalizedResponseOutput {
@@ -11,6 +20,7 @@ export function normalizeXaiResponse(response: unknown): NormalizedResponseOutpu
     return {
       assistantText: directOutputText,
       providerResponseId,
+      functionCalls: collectFunctionCalls(record),
     };
   }
 
@@ -31,7 +41,52 @@ export function normalizeXaiResponse(response: unknown): NormalizedResponseOutpu
   return {
     assistantText: chunks.join("\n").trim(),
     providerResponseId,
+    functionCalls: collectFunctionCalls(record),
   };
+}
+
+export function parseNormalizedFunctionArguments(
+  toolName: string,
+  argumentsText: string,
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(argumentsText);
+  } catch (error) {
+    throw new InvalidToolArgumentsError(
+      toolName,
+      `arguments must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new InvalidToolArgumentsError(toolName, "arguments must decode to an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function collectFunctionCalls(
+  record: Record<string, unknown>,
+): NormalizedFunctionCall[] {
+  const output = Array.isArray(record.output) ? record.output : [];
+  const functionCalls: NormalizedFunctionCall[] = [];
+  for (const item of output) {
+    const itemRecord = asRecord(item);
+    if (itemRecord.type !== "function_call") {
+      continue;
+    }
+    const callId = readString(itemRecord, ["call_id"]);
+    const name = readString(itemRecord, ["name"]);
+    const argumentsText = readString(itemRecord, ["arguments"]);
+    if (!callId || !name) {
+      continue;
+    }
+    functionCalls.push({
+      callId,
+      name,
+      argumentsText: argumentsText ?? "{}",
+    });
+  }
+  return functionCalls;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/packages/agent-core/src/providers/responses-tool-loop.ts
+++ b/packages/agent-core/src/providers/responses-tool-loop.ts
@@ -1,0 +1,331 @@
+import type { ThreadState } from "../app-server/protocol.js";
+import type {
+  AppServerProvider,
+  ProviderActiveTurn,
+  ProviderTurnEvent,
+  ProviderTurnEventListener,
+  ProviderTurnParams,
+  ProviderTurnResult,
+} from "./provider-contract.js";
+import {
+  normalizeXaiResponse,
+  parseNormalizedFunctionArguments,
+  type NormalizedFunctionCall,
+} from "./response-normalizer.js";
+import {
+  buildFunctionCallOutputInput,
+  buildXaiFunctionTools,
+  buildXaiInput,
+  type XaiResponsesClient,
+} from "./xai-responses-client.js";
+import type {
+  ToolApprovalRequest,
+  ToolExecutionContext,
+  ToolExecutor,
+} from "../tools/tool-contract.js";
+import { ToolError } from "../tools/tool-errors.js";
+
+const DEFAULT_MAX_TOOL_ROUNDS = 12;
+
+type StartResponsesToolLoopOptions = {
+  client: XaiResponsesClient;
+  params: ProviderTurnParams;
+  maxToolRounds?: number;
+};
+
+type ToolExecutionResult = Awaited<ReturnType<ToolExecutor["executeTool"]>>;
+type ProviderItemEventItem = Extract<
+  ProviderTurnEvent,
+  { type: "item_started" | "item_completed" }
+>["item"];
+
+export function startResponsesToolLoop(
+  options: StartResponsesToolLoopOptions,
+): ProviderActiveTurn {
+  const listeners = new Set<ProviderTurnEventListener>();
+  const abortController = new AbortController();
+
+  const emit = async (event: ProviderTurnEvent): Promise<void> => {
+    for (const listener of [...listeners]) {
+      await listener(event);
+    }
+  };
+
+  return {
+    result: runResponsesToolLoop({
+      client: options.client,
+      params: options.params,
+      maxToolRounds: options.maxToolRounds ?? DEFAULT_MAX_TOOL_ROUNDS,
+      signal: abortController.signal,
+      emit,
+      hasListeners: () => listeners.size > 0,
+    }),
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    steer: async () => {
+      throw new Error("GrokProvider does not support steering active turns yet");
+    },
+    interrupt: async () => {
+      abortController.abort();
+    },
+  };
+}
+
+async function runResponsesToolLoop(params: {
+  client: XaiResponsesClient;
+  params: ProviderTurnParams;
+  maxToolRounds: number;
+  signal: AbortSignal;
+  emit: (event: ProviderTurnEvent) => Promise<void>;
+  hasListeners: () => boolean;
+}): Promise<ProviderTurnResult> {
+  const tools = params.params.tools?.listTools() ?? [];
+  const xaiTools = tools.length > 0 ? buildXaiFunctionTools(tools) : undefined;
+  let response = await params.client.createResponse({
+    model: params.params.thread.model,
+    input: buildXaiInput(params.params.input),
+    previousResponseId: params.params.previousResponseId,
+    tools: xaiTools,
+    signal: params.signal,
+  });
+
+  for (let round = 0; ; round += 1) {
+    throwIfAborted(params.signal);
+    const normalized = normalizeXaiResponse(response);
+    if (normalized.functionCalls.length === 0) {
+      return {
+        assistantText: normalized.assistantText,
+        providerResponseId: normalized.providerResponseId,
+      };
+    }
+    if (round >= params.maxToolRounds) {
+      throw new Error(
+        `Grok tool loop exceeded the maximum round limit (${params.maxToolRounds})`,
+      );
+    }
+    if (!normalized.providerResponseId) {
+      throw new Error("Grok tool loop requires a response id before continuing");
+    }
+
+    const toolOutputs: Array<Record<string, unknown>> = [];
+    for (const functionCall of normalized.functionCalls) {
+      const startedItem = buildStartedItem(functionCall);
+      await params.emit({
+        type: "item_started",
+        item: startedItem,
+      });
+
+      const execution = await executeFunctionCall({
+        functionCall,
+        thread: params.params.thread,
+        tools: params.params.tools,
+        signal: params.signal,
+        emit: params.emit,
+        hasListeners: params.hasListeners,
+      });
+
+      await params.emit({
+        type: "item_completed",
+        item: {
+          id: functionCall.callId,
+          type: execution.item.type,
+          text: execution.item.text,
+          command: execution.item.command,
+          commandAction: execution.item.commandAction,
+          toolName: execution.toolName,
+          success: execution.success,
+          arguments: execution.arguments,
+        },
+      });
+
+      toolOutputs.push(
+        buildFunctionCallOutputInput(
+          functionCall.callId,
+          JSON.stringify({
+            toolName: execution.toolName,
+            success: execution.success,
+            output: execution.output,
+            data: execution.data ?? null,
+            errorCode: execution.errorCode ?? null,
+          }),
+        ),
+      );
+    }
+
+    response = await params.client.createResponse({
+      model: params.params.thread.model,
+      input: toolOutputs,
+      previousResponseId: normalized.providerResponseId,
+      tools: xaiTools,
+      signal: params.signal,
+    });
+  }
+}
+
+async function executeFunctionCall(params: {
+  functionCall: NormalizedFunctionCall;
+  thread: ThreadState;
+  tools?: ToolExecutor;
+  signal: AbortSignal;
+  emit: (event: ProviderTurnEvent) => Promise<void>;
+  hasListeners: () => boolean;
+}): Promise<ToolExecutionResult> {
+  const parsedArguments = tryParseFunctionArguments(
+    params.functionCall.name,
+    params.functionCall.argumentsText,
+  );
+
+  if (parsedArguments instanceof ToolError) {
+    return {
+      toolName: params.functionCall.name,
+      arguments: {},
+      success: false,
+      output: parsedArguments.message,
+      errorCode: parsedArguments.code,
+      item: {
+        type: itemTypeForToolName(params.functionCall.name),
+        text: parsedArguments.message,
+        toolName: params.functionCall.name,
+        success: false,
+        arguments: {},
+        command: extractCommand(undefined),
+      },
+    };
+  }
+
+  if (!params.tools) {
+    const error = new ToolError(
+      "tool_executor_missing",
+      `No local tool executor is available for ${params.functionCall.name}`,
+    );
+    return {
+      toolName: params.functionCall.name,
+      arguments: parsedArguments,
+      success: false,
+      output: error.message,
+      errorCode: error.code,
+      item: {
+        type: itemTypeForToolName(params.functionCall.name),
+        text: error.message,
+        toolName: params.functionCall.name,
+        success: false,
+        arguments: parsedArguments,
+        command: extractCommand(parsedArguments),
+      },
+    };
+  }
+
+  const executionContext: ToolExecutionContext = {
+    cwd: params.thread.cwd,
+    threadId: params.thread.threadId,
+    approvalPolicy: params.thread.approvalPolicy,
+    sandbox: params.thread.sandbox,
+    signal: params.signal,
+    requestApproval: async (request) =>
+      await requestToolApprovalFromProvider({
+        request,
+        emit: params.emit,
+        hasListeners: params.hasListeners,
+        signal: params.signal,
+      }),
+  };
+
+  return await params.tools.executeTool(
+    {
+      name: params.functionCall.name,
+      arguments: parsedArguments,
+    },
+    executionContext,
+  );
+}
+
+function buildStartedItem(functionCall: NormalizedFunctionCall): ProviderItemEventItem {
+  const parsedArguments = tryParseFunctionArguments(
+    functionCall.name,
+    functionCall.argumentsText,
+  );
+  const arguments_ = parsedArguments instanceof ToolError ? undefined : parsedArguments;
+  return {
+    id: functionCall.callId,
+    type: itemTypeForToolName(functionCall.name),
+    text: functionCall.name,
+    toolName: functionCall.name,
+    arguments: arguments_,
+    command: extractCommand(arguments_),
+  };
+}
+
+async function requestToolApprovalFromProvider(params: {
+  request: ToolApprovalRequest;
+  emit: (event: ProviderTurnEvent) => Promise<void>;
+  hasListeners: () => boolean;
+  signal: AbortSignal;
+}): Promise<unknown> {
+  if (params.signal.aborted || !params.hasListeners()) {
+    return { decision: "decline" };
+  }
+  return await new Promise<unknown>((resolve) => {
+    let settled = false;
+    const finish = (response: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      params.signal.removeEventListener("abort", onAbort);
+      resolve(response);
+    };
+    const onAbort = () => finish({ decision: "cancel" });
+    params.signal.addEventListener("abort", onAbort, { once: true });
+    void params.emit({
+      type: "request_input",
+      requestId: params.request.requestId,
+      method: "turn/requestApproval",
+      params: {
+        kind: params.request.kind,
+        reason: params.request.reason,
+        path: params.request.path,
+        command: params.request.command,
+        commandAction: params.request.commandAction,
+      },
+      respond: async (response) => {
+        finish(response);
+      },
+    });
+  });
+}
+
+function tryParseFunctionArguments(
+  toolName: string,
+  argumentsText: string,
+): Record<string, unknown> | ToolError {
+  try {
+    return parseNormalizedFunctionArguments(toolName, argumentsText);
+  } catch (error) {
+    return error instanceof ToolError
+      ? error
+      : new ToolError(
+          "tool_arguments_invalid",
+          `${toolName} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+  }
+}
+
+function itemTypeForToolName(toolName: string): "dynamicToolCall" | "commandExecution" {
+  return toolName === "shell_command" ? "commandExecution" : "dynamicToolCall";
+}
+
+function extractCommand(
+  arguments_: Record<string, unknown> | undefined,
+): string | undefined {
+  return typeof arguments_?.command === "string" ? arguments_.command : undefined;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new Error("Grok turn was interrupted");
+  }
+}

--- a/packages/agent-core/src/providers/xai-responses-client.ts
+++ b/packages/agent-core/src/providers/xai-responses-client.ts
@@ -1,4 +1,5 @@
 import type { AppServerTurnInputItem } from "../app-server/protocol.js";
+import type { ToolDescriptor } from "../tools/tool-contract.js";
 
 export type XaiResponsesClientOptions = {
   apiKey: string;
@@ -11,6 +12,16 @@ export type XaiResponseCreateRequest = {
   model?: string;
   input: Array<Record<string, unknown>>;
   previousResponseId?: string;
+  tools?: XaiFunctionTool[];
+  parallelToolCalls?: boolean;
+  signal?: AbortSignal;
+};
+
+export type XaiFunctionTool = {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
 };
 
 export class XaiResponsesClient {
@@ -36,6 +47,10 @@ export class XaiResponsesClient {
       ...(params.previousResponseId
         ? { previous_response_id: params.previousResponseId }
         : {}),
+      ...(params.tools?.length ? { tools: params.tools } : {}),
+      ...(typeof params.parallelToolCalls === "boolean"
+        ? { parallel_tool_calls: params.parallelToolCalls }
+        : {}),
       stream: false,
     };
   }
@@ -48,6 +63,7 @@ export class XaiResponsesClient {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(this.buildCreatePayload(params)),
+      signal: params.signal,
     });
     if (!response.ok) {
       const body = await response.text();
@@ -55,6 +71,37 @@ export class XaiResponsesClient {
     }
     return await response.json();
   }
+}
+
+export function buildXaiFunctionTools(
+  tools: ToolDescriptor[],
+): XaiFunctionTool[] {
+  return tools.map((tool) => ({
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    parameters: {
+      type: tool.inputSchema.type,
+      properties: tool.inputSchema.properties,
+      ...(tool.inputSchema.required?.length
+        ? { required: tool.inputSchema.required }
+        : {}),
+      ...(typeof tool.inputSchema.additionalProperties === "boolean"
+        ? { additionalProperties: tool.inputSchema.additionalProperties }
+        : {}),
+    },
+  }));
+}
+
+export function buildFunctionCallOutputInput(
+  callId: string,
+  output: unknown,
+): Record<string, unknown> {
+  return {
+    type: "function_call_output",
+    call_id: callId,
+    output,
+  };
 }
 
 export function buildXaiInput(items: AppServerTurnInputItem[]): Array<Record<string, unknown>> {

--- a/packages/agent-core/src/testing/xai-fixtures.ts
+++ b/packages/agent-core/src/testing/xai-fixtures.ts
@@ -18,6 +18,31 @@ export function makeXaiResponse(params?: {
   };
 }
 
+export function makeXaiFunctionCallResponse(params?: {
+  id?: string;
+  calls?: Array<{
+    callId?: string;
+    name?: string;
+    argumentsText?: string;
+  }>;
+}): Record<string, unknown> {
+  return {
+    id: params?.id ?? "resp_tool_123",
+    output: (params?.calls ?? [
+      {
+        callId: "call_123",
+        name: "search_code",
+        argumentsText: JSON.stringify({ query: "needle" }),
+      },
+    ]).map((call, index) => ({
+      type: "function_call",
+      call_id: call.callId ?? `call_${index + 1}`,
+      name: call.name ?? "search_code",
+      arguments: call.argumentsText ?? JSON.stringify({ query: "needle" }),
+    })),
+  };
+}
+
 export function makeDirectOutputResponse(params?: {
   id?: string;
   text?: string;

--- a/packages/agent-core/src/tools/edit-file-tool.ts
+++ b/packages/agent-core/src/tools/edit-file-tool.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readRequiredString,
+  requestToolApproval,
+} from "./tool-contract.js";
+import { InvalidToolArgumentsError, ToolExecutionFailure } from "./tool-errors.js";
+import { resolveWorkspaceFilePath } from "./workspace-paths.js";
+
+const TOOL_NAME = "edit_file";
+
+type EditFileArguments = {
+  path: string;
+  oldString: string;
+  newString: string;
+};
+
+export function createEditFileTool(): ToolDefinition<EditFileArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "Replace a unique string in a file with new content. The old string must appear exactly once.",
+    readOnly: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the file, relative to the current workspace.",
+        },
+        oldString: {
+          type: "string",
+          description: "Existing unique string to replace.",
+        },
+        newString: {
+          type: "string",
+          description: "Replacement string.",
+        },
+      },
+      required: ["path", "oldString", "newString"],
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      const newString = record.newString;
+      if (typeof newString !== "string") {
+        throw new InvalidToolArgumentsError(TOOL_NAME, '"newString" must be a string');
+      }
+      return {
+        path: readRequiredString(record, TOOL_NAME, "path"),
+        oldString: readRequiredString(record, TOOL_NAME, "oldString"),
+        newString,
+      };
+    },
+    async execute(arguments_, context) {
+      const resolved = resolveWorkspaceFilePath(context, TOOL_NAME, arguments_.path);
+      let content: string;
+      try {
+        content = await fs.readFile(resolved.absolutePath, "utf8");
+      } catch (error) {
+        throw new ToolExecutionFailure(
+          TOOL_NAME,
+          `unable to read ${resolved.relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+          "file_read_failed",
+        );
+      }
+
+      const occurrences = content.split(arguments_.oldString).length - 1;
+      if (occurrences === 0) {
+        throw new ToolExecutionFailure(
+          TOOL_NAME,
+          `oldString not found in ${resolved.relativePath}`,
+          "edit_anchor_missing",
+        );
+      }
+      if (occurrences > 1) {
+        throw new ToolExecutionFailure(
+          TOOL_NAME,
+          `oldString is not unique in ${resolved.relativePath} (${occurrences} occurrences)`,
+          "edit_anchor_not_unique",
+        );
+      }
+
+      const approval = await maybeApproveFileChange(context, resolved.relativePath);
+      if (approval) {
+        return approval;
+      }
+
+      const next = content.replace(arguments_.oldString, arguments_.newString);
+      await fs.writeFile(resolved.absolutePath, next, "utf8");
+      return {
+        success: true,
+        output: `Edited ${resolved.relativePath}.`,
+        data: {
+          path: resolved.relativePath,
+          replacements: 1,
+        },
+      };
+    },
+  };
+}
+
+async function maybeApproveFileChange(
+  context: ToolExecutionContext,
+  relativePath: string,
+) {
+  if (context.approvalPolicy === "never") {
+    return undefined;
+  }
+  const decision = await requestToolApproval(context, {
+    requestId: `${TOOL_NAME}-${Math.random().toString(36).slice(2, 10)}`,
+    kind: "fileChange",
+    reason: "edit_file modifies workspace files",
+    path: relativePath,
+  });
+  if (decision === "approve") {
+    return undefined;
+  }
+  return {
+    success: false,
+    output:
+      decision === "cancel"
+        ? `Approval cancelled for edit_file: ${relativePath}`
+        : `Approval declined for edit_file: ${relativePath}`,
+  };
+}

--- a/packages/agent-core/src/tools/list-files-tool.ts
+++ b/packages/agent-core/src/tools/list-files-tool.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readOptionalPositiveInteger,
+  readOptionalString,
+} from "./tool-contract.js";
+import { ToolExecutionFailure } from "./tool-errors.js";
+
+const execFileAsync = promisify(execFile);
+const TOOL_NAME = "list_files";
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+type ListFilesArguments = {
+  path?: string;
+  limit?: number;
+};
+
+export function createListFilesTool(): ToolDefinition<ListFilesArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "List files in the current workspace. Uses ripgrep when available and falls back to a deterministic filesystem walk.",
+    readOnly: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Optional directory path inside the workspace to scope the listing.",
+        },
+        limit: {
+          type: "integer",
+          description: "Maximum number of paths to return.",
+        },
+      },
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      return {
+        path: readOptionalString(record, TOOL_NAME, "path"),
+        limit: readOptionalPositiveInteger(record, TOOL_NAME, "limit"),
+      };
+    },
+    async execute(arguments_, context) {
+      const root = resolveWorkspacePath(context, arguments_.path);
+      const limit = Math.min(arguments_.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+      const files = await listWorkspaceFiles(root.workspacePath, root.scopePath, limit);
+      if (files.length === 0) {
+        return {
+          success: true,
+          output: `No files found in ${root.displayPath}.`,
+          data: {
+            path: root.scopeLabel,
+            files: [],
+            truncated: false,
+          },
+          commandAction: "listFiles",
+        };
+      }
+      return {
+        success: true,
+        output: files.join("\n"),
+        data: {
+          path: root.scopeLabel,
+          files,
+          truncated: files.length >= limit,
+        },
+        commandAction: "listFiles",
+      };
+    },
+  };
+}
+
+async function listWorkspaceFiles(
+  workspacePath: string,
+  scopePath: string,
+  limit: number,
+): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "rg",
+      ["--files", "."],
+      {
+        cwd: scopePath,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    const prefix = path.relative(workspacePath, scopePath);
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => (prefix ? path.posix.join(toPosix(prefix), toPosix(line)) : toPosix(line)))
+      .sort((left, right) => left.localeCompare(right))
+      .slice(0, limit);
+  } catch (error) {
+    if (!isCommandMissing(error)) {
+      throw new ToolExecutionFailure(
+        TOOL_NAME,
+        `ripgrep listing failed: ${error instanceof Error ? error.message : String(error)}`,
+        "list_files_failed",
+      );
+    }
+  }
+
+  const results: string[] = [];
+  await walk(scopePath, async (entryPath) => {
+    const relative = toPosix(path.relative(workspacePath, entryPath));
+    results.push(relative);
+    return results.length < limit;
+  });
+  return results;
+}
+
+async function walk(
+  directory: string,
+  onFile: (filePath: string) => Promise<boolean>,
+): Promise<boolean> {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+    const nextPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      const shouldContinue = await walk(nextPath, onFile);
+      if (!shouldContinue) {
+        return false;
+      }
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const shouldContinue = await onFile(nextPath);
+    if (!shouldContinue) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function resolveWorkspacePath(context: ToolExecutionContext, scope: string | undefined) {
+  const workspacePath = context.cwd?.trim();
+  if (!workspacePath) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      "thread cwd is required for repository tools",
+      "missing_cwd",
+    );
+  }
+  const scopePath = path.resolve(workspacePath, scope ?? ".");
+  const relative = path.relative(workspacePath, scopePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      `path escapes workspace: ${scope ?? "."}`,
+      "path_outside_workspace",
+    );
+  }
+  return {
+    workspacePath,
+    scopePath,
+    scopeLabel: relative ? toPosix(relative) : ".",
+    displayPath: relative ? toPosix(relative) : "workspace",
+  };
+}
+
+function isCommandMissing(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: string }).code === "ENOENT",
+  );
+}
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join(path.posix.sep);
+}

--- a/packages/agent-core/src/tools/read-file-tool.ts
+++ b/packages/agent-core/src/tools/read-file-tool.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readOptionalPositiveInteger,
+  readRequiredString,
+} from "./tool-contract.js";
+import { ToolExecutionFailure, InvalidToolArgumentsError } from "./tool-errors.js";
+
+const TOOL_NAME = "read_file";
+const DEFAULT_MAX_LINES = 200;
+const MAX_LINES = 500;
+
+type ReadFileArguments = {
+  path: string;
+  startLine?: number;
+  endLine?: number;
+};
+
+export function createReadFileTool(): ToolDefinition<ReadFileArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "Read a file from the current workspace. Returns numbered lines and supports optional line ranges.",
+    readOnly: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the file, relative to the current workspace.",
+        },
+        startLine: {
+          type: "integer",
+          description: "Optional first line to include, using 1-based numbering.",
+        },
+        endLine: {
+          type: "integer",
+          description: "Optional last line to include, using 1-based numbering.",
+        },
+      },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      const filePath = readRequiredString(record, TOOL_NAME, "path");
+      const startLine = readOptionalPositiveInteger(record, TOOL_NAME, "startLine");
+      const endLine = readOptionalPositiveInteger(record, TOOL_NAME, "endLine");
+      if (startLine && endLine && endLine < startLine) {
+        throw new InvalidToolArgumentsError(
+          TOOL_NAME,
+          `"endLine" must be greater than or equal to "startLine"`,
+        );
+      }
+      return {
+        path: filePath,
+        startLine,
+        endLine,
+      };
+    },
+    async execute(arguments_, context) {
+      const resolved = resolveWorkspacePath(context, arguments_.path);
+      let content: string;
+      try {
+        content = await fs.readFile(resolved.absolutePath, "utf8");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        throw new ToolExecutionFailure(
+          TOOL_NAME,
+          `unable to read ${resolved.relativePath}: ${message}`,
+          "file_read_failed",
+        );
+      }
+
+      if (content.includes("\0")) {
+        throw new ToolExecutionFailure(
+          TOOL_NAME,
+          `cannot read binary file: ${resolved.relativePath}`,
+          "binary_file",
+        );
+      }
+
+      const lines = content.split(/\r?\n/);
+      const startLine = arguments_.startLine ?? 1;
+      const requestedEndLine = arguments_.endLine ?? lines.length;
+      const cappedEndLine = Math.min(
+        requestedEndLine,
+        startLine + MAX_LINES - 1,
+      );
+      const limitedByDefault =
+        arguments_.startLine == null &&
+        arguments_.endLine == null &&
+        lines.length > DEFAULT_MAX_LINES;
+      const endLine = limitedByDefault
+        ? Math.min(DEFAULT_MAX_LINES, lines.length)
+        : Math.min(cappedEndLine, lines.length);
+      const visible = lines.slice(startLine - 1, endLine).map((line, index) => {
+        const lineNumber = startLine + index;
+        return `${lineNumber}: ${line}`;
+      });
+      return {
+        success: true,
+        output: `${resolved.relativePath}\n${visible.join("\n")}`.trim(),
+        data: {
+          path: resolved.relativePath,
+          startLine,
+          endLine,
+          totalLines: lines.length,
+          truncated: endLine < lines.length,
+        },
+        commandAction: "read",
+      };
+    },
+  };
+}
+
+function resolveWorkspacePath(context: ToolExecutionContext, targetPath: string) {
+  const cwd = context.cwd?.trim();
+  if (!cwd) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      "thread cwd is required for repository tools",
+      "missing_cwd",
+    );
+  }
+  const absolutePath = path.resolve(cwd, targetPath);
+  const relativePath = path.relative(cwd, absolutePath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      `path escapes workspace: ${targetPath}`,
+      "path_outside_workspace",
+    );
+  }
+  return {
+    absolutePath,
+    relativePath: relativePath || path.basename(absolutePath),
+  };
+}

--- a/packages/agent-core/src/tools/search-code-tool.ts
+++ b/packages/agent-core/src/tools/search-code-tool.ts
@@ -1,0 +1,325 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readOptionalBoolean,
+  readOptionalPositiveInteger,
+  readOptionalString,
+  readRequiredString,
+} from "./tool-contract.js";
+import { InvalidToolArgumentsError, ToolExecutionFailure } from "./tool-errors.js";
+
+const execFileAsync = promisify(execFile);
+const TOOL_NAME = "search_code";
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const BINARY_BYTES_TO_CHECK = 2048;
+
+type SearchCodeArguments = {
+  query: string;
+  path?: string;
+  limit?: number;
+  caseSensitive?: boolean;
+  fixedStrings?: boolean;
+};
+
+type SearchMatch = {
+  path: string;
+  line: number;
+  text: string;
+};
+
+export function createSearchCodeTool(): ToolDefinition<SearchCodeArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "Search repository contents with ripgrep-first behavior. Returns file paths, line numbers, and matching text.",
+    readOnly: true,
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Pattern to search for in workspace files.",
+        },
+        path: {
+          type: "string",
+          description: "Optional directory path inside the workspace to scope the search.",
+        },
+        limit: {
+          type: "integer",
+          description: "Maximum number of matches to return.",
+        },
+        caseSensitive: {
+          type: "boolean",
+          description: "When true, search case-sensitively.",
+        },
+        fixedStrings: {
+          type: "boolean",
+          description: "When true, treat the query as a literal string instead of a regular expression.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      return {
+        query: readRequiredString(record, TOOL_NAME, "query"),
+        path: readOptionalString(record, TOOL_NAME, "path"),
+        limit: readOptionalPositiveInteger(record, TOOL_NAME, "limit"),
+        caseSensitive: readOptionalBoolean(record, TOOL_NAME, "caseSensitive"),
+        fixedStrings: readOptionalBoolean(record, TOOL_NAME, "fixedStrings"),
+      };
+    },
+    async execute(arguments_, context) {
+      const root = resolveWorkspacePath(context, arguments_.path);
+      const limit = Math.min(arguments_.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+      const matches = await searchWorkspace(root.workspacePath, root.scopePath, arguments_, limit);
+      if (matches.length === 0) {
+        return {
+          success: true,
+          output: `No matches found for "${arguments_.query}" in ${root.displayPath}.`,
+          data: {
+            query: arguments_.query,
+            path: root.scopeLabel,
+            matches: [],
+          },
+          commandAction: "search",
+        };
+      }
+      return {
+        success: true,
+        output: matches
+          .map((match) => `${match.path}:${match.line}: ${match.text}`)
+          .join("\n"),
+        data: {
+          query: arguments_.query,
+          path: root.scopeLabel,
+          matches,
+          truncated: matches.length >= limit,
+        },
+        commandAction: "search",
+      };
+    },
+  };
+}
+
+async function searchWorkspace(
+  workspacePath: string,
+  scopePath: string,
+  arguments_: SearchCodeArguments,
+  limit: number,
+): Promise<SearchMatch[]> {
+  try {
+    return await searchWithRipgrep(workspacePath, scopePath, arguments_, limit);
+  } catch (error) {
+    if (!isCommandMissing(error)) {
+      if (isNoMatchesError(error)) {
+        return [];
+      }
+      throw new ToolExecutionFailure(
+        TOOL_NAME,
+        `ripgrep search failed: ${error instanceof Error ? error.message : String(error)}`,
+        "search_failed",
+      );
+    }
+  }
+  return await searchWithFallback(workspacePath, scopePath, arguments_, limit);
+}
+
+async function searchWithRipgrep(
+  workspacePath: string,
+  scopePath: string,
+  arguments_: SearchCodeArguments,
+  limit: number,
+): Promise<SearchMatch[]> {
+  const args = ["--line-number", "--no-heading", "--color", "never"];
+  if (arguments_.fixedStrings) {
+    args.push("--fixed-strings");
+  }
+  if (!arguments_.caseSensitive) {
+    args.push("--ignore-case");
+  }
+  args.push(arguments_.query, ".");
+  const { stdout } = await execFileAsync("rg", args, {
+    cwd: scopePath,
+    maxBuffer: 1024 * 1024,
+  });
+  const prefix = path.relative(workspacePath, scopePath);
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => parseRipgrepLine(prefix, line))
+    .slice(0, limit);
+}
+
+function parseRipgrepLine(prefix: string, line: string): SearchMatch {
+  const firstColon = line.indexOf(":");
+  const secondColon = line.indexOf(":", firstColon + 1);
+  const rawPath = line.slice(0, firstColon);
+  const rawLine = line.slice(firstColon + 1, secondColon);
+  const rawText = line.slice(secondColon + 1).trim();
+  return {
+    path: normalizeRelativePath(
+      prefix ? path.posix.join(toPosix(prefix), toPosix(rawPath)) : toPosix(rawPath),
+    ),
+    line: Number.parseInt(rawLine, 10),
+    text: rawText,
+  };
+}
+
+async function searchWithFallback(
+  workspacePath: string,
+  scopePath: string,
+  arguments_: SearchCodeArguments,
+  limit: number,
+): Promise<SearchMatch[]> {
+  const files = await collectFiles(scopePath, workspacePath, limit * 10);
+  const matcher = buildMatcher(arguments_);
+  const matches: SearchMatch[] = [];
+  for (const file of files) {
+    if (matches.length >= limit) {
+      break;
+    }
+    const absolutePath = path.join(workspacePath, file);
+    const buffer = await fs.readFile(absolutePath);
+    if (buffer.subarray(0, BINARY_BYTES_TO_CHECK).includes(0)) {
+      continue;
+    }
+    const lines = buffer.toString("utf8").split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      if (!matcher(lines[index] ?? "")) {
+        continue;
+      }
+      matches.push({
+        path: toPosix(file),
+        line: index + 1,
+        text: (lines[index] ?? "").trim(),
+      });
+      if (matches.length >= limit) {
+        break;
+      }
+    }
+  }
+  return matches;
+}
+
+function buildMatcher(arguments_: SearchCodeArguments) {
+  if (arguments_.fixedStrings) {
+    const query = arguments_.caseSensitive
+      ? arguments_.query
+      : arguments_.query.toLowerCase();
+    return (line: string) =>
+      (arguments_.caseSensitive ? line : line.toLowerCase()).includes(query);
+  }
+  const flags = arguments_.caseSensitive ? "" : "i";
+  let expression: RegExp;
+  try {
+    expression = new RegExp(arguments_.query, flags);
+  } catch (error) {
+    throw new InvalidToolArgumentsError(
+      TOOL_NAME,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  return (line: string) => expression.test(line);
+}
+
+async function collectFiles(
+  directory: string,
+  workspacePath: string,
+  limit: number,
+): Promise<string[]> {
+  const results: string[] = [];
+  await walk(directory, async (entryPath) => {
+    results.push(path.relative(workspacePath, entryPath));
+    return results.length < limit;
+  });
+  return results;
+}
+
+async function walk(
+  directory: string,
+  onFile: (filePath: string) => Promise<boolean>,
+): Promise<boolean> {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+    const nextPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      const shouldContinue = await walk(nextPath, onFile);
+      if (!shouldContinue) {
+        return false;
+      }
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const shouldContinue = await onFile(nextPath);
+    if (!shouldContinue) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function resolveWorkspacePath(context: ToolExecutionContext, scope: string | undefined) {
+  const workspacePath = context.cwd?.trim();
+  if (!workspacePath) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      "thread cwd is required for repository tools",
+      "missing_cwd",
+    );
+  }
+  const scopePath = path.resolve(workspacePath, scope ?? ".");
+  const relative = path.relative(workspacePath, scopePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      `path escapes workspace: ${scope ?? "."}`,
+      "path_outside_workspace",
+    );
+  }
+  return {
+    workspacePath,
+    scopePath,
+    scopeLabel: relative ? toPosix(relative) : ".",
+    displayPath: relative ? toPosix(relative) : "workspace",
+  };
+}
+
+function isCommandMissing(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: string }).code === "ENOENT",
+  );
+}
+
+function isNoMatchesError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: number }).code === 1,
+  );
+}
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join(path.posix.sep);
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.startsWith("./") ? value.slice(2) : value;
+}

--- a/packages/agent-core/src/tools/shell-command-tool.ts
+++ b/packages/agent-core/src/tools/shell-command-tool.ts
@@ -1,0 +1,185 @@
+import { exec } from "node:child_process";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readOptionalPositiveInteger,
+  readRequiredString,
+  requestToolApproval,
+} from "./tool-contract.js";
+import { ToolExecutionFailure } from "./tool-errors.js";
+import { classifyShellCommand } from "./shell-safety.js";
+import { requireWorkspacePath } from "./workspace-paths.js";
+
+const TOOL_NAME = "shell_command";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type ShellCommandArguments = {
+  command: string;
+  timeoutMs?: number;
+};
+
+export function createShellCommandTool(): ToolDefinition<ShellCommandArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "Execute a shell command in the current workspace. Safe read-only commands auto-run; mutating or ambiguous commands require approval.",
+    readOnly: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          description: "Shell command to execute in the workspace.",
+        },
+        timeoutMs: {
+          type: "integer",
+          description: "Optional timeout in milliseconds.",
+        },
+      },
+      required: ["command"],
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      return {
+        command: readRequiredString(record, TOOL_NAME, "command"),
+        timeoutMs: readOptionalPositiveInteger(record, TOOL_NAME, "timeoutMs"),
+      };
+    },
+    async execute(arguments_, context) {
+      const cwd = requireWorkspacePath(context, TOOL_NAME);
+      const classification = classifyShellCommand(arguments_.command);
+      if (!classification.safe && context.approvalPolicy !== "never") {
+        const decision = await requestToolApproval(context, {
+          requestId: `${TOOL_NAME}-${Math.random().toString(36).slice(2, 10)}`,
+          kind: "commandExecution",
+          reason: classification.reason,
+          command: arguments_.command,
+          commandAction: classification.commandAction,
+        });
+        if (decision !== "approve") {
+          return {
+            success: false,
+            output:
+              decision === "cancel"
+                ? `Approval cancelled for shell_command: ${arguments_.command}`
+                : `Approval declined for shell_command: ${arguments_.command}`,
+            commandAction: classification.commandAction,
+            itemType: "commandExecution",
+            command: arguments_.command,
+          };
+        }
+      }
+      let result;
+      try {
+        result = await runShellCommand(
+          arguments_.command,
+          cwd,
+          arguments_.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          context,
+        );
+      } catch (error) {
+        if (error instanceof ToolExecutionFailure) {
+          return {
+            success: false,
+            output: error.message,
+            data: {
+              exitCode: null,
+            },
+            commandAction: classification.commandAction,
+            itemType: "commandExecution",
+            command: arguments_.command,
+          };
+        }
+        throw error;
+      }
+      return {
+        ...result,
+        commandAction: classification.commandAction,
+        itemType: "commandExecution",
+        command: arguments_.command,
+      };
+    },
+  };
+}
+
+async function runShellCommand(
+  command: string,
+  cwd: string,
+  timeoutMs: number,
+  context: ToolExecutionContext,
+) {
+  return await new Promise<{
+    success: boolean;
+    output: string;
+    data: Record<string, unknown>;
+  }>((resolve, reject) => {
+    let settled = false;
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+    const child = exec(
+      command,
+      {
+        cwd,
+        timeout: timeoutMs,
+        maxBuffer: 10 * 1024 * 1024,
+        env: { ...process.env, FORCE_COLOR: "0" },
+      },
+      (error, stdout, stderr) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (forceKillTimer) {
+          clearTimeout(forceKillTimer);
+        }
+        context.signal?.removeEventListener("abort", onAbort);
+        const combined = [stdout.trim(), stderr.trim() ? `STDERR: ${stderr.trim()}` : ""]
+          .filter(Boolean)
+          .join("\n");
+        if (error) {
+          reject(
+            new ToolExecutionFailure(
+              TOOL_NAME,
+              combined || error.message,
+              context.signal?.aborted ? "command_cancelled" : "command_failed",
+            ),
+          );
+          return;
+        }
+        resolve({
+          success: true,
+          output: combined || "Command executed successfully (no output).",
+          data: {
+            exitCode: 0,
+          },
+        });
+      },
+    );
+
+    const onAbort = () => {
+      if (settled) {
+        return;
+      }
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        settled = true;
+        reject(new ToolExecutionFailure(TOOL_NAME, "command was cancelled", "command_cancelled"));
+        return;
+      }
+      forceKillTimer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* already exited */
+        }
+      }, 1_000);
+    };
+
+    if (context.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    context.signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/agent-core/src/tools/shell-safety.ts
+++ b/packages/agent-core/src/tools/shell-safety.ts
@@ -1,0 +1,134 @@
+import type { AppServerCommandAction } from "../app-server/protocol.js";
+
+export type ShellSafetyClassification = {
+  safe: boolean;
+  commandAction: AppServerCommandAction;
+  reason?: string;
+};
+
+const SHELL_METACHARACTER_PATTERN = /&&|\|\||[|;<>`]|[$][(]/;
+const UNSAFE_RIPGREP_WITH_VALUE = [/^--pre(?:=|$)/, /^--hostname-bin(?:=|$)/];
+const UNSAFE_RIPGREP_FLAGS = new Set(["--search-zip", "-z"]);
+const SAFE_GIT_SUBCOMMANDS = new Set([
+  "status",
+  "diff",
+  "log",
+  "show",
+  "rev-parse",
+  "grep",
+  "ls-files",
+]);
+
+export function classifyShellCommand(command: string): ShellSafetyClassification {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return {
+      safe: false,
+      commandAction: "unknown",
+      reason: "shell command cannot be empty",
+    };
+  }
+  if (SHELL_METACHARACTER_PATTERN.test(trimmed)) {
+    return {
+      safe: false,
+      commandAction: "unknown",
+      reason: "shell metacharacters require approval",
+    };
+  }
+  const tokens = splitShellWords(trimmed);
+  if (tokens.length === 0) {
+    return {
+      safe: false,
+      commandAction: "unknown",
+      reason: "shell command cannot be empty",
+    };
+  }
+  const [program, ...args] = tokens;
+  if (program === "rg") {
+    for (const arg of args) {
+      if (
+        UNSAFE_RIPGREP_FLAGS.has(arg) ||
+        UNSAFE_RIPGREP_WITH_VALUE.some((pattern) => pattern.test(arg))
+      ) {
+        return {
+          safe: false,
+          commandAction: "search",
+          reason: `ripgrep flag requires approval: ${arg}`,
+        };
+      }
+    }
+    return {
+      safe: true,
+      commandAction: "search",
+    };
+  }
+  if (program === "git") {
+    const subcommand = args[0];
+    if (subcommand && SAFE_GIT_SUBCOMMANDS.has(subcommand)) {
+      return {
+        safe: true,
+        commandAction: subcommand === "grep" ? "search" : subcommand === "ls-files" ? "listFiles" : "unknown",
+      };
+    }
+    return {
+      safe: false,
+      commandAction: "unknown",
+      reason: "mutating or unknown git commands require approval",
+    };
+  }
+  if (program === "cat" || program === "head" || program === "tail") {
+    return { safe: true, commandAction: "read" };
+  }
+  if (program === "ls" || program === "find") {
+    return { safe: true, commandAction: "listFiles" };
+  }
+  if (program === "pwd") {
+    return { safe: true, commandAction: "unknown" };
+  }
+  return {
+    safe: false,
+    commandAction: "unknown",
+    reason: `command requires approval: ${program}`,
+  };
+}
+
+export function splitShellWords(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else if (char === "\\" && quote === '"' && index + 1 < command.length) {
+        current += command[index + 1] ?? "";
+        index += 1;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (char === "\\" && index + 1 < command.length) {
+      current += command[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    current += char;
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}

--- a/packages/agent-core/src/tools/tool-contract.ts
+++ b/packages/agent-core/src/tools/tool-contract.ts
@@ -19,6 +19,9 @@ export type ToolExecutionContext = {
   approvalPolicy?: string;
   sandbox?: string;
   signal?: AbortSignal;
+  requestApproval?: (
+    request: ToolApprovalRequest,
+  ) => Promise<unknown> | unknown;
 };
 
 export type ToolInvocation = {
@@ -31,6 +34,8 @@ export type ToolExecutionOutput = {
   output: string;
   data?: Record<string, unknown>;
   commandAction?: AppServerCommandAction;
+  itemType?: "dynamicToolCall" | "commandExecution";
+  command?: string;
 };
 
 export type ToolDescriptor = {
@@ -64,15 +69,29 @@ export interface ToolExecutor {
     errorCode?: string;
     commandAction?: AppServerCommandAction;
     item: {
-      type: "dynamicToolCall";
+      type: "dynamicToolCall" | "commandExecution";
       text: string;
       toolName: string;
       success: boolean;
       arguments: Record<string, unknown>;
       commandAction?: AppServerCommandAction;
+      command?: string;
     };
   }>;
 }
+
+export type ToolApprovalKind = "fileChange" | "commandExecution";
+
+export type ToolApprovalDecision = "approve" | "decline" | "cancel";
+
+export type ToolApprovalRequest = {
+  requestId: string;
+  kind: ToolApprovalKind;
+  reason?: string;
+  path?: string;
+  command?: string;
+  commandAction?: AppServerCommandAction;
+};
 
 export function asObjectArguments(
   toolName: string,
@@ -146,4 +165,33 @@ export function readOptionalPositiveInteger(
     );
   }
   return value;
+}
+
+export function normalizeApprovalDecision(value: unknown): ToolApprovalDecision {
+  if (
+    value &&
+    typeof value === "object" &&
+    "decision" in value &&
+    typeof (value as { decision?: unknown }).decision === "string"
+  ) {
+    return normalizeApprovalDecision((value as { decision: string }).decision);
+  }
+  if (value === "approve") {
+    return "approve";
+  }
+  if (value === "cancel") {
+    return "cancel";
+  }
+  return "decline";
+}
+
+export async function requestToolApproval(
+  context: ToolExecutionContext,
+  request: ToolApprovalRequest,
+): Promise<ToolApprovalDecision> {
+  if (!context.requestApproval) {
+    return "decline";
+  }
+  const response = await context.requestApproval(request);
+  return normalizeApprovalDecision(response);
 }

--- a/packages/agent-core/src/tools/tool-contract.ts
+++ b/packages/agent-core/src/tools/tool-contract.ts
@@ -1,0 +1,149 @@
+import type { AppServerCommandAction } from "../app-server/protocol.js";
+import { InvalidToolArgumentsError } from "./tool-errors.js";
+
+export type ToolInputSchemaProperty = {
+  type: "string" | "integer" | "number" | "boolean";
+  description?: string;
+};
+
+export type ToolInputSchema = {
+  type: "object";
+  properties: Record<string, ToolInputSchemaProperty>;
+  required?: string[];
+  additionalProperties?: boolean;
+};
+
+export type ToolExecutionContext = {
+  cwd?: string;
+  threadId?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  signal?: AbortSignal;
+};
+
+export type ToolInvocation = {
+  name: string;
+  arguments?: Record<string, unknown>;
+};
+
+export type ToolExecutionOutput = {
+  success: boolean;
+  output: string;
+  data?: Record<string, unknown>;
+  commandAction?: AppServerCommandAction;
+};
+
+export type ToolDescriptor = {
+  name: string;
+  description: string;
+  inputSchema: ToolInputSchema;
+  readOnly: boolean;
+};
+
+export type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>> =
+  ToolDescriptor & {
+    parseArguments: (arguments_: Record<string, unknown>) => TArgs;
+    execute: (
+      arguments_: TArgs,
+      context: ToolExecutionContext,
+    ) => Promise<ToolExecutionOutput>;
+  };
+
+export interface ToolExecutor {
+  listTools(): ToolDescriptor[];
+  getTool(name: string): ToolDescriptor | undefined;
+  executeTool(
+    invocation: ToolInvocation,
+    context: ToolExecutionContext,
+  ): Promise<{
+    toolName: string;
+    arguments: Record<string, unknown>;
+    success: boolean;
+    output: string;
+    data?: Record<string, unknown>;
+    errorCode?: string;
+    commandAction?: AppServerCommandAction;
+    item: {
+      type: "dynamicToolCall";
+      text: string;
+      toolName: string;
+      success: boolean;
+      arguments: Record<string, unknown>;
+      commandAction?: AppServerCommandAction;
+    };
+  }>;
+}
+
+export function asObjectArguments(
+  toolName: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new InvalidToolArgumentsError(toolName, "arguments must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+export function readRequiredString(
+  arguments_: Record<string, unknown>,
+  toolName: string,
+  key: string,
+): string {
+  const value = arguments_[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new InvalidToolArgumentsError(
+      toolName,
+      `"${key}" must be a non-empty string`,
+    );
+  }
+  return value.trim();
+}
+
+export function readOptionalString(
+  arguments_: Record<string, unknown>,
+  toolName: string,
+  key: string,
+): string | undefined {
+  const value = arguments_[key];
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new InvalidToolArgumentsError(toolName, `"${key}" must be a string`);
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function readOptionalBoolean(
+  arguments_: Record<string, unknown>,
+  toolName: string,
+  key: string,
+): boolean | undefined {
+  const value = arguments_[key];
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new InvalidToolArgumentsError(toolName, `"${key}" must be a boolean`);
+  }
+  return value;
+}
+
+export function readOptionalPositiveInteger(
+  arguments_: Record<string, unknown>,
+  toolName: string,
+  key: string,
+): number | undefined {
+  const value = arguments_[key];
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new InvalidToolArgumentsError(
+      toolName,
+      `"${key}" must be a positive integer`,
+    );
+  }
+  return value;
+}

--- a/packages/agent-core/src/tools/tool-errors.ts
+++ b/packages/agent-core/src/tools/tool-errors.ts
@@ -1,0 +1,30 @@
+export class ToolError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "ToolError";
+    this.code = code;
+  }
+}
+
+export class UnknownToolError extends ToolError {
+  constructor(name: string) {
+    super("unknown_tool", `Unknown tool: ${name}`);
+    this.name = "UnknownToolError";
+  }
+}
+
+export class InvalidToolArgumentsError extends ToolError {
+  constructor(toolName: string, message: string) {
+    super("invalid_arguments", `Invalid arguments for ${toolName}: ${message}`);
+    this.name = "InvalidToolArgumentsError";
+  }
+}
+
+export class ToolExecutionFailure extends ToolError {
+  constructor(toolName: string, message: string, code = "execution_failed") {
+    super(code, `${toolName} failed: ${message}`);
+    this.name = "ToolExecutionFailure";
+  }
+}

--- a/packages/agent-core/src/tools/tool-execution.ts
+++ b/packages/agent-core/src/tools/tool-execution.ts
@@ -38,12 +38,13 @@ export class LocalToolExecutor implements ToolExecutor {
         data: execution.data,
         commandAction: execution.commandAction,
         item: {
-          type: "dynamicToolCall" as const,
+          type: execution.itemType ?? "dynamicToolCall",
           text: execution.output,
           toolName: tool.name,
           success: execution.success,
           arguments: parsedArguments,
           commandAction: execution.commandAction,
+          command: execution.command,
         },
       };
     } catch (error) {

--- a/packages/agent-core/src/tools/tool-execution.ts
+++ b/packages/agent-core/src/tools/tool-execution.ts
@@ -1,0 +1,85 @@
+import type { ToolExecutionContext, ToolExecutor, ToolInvocation } from "./tool-contract.js";
+import { InvalidToolArgumentsError, ToolError, UnknownToolError } from "./tool-errors.js";
+import { ToolRegistry } from "./tool-registry.js";
+
+export class LocalToolExecutor implements ToolExecutor {
+  private readonly registry: ToolRegistry;
+
+  constructor(registry: ToolRegistry) {
+    this.registry = registry;
+  }
+
+  listTools() {
+    return this.registry.list();
+  }
+
+  getTool(name: string) {
+    return this.registry.get(name);
+  }
+
+  async executeTool(invocation: ToolInvocation, context: ToolExecutionContext) {
+    const tool = this.registry.get(invocation.name);
+    if (!tool) {
+      return failureResult(
+        invocation.name,
+        invocation.arguments,
+        new UnknownToolError(invocation.name),
+      );
+    }
+
+    try {
+      const parsedArguments = tool.parseArguments(invocation.arguments ?? {});
+      const execution = await tool.execute(parsedArguments, context);
+      return {
+        toolName: tool.name,
+        arguments: parsedArguments,
+        success: execution.success,
+        output: execution.output,
+        data: execution.data,
+        commandAction: execution.commandAction,
+        item: {
+          type: "dynamicToolCall" as const,
+          text: execution.output,
+          toolName: tool.name,
+          success: execution.success,
+          arguments: parsedArguments,
+          commandAction: execution.commandAction,
+        },
+      };
+    } catch (error) {
+      return failureResult(tool.name, invocation.arguments, error);
+    }
+  }
+}
+
+function failureResult(
+  toolName: string,
+  arguments_: Record<string, unknown> | undefined,
+  error: unknown,
+) {
+  const normalized =
+    error instanceof ToolError
+      ? error
+      : new ToolError(
+          "execution_failed",
+          `${toolName} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+  const output =
+    error instanceof InvalidToolArgumentsError || error instanceof UnknownToolError
+      ? normalized.message
+      : normalized.message;
+  return {
+    toolName,
+    arguments: (arguments_ ?? {}) as Record<string, unknown>,
+    success: false,
+    output,
+    errorCode: normalized.code,
+    item: {
+      type: "dynamicToolCall" as const,
+      text: output,
+      toolName,
+      success: false,
+      arguments: (arguments_ ?? {}) as Record<string, unknown>,
+    },
+  };
+}

--- a/packages/agent-core/src/tools/tool-registry.ts
+++ b/packages/agent-core/src/tools/tool-registry.ts
@@ -1,0 +1,39 @@
+import type { ToolDefinition, ToolDescriptor } from "./tool-contract.js";
+import { createListFilesTool } from "./list-files-tool.js";
+import { createReadFileTool } from "./read-file-tool.js";
+import { createSearchCodeTool } from "./search-code-tool.js";
+
+export class ToolRegistry {
+  private readonly tools = new Map<string, ToolDefinition<any>>();
+
+  constructor(toolDefinitions: Array<ToolDefinition<any>> = []) {
+    for (const tool of toolDefinitions) {
+      this.register(tool);
+    }
+  }
+
+  register(tool: ToolDefinition<any>): void {
+    this.tools.set(tool.name, tool);
+  }
+
+  list(): ToolDescriptor[] {
+    return [...this.tools.values()].map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      readOnly: tool.readOnly,
+    }));
+  }
+
+  get(name: string): ToolDefinition<any> | undefined {
+    return this.tools.get(name);
+  }
+}
+
+export function createDefaultToolRegistry(): ToolRegistry {
+  return new ToolRegistry([
+    createReadFileTool(),
+    createListFilesTool(),
+    createSearchCodeTool(),
+  ]);
+}

--- a/packages/agent-core/src/tools/tool-registry.ts
+++ b/packages/agent-core/src/tools/tool-registry.ts
@@ -1,7 +1,10 @@
 import type { ToolDefinition, ToolDescriptor } from "./tool-contract.js";
 import { createListFilesTool } from "./list-files-tool.js";
+import { createEditFileTool } from "./edit-file-tool.js";
 import { createReadFileTool } from "./read-file-tool.js";
 import { createSearchCodeTool } from "./search-code-tool.js";
+import { createShellCommandTool } from "./shell-command-tool.js";
+import { createWriteFileTool } from "./write-file-tool.js";
 
 export class ToolRegistry {
   private readonly tools = new Map<string, ToolDefinition<any>>();
@@ -35,5 +38,8 @@ export function createDefaultToolRegistry(): ToolRegistry {
     createReadFileTool(),
     createListFilesTool(),
     createSearchCodeTool(),
+    createWriteFileTool(),
+    createEditFileTool(),
+    createShellCommandTool(),
   ]);
 }

--- a/packages/agent-core/src/tools/workspace-paths.ts
+++ b/packages/agent-core/src/tools/workspace-paths.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import type { ToolExecutionContext } from "./tool-contract.js";
+import { ToolExecutionFailure } from "./tool-errors.js";
+
+export function requireWorkspacePath(
+  context: ToolExecutionContext,
+  toolName: string,
+): string {
+  const workspacePath = context.cwd?.trim();
+  if (!workspacePath) {
+    throw new ToolExecutionFailure(
+      toolName,
+      "thread cwd is required for repository tools",
+      "missing_cwd",
+    );
+  }
+  return workspacePath;
+}
+
+export function resolveWorkspaceFilePath(
+  context: ToolExecutionContext,
+  toolName: string,
+  targetPath: string,
+) {
+  const workspacePath = requireWorkspacePath(context, toolName);
+  const absolutePath = path.resolve(workspacePath, targetPath);
+  const relativePath = path.relative(workspacePath, absolutePath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new ToolExecutionFailure(
+      toolName,
+      `path escapes workspace: ${targetPath}`,
+      "path_outside_workspace",
+    );
+  }
+  return {
+    workspacePath,
+    absolutePath,
+    relativePath: toPosix(relativePath || path.basename(absolutePath)),
+  };
+}
+
+export function resolveWorkspaceScopePath(
+  context: ToolExecutionContext,
+  toolName: string,
+  scope: string | undefined,
+) {
+  const workspacePath = requireWorkspacePath(context, toolName);
+  const scopePath = path.resolve(workspacePath, scope ?? ".");
+  const relative = path.relative(workspacePath, scopePath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new ToolExecutionFailure(
+      toolName,
+      `path escapes workspace: ${scope ?? "."}`,
+      "path_outside_workspace",
+    );
+  }
+  return {
+    workspacePath,
+    scopePath,
+    scopeLabel: relative ? toPosix(relative) : ".",
+    displayPath: relative ? toPosix(relative) : "workspace",
+  };
+}
+
+export function toPosix(value: string): string {
+  return value.split(path.sep).join(path.posix.sep);
+}

--- a/packages/agent-core/src/tools/write-file-tool.ts
+++ b/packages/agent-core/src/tools/write-file-tool.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
+import {
+  asObjectArguments,
+  readRequiredString,
+  requestToolApproval,
+} from "./tool-contract.js";
+import { InvalidToolArgumentsError, ToolExecutionFailure } from "./tool-errors.js";
+import { resolveWorkspaceFilePath } from "./workspace-paths.js";
+
+const TOOL_NAME = "write_file";
+
+type WriteFileArguments = {
+  path: string;
+  content: string;
+};
+
+export function createWriteFileTool(): ToolDefinition<WriteFileArguments> {
+  return {
+    name: TOOL_NAME,
+    description:
+      "Create a new file or replace an existing file with the provided content.",
+    readOnly: false,
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the file, relative to the current workspace.",
+        },
+        content: {
+          type: "string",
+          description: "Complete file contents to write.",
+        },
+      },
+      required: ["path", "content"],
+      additionalProperties: false,
+    },
+    parseArguments(arguments_) {
+      const record = asObjectArguments(TOOL_NAME, arguments_);
+      const content = record.content;
+      if (typeof content !== "string") {
+        throw new InvalidToolArgumentsError(TOOL_NAME, '"content" must be a string');
+      }
+      return {
+        path: readRequiredString(record, TOOL_NAME, "path"),
+        content,
+      };
+    },
+    async execute(arguments_, context) {
+      const resolved = resolveWorkspaceFilePath(context, TOOL_NAME, arguments_.path);
+      const approval = await maybeApproveFileChange(context, resolved.relativePath);
+      if (approval) {
+        return approval;
+      }
+      let existed = true;
+      try {
+        await fs.access(resolved.absolutePath);
+      } catch {
+        existed = false;
+      }
+      await fs.mkdir(path.dirname(resolved.absolutePath), { recursive: true });
+      await fs.writeFile(resolved.absolutePath, arguments_.content, "utf8");
+      return {
+        success: true,
+        output: `${existed ? "Updated" : "Created"} ${resolved.relativePath}.`,
+        data: {
+          path: resolved.relativePath,
+          created: !existed,
+          bytes: Buffer.byteLength(arguments_.content, "utf8"),
+        },
+      };
+    },
+  };
+}
+
+async function maybeApproveFileChange(
+  context: ToolExecutionContext,
+  relativePath: string,
+) {
+  if (context.approvalPolicy === "never") {
+    return undefined;
+  }
+  const decision = await requestToolApproval(context, {
+    requestId: `${TOOL_NAME}-${Math.random().toString(36).slice(2, 10)}`,
+    kind: "fileChange",
+    reason: "write_file modifies workspace files",
+    path: relativePath,
+  });
+  if (decision === "approve") {
+    return undefined;
+  }
+  return {
+    success: false,
+    output:
+      decision === "cancel"
+        ? `Approval cancelled for write_file: ${relativePath}`
+        : `Approval declined for write_file: ${relativePath}`,
+  };
+}


### PR DESCRIPTION
## Summary
- keep the Grok tool-usage implementation plan in `docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md`
- implement Units 1 through 3 in `packages/agent-core` so thread replay can persist structured items and provider turns can access a local repository-tool executor
- add read-only repository tools for file reads, file listing, and ripgrep-first code search with temp-workspace coverage

## What Changed
- extended the app-server protocol and replay state to persist structured tool-bearing items alongside user and assistant messages
- routed review and compaction runs through the shared turn runner so replay, progress, and pending-input handling stay consistent
- added a local tool contract, tool registry, execution wrapper, and stable tool error types in `packages/agent-core/src/tools`
- wired a default tool executor into `CodexAppServer` and `ProviderTurnParams` so providers can request tools without importing implementations directly
- implemented `read_file`, `list_files`, and `search_code` as read-only repository tools with bounded, normalized outputs and filesystem fallbacks where needed
- marked Units 1, 2, and 3 complete in the active implementation plan

## Testing
- `pnpm --filter @pwragnt/agent-core test`
- `pnpm --filter @pwragnt/agent-core typecheck` *(still fails in existing unrelated `@pwragnt/shared` resolution paths outside this change set)*

## Notes
- this PR now carries the implementation through the read-only repository-tool layer
- mutation tools, shell safety, and the Grok Responses tool loop remain in Units 4 and 5
