### PR TITLE
feat: load grok app-server config from ~/.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ When you are ready to run live xAI-backed smoke coverage, put credentials in
 `packages/agent-core/.env.local`. The tracked template lives at
 `packages/agent-core/.env.local.example`.
 
+The desktop Grok app server client also falls back to the user config
+directory. It will load `XAI_API_KEY`, `GROK_MODEL`, and `XAI_BASE_URL` from
+the first existing file under `~/.config/grok-app-server` in this order:
+
+- `config.env`
+- `.env.local`
+- `.env`
+
+Project-local env and already-exported shell env still win over that global
+fallback.
+
 CI uses the existing `live-agent-core` workflow job with the `XAI_API_KEY`
 repository secret. No separate tool-test secret is required.
 

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -1,5 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { CodexAppServer, FakeProvider } from "@pwragnt/agent-core";
+import {
+  CodexAppServer,
+  FakeProvider,
+  createTemporaryTestDirectory,
+  defaultGrokAppServerConfigPaths,
+} from "@pwragnt/agent-core";
 import { GrokAppServerClient } from "../grok-app-server/client";
 
 describe("GrokAppServerClient", () => {
@@ -84,5 +91,48 @@ describe("GrokAppServerClient", () => {
 
     unsubscribe();
     await client.close();
+  });
+
+  it("initializes from ~/.config/grok-app-server when env vars are absent", async () => {
+    const originalHome = process.env.HOME;
+    const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_MODEL;
+    delete process.env.XAI_BASE_URL;
+    delete process.env.XDG_CONFIG_HOME;
+
+    const temp = await createTemporaryTestDirectory();
+    process.env.HOME = temp.path;
+    const [configPath] = defaultGrokAppServerConfigPaths({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      "XAI_API_KEY=config-key\nGROK_MODEL=grok-4.20-fast\nXAI_BASE_URL=https://api.example.test/v1\n",
+      "utf8",
+    );
+
+    try {
+      const client = new GrokAppServerClient();
+      await expect(client.getInitializeResult()).resolves.toEqual(
+        expect.objectContaining({
+          serverInfo: expect.objectContaining({
+            name: "@pwragnt/grok-app-server",
+          }),
+        }),
+      );
+      await client.close();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      await temp.cleanup();
+    }
   });
 });

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
-import { CodexAppServer, GrokProvider, loadLocalEnv } from "@pwragnt/agent-core";
+import {
+  CodexAppServer,
+  GrokProvider,
+  loadGrokAppServerConfig,
+  loadLocalEnv,
+} from "@pwragnt/agent-core";
 import type {
   AppServerNotification,
   AppServerThreadReplay,
@@ -346,6 +351,7 @@ export class GrokAppServerClient {
     }
 
     loadLocalEnv({ override: false });
+    loadGrokAppServerConfig({ override: false });
     const apiKey = this.options.apiKey?.trim() || process.env.XAI_API_KEY?.trim();
     if (!apiKey) {
       throw new Error("grok app server unavailable: XAI_API_KEY is not set");

--- a/packages/agent-core/src/__tests__/test-harness.test.ts
+++ b/packages/agent-core/src/__tests__/test-harness.test.ts
@@ -2,13 +2,29 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTemporaryTestDirectory } from "../testing/test-harness.js";
-import { loadLocalEnv } from "../testing/load-local-env.js";
+import {
+  defaultGrokAppServerConfigPaths,
+  loadGrokAppServerConfig,
+  loadLocalEnv,
+} from "../testing/load-local-env.js";
 
-const tempEnvKeys = ["XAI_API_KEY", "GROK_MODEL"];
+const originalHome = process.env.HOME;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const tempEnvKeys = ["XAI_API_KEY", "GROK_MODEL", "XAI_BASE_URL"];
 
 afterEach(() => {
   for (const key of tempEnvKeys) {
     delete process.env[key];
+  }
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
   }
 });
 
@@ -44,6 +60,49 @@ describe("test harness helpers", () => {
     expect(result.entries).toEqual(["XAI_API_KEY", "GROK_MODEL"]);
     expect(process.env.XAI_API_KEY).toBe("test-key");
     expect(process.env.GROK_MODEL).toBe("grok-4.20-reasoning");
+
+    await temp.cleanup();
+  });
+
+  it("loads Grok app-server config from the XDG config directory", async () => {
+    const temp = await createTemporaryTestDirectory();
+    process.env.HOME = temp.path;
+    delete process.env.XDG_CONFIG_HOME;
+    const [configPath] = defaultGrokAppServerConfigPaths({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      "XAI_API_KEY=config-key\nGROK_MODEL=grok-4.20-fast\nXAI_BASE_URL=https://api.example.test/v1\n",
+    );
+
+    const result = loadGrokAppServerConfig({ homeDir: temp.path });
+
+    expect(result).toEqual({
+      path: configPath,
+      loaded: true,
+      entries: ["XAI_API_KEY", "GROK_MODEL", "XAI_BASE_URL"],
+    });
+    expect(process.env.XAI_API_KEY).toBe("config-key");
+    expect(process.env.GROK_MODEL).toBe("grok-4.20-fast");
+    expect(process.env.XAI_BASE_URL).toBe("https://api.example.test/v1");
+
+    await temp.cleanup();
+  });
+
+  it("does not override existing env values with Grok app-server config defaults", async () => {
+    const temp = await createTemporaryTestDirectory();
+    process.env.HOME = temp.path;
+    delete process.env.XDG_CONFIG_HOME;
+    process.env.XAI_API_KEY = "existing-key";
+    const [configPath] = defaultGrokAppServerConfigPaths({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, "XAI_API_KEY=config-key\nGROK_MODEL=grok-4.20-fast\n");
+
+    const result = loadGrokAppServerConfig({ homeDir: temp.path, override: false });
+
+    expect(result.loaded).toBe(true);
+    expect(process.env.XAI_API_KEY).toBe("existing-key");
+    expect(process.env.GROK_MODEL).toBe("grok-4.20-fast");
 
     await temp.cleanup();
   });

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -39,7 +39,10 @@ export {
   type FakeProviderRun,
 } from "./testing/test-harness.js";
 export {
+  defaultGrokAppServerConfigDir,
+  defaultGrokAppServerConfigPaths,
   defaultLocalEnvPath,
+  loadGrokAppServerConfig,
   loadLocalEnv,
   type LocalEnvLoadResult,
 } from "./testing/load-local-env.js";

--- a/packages/agent-core/src/testing/load-local-env.ts
+++ b/packages/agent-core/src/testing/load-local-env.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,11 +15,61 @@ export function defaultLocalEnvPath(): string {
   return path.resolve(currentDir, "../../.env.local");
 }
 
+export function defaultGrokAppServerConfigDir(options?: {
+  homeDir?: string;
+  xdgConfigHome?: string;
+}): string {
+  const homeDir = options?.homeDir ?? os.homedir();
+  const xdgConfigHome = options?.xdgConfigHome?.trim() || process.env.XDG_CONFIG_HOME?.trim();
+  return path.join(xdgConfigHome || path.join(homeDir, ".config"), "grok-app-server");
+}
+
+export function defaultGrokAppServerConfigPaths(options?: {
+  homeDir?: string;
+  xdgConfigHome?: string;
+}): string[] {
+  const configDir = defaultGrokAppServerConfigDir(options);
+  return [
+    path.join(configDir, "config.env"),
+    path.join(configDir, ".env.local"),
+    path.join(configDir, ".env"),
+  ];
+}
+
 export function loadLocalEnv(options?: {
   envPath?: string;
   override?: boolean;
 }): LocalEnvLoadResult {
   const envPath = options?.envPath ?? defaultLocalEnvPath();
+  return loadEnvFile(envPath, options?.override);
+}
+
+export function loadGrokAppServerConfig(options?: {
+  configPaths?: string[];
+  override?: boolean;
+  homeDir?: string;
+  xdgConfigHome?: string;
+}): LocalEnvLoadResult {
+  const configPaths =
+    options?.configPaths ?? defaultGrokAppServerConfigPaths(options);
+  for (const configPath of configPaths) {
+    if (fs.existsSync(configPath)) {
+      return loadEnvFile(configPath, options?.override);
+    }
+  }
+
+  return {
+    path: configPaths[0] ?? defaultGrokAppServerConfigPaths(options)[0],
+    loaded: false,
+    entries: [],
+    skippedReason: "missing",
+  };
+}
+
+function loadEnvFile(
+  envPath: string,
+  override = false,
+): LocalEnvLoadResult {
   if (!fs.existsSync(envPath)) {
     return {
       path: envPath,
@@ -44,7 +95,7 @@ export function loadLocalEnv(options?: {
     if (!key) {
       throw new Error(`Invalid env key on line ${index + 1} in ${envPath}`);
     }
-    if (options?.override || process.env[key] === undefined) {
+    if (override || process.env[key] === undefined) {
       process.env[key] = value;
     }
     entries.push(key);


### PR DESCRIPTION
## Summary
- add shared agent-core helpers to load Grok app server env config from `~/.config/grok-app-server`
- make the desktop Grok app-server client fall back to that config after explicit env and project-local `.env.local`
- document the supported config files and add tests for loader precedence and desktop initialization

## Testing
- `pnpm --dir . exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/test-harness.test.ts`

## Notes
- The new global fallback checks `config.env`, `.env.local`, then `.env` under `~/.config/grok-app-server`
- Explicit client options, exported shell env, and `packages/agent-core/.env.local` still take precedence over the global config
- A desktop-side test was added for config-backed initialization, but local execution of the `desktop-main` project in this worktree is still blocked by the existing `@pwragnt/agent-core` workspace resolution issue