### PR TITLE
fix(desktop): open thread transcripts at the latest message

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -73,6 +73,7 @@ export function ThreadView(props: ThreadViewProps) {
             loadingMore={props.loadingMore}
             messages={props.transcriptMessages}
             pagination={props.transcriptPagination}
+            threadId={props.selectedThread.id}
             onLoadOlder={props.onLoadOlder}
           />
         </section>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -179,17 +179,18 @@ export function TranscriptList(props: TranscriptListProps) {
         ))}
       </div>
 
-      <button
-        className="button button--ghost transcript-list__scroll-bottom"
-        data-has-content-below={hasContentBelow}
-        type="button"
-        aria-label="Jump to latest message"
-        onClick={() => {
-          scrollToBottom();
-        }}
-      >
-        <span className="transcript-list__scroll-bottom-icon" aria-hidden="true" />
-      </button>
+      {hasContentBelow ? (
+        <button
+          className="button button--ghost transcript-list__scroll-bottom"
+          type="button"
+          aria-label="Jump to latest message"
+          onClick={() => {
+            scrollToBottom();
+          }}
+        >
+          <span className="transcript-list__scroll-bottom-icon" aria-hidden="true" />
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   AppServerThreadMessage,
   AppServerThreadReplayPagination
@@ -10,13 +11,134 @@ type TranscriptListProps = {
   loadingMore: boolean;
   messages: AppServerThreadMessage[];
   pagination?: AppServerThreadReplayPagination;
+  threadId?: string;
   onLoadOlder: () => Promise<void>;
 };
 
+type ScrollSnapshot = {
+  clientHeight: number;
+  distanceFromBottom: number;
+  firstMessageId?: string;
+  lastMessageId?: string;
+  scrollHeight: number;
+  scrollTop: number;
+  threadId?: string;
+};
+
+const BOTTOM_THRESHOLD_PX = 24;
+
 export function TranscriptList(props: TranscriptListProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const snapshotRef = useRef<ScrollSnapshot | undefined>(undefined);
+  const shouldScrollToBottomRef = useRef(true);
+  const [hasContentBelow, setHasContentBelow] = useState(false);
   const canLoadOlder = Boolean(
     props.pagination?.supportsPagination && props.pagination.hasPreviousPage
   );
+
+  const captureSnapshot = useCallback((): ScrollSnapshot | undefined => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const firstMessageId = props.messages[0]?.id;
+    const lastMessageId = props.messages[props.messages.length - 1]?.id;
+    const distanceFromBottom = Math.max(
+      container.scrollHeight - container.clientHeight - container.scrollTop,
+      0
+    );
+
+    return {
+      clientHeight: container.clientHeight,
+      distanceFromBottom,
+      firstMessageId,
+      lastMessageId,
+      scrollHeight: container.scrollHeight,
+      scrollTop: container.scrollTop,
+      threadId: props.threadId
+    };
+  }, [props.messages, props.threadId]);
+
+  const syncScrollState = useCallback(() => {
+    const snapshot = captureSnapshot();
+    snapshotRef.current = snapshot;
+    setHasContentBelow(Boolean(snapshot && snapshot.distanceFromBottom > BOTTOM_THRESHOLD_PX));
+  }, [captureSnapshot]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      return;
+    }
+
+    if (typeof container.scrollTo === "function") {
+      container.scrollTo({
+        top: container.scrollHeight,
+        behavior
+      });
+    } else {
+      container.scrollTop = container.scrollHeight;
+    }
+
+    syncScrollState();
+  }, [syncScrollState]);
+
+  useEffect(() => {
+    shouldScrollToBottomRef.current = true;
+  }, [props.threadId]);
+
+  useEffect(() => {
+    if (props.loading) {
+      shouldScrollToBottomRef.current = true;
+    }
+  }, [props.loading]);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || props.messages.length === 0) {
+      snapshotRef.current = undefined;
+      setHasContentBelow(false);
+      return;
+    }
+
+    const previousSnapshot = snapshotRef.current;
+    const firstMessageId = props.messages[0]?.id;
+    const lastMessageId = props.messages[props.messages.length - 1]?.id;
+    const hasPrependedMessages = Boolean(
+      previousSnapshot &&
+        previousSnapshot.threadId === props.threadId &&
+        previousSnapshot.lastMessageId === lastMessageId &&
+        previousSnapshot.firstMessageId !== firstMessageId
+    );
+    const hasAppendedMessages = Boolean(
+      previousSnapshot &&
+        previousSnapshot.threadId === props.threadId &&
+        previousSnapshot.firstMessageId === firstMessageId &&
+        previousSnapshot.lastMessageId !== lastMessageId
+    );
+
+    if (hasPrependedMessages && previousSnapshot) {
+      const heightDelta = container.scrollHeight - previousSnapshot.scrollHeight;
+      container.scrollTop = previousSnapshot.scrollTop + heightDelta;
+    } else if (
+      shouldScrollToBottomRef.current ||
+      !previousSnapshot ||
+      previousSnapshot.threadId !== props.threadId
+    ) {
+      scrollToBottom("auto");
+      shouldScrollToBottomRef.current = false;
+      return;
+    } else if (
+      hasAppendedMessages &&
+      previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX
+    ) {
+      scrollToBottom("auto");
+      return;
+    }
+
+    syncScrollState();
+  }, [props.messages, props.threadId, scrollToBottom, syncScrollState]);
 
   if (props.loading && props.messages.length === 0) {
     return <p className="transcript-empty">Loading transcript…</p>;
@@ -46,11 +168,28 @@ export function TranscriptList(props: TranscriptListProps) {
 
       {props.error ? <p className="transcript-error">{props.error}</p> : null}
 
-      <div className="transcript-list__items" role="list">
+      <div
+        ref={scrollContainerRef}
+        className="transcript-list__items"
+        role="list"
+        onScroll={syncScrollState}
+      >
         {props.messages.map((message) => (
           <TranscriptMessage key={message.id} message={message} />
         ))}
       </div>
+
+      <button
+        className="button button--ghost transcript-list__scroll-bottom"
+        data-has-content-below={hasContentBelow}
+        type="button"
+        aria-label="Jump to latest message"
+        onClick={() => {
+          scrollToBottom();
+        }}
+      >
+        <span className="transcript-list__scroll-bottom-icon" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,9 +1,53 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptList } from "../TranscriptList";
 
 describe("TranscriptList", () => {
+  let scrollHeight = 480;
+  let clientHeight = 240;
+  let scrollToMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollHeight = 480;
+    clientHeight = 240;
+    scrollToMock = vi.fn(function scrollTo(
+      this: HTMLElement,
+      options?: number | ScrollToOptions,
+      y?: number
+    ) {
+      if (typeof options === "number") {
+        this.scrollTop = y ?? 0;
+        return;
+      }
+
+      this.scrollTop = options?.top ?? 0;
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return scrollHeight;
+      }
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get() {
+        return clientHeight;
+      }
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollToMock
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders transcript history and exposes incremental history loading when available", () => {
     const loadOlder = vi.fn(async () => undefined);
 
@@ -28,6 +72,7 @@ describe("TranscriptList", () => {
           hasPreviousPage: true,
           previousCursor: "cursor-1"
         }}
+        threadId="thread-1"
         onLoadOlder={loadOlder}
       />
     );
@@ -48,5 +93,91 @@ describe("TranscriptList", () => {
     fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
 
     expect(loadOlder).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Jump to latest message" })).toBeInTheDocument();
+  });
+
+  it("anchors a freshly loaded transcript to the newest message", () => {
+    render(
+      <TranscriptList
+        loading={false}
+        loadingMore={false}
+        messages={[
+          {
+            id: "message-1",
+            role: "user",
+            text: "Show me the current desktop thread shell"
+          },
+          {
+            id: "message-2",
+            role: "assistant",
+            text: "The desktop shell is live and listing Codex threads."
+          }
+        ]}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      behavior: "auto",
+      top: 480
+    });
+  });
+
+  it("preserves the reader position when older messages are prepended", () => {
+    const { rerender } = render(
+      <TranscriptList
+        loading={false}
+        loadingMore={false}
+        messages={[
+          {
+            id: "message-2",
+            role: "user",
+            text: "Second message"
+          },
+          {
+            id: "message-3",
+            role: "assistant",
+            text: "Third message"
+          }
+        ]}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 80;
+    fireEvent.scroll(list);
+
+    scrollHeight = 640;
+
+    rerender(
+      <TranscriptList
+        loading={false}
+        loadingMore={false}
+        messages={[
+          {
+            id: "message-1",
+            role: "assistant",
+            text: "First message"
+          },
+          {
+            id: "message-2",
+            role: "user",
+            text: "Second message"
+          },
+          {
+            id: "message-3",
+            role: "assistant",
+            text: "Third message"
+          }
+        ]}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(240);
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -93,7 +93,9 @@ describe("TranscriptList", () => {
     fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
 
     expect(loadOlder).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "Jump to latest message" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest message" })
+    ).not.toBeInTheDocument();
   });
 
   it("anchors a freshly loaded transcript to the newest message", () => {
@@ -179,5 +181,38 @@ describe("TranscriptList", () => {
     );
 
     expect(list.scrollTop).toBe(240);
+  });
+
+  it("shows the jump-to-latest control only when the newest message is below the viewport", () => {
+    render(
+      <TranscriptList
+        loading={false}
+        loadingMore={false}
+        messages={[
+          {
+            id: "message-1",
+            role: "user",
+            text: "First message"
+          },
+          {
+            id: "message-2",
+            role: "assistant",
+            text: "Second message"
+          }
+        ]}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest message" })
+    ).not.toBeInTheDocument();
+
+    list.scrollTop = 0;
+    fireEvent.scroll(list);
+
+    expect(screen.getByRole("button", { name: "Jump to latest message" })).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -553,7 +553,7 @@ textarea {
 
 .transcript-list__scroll-bottom {
   position: absolute;
-  right: 20px;
+  left: 50%;
   bottom: 20px;
   z-index: 1;
   display: inline-flex;
@@ -565,9 +565,7 @@ textarea {
   border-color: var(--border-strong);
   background: rgba(11, 13, 18, 0.92);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
-}
-
-.transcript-list__scroll-bottom[data-has-content-below="true"] {
+  transform: translateX(-50%);
   border-color: var(--accent-border);
   background: rgba(17, 21, 28, 0.96);
 }
@@ -919,7 +917,7 @@ textarea {
   }
 
   .transcript-list__scroll-bottom {
-    right: 16px;
+    left: 50%;
     bottom: 16px;
   }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -525,10 +525,13 @@ textarea {
 
 .transcript-list {
   display: flex;
+  position: relative;
+  flex: 1;
   flex-direction: column;
   gap: 12px;
   min-height: 0;
   padding: 16px;
+  overflow: hidden;
 }
 
 .transcript-list__load-older {
@@ -537,12 +540,45 @@ textarea {
 
 .transcript-list__items {
   display: flex;
+  position: relative;
+  flex: 1;
   flex-direction: column;
   gap: 12px;
   min-height: 0;
-  max-height: 56vh;
   overflow-y: auto;
   padding-right: 4px;
+  padding-bottom: 72px;
+  scroll-behavior: smooth;
+}
+
+.transcript-list__scroll-bottom {
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1;
+  display: inline-flex;
+  width: 40px;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-color: var(--border-strong);
+  background: rgba(11, 13, 18, 0.92);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+}
+
+.transcript-list__scroll-bottom[data-has-content-below="true"] {
+  border-color: var(--accent-border);
+  background: rgba(17, 21, 28, 0.96);
+}
+
+.transcript-list__scroll-bottom-icon {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg) translateY(-2px);
 }
 
 .transcript-message {
@@ -882,8 +918,9 @@ textarea {
     flex-direction: column;
   }
 
-  .transcript-list__items {
-    max-height: 44vh;
+  .transcript-list__scroll-bottom {
+    right: 16px;
+    bottom: 16px;
   }
 
   .context-rail,


### PR DESCRIPTION
## Summary
Desktop thread transcripts now open anchored to the newest message instead of the top of the history.

This also adds a floating jump-to-latest control in the transcript panel and preserves the current reading position when older messages are loaded into the thread.

## Testing
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm test -- --project desktop apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragnt/desktop build`
