### PR TITLE
feat(desktop): render richer thread transcript activity

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12,6 +12,11 @@ class MockBackendClient {
   private readonly listeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
   >();
+  lastReadThreadParams?: {
+    threadId: string;
+    before?: string;
+    limit?: number;
+  };
 
   constructor(
     private readonly options: {
@@ -53,8 +58,14 @@ class MockBackendClient {
     };
   }
 
-  async readThread(): Promise<AppServerThreadReplay> {
+  async readThread(_params?: {
+    threadId: string;
+    before?: string;
+    limit?: number;
+  }): Promise<AppServerThreadReplay> {
+    this.lastReadThreadParams = _params;
     return this.options.replay ?? {
+      entries: [],
       messages: [],
       pagination: {
         supportsPagination: false,
@@ -192,6 +203,33 @@ describe("DesktopBackendRegistry", () => {
     ]);
 
     unsubscribe();
+    await registry.close();
+  });
+
+  it("forwards pagination parameters when reading a thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+    });
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+      before: "cursor-1",
+      limit: 25,
+    });
+
+    expect(codexClient.lastReadThreadParams).toEqual({
+      threadId: "thread-1",
+      before: "cursor-1",
+      limit: 25,
+    });
+
     await registry.close();
   });
 });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -76,16 +76,73 @@ class MockTransport implements JsonRpcTransport {
           jsonrpc: "2.0",
           id: payload.id,
           result: {
-            messages: [
-              {
-                role: "user",
-                text: "Show me the current desktop thread shell"
-              },
-              {
-                role: "assistant",
-                text: "The desktop shell is live and listing Codex threads."
-              }
-            ]
+            thread: {
+              turns: [
+                {
+                  id: "turn-1",
+                  startedAt: 1_763_500_100,
+                  items: [
+                    {
+                      type: "userMessage",
+                      id: "item-1",
+                      content: [
+                        {
+                          type: "text",
+                          text: "Show me the current desktop thread shell"
+                        }
+                      ]
+                    },
+                    {
+                      type: "agentMessage",
+                      id: "item-2",
+                      phase: "commentary",
+                      text: "I’m tracing the transcript scroll container."
+                    },
+                    {
+                      type: "commandExecution",
+                      id: "item-3",
+                      status: "completed",
+                      command: "/bin/zsh -lc 'sed -n 1,220p TranscriptList.tsx'",
+                      commandActions: [
+                        {
+                          type: "read",
+                          path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx"
+                        }
+                      ]
+                    },
+                    {
+                      type: "commandExecution",
+                      id: "item-4",
+                      status: "completed",
+                      command: "/bin/zsh -lc 'pwd && rg --files'",
+                      commandActions: [
+                        {
+                          type: "unknown"
+                        }
+                      ]
+                    },
+                    {
+                      type: "fileChange",
+                      id: "item-5",
+                      status: "completed",
+                      changes: [
+                        {
+                          path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                          kind: {
+                            type: "update"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      type: "agentMessage",
+                      id: "item-6",
+                      text: "The desktop shell is live and listing Codex threads."
+                    }
+                  ]
+                }
+              ]
+            }
           }
         })
       );
@@ -183,15 +240,74 @@ describe("CodexAppServerClient", () => {
     });
 
     expect(replay).toEqual({
+      entries: [
+        {
+          type: "message",
+          id: "item-1",
+          role: "user",
+          text: "Show me the current desktop thread shell",
+          createdAt: 1_763_500_100_000
+        },
+        {
+          type: "message",
+          id: "item-2",
+          role: "assistant",
+          text: "I’m tracing the transcript scroll container.",
+          createdAt: 1_763_500_100_000,
+          phase: "commentary"
+        },
+        {
+          type: "activity",
+          id: "activity-item-3",
+          summary: "Explored 1 file, Ran 1 command, Edited 1 file",
+          createdAt: 1_763_500_100_000,
+          status: "completed",
+          details: [
+            {
+              id: "item-3-1",
+              kind: "read",
+              label: "Read TranscriptList.tsx",
+              path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+              status: "completed"
+            },
+            {
+              id: "item-4-1",
+              kind: "command",
+              label: "pwd && rg --files",
+              status: "completed"
+            },
+            {
+              id: "item-5-1",
+              kind: "write",
+              label: "Update TranscriptList.tsx",
+              path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+              status: "completed"
+            }
+          ]
+        },
+        {
+          type: "message",
+          id: "item-6",
+          role: "assistant",
+          text: "The desktop shell is live and listing Codex threads.",
+          createdAt: 1_763_500_100_000
+        }
+      ],
       messages: [
         {
-          id: "message-1",
+          id: "item-1",
           role: "user",
           text: "Show me the current desktop thread shell",
           createdAt: undefined
         },
         {
-          id: "message-2",
+          id: "item-2",
+          role: "assistant",
+          text: "I’m tracing the transcript scroll container.",
+          createdAt: undefined
+        },
+        {
+          id: "item-6",
           role: "assistant",
           text: "The desktop shell is live and listing Codex threads.",
           createdAt: undefined

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -84,6 +84,7 @@ describe("GrokAppServerClient", () => {
 
     const replay = await client.readThread({ threadId: "thread-1" });
     expect(replay).toEqual({
+      entries: [],
       messages: [],
       lastUserMessage: "Ship Unit 3",
       lastAssistantMessage: "Done.",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -27,7 +27,11 @@ type BackendClient = {
   onNotification(
     listener: (notification: AppServerNotification) => void | Promise<void>
   ): () => void;
-  readThread(params: { threadId: string }): Promise<AppServerReadThreadResponse["replay"]>;
+  readThread(params: {
+    threadId: string;
+    before?: string;
+    limit?: number;
+  }): Promise<AppServerReadThreadResponse["replay"]>;
   startThread(params: {
     cwd?: string;
     model?: string;
@@ -151,6 +155,8 @@ export class DesktopBackendRegistry {
     const backend = request.backend ?? "codex";
     const replay = await this.getClient(backend).readThread({
       threadId: request.threadId,
+      before: request.before,
+      limit: request.limit,
     });
 
     return {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type {
   AppServerNotification,
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadActivityStatus,
+  AppServerThreadEntry,
+  AppServerThreadMessageEntry,
   AppServerThreadReplay,
   AppServerThreadReplayPagination,
   AppServerThreadSummary,
@@ -248,6 +253,276 @@ function extractConversationMessages(
   return output;
 }
 
+function normalizeActivityStatus(
+  value: string | undefined
+): AppServerThreadActivityStatus | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "in_progress" ||
+    normalized === "completed" ||
+    normalized === "failed" ||
+    normalized === "cancelled"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function pushActivityDetail(
+  details: AppServerThreadActivityDetail[],
+  detail: AppServerThreadActivityDetail
+): void {
+  const existing = details.find((candidate) => candidate.label === detail.label);
+  if (existing) {
+    if (!existing.status || existing.status === "completed") {
+      existing.status = detail.status ?? existing.status;
+    }
+    return;
+  }
+  details.push(detail);
+}
+
+function formatCommandLabel(command: string | undefined): string {
+  if (!command) {
+    return "Ran command";
+  }
+
+  const stripped = command
+    .replace(/^\/bin\/[a-z]+ -lc /, "")
+    .replace(/^['"]|['"]$/g, "");
+  const collapsed = stripped.replace(/\s+/g, " ").trim();
+  if (!collapsed) {
+    return "Ran command";
+  }
+
+  return collapsed.length > 72 ? `${collapsed.slice(0, 69)}...` : collapsed;
+}
+
+function formatActivitySummary(parts: string[]): string {
+  return parts.join(", ");
+}
+
+function summarizeActivityItems(
+  items: Record<string, unknown>[],
+  createdAt?: number
+): AppServerThreadActivityEntry | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  const details: AppServerThreadActivityDetail[] = [];
+  let inspectedFiles = 0;
+  let commandsRun = 0;
+  let changedFiles = 0;
+  let status: AppServerThreadActivityStatus | undefined;
+
+  for (const item of items) {
+    const itemId =
+      pickString(item, ["id", "itemId", "item_id"]) ?? `activity-${details.length + 1}`;
+    const itemStatus = normalizeActivityStatus(pickString(item, ["status"]));
+    if (itemStatus === "failed") {
+      status = "failed";
+    } else if (!status) {
+      status = itemStatus;
+    }
+
+    const itemType = pickString(item, ["type"]);
+    if (itemType === "commandExecution") {
+      const command = pickString(item, ["command"]);
+      const actions = Array.isArray(item.commandActions)
+        ? item.commandActions
+            .map((entry) => asRecord(entry))
+            .filter((entry): entry is Record<string, unknown> => entry !== null)
+        : [];
+
+      if (actions.length === 0) {
+        commandsRun += 1;
+        pushActivityDetail(details, {
+          id: itemId,
+          kind: "command",
+          label: formatCommandLabel(command),
+          status: itemStatus
+        });
+        continue;
+      }
+
+      for (const [index, action] of actions.entries()) {
+        const actionType = pickString(action, ["type"]);
+        const actionPath = pickString(action, ["path"]);
+        const fallbackName = pickString(action, ["name"]);
+        const detailId = `${itemId}-${index + 1}`;
+
+        if (actionType === "read" && actionPath) {
+          inspectedFiles += 1;
+          pushActivityDetail(details, {
+            id: detailId,
+            kind: "read",
+            label: `Read ${path.basename(actionPath) || actionPath}`,
+            path: actionPath,
+            status: itemStatus
+          });
+          continue;
+        }
+
+        if (actionType === "search" && actionPath) {
+          inspectedFiles += 1;
+          pushActivityDetail(details, {
+            id: detailId,
+            kind: "read",
+            label: `Searched ${path.basename(actionPath) || actionPath}`,
+            path: actionPath,
+            status: itemStatus
+          });
+          continue;
+        }
+
+        commandsRun += 1;
+        const label =
+          actionType === "listFiles"
+            ? "Listed files"
+            : actionType === "search"
+              ? "Ran search"
+              : fallbackName?.trim() || formatCommandLabel(command);
+        pushActivityDetail(details, {
+          id: detailId,
+          kind: "command",
+          label,
+          ...(actionPath ? { path: actionPath } : {}),
+          status: itemStatus
+        });
+      }
+      continue;
+    }
+
+    if (itemType === "fileChange") {
+      const changes = Array.isArray(item.changes)
+        ? item.changes
+            .map((entry) => asRecord(entry))
+            .filter((entry): entry is Record<string, unknown> => entry !== null)
+        : [];
+
+      for (const [index, change] of changes.entries()) {
+        const changePath = pickString(change, ["path"]);
+        const changeKind = asRecord(change.kind);
+        const changeType = pickString(changeKind ?? {}, ["type"]) ?? "update";
+        changedFiles += 1;
+        pushActivityDetail(details, {
+          id: `${itemId}-${index + 1}`,
+          kind: "write",
+          label: `${changeType[0]?.toUpperCase() ?? "U"}${changeType.slice(1)} ${
+            changePath ? path.basename(changePath) || changePath : "file"
+          }`,
+          path: changePath,
+          status: itemStatus
+        });
+      }
+    }
+  }
+
+  const summaryParts: string[] = [];
+  if (inspectedFiles > 0) {
+    summaryParts.push(
+      `Explored ${inspectedFiles} file${inspectedFiles === 1 ? "" : "s"}`
+    );
+  }
+  if (commandsRun > 0) {
+    summaryParts.push(`Ran ${commandsRun} command${commandsRun === 1 ? "" : "s"}`);
+  }
+  if (changedFiles > 0) {
+    summaryParts.push(`Edited ${changedFiles} file${changedFiles === 1 ? "" : "s"}`);
+  }
+
+  if (summaryParts.length === 0 && details.length === 0) {
+    return undefined;
+  }
+
+  return {
+    type: "activity",
+    id: `activity-${pickString(items[0] ?? {}, ["id", "itemId", "item_id"]) ?? "1"}`,
+    summary:
+      summaryParts.length > 0
+        ? formatActivitySummary(summaryParts)
+        : `Recorded ${details.length} activity item${details.length === 1 ? "" : "s"}`,
+    createdAt,
+    status,
+    details
+  };
+}
+
+function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
+  const record = asRecord(value);
+  const thread = asRecord(record?.thread);
+  const turns = Array.isArray(thread?.turns)
+    ? thread.turns
+        .map((entry) => asRecord(entry))
+        .filter((entry): entry is Record<string, unknown> => entry !== null)
+    : [];
+
+  if (turns.length === 0) {
+    return extractConversationMessages(value).map(
+      (message): AppServerThreadMessageEntry => ({
+        type: "message",
+        ...message
+      })
+    );
+  }
+
+  const entries: AppServerThreadEntry[] = [];
+
+  for (const turn of turns) {
+    const createdAt = normalizeEpochTimestamp(
+      pickNumber(turn, ["startedAt", "createdAt", "timestamp", "time"])
+    );
+    const rawItems = Array.isArray(turn.items)
+      ? turn.items
+          .map((entry) => asRecord(entry))
+          .filter((entry): entry is Record<string, unknown> => entry !== null)
+      : [];
+    const pendingActivityItems: Record<string, unknown>[] = [];
+
+    const flushActivityItems = (): void => {
+      const activity = summarizeActivityItems(pendingActivityItems, createdAt);
+      pendingActivityItems.length = 0;
+      if (activity) {
+        entries.push(activity);
+      }
+    };
+
+    for (const item of rawItems) {
+      const itemType = pickString(item, ["type"]);
+      const role = normalizeConversationRole(itemType);
+      if (role) {
+        flushActivityItems();
+        const text = collectMessageText(item);
+        if (!text) {
+          continue;
+        }
+        entries.push({
+          type: "message",
+          id:
+            pickString(item, ["id", "messageId", "message_id", "itemId", "item_id"]) ??
+            `message-${entries.length + 1}`,
+          role,
+          text,
+          createdAt,
+          ...(pickString(item, ["phase"]) === "commentary"
+            ? { phase: "commentary" as const }
+            : {})
+        });
+        continue;
+      }
+
+      if (itemType === "commandExecution" || itemType === "fileChange") {
+        pendingActivityItems.push(item);
+      }
+    }
+
+    flushActivityItems();
+  }
+
+  return entries;
+}
+
 function extractReplayPagination(value: unknown): AppServerThreadReplayPagination {
   const record = asRecord(value);
   const supportsPagination = Boolean(
@@ -272,6 +547,7 @@ function extractReplayPagination(value: unknown): AppServerThreadReplayPaginatio
 }
 
 function extractThreadReplayFromReadResult(value: unknown): AppServerThreadReplay {
+  const entries = extractThreadEntries(value);
   const messages = extractConversationMessages(value);
   let lastUserMessage: string | undefined;
   let lastAssistantMessage: string | undefined;
@@ -290,6 +566,7 @@ function extractThreadReplayFromReadResult(value: unknown): AppServerThreadRepla
   }
 
   return {
+    entries,
     messages,
     lastUserMessage,
     lastAssistantMessage,

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -7,6 +7,7 @@ import {
 } from "@pwragnt/agent-core";
 import type {
   AppServerNotification,
+  AppServerThreadEntry,
   AppServerThreadReplay,
   AppServerThreadSummary,
   AppServerTurnInputItem,
@@ -135,6 +136,7 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
 
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {
+      entries: [],
       messages: [],
       pagination,
     };
@@ -151,6 +153,7 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     typeof record.lastAssistantMessage === "string"
   ) {
     return {
+      entries: [],
       messages: [],
       lastUserMessage:
         typeof record.lastUserMessage === "string"
@@ -187,6 +190,10 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
       },
     ];
   });
+  const entries: AppServerThreadEntry[] = messages.map((message) => ({
+    type: "message",
+    ...message,
+  }));
 
   let lastUserMessage: string | undefined;
   let lastAssistantMessage: string | undefined;
@@ -209,6 +216,7 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
   }
 
   return {
+    entries,
     messages,
     lastUserMessage,
     lastAssistantMessage,
@@ -300,12 +308,18 @@ export class GrokAppServerClient {
     );
   }
 
-  async readThread(params: { threadId: string }): Promise<AppServerThreadReplay> {
+  async readThread(params: {
+    threadId: string;
+    before?: string;
+    limit?: number;
+  }): Promise<AppServerThreadReplay> {
     await this.ensureInitialized();
 
     const result = await this.getServer().request("thread/read", {
       threadId: params.threadId,
       includeTurns: true,
+      before: params.before,
+      limit: params.limit,
     });
 
     return extractThreadReplay(result);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -41,7 +41,7 @@ export function App() {
           platform={desktopApi?.platform}
           selectedThread={navigation.selectedThread}
           transcriptError={transcript.error}
-          transcriptMessages={transcript.messages}
+          transcriptEntries={transcript.entries}
           transcriptPagination={transcript.response?.replay.pagination}
           onLoadOlder={transcript.loadOlder}
           onRefresh={transcript.refresh}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -94,6 +94,42 @@ describe("App", () => {
           fetchedAt: Date.now(),
           threadId: "thread-1",
           replay: {
+            entries: [
+              {
+                type: "message",
+                id: "message-1",
+                role: "user",
+                text: "Open the desktop plan and build the Codex client."
+              },
+              {
+                type: "activity",
+                id: "activity-1",
+                summary: "Explored 2 files, ran 1 command",
+                details: [
+                  {
+                    id: "detail-1",
+                    kind: "read",
+                    label: "Read TranscriptList.tsx"
+                  },
+                  {
+                    id: "detail-2",
+                    kind: "read",
+                    label: "Read ThreadView.tsx"
+                  },
+                  {
+                    id: "detail-3",
+                    kind: "command",
+                    label: "pwd && rg --files"
+                  }
+                ]
+              },
+              {
+                type: "message",
+                id: "message-2",
+                role: "assistant",
+                text: "The Codex client is wired and the thread browser is live."
+              }
+            ],
             messages: [
               {
                 id: "message-1",
@@ -155,6 +191,7 @@ describe("App", () => {
     expect(
       screen.getByText("The Codex client is wired and the thread browser is live.")
     ).toBeInTheDocument();
+    expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();
     const openContextButton = screen.getByRole("button", { name: "Open context rail" });
     openContextButton.click();
     expect(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,5 +1,5 @@
 import type {
-  AppServerThreadMessage,
+  AppServerThreadEntry,
   AppServerThreadReplayPagination,
   BackendSummary,
   NavigationThreadSummary
@@ -19,7 +19,7 @@ type ThreadViewProps = {
   platform?: string;
   selectedThread?: NavigationThreadSummary;
   transcriptError?: string;
-  transcriptMessages: AppServerThreadMessage[];
+  transcriptEntries: AppServerThreadEntry[];
   transcriptPagination?: AppServerThreadReplayPagination;
   onLoadOlder: () => Promise<void>;
   onRefresh: () => Promise<void>;
@@ -69,9 +69,9 @@ export function ThreadView(props: ThreadViewProps) {
 
           <TranscriptList
             error={props.transcriptError}
+            entries={props.transcriptEntries}
             loading={props.loading}
             loadingMore={props.loadingMore}
-            messages={props.transcriptMessages}
             pagination={props.transcriptPagination}
             threadId={props.selectedThread.id}
             onLoadOlder={props.onLoadOlder}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -1,3 +1,4 @@
+import { useId, useState } from "react";
 import type { AppServerThreadActivityEntry } from "@pwragnt/shared";
 
 type TranscriptActivityProps = {
@@ -5,24 +6,57 @@ type TranscriptActivityProps = {
 };
 
 export function TranscriptActivity(props: TranscriptActivityProps) {
+  const detailsId = useId();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasDetails = props.entry.details.length > 0;
+
   return (
     <aside className="transcript-activity">
       <header className="transcript-activity__header">
-        <span className="transcript-activity__label">{props.entry.summary}</span>
-        {props.entry.createdAt ? (
-          <time className="transcript-activity__time">
-            {new Intl.DateTimeFormat(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "numeric",
-              minute: "2-digit"
-            }).format(props.entry.createdAt)}
-          </time>
-        ) : null}
+        {hasDetails ? (
+          <button
+            type="button"
+            className="transcript-activity__toggle"
+            aria-controls={detailsId}
+            aria-expanded={isExpanded}
+            onClick={() => {
+              setIsExpanded((current) => !current);
+            }}
+          >
+            <span className="transcript-activity__label">{props.entry.summary}</span>
+            <span className="transcript-activity__meta">
+              {props.entry.createdAt ? (
+                <time className="transcript-activity__time">
+                  {new Intl.DateTimeFormat(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit"
+                  }).format(props.entry.createdAt)}
+                </time>
+              ) : null}
+              <span className="transcript-activity__chevron" aria-hidden="true" />
+            </span>
+          </button>
+        ) : (
+          <>
+            <span className="transcript-activity__label">{props.entry.summary}</span>
+            {props.entry.createdAt ? (
+              <time className="transcript-activity__time">
+                {new Intl.DateTimeFormat(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit"
+                }).format(props.entry.createdAt)}
+              </time>
+            ) : null}
+          </>
+        )}
       </header>
 
-      {props.entry.details.length > 0 ? (
-        <ul className="transcript-activity__details">
+      {hasDetails && isExpanded ? (
+        <ul id={detailsId} className="transcript-activity__details">
           {props.entry.details.map((detail) => (
             <li key={detail.id} className="transcript-activity__detail">
               {detail.label}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -1,0 +1,35 @@
+import type { AppServerThreadActivityEntry } from "@pwragnt/shared";
+
+type TranscriptActivityProps = {
+  entry: AppServerThreadActivityEntry;
+};
+
+export function TranscriptActivity(props: TranscriptActivityProps) {
+  return (
+    <aside className="transcript-activity">
+      <header className="transcript-activity__header">
+        <span className="transcript-activity__label">{props.entry.summary}</span>
+        {props.entry.createdAt ? (
+          <time className="transcript-activity__time">
+            {new Intl.DateTimeFormat(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit"
+            }).format(props.entry.createdAt)}
+          </time>
+        ) : null}
+      </header>
+
+      {props.entry.details.length > 0 ? (
+        <ul className="transcript-activity__details">
+          {props.entry.details.map((detail) => (
+            <li key={detail.id} className="transcript-activity__detail">
+              {detail.label}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
-  AppServerThreadMessage,
+  AppServerThreadEntry,
   AppServerThreadReplayPagination
 } from "@pwragnt/shared";
+import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 
 type TranscriptListProps = {
+  entries: AppServerThreadEntry[];
   error?: string;
   loading: boolean;
   loadingMore: boolean;
-  messages: AppServerThreadMessage[];
   pagination?: AppServerThreadReplayPagination;
   threadId?: string;
   onLoadOlder: () => Promise<void>;
@@ -42,8 +43,8 @@ export function TranscriptList(props: TranscriptListProps) {
       return undefined;
     }
 
-    const firstMessageId = props.messages[0]?.id;
-    const lastMessageId = props.messages[props.messages.length - 1]?.id;
+    const firstMessageId = props.entries[0]?.id;
+    const lastMessageId = props.entries[props.entries.length - 1]?.id;
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
       0
@@ -58,7 +59,7 @@ export function TranscriptList(props: TranscriptListProps) {
       scrollTop: container.scrollTop,
       threadId: props.threadId
     };
-  }, [props.messages, props.threadId]);
+  }, [props.entries, props.threadId]);
 
   const syncScrollState = useCallback(() => {
     const snapshot = captureSnapshot();
@@ -96,15 +97,15 @@ export function TranscriptList(props: TranscriptListProps) {
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container || props.messages.length === 0) {
+    if (!container || props.entries.length === 0) {
       snapshotRef.current = undefined;
       setHasContentBelow(false);
       return;
     }
 
     const previousSnapshot = snapshotRef.current;
-    const firstMessageId = props.messages[0]?.id;
-    const lastMessageId = props.messages[props.messages.length - 1]?.id;
+    const firstMessageId = props.entries[0]?.id;
+    const lastMessageId = props.entries[props.entries.length - 1]?.id;
     const hasPrependedMessages = Boolean(
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
@@ -138,17 +139,17 @@ export function TranscriptList(props: TranscriptListProps) {
     }
 
     syncScrollState();
-  }, [props.messages, props.threadId, scrollToBottom, syncScrollState]);
+  }, [props.entries, props.threadId, scrollToBottom, syncScrollState]);
 
-  if (props.loading && props.messages.length === 0) {
+  if (props.loading && props.entries.length === 0) {
     return <p className="transcript-empty">Loading transcript…</p>;
   }
 
-  if (props.error && props.messages.length === 0) {
+  if (props.error && props.entries.length === 0) {
     return <p className="transcript-error">{props.error}</p>;
   }
 
-  if (props.messages.length === 0) {
+  if (props.entries.length === 0) {
     return <p className="transcript-empty">No thread history yet.</p>;
   }
 
@@ -174,9 +175,13 @@ export function TranscriptList(props: TranscriptListProps) {
         role="list"
         onScroll={syncScrollState}
       >
-        {props.messages.map((message) => (
-          <TranscriptMessage key={message.id} message={message} />
-        ))}
+        {props.entries.map((entry) =>
+          entry.type === "activity" ? (
+            <TranscriptActivity key={entry.id} entry={entry} />
+          ) : (
+            <TranscriptMessage key={entry.id} message={entry} />
+          )
+        )}
       </div>
 
       {hasContentBelow ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,8 +1,8 @@
-import type { AppServerThreadMessage } from "@pwragnt/shared";
+import type { AppServerThreadMessageEntry } from "@pwragnt/shared";
 import { MarkdownText } from "./MarkdownText";
 
 type TranscriptMessageProps = {
-  message: AppServerThreadMessage;
+  message: AppServerThreadMessageEntry;
 };
 
 export function TranscriptMessage(props: TranscriptMessageProps) {
@@ -28,7 +28,7 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
   );
 }
 
-function labelForRole(role: AppServerThreadMessage["role"]): string {
+function labelForRole(role: AppServerThreadMessageEntry["role"]): string {
   if (role === "assistant") {
     return "Assistant";
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -63,13 +63,32 @@ describe("ThreadView", () => {
             inInbox: false
           }
         }}
-        transcriptMessages={[
+        transcriptEntries={[
           {
+            type: "message",
             id: "message-1",
             role: "user",
             text: "Inspect the app-server output."
           },
           {
+            type: "activity",
+            id: "activity-1",
+            summary: "Explored 2 files",
+            details: [
+              {
+                id: "detail-1",
+                kind: "read",
+                label: "Read TranscriptList.tsx"
+              },
+              {
+                id: "detail-2",
+                kind: "read",
+                label: "Read ThreadView.tsx"
+              }
+            ]
+          },
+          {
+            type: "message",
             id: "message-2",
             role: "assistant",
             text: "The desktop client now reads the full transcript."
@@ -89,6 +108,7 @@ describe("ThreadView", () => {
     expect(
       screen.getByText("The desktop client now reads the full transcript.")
     ).toBeInTheDocument();
+    expect(screen.getByText("Explored 2 files")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 3, name: "Thread details" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pin context rail" })).toBeInTheDocument();
     expect(screen.getByText("Codex app server")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -53,20 +53,44 @@ describe("TranscriptList", () => {
 
     render(
       <TranscriptList
-        loading={false}
-        loadingMore={false}
-        messages={[
+        entries={[
           {
+            type: "message",
             id: "message-1",
             role: "user",
             text: "Open [`ce:work`](/Users/huntharo/.codex/skills/ce-work/SKILL.md)\n\n- Check Unit 4\n- Keep Unit 3 isolated"
           },
           {
+            type: "activity",
+            id: "activity-1",
+            summary: "Explored 2 files, ran 1 command",
+            details: [
+              {
+                id: "detail-1",
+                kind: "read",
+                label: "Read TranscriptList.tsx"
+              },
+              {
+                id: "detail-2",
+                kind: "read",
+                label: "Read ThreadView.tsx"
+              },
+              {
+                id: "detail-3",
+                kind: "command",
+                label: "pwd && rg --files"
+              }
+            ]
+          },
+          {
+            type: "message",
             id: "message-2",
             role: "assistant",
             text: "The desktop shell is live.\n\nRun `pnpm test -- --project desktop-renderer` next."
           }
         ]}
+        loading={false}
+        loadingMore={false}
         pagination={{
           supportsPagination: true,
           hasPreviousPage: true,
@@ -90,6 +114,10 @@ describe("TranscriptList", () => {
     expect(
       screen.getByText("pnpm test -- --project desktop-renderer").closest("article")
     ).toHaveClass("transcript-message--assistant");
+    expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();
+    expect(screen.getByText("Read TranscriptList.tsx")).toBeInTheDocument();
+    expect(screen.getByText("Read ThreadView.tsx")).toBeInTheDocument();
+    expect(screen.getByText("pwd && rg --files")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
 
@@ -99,23 +127,47 @@ describe("TranscriptList", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("anchors a freshly loaded transcript to the newest message", () => {
+  it("anchors a freshly loaded transcript to the newest entry", () => {
     render(
       <TranscriptList
-        loading={false}
-        loadingMore={false}
-        messages={[
+        entries={[
           {
+            type: "message",
             id: "message-1",
             role: "user",
             text: "Show me the current desktop thread shell"
           },
           {
+            type: "activity",
+            id: "activity-1",
+            summary: "Explored 2 files, ran 1 command",
+            details: [
+              {
+                id: "detail-1",
+                kind: "read",
+                label: "Read TranscriptList.tsx"
+              },
+              {
+                id: "detail-2",
+                kind: "read",
+                label: "Read ThreadView.tsx"
+              },
+              {
+                id: "detail-3",
+                kind: "command",
+                label: "pwd && rg --files"
+              }
+            ]
+          },
+          {
+            type: "message",
             id: "message-2",
             role: "assistant",
             text: "The desktop shell is live and listing Codex threads."
           }
         ]}
+        loading={false}
+        loadingMore={false}
         threadId="thread-1"
         onLoadOlder={async () => undefined}
       />
@@ -130,20 +182,22 @@ describe("TranscriptList", () => {
   it("preserves the reader position when older messages are prepended", () => {
     const { rerender } = render(
       <TranscriptList
-        loading={false}
-        loadingMore={false}
-        messages={[
+        entries={[
           {
+            type: "message",
             id: "message-2",
             role: "user",
             text: "Second message"
           },
           {
+            type: "message",
             id: "message-3",
             role: "assistant",
             text: "Third message"
           }
         ]}
+        loading={false}
+        loadingMore={false}
         threadId="thread-1"
         onLoadOlder={async () => undefined}
       />
@@ -157,25 +211,28 @@ describe("TranscriptList", () => {
 
     rerender(
       <TranscriptList
-        loading={false}
-        loadingMore={false}
-        messages={[
+        entries={[
           {
+            type: "message",
             id: "message-1",
             role: "assistant",
             text: "First message"
           },
           {
+            type: "message",
             id: "message-2",
             role: "user",
             text: "Second message"
           },
           {
+            type: "message",
             id: "message-3",
             role: "assistant",
             text: "Third message"
           }
         ]}
+        loading={false}
+        loadingMore={false}
         threadId="thread-1"
         onLoadOlder={async () => undefined}
       />
@@ -184,29 +241,32 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(240);
   });
 
-  it("shows the jump-to-latest control only when the newest message is below the viewport", () => {
+  it("shows the jump-to-latest control only when the newest entry is below the viewport", () => {
     render(
       <TranscriptList
-        loading={false}
-        loadingMore={false}
-        messages={[
+        entries={[
           {
+            type: "message",
             id: "message-1",
             role: "user",
             text: "First message"
           },
           {
+            type: "message",
             id: "message-2",
             role: "assistant",
             text: "Second message"
           }
         ]}
+        loading={false}
+        loadingMore={false}
         threadId="thread-1"
         onLoadOlder={async () => undefined}
       />
     );
 
     const list = screen.getByRole("list");
+
     expect(
       screen.queryByRole("button", { name: "Jump to latest message" })
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -115,6 +115,14 @@ describe("TranscriptList", () => {
       screen.getByText("pnpm test -- --project desktop-renderer").closest("article")
     ).toHaveClass("transcript-message--assistant");
     expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();
+    expect(screen.queryByText("Read TranscriptList.tsx")).not.toBeInTheDocument();
+    expect(screen.queryByText("Read ThreadView.tsx")).not.toBeInTheDocument();
+    expect(screen.queryByText("pwd && rg --files")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Explored 2 files, ran 1 command/i })
+    );
+
     expect(screen.getByText("Read TranscriptList.tsx")).toBeInTheDocument();
     expect(screen.getByText("Read ThreadView.tsx")).toBeInTheDocument();
     expect(screen.getByText("pwd && rg --files")).toBeInTheDocument();
@@ -177,6 +185,57 @@ describe("TranscriptList", () => {
       behavior: "auto",
       top: 480
     });
+  });
+
+  it("collapses activity details by default and toggles them inline", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Explored 3 files",
+            details: [
+              {
+                id: "detail-1",
+                kind: "read",
+                label: "Read TranscriptActivity.tsx"
+              },
+              {
+                id: "detail-2",
+                kind: "read",
+                label: "Read TranscriptList.tsx"
+              },
+              {
+                id: "detail-3",
+                kind: "command",
+                label: "Searched transcript-activity"
+              }
+            ]
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const toggle = screen.getByRole("button", { name: /Explored 3 files/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Read TranscriptActivity.tsx")).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Read TranscriptActivity.tsx")).toBeInTheDocument();
+    expect(screen.getByText("Read TranscriptList.tsx")).toBeInTheDocument();
+    expect(screen.getByText("Searched transcript-activity")).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Read TranscriptActivity.tsx")).not.toBeInTheDocument();
   });
 
   it("preserves the reader position when older messages are prepended", () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -1,18 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerReadThreadResponse,
+  AppServerThreadEntry,
   AppServerThreadMessage
 } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
-function mergeMessages(
-  olderMessages: AppServerThreadMessage[],
-  newerMessages: AppServerThreadMessage[]
-): AppServerThreadMessage[] {
-  const deduped = new Map<string, AppServerThreadMessage>();
+function mergeItems<T extends { id: string }>(
+  olderItems: T[],
+  newerItems: T[]
+): T[] {
+  const deduped = new Map<string, T>();
 
-  for (const message of [...olderMessages, ...newerMessages]) {
-    deduped.set(message.id, message);
+  for (const item of [...olderItems, ...newerItems]) {
+    deduped.set(item.id, item);
   }
 
   return [...deduped.values()];
@@ -23,6 +24,7 @@ export function useThreadTranscript(params: {
   threadId?: string;
 }): {
   error?: string;
+  entries: AppServerThreadEntry[];
   loading: boolean;
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
@@ -121,10 +123,8 @@ export function useThreadTranscript(params: {
           ...olderResponse,
           replay: {
             ...olderResponse.replay,
-            messages: mergeMessages(
-              olderResponse.replay.messages,
-              current.replay.messages
-            )
+            entries: mergeItems(olderResponse.replay.entries, current.replay.entries),
+            messages: mergeItems(olderResponse.replay.messages, current.replay.messages)
           }
         };
       });
@@ -139,12 +139,18 @@ export function useThreadTranscript(params: {
     }
   }, [desktopApi, response, threadId]);
 
+  const entries = useMemo(
+    () => response?.replay.entries ?? [],
+    [response?.replay.entries]
+  );
+
   const messages = useMemo(
     () => response?.replay.messages ?? [],
     [response?.replay.messages]
   );
 
   return {
+    entries,
     error,
     loading,
     loadingMore,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -187,6 +187,7 @@ textarea {
 .button:focus-visible,
 .lens-switch__button:focus-visible,
 .thread-row:focus-visible,
+.transcript-activity__toggle:focus-visible,
 .composer__input:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -712,16 +713,51 @@ textarea {
   gap: 12px;
 }
 
+.transcript-activity__toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .transcript-activity__label {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-secondary);
 }
 
+.transcript-activity__meta {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
 .transcript-activity__time {
   flex: 0 0 auto;
   color: var(--text-muted);
   font-size: 12px;
+}
+
+.transcript-activity__chevron {
+  width: 8px;
+  height: 8px;
+  margin-top: -2px;
+  border-right: 1.5px solid var(--text-muted);
+  border-bottom: 1.5px solid var(--text-muted);
+  transform: rotate(45deg);
+  transition: transform 120ms ease;
+}
+
+.transcript-activity__toggle[aria-expanded="true"] .transcript-activity__chevron {
+  transform: rotate(225deg);
 }
 
 .transcript-activity__details {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -694,6 +694,51 @@ textarea {
   text-decoration-color: currentColor;
 }
 
+.transcript-activity {
+  width: min(100%, 760px);
+  padding: 12px 0 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.transcript-list__items > .transcript-activity:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.transcript-activity__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.transcript-activity__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.transcript-activity__time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.transcript-activity__details {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.transcript-activity__detail {
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
 .context-rail {
   display: flex;
   align-self: stretch;

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -48,6 +48,40 @@ export type AppServerThreadMessage = {
   createdAt?: number;
 };
 
+export type AppServerTranscriptPhase = "commentary" | "final";
+
+export type AppServerThreadMessageEntry = AppServerThreadMessage & {
+  type: "message";
+  phase?: AppServerTranscriptPhase;
+};
+
+export type AppServerThreadActivityStatus =
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type AppServerThreadActivityDetail = {
+  id: string;
+  kind: "read" | "write" | "command";
+  label: string;
+  path?: string;
+  status?: AppServerThreadActivityStatus;
+};
+
+export type AppServerThreadActivityEntry = {
+  type: "activity";
+  id: string;
+  summary: string;
+  createdAt?: number;
+  status?: AppServerThreadActivityStatus;
+  details: AppServerThreadActivityDetail[];
+};
+
+export type AppServerThreadEntry =
+  | AppServerThreadMessageEntry
+  | AppServerThreadActivityEntry;
+
 export type AppServerThreadReplayPagination = {
   supportsPagination: boolean;
   hasPreviousPage: boolean;
@@ -55,6 +89,7 @@ export type AppServerThreadReplayPagination = {
 };
 
 export type AppServerThreadReplay = {
+  entries: AppServerThreadEntry[];
   messages: AppServerThreadMessage[];
   lastUserMessage?: string;
   lastAssistantMessage?: string;


### PR DESCRIPTION
## Summary
- preserve structured transcript entries from `thread/read` instead of reducing everything to plain chat messages
- normalize Codex turn items into grouped activity entries so the desktop transcript can render tool-use summaries and detail rows alongside user and assistant messages
- update the thread-detail renderer to consume rich transcript entries and add a compact activity block UI
- forward `before` and `limit` through the desktop backend registry so transcript pagination uses the real app-server cursor path

## Testing
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm test -- --project desktop apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/grok-app-server-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
