### PR TITLE
feat(desktop): add composer skill mentions

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AgentEvent,
   AppServerNotification,
+  AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadSummary,
   AppServerTurnInputItem,
@@ -30,6 +31,7 @@ class MockBackendClient {
       initializeError?: Error;
       threads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
+      skills?: Array<{ cwd?: string; skills: AppServerSkillSummary[] }>;
     }
   ) {}
 
@@ -47,6 +49,10 @@ class MockBackendClient {
 
   async listThreads(): Promise<AppServerThreadSummary[]> {
     return this.options.threads ?? [];
+  }
+
+  async listSkills(): Promise<Array<{ cwd?: string; skills: AppServerSkillSummary[] }>> {
+    return this.options.skills ?? [];
   }
 
   onNotification(

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -155,6 +155,34 @@ class MockTransport implements JsonRpcTransport {
           }
         })
       );
+      return;
+    }
+
+    if (payload.method === "skills/list") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {
+            data: [
+              {
+                cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                skills: [
+                  {
+                    name: "frontend-design",
+                    description: "Design and verify renderer UI work.",
+                    shortDescription: "Renderer UI design workflow.",
+                    path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+                    scope: "user",
+                    enabled: true,
+                  },
+                ],
+                errors: [],
+              },
+            ],
+          },
+        })
+      );
     }
   }
 
@@ -344,6 +372,37 @@ describe("CodexAppServerClient", () => {
         previousCursor: undefined
       }
     });
+
+    await client.close();
+  });
+
+  it("normalizes skills/list results for composer autocomplete", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const skills = await client.listSkills({
+      cwds: ["/Users/huntharo/pwrdrvr/PwrAgnt"],
+    });
+
+    expect(skills).toEqual([
+      {
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+        skills: [
+          {
+            name: "frontend-design",
+            description: "Design and verify renderer UI work.",
+            shortDescription: "Renderer UI design workflow.",
+            path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+            scope: "user",
+            enabled: true,
+          },
+        ],
+      },
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
 class MockTransport implements JsonRpcTransport {
+  static instances: MockTransport[] = [];
+  static threadResumeResult: unknown = {
+    threadId: "thread-2",
+    threadName: "Ship desktop shell",
+    cwd: "/Users/huntharo/pwrdrvr/PwrAgnt"
+  };
+  static turnStartResult: unknown = {
+    thread: {
+      id: "thread-2"
+    },
+    turn: {
+      id: "turn-1"
+    }
+  };
+
   readonly sentMessages: string[] = [];
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
+
+  constructor() {
+    MockTransport.instances.push(this);
+  }
 
   async connect(): Promise<void> {
     return;
@@ -158,6 +177,28 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/resume") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.threadResumeResult
+        })
+      );
+      return;
+    }
+
+    if (payload.method === "turn/start") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.turnStartResult
+        })
+      );
+      return;
+    }
+
     if (payload.method === "skills/list") {
       this.messageHandler(
         JSON.stringify({
@@ -208,6 +249,23 @@ vi.mock("../codex-app-server/stdio-transport", () => {
 });
 
 describe("CodexAppServerClient", () => {
+  beforeEach(() => {
+    MockTransport.instances.length = 0;
+    MockTransport.threadResumeResult = {
+      threadId: "thread-2",
+      threadName: "Ship desktop shell",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgnt"
+    };
+    MockTransport.turnStartResult = {
+      thread: {
+        id: "thread-2"
+      },
+      turn: {
+        id: "turn-1"
+      }
+    };
+  });
+
   it("initializes once and normalizes thread/list results", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
@@ -403,6 +461,67 @@ describe("CodexAppServerClient", () => {
         ],
       },
     ]);
+
+    await client.close();
+  });
+
+  it("best-effort resumes an existing thread before starting a turn", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Reply to the existing thread" }],
+      model: "gpt-5.4"
+    });
+
+    expect(result).toEqual({
+      threadId: "thread-2",
+      runId: "turn-1"
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    const rpcMethods = transport!.sentMessages.map((message) => {
+      const payload = JSON.parse(message) as { method?: string };
+      return payload.method;
+    });
+
+    expect(rpcMethods).toContain("thread/resume");
+    expect(rpcMethods).toContain("turn/start");
+
+    const resumeIndex = rpcMethods.indexOf("thread/resume");
+    const startIndex = rpcMethods.indexOf("turn/start");
+    expect(resumeIndex).toBeGreaterThan(-1);
+    expect(startIndex).toBeGreaterThan(resumeIndex);
+
+    await client.close();
+  });
+
+  it("falls back to the requested thread and a pending run id when turn/start omits ids", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.turnStartResult = {};
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Reply even if turn/start omits ids" }],
+      model: "gpt-5.4"
+    });
+
+    expect(result).toEqual({
+      threadId: "thread-2",
+      runId: "pending:thread-2"
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEvent,
+  AppServerListSkillsResponse,
   BackendCapabilities,
   BackendSummary,
   ListBackendsRequest,
@@ -24,6 +25,10 @@ type BackendClient = {
     methods?: string[];
   }>;
   listThreads(params?: { filter?: string }): Promise<AppServerThreadSummary[]>;
+  listSkills(params?: {
+    cwd?: string;
+    cwds?: string[];
+  }): Promise<AppServerListSkillsResponse["data"]>;
   onNotification(
     listener: (notification: AppServerNotification) => void | Promise<void>
   ): () => void;
@@ -147,6 +152,20 @@ export class DesktopBackendRegistry {
     return threadLists
       .flat()
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  }
+
+  async listSkills(params: {
+    backend?: AppServerBackendKind;
+    cwd?: string;
+    cwds?: string[];
+  } = {}): Promise<Pick<AppServerListSkillsResponse, "data">> {
+    const backend = params.backend ?? "codex";
+    const data = await this.getClient(backend).listSkills({
+      cwd: params.cwd,
+      cwds: params.cwds,
+    });
+
+    return { data };
   }
 
   async readThread(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8,6 +8,7 @@ import type {
   AppServerThreadActivityStatus,
   AppServerThreadEntry,
   AppServerThreadMessageEntry,
+  AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadReplayPagination,
   AppServerThreadSummary,
@@ -44,6 +45,11 @@ type RawCodexThreadSummary = Omit<
   "source" | "linkedDirectories"
 > & {
   projectKey?: string;
+};
+
+type SkillCatalogEntry = {
+  cwd?: string;
+  skills: AppServerSkillSummary[];
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -649,6 +655,60 @@ function extractThreadIdFromValue(value: unknown): string | undefined {
   return pickString(record, ["threadId", "thread_id", "id"]);
 }
 
+function extractSkillSummary(value: unknown): AppServerSkillSummary | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const name = pickString(record, ["name", "id", "slug"]);
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    name,
+    description: pickString(record, ["description", "summary"]),
+    shortDescription: pickString(record, ["shortDescription", "short_description"]),
+    path: pickString(record, ["path", "skillPath", "skill_path"]),
+    enabled: pickBoolean(record, ["enabled"]),
+    scope: pickString(record, ["scope"])
+  };
+}
+
+function extractSkillCatalog(value: unknown): SkillCatalogEntry[] {
+  const record = asRecord(value);
+  const data = Array.isArray(record?.data)
+    ? record.data
+    : Array.isArray(value)
+      ? value
+      : [];
+
+  return data.flatMap((entry): SkillCatalogEntry[] => {
+    const entryRecord = asRecord(entry);
+    if (!entryRecord) {
+      return [];
+    }
+
+    const rawSkills = Array.isArray(entryRecord.skills)
+      ? entryRecord.skills
+      : Array.isArray(entryRecord.data)
+        ? entryRecord.data
+        : [];
+    const skills = rawSkills.flatMap((skill) => {
+      const normalized = extractSkillSummary(skill);
+      return normalized ? [normalized] : [];
+    });
+
+    return [
+      {
+        cwd: pickString(entryRecord, ["cwd"]),
+        skills
+      }
+    ];
+  });
+}
+
 function extractRunIdFromValue(value: unknown): string | undefined {
   const record = asRecord(value);
   if (!record) {
@@ -939,6 +999,23 @@ export class CodexAppServerClient {
         source: "codex"
       }))
     );
+  }
+
+  async listSkills(params?: {
+    cwd?: string;
+    cwds?: string[];
+  }): Promise<SkillCatalogEntry[]> {
+    await this.ensureInitialized();
+
+    const cwds = [...new Set([...(params?.cwds ?? []), params?.cwd].filter(Boolean))];
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["skills/list"],
+      payloads: [{ cwds }],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    });
+
+    return extractSkillCatalog(result);
   }
 
   async readThread(params: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -652,7 +652,11 @@ function extractThreadIdFromValue(value: unknown): string | undefined {
     return undefined;
   }
 
-  return pickString(record, ["threadId", "thread_id", "id"]);
+  const threadRecord = asRecord(record.thread) ?? asRecord(record.session);
+  return (
+    pickString(record, ["threadId", "thread_id", "conversationId", "conversation_id"]) ??
+    pickString(threadRecord ?? {}, ["id", "threadId", "thread_id", "conversationId"])
+  );
 }
 
 function extractSkillSummary(value: unknown): AppServerSkillSummary | undefined {
@@ -715,7 +719,11 @@ function extractRunIdFromValue(value: unknown): string | undefined {
     return undefined;
   }
 
-  return pickString(record, ["runId", "run_id", "id"]);
+  const turnRecord = asRecord(record.turn) ?? asRecord(record.run);
+  return (
+    pickString(record, ["turnId", "turn_id", "runId", "run_id"]) ??
+    pickString(turnRecord ?? {}, ["id", "turnId", "turn_id", "runId", "run_id"])
+  );
 }
 
 function extractThreadRecords(value: unknown): Record<string, unknown>[] {
@@ -905,6 +913,22 @@ function buildThreadDiscoveryPayloads(filter?: string): unknown[] {
   ];
 }
 
+function buildThreadResumePayloads(params: {
+  threadId: string;
+  model?: string;
+}): Array<Record<string, unknown>> {
+  const base: Record<string, unknown> = {
+    threadId: params.threadId,
+    persistExtendedHistory: false
+  };
+
+  if (params.model?.trim()) {
+    base.model = params.model.trim();
+  }
+
+  return [base];
+}
+
 async function requestWithFallbacks(params: {
   client: JsonRpcConnection;
   methods: string[];
@@ -1074,6 +1098,16 @@ export class CodexAppServerClient {
   }): Promise<{ threadId: string; runId: string }> {
     await this.ensureInitialized();
 
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/resume"],
+      payloads: buildThreadResumePayloads({
+        threadId: params.threadId,
+        model: params.model
+      }),
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    }).catch(() => undefined);
+
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["turn/start"],
@@ -1081,11 +1115,8 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 
-    const threadId = extractThreadIdFromValue(result);
-    const runId = extractRunIdFromValue(result);
-    if (!threadId || !runId) {
-      throw new Error("codex app server turn/start did not return threadId and runId");
-    }
+    const threadId = extractThreadIdFromValue(result) ?? params.threadId;
+    const runId = extractRunIdFromValue(result) ?? `pending:${threadId}`;
 
     return { threadId, runId };
   }

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -368,11 +368,6 @@ export class GrokAppServerClient {
     );
   }
 
-  async readThread(params: {
-    threadId: string;
-    before?: string;
-    limit?: number;
-  }): Promise<AppServerThreadReplay> {
   async listSkills(params?: {
     cwd?: string;
     cwds?: string[];

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -8,6 +8,7 @@ import {
 import type {
   AppServerNotification,
   AppServerThreadEntry,
+  AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadSummary,
   AppServerTurnInputItem,
@@ -51,6 +52,11 @@ type RawThreadSummary = {
   projectKey?: string;
   createdAt?: number;
   updatedAt?: number;
+};
+
+type SkillCatalogEntry = {
+  cwd?: string;
+  skills: AppServerSkillSummary[];
 };
 
 function normalizeThreadSummary(thread: RawThreadSummary): RawThreadSummary {
@@ -250,6 +256,60 @@ function extractRunId(value: unknown): string | undefined {
       : undefined;
 }
 
+function extractSkillsList(value: unknown): SkillCatalogEntry[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const data = Array.isArray((value as { data?: unknown }).data)
+    ? ((value as { data: unknown[] }).data)
+    : [];
+
+  return data.flatMap((entry): SkillCatalogEntry[] => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const rawSkills = Array.isArray(record.skills) ? record.skills : [];
+    const skills = rawSkills.flatMap((skill): AppServerSkillSummary[] => {
+      if (!skill || typeof skill !== "object" || Array.isArray(skill)) {
+        return [];
+      }
+
+      const item = skill as Record<string, unknown>;
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      if (!name) {
+        return [];
+      }
+
+      return [
+        {
+          name,
+          description:
+            typeof item.description === "string" ? item.description : undefined,
+          shortDescription:
+            typeof item.shortDescription === "string"
+              ? item.shortDescription
+              : typeof item.short_description === "string"
+                ? item.short_description
+                : undefined,
+          path: typeof item.path === "string" ? item.path : undefined,
+          scope: typeof item.scope === "string" ? item.scope : undefined,
+          enabled: typeof item.enabled === "boolean" ? item.enabled : undefined,
+        },
+      ];
+    });
+
+    return [
+      {
+        cwd: typeof record.cwd === "string" ? record.cwd : undefined,
+        skills,
+      },
+    ];
+  });
+}
+
 export class GrokAppServerClient {
   private readonly directoryResolver: (
     projectKey?: string
@@ -306,6 +366,22 @@ export class GrokAppServerClient {
         source: "grok" as const,
       }))
     );
+  }
+
+  async readThread(params: {
+    threadId: string;
+    before?: string;
+    limit?: number;
+  }): Promise<AppServerThreadReplay> {
+  async listSkills(params?: {
+    cwd?: string;
+    cwds?: string[];
+  }): Promise<SkillCatalogEntry[]> {
+    await this.ensureInitialized();
+
+    const cwds = [...new Set([...(params?.cwds ?? []), params?.cwd].filter(Boolean))];
+    const result = await this.getServer().request("skills/list", { cwds });
+    return extractSkillsList(result);
   }
 
   async readThread(params: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2,6 +2,8 @@ import { app, ipcMain } from "electron";
 import path from "node:path";
 import { OverlayStore } from "@pwragnt/agent-core";
 import type {
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
@@ -16,6 +18,7 @@ import {
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
 import {
+  APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -54,6 +57,31 @@ class DesktopAppServerService {
       backend: backend ?? "codex",
       fetchedAt: Date.now(),
       threads
+    };
+  }
+
+  async listSkills(
+    request: AppServerListSkillsRequest = {},
+  ): Promise<AppServerListSkillsResponse> {
+    const backend = request.backend ?? "codex";
+    const response = await getDesktopBackendRegistry().listSkills({
+      backend,
+      cwd: request.cwd,
+      cwds: request.cwds,
+    });
+
+    logDebug("listSkills", {
+      backend,
+      cwd: request.cwd ?? null,
+      cwds: request.cwds ?? [],
+      entries: response.data.length,
+      skills: response.data.reduce((count, entry) => count + entry.skills.length, 0),
+    });
+
+    return {
+      backend,
+      fetchedAt: Date.now(),
+      data: response.data,
     };
   }
 
@@ -149,6 +177,16 @@ class DesktopAppServerService {
 const appServerService = new DesktopAppServerService();
 
 export function registerAppServerIpcHandlers(): void {
+  ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_LIST_SKILLS_CHANNEL,
+    async (
+      _event,
+      request?: AppServerListSkillsRequest,
+    ): Promise<AppServerListSkillsResponse> => {
+      return await appServerService.listSkills(request);
+    }
+  );
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.handle(
     APP_SERVER_LIST_THREADS_CHANNEL,
@@ -192,6 +230,7 @@ export function registerAppServerIpcHandlers(): void {
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
+  ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -5,6 +5,8 @@ import type {
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
@@ -23,6 +25,7 @@ import {
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_TURN_CHANNEL,
+  APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   BACKEND_LIST_CHANNEL,
@@ -46,6 +49,10 @@ const desktopApi = Object.freeze({
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>
     await ipcRenderer.invoke(APP_SERVER_LIST_THREADS_CHANNEL, request),
+  listSkills: async (
+    request?: AppServerListSkillsRequest
+  ): Promise<AppServerListSkillsResponse> =>
+    await ipcRenderer.invoke(APP_SERVER_LIST_SKILLS_CHANNEL, request),
   listBackends: async (
     request?: ListBackendsRequest
   ): Promise<ListBackendsResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ export function App() {
 
       <main className="app-main">
         <ThreadView
+          addOptimisticUserMessage={transcript.addOptimisticUserMessage}
           backendError={backendSummaries.error}
           backends={backendSummaries.backends}
           fetchedAt={transcript.response?.fetchedAt}
@@ -62,6 +63,7 @@ export function App() {
           transcriptEntries={transcript.entries}
           transcriptPagination={transcript.response?.replay.pagination}
           onLoadOlder={transcript.loadOlder}
+          removeOptimisticMessage={transcript.removeOptimisticMessage}
           onRefresh={transcript.refresh}
         />
       </main>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -49,8 +49,7 @@ export function App() {
             !backendSummaries.backends.some(
               (backend) =>
                 backend.kind === navigation.selectedThread?.source &&
-                backend.available &&
-                backend.capabilities.startTurn
+                backend.available
             )
           }
           desktopApi={desktopApi}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from "./features/navigation/Sidebar";
 import { ThreadView } from "./features/thread-detail/ThreadView";
 import { getDesktopApi } from "./lib/desktop-api";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
+import { useThreadSkills } from "./lib/useThreadSkills";
 import { useThreadTranscript } from "./lib/useThreadTranscript";
 
 export function App() {
@@ -10,8 +11,13 @@ export function App() {
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
   const transcript = useThreadTranscript({
+    backend: navigation.selectedThread?.source,
     desktopApi,
     threadId: navigation.selectedThread?.id
+  });
+  const skills = useThreadSkills({
+    desktopApi,
+    thread: navigation.selectedThread,
   });
 
   return (
@@ -38,8 +44,21 @@ export function App() {
           loading={transcript.loading}
           loadingMore={transcript.loadingMore}
           messageCount={transcript.messages.length}
+          composerDisabled={
+            !navigation.selectedThread ||
+            !backendSummaries.backends.some(
+              (backend) =>
+                backend.kind === navigation.selectedThread?.source &&
+                backend.available &&
+                backend.capabilities.startTurn
+            )
+          }
+          desktopApi={desktopApi}
           platform={desktopApi?.platform}
           selectedThread={navigation.selectedThread}
+          skillError={skills.error}
+          skillLoading={skills.loading}
+          skills={skills.skills}
           transcriptError={transcript.error}
           transcriptEntries={transcript.entries}
           transcriptPagination={transcript.response?.replay.pagination}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { vi } from "vitest";
 import { App } from "../App";
 
@@ -237,5 +237,25 @@ describe("App", () => {
       screen.queryByText("This thread's backend is read-only right now. You can keep drafting, but send is unavailable.")
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+
+    const reply = screen.getByLabelText("Reply");
+    fireEvent.change(reply, {
+      target: { value: "$frontend-design what can this skill do" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("what can this skill do").closest("article")
+      ).toHaveClass("transcript-message--user");
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("Waiting for the app server…");
+    expect(
+      screen.queryByText("Waiting for the app server…", {
+        selector: ".composer__meta"
+      })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("$frontend-design").length).toBeGreaterThan(0);
+    expect(screen.getByText("3 messages")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -11,6 +11,23 @@ describe("App", () => {
       value: {
         copyText,
         ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          data: [
+            {
+              cwd: "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt",
+              skills: [
+                {
+                  name: "frontend-design",
+                  description: "Design and verify renderer UI work.",
+                  path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+                  enabled: true,
+                },
+              ],
+            },
+          ],
+        }),
         listBackends: async () => ({
           fetchedAt: Date.now(),
           backends: [
@@ -18,13 +35,13 @@ describe("App", () => {
               kind: "codex",
               label: "Codex app server",
               available: true,
-              methods: ["thread/list", "thread/read"],
+              methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
               capabilities: {
                 listThreads: true,
                 createThread: false,
                 resumeThread: true,
                 readThread: true,
-                startTurn: false,
+                startTurn: true,
                 interruptTurn: false,
                 steerTurn: false,
                 transcriptPagination: true,
@@ -152,6 +169,12 @@ describe("App", () => {
           }
         }),
         platform: "darwin",
+        startTurn: async () => ({
+          backend: "codex",
+          threadId: "thread-1",
+          runId: "turn-1",
+        }),
+        onAgentEvent: () => () => undefined,
         versions: {
           electron: "41.2.1"
         }
@@ -209,6 +232,7 @@ describe("App", () => {
     expect(screen.getByText("Codex app server")).toBeInTheDocument();
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByText("darwin")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -6,6 +6,88 @@ import { App } from "../App";
 describe("App", () => {
   it("renders the live thread shell with transcript history", async () => {
     const copyText = vi.fn(async () => undefined);
+    let readThreadCalls = 0;
+    let resolveRefreshRead:
+      | ((value: {
+          backend: "codex";
+          fetchedAt: number;
+          threadId: string;
+          replay: {
+            entries: Array<Record<string, unknown>>;
+            messages: Array<Record<string, unknown>>;
+            lastUserMessage?: string;
+            lastAssistantMessage?: string;
+            pagination: {
+              supportsPagination: boolean;
+              hasPreviousPage: boolean;
+            };
+          };
+        }) => void)
+      | undefined;
+
+    const transcriptResponse = {
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      threadId: "thread-1",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Open the desktop plan and build the Codex client."
+          },
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Explored 2 files, ran 1 command",
+            details: [
+              {
+                id: "detail-1",
+                kind: "read",
+                label: "Read TranscriptList.tsx"
+              },
+              {
+                id: "detail-2",
+                kind: "read",
+                label: "Read ThreadView.tsx"
+              },
+              {
+                id: "detail-3",
+                kind: "command",
+                label: "pwd && rg --files"
+              }
+            ]
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "The Codex client is wired and the thread browser is live."
+          }
+        ],
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            text: "Open the desktop plan and build the Codex client."
+          },
+          {
+            id: "message-2",
+            role: "assistant",
+            text: "The Codex client is wired and the thread browser is live."
+          }
+        ],
+        lastUserMessage: "Open the desktop plan and build the Codex client.",
+        lastAssistantMessage:
+          "The Codex client is wired and the thread browser is live.",
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false
+        }
+      }
+    };
+
     Object.defineProperty(window, "pwragnt", {
       configurable: true,
       value: {
@@ -106,68 +188,16 @@ describe("App", () => {
           seenAt: Date.now(),
         }),
         onWindowFocus: () => () => undefined,
-        readThread: async () => ({
-          backend: "codex",
-          fetchedAt: Date.now(),
-          threadId: "thread-1",
-          replay: {
-            entries: [
-              {
-                type: "message",
-                id: "message-1",
-                role: "user",
-                text: "Open the desktop plan and build the Codex client."
-              },
-              {
-                type: "activity",
-                id: "activity-1",
-                summary: "Explored 2 files, ran 1 command",
-                details: [
-                  {
-                    id: "detail-1",
-                    kind: "read",
-                    label: "Read TranscriptList.tsx"
-                  },
-                  {
-                    id: "detail-2",
-                    kind: "read",
-                    label: "Read ThreadView.tsx"
-                  },
-                  {
-                    id: "detail-3",
-                    kind: "command",
-                    label: "pwd && rg --files"
-                  }
-                ]
-              },
-              {
-                type: "message",
-                id: "message-2",
-                role: "assistant",
-                text: "The Codex client is wired and the thread browser is live."
-              }
-            ],
-            messages: [
-              {
-                id: "message-1",
-                role: "user",
-                text: "Open the desktop plan and build the Codex client."
-              },
-              {
-                id: "message-2",
-                role: "assistant",
-                text: "The Codex client is wired and the thread browser is live."
-              }
-            ],
-            lastUserMessage: "Open the desktop plan and build the Codex client.",
-            lastAssistantMessage:
-              "The Codex client is wired and the thread browser is live.",
-            pagination: {
-              supportsPagination: false,
-              hasPreviousPage: false
-            }
+        readThread: async () => {
+          readThreadCalls += 1;
+          if (readThreadCalls === 1) {
+            return transcriptResponse;
           }
-        }),
+
+          return await new Promise((resolve) => {
+            resolveRefreshRead = resolve;
+          });
+        },
         platform: "darwin",
         startTurn: async () => ({
           backend: "codex",
@@ -249,6 +279,9 @@ describe("App", () => {
         screen.getByText("what can this skill do").closest("article")
       ).toHaveClass("transcript-message--user");
     });
+    expect(
+      screen.getByText("The Codex client is wired and the thread browser is live.")
+    ).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Thinking");
     expect(screen.getByRole("status").querySelector(".thinking-scanner")).not.toBeNull();
     expect(
@@ -258,5 +291,7 @@ describe("App", () => {
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("$frontend-design").length).toBeGreaterThan(0);
     expect(screen.getByText("3 messages")).toBeInTheDocument();
+
+    resolveRefreshRead?.(transcriptResponse);
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -35,13 +35,13 @@ describe("App", () => {
               kind: "codex",
               label: "Codex app server",
               available: true,
-              methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+              methods: ["thread/list", "thread/read", "skills/list"],
               capabilities: {
                 listThreads: true,
                 createThread: false,
                 resumeThread: true,
                 readThread: true,
-                startTurn: true,
+                startTurn: false,
                 interruptTurn: false,
                 steerTurn: false,
                 transcriptPagination: true,
@@ -233,6 +233,9 @@ describe("App", () => {
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByText("darwin")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
+    expect(
+      screen.queryByText("This thread's backend is read-only right now. You can keep drafting, but send is unavailable.")
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -249,9 +249,10 @@ describe("App", () => {
         screen.getByText("what can this skill do").closest("article")
       ).toHaveClass("transcript-message--user");
     });
-    expect(screen.getByRole("status")).toHaveTextContent("Waiting for the app server…");
+    expect(screen.getByRole("status")).toHaveTextContent("Thinking");
+    expect(screen.getByRole("status").querySelector(".thinking-scanner")).not.toBeNull();
     expect(
-      screen.queryByText("Waiting for the app server…", {
+      screen.queryByText("Thinking", {
         selector: ".composer__meta"
       })
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3,7 +3,8 @@ import type { AppServerSkillSummary, NavigationThreadSummary } from "@pwragnt/sh
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   findSkillTrigger,
-  insertSkillMention,
+  hydrateSkillLabelsWithMarkdown,
+  insertSkillLabel,
   listMentionedSkills,
 } from "../../lib/skill-mentions";
 import { SkillChip } from "./SkillChip";
@@ -88,7 +89,7 @@ export function Composer(props: ComposerProps) {
   }, [props.desktopApi, props.onRefresh, props.thread]);
 
   const submitTurn = async (): Promise<void> => {
-    const text = draft.trim();
+    const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
     if (!text || !props.thread || !props.desktopApi?.startTurn || props.disabled) {
       return;
     }
@@ -113,11 +114,11 @@ export function Composer(props: ComposerProps) {
   };
 
   const applySkill = (skill: AppServerSkillSummary): void => {
-    if (!inputRef.current || !skill.path) {
+    if (!inputRef.current) {
       return;
     }
 
-    const inserted = insertSkillMention({
+    const inserted = insertSkillLabel({
       draft,
       skill,
       selectionStart: inputRef.current.selectionStart ?? draft.length,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10,9 +10,12 @@ import {
 import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
+  addOptimisticUserMessage?: (text: string) => string;
   desktopApi?: DesktopApi;
   disabled?: boolean;
+  onPendingStatusChange?: (status?: string) => void;
   onRefresh: () => Promise<void>;
+  removeOptimisticMessage?: (id: string) => void;
   skillError?: string;
   skillLoading?: boolean;
   skills: AppServerSkillSummary[];
@@ -25,7 +28,7 @@ export function Composer(props: ComposerProps) {
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string>();
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
-  const [activeRunId, setActiveRunId] = useState<string>();
+  const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
 
   const selectionStart = inputRef.current?.selectionStart ?? draft.length;
   const selectionEnd = inputRef.current?.selectionEnd ?? draft.length;
@@ -81,12 +84,27 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "turn/failed" ||
         event.notification.method === "turn/cancelled"
       ) {
+        if (
+          activeOptimisticMessageId &&
+          (event.notification.method === "turn/failed" ||
+            event.notification.method === "turn/cancelled")
+        ) {
+          props.removeOptimisticMessage?.(activeOptimisticMessageId);
+        }
+        props.onPendingStatusChange?.(undefined);
         setSending(false);
-        setActiveRunId(undefined);
+        setActiveOptimisticMessageId(undefined);
         void props.onRefresh();
       }
     });
-  }, [props.desktopApi, props.onRefresh, props.thread]);
+  }, [
+    activeOptimisticMessageId,
+    props.desktopApi,
+    props.onPendingStatusChange,
+    props.onRefresh,
+    props.removeOptimisticMessage,
+    props.thread
+  ]);
 
   const submitTurn = async (): Promise<void> => {
     const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
@@ -96,19 +114,25 @@ export function Composer(props: ComposerProps) {
 
     setSendError(undefined);
     setSending(true);
+    props.onPendingStatusChange?.("Waiting for the app server…");
+    const optimisticMessageId = props.addOptimisticUserMessage?.(text);
+    setActiveOptimisticMessageId(optimisticMessageId);
 
     try {
       const response = await props.desktopApi.startTurn({
         backend: props.thread.source,
         threadId: props.thread.id,
-        input: [{ type: "text", text: draft }],
+        input: [{ type: "text", text }],
       });
       setDraft("");
-      setActiveRunId(response.runId);
       await props.onRefresh();
     } catch (error) {
+      if (optimisticMessageId) {
+        props.removeOptimisticMessage?.(optimisticMessageId);
+      }
+      props.onPendingStatusChange?.(undefined);
       setSending(false);
-      setActiveRunId(undefined);
+      setActiveOptimisticMessageId(undefined);
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -215,6 +239,9 @@ export function Composer(props: ComposerProps) {
                   event.preventDefault();
                   applySkill(skill);
                 }}
+                onClick={() => {
+                  applySkill(skill);
+                }}
               >
                 <span className="composer__skill-option-title">
                   <span aria-hidden="true">🧰</span>
@@ -239,7 +266,6 @@ export function Composer(props: ComposerProps) {
           This thread's backend is unavailable right now. You can keep drafting, but send is unavailable.
         </p>
       ) : null}
-      {activeRunId ? <p className="composer__meta">Waiting for the app server…</p> : null}
 
       <div className="composer__actions">
         <button

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,36 +1,247 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { AppServerSkillSummary, NavigationThreadSummary } from "@pwragnt/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  findSkillTrigger,
+  insertSkillMention,
+  listMentionedSkills,
+} from "../../lib/skill-mentions";
+import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
+  desktopApi?: DesktopApi;
   disabled?: boolean;
+  onRefresh: () => Promise<void>;
+  skillError?: string;
+  skillLoading?: boolean;
+  skills: AppServerSkillSummary[];
+  thread?: NavigationThreadSummary;
 };
 
 export function Composer(props: ComposerProps) {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string>();
+  const [activeSkillIndex, setActiveSkillIndex] = useState(0);
+  const [activeRunId, setActiveRunId] = useState<string>();
+
+  const selectionStart = inputRef.current?.selectionStart ?? draft.length;
+  const selectionEnd = inputRef.current?.selectionEnd ?? draft.length;
+  const trigger = findSkillTrigger(draft, selectionStart);
+  const filteredSkills = useMemo(() => {
+    if (!trigger) {
+      return [];
+    }
+
+    const normalizedQuery = trigger.query.trim().toLowerCase();
+    return props.skills.filter((skill) => {
+      if (!skill.path) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return (
+        skill.name.toLowerCase().includes(normalizedQuery) ||
+        skill.description?.toLowerCase().includes(normalizedQuery) ||
+        skill.shortDescription?.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [props.skills, trigger]);
+  const hasAutocomplete = Boolean(trigger && filteredSkills.length > 0);
+  const mentionedSkills = useMemo(
+    () => listMentionedSkills(draft, props.skills),
+    [draft, props.skills]
+  );
+
+  useEffect(() => {
+    setActiveSkillIndex(0);
+  }, [trigger?.query, props.thread?.id]);
+
+  useEffect(() => {
+    if (!props.desktopApi?.onAgentEvent || !props.thread) {
+      return;
+    }
+
+    return props.desktopApi.onAgentEvent((event) => {
+      if (event.backend !== props.thread?.source) {
+        return;
+      }
+
+      if (event.notification.params.threadId !== props.thread.id) {
+        return;
+      }
+
+      if (
+        event.notification.method === "turn/completed" ||
+        event.notification.method === "turn/failed" ||
+        event.notification.method === "turn/cancelled"
+      ) {
+        setSending(false);
+        setActiveRunId(undefined);
+        void props.onRefresh();
+      }
+    });
+  }, [props.desktopApi, props.onRefresh, props.thread]);
+
+  const submitTurn = async (): Promise<void> => {
+    const text = draft.trim();
+    if (!text || !props.thread || !props.desktopApi?.startTurn || props.disabled) {
+      return;
+    }
+
+    setSendError(undefined);
+    setSending(true);
+
+    try {
+      const response = await props.desktopApi.startTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        input: [{ type: "text", text: draft }],
+      });
+      setDraft("");
+      setActiveRunId(response.runId);
+      await props.onRefresh();
+    } catch (error) {
+      setSending(false);
+      setActiveRunId(undefined);
+      setSendError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const applySkill = (skill: AppServerSkillSummary): void => {
+    if (!inputRef.current || !skill.path) {
+      return;
+    }
+
+    const inserted = insertSkillMention({
+      draft,
+      skill,
+      selectionStart: inputRef.current.selectionStart ?? draft.length,
+      selectionEnd: inputRef.current.selectionEnd ?? draft.length,
+    });
+    if (!inserted) {
+      return;
+    }
+
+    setDraft(inserted.nextDraft);
+    setActiveSkillIndex(0);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(inserted.nextSelection, inserted.nextSelection);
+    });
+  };
 
   return (
     <form
       className="composer"
       onSubmit={(event) => {
         event.preventDefault();
+        void submitTurn();
       }}
     >
       <label className="composer__label" htmlFor="thread-composer">
         Reply
       </label>
-      <textarea
-        id="thread-composer"
-        className="composer__input"
-        placeholder="Reply to this thread"
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-      />
+
+      {mentionedSkills.length > 0 ? (
+        <div className="composer__mentioned-skills" aria-label="Mentioned skills">
+          {mentionedSkills.map((skill) => (
+            <SkillChip key={skill.path ?? skill.name} skill={skill} />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="composer__input-wrap">
+        <textarea
+          ref={inputRef}
+          id="thread-composer"
+          className="composer__input"
+          disabled={props.disabled || sending}
+          placeholder="Reply to this thread"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setSendError(undefined);
+          }}
+          onClick={() => {
+            setActiveSkillIndex(0);
+          }}
+          onKeyDown={(event) => {
+            if (!hasAutocomplete) {
+              return;
+            }
+
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setActiveSkillIndex((current) =>
+                Math.min(current + 1, filteredSkills.length - 1)
+              );
+              return;
+            }
+
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setActiveSkillIndex((current) => Math.max(current - 1, 0));
+              return;
+            }
+
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setActiveSkillIndex(0);
+              return;
+            }
+
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
+            }
+          }}
+        />
+
+        {hasAutocomplete ? (
+          <div className="composer__autocomplete" role="listbox" aria-label="Skills">
+            {filteredSkills.map((skill, index) => (
+              <button
+                key={skill.path ?? skill.name}
+                aria-selected={index === activeSkillIndex}
+                className={`composer__skill-option${index === activeSkillIndex ? " is-active" : ""}`}
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  applySkill(skill);
+                }}
+              >
+                <span className="composer__skill-option-title">
+                  <span aria-hidden="true">🧰</span>
+                  <span>{`$${skill.name}`}</span>
+                </span>
+                <span className="composer__skill-option-meta">
+                  {skill.shortDescription || skill.description || skill.path}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {props.skillError ? <p className="composer__meta composer__meta--error">{props.skillError}</p> : null}
+      {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
+      {!props.skillError && props.skillLoading ? (
+        <p className="composer__meta">Loading skills…</p>
+      ) : null}
+      {activeRunId ? <p className="composer__meta">Waiting for the app server…</p> : null}
+
       <div className="composer__actions">
         <button
           className="button button--primary"
-          disabled={props.disabled}
+          disabled={props.disabled || sending || !draft.trim()}
           type="submit"
         >
-          Send
+          {sending ? "Sending…" : "Send"}
         </button>
       </div>
     </form>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -114,7 +114,7 @@ export function Composer(props: ComposerProps) {
 
     setSendError(undefined);
     setSending(true);
-    props.onPendingStatusChange?.("Waiting for the app server…");
+    props.onPendingStatusChange?.("Thinking");
     const optimisticMessageId = props.addOptimisticUserMessage?.(text);
     setActiveOptimisticMessageId(optimisticMessageId);
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -160,7 +160,7 @@ export function Composer(props: ComposerProps) {
           ref={inputRef}
           id="thread-composer"
           className="composer__input"
-          disabled={props.disabled || sending}
+          disabled={sending}
           placeholder="Reply to this thread"
           value={draft}
           onChange={(event) => {
@@ -232,6 +232,11 @@ export function Composer(props: ComposerProps) {
       {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
       {!props.skillError && props.skillLoading ? (
         <p className="composer__meta">Loading skills…</p>
+      ) : null}
+      {props.disabled ? (
+        <p className="composer__meta">
+          This thread's backend is unavailable right now. You can keep drafting, but send is unavailable.
+        </p>
       ) : null}
       {activeRunId ? <p className="composer__meta">Waiting for the app server…</p> : null}
 

--- a/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
@@ -1,0 +1,24 @@
+import type { AppServerSkillSummary } from "@pwragnt/shared";
+import { buildSkillTooltip } from "../../lib/skill-mentions";
+
+type SkillChipProps = {
+  label?: string;
+  skill: AppServerSkillSummary;
+};
+
+export function SkillChip(props: SkillChipProps) {
+  const tooltip = buildSkillTooltip(props.skill);
+
+  return (
+    <span
+      className="thread-row__chip skill-chip tooltip-target"
+      data-tooltip={tooltip || undefined}
+      tabIndex={tooltip ? 0 : -1}
+    >
+      <span aria-hidden="true" className="thread-row__chip-icon">
+        🧰
+      </span>
+      {props.label ?? `$${props.skill.name}`}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -45,6 +45,7 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toHaveValue("Use $frontend-design");
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,0 +1,65 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { Composer } from "../Composer";
+
+describe("Composer", () => {
+  it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1",
+    }));
+    const refresh = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        onRefresh={refresh}
+        skills={[
+          {
+            name: "frontend-design",
+            description: "Design and verify renderer UI work.",
+            path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Use $fr" } });
+
+    expect(screen.getByRole("listbox", { name: "Skills" })).toBeInTheDocument();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByText("$frontend-design")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "text",
+            text: "Use [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md)",
+          },
+        ],
+      });
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -45,7 +45,10 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
-    expect(screen.getByLabelText("Reply")).toHaveValue("Use $frontend-design");
+    expect(screen.getByLabelText("Reply")).toHaveValue("Use $frontend-design ");
+    expect(
+      screen.queryByRole("listbox", { name: "Skills" })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
@@ -62,5 +65,49 @@ describe("Composer", () => {
       });
     });
     expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the focused skill option when activated from the keyboard", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            runId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        onRefresh={async () => undefined}
+        skills={[
+          {
+            name: "ce:plan",
+            description: "Turn feature descriptions into implementation plans.",
+            path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "$ce:pl" } });
+
+    const option = screen.getByRole("button", { name: /\$ce:plan/i });
+    option.focus();
+    fireEvent.click(option);
+
+    expect(screen.getByLabelText("Reply")).toHaveValue("$ce:plan ");
+    expect(
+      screen.queryByRole("listbox", { name: "Skills" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -26,7 +26,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             <h3 className="directory-group__title">
               <button
                 aria-label={`Copy path for ${group.label}`}
-                className="directory-group__button path-copy-target"
+                className="directory-group__button path-copy-target tooltip-target"
                 data-tooltip={group.path ? formatCopyTooltip(group.path) : undefined}
                 type="button"
                 onClick={() => {

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -37,7 +37,7 @@ export function RecentsList(props: RecentsListProps) {
                   <span
                     aria-label={`Copy path for ${directory.label}`}
                     key={`${thread.id}:${directory.id}`}
-                    className="thread-row__chip path-copy-target"
+                    className="thread-row__chip path-copy-target tooltip-target"
                     role="button"
                     tabIndex={0}
                     data-tooltip={formatCopyTooltip(directory.path)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -1,0 +1,10 @@
+export function ThinkingScanner() {
+  return (
+    <div
+      aria-hidden="true"
+      className="thinking-scanner"
+    >
+      <div className="thinking-scanner__beam" />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -98,7 +98,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                   <li key={directory.id} className="context-list__item">
                     <button
                       aria-label={`Copy path for ${directory.label}`}
-                      className="context-list__label path-copy-target"
+                      className="context-list__label path-copy-target tooltip-target"
                       data-tooltip={formatCopyTooltip(directory.path)}
                       type="button"
                       onClick={(event) => {
@@ -112,7 +112,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                     </button>
                     <button
                       aria-label={`Copy path for ${directory.kind} ${directory.label}`}
-                      className="context-list__meta path-copy-target"
+                      className="context-list__meta path-copy-target tooltip-target"
                       data-tooltip={formatCopyTooltip(directory.worktreePath ?? directory.path)}
                       type="button"
                       onClick={(event) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,10 +1,12 @@
 import type {
   AppServerThreadEntry,
+  AppServerSkillSummary,
   AppServerThreadReplayPagination,
   BackendSummary,
   NavigationThreadSummary
 } from "@pwragnt/shared";
 import { Composer } from "../composer/Composer";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptList } from "./TranscriptList";
@@ -12,12 +14,17 @@ import { TranscriptList } from "./TranscriptList";
 type ThreadViewProps = {
   backendError?: string;
   backends: BackendSummary[];
+  composerDisabled: boolean;
+  desktopApi?: DesktopApi;
   fetchedAt?: number;
   loading: boolean;
   loadingMore: boolean;
   messageCount: number;
   platform?: string;
   selectedThread?: NavigationThreadSummary;
+  skillError?: string;
+  skillLoading?: boolean;
+  skills: AppServerSkillSummary[];
   transcriptError?: string;
   transcriptEntries: AppServerThreadEntry[];
   transcriptPagination?: AppServerThreadReplayPagination;
@@ -74,6 +81,7 @@ export function ThreadView(props: ThreadViewProps) {
             loadingMore={props.loadingMore}
             pagination={props.transcriptPagination}
             threadId={props.selectedThread.id}
+            skills={props.skills}
             onLoadOlder={props.onLoadOlder}
           />
         </section>
@@ -86,7 +94,15 @@ export function ThreadView(props: ThreadViewProps) {
         />
       </div>
 
-      <Composer disabled />
+      <Composer
+        desktopApi={props.desktopApi}
+        disabled={props.composerDisabled}
+        onRefresh={props.onRefresh}
+        skillError={props.skillError}
+        skillLoading={props.skillLoading}
+        skills={props.skills}
+        thread={props.selectedThread}
+      />
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type {
   AppServerThreadEntry,
   AppServerSkillSummary,
@@ -12,6 +13,7 @@ import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptList } from "./TranscriptList";
 
 type ThreadViewProps = {
+  addOptimisticUserMessage: (text: string) => string;
   backendError?: string;
   backends: BackendSummary[];
   composerDisabled: boolean;
@@ -29,10 +31,13 @@ type ThreadViewProps = {
   transcriptEntries: AppServerThreadEntry[];
   transcriptPagination?: AppServerThreadReplayPagination;
   onLoadOlder: () => Promise<void>;
+  removeOptimisticMessage: (id: string) => void;
   onRefresh: () => Promise<void>;
 };
 
 export function ThreadView(props: ThreadViewProps) {
+  const [pendingStatusText, setPendingStatusText] = useState<string>();
+
   if (!props.selectedThread) {
     return (
       <section className="thread-empty-state">
@@ -79,6 +84,7 @@ export function ThreadView(props: ThreadViewProps) {
             entries={props.transcriptEntries}
             loading={props.loading}
             loadingMore={props.loadingMore}
+            pendingStatusText={pendingStatusText}
             pagination={props.transcriptPagination}
             threadId={props.selectedThread.id}
             skills={props.skills}
@@ -95,9 +101,12 @@ export function ThreadView(props: ThreadViewProps) {
       </div>
 
       <Composer
+        addOptimisticUserMessage={props.addOptimisticUserMessage}
         desktopApi={props.desktopApi}
         disabled={props.composerDisabled}
+        onPendingStatusChange={setPendingStatusText}
         onRefresh={props.onRefresh}
+        removeOptimisticMessage={props.removeOptimisticMessage}
         skillError={props.skillError}
         skillLoading={props.skillLoading}
         skills={props.skills}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -12,6 +12,7 @@ type TranscriptListProps = {
   error?: string;
   loading: boolean;
   loadingMore: boolean;
+  pendingStatusText?: string;
   pagination?: AppServerThreadReplayPagination;
   threadId?: string;
   skills?: AppServerSkillSummary[];
@@ -22,7 +23,9 @@ type ScrollSnapshot = {
   clientHeight: number;
   distanceFromBottom: number;
   firstMessageId?: string;
+  itemCount: number;
   lastMessageId?: string;
+  pendingStatusText?: string;
   scrollHeight: number;
   scrollTop: number;
   threadId?: string;
@@ -48,6 +51,7 @@ export function TranscriptList(props: TranscriptListProps) {
 
     const firstMessageId = props.entries[0]?.id;
     const lastMessageId = props.entries[props.entries.length - 1]?.id;
+    const itemCount = props.entries.length + (props.pendingStatusText ? 1 : 0);
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
       0
@@ -57,12 +61,14 @@ export function TranscriptList(props: TranscriptListProps) {
       clientHeight: container.clientHeight,
       distanceFromBottom,
       firstMessageId,
+      itemCount,
       lastMessageId,
+      pendingStatusText: props.pendingStatusText,
       scrollHeight: container.scrollHeight,
       scrollTop: container.scrollTop,
       threadId: props.threadId
     };
-  }, [props.entries, props.threadId]);
+  }, [props.entries, props.pendingStatusText, props.threadId]);
 
   const syncScrollState = useCallback(() => {
     const snapshot = captureSnapshot();
@@ -119,7 +125,9 @@ export function TranscriptList(props: TranscriptListProps) {
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
         previousSnapshot.firstMessageId === firstMessageId &&
-        previousSnapshot.lastMessageId !== lastMessageId
+        (previousSnapshot.lastMessageId !== lastMessageId ||
+          previousSnapshot.pendingStatusText !== props.pendingStatusText ||
+          previousSnapshot.itemCount < props.entries.length + (props.pendingStatusText ? 1 : 0))
     );
 
     if (hasPrependedMessages && previousSnapshot) {
@@ -142,7 +150,7 @@ export function TranscriptList(props: TranscriptListProps) {
     }
 
     syncScrollState();
-  }, [props.entries, props.threadId, scrollToBottom, syncScrollState]);
+  }, [props.entries, props.pendingStatusText, props.threadId, scrollToBottom, syncScrollState]);
 
   if (props.loading && props.entries.length === 0) {
     return <p className="transcript-empty">Loading transcript…</p>;
@@ -185,6 +193,11 @@ export function TranscriptList(props: TranscriptListProps) {
             <TranscriptMessage key={entry.id} message={entry} skills={skills} />
           )
         )}
+        {props.pendingStatusText ? (
+          <div className="transcript-list__pending" role="status">
+            {props.pendingStatusText}
+          </div>
+        ) : null}
       </div>
 
       {hasContentBelow ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   AppServerThreadEntry,
+  AppServerSkillSummary,
   AppServerThreadReplayPagination
 } from "@pwragnt/shared";
 import { TranscriptActivity } from "./TranscriptActivity";
@@ -13,6 +14,7 @@ type TranscriptListProps = {
   loadingMore: boolean;
   pagination?: AppServerThreadReplayPagination;
   threadId?: string;
+  skills?: AppServerSkillSummary[];
   onLoadOlder: () => Promise<void>;
 };
 
@@ -29,6 +31,7 @@ type ScrollSnapshot = {
 const BOTTOM_THRESHOLD_PX = 24;
 
 export function TranscriptList(props: TranscriptListProps) {
+  const skills = props.skills ?? [];
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const snapshotRef = useRef<ScrollSnapshot | undefined>(undefined);
   const shouldScrollToBottomRef = useRef(true);
@@ -179,7 +182,7 @@ export function TranscriptList(props: TranscriptListProps) {
           entry.type === "activity" ? (
             <TranscriptActivity key={entry.id} entry={entry} />
           ) : (
-            <TranscriptMessage key={entry.id} message={entry} />
+            <TranscriptMessage key={entry.id} message={entry} skills={skills} />
           )
         )}
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -4,6 +4,7 @@ import type {
   AppServerSkillSummary,
   AppServerThreadReplayPagination
 } from "@pwragnt/shared";
+import { ThinkingScanner } from "./ThinkingScanner";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 
@@ -195,7 +196,8 @@ export function TranscriptList(props: TranscriptListProps) {
         )}
         {props.pendingStatusText ? (
           <div className="transcript-list__pending" role="status">
-            {props.pendingStatusText}
+            <ThinkingScanner />
+            <span>{props.pendingStatusText}</span>
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,11 +1,26 @@
 import type { AppServerThreadMessageEntry } from "@pwragnt/shared";
+  AppServerSkillSummary,
+} from "@pwragnt/shared";
+import { SkillChip } from "../composer/SkillChip";
+import { parseSkillMentionParts } from "../../lib/skill-mentions";
 import { MarkdownText } from "./MarkdownText";
 
 type TranscriptMessageProps = {
   message: AppServerThreadMessageEntry;
+  skills: AppServerSkillSummary[];
 };
 
 export function TranscriptMessage(props: TranscriptMessageProps) {
+  const parts = parseSkillMentionParts(props.message.text);
+  const hasSkillMention = parts.some((part) => part.type === "skill");
+  const skillsByPath = new Map(
+    props.skills
+      .filter(
+        (skill): skill is AppServerSkillSummary & { path: string } => Boolean(skill.path)
+      )
+      .map((skill) => [skill.path, skill])
+  );
+
   return (
     <article
       className={`transcript-message transcript-message--${props.message.role}`}
@@ -23,7 +38,34 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
           </time>
         ) : null}
       </header>
-      <MarkdownText className="transcript-message__text" text={props.message.text} />
+      {hasSkillMention ? (
+        <div className="transcript-message__text">
+          {parts.map((part, index) => {
+            if (part.type === "text") {
+              return (
+                <span key={`text:${index}`} className="transcript-message__text-part">
+                  {part.text}
+                </span>
+              );
+            }
+
+            return (
+              <SkillChip
+                key={`skill:${part.path}:${index}`}
+                label={part.label}
+                skill={
+                  skillsByPath.get(part.path) ?? {
+                    name: part.name,
+                    path: part.path,
+                  }
+                }
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <MarkdownText className="transcript-message__text" text={props.message.text} />
+      )}
     </article>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,5 +1,6 @@
-import type { AppServerThreadMessageEntry } from "@pwragnt/shared";
+import type {
   AppServerSkillSummary,
+  AppServerThreadMessageEntry,
 } from "@pwragnt/shared";
 import { SkillChip } from "../composer/SkillChip";
 import { parseSkillMentionParts } from "../../lib/skill-mentions";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -11,13 +11,13 @@ describe("ThreadView", () => {
             kind: "codex",
             label: "Codex app server",
             available: true,
-            methods: ["thread/list", "thread/read"],
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
             capabilities: {
               listThreads: true,
               createThread: false,
               resumeThread: true,
               readThread: true,
-              startTurn: false,
+              startTurn: true,
               interruptTurn: false,
               steerTurn: false,
               transcriptPagination: true,
@@ -47,6 +47,14 @@ describe("ThreadView", () => {
             unavailableReason: "XAI_API_KEY is not set"
           }
         ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
         fetchedAt={Date.now()}
         loading={false}
         loadingMore={false}
@@ -63,12 +71,20 @@ describe("ThreadView", () => {
             inInbox: false
           }
         }}
+        skills={[
+          {
+            name: "frontend-design",
+            description: "Design and verify renderer UI work.",
+            path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+            enabled: true,
+          },
+        ]}
         transcriptEntries={[
           {
             type: "message",
             id: "message-1",
             role: "user",
-            text: "Inspect the app-server output."
+            text: "Inspect [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md)."
           },
           {
             type: "activity",
@@ -96,6 +112,7 @@ describe("ThreadView", () => {
         ]}
         onLoadOlder={async () => undefined}
         onRefresh={async () => undefined}
+        skillLoading={false}
       />
     );
 
@@ -109,10 +126,11 @@ describe("ThreadView", () => {
       screen.getByText("The desktop client now reads the full transcript.")
     ).toBeInTheDocument();
     expect(screen.getByText("Explored 2 files")).toBeInTheDocument();
+    expect(screen.getByText("$frontend-design")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 3, name: "Thread details" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pin context rail" })).toBeInTheDocument();
     expect(screen.getByText("Codex app server")).toBeInTheDocument();
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -6,6 +6,7 @@ describe("ThreadView", () => {
   it("renders a directory-less thread with transcript history and context", () => {
     render(
       <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
           {
             kind: "codex",
@@ -111,6 +112,7 @@ describe("ThreadView", () => {
           }
         ]}
         onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
         onRefresh={async () => undefined}
         skillLoading={false}
       />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -200,6 +200,7 @@ describe("TranscriptList", () => {
     );
 
     expect(screen.getByRole("status")).toHaveTextContent("Waiting for the app server…");
+    expect(screen.getByRole("status").querySelector(".thinking-scanner")).not.toBeNull();
   });
 
   it("anchors a freshly loaded transcript to the newest entry", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -135,6 +135,51 @@ describe("TranscriptList", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders skill mentions as chips when present", () => {
+    const loadOlder = vi.fn(async () => undefined);
+
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Load [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md)"
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "The desktop shell is live and listing Codex threads."
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pagination={{
+          supportsPagination: true,
+          hasPreviousPage: true,
+          previousCursor: "cursor-1"
+        }}
+        skills={[
+          {
+            name: "frontend-design",
+            description: "Design and verify renderer UI work.",
+            path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        threadId="thread-1"
+        onLoadOlder={loadOlder}
+      />
+    );
+
+    expect(screen.getByText("$frontend-design")).toBeInTheDocument();
+    expect(
+      screen.getByText("$frontend-design").closest("article")
+    ).toHaveClass("transcript-message--user");
+  });
+
   it("anchors a freshly loaded transcript to the newest entry", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -180,6 +180,28 @@ describe("TranscriptList", () => {
     ).toHaveClass("transcript-message--user");
   });
 
+  it("renders pending status inside the transcript list", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "What can this skill do?"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Waiting for the app server…"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Waiting for the app server…");
+  });
+
   it("anchors a freshly loaded transcript to the newest entry", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -1,19 +1,36 @@
 import type {
+  AgentEvent,
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   GetNavigationSnapshotRequest,
+  InterruptTurnRequest,
+  InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   MarkThreadSeenRequest,
-  NavigationSnapshot
+  NavigationSnapshot,
+  StartThreadRequest,
+  StartThreadResponse,
+  StartTurnRequest,
+  StartTurnResponse
 } from "@pwragnt/shared";
 
 export type DesktopApi = {
   copyText?: (text: string) => Promise<void>;
   ping?: () => string;
+  listSkills?: (
+    request?: AppServerListSkillsRequest
+  ) => Promise<AppServerListSkillsResponse>;
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;
+  startThread?: (request: StartThreadRequest) => Promise<StartThreadResponse>;
+  startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
+  interruptTurn?: (
+    request: InterruptTurnRequest
+  ) => Promise<InterruptTurnResponse>;
   getNavigationSnapshot?: (
     request?: GetNavigationSnapshotRequest
   ) => Promise<NavigationSnapshot>;
@@ -21,6 +38,7 @@ export type DesktopApi = {
     request?: ListBackendsRequest
   ) => Promise<ListBackendsResponse>;
   markThreadSeen?: (request: MarkThreadSeenRequest) => Promise<unknown>;
+  onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {

--- a/apps/desktop/src/renderer/src/lib/skill-mentions.ts
+++ b/apps/desktop/src/renderer/src/lib/skill-mentions.ts
@@ -150,7 +150,7 @@ export function insertSkillLabel(params: {
   const mention = buildSkillLabelToken(params.skill);
   const before = params.draft.slice(0, trigger.start);
   const after = params.draft.slice(Math.max(trigger.end, params.selectionEnd));
-  const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
+  const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
   const nextDraft = `${before}${mention}${needsTrailingSpace ? " " : ""}${after}`;
 
   return {

--- a/apps/desktop/src/renderer/src/lib/skill-mentions.ts
+++ b/apps/desktop/src/renderer/src/lib/skill-mentions.ts
@@ -13,12 +13,23 @@ export type SkillMentionPart =
     };
 
 const SKILL_MENTION_PATTERN = /\[(\$[^\]\r\n]+)\]\(([^)\r\n]+)\)/g;
+const SKILL_TOKEN_BOUNDARY = "(?=$|\\s|[.,!?;:])";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildSkillLabelToken(
+  skill: Pick<AppServerSkillSummary, "name">
+): string {
+  return `$${skill.name}`;
+}
 
 export function buildSkillMentionMarkdown(
   skill: Pick<AppServerSkillSummary, "name" | "path">
 ): string {
   if (!skill.path) {
-    return `$${skill.name}`;
+    return buildSkillLabelToken(skill);
   }
 
   return `[$${skill.name}](${skill.path})`;
@@ -73,19 +84,13 @@ export function listMentionedSkills(
   text: string,
   skills: AppServerSkillSummary[]
 ): AppServerSkillSummary[] {
-  const skillsByPath = new Map(
-    skills
-      .filter((skill): skill is AppServerSkillSummary & { path: string } => Boolean(skill.path))
-      .map((skill) => [skill.path, skill])
-  );
-
   const mentioned = new Map<string, AppServerSkillSummary>();
   for (const part of parseSkillMentionParts(text)) {
     if (part.type !== "skill") {
       continue;
     }
 
-    const existing = skillsByPath.get(part.path);
+    const existing = skills.find((skill) => skill.path === part.path);
     const key = part.path || part.name;
     mentioned.set(
       key,
@@ -94,6 +99,16 @@ export function listMentionedSkills(
         path: part.path,
       }
     );
+  }
+
+  for (const skill of skills) {
+    const token = buildSkillLabelToken(skill);
+    const pattern = new RegExp(`(^|\\s)${escapeRegExp(token)}${SKILL_TOKEN_BOUNDARY}`);
+    if (!pattern.test(text)) {
+      continue;
+    }
+
+    mentioned.set(skill.path ?? skill.name, skill);
   }
 
   return [...mentioned.values()];
@@ -118,9 +133,9 @@ export function findSkillTrigger(text: string, caret: number): {
   };
 }
 
-export function insertSkillMention(params: {
+export function insertSkillLabel(params: {
   draft: string;
-  skill: Pick<AppServerSkillSummary, "name" | "path">;
+  skill: Pick<AppServerSkillSummary, "name">;
   selectionEnd: number;
   selectionStart: number;
 }): {
@@ -132,7 +147,7 @@ export function insertSkillMention(params: {
     return undefined;
   }
 
-  const mention = buildSkillMentionMarkdown(params.skill);
+  const mention = buildSkillLabelToken(params.skill);
   const before = params.draft.slice(0, trigger.start);
   const after = params.draft.slice(Math.max(trigger.end, params.selectionEnd));
   const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
@@ -142,6 +157,30 @@ export function insertSkillMention(params: {
     nextDraft,
     nextSelection: before.length + mention.length + (needsTrailingSpace ? 1 : 0),
   };
+}
+
+export function hydrateSkillLabelsWithMarkdown(
+  text: string,
+  skills: AppServerSkillSummary[]
+): string {
+  let output = text;
+
+  for (const skill of skills) {
+    if (!skill.path) {
+      continue;
+    }
+
+    const token = buildSkillLabelToken(skill);
+    const pattern = new RegExp(
+      `(^|\\s)${escapeRegExp(token)}${SKILL_TOKEN_BOUNDARY}`,
+      "g"
+    );
+    output = output.replace(pattern, (_match, prefix: string) => {
+      return `${prefix}${buildSkillMentionMarkdown(skill)}`;
+    });
+  }
+
+  return output;
 }
 
 export function buildSkillTooltip(skill: AppServerSkillSummary): string {

--- a/apps/desktop/src/renderer/src/lib/skill-mentions.ts
+++ b/apps/desktop/src/renderer/src/lib/skill-mentions.ts
@@ -1,0 +1,154 @@
+import type { AppServerSkillSummary } from "@pwragnt/shared";
+
+export type SkillMentionPart =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "skill";
+      label: string;
+      name: string;
+      path: string;
+    };
+
+const SKILL_MENTION_PATTERN = /\[(\$[^\]\r\n]+)\]\(([^)\r\n]+)\)/g;
+
+export function buildSkillMentionMarkdown(
+  skill: Pick<AppServerSkillSummary, "name" | "path">
+): string {
+  if (!skill.path) {
+    return `$${skill.name}`;
+  }
+
+  return `[$${skill.name}](${skill.path})`;
+}
+
+export function parseSkillMentionParts(text: string): SkillMentionPart[] {
+  const output: SkillMentionPart[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(SKILL_MENTION_PATTERN)) {
+    const fullMatch = match[0];
+    const label = match[1];
+    const path = match[2];
+    const start = match.index ?? -1;
+
+    if (start < 0) {
+      continue;
+    }
+
+    if (start > lastIndex) {
+      output.push({
+        type: "text",
+        text: text.slice(lastIndex, start),
+      });
+    }
+
+    output.push({
+      type: "skill",
+      label,
+      name: label.slice(1),
+      path,
+    });
+
+    lastIndex = start + fullMatch.length;
+  }
+
+  if (lastIndex < text.length) {
+    output.push({
+      type: "text",
+      text: text.slice(lastIndex),
+    });
+  }
+
+  if (output.length === 0) {
+    output.push({ type: "text", text });
+  }
+
+  return output;
+}
+
+export function listMentionedSkills(
+  text: string,
+  skills: AppServerSkillSummary[]
+): AppServerSkillSummary[] {
+  const skillsByPath = new Map(
+    skills
+      .filter((skill): skill is AppServerSkillSummary & { path: string } => Boolean(skill.path))
+      .map((skill) => [skill.path, skill])
+  );
+
+  const mentioned = new Map<string, AppServerSkillSummary>();
+  for (const part of parseSkillMentionParts(text)) {
+    if (part.type !== "skill") {
+      continue;
+    }
+
+    const existing = skillsByPath.get(part.path);
+    const key = part.path || part.name;
+    mentioned.set(
+      key,
+      existing ?? {
+        name: part.name,
+        path: part.path,
+      }
+    );
+  }
+
+  return [...mentioned.values()];
+}
+
+export function findSkillTrigger(text: string, caret: number): {
+  end: number;
+  query: string;
+  start: number;
+} | undefined {
+  const prefix = text.slice(0, caret);
+  const match = /(?:^|\s)\$([A-Za-z0-9:_-]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+
+  const start = prefix.length - match[0].length + match[0].lastIndexOf("$");
+  return {
+    start,
+    end: caret,
+    query: match[1] ?? "",
+  };
+}
+
+export function insertSkillMention(params: {
+  draft: string;
+  skill: Pick<AppServerSkillSummary, "name" | "path">;
+  selectionEnd: number;
+  selectionStart: number;
+}): {
+  nextDraft: string;
+  nextSelection: number;
+} | undefined {
+  const trigger = findSkillTrigger(params.draft, params.selectionStart);
+  if (!trigger) {
+    return undefined;
+  }
+
+  const mention = buildSkillMentionMarkdown(params.skill);
+  const before = params.draft.slice(0, trigger.start);
+  const after = params.draft.slice(Math.max(trigger.end, params.selectionEnd));
+  const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
+  const nextDraft = `${before}${mention}${needsTrailingSpace ? " " : ""}${after}`;
+
+  return {
+    nextDraft,
+    nextSelection: before.length + mention.length + (needsTrailingSpace ? 1 : 0),
+  };
+}
+
+export function buildSkillTooltip(skill: AppServerSkillSummary): string {
+  const lines = [
+    skill.shortDescription?.trim() || skill.description?.trim(),
+    skill.path?.trim(),
+  ].filter((value): value is string => Boolean(value));
+
+  return lines.join("\n");
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AppServerListSkillsResponse,
+  AppServerSkillSummary,
+  NavigationThreadSummary,
+} from "@pwragnt/shared";
+import type { DesktopApi } from "./desktop-api";
+
+type SkillState = {
+  error?: string;
+  loading: boolean;
+  response?: AppServerListSkillsResponse;
+};
+
+export function useThreadSkills(params: {
+  desktopApi?: DesktopApi;
+  thread?: NavigationThreadSummary;
+}): {
+  error?: string;
+  loading: boolean;
+  response?: AppServerListSkillsResponse;
+  skills: AppServerSkillSummary[];
+} {
+  const { desktopApi, thread } = params;
+  const [state, setState] = useState<SkillState>({ loading: false });
+  const requestVersionRef = useRef(0);
+
+  useEffect(() => {
+    if (!thread || thread.source !== "codex") {
+      setState({ loading: false, error: undefined, response: undefined });
+      return;
+    }
+
+    if (!desktopApi?.listSkills) {
+      setState({
+        loading: false,
+        error: "Desktop bridge is missing listSkills().",
+        response: undefined,
+      });
+      return;
+    }
+
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    const cwds = [...new Set(
+      thread.linkedDirectories
+        .map((directory) => directory.worktreePath ?? directory.path)
+        .filter(Boolean)
+    )];
+
+    setState((current) => ({
+      ...current,
+      loading: true,
+      error: undefined,
+    }));
+
+    void desktopApi
+      .listSkills({
+        backend: thread.source,
+        cwds: cwds.length > 0 ? cwds : undefined,
+      })
+      .then((response) => {
+        if (requestVersionRef.current !== requestVersion) {
+          return;
+        }
+
+        setState({
+          loading: false,
+          error: undefined,
+          response,
+        });
+      })
+      .catch((error: unknown) => {
+        if (requestVersionRef.current !== requestVersion) {
+          return;
+        }
+
+        setState({
+          loading: false,
+          error: error instanceof Error ? error.message : String(error),
+          response: undefined,
+        });
+      });
+  }, [desktopApi, thread]);
+
+  const skills = useMemo(() => {
+    const deduped = new Map<string, AppServerSkillSummary>();
+
+    for (const entry of state.response?.data ?? []) {
+      for (const skill of entry.skills) {
+        const key = skill.path ?? `${entry.cwd ?? "global"}:${skill.name}`;
+        deduped.set(key, skill);
+      }
+    }
+
+    return [...deduped.values()].sort((left, right) =>
+      left.name.localeCompare(right.name)
+    );
+  }, [state.response?.data]);
+
+  return {
+    error: state.error,
+    loading: state.loading,
+    response: state.response,
+    skills,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -3,6 +3,7 @@ import type {
   AppServerBackendKind,
   AppServerReadThreadResponse,
   AppServerThreadEntry,
+  AppServerThreadMessageEntry,
   AppServerThreadMessage
 } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
@@ -25,21 +26,28 @@ export function useThreadTranscript(params: {
   desktopApi?: DesktopApi;
   threadId?: string;
 }): {
+  addOptimisticUserMessage: (text: string) => string;
   error?: string;
   entries: AppServerThreadEntry[];
   loading: boolean;
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
   messages: AppServerThreadMessage[];
+  removeOptimisticMessage: (id: string) => void;
   refresh: () => Promise<void>;
   response?: AppServerReadThreadResponse;
 } {
   const { backend, desktopApi, threadId } = params;
   const [response, setResponse] = useState<AppServerReadThreadResponse>();
+  const [optimisticEntries, setOptimisticEntries] = useState<AppServerThreadMessageEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string>();
   const requestVersionRef = useRef(0);
+
+  useEffect(() => {
+    setOptimisticEntries([]);
+  }, [threadId]);
 
   const loadLatest = useCallback(async (): Promise<void> => {
     if (!threadId) {
@@ -141,23 +149,59 @@ export function useThreadTranscript(params: {
     }
   }, [backend, desktopApi, response, threadId]);
 
+  const addOptimisticUserMessage = useCallback((text: string): string => {
+    const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setOptimisticEntries((current) => [
+      ...current,
+      {
+        type: "message",
+        id,
+        role: "user",
+        text,
+        createdAt: Date.now()
+      }
+    ]);
+    return id;
+  }, []);
+
+  const removeOptimisticMessage = useCallback((id: string): void => {
+    setOptimisticEntries((current) => current.filter((entry) => entry.id !== id));
+  }, []);
+
+  const visibleOptimisticEntries = useMemo(
+    () =>
+      optimisticEntries.filter(
+        (entry) =>
+          !response?.replay.messages.some(
+            (message) => message.role === entry.role && message.text === entry.text
+          )
+      ),
+    [optimisticEntries, response?.replay.messages]
+  );
+
   const entries = useMemo(
-    () => response?.replay.entries ?? [],
-    [response?.replay.entries]
+    () => mergeItems(response?.replay.entries ?? [], visibleOptimisticEntries),
+    [response?.replay.entries, visibleOptimisticEntries]
   );
 
   const messages = useMemo(
-    () => response?.replay.messages ?? [],
-    [response?.replay.messages]
+    () =>
+      mergeItems(
+        response?.replay.messages ?? [],
+        visibleOptimisticEntries.map(({ type: _type, ...message }) => message)
+      ),
+    [response?.replay.messages, visibleOptimisticEntries]
   );
 
   return {
+    addOptimisticUserMessage,
     entries,
     error,
     loading,
     loadingMore,
     loadOlder,
     messages,
+    removeOptimisticMessage,
     refresh: loadLatest,
     response
   };

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AppServerBackendKind,
   AppServerReadThreadResponse,
   AppServerThreadEntry,
   AppServerThreadMessage
@@ -20,6 +21,7 @@ function mergeItems<T extends { id: string }>(
 }
 
 export function useThreadTranscript(params: {
+  backend?: AppServerBackendKind;
   desktopApi?: DesktopApi;
   threadId?: string;
 }): {
@@ -32,7 +34,7 @@ export function useThreadTranscript(params: {
   refresh: () => Promise<void>;
   response?: AppServerReadThreadResponse;
 } {
-  const { desktopApi, threadId } = params;
+  const { backend, desktopApi, threadId } = params;
   const [response, setResponse] = useState<AppServerReadThreadResponse>();
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -65,7 +67,7 @@ export function useThreadTranscript(params: {
 
     try {
       const nextResponse = await desktopApi.readThread({
-        backend: "codex",
+        backend,
         threadId
       });
       if (requestVersionRef.current !== requestVersion) {
@@ -83,7 +85,7 @@ export function useThreadTranscript(params: {
         setLoading(false);
       }
     }
-  }, [desktopApi, threadId]);
+  }, [backend, desktopApi, threadId]);
 
   useEffect(() => {
     void loadLatest();
@@ -106,7 +108,7 @@ export function useThreadTranscript(params: {
 
     try {
       const olderResponse = await desktopApi.readThread({
-        backend: "codex",
+        backend,
         threadId,
         before: response.replay.pagination.previousCursor
       });
@@ -137,7 +139,7 @@ export function useThreadTranscript(params: {
         setLoadingMore(false);
       }
     }
-  }, [desktopApi, response, threadId]);
+  }, [backend, desktopApi, response, threadId]);
 
   const entries = useMemo(
     () => response?.replay.entries ?? [],

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -71,7 +71,9 @@ export function useThreadTranscript(params: {
 
     setLoading(true);
     setError(undefined);
-    setResponse(undefined);
+    setResponse((current) =>
+      current?.threadId === threadId ? current : undefined
+    );
 
     try {
       const nextResponse = await desktopApi.readThread({

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -710,6 +710,14 @@ textarea {
   border-top: 0;
 }
 
+.transcript-list__pending {
+  width: min(100%, 760px);
+  padding: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .transcript-activity__header {
   display: flex;
   align-items: baseline;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -712,10 +712,56 @@ textarea {
 
 .transcript-list__pending {
   width: min(100%, 760px);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
   padding: 2px 0 0;
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.45;
+}
+
+@keyframes pwragnt-kitt-scan {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(44px); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes pwragnt-kitt-glow {
+  0%, 100% { opacity: 0.72; }
+  50% { opacity: 1; }
+}
+
+.thinking-scanner {
+  position: relative;
+  width: 62px;
+  height: 6px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(95, 14, 14, 0.56);
+  box-shadow: inset 0 0 0 1px rgba(255, 106, 94, 0.14);
+}
+
+.thinking-scanner__beam {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 18px;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 88, 72, 0.2) 0%,
+    rgba(255, 122, 112, 0.95) 48%,
+    rgba(255, 88, 72, 0.2) 100%
+  );
+  box-shadow:
+    0 0 10px rgba(255, 106, 94, 0.55),
+    0 0 18px rgba(255, 78, 68, 0.28);
+  animation:
+    pwragnt-kitt-scan 1.35s cubic-bezier(0.4, 0, 0.2, 1) infinite,
+    pwragnt-kitt-glow 0.7s ease-in-out infinite;
 }
 
 .transcript-activity__header {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -329,8 +329,11 @@ textarea {
   white-space: nowrap;
 }
 
-.path-copy-target {
+.tooltip-target {
   position: relative;
+}
+
+.path-copy-target {
   cursor: pointer;
 }
 
@@ -338,7 +341,7 @@ textarea {
   filter: brightness(1.06);
 }
 
-.path-copy-target[data-tooltip]::after {
+.tooltip-target[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;
   left: 50%;
@@ -365,24 +368,24 @@ textarea {
     transform 120ms ease;
 }
 
-.path-copy-target[data-tooltip]:hover::after,
-.path-copy-target[data-tooltip]:focus-visible::after {
+.tooltip-target[data-tooltip]:hover::after,
+.tooltip-target[data-tooltip]:focus-visible::after {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
 
-.context-list__meta.path-copy-target[data-tooltip]::after {
+.context-list__meta.tooltip-target[data-tooltip]::after {
   right: 0;
   left: auto;
   transform: translateY(4px);
 }
 
-.context-list__meta.path-copy-target[data-tooltip]:hover::after,
-.context-list__meta.path-copy-target[data-tooltip]:focus-visible::after {
+.context-list__meta.tooltip-target[data-tooltip]:hover::after,
+.context-list__meta.tooltip-target[data-tooltip]:focus-visible::after {
   transform: translateY(0);
 }
 
-.path-copy-target:focus-visible {
+.tooltip-target:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -929,6 +932,16 @@ textarea {
   background: rgba(255, 255, 255, 0.02);
 }
 
+.transcript-message__text-part {
+  white-space: pre-wrap;
+}
+
+.skill-chip {
+  max-width: 100%;
+  vertical-align: middle;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
 .context-rail {
   display: flex;
   align-self: stretch;
@@ -1201,6 +1214,76 @@ textarea {
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
   color: var(--text-primary);
+}
+
+.composer__input-wrap {
+  position: relative;
+}
+
+.composer__mentioned-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.composer__autocomplete {
+  position: absolute;
+  right: 0;
+  left: 0;
+  bottom: calc(100% + 10px);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: rgba(16, 20, 28, 0.98);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
+}
+
+.composer__skill-option {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.composer__skill-option:hover,
+.composer__skill-option.is-active {
+  background: var(--bg-row-active);
+}
+
+.composer__skill-option-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.composer__skill-option-meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.composer__meta {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.composer__meta--error {
+  color: #ffb2a0;
 }
 
 .composer__actions {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,5 +1,6 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const APP_SERVER_LIST_SKILLS_CHANNEL = "app-server:list-skills";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -104,7 +104,10 @@ export type SkillSummary = {
   cwd?: string;
   name: string;
   description?: string;
+  shortDescription?: string;
+  path?: string;
   enabled?: boolean;
+  scope?: string;
 };
 
 export type ExperimentalFeatureSummary = {

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -17,6 +17,15 @@ export type AppServerLocalImageInputItem = {
   path: string;
 };
 
+export type AppServerSkillSummary = {
+  name: string;
+  description?: string;
+  shortDescription?: string;
+  path?: string;
+  enabled?: boolean;
+  scope?: string;
+};
+
 export type AppServerTurnInputItem =
   | AppServerTextInputItem
   | AppServerImageInputItem
@@ -129,6 +138,21 @@ export type AppServerReadThreadResponse = {
   fetchedAt: number;
   threadId: ThreadIdentifier;
   replay: AppServerThreadReplay;
+};
+
+export type AppServerListSkillsRequest = {
+  backend?: AppServerBackendKind;
+  cwd?: string;
+  cwds?: string[];
+};
+
+export type AppServerListSkillsResponse = {
+  backend: AppServerBackendKind;
+  fetchedAt: number;
+  data: Array<{
+    cwd?: string;
+    skills: AppServerSkillSummary[];
+  }>;
 };
 
 export type AppServerNotification =


### PR DESCRIPTION
## Summary
- fetch skill metadata from the selected app server through the desktop IPC and backend registry
- add `$` skill autocomplete in the thread composer and insert markdown skill mentions on selection
- render skill mentions as `🧰` chips with tooltip metadata in the composer and transcript, and send them through `turn/start`
- cover the new backend normalization and renderer behavior with focused desktop tests

## Testing
- pnpm typecheck
- pnpm test -- apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
