### PR TITLE
feat(desktop): add backend-aware thread creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ playwright-report/
 test-results/
 packages/agent-core/.env.local
 .env.local
+excalidraw.log

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AppServerListThreadsRequest,
+  GetNavigationSnapshotRequest,
+  MarkThreadSeenRequest,
+} from "@pwragnt/shared";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const listThreads = vi.fn(async (_request?: { backend?: "codex" | "grok"; filter?: string }) => [
+  {
+    id: "thread-1",
+    title: "Thread one",
+    source: "codex" as const,
+    linkedDirectories: [],
+    updatedAt: 2000,
+  },
+  {
+    id: "thread-1",
+    title: "Thread one (Grok)",
+    source: "grok" as const,
+    linkedDirectories: [],
+    updatedAt: 1000,
+  },
+]);
+const readThread = vi.fn(async ({ threadId }: { threadId: string }) => ({
+  messages: [{ id: `${threadId}-message`, role: "assistant" as const, text: "Loaded" }],
+  pagination: {
+    supportsPagination: false,
+    hasPreviousPage: false,
+  },
+}));
+const reconcileNavigationSnapshot = vi.fn(async (params: unknown) => ({
+  backend: (params as { backend: "all" | "codex" | "grok" }).backend,
+  fetchedAt: 1234,
+  unchanged: false,
+  threads: (params as { threads: unknown[] }).threads,
+  inboxThreadKeys: ["grok:thread-1"],
+}));
+const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
+  backend: request.backend ?? "codex",
+  threadId: request.threadId,
+  seenAt: request.seenAt ?? 2000,
+  seenUpdatedAt: request.seenUpdatedAt,
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/pwragnt-userdata"),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("@pwragnt/agent-core", () => ({
+  OverlayStore: class MockOverlayStore {
+    reconcileNavigationSnapshot = reconcileNavigationSnapshot;
+    markThreadSeen = markThreadSeen;
+  },
+}));
+
+vi.mock("../app-server/backend-registry", () => ({
+  disposeDesktopBackendRegistry: vi.fn(async () => undefined),
+  getDesktopBackendRegistry: () => ({
+    listThreads,
+    readThread,
+  }),
+}));
+
+describe("app server ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    listThreads.mockClear();
+    readThread.mockClear();
+    reconcileNavigationSnapshot.mockClear();
+    markThreadSeen.mockClear();
+  });
+
+  it("aggregates navigation snapshots across backends by default", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    );
+
+    expect(listThreads).toHaveBeenCalledWith({ backend: undefined, filter: undefined });
+    expect(reconcileNavigationSnapshot).toHaveBeenCalledWith({
+      backend: "all",
+      fetchedAt: expect.any(Number),
+      threads: [
+        expect.objectContaining({ source: "codex", id: "thread-1" }),
+        expect.objectContaining({ source: "grok", id: "thread-1" }),
+      ],
+    });
+    expect(response).toEqual({
+      backend: "all",
+      fetchedAt: 1234,
+      unchanged: false,
+      threads: [
+        expect.objectContaining({ source: "codex", id: "thread-1" }),
+        expect.objectContaining({ source: "grok", id: "thread-1" }),
+      ],
+      inboxThreadKeys: ["grok:thread-1"],
+    });
+  });
+
+  it("returns backend scope all when listing threads without a backend filter", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { APP_SERVER_LIST_THREADS_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(APP_SERVER_LIST_THREADS_CHANNEL)?.(
+      {},
+      {} satisfies AppServerListThreadsRequest,
+    );
+
+    expect(response).toEqual({
+      backend: "all",
+      fetchedAt: expect.any(Number),
+      threads: [
+        expect.objectContaining({ source: "codex", id: "thread-1" }),
+        expect.objectContaining({ source: "grok", id: "thread-1" }),
+      ],
+    });
+  });
+
+  it("marks Grok threads seen without rejecting the backend", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_MARK_THREAD_SEEN_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_MARK_THREAD_SEEN_CHANNEL)?.({}, {
+      backend: "grok",
+      threadId: "thread-1",
+      seenUpdatedAt: 3000,
+    } satisfies MarkThreadSeenRequest);
+
+    expect(markThreadSeen).toHaveBeenCalledWith({
+      backend: "grok",
+      threadId: "thread-1",
+      seenAt: undefined,
+      seenUpdatedAt: 3000,
+    });
+    expect(response).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+      seenAt: 2000,
+      seenUpdatedAt: 3000,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18,6 +18,14 @@ class MockBackendClient {
     before?: string;
     limit?: number;
   };
+  lastStartThreadParams?: {
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  };
 
   constructor(
     private readonly options: {
@@ -80,7 +88,15 @@ class MockBackendClient {
     };
   }
 
-  async startThread(): Promise<{ threadId: string }> {
+  async startThread(params?: {
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    this.lastStartThreadParams = params;
     return { threadId: "thread-1" };
   }
 
@@ -158,6 +174,59 @@ describe("DesktopBackendRegistry", () => {
         unavailableReason: "grok app server unavailable: XAI_API_KEY is not set",
       },
     ]);
+
+    await registry.close();
+  });
+
+  it("assumes Codex can create threads when initialize omits methods", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: {
+          serverInfo: { name: "Codex App Server", version: "0.120.0" },
+        },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+    });
+
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(response.backends[0]).toMatchObject({
+      kind: "codex",
+      available: true,
+      methods: [],
+      capabilities: {
+        createThread: true,
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("creates a scratch workspace for Codex thread creation when cwd is omitted", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      createScratchProjectDirectory: async () => "/Users/test/.pwragnt/projects/2026-04-16-a1b2c3",
+    });
+
+    const response = await registry.startThread({
+      backend: "codex",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(codexClient.lastStartThreadParams).toEqual({
+      cwd: "/Users/test/.pwragnt/projects/2026-04-16-a1b2c3",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -198,6 +198,7 @@ describe("DesktopBackendRegistry", () => {
       methods: [],
       capabilities: {
         createThread: true,
+        startTurn: true,
       },
     });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3,6 +3,7 @@ import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
+  static readThreadErrorByThreadId = new Map<string, { code: number; message: string }>();
   static threadStartResult: unknown = {
     thread: {
       id: "thread-3",
@@ -97,6 +98,21 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "thread/read") {
+      const threadId = (JSON.parse(message) as { params?: { threadId?: string } }).params?.threadId;
+      const readThreadError = threadId
+        ? MockTransport.readThreadErrorByThreadId.get(threadId)
+        : undefined;
+      if (readThreadError) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            error: readThreadError
+          })
+        );
+        return;
+      }
+
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -269,6 +285,7 @@ vi.mock("../codex-app-server/stdio-transport", () => {
 describe("CodexAppServerClient", () => {
   beforeEach(() => {
     MockTransport.instances.length = 0;
+    MockTransport.readThreadErrorByThreadId.clear();
     MockTransport.threadStartResult = {
       thread: {
         id: "thread-3",
@@ -504,6 +521,35 @@ describe("CodexAppServerClient", () => {
 
     expect(created).toEqual({
       threadId: "thread-3"
+    });
+
+    await client.close();
+  });
+
+  it("treats unmaterialized new threads as empty transcripts", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadErrorByThreadId.set("thread-empty", {
+      code: -32600,
+      message:
+        "thread 019d9901-ad06-7173-8df9-cd35c38d42ff is not materialized yet; includeTurns is unavailable before first user message"
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-empty"
+    });
+
+    expect(replay).toEqual({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false
+      }
     });
 
     await client.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3,6 +3,13 @@ import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
+  static threadStartResult: unknown = {
+    thread: {
+      id: "thread-3",
+      cwd: "/Users/huntharo/.pwragnt/projects/2026-04-16-ab12cd"
+    },
+    model: "gpt-5.4"
+  };
   static threadResumeResult: unknown = {
     threadId: "thread-2",
     threadName: "Ship desktop shell",
@@ -177,6 +184,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/start") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.threadStartResult
+        })
+      );
+      return;
+    }
+
     if (payload.method === "thread/resume") {
       this.messageHandler(
         JSON.stringify({
@@ -251,6 +269,13 @@ vi.mock("../codex-app-server/stdio-transport", () => {
 describe("CodexAppServerClient", () => {
   beforeEach(() => {
     MockTransport.instances.length = 0;
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-3",
+        cwd: "/Users/huntharo/.pwragnt/projects/2026-04-16-ab12cd"
+      },
+      model: "gpt-5.4"
+    };
     MockTransport.threadResumeResult = {
       threadId: "thread-2",
       threadName: "Ship desktop shell",
@@ -461,6 +486,25 @@ describe("CodexAppServerClient", () => {
         ],
       },
     ]);
+
+    await client.close();
+  });
+
+  it("extracts thread ids from nested thread results when creating a thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const created = await client.startThread({
+      cwd: "/Users/huntharo/.pwragnt/projects/2026-04-16-ab12cd"
+    });
+
+    expect(created).toEqual({
+      threadId: "thread-3"
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -84,8 +84,32 @@ describe("GrokAppServerClient", () => {
 
     const replay = await client.readThread({ threadId: "thread-1" });
     expect(replay).toEqual({
-      entries: [],
-      messages: [],
+      entries: [
+        {
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "Ship Unit 3",
+        },
+        {
+          type: "message",
+          id: "message-2",
+          role: "assistant",
+          text: "Done.",
+        },
+      ],
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          text: "Ship Unit 3",
+        },
+        {
+          id: "message-2",
+          role: "assistant",
+          text: "Done.",
+        },
+      ],
       lastUserMessage: "Ship Unit 3",
       lastAssistantMessage: "Done.",
       pagination: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14,6 +14,7 @@ import type {
 } from "@pwragnt/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
+import { createScratchProjectDirectory } from "./scratch-projects";
 
 type BackendClient = {
   close(): Promise<void>;
@@ -63,11 +64,15 @@ const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
 
 function buildCapabilities(methods: string[], backend: AppServerBackendKind): BackendCapabilities {
   const supported = new Set(methods);
+  const assumeCodexCreateThread = backend === "codex" && methods.length === 0;
 
   return {
     listThreads:
       supported.has("thread/list") || supported.has("thread/loaded/list"),
-    createThread: supported.has("thread/start") || supported.has("thread/new"),
+    createThread:
+      supported.has("thread/start") ||
+      supported.has("thread/new") ||
+      assumeCodexCreateThread,
     resumeThread: supported.has("thread/resume"),
     readThread: supported.has("thread/read"),
     startTurn: supported.has("turn/start"),
@@ -83,6 +88,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
+  private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
   >();
@@ -91,9 +97,12 @@ export class DesktopBackendRegistry {
   constructor(options?: {
     codexClient?: BackendClient;
     grokClient?: BackendClient;
+    createScratchProjectDirectory?: () => Promise<string>;
   }) {
     this.codexClient = options?.codexClient ?? new CodexAppServerClient();
     this.grokClient = options?.grokClient ?? new GrokAppServerClient();
+    this.createScratchProjectDirectory =
+      options?.createScratchProjectDirectory ?? createScratchProjectDirectory;
 
     this.unsubscribers.push(
       this.codexClient.onNotification(async (notification) => {
@@ -195,9 +204,17 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string }> {
-    const result = await this.getClient(params.backend).startThread(params);
+    const { backend, ...request } = params;
+    const cwd =
+      backend === "codex" && !request.cwd?.trim()
+        ? await this.createScratchProjectDirectory()
+        : request.cwd;
+    const result = await this.getClient(backend).startThread({
+      ...request,
+      cwd,
+    });
     return {
-      backend: params.backend,
+      backend,
       threadId: result.threadId,
     };
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -64,7 +64,7 @@ const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
 
 function buildCapabilities(methods: string[], backend: AppServerBackendKind): BackendCapabilities {
   const supported = new Set(methods);
-  const assumeCodexCreateThread = backend === "codex" && methods.length === 0;
+  const assumeCodexAppServerSurface = backend === "codex" && methods.length === 0;
 
   return {
     listThreads:
@@ -72,10 +72,10 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     createThread:
       supported.has("thread/start") ||
       supported.has("thread/new") ||
-      assumeCodexCreateThread,
+      assumeCodexAppServerSurface,
     resumeThread: supported.has("thread/resume"),
     readThread: supported.has("thread/read"),
-    startTurn: supported.has("turn/start"),
+    startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: supported.has("turn/steer"),
     transcriptPagination: false,

--- a/apps/desktop/src/main/app-server/scratch-projects.ts
+++ b/apps/desktop/src/main/app-server/scratch-projects.ts
@@ -1,0 +1,35 @@
+import { randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function formatLocalDatePrefix(date: Date): string {
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export async function createScratchProjectDirectory(
+  now = new Date()
+): Promise<string> {
+  const projectsRoot = path.join(os.homedir(), ".pwragnt", "projects");
+  await fs.mkdir(projectsRoot, { recursive: true });
+
+  const prefix = formatLocalDatePrefix(now);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const suffix = randomBytes(3).toString("hex");
+    const scratchProjectPath = path.join(projectsRoot, `${prefix}-${suffix}`);
+
+    try {
+      await fs.mkdir(scratchProjectPath);
+      return scratchProjectPath;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error("Unable to create a unique scratch project directory.");
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -775,6 +775,15 @@ function isAlreadyInitializedError(error: unknown): boolean {
   return text.toLowerCase().includes("already initialized");
 }
 
+function isUnmaterializedThreadError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  const normalized = text.toLowerCase();
+  return (
+    normalized.includes("not materialized yet") &&
+    normalized.includes("includeturns is unavailable before first user message")
+  );
+}
+
 async function runGit(projectKey: string, args: string[]): Promise<string> {
   const result = await execFile("git", ["-C", projectKey, ...args], {
     env: process.env
@@ -1049,19 +1058,35 @@ export class CodexAppServerClient {
   }): Promise<AppServerThreadReplay> {
     await this.ensureInitialized();
 
-    const result = await requestWithFallbacks({
-      client: this.connection,
-      methods: ["thread/read"],
-      payloads: [
-        {
-          threadId: params.threadId,
-          includeTurns: true,
-          before: params.before,
-          limit: params.limit
+    let result: unknown;
+    try {
+      result = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["thread/read"],
+        payloads: [
+          {
+            threadId: params.threadId,
+            includeTurns: true,
+            before: params.before,
+            limit: params.limit
+          }
+        ],
+        timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+      });
+    } catch (error) {
+      if (!isUnmaterializedThreadError(error)) {
+        throw error;
+      }
+
+      return {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false
         }
-      ],
-      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
-    });
+      };
+    }
 
     return extractThreadReplayFromReadResult(result);
   }

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -154,13 +154,38 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     messages?: Array<{ role?: unknown; text?: unknown }>;
   };
 
+  const fallbackMessages = [
+    typeof record.lastUserMessage === "string"
+      ? {
+          id: "message-1",
+          role: "user" as const,
+          text: record.lastUserMessage,
+        }
+      : undefined,
+    typeof record.lastAssistantMessage === "string"
+      ? {
+          id:
+            typeof record.lastUserMessage === "string"
+              ? "message-2"
+              : "message-1",
+          role: "assistant" as const,
+          text: record.lastAssistantMessage,
+        }
+      : undefined,
+  ].filter((message): message is { id: string; role: "user" | "assistant"; text: string } =>
+    Boolean(message)
+  );
+
   if (
     typeof record.lastUserMessage === "string" ||
     typeof record.lastAssistantMessage === "string"
   ) {
     return {
-      entries: [],
-      messages: [],
+      entries: fallbackMessages.map((message) => ({
+        type: "message" as const,
+        ...message,
+      })),
+      messages: fallbackMessages,
       lastUserMessage:
         typeof record.lastUserMessage === "string"
           ? record.lastUserMessage

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2,6 +2,7 @@ import { app, ipcMain } from "electron";
 import path from "node:path";
 import { OverlayStore } from "@pwragnt/agent-core";
 import type {
+  AppServerBackendScope,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   AppServerListThreadsRequest,
@@ -50,13 +51,13 @@ class DesktopAppServerService {
     logDebug("listThreads", {
       backend: backend ?? "all",
       count: threads.length,
-      threadIds: threads.slice(0, 5).map((thread) => thread.id)
+      threadIds: threads.slice(0, 5).map((thread) => thread.id),
     });
 
     return {
-      backend: backend ?? "codex",
+      backend: backend ?? "all",
       fetchedAt: Date.now(),
-      threads
+      threads,
     };
   }
 
@@ -111,9 +112,9 @@ class DesktopAppServerService {
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
   ): Promise<NavigationSnapshot> {
-    const backend = request.backend ?? "codex";
+    const backend: AppServerBackendScope = request.backend ?? "all";
     const threads = await getDesktopBackendRegistry().listThreads({
-      backend,
+      backend: backend === "all" ? undefined : backend,
       filter: request.filter,
     });
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
@@ -125,7 +126,7 @@ class DesktopAppServerService {
     logDebug("getNavigationSnapshot", {
       backend,
       count: snapshot.threads.length,
-      inboxCount: snapshot.inboxThreadIds.length,
+      inboxCount: snapshot.inboxThreadKeys.length,
       unchanged: snapshot.unchanged,
     });
 
@@ -136,10 +137,6 @@ class DesktopAppServerService {
     request: MarkThreadSeenRequest,
   ): Promise<MarkThreadSeenResponse> {
     const backend = request.backend ?? "codex";
-
-    if (backend !== "codex") {
-      throw new Error(`${backend} app server is not wired yet`);
-    }
 
     const response = await this.getOverlayStore().markThreadSeen({
       backend,
@@ -237,4 +234,5 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   await appServerService.close();
 }
+
 export { APP_SERVER_LIST_THREADS_CHANNEL };

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -11,9 +11,8 @@ export function App() {
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
   const transcript = useThreadTranscript({
-    backend: navigation.selectedThread?.source,
     desktopApi,
-    threadId: navigation.selectedThread?.id
+    thread: navigation.selectedThread
   });
   const skills = useThreadSkills({
     desktopApi,
@@ -24,14 +23,18 @@ export function App() {
     <div className="app-shell">
       <Sidebar
         browseMode={navigation.browseMode}
+        backends={backendSummaries.backends}
+        createThreadError={navigation.createThreadError}
         error={navigation.error}
         fetchedAt={navigation.snapshot?.fetchedAt}
         inboxThreads={navigation.inboxThreads}
         loading={navigation.loading}
+        creatingThreadBackend={navigation.creatingThreadBackend}
         refreshing={navigation.refreshing}
-        selectedThreadId={navigation.selectedThread?.id}
+        selectedThreadKey={navigation.selectedThreadKey}
         threads={navigation.threads}
         onBrowseModeChange={navigation.setBrowseMode}
+        onCreateThread={navigation.createThread}
         onRefresh={navigation.refresh}
         onSelectThread={navigation.selectThread}
       />

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -104,11 +104,11 @@ describe("App", () => {
                   name: "frontend-design",
                   description: "Design and verify renderer UI work.",
                   path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
-                  enabled: true,
-                },
-              ],
-            },
-          ],
+                  enabled: true
+                }
+              ]
+            }
+          ]
         }),
         listBackends: async () => ({
           fetchedAt: Date.now(),
@@ -117,13 +117,13 @@ describe("App", () => {
               kind: "codex",
               label: "Codex app server",
               available: true,
-              methods: ["thread/list", "thread/read", "skills/list"],
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
               capabilities: {
                 listThreads: true,
                 createThread: false,
                 resumeThread: true,
                 readThread: true,
-                startTurn: false,
+                startTurn: true,
                 interruptTurn: false,
                 steerTurn: false,
                 transcriptPagination: true,
@@ -154,10 +154,10 @@ describe("App", () => {
           ]
         }),
         getNavigationSnapshot: async () => ({
-          backend: "codex",
+          backend: "all",
           fetchedAt: Date.now(),
           unchanged: false,
-          inboxThreadIds: ["thread-1"],
+          inboxThreadKeys: ["codex:thread-1"],
           threads: [
             {
               id: "thread-1",
@@ -176,7 +176,7 @@ describe("App", () => {
               ],
               inbox: {
                 inInbox: true,
-                reason: "new-thread",
+                reason: "new-thread"
               },
               updatedAt: Date.now()
             }
@@ -185,7 +185,7 @@ describe("App", () => {
         markThreadSeen: async () => ({
           backend: "codex",
           threadId: "thread-1",
-          seenAt: Date.now(),
+          seenAt: Date.now()
         }),
         onWindowFocus: () => () => undefined,
         readThread: async () => {
@@ -202,7 +202,7 @@ describe("App", () => {
         startTurn: async () => ({
           backend: "codex",
           threadId: "thread-1",
-          runId: "turn-1",
+          runId: "turn-1"
         }),
         onAgentEvent: () => () => undefined,
         versions: {
@@ -225,6 +225,7 @@ describe("App", () => {
     expect(
       screen.getByRole("button", { name: "Refresh threads" })
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New thread" })).toBeInTheDocument();
     expect(
       await screen.findByRole("heading", {
         level: 2,
@@ -264,7 +265,7 @@ describe("App", () => {
     expect(screen.getByText("darwin")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(
-      screen.queryByText("This thread's backend is read-only right now. You can keep drafting, but send is unavailable.")
+      screen.queryByText("This thread's backend is unavailable right now. You can keep drafting, but send is unavailable.")
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
 
@@ -293,5 +294,383 @@ describe("App", () => {
     expect(screen.getByText("3 messages")).toBeInTheDocument();
 
     resolveRefreshRead?.(transcriptResponse);
+  });
+
+  it("creates and sends on a new Grok thread", async () => {
+    const startThread = vi.fn(async ({ backend }: { backend: "codex" | "grok" }) => ({
+      backend,
+      threadId: "thread-2"
+    }));
+    const startTurn = vi.fn(
+      async ({
+        backend,
+        threadId
+      }: {
+        backend: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend,
+        threadId,
+        runId: "turn-1"
+      })
+    );
+    let navigationCallCount = 0;
+
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                readThread: true,
+                startTurn: false,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true
+              }
+            },
+            {
+              kind: "grok",
+              label: "Grok app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: true,
+                transcriptPagination: false,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: false
+              }
+            }
+          ]
+        }),
+        getNavigationSnapshot: async () => {
+          navigationCallCount += 1;
+
+          if (navigationCallCount < 2) {
+            return {
+              backend: "all",
+              fetchedAt: Date.now(),
+              unchanged: false,
+              inboxThreadKeys: ["codex:thread-1"],
+              threads: [
+                {
+                  id: "thread-1",
+                  title: "Build Codex client",
+                  summary: "Wire the app-server transport and list threads",
+                  source: "codex",
+                  gitBranch: "codex/build-codex-client",
+                  linkedDirectories: [],
+                  inbox: {
+                    inInbox: true,
+                    reason: "new-thread"
+                  },
+                  updatedAt: Date.now()
+                }
+              ]
+            };
+          }
+
+          return {
+            backend: "all",
+            fetchedAt: Date.now(),
+            unchanged: false,
+            inboxThreadKeys: ["grok:thread-2"],
+            threads: [
+              {
+                id: "thread-2",
+                title: "Investigate Grok thread",
+                summary: "Start a new thread on Grok",
+                source: "grok",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: true,
+                  reason: "new-thread"
+                },
+                updatedAt: Date.now()
+              },
+              {
+                id: "thread-1",
+                title: "Build Codex client",
+                summary: "Wire the app-server transport and list threads",
+                source: "codex",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: false
+                },
+                updatedAt: Date.now() - 1000
+              }
+            ]
+          };
+        },
+        markThreadSeen: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now()
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        readThread: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => {
+          const userText =
+            backend === "grok"
+              ? "Start a Grok-backed thread from the sidebar."
+              : "Open the desktop plan and build the Codex client.";
+          const assistantText =
+            backend === "grok"
+              ? "The Grok thread is live and selected."
+              : "The Codex client is wired and the thread browser is live.";
+
+          return {
+            backend,
+            fetchedAt: Date.now(),
+            threadId,
+            replay: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: userText
+                },
+                {
+                  type: "activity",
+                  id: "activity-1",
+                  summary: "Explored 2 files, ran 1 command",
+                  details: []
+                },
+                {
+                  type: "message",
+                  id: "message-2",
+                  role: "assistant",
+                  text: assistantText
+                }
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: userText
+                },
+                {
+                  id: "message-2",
+                  role: "assistant",
+                  text: assistantText
+                }
+              ],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false
+              }
+            }
+          };
+        },
+        startThread,
+        startTurn,
+        platform: "darwin",
+        versions: {
+          electron: "41.2.1"
+        }
+      }
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Build Codex client"
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "New thread" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Create thread with Grok" }));
+
+    expect(startThread).toHaveBeenCalledWith({ backend: "grok" });
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Investigate Grok thread" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Grok").length).toBeGreaterThan(0);
+    expect(
+      await screen.findByText("The Grok thread is live and selected.")
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: {
+        value: "Can you check the plugin sdk boundary?"
+      }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(startTurn).toHaveBeenCalledWith({
+      backend: "grok",
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Can you check the plugin sdk boundary?" }]
+    });
+  });
+
+  it("keeps a newly created Codex thread selected when thread/list lags behind creation", async () => {
+    const startThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-new"
+    }));
+    const startTurn = vi.fn(
+      async ({
+        backend,
+        threadId
+      }: {
+        backend: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend,
+        threadId,
+        runId: "turn-1"
+      })
+    );
+
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true
+              }
+            }
+          ]
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all",
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-existing"],
+          threads: [
+            {
+              id: "thread-existing",
+              title: "Existing Codex thread",
+              summary: "Already in the list",
+              source: "codex",
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread"
+              },
+              updatedAt: Date.now()
+            }
+          ]
+        }),
+        markThreadSeen: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now()
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        readThread: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false
+            }
+          }
+        }),
+        startThread,
+        startTurn,
+        platform: "darwin",
+        versions: {
+          electron: "41.2.1"
+        }
+      }
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Existing Codex thread"
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "New thread" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Create thread with Codex" }));
+
+    expect(startThread).toHaveBeenCalledWith({ backend: "codex" });
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Untitled thread" })
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: {
+        value: "hello new codex thread"
+      }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-new",
+      input: [{ type: "text", text: "hello new codex thread" }]
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,8 +1,10 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 
 type DirectoriesListProps = {
-  selectedThreadId?: string;
+  selectedThreadKey?: string;
   threads: NavigationThreadSummary[];
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -48,10 +50,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
           <div className="sidebar-list sidebar-list--compact" role="list">
             {group.threads.map((thread) => {
-              const selected = thread.id === props.selectedThreadId;
+              const selected =
+                buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
               return (
                 <button
-                  key={`${group.id}:${thread.id}`}
+                  key={`${group.id}:${buildThreadIdentityKey(thread.source, thread.id)}`}
                   aria-pressed={selected}
                   className={`thread-row thread-row--compact${selected ? " is-selected" : ""}`}
                   type="button"
@@ -59,6 +62,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 >
                   <span className="thread-row__header">
                     <span className="thread-row__title">{thread.title}</span>
+                    <span className="thread-row__chip thread-row__chip--backend">
+                      {formatBackendLabel(thread.source)}
+                    </span>
                     <span className="thread-row__time">
                       {formatRelativeTime(thread.updatedAt)}
                     </span>

--- a/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
@@ -1,7 +1,9 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 
 type InboxListProps = {
-  selectedThreadId?: string;
+  selectedThreadKey?: string;
   threads: NavigationThreadSummary[];
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -18,16 +20,22 @@ export function InboxList(props: InboxListProps) {
   return (
     <div className="sidebar-list" role="list">
       {props.threads.slice(0, 4).map((thread) => {
-        const selected = thread.id === props.selectedThreadId;
+        const selected =
+          buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
         return (
           <button
-            key={thread.id}
+            key={buildThreadIdentityKey(thread.source, thread.id)}
             aria-pressed={selected}
             className={`thread-row thread-row--compact${selected ? " is-selected" : ""}`}
             type="button"
             onClick={() => props.onSelectThread(thread)}
           >
-            <span className="thread-row__title">{thread.title}</span>
+            <span className="thread-row__header">
+              <span className="thread-row__title">{thread.title}</span>
+              <span className="thread-row__chip thread-row__chip--backend">
+                {formatBackendLabel(thread.source)}
+              </span>
+            </span>
             <span className="thread-row__time">
               {formatRelativeTime(thread.updatedAt)}
             </span>

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,8 +1,10 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 
 type RecentsListProps = {
-  selectedThreadId?: string;
+  selectedThreadKey?: string;
   threads: NavigationThreadSummary[];
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -11,10 +13,11 @@ export function RecentsList(props: RecentsListProps) {
   return (
     <div className="sidebar-list sidebar-list--dense" role="list">
       {props.threads.map((thread) => {
-        const selected = thread.id === props.selectedThreadId;
+        const selected =
+          buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
         return (
           <button
-            key={thread.id}
+            key={buildThreadIdentityKey(thread.source, thread.id)}
             aria-pressed={selected}
             className={`thread-row${selected ? " is-selected" : ""}`}
             type="button"
@@ -32,6 +35,10 @@ export function RecentsList(props: RecentsListProps) {
             ) : null}
 
             <span className="thread-row__meta">
+              <span className="thread-row__chip thread-row__chip--backend">
+                {formatBackendLabel(thread.source)}
+              </span>
+
               {thread.linkedDirectories.length > 0 ? (
                 thread.linkedDirectories.map((directory) => (
                   <span

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,24 +1,46 @@
-import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { useMemo, useState } from "react";
+import type { AppServerBackendKind, BackendSummary, NavigationThreadSummary } from "@pwragnt/shared";
 import type { BrowseMode } from "../../lib/useThreadNavigation";
+import { formatBackendLabel } from "../../lib/backend-label";
 import { DirectoriesList } from "./DirectoriesList";
 import { InboxList } from "./InboxList";
 import { RecentsList } from "./RecentsList";
 
 type SidebarProps = {
+  backends: BackendSummary[];
   browseMode: BrowseMode;
+  createThreadError?: string;
   error?: string;
   fetchedAt?: number;
   inboxThreads: NavigationThreadSummary[];
   loading: boolean;
+  creatingThreadBackend?: AppServerBackendKind;
   refreshing: boolean;
-  selectedThreadId?: string;
+  selectedThreadKey?: string;
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
+  onCreateThread: (backend: AppServerBackendKind) => Promise<void>;
   onRefresh: () => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
 
 export function Sidebar(props: SidebarProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const createThreadOptions = useMemo(
+    () =>
+      props.backends.map((backend) => ({
+        backend,
+        enabled: backend.available && backend.capabilities.createThread,
+        helperText: backend.available
+          ? backend.capabilities.createThread
+            ? "Ready"
+            : "Thread creation unavailable"
+          : backend.unavailableReason ?? "Unavailable",
+      })),
+    [props.backends],
+  );
+  const hasCreateThreadOptions = createThreadOptions.some((option) => option.enabled);
+
   return (
     <aside className="sidebar">
       <header className="sidebar__masthead">
@@ -26,17 +48,65 @@ export function Sidebar(props: SidebarProps) {
           <p className="eyebrow">PwrAgnt</p>
           <h1 className="sidebar__title">Threads</h1>
         </div>
-        <button
-          aria-label="Refresh threads"
-          className="button button--ghost"
-          type="button"
-          onClick={() => {
-            void props.onRefresh();
-          }}
-        >
-          {props.refreshing ? "Syncing" : "Refresh"}
-        </button>
+
+        <div className="sidebar__masthead-actions">
+          <div className="sidebar__new-thread">
+            <button
+              aria-expanded={menuOpen}
+              aria-haspopup="menu"
+              className="button button--primary"
+              disabled={!hasCreateThreadOptions || Boolean(props.creatingThreadBackend)}
+              type="button"
+              onClick={() => {
+                setMenuOpen((current) => !current);
+              }}
+            >
+              {props.creatingThreadBackend
+                ? `Starting ${formatBackendLabel(props.creatingThreadBackend)}...`
+                : "New thread"}
+            </button>
+
+            {menuOpen ? (
+              <div className="sidebar__menu" role="menu" aria-label="New thread backend">
+                {createThreadOptions.map(({ backend, enabled, helperText }) => (
+                  <button
+                    key={backend.kind}
+                    aria-label={`Create thread with ${formatBackendLabel(backend.kind)}`}
+                    className="sidebar__menu-item"
+                    disabled={!enabled || Boolean(props.creatingThreadBackend)}
+                    role="menuitem"
+                    type="button"
+                    onClick={() => {
+                      void props.onCreateThread(backend.kind);
+                      setMenuOpen(false);
+                    }}
+                  >
+                    <span className="sidebar__menu-item-title">
+                      {formatBackendLabel(backend.kind)}
+                    </span>
+                    <span className="sidebar__menu-item-detail">{helperText}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <button
+            aria-label="Refresh threads"
+            className="button button--ghost"
+            type="button"
+            onClick={() => {
+              void props.onRefresh();
+            }}
+          >
+            {props.refreshing ? "Syncing" : "Refresh"}
+          </button>
+        </div>
       </header>
+
+      {props.createThreadError ? (
+        <p className="sidebar-error sidebar-error--masthead">{props.createThreadError}</p>
+      ) : null}
 
       <section className="sidebar__section">
         <div className="sidebar__section-header">
@@ -44,7 +114,7 @@ export function Sidebar(props: SidebarProps) {
           <span className="count-pill">{props.inboxThreads.length}</span>
         </div>
         <InboxList
-          selectedThreadId={props.selectedThreadId}
+          selectedThreadKey={props.selectedThreadKey}
           threads={props.inboxThreads}
           onSelectThread={props.onSelectThread}
         />
@@ -79,20 +149,20 @@ export function Sidebar(props: SidebarProps) {
 
         <div className="sidebar__scroll-region">
           {props.loading ? (
-            <p className="sidebar-empty">Loading Codex threads…</p>
+            <p className="sidebar-empty">Loading threads…</p>
           ) : props.error ? (
             <p className="sidebar-error">{props.error}</p>
           ) : props.threads.length === 0 ? (
-            <p className="sidebar-empty">Codex returned zero threads.</p>
+            <p className="sidebar-empty">No threads yet.</p>
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
-              selectedThreadId={props.selectedThreadId}
+              selectedThreadKey={props.selectedThreadKey}
               threads={props.threads}
               onSelectThread={props.onSelectThread}
             />
           ) : (
             <RecentsList
-              selectedThreadId={props.selectedThreadId}
+              selectedThreadKey={props.selectedThreadKey}
               threads={props.threads}
               onSelectThread={props.onSelectThread}
             />

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2,7 +2,50 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react";
 import { vi } from "vitest";
+import type { BackendSummary } from "@pwragnt/shared";
 import { Sidebar } from "../Sidebar";
+
+const backends: BackendSummary[] = [
+  {
+    kind: "codex",
+    label: "Codex app server",
+    available: true,
+    methods: ["thread/start"],
+    capabilities: {
+      listThreads: true,
+      createThread: true,
+      resumeThread: true,
+      readThread: true,
+      startTurn: true,
+      interruptTurn: true,
+      steerTurn: true,
+      transcriptPagination: true,
+      toolUse: false,
+      approvalRequests: false,
+      multiDirectoryThreads: true,
+    },
+  },
+  {
+    kind: "grok",
+    label: "Grok app server",
+    available: false,
+    methods: [],
+    capabilities: {
+      listThreads: false,
+      createThread: false,
+      resumeThread: false,
+      readThread: false,
+      startTurn: false,
+      interruptTurn: false,
+      steerTurn: false,
+      transcriptPagination: false,
+      toolUse: false,
+      approvalRequests: false,
+      multiDirectoryThreads: false,
+    },
+    unavailableReason: "XAI_API_KEY is not set",
+  },
+];
 
 const sharedThread = {
   id: "thread-1",
@@ -36,12 +79,15 @@ describe("Sidebar", () => {
   it("keeps Inbox first and groups a thread under each linked directory lens", () => {
     render(
       <Sidebar
+        backends={backends}
         browseMode="directories"
+        createThreadError={undefined}
         fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         loading={false}
+        creatingThreadBackend={undefined}
         refreshing={false}
-        selectedThreadId="thread-1"
+        selectedThreadKey="codex:thread-1"
         threads={[
           sharedThread,
           {
@@ -57,6 +103,7 @@ describe("Sidebar", () => {
           }
         ]}
         onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
         onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
@@ -79,6 +126,7 @@ describe("Sidebar", () => {
       within(screen.getByRole("heading", { level: 3, name: "PwrAgnt" })).getByText("📁")
     ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /Cross-project cleanup/i })).toHaveLength(2);
+    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
   });
 
   it("copies a linked directory path from the recents chip", () => {
@@ -92,14 +140,18 @@ describe("Sidebar", () => {
 
     render(
       <Sidebar
+        backends={backends}
         browseMode="recents"
+        createThreadError={undefined}
         fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         loading={false}
+        creatingThreadBackend={undefined}
         refreshing={false}
-        selectedThreadId="thread-1"
+        selectedThreadKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
         onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
@@ -108,5 +160,38 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy path for PwrAgnt" }));
 
     expect(copyText).toHaveBeenCalledWith("/Users/huntharo/pwrdrvr/PwrAgnt");
+  });
+
+  it("opens a new-thread picker with enabled and disabled backend options", async () => {
+    const onCreateThread = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        fetchedAt={Date.now()}
+        inboxThreads={[sharedThread]}
+        loading={false}
+        creatingThreadBackend={undefined}
+        refreshing={false}
+        selectedThreadKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={onCreateThread}
+        onRefresh={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New thread" }));
+
+    expect(screen.getByRole("menu", { name: "New thread backend" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Create thread with Codex" })).toBeEnabled();
+    expect(screen.getByRole("menuitem", { name: "Create thread with Grok" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Create thread with Codex" }));
+
+    expect(onCreateThread).toHaveBeenCalledWith("codex");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,4 +1,5 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
 
 type ThreadHeaderProps = {
   fetchedAt?: number;
@@ -10,7 +11,12 @@ export function ThreadHeader(props: ThreadHeaderProps) {
   return (
     <header className="thread-header">
       <div>
-        <p className="eyebrow">Thread detail</p>
+        <div className="thread-header__eyebrow-row">
+          <p className="eyebrow">Thread detail</p>
+          <span className="thread-row__chip thread-row__chip--backend">
+            {formatBackendLabel(props.thread.source)}
+          </span>
+        </div>
         <h2 className="thread-header__title">{props.thread.title}</h2>
         {props.thread.summary ? (
           <p className="thread-header__summary">{props.thread.summary}</p>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -121,6 +121,7 @@ describe("ThreadView", () => {
     expect(
       screen.getByRole("heading", { level: 2, name: "Plan the app-server protocol" })
     ).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open context rail" }));
 
     expect(screen.getByText("No linked directory")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/lib/backend-label.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-label.ts
@@ -1,0 +1,5 @@
+import type { AppServerBackendKind } from "@pwragnt/shared";
+
+export function formatBackendLabel(backend: AppServerBackendKind): string {
+  return backend === "grok" ? "Grok" : "Codex";
+}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -2,6 +2,8 @@ import type {
   AgentEvent,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
+  AppServerListThreadsRequest,
+  AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   GetNavigationSnapshotRequest,
@@ -37,6 +39,9 @@ export type DesktopApi = {
   listBackends?: (
     request?: ListBackendsRequest
   ) => Promise<ListBackendsResponse>;
+  listThreads?: (
+    request?: AppServerListThreadsRequest
+  ) => Promise<AppServerListThreadsResponse>;
   markThreadSeen?: (request: MarkThreadSeenRequest) => Promise<unknown>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -38,6 +38,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
   const [selectedThreadKey, setSelectedThreadKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
+  const [optimisticThread, setOptimisticThread] = useState<NavigationThreadSummary>();
   const [creatingThreadBackend, setCreatingThreadBackend] =
     useState<AppServerBackendKind>();
   const [createThreadError, setCreateThreadError] = useState<string>();
@@ -46,7 +47,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     refreshing: false
   });
 
-  const refresh = useCallback(async (preferredThreadKey?: string): Promise<void> => {
+  const refresh = useCallback(async (
+    preferredThreadKey?: string,
+    preferredOptimisticThread?: NavigationThreadSummary
+  ): Promise<void> => {
     if (!desktopApi?.getNavigationSnapshot) {
       setState({
         loading: false,
@@ -66,6 +70,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
 
     try {
       const response = await desktopApi.getNavigationSnapshot();
+      const optimisticSelection = preferredOptimisticThread ?? optimisticThread;
+      const optimisticThreadKey = optimisticSelection
+        ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
+        : undefined;
+      const hasPreferredThread = Boolean(
+        preferredThreadKey &&
+          response.threads.some(
+            (thread) =>
+              buildThreadIdentityKey(thread.source, thread.id) === preferredThreadKey,
+          )
+      );
+      const hasOptimisticThread = Boolean(
+        optimisticThreadKey &&
+          response.threads.some(
+            (thread) =>
+              buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey,
+          )
+      );
+
       setState((current) => {
         if (current.response && response.unchanged) {
           return {
@@ -84,26 +107,35 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         };
       });
 
+      if (hasOptimisticThread) {
+        setOptimisticThread(undefined);
+      }
+
       if (!response.unchanged || preferredThreadKey) {
         setSelectedThreadKey((current) => {
           if (
             preferredThreadKey &&
-            response.threads.some(
-              (thread) =>
-                buildThreadIdentityKey(thread.source, thread.id) === preferredThreadKey,
-            )
+            (hasPreferredThread || preferredThreadKey === optimisticThreadKey)
           ) {
             return preferredThreadKey;
           }
 
           if (
             current &&
-            response.threads.some(
-              (thread) => buildThreadIdentityKey(thread.source, thread.id) === current,
+            (
+              response.threads.some(
+                (thread) => buildThreadIdentityKey(thread.source, thread.id) === current,
+              ) ||
+              current === optimisticThreadKey
             )
           ) {
             return current;
           }
+
+          if (optimisticThreadKey) {
+            return optimisticThreadKey;
+          }
+
           return response.threads[0]
             ? buildThreadIdentityKey(response.threads[0].source, response.threads[0].id)
             : undefined;
@@ -117,11 +149,11 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         error: error instanceof Error ? error.message : String(error)
       }));
     }
-  }, [desktopApi]);
+  }, [desktopApi, optimisticThread]);
 
   useEffect(() => {
     void refresh();
-  }, [refresh]);
+  }, [desktopApi, refresh]);
 
   useEffect(() => {
     if (!desktopApi?.onWindowFocus) {
@@ -133,11 +165,33 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     });
   }, [desktopApi, refresh]);
 
-  const threads = state.response?.threads ?? [];
+  const threads = useMemo(() => {
+    const currentThreads = state.response?.threads ?? [];
+    if (!optimisticThread) {
+      return currentThreads;
+    }
+
+    const optimisticThreadKey = buildThreadIdentityKey(
+      optimisticThread.source,
+      optimisticThread.id
+    );
+
+    if (
+      currentThreads.some(
+        (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+      )
+    ) {
+      return currentThreads;
+    }
+
+    return [optimisticThread, ...currentThreads];
+  }, [optimisticThread, state.response?.threads]);
+
   const inboxThreads = useMemo(() => {
     const inboxThreadKeys = new Set(state.response?.inboxThreadKeys ?? []);
     return threads.filter((thread) =>
-      inboxThreadKeys.has(buildThreadIdentityKey(thread.source, thread.id)),
+      inboxThreadKeys.has(buildThreadIdentityKey(thread.source, thread.id)) ||
+      thread.inbox.inInbox,
     );
   }, [state.response?.inboxThreadKeys, threads]);
 
@@ -208,10 +262,24 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
 
       try {
         const response = await startThread({ backend });
+        const optimisticUpdatedAt = Date.now();
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        const nextOptimisticThread: NavigationThreadSummary = {
+          id: response.threadId,
+          title: "Untitled thread",
+          summary: undefined,
+          source: response.backend,
+          linkedDirectories: [],
+          updatedAt: optimisticUpdatedAt,
+          inbox: {
+            inInbox: true,
+            reason: "new-thread"
+          }
+        };
+        setOptimisticThread(nextOptimisticThread);
         setSelectedThreadKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);
-        await refresh(nextThreadKey);
+        await refresh(nextThreadKey, nextOptimisticThread);
       } catch (error) {
         setCreateThreadError(error instanceof Error ? error.message : String(error));
       } finally {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
+  AppServerBackendKind,
   NavigationSnapshot,
   NavigationThreadSummary
 } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
 export type BrowseMode = "recents" | "directories";
@@ -16,27 +18,35 @@ type NavigationState = {
 
 export function useThreadNavigation(desktopApi?: DesktopApi): {
   browseMode: BrowseMode;
+  createThread: (backend: AppServerBackendKind) => Promise<void>;
+  createThreadError?: string;
+  creatingThreadBackend?: AppServerBackendKind;
   error?: string;
   inboxThreads: NavigationThreadSummary[];
   loading: boolean;
   refreshing: boolean;
   refresh: () => Promise<void>;
   selectedThread?: NavigationThreadSummary;
+  selectedThreadKey?: string;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
   snapshot?: NavigationSnapshot;
   threads: NavigationThreadSummary[];
 } {
   const markThreadSeen = desktopApi?.markThreadSeen;
+  const startThread = desktopApi?.startThread;
   const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
-  const [selectedThreadId, setSelectedThreadId] = useState<string>();
-  const [pendingSeenThreadId, setPendingSeenThreadId] = useState<string>();
+  const [selectedThreadKey, setSelectedThreadKey] = useState<string>();
+  const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
+  const [creatingThreadBackend, setCreatingThreadBackend] =
+    useState<AppServerBackendKind>();
+  const [createThreadError, setCreateThreadError] = useState<string>();
   const [state, setState] = useState<NavigationState>({
     loading: true,
     refreshing: false
   });
 
-  const refresh = useCallback(async (): Promise<void> => {
+  const refresh = useCallback(async (preferredThreadKey?: string): Promise<void> => {
     if (!desktopApi?.getNavigationSnapshot) {
       setState({
         loading: false,
@@ -55,7 +65,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     }));
 
     try {
-      const response = await desktopApi.getNavigationSnapshot({ backend: "codex" });
+      const response = await desktopApi.getNavigationSnapshot();
       setState((current) => {
         if (current.response && response.unchanged) {
           return {
@@ -74,12 +84,29 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         };
       });
 
-      if (!response.unchanged) {
-        setSelectedThreadId((current) => {
-          if (current && response.threads.some((thread) => thread.id === current)) {
+      if (!response.unchanged || preferredThreadKey) {
+        setSelectedThreadKey((current) => {
+          if (
+            preferredThreadKey &&
+            response.threads.some(
+              (thread) =>
+                buildThreadIdentityKey(thread.source, thread.id) === preferredThreadKey,
+            )
+          ) {
+            return preferredThreadKey;
+          }
+
+          if (
+            current &&
+            response.threads.some(
+              (thread) => buildThreadIdentityKey(thread.source, thread.id) === current,
+            )
+          ) {
             return current;
           }
-          return response.threads[0]?.id;
+          return response.threads[0]
+            ? buildThreadIdentityKey(response.threads[0].source, response.threads[0].id)
+            : undefined;
         });
       }
     } catch (error) {
@@ -108,22 +135,29 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
 
   const threads = state.response?.threads ?? [];
   const inboxThreads = useMemo(() => {
-    const inboxIds = new Set(state.response?.inboxThreadIds ?? []);
-    return threads.filter((thread) => inboxIds.has(thread.id));
-  }, [state.response?.inboxThreadIds, threads]);
+    const inboxThreadKeys = new Set(state.response?.inboxThreadKeys ?? []);
+    return threads.filter((thread) =>
+      inboxThreadKeys.has(buildThreadIdentityKey(thread.source, thread.id)),
+    );
+  }, [state.response?.inboxThreadKeys, threads]);
 
   const selectedThread = useMemo(
-    () => threads.find((thread) => thread.id === selectedThreadId) ?? threads[0],
-    [selectedThreadId, threads]
+    () =>
+      threads.find(
+        (thread) =>
+          buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey,
+      ) ?? threads[0],
+    [selectedThreadKey, threads]
   );
 
   useEffect(() => {
     const submitMarkThreadSeen = markThreadSeen;
 
     if (
-      !pendingSeenThreadId ||
+      !pendingSeenThreadKey ||
       !selectedThread ||
-      pendingSeenThreadId !== selectedThread.id ||
+      pendingSeenThreadKey !==
+        buildThreadIdentityKey(selectedThread.source, selectedThread.id) ||
       !submitMarkThreadSeen
     ) {
       return;
@@ -134,7 +168,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     async function markSeen(): Promise<void> {
       try {
         await submitMarkThreadSeen!({
-          backend: "codex",
+          backend: selectedThread.source,
           threadId: selectedThread.id,
           seenUpdatedAt: selectedThread.updatedAt
         });
@@ -143,7 +177,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         }
       } finally {
         if (!cancelled) {
-          setPendingSeenThreadId(undefined);
+          setPendingSeenThreadKey(undefined);
         }
       }
     }
@@ -153,21 +187,52 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return () => {
       cancelled = true;
     };
-  }, [markThreadSeen, pendingSeenThreadId, refresh, selectedThread]);
+  }, [markThreadSeen, pendingSeenThreadKey, refresh, selectedThread]);
 
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
-    setSelectedThreadId(thread.id);
-    setPendingSeenThreadId(thread.id);
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    setCreateThreadError(undefined);
+    setSelectedThreadKey(threadKey);
+    setPendingSeenThreadKey(threadKey);
   }, []);
+
+  const createThread = useCallback(
+    async (backend: AppServerBackendKind): Promise<void> => {
+      if (!startThread) {
+        setCreateThreadError("Desktop bridge is missing startThread().");
+        return;
+      }
+
+      setCreatingThreadBackend(backend);
+      setCreateThreadError(undefined);
+
+      try {
+        const response = await startThread({ backend });
+        const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        setSelectedThreadKey(nextThreadKey);
+        setPendingSeenThreadKey(nextThreadKey);
+        await refresh(nextThreadKey);
+      } catch (error) {
+        setCreateThreadError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setCreatingThreadBackend(undefined);
+      }
+    },
+    [refresh, startThread],
+  );
 
   return {
     browseMode,
+    createThread,
+    createThreadError,
+    creatingThreadBackend,
     error: state.error,
     inboxThreads,
     loading: state.loading,
     refreshing: state.refreshing,
     refresh,
     selectedThread,
+    selectedThreadKey,
     setBrowseMode,
     selectThread,
     snapshot: state.response,

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
-  AppServerBackendKind,
   AppServerReadThreadResponse,
   AppServerThreadEntry,
+  AppServerThreadMessage,
   AppServerThreadMessageEntry,
-  AppServerThreadMessage
+  NavigationThreadSummary
 } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
@@ -22,9 +22,8 @@ function mergeItems<T extends { id: string }>(
 }
 
 export function useThreadTranscript(params: {
-  backend?: AppServerBackendKind;
   desktopApi?: DesktopApi;
-  threadId?: string;
+  thread?: NavigationThreadSummary;
 }): {
   addOptimisticUserMessage: (text: string) => string;
   error?: string;
@@ -37,7 +36,7 @@ export function useThreadTranscript(params: {
   refresh: () => Promise<void>;
   response?: AppServerReadThreadResponse;
 } {
-  const { backend, desktopApi, threadId } = params;
+  const { desktopApi, thread } = params;
   const [response, setResponse] = useState<AppServerReadThreadResponse>();
   const [optimisticEntries, setOptimisticEntries] = useState<AppServerThreadMessageEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -47,10 +46,10 @@ export function useThreadTranscript(params: {
 
   useEffect(() => {
     setOptimisticEntries([]);
-  }, [threadId]);
+  }, [thread?.id]);
 
   const loadLatest = useCallback(async (): Promise<void> => {
-    if (!threadId) {
+    if (!thread) {
       setResponse(undefined);
       setError(undefined);
       setLoading(false);
@@ -72,13 +71,13 @@ export function useThreadTranscript(params: {
     setLoading(true);
     setError(undefined);
     setResponse((current) =>
-      current?.threadId === threadId ? current : undefined
+      current?.threadId === thread.id ? current : undefined
     );
 
     try {
       const nextResponse = await desktopApi.readThread({
-        backend,
-        threadId
+        backend: thread.source,
+        threadId: thread.id
       });
       if (requestVersionRef.current !== requestVersion) {
         return;
@@ -95,7 +94,7 @@ export function useThreadTranscript(params: {
         setLoading(false);
       }
     }
-  }, [backend, desktopApi, threadId]);
+  }, [desktopApi, thread]);
 
   useEffect(() => {
     void loadLatest();
@@ -103,7 +102,7 @@ export function useThreadTranscript(params: {
 
   const loadOlder = useCallback(async (): Promise<void> => {
     if (
-      !threadId ||
+      !thread ||
       !desktopApi?.readThread ||
       !response?.replay.pagination.supportsPagination ||
       !response.replay.pagination.hasPreviousPage ||
@@ -118,8 +117,8 @@ export function useThreadTranscript(params: {
 
     try {
       const olderResponse = await desktopApi.readThread({
-        backend,
-        threadId,
+        backend: thread.source,
+        threadId: thread.id,
         before: response.replay.pagination.previousCursor
       });
       if (requestVersionRef.current !== requestVersion) {
@@ -149,7 +148,7 @@ export function useThreadTranscript(params: {
         setLoadingMore(false);
       }
     }
-  }, [backend, desktopApi, response, threadId]);
+  }, [desktopApi, response, thread]);
 
   const addOptimisticUserMessage = useCallback((text: string): string => {
     const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -76,6 +76,65 @@ textarea {
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.sidebar__masthead-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.sidebar__new-thread {
+  position: relative;
+}
+
+.sidebar__menu {
+  display: flex;
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 20;
+  min-width: 208px;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: rgba(16, 20, 28, 0.98);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.32);
+}
+
+.sidebar__menu-item {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.sidebar__menu-item:hover {
+  background: var(--bg-panel-hover);
+}
+
+.sidebar__menu-item[disabled] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.sidebar__menu-item-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.sidebar__menu-item-detail {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .eyebrow {
   margin: 0 0 8px;
   color: var(--accent);
@@ -329,6 +388,17 @@ textarea {
   white-space: nowrap;
 }
 
+.thread-row__chip--backend {
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.path-copy-target {
+  position: relative;
+}
+
 .tooltip-target {
   position: relative;
 }
@@ -465,6 +535,10 @@ textarea {
   line-height: 1.45;
 }
 
+.sidebar-error--masthead {
+  margin-top: 12px;
+}
+
 .app-main {
   display: flex;
   min-height: 0;
@@ -485,6 +559,12 @@ textarea {
 .thread-header__title {
   font-size: 40px;
   font-weight: 700;
+}
+
+.thread-header__eyebrow-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .thread-header__stats {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1425,6 +1425,12 @@ textarea {
   justify-content: flex-end;
 }
 
+.composer__error {
+  margin: 0 16px;
+  color: var(--danger-text);
+  font-size: 13px;
+}
+
 .thread-empty-state {
   display: flex;
   flex-direction: column;

--- a/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
+++ b/docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md
@@ -4,17 +4,18 @@ type: feat
 status: active
 date: 2026-04-16
 origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
+deepened: 2026-04-16
 ---
 
 # feat: Thread-centric agent desktop foundation
 
 ## Overview
 
-Build the first real version of a desktop coding agent whose differentiator is thread navigation rather than repo-first attachment. The milestone should ship a runnable Electron app with a real provider/harness path, desktop-owned overlay state, Inbox plus Recents plus Directories navigation, multi-directory thread associations, and enough plugin/wiki infrastructure that the product already feels accumulative instead of stateless.
+Build the first real version of a desktop coding agent whose differentiator is thread navigation rather than repo-first attachment. The milestone should ship a runnable Electron app with a real provider/harness path, desktop-owned overlay state, Inbox plus Recents plus Directories navigation, multi-directory thread associations, backend-aware thread creation, and enough plugin/wiki infrastructure that the product already feels accumulative instead of stateless.
 
 ## Problem Frame
 
-The origin requirements define a thread-first product surface where users can start from a blank thread, attach repos later, and find important work from Inbox before drilling into Recents or Directories (see origin: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`). The technical plan must preserve that product behavior while creating the repo structure, desktop-owned overlay state, IPC boundaries, and provider abstraction needed for a credible interview-ready demo.
+The origin requirements define a thread-first product surface where users can start from a blank thread, attach repos later, and find important work from Inbox before drilling into Recents or Directories (see origin: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`). The current desktop code now has real Codex and Grok backend integration, but the renderer still loads navigation and transcripts as Codex-only and exposes no shipped "New thread" entrypoint. This plan update closes that gap by making backend choice explicit at thread creation time and by making backend provenance visible in thread lists without turning backend choice into a new primary navigation lens.
 
 ## Requirements Trace
 
@@ -24,6 +25,7 @@ The origin requirements define a thread-first product surface where users can st
 - R16-R19. Support guarded versus full-access execution modes with a risk-based approval layer.
 - R20-R22. Provide a real Grok-first but provider-agnostic agent harness and core coding loop.
 - R23-R26. Include real skills/plugins and wiki memory foundations with lexical and semantic search paths.
+- User-request refinement on R1, R10, R21, and R22. Users can start a thread against either Codex or Grok, and every thread-list row should expose that backend relationship at a glance through compact chip metadata.
 
 ## Scope Boundaries
 
@@ -36,8 +38,11 @@ The origin requirements define a thread-first product surface where users can st
 
 ### Relevant Code and Patterns
 
-- The repo is currently greenfield aside from the brainstorm document.
-- There are no local implementation patterns yet, so Unit 1 must establish the workspace, testing, typing, and package boundaries that later units follow.
+- `apps/desktop/src/main/app-server/backend-registry.ts` already normalizes Codex and Grok clients behind one desktop registry and exposes per-backend capabilities plus `startThread`, `startTurn`, and `readThread`.
+- `packages/shared/src/contracts/app-server.ts` and `packages/shared/src/contracts/navigation.ts` already carry per-thread backend/source metadata, so the renderer can show backend provenance without inventing a second model.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` and `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts` still hard-code `backend: "codex"` for snapshot reads, mark-seen writes, and transcript loads.
+- `packages/agent-core/src/persistence/overlay-store.ts` and `packages/agent-core/src/persistence/migrations.ts` currently key overlay state by bare `threadId`, which is acceptable for single-backend snapshots but unsafe once Codex and Grok threads can coexist in one navigation surface.
+- `apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx`, `InboxList.tsx`, and `DirectoriesList.tsx` already use shared chip styling (`thread-row__chip`), which gives the plan a local pattern for adding a backend pill without new visual primitives.
 
 ### Institutional Learnings
 
@@ -55,11 +60,15 @@ The origin requirements define a thread-first product surface where users can st
 - Use a `pnpm` workspace from day one so the Electron app, shared contracts, agent runtime, plugin runtime, and wiki services can evolve without immediate repo surgery.
 - Keep privileged orchestration in the Electron main process, expose only typed preload APIs to the renderer, and treat renderer code as unprivileged UI per Electron's process and preload model.
 - Use TypeScript across the workspace so IPC contracts, persisted thread models, provider interfaces, and plugin manifests share one type system.
-- Persist thread, directory, execution-mode, inbox-state, and message/event data in a local relational store so many-to-many thread-to-directory navigation remains queryable.
+- Persist desktop-owned navigation data in a local store, starting with the file-backed overlay state already shipped for inbox and refresh reconciliation, and defer heavier relational storage until thread, project, or wiki features truly need it.
 - Keep Git roots and working directories as separate persisted concepts so local mode and worktree mode can share one thread model.
 - Start with one internal plugin/skill registration path that the app itself consumes, then generalize only after the first milestone proves the shape.
 - Treat semantic wiki search as a service boundary, not a UI trick, so the first milestone can start with a pluggable indexer and avoid hard-coding one search backend into the renderer.
 - For Grok-based desktop integration, target the OpenClaw-consumed Codex App Server subset rather than a turn-only proof of concept, so the desktop can rely on one existing client contract for thread discovery, turn control, review, and compaction.
+- Treat sidebar navigation as a mixed-backend surface by default. Backend is provenance metadata on each thread row, not a replacement for Inbox, Recents, or Directories as the primary browsing lenses.
+- Put the first shipped "New thread" action in the sidebar masthead, because the style guide expects global actions at the top of the operating rail and the current shell already reserves that space beside refresh.
+- Qualify desktop overlay identity by backend plus thread id rather than bare thread id so seen state, inbox reconciliation, and extra linked directories cannot bleed across Codex and Grok threads that happen to share ids.
+- Render backend provenance from the stable thread `source` field using compact title-case chips (`Codex`, `Grok`) in thread rows. Do not depend on verbose backend status labels like "Codex app server" for row metadata.
 
 ## Open Questions
 
@@ -67,14 +76,18 @@ The origin requirements define a thread-first product surface where users can st
 
 - Workspace shape: use a single workspace repo with one Electron app and a small number of packages rather than one large app folder.
 - Process split: place agent runtime, git/project services, approvals, plugin loading, and wiki indexing behind main-process services; renderer consumes them through typed preload APIs.
-- Persistence model: use a relational local store for thread navigation and directory associations instead of file-name-driven discovery or ad hoc JSON blobs.
+- Persistence model: keep the current file-backed overlay store for desktop-only navigation state, and introduce heavier storage only when later units need richer cross-feature queries.
 - Milestone emphasis: prioritize thread navigation and agent/provider reality first; credential mediation stays deferred.
+- Mixed-backend thread browsing: navigation should merge available Codex and Grok threads into one recents or inbox surface, sorted by activity, with backend chips used for provenance.
+- Backend-picker scope: the first shipped picker should offer only currently available backends that advertise `createThread`, rather than introducing a broader model picker or provider settings surface.
+- Backend row labeling: use compact backend-kind chips in list rows and header metadata, while keeping the fuller backend availability list in the context rail.
 
 ### Deferred to Implementation
 
 - Exact scoring weights for Inbox ordering should be tuned while wiring real event flows rather than guessed fully in the plan.
 - Exact semantic-search backend can be finalized once the first wiki corpus and performance envelope are known.
 - Exact provider adapter edge cases, especially tool streaming and interruption behavior, should be finalized while integrating the first real provider.
+- The exact interaction pattern for the backend picker can settle during implementation as long as it stays in the sidebar masthead and exposes only available create-thread targets with clear disabled-state copy.
 
 ## High-Level Technical Design
 
@@ -310,7 +323,69 @@ flowchart TB
 
 **Status note:** Completed, with the originally planned end-to-end Playwright spec still deferred. The renderer now ships Inbox-first navigation, Recents and Directories lenses, thread detail, transcript history with pagination-aware loading, and context/sidebar refinements that make multi-directory thread work legible.
 
-- [ ] **Unit 5: Add project attachment, worktree awareness, and repo-status enrichment**
+- [x] **Unit 5: Add backend-aware thread creation and backend provenance in navigation**
+
+**Goal:** Let users create a new thread on either Codex or Grok from the existing sidebar shell, and make mixed-backend threads legible in Inbox, Recents, and Directories without opening thread detail.
+
+**Requirements:** R1-R4, R10, R21-R22
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `packages/shared/src/contracts/navigation.ts`
+- Modify: `packages/agent-core/src/domain/navigation-state.ts`
+- Modify: `packages/agent-core/src/persistence/overlay-store.ts`
+- Modify: `packages/agent-core/src/persistence/migrations.ts`
+- Modify: `packages/agent-core/src/__tests__/overlay-store.test.ts`
+- Modify: `packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
+- Modify: `apps/desktop/src/main/ipc/app-server.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/InboxList.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Change desktop navigation from a Codex-only fetch to an aggregated snapshot that can contain threads from every available backend, while preserving `thread.source` as the read or write routing key for later transcript and run actions.
+- Update overlay persistence and migration logic so desktop-only state is keyed by backend-qualified thread identity instead of bare `threadId`; this avoids collisions when Codex and Grok emit the same thread id value.
+- Reuse the existing `AGENT_START_THREAD_CHANNEL` path and backend capability metadata for the new thread action rather than inventing a second create-thread transport.
+- Add a compact backend picker in the sidebar masthead. It should list only available backends that advertise `createThread`, surface disabled or unavailable reasons clearly, and select the new thread immediately after creation.
+- Reuse the existing thread-row chip pattern for backend provenance in Inbox, Recents, and Directories. The chip should stay compact and secondary to thread title, summary, directory chips, and branch metadata.
+- Route transcript reads, mark-seen writes, and future thread-scoped actions from the selected thread's backend source instead of assuming Codex everywhere.
+- Keep backend status and capability detail in the context rail; the list-row chip should answer only "which backend owns this thread?"
+
+**Patterns to follow:**
+- Typed preload and IPC boundaries from Units 1 and 3.
+- Existing `thread-row__chip` styling and compact sidebar metadata treatment from Unit 4.
+- Existing backend capability summaries from `apps/desktop/src/main/app-server/backend-registry.ts`.
+
+**Test scenarios:**
+- Happy path: the sidebar masthead exposes a "New thread" action that offers both Codex and Grok when both are available and create-thread capable.
+- Happy path: choosing Grok creates a Grok-backed thread, selects it immediately, reads transcript history through Grok, and shows a `Grok` chip in Inbox, Recents, and Directories.
+- Happy path: choosing Codex creates a Codex-backed thread and preserves the same selection and transcript-loading behavior.
+- Happy path: a mixed Codex/Grok snapshot sorts threads together by `updatedAt` while keeping backend provenance visible on every row.
+- Edge case: a backend that is unavailable or lacks `createThread` is visibly disabled in the picker and cannot be selected accidentally.
+- Edge case: Codex and Grok threads sharing the same `threadId` keep separate seen state, inbox membership, and extra linked-directory overlays after the migration.
+- Error path: create-thread failure leaves the existing selection intact and surfaces an actionable error near the sidebar action instead of wedging the shell.
+- Integration: selecting a Grok-backed thread and marking it seen no longer writes to Codex overlay state or falls back to Codex transcript reads.
+
+**Verification:**
+- A user can create a thread on either backend from the sidebar and can distinguish mixed-backend threads at a glance everywhere they browse them.
+
+**Status note:** Completed. The desktop now loads aggregated thread navigation across backends, keys overlay state by backend-qualified thread identity, lets users start a new Codex or Grok thread from the sidebar masthead, and shows backend chips in Inbox, Recents, Directories, and thread detail.
+
+- [ ] **Unit 6: Add project attachment, worktree awareness, and repo-status enrichment**
 
 **Goal:** Let threads attach projects after creation, distinguish Git roots from working directories, and surface branch/PR/worktree context cleanly.
 
@@ -350,7 +425,7 @@ flowchart TB
 **Verification:**
 - Users can start vague, then concretize a thread into one or more repos without reopening or recreating the thread.
 
-- [ ] **Unit 6: Introduce the first real plugin and skill runtime**
+- [ ] **Unit 7: Introduce the first real plugin and skill runtime**
 
 **Goal:** Make extensibility real enough that internal and future external capabilities can register tools, prompts, and metadata without hard-coding everything into the harness.
 
@@ -387,13 +462,13 @@ flowchart TB
 **Verification:**
 - The app can prove that capabilities are discovered through a registry rather than hard-coded directly into the renderer or harness.
 
-- [ ] **Unit 7: Add the maintained wiki and searchable memory foundation**
+- [ ] **Unit 8: Add the maintained wiki and searchable memory foundation**
 
 **Goal:** Create a first-class memory/wiki subsystem that the product maintains and the user can browse, search, and lightly edit.
 
 **Requirements:** R24-R26
 
-**Dependencies:** Unit 6
+**Dependencies:** Unit 7
 
 **Files:**
 - Create: `packages/shared/src/contracts/wiki.ts`
@@ -415,7 +490,7 @@ flowchart TB
 - Expose the wiki in the UI as inspectable and lightly editable system memory rather than a hidden settings blob.
 
 **Patterns to follow:**
-- Registry/service patterns from Units 2, 3, and 6.
+- Registry/service patterns from Units 2, 3, and 7.
 
 **Test scenarios:**
 - Happy path: creating a wiki entry makes it retrievable through lexical search.
@@ -430,10 +505,10 @@ flowchart TB
 ## System-Wide Impact
 
 - **Interaction graph:** renderer -> preload -> main IPC -> agent core services -> local store/provider/git/plugin/wiki services.
-- **Error propagation:** provider, git, search, or plugin failures should surface as thread or feature-level state without crashing the renderer or corrupting persisted thread state.
-- **State lifecycle risks:** thread runs, approvals, and directory attachments can race with navigation updates; the overlay store must remain the source of truth for desktop-only inbox and refresh state, while the app server remains the source of truth for transcript and run history.
+- **Error propagation:** provider, git, search, plugin, or create-thread failures should surface as thread or feature-level state without crashing the renderer or corrupting persisted thread state.
+- **State lifecycle risks:** thread runs, approvals, backend selection, and directory attachments can race with navigation updates; the overlay store must remain the source of truth for desktop-only inbox and refresh state, while the app server remains the source of truth for transcript and run history.
 - **API surface parity:** provider adapters, plugin manifests, wiki search interfaces, and thread IPC payloads all depend on stable shared contracts in `packages/shared`.
-- **Integration coverage:** cross-layer tests are required for provider event flow, project attachment flow, and wiki edit/search flow because unit tests alone will not prove IPC and persistence behavior.
+- **Integration coverage:** cross-layer tests are required for provider event flow, mixed-backend thread creation, project attachment flow, and wiki edit/search flow because unit tests alone will not prove IPC and persistence behavior.
 - **Unchanged invariants:** credential mediation stays out of scope; thread-first navigation remains the hero even as plugins and wiki memory are added.
 
 ## Risk Analysis & Mitigation
@@ -444,6 +519,7 @@ flowchart TB
 | Electron IPC boundary becomes ad hoc and insecure | Medium | High | Centralize typed preload APIs and IPC contracts in shared packages from Unit 1 onward |
 | Many-to-many directory modeling becomes confusing in UI | Medium | High | Treat persisted thread identity as canonical and add list/detail visibility tests for multi-directory cases |
 | Provider abstraction collapses into Grok-specific behavior | Medium | High | Implement a second responses-style adapter in the same milestone to force normalization early |
+| Mixed-backend overlay migration corrupts seen state or extra directory links | Medium | High | Migrate to backend-qualified overlay identity, add collision-focused tests, and preserve legacy Codex-only records during upgrade |
 | Inbox becomes noisy and fails the product promise | High | Medium | Persist explicit inbox signals and keep ranking logic isolated and testable rather than buried in UI components |
 | Wiki semantic search becomes a rabbit hole | Medium | Medium | Keep semantic search behind an interface and ship lexical search as the guaranteed fallback |
 
@@ -451,11 +527,16 @@ flowchart TB
 
 - Add onboarding/setup instructions to the root `README.md` as Unit 1 lands.
 - Add a short architecture note once Units 2 and 3 land, covering process boundaries and shared contracts.
-- Add user-facing documentation for plugin discovery and wiki behavior once Units 6 and 7 land.
+- Document the desktop navigation contract once Unit 5 lands, especially mixed-backend thread identity and backend-qualified overlay keys.
+- Add user-facing documentation for plugin discovery and wiki behavior once Units 7 and 8 land.
 
 ## Sources & References
 
 - **Origin document:** [docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md](../brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md)
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- Related code: `packages/agent-core/src/persistence/overlay-store.ts`
 - External docs: [Electron process model](https://www.electronjs.org/docs/latest/tutorial/process-model)
 - External docs: [Electron preload](https://www.electronjs.org/docs/latest/tutorial/tutorial-preload)
 - External docs: [Electron IPC](https://www.electronjs.org/docs/latest/tutorial/ipc)

--- a/packages/agent-core/src/__tests__/inbox-ranking.test.ts
+++ b/packages/agent-core/src/__tests__/inbox-ranking.test.ts
@@ -1,26 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { rankInboxThreadIds } from "../domain/inbox";
+import { rankInboxThreadKeys } from "../domain/inbox";
 
-describe("rankInboxThreadIds", () => {
+describe("rankInboxThreadKeys", () => {
   it("ranks new threads ahead of updated threads and sorts by recency within each bucket", () => {
-    const ranked = rankInboxThreadIds([
+    const ranked = rankInboxThreadKeys([
       {
         id: "updated-old",
+        source: "codex",
         inbox: { inInbox: true, reason: "updated-since-seen" },
         updatedAt: 1000,
       },
       {
         id: "new-thread",
+        source: "grok",
         inbox: { inInbox: true, reason: "new-thread" },
         updatedAt: 500,
       },
       {
         id: "updated-newer",
+        source: "codex",
         inbox: { inInbox: true, reason: "updated-since-seen" },
         updatedAt: 2000,
       },
     ]);
 
-    expect(ranked).toEqual(["new-thread", "updated-newer", "updated-old"]);
+    expect(ranked).toEqual([
+      "grok:new-thread",
+      "codex:updated-newer",
+      "codex:updated-old",
+    ]);
   });
 });

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -54,10 +54,14 @@ describe("OverlayStore", () => {
     const raw = JSON.parse(
       await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
     ) as {
-      threads: Record<string, { lastSeenAt?: number; lastSeenUpdatedAt?: number }>;
+      threads: Record<
+        string,
+        { backend?: string; lastSeenAt?: number; lastSeenUpdatedAt?: number }
+      >;
     };
 
-    expect(raw.threads["thread-1"]).toMatchObject({
+    expect(raw.threads["codex:thread-1"]).toMatchObject({
+      backend: "codex",
       lastSeenAt: 2000,
       lastSeenUpdatedAt: 1000,
     });
@@ -67,6 +71,7 @@ describe("OverlayStore", () => {
     const store = await createStore();
 
     await store.addLinkedDirectory({
+      backend: "grok",
       threadId: "thread-2",
       directory: {
         id: "/Users/huntharo/pwrdrvr/openclaw",
@@ -79,11 +84,54 @@ describe("OverlayStore", () => {
     const raw = JSON.parse(
       await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
     ) as {
-      threads: Record<string, { extraLinkedDirectories: Array<{ label: string }> }>;
+      threads: Record<
+        string,
+        { backend?: string; extraLinkedDirectories: Array<{ label: string }> }
+      >;
     };
 
-    expect(raw.threads["thread-2"]?.extraLinkedDirectories).toEqual([
+    expect(raw.threads["grok:thread-2"]).toMatchObject({
+      backend: "grok",
+    });
+    expect(raw.threads["grok:thread-2"]?.extraLinkedDirectories).toEqual([
       expect.objectContaining({ label: "openclaw" }),
     ]);
+  });
+
+  it("keeps backend-qualified overlay state separate for duplicate thread ids", async () => {
+    const store = await createStore();
+
+    await store.markThreadSeen({
+      backend: "codex",
+      threadId: "thread-1",
+      seenAt: 2000,
+      seenUpdatedAt: 1000,
+    });
+    await store.markThreadSeen({
+      backend: "grok",
+      threadId: "thread-1",
+      seenAt: 3000,
+      seenUpdatedAt: 2500,
+    });
+
+    const raw = JSON.parse(
+      await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
+    ) as {
+      threads: Record<
+        string,
+        { backend?: string; lastSeenAt?: number; lastSeenUpdatedAt?: number }
+      >;
+    };
+
+    expect(raw.threads["codex:thread-1"]).toMatchObject({
+      backend: "codex",
+      lastSeenAt: 2000,
+      lastSeenUpdatedAt: 1000,
+    });
+    expect(raw.threads["grok:thread-1"]).toMatchObject({
+      backend: "grok",
+      lastSeenAt: 3000,
+      lastSeenUpdatedAt: 2500,
+    });
   });
 });

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -45,7 +45,7 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.unchanged).toBe(false);
-    expect(snapshot.inboxThreadIds).toEqual([]);
+    expect(snapshot.inboxThreadKeys).toEqual([]);
     expect(snapshot.threads[0]?.inbox.inInbox).toBe(false);
   });
 
@@ -65,7 +65,7 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.unchanged).toBe(false);
-    expect(snapshot.inboxThreadIds).toEqual(["thread-1"]);
+    expect(snapshot.inboxThreadKeys).toEqual(["codex:thread-1"]);
     expect(snapshot.threads[0]?.inbox.reason).toBe("updated-since-seen");
   });
 
@@ -85,5 +85,42 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.unchanged).toBe(true);
+  });
+
+  it("tracks mixed-backend threads with duplicate ids independently in aggregate snapshots", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 1000,
+      threads: [
+        buildThread(),
+        buildThread({
+          source: "grok",
+          title: "Desktop App (Grok)",
+          updatedAt: 1000,
+        }),
+      ],
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 2000,
+      threads: [
+        buildThread({ updatedAt: 3000 }),
+        buildThread({
+          source: "grok",
+          title: "Desktop App (Grok)",
+          updatedAt: 1000,
+        }),
+      ],
+    });
+
+    expect(snapshot.inboxThreadKeys).toEqual(["codex:thread-1"]);
+    expect(snapshot.threads).toHaveLength(2);
+    expect(snapshot.threads.map((thread) => `${thread.source}:${thread.id}`)).toEqual([
+      "codex:thread-1",
+      "grok:thread-1",
+    ]);
   });
 });

--- a/packages/agent-core/src/domain/inbox.ts
+++ b/packages/agent-core/src/domain/inbox.ts
@@ -1,7 +1,5 @@
-import type {
-  AppServerThreadSummary,
-  ThreadIdentifier,
-} from "@pwragnt/shared";
+import type { AppServerThreadSummary } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { InboxReason, ThreadInboxState, ThreadOverlayState } from "@pwragnt/shared";
 
 function isSuppressed(
@@ -71,11 +69,12 @@ export function deriveInboxState(params: {
   };
 }
 
-export function rankInboxThreadIds(threads: Array<{
-  id: ThreadIdentifier;
+export function rankInboxThreadKeys(threads: Array<{
+  id: string;
+  source: AppServerThreadSummary["source"];
   inbox: ThreadInboxState;
   updatedAt?: number;
-}>): ThreadIdentifier[] {
+}>): string[] {
   return threads
     .filter((thread) => thread.inbox.inInbox)
     .sort((left, right) => {
@@ -97,5 +96,5 @@ export function rankInboxThreadIds(threads: Array<{
 
       return (right.updatedAt ?? 0) - (left.updatedAt ?? 0);
     })
-    .map((thread) => thread.id);
+    .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
 }

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -1,12 +1,13 @@
 import type {
-  AppServerBackendKind,
+  AppServerBackendScope,
   AppServerThreadSummary,
   LinkedDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
   ThreadOverlayState,
 } from "@pwragnt/shared";
-import { deriveInboxState, rankInboxThreadIds } from "./inbox";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import { deriveInboxState, rankInboxThreadKeys } from "./inbox";
 
 function dedupeLinkedDirectories(
   directories: LinkedDirectorySummary[],
@@ -25,14 +26,15 @@ function dedupeLinkedDirectories(
 export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
-  overlayByThreadId: Record<string, ThreadOverlayState | undefined>;
-  previousKnownThreadIds: string[];
+  overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
+  previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
 }): NavigationThreadSummary[] {
-  const previousKnownThreadIds = new Set(params.previousKnownThreadIds);
+  const previousKnownThreadKeys = new Set(params.previousKnownThreadKeys);
 
   return params.threads.map((thread) => {
-    const overlay = params.overlayByThreadId[thread.id];
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const overlay = params.overlayByThreadKey[threadKey];
     const linkedDirectories = dedupeLinkedDirectories([
       ...thread.linkedDirectories,
       ...(overlay?.extraLinkedDirectories ?? []),
@@ -43,7 +45,7 @@ export function materializeNavigationThreads(params: {
       linkedDirectories,
       inbox: deriveInboxState({
         firstSnapshot: params.firstSnapshot,
-        isNewThread: !previousKnownThreadIds.has(thread.id),
+        isNewThread: !previousKnownThreadKeys.has(threadKey),
         now: params.now,
         overlay,
         thread,
@@ -53,20 +55,20 @@ export function materializeNavigationThreads(params: {
 }
 
 export function buildNavigationSnapshot(params: {
-  backend: AppServerBackendKind;
+  backend: AppServerBackendScope;
   fetchedAt: number;
   firstSnapshot: boolean;
   now?: number;
-  overlayByThreadId: Record<string, ThreadOverlayState | undefined>;
-  previousKnownThreadIds: string[];
+  overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
+  previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
   unchanged: boolean;
 }): NavigationSnapshot {
   const threads = materializeNavigationThreads({
     firstSnapshot: params.firstSnapshot,
     now: params.now,
-    overlayByThreadId: params.overlayByThreadId,
-    previousKnownThreadIds: params.previousKnownThreadIds,
+    overlayByThreadKey: params.overlayByThreadKey,
+    previousKnownThreadKeys: params.previousKnownThreadKeys,
     threads: params.threads,
   });
 
@@ -75,17 +77,18 @@ export function buildNavigationSnapshot(params: {
     fetchedAt: params.fetchedAt,
     unchanged: params.unchanged,
     threads,
-    inboxThreadIds: rankInboxThreadIds(threads),
+    inboxThreadKeys: rankInboxThreadKeys(threads),
   };
 }
 
 export function buildNavigationSnapshotHash(params: {
-  backend: AppServerBackendKind;
+  backend: AppServerBackendScope;
   threads: NavigationThreadSummary[];
 }): string {
   return JSON.stringify({
     backend: params.backend,
     threads: params.threads.map((thread) => ({
+      source: thread.source,
       id: thread.id,
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -1,6 +1,11 @@
-import type { AppServerBackendKind, ThreadOverlayState } from "@pwragnt/shared";
+import type {
+  AppServerBackendKind,
+  AppServerBackendScope,
+  ThreadOverlayState,
+} from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 
-export const CURRENT_OVERLAY_STORE_VERSION = 1;
+export const CURRENT_OVERLAY_STORE_VERSION = 2;
 
 export type OverlayStoreData = {
   version: number;
@@ -8,13 +13,48 @@ export type OverlayStoreData = {
     Record<
       AppServerBackendKind,
       {
-        knownThreadIds: string[];
+        knownThreadKeys: string[];
         lastSnapshotHash?: string;
       }
-    >
+    > &
+      Partial<
+        Record<
+          Extract<AppServerBackendScope, "all">,
+          {
+            knownThreadKeys: string[];
+            lastSnapshotHash?: string;
+          }
+        >
+      >
   >;
   threads: Record<string, ThreadOverlayState>;
 };
+
+function migrateBackendState(
+  scope: AppServerBackendScope,
+  value: unknown,
+): { knownThreadKeys: string[]; lastSnapshotHash?: string } | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const knownThreadKeys = Array.isArray(record.knownThreadKeys)
+    ? (record.knownThreadKeys as string[])
+    : Array.isArray(record.knownThreadIds)
+      ? (record.knownThreadIds as string[]).map((threadId) =>
+          scope === "all" ? threadId : buildThreadIdentityKey(scope, threadId),
+        )
+      : [];
+
+  return {
+    knownThreadKeys,
+    lastSnapshotHash:
+      typeof record.lastSnapshotHash === "string"
+        ? (record.lastSnapshotHash as string)
+        : undefined,
+  };
+}
 
 const EMPTY_OVERLAY_STORE_DATA: OverlayStoreData = {
   version: CURRENT_OVERLAY_STORE_VERSION,
@@ -44,35 +84,25 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
   return {
     version,
     backends: {
-      codex: asRecord(backendsRecord.codex)
-        ? {
-            knownThreadIds: Array.isArray(asRecord(backendsRecord.codex)?.knownThreadIds)
-              ? (asRecord(backendsRecord.codex)?.knownThreadIds as string[])
-              : [],
-            lastSnapshotHash:
-              typeof asRecord(backendsRecord.codex)?.lastSnapshotHash === "string"
-                ? (asRecord(backendsRecord.codex)?.lastSnapshotHash as string)
-                : undefined,
-          }
-        : undefined,
-      grok: asRecord(backendsRecord.grok)
-        ? {
-            knownThreadIds: Array.isArray(asRecord(backendsRecord.grok)?.knownThreadIds)
-              ? (asRecord(backendsRecord.grok)?.knownThreadIds as string[])
-              : [],
-            lastSnapshotHash:
-              typeof asRecord(backendsRecord.grok)?.lastSnapshotHash === "string"
-                ? (asRecord(backendsRecord.grok)?.lastSnapshotHash as string)
-                : undefined,
-          }
-        : undefined,
+      codex: migrateBackendState("codex", backendsRecord.codex),
+      grok: migrateBackendState("grok", backendsRecord.grok),
+      all: migrateBackendState("all", backendsRecord.all),
     },
     threads: Object.fromEntries(
-      Object.entries(threadsRecord).map(([threadId, value]) => {
+      Object.entries(threadsRecord).map(([rawKey, value]) => {
         const threadRecord = asRecord(value) ?? {};
+        const threadId =
+          typeof threadRecord.threadId === "string" ? threadRecord.threadId : rawKey;
+        const backend =
+          threadRecord.backend === "grok" || threadRecord.backend === "codex"
+            ? (threadRecord.backend as AppServerBackendKind)
+            : "codex";
+        const threadKey = buildThreadIdentityKey(backend, threadId);
+
         return [
-          threadId,
+          threadKey,
           {
+            backend,
             threadId,
             lastSeenAt:
               typeof threadRecord.lastSeenAt === "number"

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -1,13 +1,14 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
-  AppServerBackendKind,
+  AppServerBackendScope,
   AppServerThreadSummary,
   LinkedDirectorySummary,
   MarkThreadSeenResponse,
   NavigationSnapshot,
   ThreadOverlayState,
 } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 import {
   buildNavigationSnapshot,
   buildNavigationSnapshotHash,
@@ -24,37 +25,41 @@ export class OverlayStore {
   constructor(private readonly filePath: string) {}
 
   async reconcileNavigationSnapshot(params: {
-    backend: AppServerBackendKind;
+    backend: AppServerBackendScope;
     fetchedAt: number;
     threads: AppServerThreadSummary[];
   }): Promise<NavigationSnapshot> {
     return await this.withData(async (data) => {
       const backendState = data.backends[params.backend];
       const firstSnapshot = !backendState?.lastSnapshotHash;
-      const overlayByThreadId = Object.fromEntries(
-        params.threads.map((thread) => [thread.id, data.threads[thread.id]]),
-      );
 
       if (firstSnapshot) {
         for (const thread of params.threads) {
-          data.threads[thread.id] = {
+          const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          data.threads[threadKey] = {
+            backend: thread.source,
             threadId: thread.id,
             lastSeenAt: params.fetchedAt,
             lastSeenUpdatedAt: thread.updatedAt,
             extraLinkedDirectories:
-              data.threads[thread.id]?.extraLinkedDirectories ?? [],
+              data.threads[threadKey]?.extraLinkedDirectories ?? [],
           };
         }
       }
+
+      const overlayByThreadKey = Object.fromEntries(
+        params.threads.map((thread) => {
+          const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          return [threadKey, data.threads[threadKey]];
+        }),
+      );
 
       const snapshot = buildNavigationSnapshot({
         backend: params.backend,
         fetchedAt: params.fetchedAt,
         firstSnapshot,
-        overlayByThreadId: Object.fromEntries(
-          params.threads.map((thread) => [thread.id, data.threads[thread.id]]),
-        ),
-        previousKnownThreadIds: backendState?.knownThreadIds ?? [],
+        overlayByThreadKey,
+        previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
         threads: params.threads,
         unchanged: false,
       });
@@ -66,7 +71,9 @@ export class OverlayStore {
       const unchanged = backendState?.lastSnapshotHash === nextHash;
 
       data.backends[params.backend] = {
-        knownThreadIds: params.threads.map((thread) => thread.id),
+        knownThreadKeys: params.threads.map((thread) =>
+          buildThreadIdentityKey(thread.source, thread.id),
+        ),
         lastSnapshotHash: nextHash,
       };
 
@@ -78,16 +85,18 @@ export class OverlayStore {
   }
 
   async markThreadSeen(params: {
-    backend: AppServerBackendKind;
+    backend: ThreadOverlayState["backend"];
     seenAt?: number;
     seenUpdatedAt?: number;
     threadId: string;
   }): Promise<MarkThreadSeenResponse> {
     return await this.withData(async (data) => {
-      const current = data.threads[params.threadId];
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey];
       const seenAt = params.seenAt ?? Date.now();
 
-      data.threads[params.threadId] = {
+      data.threads[threadKey] = {
+        backend: params.backend,
         threadId: params.threadId,
         dismissedAt: current?.dismissedAt,
         snoozedUntil: current?.snoozedUntil,
@@ -106,11 +115,14 @@ export class OverlayStore {
   }
 
   async addLinkedDirectory(params: {
+    backend: ThreadOverlayState["backend"];
     directory: LinkedDirectorySummary;
     threadId: string;
   }): Promise<ThreadOverlayState> {
     return await this.withData(async (data) => {
-      const current = data.threads[params.threadId] ?? {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
         threadId: params.threadId,
         extraLinkedDirectories: [],
       };
@@ -126,7 +138,7 @@ export class OverlayStore {
         ...current,
         extraLinkedDirectories: nextDirectories,
       };
-      data.threads[params.threadId] = nextState;
+      data.threads[threadKey] = nextState;
       return nextState;
     });
   }

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -1,4 +1,5 @@
 export type AppServerBackendKind = "codex" | "grok";
+export type AppServerBackendScope = AppServerBackendKind | "all";
 
 export type ThreadIdentifier = string;
 
@@ -121,7 +122,7 @@ export type AppServerListThreadsRequest = {
 };
 
 export type AppServerListThreadsResponse = {
-  backend: AppServerBackendKind;
+  backend: AppServerBackendScope;
   fetchedAt: number;
   threads: AppServerThreadSummary[];
 };

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1,4 +1,5 @@
 import type {
+  AppServerBackendScope,
   AppServerBackendKind,
   AppServerThreadSummary,
   LinkedDirectorySummary,
@@ -18,16 +19,23 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
 };
 
+export function buildThreadIdentityKey(
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+): string {
+  return `${backend}:${threadId}`;
+}
+
 export type NavigationSnapshot = {
-  backend: AppServerBackendKind;
+  backend: AppServerBackendScope;
   fetchedAt: number;
   unchanged: boolean;
   threads: NavigationThreadSummary[];
-  inboxThreadIds: ThreadIdentifier[];
+  inboxThreadKeys: string[];
 };
 
 export type GetNavigationSnapshotRequest = {
-  backend?: AppServerBackendKind;
+  backend?: AppServerBackendScope;
   filter?: string;
 };
 
@@ -46,6 +54,7 @@ export type MarkThreadSeenResponse = {
 };
 
 export type ThreadOverlayState = {
+  backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   lastSeenAt?: number;
   lastSeenUpdatedAt?: number;


### PR DESCRIPTION
## Summary
- aggregate desktop thread navigation across available backends and key navigation state by backend-qualified thread identity
- add a New thread picker that lets users start a Codex or Grok thread when that backend supports creation
- show backend chips in inbox, recents, directories, and thread detail while routing transcript loading and seen-state updates through the selected backend

## Testing
- pnpm test
- pnpm typecheck
- git diff --check

## Post-Deploy Monitoring & Validation
No hosted deploy is involved here; this is a desktop app workflow change.

Manual validation should confirm:
- the New thread control offers the expected backends based on availability and create-thread capability
- creating a Codex or Grok thread selects the new thread and loads the correct transcript source
- backend chips stay visible in thread lists and duplicate thread ids from different backends remain isolated

Failure signals to watch for:
- new thread creation leaves the shell in a broken state
- Grok threads load Codex transcripts or seen-state updates hit the wrong backend
- inbox/recents rows collapse onto the wrong thread when two backends share the same thread id
