### PR TITLE
feat(desktop): render elided transcript diffs

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -130,7 +130,16 @@ class MockTransport implements JsonRpcTransport {
                           path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
                           kind: {
                             type: "update"
-                          }
+                          },
+                          diff: [
+                            "--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                            "+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                            "@@ -1,3 +1,4 @@",
+                            " import { useCallback } from \"react\";",
+                            "-import { TranscriptMessage } from \"./TranscriptMessage\";",
+                            "+import { TranscriptActivity } from \"./TranscriptActivity\";",
+                            "+import { TranscriptMessage } from \"./TranscriptMessage\";"
+                          ].join("\n")
                         }
                       ]
                     },
@@ -281,7 +290,21 @@ describe("CodexAppServerClient", () => {
               kind: "write",
               label: "Update TranscriptList.tsx",
               path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
-              status: "completed"
+              status: "completed",
+              fileDiff: {
+                kind: "update",
+                diff: [
+                  "--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                  "+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                  "@@ -1,3 +1,4 @@",
+                  " import { useCallback } from \"react\";",
+                  "-import { TranscriptMessage } from \"./TranscriptMessage\";",
+                  "+import { TranscriptActivity } from \"./TranscriptActivity\";",
+                  "+import { TranscriptMessage } from \"./TranscriptMessage\";"
+                ].join("\n"),
+                additions: 2,
+                removals: 1
+              }
             }
           ]
         },

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -282,6 +282,58 @@ function pushActivityDetail(
   details.push(detail);
 }
 
+function normalizeFileChangeKind(
+  value: string | undefined
+): "add" | "delete" | "update" {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "add" || normalized === "delete" || normalized === "update") {
+    return normalized;
+  }
+  return "update";
+}
+
+function extractDiffText(change: Record<string, unknown>): string | undefined {
+  const directDiff = pickString(change, ["diff", "patch", "unifiedDiff", "unified_diff"]);
+  if (directDiff) {
+    return directDiff;
+  }
+
+  const diffRecord = asRecord(change.diff);
+  if (diffRecord) {
+    return pickString(diffRecord, ["text", "patch", "diff", "unifiedDiff", "unified_diff"]);
+  }
+
+  return undefined;
+}
+
+function summarizeDiff(diff: string): { additions: number; removals: number } {
+  let additions = 0;
+  let removals = 0;
+
+  for (const line of diff.split("\n")) {
+    if (
+      !line ||
+      line.startsWith("+++") ||
+      line.startsWith("---") ||
+      line.startsWith("@@") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      additions += 1;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+
+  return { additions, removals };
+}
+
 function formatCommandLabel(command: string | undefined): string {
   if (!command) {
     return "Ran command";
@@ -404,7 +456,11 @@ function summarizeActivityItems(
       for (const [index, change] of changes.entries()) {
         const changePath = pickString(change, ["path"]);
         const changeKind = asRecord(change.kind);
-        const changeType = pickString(changeKind ?? {}, ["type"]) ?? "update";
+        const changeType = normalizeFileChangeKind(
+          pickString(changeKind ?? {}, ["type"]) ?? pickString(change, ["kind"])
+        );
+        const diff = extractDiffText(change);
+        const diffSummary = diff ? summarizeDiff(diff) : undefined;
         changedFiles += 1;
         pushActivityDetail(details, {
           id: `${itemId}-${index + 1}`,
@@ -413,7 +469,17 @@ function summarizeActivityItems(
             changePath ? path.basename(changePath) || changePath : "file"
           }`,
           path: changePath,
-          status: itemStatus
+          status: itemStatus,
+          ...(diff && diffSummary
+            ? {
+                fileDiff: {
+                  kind: changeType,
+                  diff,
+                  additions: diffSummary.additions,
+                  removals: diffSummary.removals
+                }
+              }
+            : {})
         });
       }
     }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -1,5 +1,6 @@
 import { useId, useState } from "react";
 import type { AppServerThreadActivityEntry } from "@pwragnt/shared";
+import { TranscriptDiff } from "./TranscriptDiff";
 
 type TranscriptActivityProps = {
   entry: AppServerThreadActivityEntry;
@@ -59,7 +60,8 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
         <ul id={detailsId} className="transcript-activity__details">
           {props.entry.details.map((detail) => (
             <li key={detail.id} className="transcript-activity__detail">
-              {detail.label}
+              <span className="transcript-activity__detail-label">{detail.label}</span>
+              {detail.fileDiff ? <TranscriptDiff detail={detail} /> : null}
             </li>
           ))}
         </ul>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState } from "react";
+import type { AppServerThreadActivityDetail } from "@pwragnt/shared";
+
+type TranscriptDiffProps = {
+  detail: AppServerThreadActivityDetail;
+};
+
+type DiffRow =
+  | {
+      kind: "added";
+      newNumber: number;
+      text: string;
+    }
+  | {
+      kind: "context";
+      newNumber: number;
+      oldNumber: number;
+      text: string;
+    }
+  | {
+      kind: "hunk";
+      text: string;
+    }
+  | {
+      kind: "removed";
+      oldNumber: number;
+      text: string;
+    }
+  | {
+      kind: "separator";
+      count: number;
+    };
+
+const CONTEXT_RADIUS = 1;
+
+export function TranscriptDiff(props: TranscriptDiffProps) {
+  const [isZoomedIn, setIsZoomedIn] = useState(false);
+  const diff = props.detail.fileDiff;
+  const rows = useMemo(() => parsePatch(diff?.diff ?? ""), [diff?.diff]);
+  const visibleRows = useMemo(
+    () => (isZoomedIn ? rows : condenseRows(rows)),
+    [isZoomedIn, rows]
+  );
+
+  if (!diff || rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="transcript-diff">
+      {props.detail.path ? (
+        <p className="transcript-diff__path" title={props.detail.path}>
+          {props.detail.path}
+        </p>
+      ) : null}
+
+      <div className="transcript-diff__toolbar">
+        <div className="transcript-diff__stats" aria-label="Diff summary">
+          <span className="transcript-diff__stat transcript-diff__stat--removed">
+            -{diff.removals}
+          </span>
+          <span className="transcript-diff__stat transcript-diff__stat--added">
+            +{diff.additions}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="button button--ghost transcript-diff__toggle"
+          onClick={() => {
+            setIsZoomedIn((current) => !current);
+          }}
+        >
+          {isZoomedIn ? "Zoom out" : "Zoom in"}
+        </button>
+      </div>
+
+      <div className="transcript-diff__rows" role="table" aria-label={`${props.detail.label} diff`}>
+        {visibleRows.map((row, index) => {
+          if (row.kind === "separator") {
+            return (
+              <div
+                key={`separator-${index}`}
+                className="transcript-diff__separator"
+                role="row"
+              >
+                {row.count} unmodified line{row.count === 1 ? "" : "s"} skipped
+              </div>
+            );
+          }
+
+          if (row.kind === "hunk") {
+            return (
+              <div key={`hunk-${index}`} className="transcript-diff__hunk" role="row">
+                {row.text}
+              </div>
+            );
+          }
+
+          const oldNumber = row.kind === "added" ? undefined : row.oldNumber;
+          const newNumber = row.kind === "removed" ? undefined : row.newNumber;
+
+          return (
+            <div
+              key={`${row.kind}-${oldNumber ?? "na"}-${newNumber ?? "na"}-${index}`}
+              className={`transcript-diff__row transcript-diff__row--${row.kind}`}
+              role="row"
+            >
+              <span className="transcript-diff__line-number">
+                {formatLineNumber(oldNumber)}
+              </span>
+              <span className="transcript-diff__line-number">
+                {formatLineNumber(newNumber)}
+              </span>
+              <span className="transcript-diff__symbol" aria-hidden="true">
+                {row.kind === "added" ? "+" : row.kind === "removed" ? "-" : " "}
+              </span>
+              <code className="transcript-diff__text">{row.text || " "}</code>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function parsePatch(patch: string): DiffRow[] {
+  const lines = patch.replace(/\r\n?/g, "\n").split("\n");
+  const rows: DiffRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const line of lines) {
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      oldLine = Number.parseInt(hunkMatch[1], 10);
+      newLine = Number.parseInt(hunkMatch[2], 10);
+      rows.push({ kind: "hunk", text: line });
+      continue;
+    }
+
+    if (
+      line.startsWith("---") ||
+      line.startsWith("+++") ||
+      line.startsWith("Index:") ||
+      line.startsWith("====") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      rows.push({
+        kind: "removed",
+        oldNumber: oldLine,
+        text: line.slice(1)
+      });
+      oldLine += 1;
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      rows.push({
+        kind: "added",
+        newNumber: newLine,
+        text: line.slice(1)
+      });
+      newLine += 1;
+      continue;
+    }
+
+    if (oldLine > 0 || newLine > 0 || line.length > 0) {
+      rows.push({
+        kind: "context",
+        oldNumber: oldLine,
+        newNumber: newLine,
+        text: line.startsWith(" ") ? line.slice(1) : line
+      });
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return rows;
+}
+
+function condenseRows(rows: DiffRow[]): DiffRow[] {
+  const condensed: DiffRow[] = [];
+  let contextBuffer: Extract<DiffRow, { kind: "context" }>[] = [];
+
+  const flushContext = () => {
+    if (contextBuffer.length === 0) {
+      return;
+    }
+
+    if (contextBuffer.length <= CONTEXT_RADIUS * 2) {
+      condensed.push(...contextBuffer);
+      contextBuffer = [];
+      return;
+    }
+
+    condensed.push(...contextBuffer.slice(0, CONTEXT_RADIUS));
+    condensed.push({
+      kind: "separator",
+      count: contextBuffer.length - CONTEXT_RADIUS * 2
+    });
+    condensed.push(...contextBuffer.slice(-CONTEXT_RADIUS));
+    contextBuffer = [];
+  };
+
+  for (const row of rows) {
+    if (row.kind === "context") {
+      contextBuffer.push(row);
+      continue;
+    }
+
+    flushContext();
+    condensed.push(row);
+  }
+
+  flushContext();
+  return condensed;
+}
+
+function formatLineNumber(value: number | undefined): string {
+  if (typeof value !== "number") {
+    return "";
+  }
+  return String(value);
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -238,6 +238,61 @@ describe("TranscriptList", () => {
     expect(screen.queryByText("Read TranscriptActivity.tsx")).not.toBeInTheDocument();
   });
 
+  it("renders write diffs zoomed out by default and expands them on demand", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Edited 1 file",
+            details: [
+              {
+                id: "detail-1",
+                kind: "write",
+                label: "Update TranscriptList.tsx",
+                path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                fileDiff: {
+                  kind: "update",
+                  additions: 1,
+                  removals: 1,
+                  diff: [
+                    "--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                    "+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx",
+                    "@@ -10,6 +10,6 @@",
+                    " export function TranscriptList() {",
+                    "   const a = 1;",
+                    "   const b = 2;",
+                    "   const c = 3;",
+                    "-  return a + b;",
+                    "+  return a + b + c;",
+                    " }"
+                  ].join("\n")
+                }
+              }
+            ]
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Edited 1 file/i }));
+
+    expect(screen.getByText("Update TranscriptList.tsx")).toBeInTheDocument();
+    expect(screen.getByText("2 unmodified lines skipped")).toBeInTheDocument();
+    expect(screen.queryByText("const b = 2;")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+
+    expect(screen.getByText("const b = 2;")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+  });
+
   it("preserves the reader position when older messages are prepended", () => {
     const { rerender } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: dark;
   font-family: "Geist", "IBM Plex Sans", "SF Pro Text", "Inter", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, monospace;
   --bg-app: #0b0d12;
   --bg-sidebar: #11151c;
   --bg-panel: #151a22;
@@ -770,9 +771,162 @@ textarea {
 }
 
 .transcript-activity__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   color: var(--text-primary);
   font-size: 14px;
   line-height: 1.45;
+}
+
+.transcript-activity__detail-label {
+  color: var(--text-primary);
+}
+
+.transcript-diff {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.transcript-diff__path,
+.transcript-diff__hunk,
+.transcript-diff__separator,
+.transcript-diff__text,
+.transcript-diff__line-number,
+.transcript-diff__stat {
+  font-family: var(--font-mono);
+}
+
+.transcript-diff__path {
+  margin: 0;
+  padding: 10px 12px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.transcript-diff__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px 12px;
+}
+
+.transcript-diff__stats {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.transcript-diff__stat {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  padding: 0 8px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.transcript-diff__stat--added {
+  background: rgba(49, 138, 83, 0.18);
+  color: #9ce5b3;
+}
+
+.transcript-diff__stat--removed {
+  background: rgba(171, 73, 73, 0.18);
+  color: #ffb0a1;
+}
+
+.transcript-diff__toggle {
+  min-height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.transcript-diff__rows {
+  display: flex;
+  flex-direction: column;
+  overflow-x: auto;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.transcript-diff__row,
+.transcript-diff__hunk,
+.transcript-diff__separator {
+  min-width: 100%;
+}
+
+.transcript-diff__row {
+  display: grid;
+  grid-template-columns: 44px 44px 16px minmax(0, 1fr);
+  align-items: baseline;
+  gap: 8px;
+  padding: 5px 12px;
+}
+
+.transcript-diff__row--added {
+  background: rgba(49, 138, 83, 0.12);
+}
+
+.transcript-diff__row--removed {
+  background: rgba(171, 73, 73, 0.12);
+}
+
+.transcript-diff__row--context {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.transcript-diff__line-number {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+.transcript-diff__symbol {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.transcript-diff__text {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.transcript-diff__row--added .transcript-diff__symbol,
+.transcript-diff__row--added .transcript-diff__text {
+  color: #9ce5b3;
+}
+
+.transcript-diff__row--removed .transcript-diff__symbol,
+.transcript-diff__row--removed .transcript-diff__text {
+  color: #ffb0a1;
+}
+
+.transcript-diff__hunk,
+.transcript-diff__separator {
+  padding: 6px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.transcript-diff__hunk {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.transcript-diff__separator {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 .context-rail {

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -61,12 +61,22 @@ export type AppServerThreadActivityStatus =
   | "failed"
   | "cancelled";
 
+export type AppServerThreadFileChangeKind = "add" | "delete" | "update";
+
+export type AppServerThreadFileDiff = {
+  kind: AppServerThreadFileChangeKind;
+  diff: string;
+  additions: number;
+  removals: number;
+};
+
 export type AppServerThreadActivityDetail = {
   id: string;
   kind: "read" | "write" | "command";
   label: string;
   path?: string;
   status?: AppServerThreadActivityStatus;
+  fileDiff?: AppServerThreadFileDiff;
 };
 
 export type AppServerThreadActivityEntry = {


### PR DESCRIPTION
## Summary
- carry file-change diff metadata through the shared desktop transcript contract and Codex app-server normalization
- render transcript file edits with a compressed unified diff view by default and an inline `Zoom in` toggle for the full patch
- cover the normalization path and the zoomed-out/zoomed-in renderer behavior with focused desktop tests

## Testing
- `pnpm test -- apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm typecheck`

## Screenshots
- Not attached in this pass. This change stays inside the existing Electron transcript surface and was validated with focused tests.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is a renderer-side presentation change for transcript diff activity with targeted test and typecheck coverage.
