### PR TITLE
feat: normalize thread naming parity across Codex and Grok

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -10,6 +10,7 @@ const listThreads = vi.fn(async (_request?: { backend?: "codex" | "grok"; filter
   {
     id: "thread-1",
     title: "Thread one",
+    titleSource: "explicit" as const,
     source: "codex" as const,
     linkedDirectories: [],
     updatedAt: 2000,
@@ -17,6 +18,7 @@ const listThreads = vi.fn(async (_request?: { backend?: "codex" | "grok"; filter
   {
     id: "thread-1",
     title: "Thread one (Grok)",
+    titleSource: "explicit" as const,
     source: "grok" as const,
     linkedDirectories: [],
     updatedAt: 1000,

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -103,6 +103,29 @@ class MockTransport implements JsonRpcTransport {
         return;
       }
 
+      if (searchTerm === "forked-worktree") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data: params.params?.archived
+                ? []
+                : [
+                    {
+                      id: "thread-forked-worktree",
+                      name: "Plan Slidev theme extraction",
+                      updatedAt: 1_776_100_000,
+                      cwd: "/Users/huntharo/.codex/worktrees/be87/search-product",
+                      path: "/tmp/forked-worktree-rollout.jsonl",
+                    }
+                  ]
+            }
+          })
+        );
+        return;
+      }
+
       if (params.params?.archived === true) {
         this.messageHandler(
           JSON.stringify({
@@ -111,11 +134,18 @@ class MockTransport implements JsonRpcTransport {
             result: {
               data: [
                 {
-                  id: "thread-archive",
+                  id: "thread-renamed",
                   name: "Spud up the thread",
                   preview:
                     "Name this thread something funny and spunky. Something about potatoes.",
                   updatedAt: 1_763_500_500,
+                  cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                },
+                {
+                  id: "thread-archive",
+                  name: "Retired archived thread",
+                  preview: "This one should not appear in the active navigation list.",
+                  updatedAt: 1_763_500_250,
                   cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
                 }
               ]
@@ -148,6 +178,15 @@ class MockTransport implements JsonRpcTransport {
                 updatedAt: 1_763_400_000,
                 session: {
                   cwd: "/Users/huntharo/pwrdrvr/openclaw-codex-app-server"
+                }
+              },
+              {
+                id: "thread-renamed",
+                preview:
+                  "Name this thread something funny and spunky. Something about potatoes.",
+                updatedAt: 1_763_500_100,
+                session: {
+                  cwd: "/Users/huntharo/pwrdrvr/PwrAgnt"
                 }
               }
             ]
@@ -414,6 +453,7 @@ describe("CodexAppServerClient", () => {
     const threads = await client.listThreads();
     const primaryThread = threads.find((thread) => thread.id === "thread-2");
     const derivedThread = threads.find((thread) => thread.id === "thread-1");
+    const renamedThread = threads.find((thread) => thread.id === "thread-renamed");
     const archivedThread = threads.find((thread) => thread.id === "thread-archive");
 
     expect(threads).toHaveLength(3);
@@ -437,11 +477,12 @@ describe("CodexAppServerClient", () => {
     );
     expect(derivedThread?.titleSource).toBe("derived");
     expect(derivedThread?.summary).toBeUndefined();
-    expect(archivedThread).toMatchObject({
-      id: "thread-archive",
+    expect(renamedThread).toMatchObject({
+      id: "thread-renamed",
       title: "Spud up the thread",
       titleSource: "explicit",
     });
+    expect(archivedThread).toBeUndefined();
 
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();
@@ -556,6 +597,99 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("recovers the stable repo directory from rollout metadata when codex cwd is a removed worktree", async () => {
+    vi.resetModules();
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === "/Users/huntharo/.codex/worktrees/be87/search-product") {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+      }),
+      readFile: vi.fn(async (targetPath: string) => {
+        if (targetPath !== "/tmp/forked-worktree-rollout.jsonl") {
+          throw new Error(`Unexpected read: ${targetPath}`);
+        }
+
+        return [
+          JSON.stringify({
+            type: "session_meta",
+            payload: {
+              id: "thread-forked-worktree",
+              forked_from_id: "thread-parent",
+              cwd: "/Users/huntharo/.codex/worktrees/be87/search-product"
+            }
+          }),
+          JSON.stringify({
+            type: "session_meta",
+            payload: {
+              id: "thread-parent",
+              cwd: "/Users/huntharo/GIPHY/search-product"
+            }
+          })
+        ].join("\n");
+      })
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(
+        (
+          _file: string,
+          args: string[],
+          _options: unknown,
+          callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+        ) => {
+          if (args.includes("rev-parse")) {
+            callback(null, {
+              stdout: "/Users/huntharo/GIPHY/search-product\n",
+              stderr: "",
+            });
+            return;
+          }
+
+          if (args.includes("worktree")) {
+            callback(null, {
+              stdout: "worktree /Users/huntharo/GIPHY/search-product\n",
+              stderr: "",
+            });
+            return;
+          }
+
+          callback(new Error(`Unexpected git invocation: ${args.join(" ")}`));
+        }
+      )
+    }));
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+      const client = new CodexAppServerClient({
+        command: "codex"
+      });
+
+      const threads = await client.listThreads({ filter: "forked-worktree" });
+
+      expect(threads).toEqual([
+        expect.objectContaining({
+          id: "thread-forked-worktree",
+          projectKey: "/Users/huntharo/GIPHY/search-product",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/GIPHY/search-product",
+              label: "search-product",
+              path: "/Users/huntharo/GIPHY/search-product",
+              kind: "local"
+            }
+          ]
+        })
+      ]);
+
+      await client.close();
+    } finally {
+      vi.doUnmock("node:fs/promises");
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
   it("does not synthesize summaries from raw conversation text", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
@@ -592,12 +726,13 @@ describe("CodexAppServerClient", () => {
 
     const threads = await client.listThreads();
 
-    expect(threads.find((thread) => thread.id === "thread-archive")).toMatchObject({
-      id: "thread-archive",
+    expect(threads.find((thread) => thread.id === "thread-renamed")).toMatchObject({
+      id: "thread-renamed",
       title: "Spud up the thread",
       titleSource: "explicit",
       source: "codex",
     });
+    expect(threads.find((thread) => thread.id === "thread-archive")).toBeUndefined();
 
     const threadListRequests = MockTransport.instances[0]?.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: { archived?: boolean } })

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -75,7 +75,34 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "thread/list") {
-      const params = JSON.parse(message) as { params?: { archived?: boolean } };
+      const params = JSON.parse(message) as {
+        params?: { archived?: boolean; searchTerm?: string; query?: string; filter?: string };
+      };
+      const searchTerm =
+        params.params?.searchTerm ?? params.params?.query ?? params.params?.filter;
+
+      if (searchTerm === "missing-worktree") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data: params.params?.archived
+                ? []
+                : [
+                    {
+                      id: "thread-missing-worktree",
+                      name: "Investigate chunk file errors",
+                      updatedAt: 1_776_000_000,
+                      cwd: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+                    }
+                  ]
+            }
+          })
+        );
+        return;
+      }
+
       if (params.params?.archived === true) {
         this.messageHandler(
           JSON.stringify({
@@ -419,11 +446,26 @@ describe("CodexAppServerClient", () => {
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();
 
-    const threadListRequest = transport!.sentMessages
+    const threadListRequests = transport!.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
-      .find((payload) => payload.method === "thread/list");
+      .filter((payload) => payload.method === "thread/list");
 
-    expect(threadListRequest?.params).toEqual({});
+    expect(threadListRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: {
+            archived: false,
+            limit: 100
+          }
+        }),
+        expect.objectContaining({
+          params: {
+            archived: true,
+            limit: 100
+          }
+        })
+      ])
+    );
 
     await client.close();
   });
@@ -441,16 +483,77 @@ describe("CodexAppServerClient", () => {
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();
 
-    const threadListRequest = transport!.sentMessages
+    const threadListRequests = transport!.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
-      .find((payload) => payload.method === "thread/list");
+      .filter((payload) => payload.method === "thread/list");
 
-    expect(threadListRequest?.params).toEqual({
-      query: "web-app",
-      limit: 100
-    });
+    expect(threadListRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: {
+            searchTerm: "web-app",
+            archived: false,
+            limit: 100
+          }
+        }),
+        expect.objectContaining({
+          params: {
+            searchTerm: "web-app",
+            archived: true,
+            limit: 100
+          }
+        })
+      ])
+    );
 
     await client.close();
+  });
+
+  it("ignores missing worktree cwd paths when deriving linked directories", async () => {
+    vi.resetModules();
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === "/Users/huntharo/.codex/worktrees/0cb4/web-app") {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+      })
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(
+        (
+          _file: string,
+          _args: string[],
+          _options: unknown,
+          callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void
+        ) => {
+          callback(null, { stdout: "", stderr: "" });
+        }
+      )
+    }));
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+      const client = new CodexAppServerClient({
+        command: "codex"
+      });
+
+      const threads = await client.listThreads({ filter: "missing-worktree" });
+
+      expect(threads).toEqual([
+        expect.objectContaining({
+          id: "thread-missing-worktree",
+          projectKey: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+          linkedDirectories: []
+        })
+      ]);
+
+      await client.close();
+    } finally {
+      vi.doUnmock("node:fs/promises");
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
   });
 
   it("does not synthesize summaries from raw conversation text", async () => {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -92,7 +92,8 @@ class MockTransport implements JsonRpcTransport {
               },
               {
                 id: "thread-1",
-                title: "Plan Codex compatibility",
+                preview:
+                  "I need a bedtime story about Nvidia and building AI through programmable shaders as an accident.",
                 text: "Do not leak this planning prompt into the thread browser",
                 updatedAt: 1_763_400_000,
                 session: {
@@ -366,6 +367,7 @@ describe("CodexAppServerClient", () => {
     expect(threads[0]).toMatchObject({
       id: "thread-2",
       title: "Ship desktop shell",
+      titleSource: "explicit",
       source: "codex",
       linkedDirectories: [
         {
@@ -377,7 +379,11 @@ describe("CodexAppServerClient", () => {
         }
       ]
     });
-    expect(threads[1]?.title).toBe("Plan Codex compatibility");
+    expect(threads[1]?.title).toBe(
+      "A bedtime story about Nvidia and building AI through programmable...",
+    );
+    expect(threads[1]?.titleSource).toBe("derived");
+    expect(threads[1]?.summary).toBeUndefined();
 
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -75,6 +75,29 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "thread/list") {
+      const params = JSON.parse(message) as { params?: { archived?: boolean } };
+      if (params.params?.archived === true) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data: [
+                {
+                  id: "thread-archive",
+                  name: "Spud up the thread",
+                  preview:
+                    "Name this thread something funny and spunky. Something about potatoes.",
+                  updatedAt: 1_763_500_500,
+                  cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                }
+              ]
+            }
+          })
+        );
+        return;
+      }
+
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -362,9 +385,12 @@ describe("CodexAppServerClient", () => {
     });
 
     const threads = await client.listThreads();
+    const primaryThread = threads.find((thread) => thread.id === "thread-2");
+    const derivedThread = threads.find((thread) => thread.id === "thread-1");
+    const archivedThread = threads.find((thread) => thread.id === "thread-archive");
 
-    expect(threads).toHaveLength(2);
-    expect(threads[0]).toMatchObject({
+    expect(threads).toHaveLength(3);
+    expect(primaryThread).toMatchObject({
       id: "thread-2",
       title: "Ship desktop shell",
       titleSource: "explicit",
@@ -379,11 +405,16 @@ describe("CodexAppServerClient", () => {
         }
       ]
     });
-    expect(threads[1]?.title).toBe(
+    expect(derivedThread?.title).toBe(
       "A bedtime story about Nvidia and building AI through programmable...",
     );
-    expect(threads[1]?.titleSource).toBe("derived");
-    expect(threads[1]?.summary).toBeUndefined();
+    expect(derivedThread?.titleSource).toBe("derived");
+    expect(derivedThread?.summary).toBeUndefined();
+    expect(archivedThread).toMatchObject({
+      id: "thread-archive",
+      title: "Spud up the thread",
+      titleSource: "explicit",
+    });
 
     const transport = MockTransport.instances.at(-1);
     expect(transport).toBeDefined();
@@ -431,8 +462,45 @@ describe("CodexAppServerClient", () => {
     });
 
     const threads = await client.listThreads();
+    const derivedThread = threads.find((thread) => thread.id === "thread-1");
 
-    expect(threads[1]?.summary).toBeUndefined();
+    expect(derivedThread?.summary).toBeUndefined();
+
+    await client.close();
+  });
+
+  it("hydrates archived threads so persisted explicit names survive reload", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async (projectKey) =>
+        projectKey
+          ? [
+              {
+                id: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                label: "PwrAgnt",
+                path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                kind: "local"
+              }
+            ]
+          : []
+    });
+
+    const threads = await client.listThreads();
+
+    expect(threads.find((thread) => thread.id === "thread-archive")).toMatchObject({
+      id: "thread-archive",
+      title: "Spud up the thread",
+      titleSource: "explicit",
+      source: "codex",
+    });
+
+    const threadListRequests = MockTransport.instances[0]?.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: { archived?: boolean } })
+      .filter((message) => message.method === "thread/list");
+    expect(threadListRequests?.some((message) => message.params?.archived === false)).toBe(true);
+    expect(threadListRequests?.some((message) => message.params?.archived === true)).toBe(true);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -343,6 +343,7 @@ describe("GrokAppServerClient", () => {
         {
           id: "thread-1",
           title: "Untitled thread",
+          titleSource: "fallback",
           summary: undefined,
           createdAt: expect.any(Number),
           updatedAt: expect.any(Number),

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -55,6 +55,7 @@ describe("GrokAppServerClient", () => {
       {
         id: "thread-1",
         title: "Untitled thread",
+        titleSource: "fallback",
         summary: undefined,
         createdAt: expect.any(Number),
         updatedAt: expect.any(Number),
@@ -82,6 +83,26 @@ describe("GrokAppServerClient", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
+
+    expect(await client.listThreads()).toEqual([
+      {
+        id: "thread-1",
+        title: "Ship Unit 3",
+        titleSource: "derived",
+        summary: "Done.",
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+        linkedDirectories: [
+          {
+            id: "/repo/workspace",
+            label: "workspace",
+            path: "/repo/workspace",
+            kind: "local",
+          },
+        ],
+        source: "grok",
+      },
+    ]);
 
     const replay = await client.readThread({ threadId: "thread-1" });
     expect(replay).toEqual({

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1036,24 +1036,75 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
   );
 }
 
-function buildThreadDiscoveryPayloads(filter?: string): unknown[] {
-  const normalizedFilter = filter?.trim();
-
-  if (!normalizedFilter) {
-    return [{}];
-  }
+function buildThreadDiscoveryPayloads(
+  filter?: string,
+  archived?: boolean
+): unknown[] {
+  const searchTerm = filter?.trim() || undefined;
 
   return [
     {
-      query: normalizedFilter,
+      searchTerm,
+      archived,
       limit: 100
     },
     {
-      filter: normalizedFilter,
+      query: searchTerm,
+      archived,
+      limit: 100
+    },
+    {
+      filter: searchTerm,
+      archived,
+      limit: 100
+    },
+    {
+      archived,
       limit: 100
     },
     {}
   ];
+}
+
+function threadTitleSourcePriority(
+  titleSource: AppServerThreadTitleSource
+): number {
+  switch (titleSource) {
+    case "explicit":
+      return 2;
+    case "derived":
+      return 1;
+    case "fallback":
+    default:
+      return 0;
+  }
+}
+
+function mergeThreadSummaries(
+  threads: RawCodexThreadSummary[]
+): RawCodexThreadSummary[] {
+  const merged = new Map<string, RawCodexThreadSummary>();
+
+  for (const thread of threads) {
+    const current = merged.get(thread.id);
+    if (!current) {
+      merged.set(thread.id, thread);
+      continue;
+    }
+
+    const currentPriority = threadTitleSourcePriority(current.titleSource);
+    const nextPriority = threadTitleSourcePriority(thread.titleSource);
+    const preferNext =
+      nextPriority > currentPriority ||
+      (nextPriority === currentPriority &&
+        (thread.updatedAt ?? 0) > (current.updatedAt ?? 0));
+
+    merged.set(thread.id, preferNext ? thread : current);
+  }
+
+  return [...merged.values()].sort(
+    (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
+  );
 }
 
 function buildThreadResumePayloads(params: {
@@ -1226,15 +1277,28 @@ export class CodexAppServerClient {
   async listThreads(params?: { filter?: string }): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
-    const result = await requestWithFallbacks({
+    const requestParams = {
       client: this.connection,
-      methods: ["thread/list", "thread/loaded/list"],
-      payloads: buildThreadDiscoveryPayloads(params?.filter),
+      methods: ["thread/list", "thread/loaded/list"] as string[],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
-    });
+    };
+    const [activeResult, archivedResult] = await Promise.all([
+      requestWithFallbacks({
+        ...requestParams,
+        payloads: buildThreadDiscoveryPayloads(params?.filter, false),
+      }),
+      requestWithFallbacks({
+        ...requestParams,
+        payloads: buildThreadDiscoveryPayloads(params?.filter, true),
+      }).catch(() => undefined),
+    ]);
+    const threads = mergeThreadSummaries([
+      ...extractThreadsFromValue(activeResult),
+      ...extractThreadsFromValue(archivedResult),
+    ]);
 
     return await Promise.all(
-      extractThreadsFromValue(result).map(async (thread) => ({
+      threads.map(async (thread) => ({
         ...thread,
         linkedDirectories: await this.directoryResolver(thread.projectKey),
         source: "codex"

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,6 +1,9 @@
 import { execFile as execFileCallback } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
+import {
+  shortenDerivedThreadTitle,
+} from "@pwragnt/shared";
 import type {
   AppServerNotification,
   AppServerPendingRequestNotification,
@@ -12,9 +15,10 @@ import type {
   AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadReplayPagination,
+  AppServerThreadTitleSource,
   AppServerThreadSummary,
   AppServerTurnInputItem,
-  LinkedDirectorySummary
+  LinkedDirectorySummary,
 } from "@pwragnt/shared";
 import { JsonRpcConnection } from "./json-rpc";
 import { StdioJsonRpcTransport } from "./stdio-transport";
@@ -225,6 +229,44 @@ function normalizeThreadSummary(value: string | undefined): string | undefined {
   }
 
   return trimmed;
+}
+
+function getThreadTitleInfo(record: Record<string, unknown>): {
+  title: string;
+  titleSource: AppServerThreadTitleSource;
+} {
+  const sessionRecord = asRecord(record.session);
+  const explicitTitle =
+    pickString(record, ["title", "name", "headline"]) ??
+    pickString(sessionRecord ?? {}, ["title", "name", "headline"]);
+
+  if (explicitTitle) {
+    return {
+      title: explicitTitle,
+      titleSource: "explicit",
+    };
+  }
+
+  const derivedTitle =
+    pickString(record, ["preview", "snippet", "firstUserMessage", "first_user_message"]) ??
+    pickString(sessionRecord ?? {}, [
+      "preview",
+      "snippet",
+      "firstUserMessage",
+      "first_user_message",
+    ]);
+
+  if (derivedTitle) {
+    return {
+      title: shortenDerivedThreadTitle(derivedTitle) ?? derivedTitle,
+      titleSource: "derived",
+    };
+  }
+
+  return {
+    title: "Untitled thread",
+    titleSource: "fallback",
+  };
 }
 
 function normalizeConversationRole(
@@ -936,17 +978,42 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
     const projectKey =
       pickString(record, ["projectKey", "project_key", "cwd"]) ??
       pickString(sessionRecord ?? {}, ["cwd", "projectKey", "project_key"]);
+    const titleInfo = getThreadTitleInfo(record);
+    const rawDerivedTitle =
+      pickString(record, ["preview", "snippet", "firstUserMessage", "first_user_message"]) ??
+      pickString(sessionRecord ?? {}, [
+        "preview",
+        "snippet",
+        "firstUserMessage",
+        "first_user_message",
+      ]);
+    const summary = normalizeThreadSummary(
+      pickString(record, [
+        "summary",
+        "preview",
+        "snippet",
+        "firstUserMessage",
+        "first_user_message",
+      ]) ??
+        pickString(sessionRecord ?? {}, [
+          "summary",
+          "preview",
+          "snippet",
+          "firstUserMessage",
+          "first_user_message",
+        ])
+    );
 
     summaries.set(threadId, {
       id: threadId,
-      title:
-        pickString(record, ["title", "name", "headline"]) ??
-        pickString(sessionRecord ?? {}, ["title", "name"]) ??
-        "Untitled thread",
-      summary: normalizeThreadSummary(
-        pickString(record, ["summary", "preview", "snippet"]) ??
-          pickString(sessionRecord ?? {}, ["summary", "preview", "snippet"])
-      ),
+      title: titleInfo.title,
+      titleSource: titleInfo.titleSource,
+      summary:
+        summary === titleInfo.title ||
+        (titleInfo.titleSource === "derived" &&
+          summary === normalizeThreadSummary(rawDerivedTitle))
+          ? undefined
+          : summary,
       projectKey,
       createdAt: normalizeEpochTimestamp(
         pickNumber(record, ["createdAt", "created_at"]) ??

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -51,6 +51,7 @@ type RawCodexThreadSummary = Omit<
   "source" | "linkedDirectories"
 > & {
   projectKey?: string;
+  rolloutPath?: string;
 };
 
 type SkillCatalogEntry = {
@@ -232,6 +233,10 @@ function normalizeThreadSummary(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+function isLikelyCodexWorktreePath(value: string): boolean {
+  return /[\\/]\.codex[\\/]worktrees[\\/]/.test(value);
+}
+
 function getThreadTitleInfo(record: Record<string, unknown>): {
   title: string;
   titleSource: AppServerThreadTitleSource;
@@ -268,6 +273,66 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
     title: "Untitled thread",
     titleSource: "fallback",
   };
+}
+
+async function extractProjectKeyFromRollout(
+  rolloutPath: string | undefined
+): Promise<string | undefined> {
+  if (!rolloutPath || !(await pathExists(rolloutPath))) {
+    return undefined;
+  }
+
+  let fallbackPath: string | undefined;
+
+  try {
+    const contents = await readFile(rolloutPath, "utf8");
+
+    for (const line of contents.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      const record = asRecord(JSON.parse(trimmed));
+      if (record?.type !== "session_meta") {
+        continue;
+      }
+
+      const payload = asRecord(record.payload);
+      const cwd = pickString(payload ?? {}, ["cwd"]);
+      if (!cwd) {
+        continue;
+      }
+
+      if (await pathExists(cwd)) {
+        return cwd;
+      }
+
+      if (!fallbackPath && !isLikelyCodexWorktreePath(cwd)) {
+        fallbackPath = cwd;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return fallbackPath;
+}
+
+async function resolveThreadProjectKey(
+  thread: RawCodexThreadSummary
+): Promise<string | undefined> {
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey && await pathExists(projectKey)) {
+    return projectKey;
+  }
+
+  const rolloutProjectKey = await extractProjectKeyFromRollout(thread.rolloutPath);
+  if (rolloutProjectKey) {
+    return rolloutProjectKey;
+  }
+
+  return projectKey;
 }
 
 function normalizeConversationRole(
@@ -1029,6 +1094,9 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
           ? undefined
           : summary,
       projectKey,
+      rolloutPath:
+        pickString(record, ["path", "rolloutPath", "rollout_path"]) ??
+        pickString(sessionRecord ?? {}, ["path", "rolloutPath", "rollout_path"]),
       createdAt: normalizeEpochTimestamp(
         pickNumber(record, ["createdAt", "created_at"]) ??
           pickNumber(sessionRecord ?? {}, ["createdAt", "created_at"])
@@ -1119,6 +1187,26 @@ function mergeThreadSummaries(
   return [...merged.values()].sort(
     (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
   );
+}
+
+function mergeArchivedThreadMetadata(params: {
+  activeThreads: RawCodexThreadSummary[];
+  archivedThreads: RawCodexThreadSummary[];
+}): RawCodexThreadSummary[] {
+  const archivedById = new Map(
+    params.archivedThreads.map((thread) => [thread.id, thread] as const)
+  );
+
+  return params.activeThreads
+    .map((thread) => {
+      const archived = archivedById.get(thread.id);
+      if (!archived) {
+        return thread;
+      }
+
+      return mergeThreadSummaries([thread, archived])[0] ?? thread;
+    })
+    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
 }
 
 function buildThreadResumePayloads(params: {
@@ -1306,17 +1394,21 @@ export class CodexAppServerClient {
         payloads: buildThreadDiscoveryPayloads(params?.filter, true),
       }).catch(() => undefined),
     ]);
-    const threads = mergeThreadSummaries([
-      ...extractThreadsFromValue(activeResult),
-      ...extractThreadsFromValue(archivedResult),
-    ]);
+    const threads = mergeArchivedThreadMetadata({
+      activeThreads: extractThreadsFromValue(activeResult),
+      archivedThreads: extractThreadsFromValue(archivedResult),
+    });
 
     return await Promise.all(
-      threads.map(async (thread) => ({
-        ...thread,
-        linkedDirectories: await this.directoryResolver(thread.projectKey),
-        source: "codex"
-      }))
+      threads.map(async (thread) => {
+        const projectKey = await resolveThreadProjectKey(thread);
+        return {
+          ...thread,
+          projectKey,
+          linkedDirectories: await this.directoryResolver(projectKey),
+          source: "codex"
+        };
+      })
     );
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -894,6 +895,15 @@ async function runGit(projectKey: string, args: string[]): Promise<string> {
   return result.stdout.trim();
 }
 
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function parseGitWorktrees(output: string): string[] {
   return output
     .split("\n")
@@ -929,8 +939,12 @@ async function resolveLinkedDirectories(
     return [];
   }
 
+  const currentPath = path.resolve(normalizedPath);
+  if (!(await pathExists(currentPath))) {
+    return [];
+  }
+
   try {
-    const currentPath = path.resolve(normalizedPath);
     const repoRoot = await runGit(normalizedPath, ["rev-parse", "--show-toplevel"]);
     const worktreeList = await runGit(normalizedPath, ["worktree", "list", "--porcelain"]);
     const worktreePaths = parseGitWorktrees(worktreeList);

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -7,12 +7,16 @@ import {
   loadLocalEnv,
   resolveGrokAppServerRuntimeConfig,
 } from "@pwragnt/agent-core";
+import {
+  shortenDerivedThreadTitle,
+} from "@pwragnt/shared";
 import type {
   AppServerNotification,
   AppServerPendingRequestNotification,
   AppServerThreadEntry,
   AppServerSkillSummary,
   AppServerThreadReplay,
+  AppServerThreadTitleSource,
   AppServerThreadSummary,
   AppServerTurnInputItem,
   LinkedDirectorySummary,
@@ -58,6 +62,7 @@ type GrokClientOptions = {
 type RawThreadSummary = {
   threadId: string;
   title?: string;
+  titleSource?: AppServerThreadTitleSource;
   summary?: string;
   projectKey?: string;
   createdAt?: number;
@@ -70,11 +75,34 @@ type SkillCatalogEntry = {
 };
 
 function normalizeThreadSummary(thread: RawThreadSummary): RawThreadSummary {
+  const normalizedTitleSource = normalizeTitleSource(thread.titleSource);
+  const normalizedRawTitle = thread.title?.trim();
+  const normalizedTitle =
+    normalizedTitleSource === "derived"
+      ? shortenDerivedThreadTitle(normalizedRawTitle) ?? "Untitled thread"
+      : normalizedRawTitle || "Untitled thread";
+  const normalizedSummary = thread.summary?.trim() || undefined;
+
   return {
     ...thread,
-    title: thread.title?.trim() || "Untitled thread",
-    summary: thread.summary?.trim() || undefined,
+    title: normalizedTitle,
+    titleSource:
+      normalizedTitleSource ??
+      (normalizedTitle === "Untitled thread" ? "fallback" : "explicit"),
+    summary:
+      normalizedSummary === normalizedTitle ||
+      (normalizedTitleSource === "derived" && normalizedSummary === normalizedRawTitle)
+        ? undefined
+        : normalizedSummary,
   };
+}
+
+function normalizeTitleSource(
+  value: unknown
+): AppServerThreadTitleSource | undefined {
+  return value === "explicit" || value === "derived" || value === "fallback"
+    ? value
+    : undefined;
 }
 
 async function resolveLinkedDirectories(
@@ -127,6 +155,7 @@ function extractThreadSummaryList(value: unknown): RawThreadSummary[] {
         {
           threadId,
           title: typeof record.title === "string" ? record.title : undefined,
+          titleSource: normalizeTitleSource(record.titleSource),
           summary: typeof record.summary === "string" ? record.summary : undefined,
           projectKey:
             typeof record.projectKey === "string"
@@ -409,15 +438,19 @@ export class GrokAppServerClient {
 
     const result = await this.getServer().request("thread/list", {});
     return await Promise.all(
-      extractThreadSummaryList(result).map(async (thread) => ({
-        id: thread.threadId,
-        title: normalizeThreadSummary(thread).title ?? "Untitled thread",
-        summary: normalizeThreadSummary(thread).summary,
-        createdAt: thread.createdAt,
-        updatedAt: thread.updatedAt,
-        linkedDirectories: await this.directoryResolver(thread.projectKey),
-        source: "grok" as const,
-      }))
+      extractThreadSummaryList(result).map(async (thread) => {
+        const normalized = normalizeThreadSummary(thread);
+        return {
+          id: thread.threadId,
+          title: normalized.title ?? "Untitled thread",
+          titleSource: normalized.titleSource ?? "fallback",
+          summary: normalized.summary,
+          createdAt: thread.createdAt,
+          updatedAt: thread.updatedAt,
+          linkedDirectories: await this.directoryResolver(thread.projectKey),
+          source: "grok" as const,
+        };
+      })
     );
   }
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { App } from "../App";
 
@@ -188,6 +188,7 @@ describe("App", () => {
             {
               id: "thread-1",
               title: "Build Codex client",
+              titleSource: "explicit",
               summary: "Wire the app-server transport and list threads",
               source: "codex",
               executionMode: "default",
@@ -445,6 +446,7 @@ describe("App", () => {
                 {
                   id: "thread-1",
                   title: "Build Codex client",
+                  titleSource: "explicit",
                   summary: "Wire the app-server transport and list threads",
                   source: "codex",
                   executionMode: "default",
@@ -469,6 +471,7 @@ describe("App", () => {
               {
                 id: "thread-2",
                 title: "Investigate Grok thread",
+                titleSource: "explicit",
                 summary: "Start a new thread on Grok",
                 source: "grok",
                 executionMode: "default",
@@ -482,6 +485,7 @@ describe("App", () => {
               {
                 id: "thread-1",
                 title: "Build Codex client",
+                titleSource: "explicit",
                 summary: "Wire the app-server transport and list threads",
                 source: "codex",
                 executionMode: "default",
@@ -619,6 +623,36 @@ describe("App", () => {
       threadId: "thread-new",
       executionMode: "default" as const,
     }));
+    const agentEventListeners = new Set<
+      (event: {
+        backend: "codex" | "grok";
+        notification: {
+          method: string;
+          params: Record<string, unknown>;
+        };
+      }) => void
+    >();
+    let navigationSnapshot: any = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-existing"],
+      threads: [
+        {
+          id: "thread-existing",
+          title: "Existing Codex thread",
+          titleSource: "explicit" as const,
+          summary: "Already in the list",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const
+          },
+          updatedAt: Date.now()
+        }
+      ]
+    };
     const startTurn = vi.fn(
       async ({
         backend,
@@ -674,27 +708,7 @@ describe("App", () => {
             }
           ]
         }),
-        getNavigationSnapshot: async () => ({
-          backend: "all",
-          fetchedAt: Date.now(),
-          unchanged: false,
-          inboxThreadKeys: ["codex:thread-existing"],
-          threads: [
-            {
-              id: "thread-existing",
-              title: "Existing Codex thread",
-              summary: "Already in the list",
-              source: "codex",
-              executionMode: "default",
-              linkedDirectories: [],
-              inbox: {
-                inInbox: true,
-                reason: "new-thread"
-              },
-              updatedAt: Date.now()
-            }
-          ]
-        }),
+        getNavigationSnapshot: async () => navigationSnapshot,
         markThreadSeen: async ({
           backend,
           threadId
@@ -706,7 +720,20 @@ describe("App", () => {
           threadId,
           seenAt: Date.now()
         }),
-        onAgentEvent: () => () => undefined,
+        onAgentEvent: (
+          listener: (event: {
+            backend: "codex" | "grok";
+            notification: {
+              method: string;
+              params: Record<string, unknown>;
+            };
+          }) => void
+        ) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
         onWindowFocus: () => () => undefined,
         readThread: async ({
           backend,
@@ -766,6 +793,50 @@ describe("App", () => {
       backend: "codex",
       threadId: "thread-new",
       input: [{ type: "text", text: "hello new codex thread" }]
+    });
+
+    navigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-new"],
+      threads: [
+        {
+          id: "thread-new",
+          title: "hello new codex thread",
+          titleSource: "derived",
+          summary: undefined,
+          source: "codex",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread"
+          },
+          updatedAt: Date.now()
+        },
+        ...navigationSnapshot.threads,
+      ]
+    };
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-new",
+              runId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 2, name: "hello new codex thread" })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1,9 +1,21 @@
 import "@testing-library/jest-dom/vitest";
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "../App";
 
 describe("App", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders the live thread shell with transcript history", async () => {
     const copyText = vi.fn(async () => undefined);
     const interruptTurn = vi.fn(async () => ({
@@ -369,6 +381,11 @@ describe("App", () => {
       configurable: true,
       value: {
         ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          data: []
+        }),
         listBackends: async () => ({
           fetchedAt: Date.now(),
           backends: [
@@ -913,7 +930,20 @@ describe("App", () => {
                 toolUse: false,
                 approvalRequests: false,
                 multiDirectoryThreads: true
-              }
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true
+                },
+                {
+                  mode: "full-access",
+                  label: "Full Access",
+                  available: true
+                }
+              ]
             }
           ]
         }),
@@ -980,7 +1010,11 @@ describe("App", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "New thread" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Create thread with Codex" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "Create thread with Codex in Default Access"
+      })
+    );
 
     fireEvent.change(screen.getByLabelText("Reply"), {
       target: {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -839,4 +839,217 @@ describe("App", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("applies explicit thread names from thread/name/updated notifications", async () => {
+    const startThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-new"
+    }));
+    const agentEventListeners = new Set<
+      (event: {
+        backend: "codex" | "grok";
+        notification: {
+          method: string;
+          params: Record<string, unknown>;
+        };
+      }) => void
+    >();
+    let navigationSnapshot: any = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-existing"],
+      threads: [
+        {
+          id: "thread-existing",
+          title: "Existing Codex thread",
+          titleSource: "explicit" as const,
+          summary: "Already in the list",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const
+          },
+          updatedAt: Date.now()
+        }
+      ]
+    };
+    const startTurn = vi.fn(
+      async ({
+        backend,
+        threadId
+      }: {
+        backend: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend,
+        threadId,
+        runId: "turn-1"
+      })
+    );
+
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true
+              }
+            }
+          ]
+        }),
+        getNavigationSnapshot: async () => navigationSnapshot,
+        markThreadSeen: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now()
+        }),
+        onAgentEvent: (
+          listener: (event: {
+            backend: "codex" | "grok";
+            notification: {
+              method: string;
+              params: Record<string, unknown>;
+            };
+          }) => void
+        ) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        onWindowFocus: () => () => undefined,
+        readThread: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false
+            }
+          }
+        }),
+        startThread,
+        startTurn,
+        platform: "darwin",
+        versions: {
+          electron: "41.2.1"
+        }
+      }
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Existing Codex thread"
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "New thread" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Create thread with Codex" }));
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: {
+        value: "Name this thread something funny and spunky. Something about potatoes."
+      }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    navigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-new"],
+      threads: [
+        {
+          id: "thread-new",
+          title: "Name this thread something funny and spunky. Something about potatoes.",
+          titleSource: "derived",
+          summary: undefined,
+          source: "codex",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread"
+          },
+          updatedAt: Date.now()
+        }
+      ]
+    };
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-new",
+              runId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Name this thread something funny and spunky. Something about potatoes."
+    });
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/name/updated",
+            params: {
+              threadId: "thread-new",
+              threadName: "Spud up the thread",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 2, name: "Spud up the thread" })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,7 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Composer } from "../Composer";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Composer", () => {
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -150,6 +150,7 @@ describe("Composer", () => {
         thread={{
           id: "thread-1",
           title: "Build Codex client",
+          titleSource: "explicit",
           source: "codex",
           linkedDirectories: [],
           inbox: { inInbox: false },
@@ -249,6 +250,7 @@ describe("Composer", () => {
         thread={{
           id: "thread-1",
           title: "Build Codex client",
+          titleSource: "explicit",
           source: "codex",
           linkedDirectories: [],
           inbox: { inInbox: false },

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -31,6 +31,7 @@ describe("Composer", () => {
         thread={{
           id: "thread-1",
           title: "Build Codex client",
+          titleSource: "explicit",
           source: "codex",
           linkedDirectories: [],
           inbox: { inInbox: false },
@@ -88,6 +89,7 @@ describe("Composer", () => {
         thread={{
           id: "thread-1",
           title: "Build Codex client",
+          titleSource: "explicit",
           source: "codex",
           linkedDirectories: [],
           inbox: { inInbox: false },

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -38,6 +38,10 @@ const DIRECTORY_THREAD_AGE_OUT_MS = 30 * 24 * 60 * 60 * 1000;
 export function DirectoriesList(props: DirectoriesListProps) {
   const groups = groupThreadsByDirectory(props.threads);
 
+  if (groups.length === 0) {
+    return <p className="sidebar-empty">No directory-linked threads.</p>;
+  }
+
   return (
     <div className="directory-groups">
       {groups.map((group) => (
@@ -104,6 +108,10 @@ function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryG
 
   for (const thread of visibleThreads) {
     if (thread.linkedDirectories.length === 0) {
+      if (thread.projectKey?.trim()) {
+        continue;
+      }
+
       const unlinked = groups.get("unlinked");
       if (unlinked) {
         unlinked.threads.push(thread);

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -33,6 +33,8 @@ type DirectoryIdentity =
       label: string;
     };
 
+const DIRECTORY_THREAD_AGE_OUT_MS = 30 * 24 * 60 * 60 * 1000;
+
 export function DirectoriesList(props: DirectoriesListProps) {
   const groups = groupThreadsByDirectory(props.threads);
 
@@ -97,9 +99,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
 function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryGroup[] {
   const groups = new Map<string, DirectoryGroup>();
-  const stablePathByLabel = collectStablePathByLabel(threads);
+  const visibleThreads = threads.filter((thread) => shouldShowThreadInDirectories(thread));
+  const stablePathByLabel = collectStablePathByLabel(visibleThreads);
 
-  for (const thread of threads) {
+  for (const thread of visibleThreads) {
     if (thread.linkedDirectories.length === 0) {
       const unlinked = groups.get("unlinked");
       if (unlinked) {
@@ -131,6 +134,18 @@ function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryG
   }
 
   return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function shouldShowThreadInDirectories(thread: NavigationThreadSummary): boolean {
+  if (thread.inbox.inInbox) {
+    return true;
+  }
+
+  if (!thread.updatedAt) {
+    return true;
+  }
+
+  return Date.now() - thread.updatedAt < DIRECTORY_THREAD_AGE_OUT_MS;
 }
 
 function collectStablePathByLabel(

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -169,6 +169,7 @@ describe("Sidebar", () => {
           {
             id: "thread-3",
             title: "Untitled thread",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),
@@ -187,6 +188,7 @@ describe("Sidebar", () => {
           {
             id: "thread-4",
             title: "Second untitled thread",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),
@@ -220,7 +222,7 @@ describe("Sidebar", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("merges stale codex worktree paths into the stable repo directory group", () => {
+  it("merges codex worktree paths into the stable repo directory group", () => {
     render(
       <Sidebar
         backends={backends}
@@ -236,6 +238,7 @@ describe("Sidebar", () => {
           {
             id: "thread-5",
             title: "Check web API proxy support",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),
@@ -254,6 +257,7 @@ describe("Sidebar", () => {
           {
             id: "thread-6",
             title: "Explain web app login flow",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),
@@ -272,6 +276,7 @@ describe("Sidebar", () => {
           {
             id: "thread-7",
             title: "Investigate chunk file errors",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
 import type { BackendSummary } from "@pwragnt/shared";
 import { Sidebar } from "../Sidebar";
 
@@ -97,6 +97,10 @@ const sharedThread = {
     }
   ]
 };
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Sidebar", () => {
   it("keeps Inbox first and groups a thread under each linked directory lens", () => {
@@ -302,6 +306,79 @@ describe("Sidebar", () => {
 
     expect(screen.getAllByRole("heading", { level: 3, name: "web-app" })).toHaveLength(1);
     expect(screen.getByText("3 threads")).toBeInTheDocument();
+  });
+
+  it("ages old non-inbox threads out of directory groups", () => {
+    const now = new Date("2026-04-17T13:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    try {
+      render(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          fetchedAt={now}
+          inboxThreads={[]}
+          loading={false}
+          creatingThread={undefined}
+          refreshing={false}
+          selectedThreadKey={undefined}
+          threads={[
+            {
+              id: "thread-recent",
+              title: "Check web API proxy support",
+              titleSource: "explicit",
+              summary: undefined,
+              source: "codex",
+              updatedAt: now - 5 * 24 * 60 * 60 * 1000,
+              inbox: {
+                inInbox: false
+              },
+              linkedDirectories: [
+                {
+                  id: "web-app-root",
+                  label: "web-app",
+                  path: "/Users/huntharo/GIPHY/web-app",
+                  kind: "local"
+                }
+              ]
+            },
+            {
+              id: "thread-old",
+              title: "Explain web app login flow",
+              titleSource: "explicit",
+              summary: undefined,
+              source: "codex",
+              updatedAt: now - 38 * 24 * 60 * 60 * 1000,
+              inbox: {
+                inInbox: false
+              },
+              linkedDirectories: [
+                {
+                  id: "web-app-root-2",
+                  label: "web-app",
+                  path: "/Users/huntharo/GIPHY/web-app",
+                  kind: "local"
+                }
+              ]
+            }
+          ]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onRefresh={async () => undefined}
+          onSelectThread={() => undefined}
+        />
+      );
+
+      expect(screen.getByRole("heading", { level: 3, name: "web-app" })).toBeInTheDocument();
+      expect(screen.getByText("1 thread")).toBeInTheDocument();
+      expect(screen.getByText("Check web API proxy support")).toBeInTheDocument();
+      expect(screen.queryByText("Explain web app login flow")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("copies a linked directory path from the recents chip", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -381,6 +381,58 @@ describe("Sidebar", () => {
     }
   });
 
+  it("does not place unresolved worktree threads under No linked directory", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        fetchedAt={Date.now()}
+        inboxThreads={[]}
+        loading={false}
+        creatingThread={undefined}
+        refreshing={false}
+        selectedThreadKey={undefined}
+        threads={[
+          {
+            id: "thread-missing-cwd",
+            title: "Plan Slidev theme extraction",
+            titleSource: "explicit",
+            summary: undefined,
+            source: "codex",
+            projectKey: "/Users/huntharo/.codex/worktrees/be87/search-product",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: []
+          },
+          {
+            id: "thread-unlinked",
+            title: "Untitled thread",
+            titleSource: "explicit",
+            summary: undefined,
+            source: "grok",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: []
+          }
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onRefresh={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("heading", { level: 3, name: "No linked directory" })).toBeInTheDocument();
+    expect(screen.getByText("1 thread")).toBeInTheDocument();
+    expect(screen.getByText("Untitled thread")).toBeInTheDocument();
+    expect(screen.queryByText("Plan Slidev theme extraction")).not.toBeInTheDocument();
+  });
+
   it("copies a linked directory path from the recents chip", () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -72,6 +72,7 @@ const backends: BackendSummary[] = [
 const sharedThread = {
   id: "thread-1",
   title: "Cross-project cleanup",
+  titleSource: "explicit" as const,
   summary: "Line up the desktop shell with the app server",
   source: "codex" as const,
   gitBranch: "codex/thread-centric-ui",
@@ -115,6 +116,7 @@ describe("Sidebar", () => {
           {
             id: "thread-2",
             title: "Unlinked planning thread",
+            titleSource: "explicit",
             summary: undefined,
             source: "codex",
             updatedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -137,6 +137,39 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                   </li>
                 ))}
               </ul>
+            ) : props.thread.projectKey?.trim() ? (
+              <>
+                <ul className="context-list">
+                  <li className="context-list__item">
+                    <button
+                      aria-label="Copy recorded working directory"
+                      className="context-list__label path-copy-target tooltip-target"
+                      data-tooltip={formatCopyTooltip(props.thread.projectKey)}
+                      type="button"
+                      onClick={(event) => {
+                        void handleCopyPath(event, props.thread.projectKey!);
+                      }}
+                    >
+                      <span aria-hidden="true" className="context-list__icon">
+                        📁
+                      </span>
+                      {pathBaseName(props.thread.projectKey)}
+                    </button>
+                    <button
+                      aria-label="Copy missing working directory path"
+                      className="context-list__meta path-copy-target tooltip-target"
+                      data-tooltip={formatCopyTooltip(props.thread.projectKey)}
+                      type="button"
+                      onClick={(event) => {
+                        void handleCopyPath(event, props.thread.projectKey!);
+                      }}
+                    >
+                      missing
+                    </button>
+                  </li>
+                </ul>
+                <p className="context-empty">Recorded working directory is no longer available.</p>
+              </>
             ) : (
               <p className="context-empty">No linked directory</p>
             )}
@@ -148,6 +181,22 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               <div>
                 <dt>Backend</dt>
                 <dd>{props.thread.source}</dd>
+              </div>
+              <div>
+                <dt>Thread ID</dt>
+                <dd>
+                  <button
+                    aria-label="Copy thread id"
+                    className="context-grid__copy context-grid__mono path-copy-target tooltip-target"
+                    data-tooltip={formatCopyTooltip(props.thread.id, 48)}
+                    type="button"
+                    onClick={(event) => {
+                      void handleCopyPath(event, props.thread.id);
+                    }}
+                  >
+                    {props.thread.id}
+                  </button>
+                </dd>
               </div>
               <div>
                 <dt>Access</dt>
@@ -257,4 +306,10 @@ function formatTimestamp(timestamp: number): string {
     hour: "numeric",
     minute: "2-digit"
   }).format(timestamp);
+}
+
+function pathBaseName(pathname: string): string {
+  const normalized = pathname.replace(/[\\/]+$/, "");
+  const segments = normalized.split(/[\\/]/).filter(Boolean);
+  return segments.at(-1) ?? pathname;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -87,6 +87,7 @@ describe("ThreadView", () => {
         selectedThread={{
           id: "thread-2",
           title: "Plan the app-server protocol",
+          titleSource: "explicit",
           summary: "Inspect Codex thread/read output and normalize it for desktop.",
           source: "codex",
           executionMode: "default",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,7 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadView } from "../ThreadView";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("ThreadView", () => {
   it("renders a directory-less thread with transcript history and context", () => {
@@ -161,6 +165,95 @@ describe("ThreadView", () => {
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("shows missing recorded working directory details and copies the thread id", async () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        copyText
+      }
+    });
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "019d88a2-0e0b-77f0-bfce-130ae8e37d8f",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "019d88a2-0e0b-77f0-bfce-130ae8e37d8f",
+          title: "Plan Slidev theme extraction",
+          titleSource: "explicit",
+          source: "codex",
+          projectKey: "/Users/huntharo/.codex/worktrees/be87/search-product",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "assistant",
+            text: "The thread still loads."
+          }
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={vi.fn(async () => undefined)}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open context rail" }));
+
+    expect(screen.getByText("Recorded working directory is no longer available.")).toBeInTheDocument();
+    expect(screen.getByText("search-product")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy thread id" }));
+
+    expect(copyText).toHaveBeenCalledWith("019d88a2-0e0b-77f0-bfce-130ae8e37d8f");
   });
 
   it("renders live assistant commentary from item/agentMessage/delta notifications", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -244,6 +244,7 @@ describe("ThreadView", () => {
         selectedThread={{
           id: "thread-2",
           title: "Plan the app-server protocol",
+          titleSource: "explicit",
           source: "codex",
           updatedAt: Date.now(),
           linkedDirectories: [],

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -185,6 +185,24 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     });
   }, [desktopApi, refresh]);
 
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
+
+    return desktopApi.onAgentEvent((event) => {
+      const method = event.notification.method;
+      if (
+        method === "thread/name/updated" ||
+        method === "turn/completed" ||
+        method === "turn/failed" ||
+        method === "turn/cancelled"
+      ) {
+        void refresh();
+      }
+    });
+  }, [desktopApi, refresh]);
+
   const threads = useMemo(() => {
     const currentThreads = state.response?.threads ?? [];
     if (!optimisticThread) {
@@ -291,6 +309,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         const nextOptimisticThread: NavigationThreadSummary = {
           id: response.threadId,
           title: "Untitled thread",
+          titleSource: "fallback",
           summary: undefined,
           source: response.backend,
           executionMode: response.executionMode,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -17,6 +17,41 @@ type NavigationState = {
   response?: NavigationSnapshot;
 };
 
+function applyThreadNameUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: { backend: AppServerBackendKind; threadId: string; threadName?: string }
+): NavigationSnapshot | undefined {
+  const threadName = params.threadName?.trim();
+  if (!snapshot || !threadName) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+
+    if (thread.title === threadName && thread.titleSource === "explicit") {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      title: threadName,
+      titleSource: "explicit" as const,
+    };
+  });
+
+  return changed
+    ? {
+        ...snapshot,
+        threads,
+      }
+    : snapshot;
+}
+
 export function useThreadNavigation(desktopApi?: DesktopApi): {
   browseMode: BrowseMode;
   createThread: (
@@ -192,8 +227,39 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
 
     return desktopApi.onAgentEvent((event) => {
       const method = event.notification.method;
+      if (method === "thread/name/updated") {
+        const { threadId, threadName } = event.notification.params as {
+          threadId: string;
+          threadName?: string;
+        };
+        setState((current) => ({
+          ...current,
+          response: applyThreadNameUpdate(current.response, {
+            backend: event.backend,
+            threadId,
+            threadName,
+          }),
+        }));
+        setOptimisticThread((current) => {
+          if (current?.source !== event.backend || current.id !== threadId) {
+            return current;
+          }
+
+          const nextThreadName = threadName?.trim();
+          if (!nextThreadName) {
+            return current;
+          }
+
+          return {
+            ...current,
+            title: nextThreadName,
+            titleSource: "explicit",
+          };
+        });
+        return;
+      }
+
       if (
-        method === "thread/name/updated" ||
         method === "turn/completed" ||
         method === "turn/failed" ||
         method === "turn/cancelled"

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1361,6 +1361,14 @@ textarea {
   font-size: 14px;
 }
 
+.context-grid__copy {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
 .context-mode-switch {
   margin-top: 16px;
 }

--- a/docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md
+++ b/docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Normalize thread naming across Codex and Grok
 type: feat
-status: active
+status: completed
 date: 2026-04-16
 origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
 ---
@@ -107,7 +107,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Normalize Codex thread metadata into explicit versus derived title states**
+- [x] **Unit 1: Normalize Codex thread metadata into explicit versus derived title states**
 
 **Goal:** Stop treating Codex `preview` as summary-only metadata and instead produce the correct desktop title for Codex threads before any explicit rename exists.
 
@@ -142,7 +142,7 @@ flowchart TB
 **Verification:**
 - Codex-backed threads show a meaningful label in thread discovery immediately after the first user turn, without requiring an explicit rename.
 
-- [ ] **Unit 2: Make Grok thread state preserve explicit names and first-user-message-derived titles separately**
+- [x] **Unit 2: Make Grok thread state preserve explicit names and first-user-message-derived titles separately**
 
 **Goal:** Bring Grok onto the same naming model as Codex so mixed-backend thread rows mean the same thing.
 
@@ -181,7 +181,7 @@ flowchart TB
 **Verification:**
 - Grok and Codex threads follow the same naming rules in the desktop sidebar even before Grok persistence lands.
 
-- [ ] **Unit 3: Propagate naming changes live through desktop navigation**
+- [x] **Unit 3: Propagate naming changes live through desktop navigation**
 
 **Goal:** Ensure derived or explicit title changes actually appear in the renderer without waiting for a manual refresh or window-focus event.
 
@@ -219,7 +219,7 @@ flowchart TB
 **Verification:**
 - Title changes become visible in the thread list and thread header during normal use, not only after a full refresh cycle.
 
-- [ ] **Unit 4: Lock the naming contract down with mixed-backend regression coverage**
+- [x] **Unit 4: Lock the naming contract down with mixed-backend regression coverage**
 
 **Goal:** Prevent future protocol and persistence work from regressing naming semantics, especially while Grok persistence is landing in parallel.
 

--- a/docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md
+++ b/docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md
@@ -1,0 +1,291 @@
+---
+title: feat: Normalize thread naming across Codex and Grok
+type: feat
+status: active
+date: 2026-04-16
+origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
+---
+
+# feat: Normalize thread naming across Codex and Grok
+
+## Overview
+
+Make thread naming behave the way Codex actually behaves instead of the way the current desktop assumes it behaves. The desktop should show a meaningful thread title as soon as the first user turn exists, while still distinguishing between an explicit user-set name and a derived first-message title. Grok should participate in the same model so the mixed-backend sidebar does not treat Codex and Grok threads as different kinds of objects.
+
+## Problem Frame
+
+The desktop currently treats `title/name` as the only real thread title and treats `summary/preview` as secondary metadata. In the inspected Codex implementation, that is not how thread identity works. A fresh thread starts with no `name`, and the first durable label is the first user message, which is stored as both `first_user_message` and the initial metadata `title`. Codex only surfaces a distinct `name` when the thread is explicitly renamed. The app-server then suppresses `name` when it matches `first_user_message`, which means the default Codex thread-row label is effectively "first user message as preview," not a hidden model-generated title.
+
+That matters for PwrAgnt because the desktop currently converts Codex `preview` into `summary` and falls back to `"Untitled thread"` for `title`, so meaningful Codex threads remain visually untitled. Grok currently has the same conceptual gap in a different form: it stores an explicit `threadName` plus a synthesized summary from recent messages, but it does not separately model the first user message as the default thread label. If the product is truly thread-first, "unnamed but already has a clear derived title" needs to be a first-class state across both backends.
+
+## Requirements Trace
+
+- R1-R4. Threads remain first-class objects even before users attach repos or explicitly rename them; a newly started thread still needs recognizable identity.
+- R5-R11. Thread lists and thread detail surfaces must show enough context to understand what a thread is at a glance.
+- R20-R22. The real coding loop must feel coherent across Codex and Grok, not like two different products with different naming semantics.
+- User request requirement. Determine whether Codex generates a hidden LLM naming prompt or simply derives thread identity from visible thread state, then implement parity in the correct layer.
+- Compatibility requirement. Grok must participate in the same naming model so the sidebar can render mixed-backend threads consistently.
+
+## Scope Boundaries
+
+- In scope: desktop normalization of Codex thread metadata, Grok-side parity for explicit versus derived titles, and live refresh behavior so title changes appear promptly in the UI.
+- In scope: in-memory Grok session-state changes that establish the naming contract before the parallel persistence work lands.
+- In scope: notification and snapshot updates needed for title changes to propagate without relying on window focus refresh.
+- Out of scope: designing a new AI-generated summarization feature for titles. The inspected Codex code does not show that behavior, so this plan does not add it.
+- Out of scope: full durable Grok persistence design. This plan only defines the semantics that the separate persistence branch should preserve.
+- Out of scope: adding a rename UI workflow if one does not already exist in the desktop shell.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_start.rs` shows new Codex threads serialize `name: null` on `thread/start` and `thread/started`.
+- `/Users/huntharo/github/codex/codex-rs/state/src/extract.rs` applies `EventMsg::UserMessage` by setting `first_user_message` and the initial metadata `title` from the visible user message, and only replaces that title when `EventMsg::ThreadNameUpdated` appears.
+- `/Users/huntharo/github/codex/codex-rs/app-server/src/codex_message_processor.rs` uses `distinct_title()` to suppress `thread.name` when the stored title equals `first_user_message`, and otherwise attaches a title only from persisted metadata or explicit rename state.
+- `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_name_websocket.rs` shows `thread/name/set` is an explicit metadata mutation that emits `thread/name/updated`; it is not a hidden side effect of normal turns.
+- `apps/desktop/src/main/codex-app-server/client.ts` currently maps `title/name` to the desktop thread title and maps `summary/preview` to the desktop summary, which produces `"Untitled thread"` for Codex threads that only have preview-derived identity.
+- `apps/desktop/src/main/grok-app-server/client.ts` currently trusts `thread.title` from the Grok server and otherwise falls back to `"Untitled thread"`.
+- `packages/agent-core/src/app-server/session-state.ts` currently stores only `threadName` plus message history; it does not separately preserve a first-user-message-derived title.
+- `packages/shared/src/contracts/app-server.ts` currently requires a single `title` string and has no way to tell whether that title is explicit, derived, or fallback.
+- `packages/agent-core/src/domain/navigation-state.ts` hashes thread snapshots without `title` or `summary`, so metadata-only naming changes can be treated as unchanged.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` refreshes on focus and optimistic thread creation, but not on metadata-affecting agent events.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist yet for thread naming or mixed-backend title normalization in this repository.
+
+### External References
+
+- None beyond the inspected local Codex source tree. The open-source Codex implementation is the authoritative reference for this feature.
+
+## Key Technical Decisions
+
+- Treat Codex's first visible user message as a derived thread title, not as summary-only metadata. That matches the inspected Codex state and app-server code.
+- Model thread title state explicitly in shared contracts with three modes: `explicit`, `derived`, and `fallback`. The desktop should display all three, but only `explicit` means the thread has been user-renamed.
+- Implement Codex parity in the desktop client layer, because the Codex app server already emits the necessary inputs (`name` and `preview`) and the inspected code shows no hidden title-generation prompt to capture.
+- Implement Grok parity in server/session-state semantics, because the Grok side currently owns the shape of its thread-list payloads and should converge on the same explicit-versus-derived contract.
+- Refresh navigation on metadata-affecting events and include title fields in snapshot hashing. Without that, correct naming semantics still will not appear live in the UI.
+- Keep explicit name and first-user-message-derived title as separate stored concepts so the parallel Grok persistence work can merge cleanly without conflating them.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does Codex send a hidden synthetic prompt to name the thread? Based on the inspected open-source `codex-rs` app-server and state code, no evidence of a hidden naming prompt was found. The default label comes from the first visible user message, and explicit names come from `thread/name/set` or persisted `ThreadNameUpdated` events.
+- Is the missing behavior primarily an app-server protocol catch-up or a desktop normalization bug? For Codex, it is primarily a desktop normalization bug. For Grok, it is a server-plus-client parity gap.
+- Should PwrAgnt wait for Grok persistence before fixing the UI behavior? No. The semantic split can ship against in-memory Grok state first, and the persistence branch can adopt the same fields afterward.
+
+### Deferred to Implementation
+
+- Whether the UI should visually indicate `derived` versus `explicit` title state in the thread row or thread header, beyond the internal contract field.
+- Whether Grok should emit a dedicated metadata notification when the first user message establishes a derived title, or whether `turn/completed`-triggered refresh is sufficient for the first pass.
+- Whether persisted overlay state should remember a local rename-draft or pinning concept later; this plan does not introduce local title overrides.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+| Backend state | Raw backend fields | Desktop normalized title | `titleSource` | Desktop summary |
+|---|---|---|---|---|
+| Fresh new thread | no explicit name, no first user message | `Untitled thread` | `fallback` | none |
+| First user turn exists, no explicit rename | first user message / preview present, explicit name absent | first user message | `derived` | omit if duplicate; otherwise keep secondary preview/snippet |
+| Explicit rename exists | explicit name present | explicit name | `explicit` | first user message or other secondary preview when non-duplicate |
+
+```mermaid
+flowchart TB
+    CODEx["Codex app server\nname + preview"]
+    GROK["Grok app server\nthreadName + first user message"]
+    CLIENTS["Desktop backend clients\nnormalize title + titleSource"]
+    SNAPSHOT["Navigation snapshot\nhash includes title fields"]
+    UI["Sidebar + thread header\nshow normalized title"]
+
+    CODEx --> CLIENTS
+    GROK --> CLIENTS
+    CLIENTS --> SNAPSHOT
+    SNAPSHOT --> UI
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Normalize Codex thread metadata into explicit versus derived title states**
+
+**Goal:** Stop treating Codex `preview` as summary-only metadata and instead produce the correct desktop title for Codex threads before any explicit rename exists.
+
+**Requirements:** R1-R4, R5-R11, R20-R22
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Extend `AppServerThreadSummary` with a lightweight title provenance field such as `titleSource`.
+- In the Codex desktop client, derive `title` from `name` when present, otherwise from `preview`/`first_user_message` style fields, and fall back to `"Untitled thread"` only when neither exists.
+- When the derived title and summary candidate are the same string, drop the summary so the row does not duplicate itself.
+- Keep the normalizer conservative by reusing existing trimming and summary-suppression heuristics rather than blindly promoting long or noisy preview strings.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `/Users/huntharo/github/codex/codex-rs/state/src/extract.rs`
+- `/Users/huntharo/github/codex/codex-rs/app-server/src/codex_message_processor.rs`
+
+**Test scenarios:**
+- Happy path: a Codex thread list item with `name: "Renamed thread"` returns `title: "Renamed thread"` and `titleSource: "explicit"`.
+- Happy path: a Codex thread list item with no `name` but `preview: "Investigate thread naming"` returns `title: "Investigate thread naming"` and `titleSource: "derived"`.
+- Edge case: a fresh Codex thread with neither `name` nor `preview` returns `title: "Untitled thread"` and `titleSource: "fallback"`.
+- Edge case: when `preview` and the summary candidate are identical after normalization, the summary is omitted.
+- Error path: malformed or empty list entries still normalize without throwing and keep the thread discoverable.
+
+**Verification:**
+- Codex-backed threads show a meaningful label in thread discovery immediately after the first user turn, without requiring an explicit rename.
+
+- [ ] **Unit 2: Make Grok thread state preserve explicit names and first-user-message-derived titles separately**
+
+**Goal:** Bring Grok onto the same naming model as Codex so mixed-backend thread rows mean the same thing.
+
+**Requirements:** R1-R4, R5-R11, R20-R22
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/agent-core/src/app-server/protocol.ts`
+- Modify: `packages/agent-core/src/app-server/session-state.ts`
+- Modify: `packages/agent-core/src/app-server/codex-app-server.ts`
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Test: `packages/agent-core/src/__tests__/session-state.test.ts`
+- Test: `packages/agent-core/src/__tests__/codex-app-server-contract.test.ts`
+- Test: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+
+**Approach:**
+- Add an internal first-user-message field to Grok session state that is populated from the earliest meaningful user text and is not overwritten by later assistant output.
+- Keep explicit `threadName` as a separate field that overrides the derived title when present.
+- Return list/read payloads that let the desktop normalize Grok threads with the same `titleSource` semantics as Codex.
+- Emit `thread/name/updated` for explicit rename calls so Grok matches the Codex metadata update surface where practical.
+- Keep the new fields local to session state and protocol DTOs so the parallel persistence work can adopt them without changing the desktop contract again.
+
+**Patterns to follow:**
+- `packages/agent-core/src/app-server/session-state.ts`
+- `packages/agent-core/src/app-server/codex-app-server.ts`
+- `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_name_websocket.rs`
+
+**Test scenarios:**
+- Happy path: after the first Grok user turn, `thread/list` returns that user text as the title with `titleSource: "derived"`.
+- Happy path: after `thread/name/set`, `thread/list` returns the explicit name with `titleSource: "explicit"` and retains the original first user message separately for summary/replay use.
+- Edge case: image-only or blank initial turns do not create a bogus derived title and still fall back to `"Untitled thread"`.
+- Error path: renaming an unknown Grok thread continues to return a deterministic protocol error.
+- Integration: `thread/read` and `thread/list` stay consistent about which value is explicit name versus derived title.
+
+**Verification:**
+- Grok and Codex threads follow the same naming rules in the desktop sidebar even before Grok persistence lands.
+
+- [ ] **Unit 3: Propagate naming changes live through desktop navigation**
+
+**Goal:** Ensure derived or explicit title changes actually appear in the renderer without waiting for a manual refresh or window-focus event.
+
+**Requirements:** R5-R11, R20-R22
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `packages/shared/src/contracts/agent.ts`
+- Modify: `packages/agent-core/src/domain/navigation-state.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Test: `packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+- Test: `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+
+**Approach:**
+- Extend shared notification types to include the thread metadata events the desktop actually needs to react to, especially rename-style updates; treat `turn/completed` as the fallback signal for first-message-derived title changes.
+- Update navigation snapshot hashing so title, title provenance, and summary changes count as material updates.
+- Subscribe `useThreadNavigation` to agent events that affect list metadata and refresh in the background while preserving current selection and optimistic rows.
+- Keep refresh throttling and unchanged-snapshot fast paths intact so title correctness does not create noisy rerenders.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- `packages/agent-core/src/domain/navigation-state.ts`
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+
+**Test scenarios:**
+- Happy path: when a new first user turn completes, the selected thread row updates from `"Untitled thread"` to the derived title without requiring focus change.
+- Happy path: when `thread/name/updated` arrives, the row and thread header update to the explicit title while keeping the same thread id and selection.
+- Edge case: a metadata-only title change still produces a non-unchanged navigation snapshot.
+- Edge case: unrelated turn notifications for another backend or thread do not refresh the selected thread unnecessarily.
+- Integration: optimistic new-thread rows are replaced cleanly by fetched rows once the backend exposes the derived or explicit title.
+
+**Verification:**
+- Title changes become visible in the thread list and thread header during normal use, not only after a full refresh cycle.
+
+- [ ] **Unit 4: Lock the naming contract down with mixed-backend regression coverage**
+
+**Goal:** Prevent future protocol and persistence work from regressing naming semantics, especially while Grok persistence is landing in parallel.
+
+**Requirements:** R20-R22
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `packages/agent-core/src/__tests__/codex-metadata-contract.test.ts`
+- Modify: `packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Modify: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Add contract tests that assert Codex and Grok produce the same desktop-visible title states for fresh, derived, and explicit-name cases.
+- Add reconciliation tests that prove title-only changes are treated as material snapshot changes.
+- Add mixed-backend tests for duplicate thread ids so title updates do not bleed across `codex:<id>` and `grok:<id>` identities.
+- Keep the tests focused on observable metadata and UI behavior so the parallel persistence branch can merge them even if storage internals change.
+
+**Patterns to follow:**
+- `packages/agent-core/src/__tests__/codex-metadata-contract.test.ts`
+- `packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Test scenarios:**
+- Happy path: Codex and Grok both surface the first user message as a derived title after the first turn.
+- Happy path: explicit rename wins over the derived title for both backends.
+- Edge case: duplicate backend ids remain isolated by `source:id` identity keys during title updates.
+- Edge case: fallback `"Untitled thread"` remains only for threads with no explicit name and no usable first user message.
+- Integration: renderer thread header and sidebar row stay in sync for derived and explicit titles.
+
+**Verification:**
+- The repo has regression coverage for the exact naming semantics this plan introduces, making later persistence and protocol work safer to merge.
+
+## System-Wide Impact
+
+- **Interaction graph:** backend payloads feed desktop backend clients, which feed navigation snapshots, which feed the sidebar and thread header. Grok session state is the local source of truth for naming semantics until persistence is added.
+- **Error propagation:** malformed or missing title fields should degrade to `"Untitled thread"` instead of breaking thread discovery or selection.
+- **State lifecycle risks:** derived title must be created once from the first meaningful user turn, explicit rename must override without destroying first-user-message context, and snapshot reconciliation must recognize title-only changes.
+- **API surface parity:** `AppServerThreadSummary`, app-server notification unions, and Grok protocol DTOs all change together; they must stay aligned across `packages/shared`, `packages/agent-core`, and the desktop clients.
+- **Integration coverage:** thread start, first turn completion, explicit rename, mixed-backend duplicate ids, and metadata-only refreshes all need end-to-end verification.
+- **Unchanged invariants:** thread ids, backend identity keys, linked-directory overlay behavior, and transcript replay ordering should remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The parallel Grok persistence branch touches the same session-state files. | Keep the semantic change small and centered on explicit-name versus first-user-message fields so the persistence branch can adopt the same field split with minimal conflict. |
+| Codex preview text may sometimes be noisy or duplicate the summary. | Reuse the existing summary normalization and drop duplicate secondary text after promoting preview to derived title. |
+| Title changes may still not show up because navigation treats them as unchanged. | Include title fields in snapshot hashing and cover metadata-only updates in reconciliation tests. |
+| Shared notification typing may lag raw backend behavior. | Extend shared notification unions only for the metadata events the renderer truly consumes, and keep `turn/completed` as a safe fallback refresh trigger. |
+
+## Documentation / Operational Notes
+
+- The plan assumes the inspected local Codex source tree is representative of the open-source app-server behavior for thread naming as of 2026-04-16.
+- When the separate Grok persistence work lands, it should preserve three states explicitly: explicit thread name, first meaningful user message, and fallback untitled state.
+- If a future product decision adds true model-generated titles, that should be treated as a new feature with a new contract field rather than overloading `derived` to mean two different things.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`
+- Related current-repo code: `apps/desktop/src/main/codex-app-server/client.ts`
+- Related current-repo code: `apps/desktop/src/main/grok-app-server/client.ts`
+- Related current-repo code: `packages/agent-core/src/app-server/session-state.ts`
+- Related current-repo code: `packages/agent-core/src/domain/navigation-state.ts`
+- Related Codex reference: `/Users/huntharo/github/codex/codex-rs/state/src/extract.rs`
+- Related Codex reference: `/Users/huntharo/github/codex/codex-rs/app-server/src/codex_message_processor.rs`
+- Related Codex reference: `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_start.rs`
+- Related Codex reference: `/Users/huntharo/github/codex/codex-rs/app-server/tests/suite/v2/thread_name_websocket.rs`

--- a/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
@@ -45,7 +45,7 @@ describe("Codex app-server contract", () => {
   });
 
   it("creates, lists, renames, and resumes a thread without requiring cwd on resume", async () => {
-    const { server } = createTestHarness();
+    const { server, notifications } = createTestHarness();
 
     const created = await server.request("thread/start", {
       cwd: "/repo/workspace",
@@ -55,6 +55,7 @@ describe("Codex app-server contract", () => {
     expect(created).toEqual({
       threadId: "thread-1",
       threadName: undefined,
+      firstUserMessage: undefined,
       cwd: "/repo/workspace",
       model: "grok-4.20-reasoning",
       modelProvider: "xai",
@@ -82,6 +83,7 @@ describe("Codex app-server contract", () => {
     expect(renamed).toEqual({
       threadId: "thread-1",
       threadName: "OpenClaw parity",
+      firstUserMessage: undefined,
       cwd: "/repo/workspace",
       model: "grok-4.20-reasoning",
       modelProvider: "xai",
@@ -95,6 +97,7 @@ describe("Codex app-server contract", () => {
     expect(resumed).toEqual({
       threadId: "thread-1",
       threadName: "OpenClaw parity",
+      firstUserMessage: undefined,
       cwd: "/repo/workspace",
       model: "grok-4.20-fast",
       modelProvider: "xai",
@@ -110,6 +113,7 @@ describe("Codex app-server contract", () => {
         {
           threadId: "thread-1",
           title: "OpenClaw parity",
+          titleSource: "explicit",
           summary: undefined,
           projectKey: "/repo/workspace",
           model: "grok-4.20-fast",
@@ -117,6 +121,13 @@ describe("Codex app-server contract", () => {
           updatedAt: expect.any(Number),
         },
       ],
+    });
+    expect(notifications).toContainEqual({
+      method: "thread/name/updated",
+      params: {
+        threadId: "thread-1",
+        threadName: "OpenClaw parity",
+      },
     });
   });
 
@@ -148,6 +159,7 @@ describe("Codex app-server contract", () => {
       thread: {
         threadId: "thread-1",
         threadName: undefined,
+        firstUserMessage: "Ship it",
         cwd: "/repo/workspace",
         model: undefined,
         modelProvider: "xai",

--- a/packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts
@@ -55,6 +55,7 @@ describe("CodexAppServer persistence", () => {
           {
             threadId: "thread-1",
             title: "OpenClaw parity",
+            titleSource: "explicit",
             summary: "Done.",
             projectKey: "/repo/workspace",
             model: "grok-4.20-reasoning",

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -17,6 +17,7 @@ function buildThread(overrides: Partial<AppServerThreadSummary> = {}): AppServer
   return {
     id: "thread-1",
     title: "Desktop App",
+    titleSource: "explicit",
     source: "codex",
     linkedDirectories: [],
     updatedAt: 1000,

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -17,6 +17,7 @@ function buildThread(overrides: Partial<AppServerThreadSummary> = {}): AppServer
   return {
     id: "thread-1",
     title: "Desktop App",
+    titleSource: "explicit",
     source: "codex",
     linkedDirectories: [],
     updatedAt: 1000,
@@ -85,6 +86,24 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.unchanged).toBe(true);
+  });
+
+  it("treats title metadata changes as material snapshot changes", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread()],
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [buildThread({ title: "first prompt", titleSource: "derived" })],
+    });
+
+    expect(snapshot.unchanged).toBe(false);
   });
 
   it("tracks mixed-backend threads with duplicate ids independently in aggregate snapshots", async () => {

--- a/packages/agent-core/src/__tests__/session-state.test.ts
+++ b/packages/agent-core/src/__tests__/session-state.test.ts
@@ -26,6 +26,7 @@ describe("AppServerSessionState", () => {
       {
         threadId: "thread-2",
         title: "Second thread",
+        titleSource: "explicit",
         summary: "latest reply",
         projectKey: "/repo/two",
         model: "grok-4.20-fast",
@@ -35,9 +36,68 @@ describe("AppServerSessionState", () => {
       {
         threadId: "thread-1",
         title: "First thread",
+        titleSource: "explicit",
         summary: "first prompt",
         projectKey: "/repo/one",
         model: "grok-4.20-reasoning",
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("derives the title from the first user message until a real name exists", () => {
+    const state = new AppServerSessionState();
+
+    state.createThread({ threadId: "thread-1", cwd: "/repo/workspace" });
+    state.appendInput("thread-1", [{ type: "text", text: "Ship Unit 3" }]);
+
+    expect(state.listThreads()).toEqual([
+      {
+        threadId: "thread-1",
+        title: "Ship Unit 3",
+        titleSource: "derived",
+        summary: undefined,
+        projectKey: "/repo/workspace",
+        model: undefined,
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      },
+    ]);
+
+    state.appendAssistant("thread-1", "Done.");
+
+    expect(state.listThreads()[0]).toEqual({
+      threadId: "thread-1",
+      title: "Ship Unit 3",
+      titleSource: "derived",
+      summary: "Done.",
+      projectKey: "/repo/workspace",
+      model: undefined,
+      createdAt: expect.any(Number),
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("shortens long derived titles without surfacing the full first prompt as summary", () => {
+    const state = new AppServerSessionState();
+
+    state.createThread({ threadId: "thread-1", cwd: "/repo/workspace" });
+    state.appendInput("thread-1", [
+      {
+        type: "text",
+        text: "I need a bedtime story about Nvidia and building AI through programmable shaders as an accident.",
+      },
+    ]);
+
+    expect(state.listThreads()).toEqual([
+      {
+        threadId: "thread-1",
+        title: "A bedtime story about Nvidia and building AI through programmable...",
+        titleSource: "derived",
+        summary: undefined,
+        projectKey: "/repo/workspace",
+        model: undefined,
         createdAt: expect.any(Number),
         updatedAt: expect.any(Number),
       },
@@ -58,6 +118,7 @@ describe("AppServerSessionState", () => {
       threadId: "thread-1",
       thread: expect.objectContaining({
         threadId: "thread-1",
+        firstUserMessage: "Ship it",
         cwd: "/repo/workspace",
         modelProvider: "xai",
         approvalPolicy: "on-request",

--- a/packages/agent-core/src/__tests__/session-state.test.ts
+++ b/packages/agent-core/src/__tests__/session-state.test.ts
@@ -175,7 +175,8 @@ describe("AppServerSessionState", () => {
       expect(hydratedState.listThreads()).toEqual([
         {
           threadId: "thread-1",
-          title: undefined,
+          title: "Untitled thread",
+          titleSource: "fallback",
           summary: "Done.",
           projectKey: "/repo/workspace",
           model: "grok-4.20-fast",

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -224,13 +224,20 @@ export class CodexAppServer {
     return thread;
   }
 
-  private setThreadName(params: Record<string, unknown>): ThreadState {
+  private async setThreadName(params: Record<string, unknown>): Promise<ThreadState> {
     const threadId = asRequiredString(params.threadId, "thread/name/set requires threadId");
     const name = asRequiredString(params.name, "thread/name/set requires name");
     const thread = this.state.setThreadName(threadId, name);
     if (!thread) {
       throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
     }
+    await this.emit({
+      method: "thread/name/updated",
+      params: {
+        threadId,
+        threadName: thread.threadName,
+      },
+    });
     return thread;
   }
 

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -28,9 +28,12 @@ export type AppServerTurnInput = {
   model?: string;
 };
 
+export type ThreadTitleSource = "explicit" | "derived" | "fallback";
+
 export type ThreadState = {
   threadId: string;
   threadName?: string;
+  firstUserMessage?: string;
   cwd?: string;
   model?: string;
   modelProvider?: string;
@@ -44,7 +47,8 @@ export type ThreadState = {
 
 export type ThreadSummary = {
   threadId: string;
-  title?: string;
+  title: string;
+  titleSource: ThreadTitleSource;
   summary?: string;
   projectKey?: string;
   model?: string;
@@ -256,6 +260,13 @@ export type AppServerNotification =
         threadId: string;
         runId?: string;
         requestId: string;
+      };
+    }
+  | {
+      method: "thread/name/updated";
+      params: {
+        threadId: string;
+        threadName?: string;
       };
     }
   | {

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -5,12 +5,14 @@ import type {
   ThreadReplayItem,
   ThreadState,
   ThreadSummary,
+  ThreadTitleSource,
 } from "./protocol.js";
 import type {
   AppServerSessionStore,
   HydratedSessionState,
   StoredMessage,
 } from "../persistence/grok-rollout-store.js";
+import { shortenDerivedThreadTitle } from "@pwragnt/shared";
 import type { ProviderActiveTurn } from "../providers/provider-contract.js";
 
 type ActiveRunRecord = {
@@ -59,6 +61,7 @@ export class AppServerSessionState {
     const thread: ThreadState = {
       threadId: params.threadId,
       threadName: undefined,
+      firstUserMessage: undefined,
       cwd: params.cwd,
       model: params.model,
       modelProvider: params.modelProvider ?? "xai",
@@ -79,15 +82,23 @@ export class AppServerSessionState {
 
   listThreads(): ThreadSummary[] {
     return [...this.threads.values()]
-      .map((thread) => ({
-        threadId: thread.threadId,
-        title: thread.threadName,
-        summary: this.summarizeThread(thread.threadId),
-        projectKey: thread.cwd,
-        model: thread.model,
-        createdAt: thread.createdAt,
-        updatedAt: thread.updatedAt,
-      }))
+      .map((thread) => {
+        const title = getThreadTitle(thread);
+        const summary = this.summarizeThread(thread.threadId, [
+          title.title,
+          title.titleSource === "derived" ? thread.firstUserMessage?.trim() : undefined,
+        ]);
+        return {
+          threadId: thread.threadId,
+          title: title.title,
+          titleSource: title.titleSource,
+          summary,
+          projectKey: thread.cwd,
+          model: thread.model,
+          createdAt: thread.createdAt,
+          updatedAt: thread.updatedAt,
+        };
+      })
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
   }
 
@@ -97,13 +108,13 @@ export class AppServerSessionState {
 
   setThreadName(threadId: string, threadName: string): ThreadState | undefined {
     const trimmed = threadName.trim();
-    if (!trimmed) {
-      return this.updateThread(threadId, { threadName: undefined });
-    }
-    return this.updateThread(threadId, { threadName: trimmed });
+    return this.updateThread(threadId, { threadName: trimmed || null });
   }
 
-  updateThread(threadId: string, patch: ThreadMutation): ThreadState | undefined {
+  updateThread(
+    threadId: string,
+    patch: ThreadMutation | Record<string, unknown>,
+  ): ThreadState | undefined {
     const thread = this.threads.get(threadId);
     if (!thread) {
       return undefined;
@@ -113,6 +124,9 @@ export class AppServerSessionState {
       ...Object.fromEntries(Object.entries(patch).filter(([, value]) => value !== undefined)),
       updatedAt: this.nextTimestamp(),
     };
+    if ("threadName" in patch && patch.threadName === null) {
+      next.threadName = undefined;
+    }
     this.threads.set(threadId, next);
     this.persistThread(threadId);
     return next;
@@ -129,6 +143,10 @@ export class AppServerSessionState {
     if (!text) {
       this.touchThread(threadId);
       return;
+    }
+    const thread = this.threads.get(threadId);
+    if (thread && !thread.firstUserMessage) {
+      thread.firstUserMessage = text;
     }
     this.appendMessage(threadId, { role: "user", text }, {
       id: this.nextItemId("user"),
@@ -318,12 +336,21 @@ export class AppServerSessionState {
     return run;
   }
 
-  private summarizeThread(threadId: string): string | undefined {
+  private summarizeThread(threadId: string, suppressedTexts: Array<string | undefined>): string | undefined {
     const messages = this.messages.get(threadId) ?? [];
+    const ignored = new Set(
+      suppressedTexts
+        .map((text) => text?.trim())
+        .filter((text): text is string => Boolean(text)),
+    );
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index];
-      if (message?.text.trim()) {
-        return message.text;
+      const text = message?.text.trim();
+      if (!text) {
+        continue;
+      }
+      if (!ignored.has(text)) {
+        return text;
       }
     }
     return undefined;
@@ -434,4 +461,30 @@ function nextReplayItemOccurrenceId(baseId: string, items: ThreadReplayItem[]): 
 function stripReplayItemSuffix(id: string): string {
   const match = /^(.*)#\d+$/.exec(id);
   return match?.[1] ?? id;
+}
+
+function getThreadTitle(thread: ThreadState): {
+  title: string;
+  titleSource: ThreadTitleSource;
+} {
+  const explicit = thread.threadName?.trim();
+  if (explicit) {
+    return {
+      title: explicit,
+      titleSource: "explicit",
+    };
+  }
+
+  const derived = thread.firstUserMessage?.trim();
+  if (derived) {
+    return {
+      title: shortenDerivedThreadTitle(derived) ?? derived,
+      titleSource: "derived",
+    };
+  }
+
+  return {
+    title: "Untitled thread",
+    titleSource: "fallback",
+  };
 }

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -94,6 +94,7 @@ export function buildNavigationSnapshotHash(params: {
       title: thread.title,
       titleSource: thread.titleSource,
       summary: thread.summary ?? null,
+      projectKey: thread.projectKey ?? null,
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,
       executionMode: thread.executionMode ?? "default",

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -91,6 +91,9 @@ export function buildNavigationSnapshotHash(params: {
     threads: params.threads.map((thread) => ({
       source: thread.source,
       id: thread.id,
+      title: thread.title,
+      titleSource: thread.titleSource,
+      summary: thread.summary ?? null,
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,
       executionMode: thread.executionMode ?? "default",

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -41,9 +41,12 @@ export type LinkedDirectorySummary = {
   kind: "local" | "worktree";
 };
 
+export type AppServerThreadTitleSource = "explicit" | "derived" | "fallback";
+
 export type AppServerThreadSummary = {
   id: ThreadIdentifier;
   title: string;
+  titleSource: AppServerThreadTitleSource;
   summary?: string;
   createdAt?: number;
   updatedAt?: number;
@@ -289,6 +292,13 @@ export type AppServerNotification =
         threadId: string;
         runId?: string;
         requestId: string;
+      };
+    }
+  | {
+      method: "thread/name/updated";
+      params: {
+        threadId: string;
+        threadName?: string;
       };
     }
   | {

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -48,6 +48,7 @@ export type AppServerThreadSummary = {
   title: string;
   titleSource: AppServerThreadTitleSource;
   summary?: string;
+  projectKey?: string;
   createdAt?: number;
   updatedAt?: number;
   linkedDirectories: LinkedDirectorySummary[];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./contracts/app-server";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/navigation";
+export * from "./thread-titles";

--- a/packages/shared/src/thread-titles.ts
+++ b/packages/shared/src/thread-titles.ts
@@ -1,0 +1,68 @@
+const MAX_DERIVED_THREAD_TITLE_LENGTH = 72;
+const MIN_PREFERRED_BREAK_INDEX = 36;
+
+const LEADING_SKILL_LINK_RE = /^(?:\[\$[^\]]+\]\([^)]+\)\s*)+/i;
+const LEADING_SKILL_TOKEN_RE = /^(?:\$[\w:-]+\s+)+/i;
+const LEADING_REQUEST_PREFIX_RE =
+  /^(?:i need(?: you to)?|can you|could you|would you|please|help me|let's|show me|tell me)\s+/i;
+
+function trimTrailingPunctuation(value: string): string {
+  return value.replace(/[\s,;:.-]+$/g, "").trim();
+}
+
+function uppercaseFirstLetter(value: string): string {
+  if (!value) {
+    return value;
+  }
+  return value[0]!.toUpperCase() + value.slice(1);
+}
+
+function normalizeTitleInput(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const withoutSkillLinks = trimmed.replace(LEADING_SKILL_LINK_RE, "");
+  const withoutSkillTokens = withoutSkillLinks.replace(LEADING_SKILL_TOKEN_RE, "");
+  return withoutSkillTokens || trimmed;
+}
+
+export function shortenDerivedThreadTitle(value: string | undefined): string | undefined {
+  const normalized = normalizeTitleInput(value);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const requestTrimmed = normalized.replace(LEADING_REQUEST_PREFIX_RE, "");
+  const candidateBase =
+    requestTrimmed && requestTrimmed.length < normalized.length
+      ? uppercaseFirstLetter(requestTrimmed)
+      : normalized;
+  const candidate = trimTrailingPunctuation(candidateBase);
+
+  if (candidate.length <= MAX_DERIVED_THREAD_TITLE_LENGTH) {
+    return candidate;
+  }
+
+  const breakpointWindow = candidate.slice(0, MAX_DERIVED_THREAD_TITLE_LENGTH + 1);
+  const punctuationBreaks = [
+    breakpointWindow.lastIndexOf(". "),
+    breakpointWindow.lastIndexOf("? "),
+    breakpointWindow.lastIndexOf("! "),
+    breakpointWindow.lastIndexOf(": "),
+    breakpointWindow.lastIndexOf("; "),
+    breakpointWindow.lastIndexOf(", "),
+  ];
+  const punctuationBreak = Math.max(...punctuationBreaks);
+  if (punctuationBreak >= MIN_PREFERRED_BREAK_INDEX) {
+    return `${trimTrailingPunctuation(candidate.slice(0, punctuationBreak))}...`;
+  }
+
+  const wordBreak = breakpointWindow.lastIndexOf(" ");
+  if (wordBreak >= MIN_PREFERRED_BREAK_INDEX) {
+    return `${trimTrailingPunctuation(candidate.slice(0, wordBreak))}...`;
+  }
+
+  return `${trimTrailingPunctuation(candidate.slice(0, MAX_DERIVED_THREAD_TITLE_LENGTH))}...`;
+}


### PR DESCRIPTION
## Summary
- add explicit, derived, and fallback thread title provenance to the shared app-server contract
- normalize Codex and Grok thread lists so first-user-message titles surface immediately and explicit renames emit metadata updates
- refresh desktop navigation on metadata-affecting events and lock the behavior down with agent-core and desktop regression coverage

## Why
PwrAgnt was treating Codex previews as secondary summary text and falling back to `Untitled thread` even when Codex already had a clear first-message-derived identity. Grok also lacked the same explicit-versus-derived split. This change makes both backends follow the same title model and keeps the sidebar and thread header in sync as names change.

## Testing
- `pnpm --filter @pwragnt/agent-core typecheck`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/session-state.test.ts packages/agent-core/src/__tests__/codex-app-server-contract.test.ts packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
