### PR TITLE
feat(grok): persist Grok app server threads

### DIFF
--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -5,6 +5,7 @@ import {
   CodexAppServer,
   FakeProvider,
   createTemporaryTestDirectory,
+  defaultGrokAppServerConfigPath,
   defaultGrokAppServerConfigPaths,
 } from "@pwragnt/agent-core";
 import { GrokAppServerClient } from "../grok-app-server/client";
@@ -162,6 +163,99 @@ describe("GrokAppServerClient", () => {
       } else {
         process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
       }
+      await temp.cleanup();
+    }
+  });
+
+  it("initializes from config.toml when env vars are absent", async () => {
+    const originalHome = process.env.HOME;
+    const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_MODEL;
+    delete process.env.XAI_BASE_URL;
+    delete process.env.XDG_CONFIG_HOME;
+
+    const temp = await createTemporaryTestDirectory();
+    process.env.HOME = temp.path;
+    const configPath = defaultGrokAppServerConfigPath({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      [
+        'xai_api_key = "config-key"',
+        'grok_model = "grok-4.20-fast"',
+        'xai_base_url = "https://api.example.test/v1"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    try {
+      const client = new GrokAppServerClient();
+      await expect(client.getInitializeResult()).resolves.toEqual(
+        expect.objectContaining({
+          serverInfo: expect.objectContaining({
+            name: "@pwragnt/grok-app-server",
+          }),
+        }),
+      );
+      await client.close();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      await temp.cleanup();
+    }
+  });
+
+  it("reloads persisted Grok thread metadata after client recreation", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const stateRoot = path.join(temp.path, "state");
+
+    try {
+      const firstClient = new GrokAppServerClient({
+        apiKey: "test-key",
+        stateRoot,
+        threadIdGenerator: () => "thread-1",
+      });
+      await firstClient.startThread({
+        model: "grok-4.20-fast",
+      });
+      await firstClient.close();
+
+      const secondClient = new GrokAppServerClient({
+        apiKey: "test-key",
+        stateRoot,
+      });
+
+      await expect(secondClient.listThreads()).resolves.toEqual([
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          summary: undefined,
+          createdAt: expect.any(Number),
+          updatedAt: expect.any(Number),
+          linkedDirectories: [],
+          source: "grok",
+        },
+      ]);
+      await expect(secondClient.readThread({ threadId: "thread-1" })).resolves.toEqual({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      });
+      await secondClient.close();
+    } finally {
       await temp.cleanup();
     }
   });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -124,6 +124,89 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves the full Grok message sequence when last-message summaries are also present", async () => {
+    const provider = new FakeProvider();
+    const server = new CodexAppServer({
+      provider,
+      threadIdGenerator: () => "thread-1",
+      runIdGenerator: (() => {
+        let index = 0;
+        return () => `turn-${++index}`;
+      })(),
+    });
+
+    const client = new GrokAppServerClient({ server });
+
+    await client.startThread({
+      model: "grok-4.20-reasoning",
+    });
+
+    await client.startTurn({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Who are you?" }],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "I'm Grok 4, built by xAI.",
+      providerResponseId: "resp_1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await client.startTurn({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "What model are you?" }],
+    });
+    await Promise.resolve();
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toEqual({
+      entries: [
+        {
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "Who are you?",
+        },
+        {
+          type: "message",
+          id: "message-2",
+          role: "assistant",
+          text: "I'm Grok 4, built by xAI.",
+        },
+        {
+          type: "message",
+          id: "message-3",
+          role: "user",
+          text: "What model are you?",
+        },
+      ],
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          text: "Who are you?",
+        },
+        {
+          id: "message-2",
+          role: "assistant",
+          text: "I'm Grok 4, built by xAI.",
+        },
+        {
+          id: "message-3",
+          role: "user",
+          text: "What model are you?",
+        },
+      ],
+      lastUserMessage: "What model are you?",
+      lastAssistantMessage: "I'm Grok 4, built by xAI.",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    });
+
+    await client.close();
+  });
+
   it("initializes from ~/.config/grok-app-server when env vars are absent", async () => {
     const originalHome = process.env.HOME;
     const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import {
+  AppServerSessionState,
   CodexAppServer,
+  GrokRolloutStore,
   GrokProvider,
-  loadGrokAppServerConfig,
   loadLocalEnv,
+  resolveGrokAppServerRuntimeConfig,
 } from "@pwragnt/agent-core";
 import type {
   AppServerNotification,
@@ -37,6 +39,7 @@ type GrokClientOptions = {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+  stateRoot?: string;
   directoryResolver?: (
     projectKey?: string
   ) => Promise<LinkedDirectorySummary[]>;
@@ -499,20 +502,26 @@ export class GrokAppServerClient {
     }
 
     loadLocalEnv({ override: false });
-    loadGrokAppServerConfig({ override: false });
-    const apiKey = this.options.apiKey?.trim() || process.env.XAI_API_KEY?.trim();
+    const runtimeConfig = resolveGrokAppServerRuntimeConfig();
+    const apiKey = this.options.apiKey?.trim() || runtimeConfig.apiKey;
     if (!apiKey) {
       throw new Error("grok app server unavailable: XAI_API_KEY is not set");
     }
 
     const provider = new GrokProvider({
       apiKey,
-      baseUrl: this.options.baseUrl?.trim() || process.env.XAI_BASE_URL?.trim(),
-      model: this.options.model?.trim() || process.env.GROK_MODEL?.trim(),
+      baseUrl: this.options.baseUrl?.trim() || runtimeConfig.baseUrl,
+      model: this.options.model?.trim() || runtimeConfig.model,
+    });
+    const sessionState = new AppServerSessionState({
+      store: new GrokRolloutStore(
+        this.options.stateRoot?.trim() || runtimeConfig.stateRoot,
+      ),
     });
 
     this.server = new CodexAppServer({
       provider,
+      sessionState,
       threadIdGenerator: this.options.threadIdGenerator,
       runIdGenerator: this.options.runIdGenerator,
     });

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -157,51 +157,50 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     messages?: Array<{ role?: unknown; text?: unknown }>;
   };
 
-  const fallbackMessages = [
-    typeof record.lastUserMessage === "string"
-      ? {
-          id: "message-1",
-          role: "user" as const,
-          text: record.lastUserMessage,
-        }
-      : undefined,
-    typeof record.lastAssistantMessage === "string"
-      ? {
-          id:
-            typeof record.lastUserMessage === "string"
-              ? "message-2"
-              : "message-1",
-          role: "assistant" as const,
-          text: record.lastAssistantMessage,
-        }
-      : undefined,
-  ].filter((message): message is { id: string; role: "user" | "assistant"; text: string } =>
-    Boolean(message)
-  );
+  const rawMessages = Array.isArray(record.messages) ? record.messages : [];
+  if (rawMessages.length === 0) {
+    const fallbackMessages = [
+      typeof record.lastUserMessage === "string"
+        ? {
+            id: "message-1",
+            role: "user" as const,
+            text: record.lastUserMessage,
+          }
+        : undefined,
+      typeof record.lastAssistantMessage === "string"
+        ? {
+            id:
+              typeof record.lastUserMessage === "string"
+                ? "message-2"
+                : "message-1",
+            role: "assistant" as const,
+            text: record.lastAssistantMessage,
+          }
+        : undefined,
+    ].filter((message): message is { id: string; role: "user" | "assistant"; text: string } =>
+      Boolean(message)
+    );
 
-  if (
-    typeof record.lastUserMessage === "string" ||
-    typeof record.lastAssistantMessage === "string"
-  ) {
-    return {
-      entries: fallbackMessages.map((message) => ({
-        type: "message" as const,
-        ...message,
-      })),
-      messages: fallbackMessages,
-      lastUserMessage:
-        typeof record.lastUserMessage === "string"
-          ? record.lastUserMessage
-          : undefined,
-      lastAssistantMessage:
-        typeof record.lastAssistantMessage === "string"
-          ? record.lastAssistantMessage
-          : undefined,
-      pagination,
-    };
+    if (fallbackMessages.length > 0) {
+      return {
+        entries: fallbackMessages.map((message) => ({
+          type: "message" as const,
+          ...message,
+        })),
+        messages: fallbackMessages,
+        lastUserMessage:
+          typeof record.lastUserMessage === "string"
+            ? record.lastUserMessage
+            : undefined,
+        lastAssistantMessage:
+          typeof record.lastAssistantMessage === "string"
+            ? record.lastAssistantMessage
+            : undefined,
+        pagination,
+      };
+    }
   }
 
-  const rawMessages = Array.isArray(record.messages) ? record.messages : [];
   const messages = rawMessages.flatMap((message, index) => {
     if (!message || typeof message !== "object") {
       return [];

--- a/docs/plans/2026-04-16-004-feat-grok-thread-storage-plan.md
+++ b/docs/plans/2026-04-16-004-feat-grok-thread-storage-plan.md
@@ -1,0 +1,472 @@
+---
+title: feat: Add durable thread storage for the Grok app server
+type: feat
+status: active
+date: 2026-04-16
+origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
+---
+
+# feat: Add durable thread storage for the Grok app server
+
+## Overview
+
+Add durable Grok thread storage so Grok-backed threads survive desktop app restarts, remain readable through `thread/list` and `thread/read`, and keep enough provider state to continue the conversation after a restart. At the same time, replace the Grok app-server's current env-file-only configuration with a user-editable TOML config under XDG config paths, while storing thread history as grep-friendly JSONL rollout files under XDG state paths. If indexing later becomes necessary for scale, SQLite should be introduced as a derived cache, not the source of truth.
+
+## Problem Frame
+
+The current Grok app-server path is effectively stateless across process restarts:
+
+- [`apps/desktop/src/main/grok-app-server/client.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/apps/desktop/src/main/grok-app-server/client.ts) creates an in-process `CodexAppServer`
+- [`packages/agent-core/src/app-server/codex-app-server.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/codex-app-server.ts) owns an in-memory `AppServerSessionState`
+- [`packages/agent-core/src/app-server/session-state.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/session-state.ts) stores threads, messages, replay items, previous response ids, and active runs only in maps
+
+That is why restarting the desktop app drops every Grok thread. The app already persists navigation overlay state through [`packages/agent-core/src/persistence/overlay-store.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts), but the server-side thread data the desktop actually needs to render and resume Grok threads is not durable.
+
+The current config story is also awkward. Runtime code imports [`packages/agent-core/src/testing/load-local-env.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/testing/load-local-env.ts), which loads `XAI_API_KEY`, `XAI_BASE_URL`, and `GROK_MODEL` from `~/.config/grok-app-server/config.env` or legacy `.env` files. That helper works, but it couples production startup to a testing-oriented env parser and gives us no clean place to put storage settings.
+
+The earlier draft of this plan leaned toward SQLite as the canonical runtime store. That is operationally tidy, but it fights the way this product is likely to be debugged and inspected. For Grok threads, plain text matters:
+
+- humans should be able to inspect raw thread artifacts
+- `rg` should work over stored transcripts
+- agents should be able to search thread history without a custom database query path
+- restart durability should not require opaque binary state as the only source of truth
+
+This revision therefore fixes both issues together:
+
+- durable thread persistence for the Grok app server
+- a clearer XDG config/state split
+- text-first JSONL rollouts as canonical thread storage
+
+## Requirements Trace
+
+- R4. Threads remain first-class objects even when they have no attached directory.
+- R8. Recents is the default browsing lens, which only works if completed and inactive threads still exist after restart.
+- R20. The first milestone includes a real provider and agent harness, not a fake shell.
+- R21. The system is Grok-first for the first milestone.
+- R22. The first milestone supports the core coding loop: create or open a thread, run agent work, inspect progress, and review results inside the app.
+- R24-R26. The product should not feel stateless; its memory and guidance systems must accumulate over time.
+- User-requested durability requirement. Restarting the desktop app must not erase Grok threads.
+- Derived continuity requirement. A persisted thread must retain enough provider continuity data to support a follow-up Grok turn after restart, not just a read-only transcript.
+- Derived operability requirement. Stored Grok thread artifacts should remain inspectable and searchable with ordinary filesystem tools such as `rg`.
+
+## Scope Boundaries
+
+- In scope: the Grok app-server persistence path used by the desktop app.
+- In scope: durable storage for thread metadata, transcript content, replay items, and provider continuation metadata.
+- In scope: replacing the Grok app-server config file format with TOML, plus a compatibility fallback for existing env files.
+- In scope: XDG-based config and state paths.
+- In scope: JSONL rollouts as canonical thread history storage.
+- In scope: an optional derived SQLite index only if needed for list or search performance.
+- In scope: restart recovery for completed or idle threads.
+- Out of scope: changing Codex thread persistence.
+- Out of scope: syncing threads across machines or user accounts.
+- Out of scope: persisting live provider handles or resuming in-flight turns exactly where they left off after process death.
+- Out of scope: full parity with Codex's rollout tree, indexing rules, and broader state-db architecture.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- [`packages/agent-core/src/app-server/session-state.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/session-state.ts) is the direct source of the restart bug. It owns the thread registry, transcript messages, replay items, previous response ids, and run map entirely in memory.
+- [`packages/agent-core/src/app-server/codex-app-server.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/codex-app-server.ts) creates `AppServerSessionState` internally, so persistence has to be wired through the server constructor rather than bolted on in the desktop shell.
+- [`packages/agent-core/src/app-server/turn-runner.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/turn-runner.ts), [`packages/agent-core/src/app-server/compaction-runner.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/compaction-runner.ts), and [`packages/agent-core/src/app-server/review-runner.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/review-runner.ts) already funnel all durable thread mutations through `AppServerSessionState`. That makes a write-through persistence layer feasible without rewriting the runners.
+- [`apps/desktop/src/main/grok-app-server/client.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/apps/desktop/src/main/grok-app-server/client.ts) currently loads env defaults and instantiates `CodexAppServer` directly. That is the right integration point for config loading and storage-path wiring.
+- [`packages/agent-core/src/persistence/overlay-store.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts) shows the existing local persistence style in this repo: simple durable files, explicit migrations, and atomic writes for small metadata payloads.
+- [`docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md) explicitly left durable cross-process thread persistence out of scope. This plan is the follow-on that closes that gap.
+
+### Comparison: `codex`
+
+- `codex` keeps human-edited configuration in `~/.codex/config.toml`.
+- It stores thread rollouts on disk as JSONL under `~/.codex/sessions/YYYY/MM/DD/rollout-...jsonl`.
+- It also maintains SQLite state and logs databases under `CODEX_HOME` for metadata and indexing.
+
+Relevant references:
+
+- `/Users/huntharo/github/codex/codex-rs/config/src/types.rs`
+- `/Users/huntharo/github/codex/codex-rs/rollout/src/list.rs`
+- `/Users/huntharo/github/codex/codex-rs/state/src/runtime.rs`
+
+What matters here is not copying Codex wholesale. The useful patterns are:
+
+- TOML for user-managed configuration
+- appendable text artifacts for thread history
+- optional database indexing layered on top of those artifacts
+
+### Comparison: `grok-cli`
+
+- `grok-cli` stores user settings separately from runtime state.
+- It uses `~/.grok/grok.db` as the durable runtime store.
+- Its SQLite schema persists sessions, messages, tool calls, tool results, usage, and compactions.
+
+Relevant references:
+
+- `/Users/huntharo/github/grok-cli/src/storage/db.ts`
+- `/Users/huntharo/github/grok-cli/src/storage/migrations.ts`
+- `/Users/huntharo/github/grok-cli/src/storage/sessions.ts`
+- `/Users/huntharo/github/grok-cli/src/storage/transcript.ts`
+
+`grok-cli` is still useful as a schema-design reference, especially for what data should be persisted. But for PwrAgnt, its SQLite-first storage shape is a worse fit than Codex's text-first artifacts because the desktop app and this repo benefit more from inspectable files than from database-only storage.
+
+### Institutional Learnings
+
+- No `docs/solutions/` documents exist yet for Grok app-server persistence in this repository.
+
+### External Research
+
+- Skipped. The repo and the adjacent `codex` and `grok-cli` codebases already provide the relevant storage and config patterns for this decision.
+
+## Key Technical Decisions
+
+- Use an XDG split for config and state:
+  - `XDG_CONFIG_HOME/grok-app-server/config.toml` with fallback `~/.config/grok-app-server/config.toml`
+  - `XDG_STATE_HOME/grok-app-server/...` with fallback `~/.local/state/grok-app-server/...`
+  This is the standard, unsurprising place for a cross-platform developer tool that wants to remain compatible with XDG-aware setups.
+- Use TOML for Grok app-server configuration. It is a better fit than env files for structured defaults and a better fit than YAML for low-surprise local editing.
+- Keep environment variables as highest-precedence overrides, then read `config.toml`, then fall back to legacy env files during the migration window. This preserves current operator behavior and avoids breaking existing setups on day one.
+- Store Grok thread history canonically as text-first rollout artifacts under the XDG state directory. The rollout data should be searchable with `rg` and inspectable without custom tooling.
+- Use a per-thread directory layout under state root, for example:
+  - `threads/<thread-id>/thread.toml`
+  - `threads/<thread-id>/rollout.jsonl`
+  `thread.toml` holds durable summary metadata. `rollout.jsonl` holds append-only message and replay events.
+- If list or query performance later becomes a real problem, add SQLite only as a derived index or cache that can be rebuilt from the rollout files. SQLite should not be the only authoritative copy of thread history.
+- Encapsulate persistence behind a narrow app-server storage adapter and keep `AppServerSessionState` as the main mutation surface. That preserves the existing turn, compaction, and review runner structure instead of scattering filesystem logic across the app-server.
+- Persist only durable, restart-safe state:
+  - thread metadata
+  - ordered user and assistant transcript messages
+  - replay items used by the desktop transcript surfaces
+  - previous provider response id
+  - created and updated timestamps
+  Do not attempt to persist live provider handles, pending approval callbacks, or active-run subscriptions.
+- On startup, treat any previously active run as no longer resumable. The persisted thread remains readable and usable for a new turn, but the server does not promise exact mid-turn recovery after a crash or restart.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should thread data live in the existing config directory? No. Keep config and runtime state separate even if both are under the Grok app-server namespace.
+- Should the new config remain env-shaped? No. Use TOML for the config file and keep env vars as overrides.
+- Should PwrAgnt use XDG paths? Yes. Use XDG config and state locations with the standard `~/.config` and `~/.local/state` fallbacks.
+- Should PwrAgnt copy Codex's JSONL rollout idea? Yes, at the level of canonical text-first thread artifacts, but not the full Codex rollout-plus-state-db architecture.
+- Should SQLite be the source of truth? No. If SQLite appears later, it should be a derived index, not the canonical history store.
+- Should the first persistence pass try to recover in-flight runs? No. Persist completed thread history and allow new turns after restart; do not promise crash-exact active turn recovery.
+
+### Deferred to Implementation
+
+- Whether the migration experience should create `config.toml` automatically from a detected legacy env file or only continue reading the env file until the user opts in.
+- Whether replay-item payloads should live entirely in rollout JSONL or split between `thread.toml` summary fields and rollout events for faster summary reads.
+- Whether the first pass should ship with no SQLite index at all, or with a minimal rebuildable index for `thread/list` performance once the thread count grows.
+- Whether stale active runs should be marked as `cancelled` during hydration or simply omitted from the active run set while preserving prior completed replay items.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    CONFIG["config.toml + env overrides"]
+    PATHS["XDG config/state path resolver"]
+    CLIENT["GrokAppServerClient"]
+    SERVER["CodexAppServer"]
+    STATE["AppServerSessionState"]
+    META["thread.toml per thread"]
+    ROLLOUT["rollout.jsonl per thread"]
+    INDEX["optional derived SQLite index"]
+    RUNNERS["turn / review / compaction runners"]
+    DESKTOP["desktop thread list/read UI"]
+
+    CONFIG --> CLIENT
+    PATHS --> CLIENT
+    CLIENT --> SERVER
+    SERVER --> STATE
+    RUNNERS --> STATE
+    STATE <--> META
+    STATE <--> ROLLOUT
+    META --> INDEX
+    ROLLOUT --> INDEX
+    SERVER --> DESKTOP
+```
+
+### Data Shape Guidance
+
+- `thread.toml`
+  - thread id
+  - thread name
+  - cwd
+  - model
+  - model provider
+  - previous response id
+  - created and updated timestamps
+- `rollout.jsonl`
+  - ordered user and assistant messages
+  - replay items with stable item ids
+  - command or tool metadata needed by transcript surfaces
+  - compaction and review outputs as normal persisted events
+- optional `index.sqlite`
+  - derived summaries for fast `thread/list`
+  - rebuildable from `thread.toml` plus `rollout.jsonl`
+
+The persistence adapter should hydrate the in-memory session state at boot and then write through on thread mutations. `thread/list` and `thread/read` stay routed through the same app-server APIs the desktop already consumes.
+
+## Alternative Approaches Considered
+
+- Single JSON file under `XDG_STATE_HOME/grok-app-server/`
+  - Rejected because it mixes many threads into one mutable blob, rewrites too much data on each change, and scales poorly as transcript size grows.
+- SQLite-only canonical storage
+  - Rejected because it hides the source of truth behind a database, makes `rg` and manual inspection much worse, and creates an unnecessary custom-query barrier for debugging.
+- Full Codex-style rollout tree plus state-db indexing from day one
+  - Rejected because it imports more architecture than this repo currently needs.
+- JSON or YAML for config
+  - JSON is workable but awkward for user-edited local config.
+  - YAML adds parsing edge cases and more surface area than this repo needs.
+  - TOML is the best fit for a small structured local config file.
+
+## Implementation Units
+
+- [x] **Unit 1: Replace env-only Grok app-server config with a runtime config module**
+
+**Goal:** Move Grok app-server configuration out of the testing helper and into a runtime config loader that supports TOML, XDG paths, and compatibility fallbacks.
+
+**Requirements:** R20, R21, R22, user-requested durability requirement
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/agent-core/src/config/grok-app-server-config.ts`
+- Modify: `packages/agent-core/src/index.ts`
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Test: `packages/agent-core/src/__tests__/test-harness.test.ts`
+- Test: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+
+**Approach:**
+- Introduce helpers for default XDG config and state paths under the Grok app-server namespace.
+- Parse `config.toml` for Grok settings and storage options.
+- Preserve current environment-variable override behavior.
+- Keep the current `config.env` or `.env` loading path as a compatibility fallback during migration rather than breaking existing users immediately.
+
+**Patterns to follow:**
+- [`packages/agent-core/src/testing/load-local-env.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/testing/load-local-env.ts)
+- `/Users/huntharo/github/codex/codex-rs/config/src/types.rs`
+
+**Test scenarios:**
+- Happy path: when `config.toml` exists, the loader returns configured model, base URL, and state-root values.
+- Happy path: explicit process env values override TOML defaults.
+- Edge case: when `config.toml` is absent, legacy `config.env` or `.env` files still initialize the Grok client.
+- Edge case: custom `XDG_CONFIG_HOME` and `XDG_STATE_HOME` values redirect the resolved paths correctly.
+- Error path: malformed TOML returns a helpful startup error that identifies the file path.
+- Integration: `GrokAppServerClient` bootstraps from the new config loader without changing the desktop call sites.
+
+**Verification:**
+- The desktop can initialize the Grok app server from TOML-backed XDG config without importing testing-only env helpers.
+
+- [x] **Unit 2: Add a canonical Grok rollout store for durable thread artifacts**
+
+**Goal:** Create the text-first storage layer that persists and reloads Grok thread state across process restarts.
+
+**Requirements:** R4, R20-R22, derived continuity requirement, derived operability requirement
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `packages/agent-core/src/persistence/grok-rollout-store.ts`
+- Create: `packages/agent-core/src/persistence/grok-rollout-records.ts`
+- Modify: `packages/agent-core/src/app-server/protocol.ts`
+- Modify: `packages/agent-core/src/app-server/session-state.ts`
+- Test: `packages/agent-core/src/__tests__/grok-rollout-store.test.ts`
+- Test: `packages/agent-core/src/__tests__/session-state.test.ts`
+
+**Approach:**
+- Add a storage adapter that persists each thread into its own directory under the XDG state root.
+- Use `thread.toml` for thread summary metadata and `rollout.jsonl` for append-only transcript and replay events.
+- Keep the persisted event shapes aligned with the current `AppServerSessionState` model rather than inventing a second conversation model.
+- Hydrate `AppServerSessionState` from the store at startup.
+- Write through on thread creation, thread mutation, user message append, assistant message append, replay item updates, and previous response id changes.
+- Keep active run handles in memory only.
+
+**Execution note:** Implement new store behavior test-first because this unit changes persistent state and restart semantics.
+
+**Patterns to follow:**
+- [`packages/agent-core/src/persistence/overlay-store.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts)
+- `/Users/huntharo/github/codex/codex-rs/rollout/src/list.rs`
+
+**Test scenarios:**
+- Happy path: a persisted thread reloads with the same id, name, cwd, model, and timestamps after a new state instance is created.
+- Happy path: persisted rollout messages reload in order and reproduce `lastUserMessage` and `lastAssistantMessage`.
+- Happy path: persisted previous response id reloads and is available for the next turn.
+- Edge case: directory-less threads persist and reload without a cwd.
+- Edge case: replay items with command and tool metadata round-trip through rollout records.
+- Error path: malformed `thread.toml` or corrupted JSONL event lines fail with a deterministic storage error that identifies the thread path.
+- Integration: a compaction or review output persisted through the rollout store is visible in a subsequent `readThread` call after rehydration.
+
+**Verification:**
+- A fresh `AppServerSessionState` instance pointed at the same state root can list and read previously stored Grok threads correctly from text artifacts alone.
+
+- [ ] **Unit 3: Add an optional derived index path without changing the source of truth**
+
+**Goal:** Leave room for fast listing at scale without making SQLite authoritative.
+
+**Requirements:** R20-R22, derived operability requirement
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `packages/agent-core/src/persistence/grok-thread-index.ts`
+- Create: `packages/agent-core/src/persistence/grok-thread-index-migrations.ts`
+- Test: `packages/agent-core/src/__tests__/grok-thread-index.test.ts`
+
+**Approach:**
+- Keep this unit narrow and optional.
+- Design a rebuildable index that summarizes per-thread metadata and last-activity timestamps from `thread.toml` and `rollout.jsonl`.
+- Make the server able to fall back to direct filesystem scans when the index is absent or stale.
+- Do not require this unit for correctness; it is purely a performance path.
+
+**Patterns to follow:**
+- `/Users/huntharo/github/codex/codex-rs/state/src/runtime.rs`
+- `/Users/huntharo/github/grok-cli/src/storage/migrations.ts`
+
+**Test scenarios:**
+- Happy path: the derived index can be rebuilt from rollout files and returns the same thread summaries as a direct file scan.
+- Edge case: deleting the index does not lose thread history because rollout files remain canonical.
+- Error path: a stale or unreadable index causes a fallback to direct file scanning rather than an empty thread list.
+
+**Verification:**
+- Performance optimizations remain decoupled from correctness and inspectability.
+
+- [x] **Unit 4: Wire persistent session state into the Grok app server**
+
+**Goal:** Make the real server use the new rollout store without changing the desktop's app-server contract.
+
+**Requirements:** R20-R22, user-requested durability requirement, derived continuity requirement
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `packages/agent-core/src/app-server/codex-app-server.ts`
+- Modify: `packages/agent-core/src/app-server/turn-runner.ts`
+- Modify: `packages/agent-core/src/app-server/compaction-runner.ts`
+- Modify: `packages/agent-core/src/app-server/review-runner.ts`
+- Create: `packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts`
+- Modify: `packages/agent-core/src/__tests__/codex-app-server-contract.test.ts`
+
+**Approach:**
+- Extend `CodexAppServer` construction so callers can pass a persistent session-state dependency instead of always creating a blank in-memory state.
+- Keep request routing and notification shapes unchanged.
+- Ensure runner-driven mutations continue to flow through `AppServerSessionState`, so persistence remains centralized.
+- Define restart behavior for stale active runs: thread data reloads, but active subscriptions do not.
+- Optionally layer the derived index in for listing if Unit 3 exists, but keep file-based hydration as the fallback path.
+
+**Patterns to follow:**
+- [`packages/agent-core/src/app-server/codex-app-server.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/codex-app-server.ts)
+- [`packages/agent-core/src/app-server/turn-runner.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/turn-runner.ts)
+
+**Test scenarios:**
+- Happy path: a server instance creates a thread, records a completed turn, shuts down, and a new server instance on the same state root returns the same thread from `thread/list`.
+- Happy path: the reloaded thread can be opened with `thread/read` and then used for a new `turn/start`.
+- Edge case: restarting after a thread rename preserves the human title.
+- Edge case: restarting after compaction preserves the compacted transcript state used by later prompts.
+- Error path: a missing thread still returns the existing protocol error after persistence wiring.
+- Integration: `previousResponseId` survives server recreation so follow-up turns continue the same Grok conversation instead of silently starting over.
+
+**Verification:**
+- The in-process Grok app server behaves like a durable service rather than a per-process scratchpad.
+
+- [x] **Unit 5: Connect desktop startup to persistent Grok storage and verify restart behavior**
+
+**Goal:** Ensure the desktop integration actually benefits from the new persistence path, including the restart case the user reported.
+
+**Requirements:** R4, R8, R21, R22, user-requested durability requirement
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Pass the resolved state root into the Grok app-server constructor from the desktop main process.
+- Keep backend capability detection and list or read behavior unchanged from the renderer's perspective.
+- Add a desktop-level restart-style test that creates one Grok client, writes thread state, disposes it, then recreates the client against the same state root and verifies the thread is still present.
+
+**Patterns to follow:**
+- [`apps/desktop/src/main/grok-app-server/client.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/apps/desktop/src/main/grok-app-server/client.ts)
+- [`apps/desktop/src/main/app-server/backend-registry.ts`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/apps/desktop/src/main/app-server/backend-registry.ts)
+
+**Test scenarios:**
+- Happy path: a thread created through `GrokAppServerClient` survives client teardown and re-creation.
+- Happy path: backend registry thread listing includes persisted Grok threads after reinitialization.
+- Edge case: a thread with no linked directory still reappears in the desktop Grok thread list.
+- Error path: an unreadable rollout root surfaces a clear Grok backend availability error rather than silently returning an empty list.
+- Integration: desktop readback after restart shows transcript content from before restart, not just thread shell metadata.
+
+**Verification:**
+- The original bug is closed at the desktop integration level, not only in isolated `agent-core` tests.
+
+- [ ] **Unit 6: Document the config migration and storage contract**
+
+**Goal:** Make the new storage layout and compatibility story explicit so future work builds on the same assumptions.
+
+**Requirements:** R20-R22
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`
+
+**Approach:**
+- Document the new XDG config path, XDG state path, per-thread rollout layout, precedence rules, and legacy env fallback.
+- Update the app-server compatibility plan to remove durable persistence from the "out of scope" bucket now that this plan covers it.
+- Call out the restart semantics explicitly: historical threads survive restart, active runs do not resume in place.
+- Document that rollout files are canonical and any SQLite index is rebuildable.
+
+**Patterns to follow:**
+- Existing plan-document style in [`docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md)
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only unit.
+
+**Verification:**
+- Future implementers and users can discover the new Grok config and storage contract without reverse-engineering the code.
+
+## System-Wide Impact
+
+- **Interaction graph:** desktop main process -> `GrokAppServerClient` -> `CodexAppServer` -> `AppServerSessionState` -> `thread.toml` plus `rollout.jsonl` -> optional derived SQLite index
+- **Error propagation:** config parse failures and storage-open failures should surface as Grok backend availability errors, not as silently empty thread lists
+- **State lifecycle risks:** thread metadata, transcript messages, replay items, and previous response ids must stay consistent across restarts; active run handles must never be deserialized as if they were valid
+- **API surface parity:** `thread/list`, `thread/read`, and `turn/start` behavior must stay compatible with the existing desktop and OpenClaw-oriented app-server contract while storage moves underneath them
+- **Integration coverage:** restart tests must prove list, read, and follow-up turn behavior against persisted rollout artifacts; unit tests alone will not catch continuity regressions
+- **Unchanged invariants:** the desktop renderer and shared app-server request or response contracts should not need new persistence-specific branches to consume Grok threads
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `thread.toml` and `rollout.jsonl` drift out of sync | Keep summary metadata updates narrowly scoped, derive as much as possible from rollout events, and test rehydration from disk rather than only in-memory state |
+| Direct filesystem scans become slow with many threads | Keep the optional derived-index path available, but treat it as rebuildable and non-authoritative |
+| Config migration breaks existing users with `config.env` or `.env` files | Keep legacy env fallback during the migration window and test both paths |
+| Persisting only transcript text but not provider continuation metadata causes restarted threads to fork silently | Persist `previousResponseId` in `thread.toml` and cover it in restart tests |
+| Attempting to persist active runs creates false expectations of crash-exact recovery | Explicitly treat active runs as non-durable and document the restart semantics |
+| Corrupted rollout artifacts cause the Grok backend to appear empty | Fail loudly with path-specific storage errors and targeted corruption tests |
+
+## Documentation / Operational Notes
+
+- The new config format should be documented as TOML-first, env-compatible during migration, and XDG-style in location.
+- Keep the config and state path helpers centralized so later storage additions, such as wiki memory or cached skill indexes, follow the same layout.
+- Treat rollout files as source artifacts suitable for manual inspection, grep, backup, and export.
+- If the implementation later needs cross-process access, revisit file-locking and append semantics explicitly rather than assuming the single-process desktop defaults still hold.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md)
+- Related code: [apps/desktop/src/main/grok-app-server/client.ts](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/apps/desktop/src/main/grok-app-server/client.ts)
+- Related code: [packages/agent-core/src/app-server/codex-app-server.ts](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/codex-app-server.ts)
+- Related code: [packages/agent-core/src/app-server/session-state.ts](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/app-server/session-state.ts)
+- Related code: [packages/agent-core/src/persistence/overlay-store.ts](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts)
+- Related plan: [docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md](/Users/huntharo/.codex/worktrees/4978/PwrAgnt/docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md)
+- Comparison repo: `/Users/huntharo/github/codex/codex-rs/config/src/types.rs`
+- Comparison repo: `/Users/huntharo/github/codex/codex-rs/rollout/src/list.rs`
+- Comparison repo: `/Users/huntharo/github/codex/codex-rs/state/src/runtime.rs`
+- Comparison repo: `/Users/huntharo/github/grok-cli/src/storage/db.ts`
+- Comparison repo: `/Users/huntharo/github/grok-cli/src/storage/migrations.ts`
+- Comparison repo: `/Users/huntharo/github/grok-cli/src/storage/transcript.ts`

--- a/packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { CodexAppServer } from "../app-server/codex-app-server.js";
+import { AppServerSessionState } from "../app-server/session-state.js";
+import { GrokRolloutStore } from "../persistence/grok-rollout-store.js";
+import { FakeProvider, createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+describe("CodexAppServer persistence", () => {
+  it("reloads threads and previous response ids across server recreation", async () => {
+    const temp = await createTemporaryTestDirectory();
+
+    try {
+      const firstProvider = new FakeProvider();
+      const firstServer = new CodexAppServer({
+        provider: firstProvider,
+        sessionState: new AppServerSessionState({
+          store: new GrokRolloutStore(temp.path),
+        }),
+        threadIdGenerator: () => "thread-1",
+        runIdGenerator: () => "turn-1",
+      });
+
+      await firstServer.request("thread/start", {
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      });
+      await firstServer.request("thread/name/set", {
+        threadId: "thread-1",
+        name: "OpenClaw parity",
+      });
+      await firstServer.request("turn/start", {
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Ship it" }],
+        collaborationMode: { mode: "default" },
+      });
+
+      firstProvider.runs[0]?.deferred.resolve({
+        assistantText: "Done.",
+        providerResponseId: "resp_1",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const secondProvider = new FakeProvider();
+      const secondServer = new CodexAppServer({
+        provider: secondProvider,
+        sessionState: new AppServerSessionState({
+          store: new GrokRolloutStore(temp.path),
+        }),
+        threadIdGenerator: () => "thread-2",
+        runIdGenerator: () => "turn-2",
+      });
+
+      await expect(secondServer.request("thread/list", {})).resolves.toEqual({
+        threads: [
+          {
+            threadId: "thread-1",
+            title: "OpenClaw parity",
+            summary: "Done.",
+            projectKey: "/repo/workspace",
+            model: "grok-4.20-reasoning",
+            createdAt: expect.any(Number),
+            updatedAt: expect.any(Number),
+          },
+        ],
+      });
+      await expect(
+        secondServer.request("thread/read", { threadId: "thread-1" }),
+      ).resolves.toEqual({
+        threadId: "thread-1",
+        thread: expect.objectContaining({
+          threadId: "thread-1",
+          threadName: "OpenClaw parity",
+          cwd: "/repo/workspace",
+        }),
+        messages: [
+          { role: "user", text: "Ship it" },
+          { role: "assistant", text: "Done." },
+        ],
+        items: [
+          {
+            id: expect.any(String),
+            type: "userMessage",
+            status: "completed",
+            role: "user",
+            text: "Ship it",
+          },
+          {
+            id: expect.any(String),
+            type: "agentMessage",
+            status: "completed",
+            role: "assistant",
+            text: "Done.",
+          },
+        ],
+        lastUserMessage: "Ship it",
+        lastAssistantMessage: "Done.",
+      });
+
+      await secondServer.request("turn/start", {
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Follow up" }],
+        collaborationMode: { mode: "default" },
+      });
+
+      expect(secondProvider.runs[0]?.previousResponseId).toBe("resp_1");
+    } finally {
+      await temp.cleanup();
+    }
+  });
+});

--- a/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
+++ b/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AppServerSessionState } from "../app-server/session-state.js";
+import { GrokRolloutStore } from "../persistence/grok-rollout-store.js";
+import { createTemporaryTestDirectory } from "../testing/test-harness.js";
+
+describe("GrokRolloutStore", () => {
+  it("round-trips thread metadata, rollout events, and provider continuity", async () => {
+    const temp = await createTemporaryTestDirectory();
+
+    try {
+      const store = new GrokRolloutStore(temp.path);
+      const state = new AppServerSessionState({ store });
+      state.createThread({
+        threadId: "thread-1",
+        model: "grok-4.20-fast",
+      });
+      state.setThreadName("thread-1", "Bug bash");
+      state.appendInput("thread-1", [{ type: "text", text: "Ship Unit 3" }]);
+      state.appendAssistant("thread-1", "Done.");
+      state.upsertItem("thread-1", {
+        id: "tool-7",
+        type: "execCommand",
+        status: "completed",
+        command: "rg --files",
+        commandAction: "search",
+      });
+      state.setPreviousResponseId("thread-1", "resp_1");
+
+      const hydrated = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+
+      expect(hydrated.readThread("thread-1")).toEqual({
+        threadId: "thread-1",
+        thread: expect.objectContaining({
+          threadId: "thread-1",
+          threadName: "Bug bash",
+          model: "grok-4.20-fast",
+        }),
+        messages: [
+          { role: "user", text: "Ship Unit 3" },
+          { role: "assistant", text: "Done." },
+        ],
+        items: [
+          {
+            id: expect.any(String),
+            type: "userMessage",
+            status: "completed",
+            role: "user",
+            text: "Ship Unit 3",
+          },
+          {
+            id: expect.any(String),
+            type: "agentMessage",
+            status: "completed",
+            role: "assistant",
+            text: "Done.",
+          },
+          {
+            id: "tool-7",
+            type: "execCommand",
+            status: "completed",
+            command: "rg --files",
+            commandAction: "search",
+          },
+        ],
+        lastUserMessage: "Ship Unit 3",
+        lastAssistantMessage: "Done.",
+      });
+      expect(hydrated.getPreviousResponseId("thread-1")).toBe("resp_1");
+
+      const threadToml = await fs.readFile(
+        path.join(temp.path, "threads/thread-1/thread.toml"),
+        "utf8",
+      );
+      const rolloutJsonl = await fs.readFile(
+        path.join(temp.path, "threads/thread-1/rollout.jsonl"),
+        "utf8",
+      );
+
+      expect(threadToml).toContain('thread_id = "thread-1"');
+      expect(threadToml).toContain('previous_response_id = "resp_1"');
+      expect(rolloutJsonl).toContain('"type":"message"');
+      expect(rolloutJsonl).toContain("Ship Unit 3");
+      expect(rolloutJsonl).toContain('"command":"rg --files"');
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  it("fails with a path-specific error for malformed rollout data", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const threadDir = path.join(temp.path, "threads/thread-1");
+    const threadTomlPath = path.join(threadDir, "thread.toml");
+    const rolloutPath = path.join(threadDir, "rollout.jsonl");
+
+    try {
+      await fs.mkdir(threadDir, { recursive: true });
+      await fs.writeFile(
+        threadTomlPath,
+        [
+          'thread_id = "thread-1"',
+          "created_at = 1",
+          "updated_at = 2",
+          "",
+        ].join("\n"),
+      );
+      await fs.writeFile(rolloutPath, "{not-json}\n");
+
+      expect(() => new GrokRolloutStore(temp.path).load()).toThrow(
+        `Invalid JSONL record 1 in ${rolloutPath}`,
+      );
+    } finally {
+      await temp.cleanup();
+    }
+  });
+});

--- a/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
+++ b/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
@@ -116,4 +116,51 @@ describe("GrokRolloutStore", () => {
       await temp.cleanup();
     }
   });
+
+  it("preserves repeated tool ids from separate turns after hydration", async () => {
+    const temp = await createTemporaryTestDirectory();
+
+    try {
+      const state = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+      state.createThread({
+        threadId: "thread-1",
+      });
+      state.appendInput("thread-1", [{ type: "text", text: "First turn" }]);
+      state.upsertItem("thread-1", {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        status: "completed",
+        text: "first result",
+      });
+      state.appendAssistant("thread-1", "Done.");
+      state.appendInput("thread-1", [{ type: "text", text: "Second turn" }]);
+      state.upsertItem("thread-1", {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        status: "completed",
+        text: "second result",
+      });
+
+      const hydrated = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+
+      expect(hydrated.readThread("thread-1").items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "tool-1",
+            text: "first result",
+          }),
+          expect.objectContaining({
+            id: "tool-1#2",
+            text: "second result",
+          }),
+        ]),
+      );
+    } finally {
+      await temp.cleanup();
+    }
+  });
 });

--- a/packages/agent-core/src/__tests__/session-state.test.ts
+++ b/packages/agent-core/src/__tests__/session-state.test.ts
@@ -157,4 +157,62 @@ describe("AppServerSessionState", () => {
       await temp.cleanup();
     }
   });
+
+  it("keeps repeated tool ids from separate turns as distinct replay items", () => {
+    const state = new AppServerSessionState();
+
+    state.createThread({ threadId: "thread-1", cwd: "/repo/workspace" });
+    state.appendInput("thread-1", [{ type: "text", text: "First turn" }]);
+    state.upsertItem("thread-1", {
+      id: "tool-1",
+      type: "dynamicToolCall",
+      status: "completed",
+      text: "first result",
+    });
+    state.appendAssistant("thread-1", "Done.");
+
+    state.appendInput("thread-1", [{ type: "text", text: "Second turn" }]);
+    state.upsertItem("thread-1", {
+      id: "tool-1",
+      type: "dynamicToolCall",
+      status: "completed",
+      text: "second result",
+    });
+
+    expect(state.readThread("thread-1").items).toEqual([
+      {
+        id: expect.any(String),
+        type: "userMessage",
+        status: "completed",
+        role: "user",
+        text: "First turn",
+      },
+      {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        status: "completed",
+        text: "first result",
+      },
+      {
+        id: expect.any(String),
+        type: "agentMessage",
+        status: "completed",
+        role: "assistant",
+        text: "Done.",
+      },
+      {
+        id: expect.any(String),
+        type: "userMessage",
+        status: "completed",
+        role: "user",
+        text: "Second turn",
+      },
+      {
+        id: "tool-1#2",
+        type: "dynamicToolCall",
+        status: "completed",
+        text: "second result",
+      },
+    ]);
+  });
 });

--- a/packages/agent-core/src/__tests__/session-state.test.ts
+++ b/packages/agent-core/src/__tests__/session-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AppServerSessionState } from "../app-server/session-state.js";
-import { Deferred } from "../testing/test-harness.js";
+import { GrokRolloutStore } from "../persistence/grok-rollout-store.js";
+import { Deferred, createTemporaryTestDirectory } from "../testing/test-harness.js";
 import type { ProviderActiveTurn } from "../providers/provider-contract.js";
 
 function createActiveTurn(): ProviderActiveTurn {
@@ -88,5 +89,72 @@ describe("AppServerSessionState", () => {
       lastAssistantMessage: "Done.",
     });
     expect(replay.thread.updatedAt).toBeGreaterThanOrEqual(created.updatedAt ?? 0);
+  });
+
+  it("hydrates persisted threads from the rollout store on startup", async () => {
+    const temp = await createTemporaryTestDirectory();
+
+    try {
+      const initialState = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+      initialState.createThread({
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-fast",
+      });
+      initialState.appendInput("thread-1", [{ type: "text", text: "Ship it" }]);
+      initialState.appendAssistant("thread-1", "Done.");
+      initialState.setPreviousResponseId("thread-1", "resp_1");
+
+      const hydratedState = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+
+      expect(hydratedState.listThreads()).toEqual([
+        {
+          threadId: "thread-1",
+          title: undefined,
+          summary: "Done.",
+          projectKey: "/repo/workspace",
+          model: "grok-4.20-fast",
+          createdAt: expect.any(Number),
+          updatedAt: expect.any(Number),
+        },
+      ]);
+      expect(hydratedState.readThread("thread-1")).toEqual({
+        threadId: "thread-1",
+        thread: expect.objectContaining({
+          threadId: "thread-1",
+          cwd: "/repo/workspace",
+          model: "grok-4.20-fast",
+        }),
+        messages: [
+          { role: "user", text: "Ship it" },
+          { role: "assistant", text: "Done." },
+        ],
+        items: [
+          {
+            id: expect.any(String),
+            type: "userMessage",
+            status: "completed",
+            role: "user",
+            text: "Ship it",
+          },
+          {
+            id: expect.any(String),
+            type: "agentMessage",
+            status: "completed",
+            role: "assistant",
+            text: "Done.",
+          },
+        ],
+        lastUserMessage: "Ship it",
+        lastAssistantMessage: "Done.",
+      });
+      expect(hydratedState.getPreviousResponseId("thread-1")).toBe("resp_1");
+    } finally {
+      await temp.cleanup();
+    }
   });
 });

--- a/packages/agent-core/src/__tests__/test-harness.test.ts
+++ b/packages/agent-core/src/__tests__/test-harness.test.ts
@@ -3,15 +3,25 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTemporaryTestDirectory } from "../testing/test-harness.js";
 import {
+  defaultGrokAppServerConfigPath,
+  defaultGrokAppServerStateDir,
   defaultGrokAppServerConfigPaths,
+  resolveGrokAppServerRuntimeConfig,
   defaultLocalEnvPath,
   loadGrokAppServerConfig,
   loadLocalEnv,
-} from "../testing/load-local-env.js";
+} from "../index.js";
+import { stringifyFlatToml } from "../config/simple-toml.js";
 
 const originalHome = process.env.HOME;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
-const tempEnvKeys = ["XAI_API_KEY", "GROK_MODEL", "XAI_BASE_URL"];
+const originalXdgStateHome = process.env.XDG_STATE_HOME;
+const tempEnvKeys = [
+  "XAI_API_KEY",
+  "GROK_MODEL",
+  "XAI_BASE_URL",
+  "GROK_APP_SERVER_STATE_ROOT",
+];
 
 afterEach(() => {
   for (const key of tempEnvKeys) {
@@ -26,6 +36,11 @@ afterEach(() => {
     delete process.env.XDG_CONFIG_HOME;
   } else {
     process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
+  if (originalXdgStateHome === undefined) {
+    delete process.env.XDG_STATE_HOME;
+  } else {
+    process.env.XDG_STATE_HOME = originalXdgStateHome;
   }
 });
 
@@ -123,6 +138,77 @@ describe("test harness helpers", () => {
     await temp.cleanup();
   });
 
+  it("resolves TOML config and XDG state paths for runtime startup", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const xdgConfigHome = path.join(temp.path, ".xdg-config");
+    const xdgStateHome = path.join(temp.path, ".xdg-state");
+    const configPath = defaultGrokAppServerConfigPath({
+      homeDir: temp.path,
+      xdgConfigHome,
+    });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      stringifyFlatToml({
+        xai_api_key: "toml-key",
+        xai_base_url: "https://api.example.test/v1",
+        grok_model: "grok-4.20-fast",
+      }),
+    );
+
+    const runtimeConfig = resolveGrokAppServerRuntimeConfig({
+      homeDir: temp.path,
+      xdgConfigHome,
+      xdgStateHome,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(runtimeConfig).toEqual({
+      apiKey: "toml-key",
+      baseUrl: "https://api.example.test/v1",
+      model: "grok-4.20-fast",
+      configPath,
+      stateRoot: defaultGrokAppServerStateDir({
+        homeDir: temp.path,
+        xdgStateHome,
+      }),
+    });
+
+    await temp.cleanup();
+  });
+
+  it("prefers explicit env overrides over TOML defaults", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const configPath = defaultGrokAppServerConfigPath({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      stringifyFlatToml({
+        xai_api_key: "toml-key",
+        xai_base_url: "https://api.example.test/v1",
+        grok_model: "grok-4.20-fast",
+        state_root: "/tmp/from-toml",
+      }),
+    );
+
+    const runtimeConfig = resolveGrokAppServerRuntimeConfig({
+      homeDir: temp.path,
+      env: {
+        XAI_API_KEY: "env-key",
+        XAI_BASE_URL: "https://override.example.test/v1",
+        GROK_MODEL: "grok-4.20-reasoning",
+        GROK_APP_SERVER_STATE_ROOT: "/tmp/from-env",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(runtimeConfig.apiKey).toBe("env-key");
+    expect(runtimeConfig.baseUrl).toBe("https://override.example.test/v1");
+    expect(runtimeConfig.model).toBe("grok-4.20-reasoning");
+    expect(runtimeConfig.stateRoot).toBe("/tmp/from-env");
+
+    await temp.cleanup();
+  });
+
   it("does not override existing env values with Grok app-server config defaults", async () => {
     const temp = await createTemporaryTestDirectory();
     process.env.HOME = temp.path;
@@ -147,6 +233,22 @@ describe("test harness helpers", () => {
     await fs.writeFile(envPath, "XAI_API_KEY\n");
 
     expect(() => loadLocalEnv({ envPath })).toThrow(`Invalid env line 1 in ${envPath}`);
+
+    await temp.cleanup();
+  });
+
+  it("throws a helpful error for malformed TOML config", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const configPath = defaultGrokAppServerConfigPath({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, "[thread]\nname = \"bad\"\n");
+
+    expect(() =>
+      resolveGrokAppServerRuntimeConfig({
+        homeDir: temp.path,
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toThrow(`Unsupported TOML table on line 1 in ${configPath}`);
 
     await temp.cleanup();
   });

--- a/packages/agent-core/src/__tests__/test-harness.test.ts
+++ b/packages/agent-core/src/__tests__/test-harness.test.ts
@@ -252,4 +252,30 @@ describe("test harness helpers", () => {
 
     await temp.cleanup();
   });
+
+  it("ignores inline comments in TOML config values", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const configPath = defaultGrokAppServerConfigPath({ homeDir: temp.path });
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      [
+        'xai_api_key = "comment-key" # default key',
+        'xai_base_url = "https://api.example.test/v1" # sandbox',
+        'grok_model = "grok-4.20-fast" # default model',
+        "",
+      ].join("\n"),
+    );
+
+    const runtimeConfig = resolveGrokAppServerRuntimeConfig({
+      homeDir: temp.path,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(runtimeConfig.apiKey).toBe("comment-key");
+    expect(runtimeConfig.baseUrl).toBe("https://api.example.test/v1");
+    expect(runtimeConfig.model).toBe("grok-4.20-fast");
+
+    await temp.cleanup();
+  });
 });

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -31,6 +31,7 @@ type ServerOptions = {
   provider: AppServerProvider;
   threadIdGenerator?: () => string;
   runIdGenerator?: () => string;
+  sessionState?: AppServerSessionState;
 };
 
 const SUPPORTED_METHODS = [
@@ -61,7 +62,7 @@ function createId(prefix: string): string {
 
 export class CodexAppServer {
   private readonly provider: AppServerProvider;
-  private readonly state = new AppServerSessionState();
+  private readonly state: AppServerSessionState;
   private readonly metadata = new AppServerMetadataService();
   private readonly notificationHandlers = new Set<NotificationHandler>();
   private readonly requestHandlers = new Set<RequestHandler>();
@@ -74,6 +75,7 @@ export class CodexAppServer {
 
   constructor(options: ServerOptions) {
     this.provider = options.provider;
+    this.state = options.sessionState ?? new AppServerSessionState();
     this.toolExecutor = new LocalToolExecutor(createDefaultToolRegistry());
     this.createThreadId = options.threadIdGenerator ?? (() => createId("thread"));
     this.createRunId = options.runIdGenerator ?? (() => createId("turn"));

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -1,18 +1,18 @@
 import type {
   AppServerItemStatus,
-  AppServerRole,
   AppServerTurnInputItem,
   ThreadReplay,
   ThreadReplayItem,
   ThreadState,
   ThreadSummary,
 } from "./protocol.js";
+import type {
+  AppServerSessionStore,
+  HydratedSessionState,
+  StoredMessage,
+} from "../persistence/grok-rollout-store.js";
 import type { ProviderActiveTurn } from "../providers/provider-contract.js";
 
-type StoredMessage = {
-  role: AppServerRole;
-  text: string;
-};
 type ActiveRunRecord = {
   runId: string;
   threadId: string;
@@ -34,6 +34,7 @@ type CreateThreadParams = {
 type ThreadMutation = Partial<Omit<ThreadState, "threadId" | "createdAt">>;
 
 export class AppServerSessionState {
+  private readonly store?: AppServerSessionStore;
   private readonly threads = new Map<string, ThreadState>();
   private readonly messages = new Map<string, StoredMessage[]>();
   private readonly items = new Map<string, ThreadReplayItem[]>();
@@ -41,6 +42,13 @@ export class AppServerSessionState {
   private readonly runs = new Map<string, ActiveRunRecord>();
   private lastTimestamp = 0;
   private itemSequence = 0;
+
+  constructor(options?: { store?: AppServerSessionStore }) {
+    this.store = options?.store;
+    if (this.store) {
+      this.hydrate(this.store.load());
+    }
+  }
 
   createThread(params: CreateThreadParams): ThreadState {
     const timestamp = this.nextTimestamp();
@@ -60,6 +68,7 @@ export class AppServerSessionState {
     this.threads.set(thread.threadId, thread);
     this.messages.set(thread.threadId, []);
     this.items.set(thread.threadId, []);
+    this.persistThread(thread.threadId);
     return thread;
   }
 
@@ -100,6 +109,7 @@ export class AppServerSessionState {
       updatedAt: this.nextTimestamp(),
     };
     this.threads.set(threadId, next);
+    this.persistThread(threadId);
     return next;
   }
 
@@ -153,6 +163,10 @@ export class AppServerSessionState {
     }
     this.items.set(threadId, items);
     this.touchThread(threadId);
+    this.store?.appendItem({
+      threadId,
+      item: normalized,
+    });
     return normalized;
   }
 
@@ -191,6 +205,11 @@ export class AppServerSessionState {
     items.push(item);
     this.items.set(threadId, items);
     this.touchThread(threadId);
+    this.store?.appendMessage({
+      threadId,
+      message,
+      item,
+    });
   }
 
   readThread(threadId: string): ThreadReplay {
@@ -303,6 +322,7 @@ export class AppServerSessionState {
       return;
     }
     thread.updatedAt = this.nextTimestamp();
+    this.persistThread(threadId);
   }
 
   private nextTimestamp(): number {
@@ -313,6 +333,34 @@ export class AppServerSessionState {
   private nextItemId(prefix: string): string {
     this.itemSequence += 1;
     return `${prefix}-${this.itemSequence}`;
+  }
+
+  private persistThread(threadId: string): void {
+    const thread = this.threads.get(threadId);
+    if (!thread) {
+      return;
+    }
+    this.store?.persistThread({
+      thread,
+      previousResponseId: this.responseIds.get(threadId),
+    });
+  }
+
+  private hydrate(data: HydratedSessionState): void {
+    for (const thread of data.threads) {
+      this.threads.set(thread.threadId, thread);
+    }
+    for (const [threadId, messages] of Object.entries(data.messagesByThread)) {
+      this.messages.set(threadId, [...messages]);
+    }
+    for (const [threadId, items] of Object.entries(data.itemsByThread)) {
+      this.items.set(threadId, [...items]);
+    }
+    for (const [threadId, responseId] of Object.entries(data.responseIds)) {
+      this.responseIds.set(threadId, responseId);
+    }
+    this.itemSequence = data.itemSequence;
+    this.lastTimestamp = data.lastTimestamp;
   }
 }
 

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -38,6 +38,10 @@ export class AppServerSessionState {
   private readonly threads = new Map<string, ThreadState>();
   private readonly messages = new Map<string, StoredMessage[]>();
   private readonly items = new Map<string, ThreadReplayItem[]>();
+  private readonly itemOccurrences = new Map<
+    string,
+    Map<string, { resolvedId: string; lastMessageCount: number }>
+  >();
   private readonly responseIds = new Map<string, string>();
   private readonly runs = new Map<string, ActiveRunRecord>();
   private lastTimestamp = 0;
@@ -68,6 +72,7 @@ export class AppServerSessionState {
     this.threads.set(thread.threadId, thread);
     this.messages.set(thread.threadId, []);
     this.items.set(thread.threadId, []);
+    this.itemOccurrences.set(thread.threadId, new Map());
     this.persistThread(thread.threadId);
     return thread;
   }
@@ -152,22 +157,30 @@ export class AppServerSessionState {
   upsertItem(threadId: string, item: ThreadReplayItem): ThreadReplayItem {
     const items = this.items.get(threadId) ?? [];
     const normalized = normalizeReplayItem(item);
-    const index = items.findIndex((entry) => entry.id === normalized.id);
-    if (index >= 0) {
-      items[index] = {
-        ...items[index],
-        ...normalized,
+    const resolvedId = this.resolveReplayItemId(threadId, normalized.id);
+    const normalizedWithResolvedId =
+      resolvedId === normalized.id
+        ? normalized
+        : normalizeReplayItem({
+            ...normalized,
+            id: resolvedId,
+          });
+    const resolvedIndex = items.findIndex((entry) => entry.id === normalizedWithResolvedId.id);
+    if (resolvedIndex >= 0) {
+      items[resolvedIndex] = {
+        ...items[resolvedIndex],
+        ...normalizedWithResolvedId,
       };
     } else {
-      items.push(normalized);
+      items.push(normalizedWithResolvedId);
     }
     this.items.set(threadId, items);
     this.touchThread(threadId);
     this.store?.appendItem({
       threadId,
-      item: normalized,
+      item: normalizedWithResolvedId,
     });
-    return normalized;
+    return normalizedWithResolvedId;
   }
 
   appendItemTextDelta(
@@ -349,12 +362,23 @@ export class AppServerSessionState {
   private hydrate(data: HydratedSessionState): void {
     for (const thread of data.threads) {
       this.threads.set(thread.threadId, thread);
+      this.itemOccurrences.set(thread.threadId, new Map());
     }
     for (const [threadId, messages] of Object.entries(data.messagesByThread)) {
       this.messages.set(threadId, [...messages]);
     }
     for (const [threadId, items] of Object.entries(data.itemsByThread)) {
       this.items.set(threadId, [...items]);
+      const occurrences = this.itemOccurrences.get(threadId) ?? new Map();
+      const lastMessageCount = this.messages.get(threadId)?.length ?? 0;
+      for (const item of items) {
+        const baseId = stripReplayItemSuffix(item.id);
+        occurrences.set(baseId, {
+          resolvedId: item.id,
+          lastMessageCount,
+        });
+      }
+      this.itemOccurrences.set(threadId, occurrences);
     }
     for (const [threadId, responseId] of Object.entries(data.responseIds)) {
       this.responseIds.set(threadId, responseId);
@@ -362,10 +386,52 @@ export class AppServerSessionState {
     this.itemSequence = data.itemSequence;
     this.lastTimestamp = data.lastTimestamp;
   }
+
+  private resolveReplayItemId(threadId: string, baseId: string): string {
+    const currentMessageCount = this.messages.get(threadId)?.length ?? 0;
+    const occurrences = this.itemOccurrences.get(threadId) ?? new Map();
+    const existing = occurrences.get(baseId);
+    if (!existing) {
+      occurrences.set(baseId, {
+        resolvedId: baseId,
+        lastMessageCount: currentMessageCount,
+      });
+      this.itemOccurrences.set(threadId, occurrences);
+      return baseId;
+    }
+
+    if (existing.lastMessageCount < currentMessageCount) {
+      const resolvedId = nextReplayItemOccurrenceId(baseId, this.items.get(threadId) ?? []);
+      occurrences.set(baseId, {
+        resolvedId,
+        lastMessageCount: currentMessageCount,
+      });
+      this.itemOccurrences.set(threadId, occurrences);
+      return resolvedId;
+    }
+
+    existing.lastMessageCount = currentMessageCount;
+    return existing.resolvedId;
+  }
 }
 
 function normalizeReplayItem(item: ThreadReplayItem): ThreadReplayItem {
   return Object.fromEntries(
     Object.entries(item).filter(([, value]) => value !== undefined),
   ) as ThreadReplayItem;
+}
+
+function nextReplayItemOccurrenceId(baseId: string, items: ThreadReplayItem[]): string {
+  const takenIds = new Set(items.map((item) => item.id));
+  for (let index = 2; ; index += 1) {
+    const candidate = `${baseId}#${index}`;
+    if (!takenIds.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function stripReplayItemSuffix(id: string): string {
+  const match = /^(.*)#\d+$/.exec(id);
+  return match?.[1] ?? id;
 }

--- a/packages/agent-core/src/config/grok-app-server-config.ts
+++ b/packages/agent-core/src/config/grok-app-server-config.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseFlatToml } from "./simple-toml.js";
+
+type ConfigDirOptions = {
+  homeDir?: string;
+  xdgConfigHome?: string;
+};
+
+type StateDirOptions = {
+  homeDir?: string;
+  xdgStateHome?: string;
+};
+
+type ResolveConfigOptions = ConfigDirOptions &
+  StateDirOptions & {
+    env?: NodeJS.ProcessEnv;
+  };
+
+export type GrokAppServerRuntimeConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  configPath: string;
+  stateRoot: string;
+};
+
+export function defaultGrokAppServerConfigDir(options?: ConfigDirOptions): string {
+  const homeDir = options?.homeDir ?? os.homedir();
+  const xdgConfigHome =
+    options?.xdgConfigHome?.trim() || process.env.XDG_CONFIG_HOME?.trim();
+  return path.join(xdgConfigHome || path.join(homeDir, ".config"), "grok-app-server");
+}
+
+export function defaultGrokAppServerConfigPath(options?: ConfigDirOptions): string {
+  return path.join(defaultGrokAppServerConfigDir(options), "config.toml");
+}
+
+export function defaultGrokAppServerStateDir(options?: StateDirOptions): string {
+  const homeDir = options?.homeDir ?? os.homedir();
+  const xdgStateHome =
+    options?.xdgStateHome?.trim() || process.env.XDG_STATE_HOME?.trim();
+  return path.join(
+    xdgStateHome || path.join(homeDir, ".local", "state"),
+    "grok-app-server",
+  );
+}
+
+export function resolveGrokAppServerRuntimeConfig(
+  options?: ResolveConfigOptions,
+): GrokAppServerRuntimeConfig {
+  const env = options?.env ?? process.env;
+  const configPath = defaultGrokAppServerConfigPath(options);
+  const stateRoot =
+    env.GROK_APP_SERVER_STATE_ROOT?.trim() || undefined;
+  const parsedConfig = readConfigToml(configPath);
+  const legacyConfig = readLegacyEnvConfig(options);
+
+  return {
+    apiKey:
+      env.XAI_API_KEY?.trim()
+      || readString(parsedConfig.xai_api_key)
+      || legacyConfig.XAI_API_KEY,
+    baseUrl:
+      env.XAI_BASE_URL?.trim()
+      || readString(parsedConfig.xai_base_url)
+      || legacyConfig.XAI_BASE_URL,
+    model:
+      env.GROK_MODEL?.trim()
+      || readString(parsedConfig.grok_model)
+      || legacyConfig.GROK_MODEL,
+    configPath,
+    stateRoot:
+      stateRoot
+      || readString(parsedConfig.state_root)
+      || defaultGrokAppServerStateDir(options),
+  };
+}
+
+function readConfigToml(configPath: string): Record<string, string | number | boolean> {
+  if (!fs.existsSync(configPath)) {
+    return {};
+  }
+
+  const contents = fs.readFileSync(configPath, "utf8");
+  return parseFlatToml(contents, configPath);
+}
+
+function readLegacyEnvConfig(
+  options?: ResolveConfigOptions,
+): Partial<Record<"XAI_API_KEY" | "XAI_BASE_URL" | "GROK_MODEL", string>> {
+  const configDir = defaultGrokAppServerConfigDir(options);
+  const legacyPaths = [
+    path.join(configDir, "config.env"),
+    path.join(configDir, ".env.local"),
+    path.join(configDir, ".env"),
+  ];
+
+  for (const filePath of legacyPaths) {
+    if (fs.existsSync(filePath)) {
+      return parseLegacyEnvFile(filePath);
+    }
+  }
+
+  return {};
+}
+
+function parseLegacyEnvFile(
+  filePath: string,
+): Partial<Record<"XAI_API_KEY" | "XAI_BASE_URL" | "GROK_MODEL", string>> {
+  const values: Partial<Record<"XAI_API_KEY" | "XAI_BASE_URL" | "GROK_MODEL", string>> = {};
+  const contents = fs.readFileSync(filePath, "utf8");
+
+  for (const [index, rawLine] of contents.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex < 1) {
+      throw new Error(`Invalid env line ${index + 1} in ${filePath}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (key === "XAI_API_KEY" || key === "XAI_BASE_URL" || key === "GROK_MODEL") {
+      values[key] = value;
+    }
+  }
+
+  return values;
+}
+
+function readString(value: string | number | boolean | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/packages/agent-core/src/config/simple-toml.ts
+++ b/packages/agent-core/src/config/simple-toml.ts
@@ -1,0 +1,104 @@
+type TomlValue = string | number | boolean;
+
+export function parseFlatToml(contents: string, filePath: string): Record<string, TomlValue> {
+  const values: Record<string, TomlValue> = {};
+
+  for (const [index, rawLine] of contents.split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    if (line.startsWith("[") && line.endsWith("]")) {
+      throw new Error(`Unsupported TOML table on line ${index + 1} in ${filePath}`);
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex < 1) {
+      throw new Error(`Invalid TOML line ${index + 1} in ${filePath}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+    if (!key) {
+      throw new Error(`Invalid TOML key on line ${index + 1} in ${filePath}`);
+    }
+    values[key] = parseValue(rawValue, filePath, index + 1);
+  }
+
+  return values;
+}
+
+export function stringifyFlatToml(values: Record<string, TomlValue | undefined>): string {
+  return Object.entries(values)
+    .filter(([, value]) => value !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key} = ${formatValue(value as TomlValue)}`)
+    .join("\n")
+    .concat("\n");
+}
+
+function parseValue(value: string, filePath: string, lineNumber: number): TomlValue {
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) {
+    return Number(value);
+  }
+  if (value.startsWith("\"") && value.endsWith("\"")) {
+    return unescapeQuotedString(value.slice(1, -1), filePath, lineNumber);
+  }
+
+  return value;
+}
+
+function unescapeQuotedString(
+  value: string,
+  filePath: string,
+  lineNumber: number,
+): string {
+  let result = "";
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character !== "\\") {
+      result += character;
+      continue;
+    }
+
+    index += 1;
+    const escape = value[index];
+    if (escape === undefined) {
+      throw new Error(`Invalid TOML escape on line ${lineNumber} in ${filePath}`);
+    }
+    if (escape === "\\" || escape === "\"") {
+      result += escape;
+      continue;
+    }
+    if (escape === "n") {
+      result += "\n";
+      continue;
+    }
+    if (escape === "t") {
+      result += "\t";
+      continue;
+    }
+    throw new Error(`Unsupported TOML escape \\${escape} on line ${lineNumber} in ${filePath}`);
+  }
+
+  return result;
+}
+
+function formatValue(value: TomlValue): string {
+  if (typeof value === "boolean" || typeof value === "number") {
+    return String(value);
+  }
+
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/"/g, '\\"')}"`;
+}

--- a/packages/agent-core/src/config/simple-toml.ts
+++ b/packages/agent-core/src/config/simple-toml.ts
@@ -4,7 +4,7 @@ export function parseFlatToml(contents: string, filePath: string): Record<string
   const values: Record<string, TomlValue> = {};
 
   for (const [index, rawLine] of contents.split(/\r?\n/).entries()) {
-    const line = rawLine.trim();
+    const line = stripInlineComment(rawLine).trim();
     if (!line || line.startsWith("#")) {
       continue;
     }
@@ -52,6 +52,32 @@ function parseValue(value: string, filePath: string, lineNumber: number): TomlVa
   }
 
   return value;
+}
+
+function stripInlineComment(line: string): string {
+  let inQuotedString = false;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = inQuotedString;
+      continue;
+    }
+    if (character === "\"") {
+      inQuotedString = !inQuotedString;
+      continue;
+    }
+    if (character === "#" && !inQuotedString) {
+      return line.slice(0, index);
+    }
+  }
+
+  return line;
 }
 
 function unescapeQuotedString(

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,4 +1,5 @@
 export { CodexAppServer } from "./app-server/codex-app-server.js";
+export { AppServerSessionState } from "./app-server/session-state.js";
 export type {
   AccountSummary,
   AppServerInitializeResult,
@@ -39,6 +40,12 @@ export {
   type FakeProviderRun,
 } from "./testing/test-harness.js";
 export {
+  defaultGrokAppServerConfigPath,
+  defaultGrokAppServerStateDir,
+  resolveGrokAppServerRuntimeConfig,
+  type GrokAppServerRuntimeConfig,
+} from "./config/grok-app-server-config.js";
+export {
   defaultGrokAppServerConfigDir,
   defaultGrokAppServerConfigPaths,
   defaultLocalEnvPath,
@@ -47,6 +54,12 @@ export {
   type LocalEnvLoadResult,
 } from "./testing/load-local-env.js";
 export { OverlayStore } from "./persistence/overlay-store.js";
+export {
+  GrokRolloutStore,
+  type AppServerSessionStore,
+  type HydratedSessionState,
+  type StoredMessage,
+} from "./persistence/grok-rollout-store.js";
 export {
   asObjectArguments,
   readOptionalBoolean,

--- a/packages/agent-core/src/persistence/grok-rollout-store.ts
+++ b/packages/agent-core/src/persistence/grok-rollout-store.ts
@@ -1,0 +1,290 @@
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  AppServerRole,
+  ThreadReplayItem,
+  ThreadState,
+} from "../app-server/protocol.js";
+import { parseFlatToml, stringifyFlatToml } from "../config/simple-toml.js";
+
+export type StoredMessage = {
+  role: AppServerRole;
+  text: string;
+};
+
+export type HydratedSessionState = {
+  threads: ThreadState[];
+  messagesByThread: Record<string, StoredMessage[]>;
+  itemsByThread: Record<string, ThreadReplayItem[]>;
+  responseIds: Record<string, string>;
+  itemSequence: number;
+  lastTimestamp: number;
+};
+
+export interface AppServerSessionStore {
+  load(): HydratedSessionState;
+  persistThread(params: {
+    thread: ThreadState;
+    previousResponseId?: string;
+  }): void;
+  appendMessage(params: {
+    threadId: string;
+    message: StoredMessage;
+    item: ThreadReplayItem;
+  }): void;
+  appendItem(params: {
+    threadId: string;
+    item: ThreadReplayItem;
+  }): void;
+}
+
+type RolloutRecord =
+  | {
+      type: "message";
+      role: AppServerRole;
+      text: string;
+    }
+  | {
+      type: "item";
+      item: ThreadReplayItem;
+    };
+
+export class GrokRolloutStore implements AppServerSessionStore {
+  constructor(private readonly stateRoot: string) {}
+
+  load(): HydratedSessionState {
+    const threads: ThreadState[] = [];
+    const messagesByThread: Record<string, StoredMessage[]> = {};
+    const itemsByThread: Record<string, ThreadReplayItem[]> = {};
+    const responseIds: Record<string, string> = {};
+    let itemSequence = 0;
+    let lastTimestamp = 0;
+
+    for (const threadDir of this.listThreadDirectories()) {
+      const threadPath = path.join(threadDir, "thread.toml");
+      if (!fs.existsSync(threadPath)) {
+        continue;
+      }
+      const thread = readThreadToml(threadPath);
+      threads.push(thread);
+      lastTimestamp = Math.max(lastTimestamp, thread.createdAt ?? 0, thread.updatedAt ?? 0);
+
+      const previousResponseId = readPreviousResponseId(threadPath);
+      if (previousResponseId) {
+        responseIds[thread.threadId] = previousResponseId;
+      }
+
+      const rolloutPath = path.join(threadDir, "rollout.jsonl");
+      const { messages, items } = readRolloutFile(rolloutPath);
+      messagesByThread[thread.threadId] = messages;
+      itemsByThread[thread.threadId] = items;
+      for (const item of items) {
+        itemSequence = Math.max(itemSequence, trailingSequence(item.id));
+      }
+    }
+
+    return {
+      threads,
+      messagesByThread,
+      itemsByThread,
+      responseIds,
+      itemSequence,
+      lastTimestamp,
+    };
+  }
+
+  persistThread(params: {
+    thread: ThreadState;
+    previousResponseId?: string;
+  }): void {
+    const threadDir = this.ensureThreadDirectory(params.thread.threadId);
+    const threadPath = path.join(threadDir, "thread.toml");
+    writeAtomicFile(
+      threadPath,
+      stringifyFlatToml({
+        approval_policy: params.thread.approvalPolicy,
+        created_at: params.thread.createdAt,
+        cwd: params.thread.cwd,
+        model: params.thread.model,
+        model_provider: params.thread.modelProvider,
+        previous_response_id: params.previousResponseId,
+        reasoning_effort: params.thread.reasoningEffort,
+        sandbox: params.thread.sandbox,
+        service_tier: params.thread.serviceTier,
+        thread_id: params.thread.threadId,
+        thread_name: params.thread.threadName,
+        updated_at: params.thread.updatedAt,
+      }),
+    );
+  }
+
+  appendMessage(params: {
+    threadId: string;
+    message: StoredMessage;
+    item: ThreadReplayItem;
+  }): void {
+    this.appendRecord(params.threadId, {
+      type: "message",
+      role: params.message.role,
+      text: params.message.text,
+    });
+    this.appendRecord(params.threadId, {
+      type: "item",
+      item: params.item,
+    });
+  }
+
+  appendItem(params: {
+    threadId: string;
+    item: ThreadReplayItem;
+  }): void {
+    this.appendRecord(params.threadId, {
+      type: "item",
+      item: params.item,
+    });
+  }
+
+  private listThreadDirectories(): string[] {
+    const threadsRoot = path.join(this.stateRoot, "threads");
+    if (!fs.existsSync(threadsRoot)) {
+      return [];
+    }
+
+    return fs
+      .readdirSync(threadsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(threadsRoot, entry.name));
+  }
+
+  private ensureThreadDirectory(threadId: string): string {
+    const threadDir = path.join(this.stateRoot, "threads", threadId);
+    fs.mkdirSync(threadDir, { recursive: true });
+    return threadDir;
+  }
+
+  private appendRecord(threadId: string, record: RolloutRecord): void {
+    const threadDir = this.ensureThreadDirectory(threadId);
+    fs.appendFileSync(
+      path.join(threadDir, "rollout.jsonl"),
+      `${JSON.stringify(record)}\n`,
+      "utf8",
+    );
+  }
+}
+
+function readThreadToml(filePath: string): ThreadState {
+  const values = parseFlatToml(fs.readFileSync(filePath, "utf8"), filePath);
+  const threadId = asRequiredString(values.thread_id, filePath, "thread_id");
+
+  return {
+    threadId,
+    threadName: asOptionalString(values.thread_name),
+    cwd: asOptionalString(values.cwd),
+    model: asOptionalString(values.model),
+    modelProvider: asOptionalString(values.model_provider),
+    approvalPolicy: asOptionalString(values.approval_policy),
+    sandbox: asOptionalString(values.sandbox),
+    serviceTier: asOptionalString(values.service_tier),
+    reasoningEffort: asOptionalString(values.reasoning_effort),
+    createdAt: asOptionalNumber(values.created_at),
+    updatedAt: asOptionalNumber(values.updated_at),
+  };
+}
+
+function readPreviousResponseId(filePath: string): string | undefined {
+  const values = parseFlatToml(fs.readFileSync(filePath, "utf8"), filePath);
+  return asOptionalString(values.previous_response_id);
+}
+
+function readRolloutFile(filePath: string): {
+  messages: StoredMessage[];
+  items: ThreadReplayItem[];
+} {
+  if (!fs.existsSync(filePath)) {
+    return { messages: [], items: [] };
+  }
+
+  const messages: StoredMessage[] = [];
+  const itemOrder: string[] = [];
+  const itemMap = new Map<string, ThreadReplayItem>();
+
+  for (const [index, rawLine] of fs.readFileSync(filePath, "utf8").split(/\r?\n/).entries()) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    let record: RolloutRecord;
+    try {
+      record = JSON.parse(line) as RolloutRecord;
+    } catch (error) {
+      throw new Error(`Invalid JSONL record ${index + 1} in ${filePath}: ${String(error)}`);
+    }
+
+    if (record.type === "message") {
+      messages.push({
+        role: record.role,
+        text: record.text,
+      });
+      continue;
+    }
+
+    const item = normalizeReplayItem(record.item);
+    if (!itemMap.has(item.id)) {
+      itemOrder.push(item.id);
+    }
+    itemMap.set(item.id, item);
+  }
+
+  return {
+    messages,
+    items: itemOrder.flatMap((itemId) => {
+      const item = itemMap.get(itemId);
+      return item ? [item] : [];
+    }),
+  };
+}
+
+function trailingSequence(value: string): number {
+  const match = /(\d+)$/.exec(value);
+  return match ? Number(match[1]) : 0;
+}
+
+function asRequiredString(
+  value: string | number | boolean | undefined,
+  filePath: string,
+  key: string,
+): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Missing ${key} in ${filePath}`);
+  }
+  return value.trim();
+}
+
+function asOptionalString(value: string | number | boolean | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asOptionalNumber(value: string | number | boolean | undefined): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function writeAtomicFile(filePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp`;
+  fs.writeFileSync(tempPath, contents, "utf8");
+  fs.renameSync(tempPath, filePath);
+}
+
+function normalizeReplayItem(item: ThreadReplayItem): ThreadReplayItem {
+  return Object.fromEntries(
+    Object.entries(item).filter(([, value]) => value !== undefined),
+  ) as ThreadReplayItem;
+}

--- a/packages/agent-core/src/persistence/grok-rollout-store.ts
+++ b/packages/agent-core/src/persistence/grok-rollout-store.ts
@@ -207,6 +207,8 @@ function readRolloutFile(filePath: string): {
   const messages: StoredMessage[] = [];
   const itemOrder: string[] = [];
   const itemMap = new Map<string, ThreadReplayItem>();
+  const itemOccurrences = new Map<string, { resolvedId: string; lastMessageCount: number }>();
+  let messageCount = 0;
 
   for (const [index, rawLine] of fs.readFileSync(filePath, "utf8").split(/\r?\n/).entries()) {
     const line = rawLine.trim();
@@ -226,14 +228,28 @@ function readRolloutFile(filePath: string): {
         role: record.role,
         text: record.text,
       });
+      messageCount += 1;
       continue;
     }
 
     const item = normalizeReplayItem(record.item);
-    if (!itemMap.has(item.id)) {
-      itemOrder.push(item.id);
+    const resolvedId = resolveReplayItemOccurrenceId(
+      item.id,
+      itemOccurrences,
+      itemMap,
+      messageCount,
+    );
+    const normalizedItem =
+      resolvedId === item.id
+        ? item
+        : normalizeReplayItem({
+            ...item,
+            id: resolvedId,
+          });
+    if (!itemMap.has(normalizedItem.id)) {
+      itemOrder.push(normalizedItem.id);
     }
-    itemMap.set(item.id, item);
+    itemMap.set(normalizedItem.id, normalizedItem);
   }
 
   return {
@@ -248,6 +264,46 @@ function readRolloutFile(filePath: string): {
 function trailingSequence(value: string): number {
   const match = /(\d+)$/.exec(value);
   return match ? Number(match[1]) : 0;
+}
+
+function resolveReplayItemOccurrenceId(
+  baseId: string,
+  occurrences: Map<string, { resolvedId: string; lastMessageCount: number }>,
+  itemMap: Map<string, ThreadReplayItem>,
+  currentMessageCount: number,
+): string {
+  const existing = occurrences.get(baseId);
+  if (!existing) {
+    occurrences.set(baseId, {
+      resolvedId: baseId,
+      lastMessageCount: currentMessageCount,
+    });
+    return baseId;
+  }
+
+  if (existing.lastMessageCount < currentMessageCount) {
+    const resolvedId = nextReplayItemOccurrenceId(baseId, itemMap);
+    occurrences.set(baseId, {
+      resolvedId,
+      lastMessageCount: currentMessageCount,
+    });
+    return resolvedId;
+  }
+
+  existing.lastMessageCount = currentMessageCount;
+  return existing.resolvedId;
+}
+
+function nextReplayItemOccurrenceId(
+  baseId: string,
+  itemMap: Map<string, ThreadReplayItem>,
+): string {
+  for (let index = 2; ; index += 1) {
+    const candidate = `${baseId}#${index}`;
+    if (!itemMap.has(candidate)) {
+      return candidate;
+    }
+  }
 }
 
 function asRequiredString(

--- a/packages/agent-core/src/testing/test-harness.ts
+++ b/packages/agent-core/src/testing/test-harness.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AppServerNotification, AppServerTurnInputItem, ThreadState } from "../app-server/protocol.js";
 import { CodexAppServer } from "../app-server/codex-app-server.js";
+import { AppServerSessionState } from "../app-server/session-state.js";
 import type {
   AppServerProvider,
   ProviderActiveTurn,
@@ -89,12 +90,14 @@ export class FakeProvider implements AppServerProvider {
 export function createTestHarness(options?: {
   provider?: AppServerProvider;
   requestHandler?: (method: string, params: Record<string, unknown>) => Promise<unknown> | unknown;
+  sessionState?: AppServerSessionState;
 }) {
   const provider = options?.provider ?? new FakeProvider();
   const notifications: AppServerNotification[] = [];
   const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
   const server = new CodexAppServer({
     provider,
+    sessionState: options?.sessionState,
     threadIdGenerator: (() => {
       let index = 0;
       return () => `thread-${++index}`;


### PR DESCRIPTION
## Summary
This makes the Grok app server durable across desktop restarts instead of treating thread state as process-local scratch state.

The change adds a runtime Grok config loader with XDG-aware TOML config, persists thread metadata and rollout history as text-first artifacts under XDG state paths, hydrates that state back into the app server on startup, and wires the desktop Grok client to use the persistent store.

## What changed
- added `config.toml` runtime loading for Grok app-server config with XDG config/state resolution and legacy env fallback
- added a flat TOML parser and a per-thread rollout store using `thread.toml` + `rollout.jsonl`
- taught `AppServerSessionState` to hydrate from and write through to the rollout store
- let `CodexAppServer` accept injected session state so persistence is not hard-coded to in-memory maps
- wired `GrokAppServerClient` to build the persistent session state and reuse it after restart
- added restart/config tests at the store, session-state, server, and desktop-client layers
- updated the implementation plan with the completed persistence units

## Verification
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/test-harness.test.ts packages/agent-core/src/__tests__/session-state.test.ts packages/agent-core/src/__tests__/grok-rollout-store.test.ts packages/agent-core/src/__tests__/codex-app-server-persistence.test.ts packages/agent-core/src/__tests__/codex-app-server-contract.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/grok-app-server-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`

## Notes
- rollout files are the source of truth; SQLite is still deferred as an optional derived index
- active in-flight runs are not recovered after restart; completed and idle thread state is
