### PR TITLE
fix(desktop): polish sidebar browse navigation

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -346,6 +346,40 @@ describe("CodexAppServerClient", () => {
     });
     expect(threads[1]?.title).toBe("Plan Codex compatibility");
 
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    const threadListRequest = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/list");
+
+    expect(threadListRequest?.params).toEqual({});
+
+    await client.close();
+  });
+
+  it("uses query payloads when filtering the codex thread list", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.listThreads({ filter: "web-app" });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    const threadListRequest = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/list");
+
+    expect(threadListRequest?.params).toEqual({
+      query: "web-app",
+      limit: 100
+    });
+
     await client.close();
   });
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -909,13 +909,19 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
 }
 
 function buildThreadDiscoveryPayloads(filter?: string): unknown[] {
+  const normalizedFilter = filter?.trim();
+
+  if (!normalizedFilter) {
+    return [{}];
+  }
+
   return [
     {
-      query: filter?.trim() || undefined,
+      query: normalizedFilter,
       limit: 100
     },
     {
-      filter: filter?.trim() || undefined,
+      filter: normalizedFilter,
       limit: 100
     },
     {}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,4 +1,4 @@
-import type { NavigationThreadSummary } from "@pwragnt/shared";
+import type { LinkedDirectorySummary, NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
@@ -99,23 +99,45 @@ function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryG
     }
 
     for (const directory of thread.linkedDirectories) {
-      const existing = groups.get(directory.id);
+      const descriptor = getDirectoryGroupDescriptor(directory);
+      const existing = groups.get(descriptor.id);
       if (existing) {
         existing.threads.push(thread);
         continue;
       }
 
-      groups.set(directory.id, {
-        id: directory.id,
-        icon: "📁",
-        label: directory.label,
-        path: directory.path,
+      groups.set(descriptor.id, {
+        ...descriptor,
         threads: [thread]
       });
     }
   }
 
   return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function getDirectoryGroupDescriptor(
+  directory: LinkedDirectorySummary
+): Omit<DirectoryGroup, "threads"> {
+  const scratchWorkspaceMatch = directory.path.match(
+    /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/
+  );
+
+  if (scratchWorkspaceMatch) {
+    return {
+      id: `workspaces:${scratchWorkspaceMatch[1]}`,
+      icon: "📁",
+      label: "Workspaces",
+      path: scratchWorkspaceMatch[1]
+    };
+  }
+
+  return {
+    id: directory.id,
+    icon: "📁",
+    label: directory.label,
+    path: directory.path
+  };
 }
 
 function formatRelativeTime(timestamp?: number): string {

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -17,6 +17,22 @@ type DirectoryGroup = {
   threads: NavigationThreadSummary[];
 };
 
+type DirectoryGroupDescriptor = Omit<DirectoryGroup, "threads">;
+type DirectoryIdentity =
+  | {
+      kind: "scratch-workspaces";
+      path: string;
+    }
+  | {
+      kind: "stable";
+      label: string;
+      path: string;
+    }
+  | {
+      kind: "codex-worktree";
+      label: string;
+    };
+
 export function DirectoriesList(props: DirectoriesListProps) {
   const groups = groupThreadsByDirectory(props.threads);
 
@@ -81,6 +97,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
 function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryGroup[] {
   const groups = new Map<string, DirectoryGroup>();
+  const stablePathByLabel = collectStablePathByLabel(threads);
 
   for (const thread of threads) {
     if (thread.linkedDirectories.length === 0) {
@@ -99,7 +116,7 @@ function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryG
     }
 
     for (const directory of thread.linkedDirectories) {
-      const descriptor = getDirectoryGroupDescriptor(directory);
+      const descriptor = getDirectoryGroupDescriptor(directory, stablePathByLabel);
       const existing = groups.get(descriptor.id);
       if (existing) {
         existing.threads.push(thread);
@@ -116,28 +133,117 @@ function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryG
   return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
 }
 
-function getDirectoryGroupDescriptor(
-  directory: LinkedDirectorySummary
-): Omit<DirectoryGroup, "threads"> {
-  const scratchWorkspaceMatch = directory.path.match(
-    /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/
-  );
+function collectStablePathByLabel(
+  threads: NavigationThreadSummary[]
+): Map<string, string | undefined> {
+  const pathsByLabel = new Map<string, Set<string>>();
 
-  if (scratchWorkspaceMatch) {
+  for (const thread of threads) {
+    for (const directory of thread.linkedDirectories) {
+      const identity = classifyDirectory(directory);
+      if (identity.kind !== "stable") {
+        continue;
+      }
+
+      const paths = pathsByLabel.get(identity.label) ?? new Set<string>();
+      paths.add(identity.path);
+      pathsByLabel.set(identity.label, paths);
+    }
+  }
+
+  return new Map(
+    [...pathsByLabel.entries()].map(([label, paths]) => [
+      label,
+      paths.size === 1 ? [...paths][0] : undefined
+    ])
+  );
+}
+
+function getDirectoryGroupDescriptor(
+  directory: LinkedDirectorySummary,
+  stablePathByLabel: Map<string, string | undefined>
+): DirectoryGroupDescriptor {
+  const identity = classifyDirectory(directory);
+
+  if (identity.kind === "scratch-workspaces") {
     return {
-      id: `workspaces:${scratchWorkspaceMatch[1]}`,
+      id: `workspaces:${identity.path}`,
       icon: "📁",
       label: "Workspaces",
-      path: scratchWorkspaceMatch[1]
+      path: identity.path
+    };
+  }
+
+  if (identity.kind === "codex-worktree") {
+    const stablePath = stablePathByLabel.get(identity.label);
+    if (stablePath) {
+      return {
+        id: `directory:${stablePath}`,
+        icon: "📁",
+        label: identity.label,
+        path: stablePath
+      };
+    }
+
+    return {
+      id: `codex-worktree:${identity.label}`,
+      icon: "📁",
+      label: identity.label
     };
   }
 
   return {
-    id: directory.id,
+    id: `directory:${identity.path}`,
     icon: "📁",
+    label: identity.label,
+    path: identity.path
+  };
+}
+
+function classifyDirectory(directory: LinkedDirectorySummary): DirectoryIdentity {
+  const scratchWorkspaceMatch = directory.path.match(
+    /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/
+  );
+  if (scratchWorkspaceMatch) {
+    return {
+      kind: "scratch-workspaces",
+      path: scratchWorkspaceMatch[1]
+    };
+  }
+
+  const repoWorktreeMatch = directory.path.match(
+    /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/].*)?$/
+  );
+  if (repoWorktreeMatch) {
+    const canonicalPath = repoWorktreeMatch[1];
+    return {
+      kind: "stable",
+      label: pathBaseName(canonicalPath),
+      path: canonicalPath
+    };
+  }
+
+  const codexWorktreeMatch = directory.path.match(
+    /^[\\/].*[\\/]\.codex[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/
+  );
+  if (codexWorktreeMatch) {
+    return {
+      kind: "codex-worktree",
+      label: codexWorktreeMatch[1]
+    };
+  }
+
+  return {
+    kind: "stable",
     label: directory.label,
     path: directory.path
   };
+}
+
+function pathBaseName(pathname: string): string {
+  const normalized = pathname.replace(/[\\/]+$/, "");
+  const segments = normalized.split(/[\\/]/).filter(Boolean);
+  return segments.at(-1) ?? pathname;
 }
 
 function formatRelativeTime(timestamp?: number): string {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -129,6 +129,73 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
   });
 
+  it("lumps scratch workspaces under a shared Workspaces directory group", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        fetchedAt={Date.now()}
+        inboxThreads={[]}
+        loading={false}
+        creatingThreadBackend={undefined}
+        refreshing={false}
+        selectedThreadKey={undefined}
+        threads={[
+          {
+            id: "thread-3",
+            title: "Untitled thread",
+            summary: undefined,
+            source: "codex",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: [
+              {
+                id: "scratch-1",
+                label: "2026-04-17-a15d5e",
+                path: "/Users/huntharo/.pwragnt/projects/2026-04-17-a15d5e",
+                kind: "local"
+              }
+            ]
+          },
+          {
+            id: "thread-4",
+            title: "Second untitled thread",
+            summary: undefined,
+            source: "codex",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: [
+              {
+                id: "scratch-2",
+                label: "2026-04-17-b83f91",
+                path: "/Users/huntharo/.pwragnt/projects/2026-04-17-b83f91",
+                kind: "local"
+              }
+            ]
+          }
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onRefresh={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("heading", { level: 3, name: "Workspaces" })).toBeInTheDocument();
+    expect(screen.getByText("2 threads")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "2026-04-17-a15d5e" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "2026-04-17-b83f91" })
+    ).not.toBeInTheDocument();
+  });
+
   it("copies a linked directory path from the recents chip", () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -196,6 +196,85 @@ describe("Sidebar", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("merges stale codex worktree paths into the stable repo directory group", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        fetchedAt={Date.now()}
+        inboxThreads={[]}
+        loading={false}
+        creatingThreadBackend={undefined}
+        refreshing={false}
+        selectedThreadKey={undefined}
+        threads={[
+          {
+            id: "thread-5",
+            title: "Check web API proxy support",
+            summary: undefined,
+            source: "codex",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: [
+              {
+                id: "web-app-root",
+                label: "web-app",
+                path: "/Users/huntharo/GIPHY/web-app",
+                kind: "local"
+              }
+            ]
+          },
+          {
+            id: "thread-6",
+            title: "Explain web app login flow",
+            summary: undefined,
+            source: "codex",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: [
+              {
+                id: "web-app-worktree-1",
+                label: "web-app",
+                path: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+                kind: "local"
+              }
+            ]
+          },
+          {
+            id: "thread-7",
+            title: "Investigate chunk file errors",
+            summary: undefined,
+            source: "codex",
+            updatedAt: Date.now(),
+            inbox: {
+              inInbox: false
+            },
+            linkedDirectories: [
+              {
+                id: "web-app-worktree-2",
+                label: "web-app",
+                path: "/Users/huntharo/.codex/worktrees/1f9a/web-app",
+                kind: "local"
+              }
+            ]
+          }
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onRefresh={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole("heading", { level: 3, name: "web-app" })).toHaveLength(1);
+    expect(screen.getByText("3 threads")).toBeInTheDocument();
+  });
+
   it("copies a linked directory path from the recents chip", () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -169,7 +169,9 @@ textarea {
 }
 
 .sidebar__scroll-region {
+  display: flex;
   flex: 1;
+  flex-direction: column;
   min-height: 0;
   overflow: hidden;
 }
@@ -289,6 +291,8 @@ textarea {
   overflow-y: auto;
   min-height: 0;
   padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(168, 176, 187, 0.4) rgba(255, 255, 255, 0.04);
 }
 
 .directory-groups {
@@ -296,6 +300,33 @@ textarea {
   min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(168, 176, 187, 0.4) rgba(255, 255, 255, 0.04);
+}
+
+.sidebar-list--dense::-webkit-scrollbar,
+.directory-groups::-webkit-scrollbar {
+  width: 10px;
+}
+
+.sidebar-list--dense::-webkit-scrollbar-track,
+.directory-groups::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 999px;
+}
+
+.sidebar-list--dense::-webkit-scrollbar-thumb,
+.directory-groups::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: rgba(168, 176, 187, 0.4);
+  background-clip: padding-box;
+}
+
+.sidebar-list--dense::-webkit-scrollbar-thumb:hover,
+.directory-groups::-webkit-scrollbar-thumb:hover {
+  background: rgba(168, 176, 187, 0.58);
+  background-clip: padding-box;
 }
 
 .sidebar-list--compact {


### PR DESCRIPTION
## Summary
Tighten the desktop app's sidebar browse experience so it behaves like a usable navigation surface again.

## What changed
- restore the left-rail browse list as a constrained scroll region instead of letting it grow and get clipped
- add explicit thin scrollbar styling for the recents and directories lists so the scroll affordance stays visible in Electron
- collapse scratch workspaces created under `~/.pwragnt/projects/<date-suffix>` into a shared `Workspaces` directory bucket
- keep the underlying per-thread workspace paths intact while removing the one-folder-per-thread noise from the directories lens

## Validation
- pnpm test -- --run apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
- pnpm typecheck
