### PR TITLE
fix(desktop): align thread rows across browse tabs

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,7 +1,7 @@
 import type { LinkedDirectorySummary, NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
-import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
+import { ThreadMetaChips } from "./ThreadMetaChips";
 
 type DirectoriesListProps = {
   selectedThreadKey?: string;
@@ -78,19 +78,17 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 <button
                   key={`${group.id}:${buildThreadIdentityKey(thread.source, thread.id)}`}
                   aria-pressed={selected}
-                  className={`thread-row thread-row--compact${selected ? " is-selected" : ""}`}
+                  className={`thread-row${selected ? " is-selected" : ""}`}
                   type="button"
                   onClick={() => props.onSelectThread(thread)}
                 >
                   <span className="thread-row__header">
                     <span className="thread-row__title">{thread.title}</span>
-                    <span className="thread-row__chip thread-row__chip--backend">
-                      {formatBackendLabel(thread.source)}
-                    </span>
                     <span className="thread-row__time">
                       {formatRelativeTime(thread.updatedAt)}
                     </span>
                   </span>
+                  <ThreadMetaChips thread={thread} />
                 </button>
               );
             })}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,7 +1,6 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
-import { formatBackendLabel } from "../../lib/backend-label";
-import { copyText, formatCopyTooltip } from "../../lib/copy-text";
+import { ThreadMetaChips } from "./ThreadMetaChips";
 
 type RecentsListProps = {
   selectedThreadKey?: string;
@@ -30,60 +29,7 @@ export function RecentsList(props: RecentsListProps) {
               </span>
             </span>
 
-            {thread.summary ? (
-              <span className="thread-row__summary">{thread.summary}</span>
-            ) : null}
-
-            <span className="thread-row__meta">
-              <span className="thread-row__chip thread-row__chip--backend">
-                {formatBackendLabel(thread.source)}
-              </span>
-
-              {thread.linkedDirectories.length > 0 ? (
-                thread.linkedDirectories.map((directory) => (
-                  <span
-                    aria-label={`Copy path for ${directory.label}`}
-                    key={`${thread.id}:${directory.id}`}
-                    className="thread-row__chip path-copy-target tooltip-target"
-                    role="button"
-                    tabIndex={0}
-                    data-tooltip={formatCopyTooltip(directory.path)}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void copyText(directory.path);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter" && event.key !== " ") {
-                        return;
-                      }
-
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void copyText(directory.path);
-                    }}
-                  >
-                    <span aria-hidden="true" className="thread-row__chip-icon">
-                      {directory.kind === "worktree" ? "🔀" : "📁"}
-                    </span>
-                    {directory.label}
-                  </span>
-                ))
-              ) : (
-                <span className="thread-row__chip thread-row__chip--muted">
-                  No linked directory
-                </span>
-              )}
-
-              {thread.gitBranch ? (
-                <span className="thread-row__chip thread-row__chip--mono">
-                  <span aria-hidden="true" className="thread-row__chip-icon">
-                    🌿
-                  </span>
-                  {thread.gitBranch}
-                </span>
-              ) : null}
-            </span>
+            <ThreadMetaChips includeLinkedDirectories thread={thread} />
           </button>
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,0 +1,70 @@
+import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { formatBackendLabel } from "../../lib/backend-label";
+import { copyText, formatCopyTooltip } from "../../lib/copy-text";
+
+type ThreadMetaChipsProps = {
+  includeLinkedDirectories?: boolean;
+  thread: NavigationThreadSummary;
+};
+
+export function ThreadMetaChips({
+  includeLinkedDirectories = false,
+  thread,
+}: ThreadMetaChipsProps) {
+  const linkedDirectoryChips = includeLinkedDirectories
+    ? thread.linkedDirectories.length > 0
+      ? thread.linkedDirectories.map((directory) => (
+          <span
+            aria-label={`Copy path for ${directory.label}`}
+            key={`${thread.id}:${directory.id}`}
+            className="thread-row__chip path-copy-target tooltip-target"
+            role="button"
+            tabIndex={0}
+            data-tooltip={formatCopyTooltip(directory.path)}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void copyText(directory.path);
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" && event.key !== " ") {
+                return;
+              }
+
+              event.preventDefault();
+              event.stopPropagation();
+              void copyText(directory.path);
+            }}
+          >
+            <span aria-hidden="true" className="thread-row__chip-icon">
+              {directory.kind === "worktree" ? "🔀" : "📁"}
+            </span>
+            {directory.label}
+          </span>
+        ))
+      : (
+          <span className="thread-row__chip thread-row__chip--muted">
+            No linked directory
+          </span>
+        )
+    : null;
+
+  return (
+    <span className="thread-row__meta">
+      <span className="thread-row__chip thread-row__chip--backend">
+        {formatBackendLabel(thread.source)}
+      </span>
+
+      {linkedDirectoryChips}
+
+      {thread.gitBranch ? (
+        <span className="thread-row__chip thread-row__chip--mono">
+          <span aria-hidden="true" className="thread-row__chip-icon">
+            🌿
+          </span>
+          {thread.gitBranch}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary } from "@pwragnt/shared";
 import { Sidebar } from "../Sidebar";
 
@@ -155,6 +155,17 @@ describe("Sidebar", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /Cross-project cleanup/i }).length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
+    const pwrAgntSection = screen
+      .getByRole("heading", { level: 3, name: "PwrAgnt" })
+      .closest("section");
+    expect(pwrAgntSection).not.toBeNull();
+    const groupedThread = within(pwrAgntSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+    expect(groupedThread).toHaveClass("thread-row");
+    expect(groupedThread).not.toHaveClass("thread-row--compact");
+    expect(within(groupedThread).getByText("Codex")).toBeInTheDocument();
+    expect(within(groupedThread).getByText("codex/thread-centric-ui")).toBeInTheDocument();
   });
 
   it("lumps scratch workspaces under a shared Workspaces directory group", () => {
@@ -464,6 +475,9 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy path for PwrAgnt" }));
 
     expect(copyText).toHaveBeenCalledWith("/Users/huntharo/pwrdrvr/PwrAgnt");
+    expect(
+      screen.queryByText("Line up the desktop shell with the app server")
+    ).not.toBeInTheDocument();
   });
 
   it("opens a new-thread picker with enabled and disabled backend options", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -299,6 +299,7 @@ textarea {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  padding-top: 0;
   padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgba(168, 176, 187, 0.4) rgba(255, 255, 255, 0.04);
@@ -519,15 +520,21 @@ textarea {
 }
 
 .directory-group:first-child {
-  padding-top: 0;
+  padding-top: 12px;
   border-top: 0;
 }
 
 .directory-group__header {
   display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 2;
   justify-content: space-between;
   gap: 12px;
+  padding-top: 8px;
   padding-bottom: 8px;
+  background: var(--bg-sidebar);
+  box-shadow: 0 1px 0 var(--border-subtle);
 }
 
 .directory-group__title {


### PR DESCRIPTION
## Summary
- align Directories tab thread rows with the Recents row structure so titles stay left, timestamps stay right-aligned, and chips wrap onto the next line
- remove the first-request summary line from Recents rows
- extract shared thread metadata chip rendering and extend sidebar tests around the shared row behavior

## Verification
- pnpm --filter @pwragnt/desktop typecheck
- pnpm exec vitest run apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx --environment jsdom
