### PR TITLE
feat(desktop): render plan progress in transcripts

### DIFF
--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -97,3 +97,5 @@ fixture for CI.
   plan
 - `grok-todo-list/`: Grok-backed task plan rendering contract for the shared
   transcript plan UI
+- `live-plan-updates/`: live `turn/plan/updated` rendering for in-flight task
+  plan UI

--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -93,3 +93,7 @@ fixture for CI.
 - `turn-lifecycle/`: turn start, visible Stop button, and clean completion
 - `edited-changes-order/`: edited-file activity that must remain in transcript
   order when expanded
+- `codex-todo-list/`: selected Codex thread renders a persisted transcript task
+  plan
+- `grok-todo-list/`: Grok-backed task plan rendering contract for the shared
+  transcript plan UI

--- a/apps/desktop/e2e/fixtures/codex-todo-list/capture-recipe.md
+++ b/apps/desktop/e2e/fixtures/codex-todo-list/capture-recipe.md
@@ -1,0 +1,75 @@
+# Codex To-Do List Capture Recipe
+
+## Goal
+
+Capture a real Codex thread whose persisted `thread/read` response already
+contains a normalized `plan` entry, so replay can assert that selecting the
+thread paints the transcript to-do list immediately.
+
+## Backend and Mode
+
+- Backend: Codex
+- Mode: `Default Access`
+
+## Current Seed
+
+This fixture is curated from the live Codex thread
+`019ce224-97ac-7c01-a2ae-55da8b7a4006` (`Add AGENTS docs for media VCL`), which
+returned a persisted `plan` entry from `thread/read` during the desktop replay
+probe on April 18, 2026.
+
+The replay fixture trims that large live plan down to three stable steps from
+the same persisted entry so the assertion surface stays small and deterministic.
+
+## Launch
+
+```bash
+PWRAGNT_PROTOCOL_CAPTURE=true \
+PWRAGNT_PROTOCOL_CAPTURE_ROOT=/tmp/pwragnt-protocol-captures \
+pnpm dev
+```
+
+## Computer Use Steps
+
+1. Wait for the desktop shell to show the `Threads` heading.
+2. Open the existing Codex thread `Add AGENTS docs for media VCL`.
+3. Wait for the transcript to render a `Task plan` group without sending a new
+   turn.
+4. Record the thread id from the context rail.
+
+## Stop Point
+
+Stop once the selected thread shows a persisted transcript plan. Do not send a
+new message for this scenario.
+
+## Export Hints
+
+- Preferred selector: `codex:019ce224-97ac-7c01-a2ae-55da8b7a4006`
+- Initial replay window: first `initialize`, first `thread/list`, first
+  `skills/list`, and the `thread/read` response containing the persisted plan
+- Expected replay assertion surface:
+  - selected thread heading renders
+  - transcript includes `Task plan`
+  - summary reads `0 out of 3 tasks completed`
+  - all three plan rows show `Pending`
+
+## Promotion Commands
+
+```bash
+pnpm --filter @pwragnt/desktop export:session-capture -- \
+  --capture-root /tmp/pwragnt-protocol-captures \
+  --session codex:019ce224-97ac-7c01-a2ae-55da8b7a4006 \
+  --output /tmp/codex-todo-list.raw.capture.jsonl
+```
+
+```bash
+pnpm --filter @pwragnt/desktop derive:replay-fixture -- \
+  --input /tmp/codex-todo-list.raw.capture.jsonl \
+  --output-dir apps/desktop/e2e/fixtures/codex-todo-list \
+  --scenario codex-todo-list \
+  --backend codex \
+  --thread-id 019ce224-97ac-7c01-a2ae-55da8b7a4006 \
+  --source-capture-id 2026-04-19T01-40-27-292Z-codex \
+  --start <sequence> \
+  --end <sequence>
+```

--- a/apps/desktop/e2e/fixtures/codex-todo-list/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/codex-todo-list/replay.fixture.json
@@ -1,0 +1,140 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "codex-todo-list",
+    "sourceCaptureId": "2026-04-19T01-40-27-292Z-codex",
+    "threadId": "019ce224-97ac-7c01-a2ae-55da8b7a4006"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list"]
+      }
+    },
+    {
+      "id": "initialize-2",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list"]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "019ce224-97ac-7c01-a2ae-55da8b7a4006",
+          "title": "Add AGENTS docs for media VCL",
+          "titleSource": "explicit",
+          "summary": "Captured Codex thread with a persisted task plan",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776562836000
+        }
+      ]
+    },
+    {
+      "id": "thread-list-2",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "019ce224-97ac-7c01-a2ae-55da8b7a4006",
+          "title": "Add AGENTS docs for media VCL",
+          "titleSource": "explicit",
+          "summary": "Captured Codex thread with a persisted task plan",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776562836000
+        }
+      ]
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Document the current VCL behavior and keep the work tracked."
+          },
+          {
+            "type": "plan",
+            "id": "019ce22a-076d-7293-ba32-19a799d3c3f7-plan",
+            "createdAt": 1776562834000,
+            "steps": [
+              {
+                "step": "Start the implementation by creating a local root plan file named `IMPLEMENTATION_PLAN.local.md` and add that exact filename to `.gitignore`.",
+                "status": "pending"
+              },
+              {
+                "step": "The local plan file should begin with a short facts/goals section, followed by a `To-Do` section using Markdown checkboxes that get updated as work is completed.",
+                "status": "pending"
+              },
+              {
+                "step": "Establish the repo pattern for scoped context, but implement it fully only for `gif-media` in this pass.",
+                "status": "pending"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "I’ll keep the implementation checklist in sync while I work through the documentation pass."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Document the current VCL behavior and keep the work tracked."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "I’ll keep the implementation checklist in sync while I work through the documentation pass."
+          }
+        ],
+        "lastUserMessage": "Document the current VCL behavior and keep the work tracked.",
+        "lastAssistantMessage": "I’ll keep the implementation checklist in sync while I work through the documentation pass.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/fixtures/grok-todo-list/capture-recipe.md
+++ b/apps/desktop/e2e/fixtures/grok-todo-list/capture-recipe.md
@@ -1,0 +1,79 @@
+# Grok To-Do List Capture Recipe
+
+## Goal
+
+Capture a real Grok thread whose transcript includes a normalized `plan` entry,
+so replay can assert that the desktop renderer paints the same to-do list UI
+for Grok-backed threads.
+
+## Backend and Mode
+
+- Backend: Grok
+- Mode: `Default Access`
+
+## Current Live Result
+
+As of April 18, 2026, the live Grok probe did not emit a plan.
+
+- Probe thread: `thread-3mefc6i7`
+- Capture root: `/tmp/pwragnt-protocol-captures-grok-todo-e2e`
+- Prompt:
+
+  ```text
+  Before you do any work, use your built-in plan/task-list tool to create
+  exactly 3 short tasks and keep it updated as you go. Do not print a markdown
+  checklist in chat.
+
+  Task:
+  1. Inspect packages/shared/src/contracts/app-server.ts for the
+     AppServerThreadPlanEntry type.
+  2. Inspect apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+     for how plan entries render.
+  3. Summarize in 2 sentences whether the renderer depends on backend source.
+  ```
+
+The thread completed with ordinary assistant messages only. It produced no
+`turn/plan/updated` notification and no persisted `plan` entry in `thread/read`.
+
+Because we still need renderer coverage for Grok-backed plan entries, the
+current `replay.fixture.json` is a contract fixture that mirrors the normalized
+desktop plan shape the UI already supports. Replace it with a fully derived
+fixture as soon as Grok emits live plan data.
+
+## Launch
+
+```bash
+PWRAGNT_PROTOCOL_CAPTURE=true \
+PWRAGNT_PROTOCOL_CAPTURE_ROOT=/tmp/pwragnt-protocol-captures \
+pnpm dev
+```
+
+## Refresh Instructions
+
+1. Start a new Grok thread in `Default Access`.
+2. Send a plan-heavy prompt that causes Grok to emit either:
+   - a `turn/plan/updated` notification, or
+   - a persisted `plan` entry in `thread/read`
+3. Stop once the transcript visibly shows the to-do list.
+4. Export the capture and replace this contract fixture with a derived replay.
+
+## Promotion Commands
+
+```bash
+pnpm --filter @pwragnt/desktop export:session-capture -- \
+  --capture-root /tmp/pwragnt-protocol-captures \
+  --session grok:<thread-id> \
+  --output /tmp/grok-todo-list.raw.capture.jsonl
+```
+
+```bash
+pnpm --filter @pwragnt/desktop derive:replay-fixture -- \
+  --input /tmp/grok-todo-list.raw.capture.jsonl \
+  --output-dir apps/desktop/e2e/fixtures/grok-todo-list \
+  --scenario grok-todo-list \
+  --backend grok \
+  --thread-id <thread-id> \
+  --source-capture-id <capture-id> \
+  --start <sequence> \
+  --end <sequence>
+```

--- a/apps/desktop/e2e/fixtures/grok-todo-list/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/grok-todo-list/replay.fixture.json
@@ -1,0 +1,134 @@
+{
+  "metadata": {
+    "backend": "grok",
+    "scenario": "grok-todo-list",
+    "threadId": "thread-3mefc6i7"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Grok",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list"]
+      }
+    },
+    {
+      "id": "initialize-2",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Grok",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list"]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-3mefc6i7",
+          "title": "Grok to-do list replay",
+          "titleSource": "explicit",
+          "summary": "Contract fixture for Grok-backed task plan rendering",
+          "source": "grok",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563200000
+        }
+      ]
+    },
+    {
+      "id": "thread-list-2",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-3mefc6i7",
+          "title": "Grok to-do list replay",
+          "titleSource": "explicit",
+          "summary": "Contract fixture for Grok-backed task plan rendering",
+          "source": "grok",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563200000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Use the task list tool before summarizing the renderer dependency."
+          },
+          {
+            "type": "plan",
+            "id": "grok-plan-1",
+            "createdAt": 1776563201000,
+            "explanation": "Checking the shared contract and renderer before summarizing the dependency.",
+            "steps": [
+              {
+                "step": "Inspect contract type",
+                "status": "completed"
+              },
+              {
+                "step": "Inspect renderer usage",
+                "status": "in_progress"
+              },
+              {
+                "step": "Summarize dependency",
+                "status": "pending"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "I’m checking the contract and renderer now."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Use the task list tool before summarizing the renderer dependency."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "I’m checking the contract and renderer now."
+          }
+        ],
+        "lastUserMessage": "Use the task list tool before summarizing the renderer dependency.",
+        "lastAssistantMessage": "I’m checking the contract and renderer now.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/fixtures/live-plan-updates/capture-recipe.md
+++ b/apps/desktop/e2e/fixtures/live-plan-updates/capture-recipe.md
@@ -1,0 +1,104 @@
+# Live Plan Updates Capture Recipe
+
+## Goal
+
+Capture a Codex thread that first emits a live `turn/plan/updated`
+notification, then persists the same plan into `thread/read`, so replay can
+assert both behaviors:
+
+- the transcript renders the live to-do list while the turn is still in flight
+- the transient plan copy disappears once replay catches up with the persisted
+  plan entry
+
+## Backend and Mode
+
+- Backend: Codex
+- Mode: `Default Access`
+
+## Current Fixture Status
+
+The current `replay.fixture.json` is a contract fixture.
+
+During the April 18, 2026 plan probes, Codex did emit real
+`turn/plan/updated` notifications, but the temporary capture roots created for
+those probes only retained malformed or truncated capture metadata, so they
+could not be promoted cleanly with `export:session-capture`.
+
+That means this scenario is covered in CI today, but it still needs a clean
+replacement capture when we record the flow again.
+
+## Launch
+
+```bash
+PWRAGNT_PROTOCOL_CAPTURE=true \
+PWRAGNT_PROTOCOL_CAPTURE_ROOT=/tmp/pwragnt-protocol-captures \
+pnpm dev
+```
+
+## Computer Use Steps
+
+1. Wait for the desktop shell to show the `Threads` heading.
+2. Click `New thread`.
+3. Choose `Create thread with Codex in Default Access`.
+4. Send a plan-heavy prompt that reliably triggers the built-in task list. The
+   current best probe prompt is:
+
+   ```text
+   Before you do any work, use your built-in plan/task-list tool to create
+   exactly 3 short tasks and keep it updated as you go. Do not print a markdown
+   checklist in chat.
+
+   Task:
+   1. Inspect packages/shared/src/contracts/app-server.ts for the
+      AppServerThreadPlanEntry type.
+   2. Inspect apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+      for how plan entries render.
+   3. Summarize in 2 sentences whether the renderer depends on backend source.
+   ```
+
+5. Wait for the transcript to show the `Task plan` group before the turn
+   finishes.
+6. Continue waiting until the turn completes and the same plan remains visible
+   as persisted transcript content.
+
+## Stop Point
+
+Stop once the turn has completed and the transcript still shows exactly one
+task-plan card.
+
+## Export Hints
+
+- Preferred selector: `codex:<thread-id>`
+- Initial replay window:
+  - first `initialize`
+  - first `thread/list`
+  - first `skills/list`
+  - first baseline `thread/read`
+  - `turn/start`
+  - the `turn/plan/updated` notification
+  - the follow-up `thread/read` response that persists the plan
+- Expected replay assertion surface:
+  - plan appears from live notification
+  - transcript still shows only one `Task plan` group after replay catches up
+  - final assistant message remains below the plan
+
+## Promotion Commands
+
+```bash
+pnpm --filter @pwragnt/desktop export:session-capture -- \
+  --capture-root /tmp/pwragnt-protocol-captures \
+  --session codex:<thread-id> \
+  --output /tmp/live-plan-updates.raw.capture.jsonl
+```
+
+```bash
+pnpm --filter @pwragnt/desktop derive:replay-fixture -- \
+  --input /tmp/live-plan-updates.raw.capture.jsonl \
+  --output-dir apps/desktop/e2e/fixtures/live-plan-updates \
+  --scenario live-plan-updates \
+  --backend codex \
+  --thread-id <thread-id> \
+  --source-capture-id <capture-id> \
+  --start <sequence> \
+  --end <sequence>
+```

--- a/apps/desktop/e2e/fixtures/live-plan-updates/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/live-plan-updates/replay.fixture.json
@@ -1,0 +1,411 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "live-plan-updates",
+    "threadId": "thread-live-plan-updates"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list", "turn/start"]
+      }
+    },
+    {
+      "id": "initialize-2",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": ["thread/list", "thread/read", "skills/list", "turn/start"]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-live-plan-updates",
+          "title": "Live plan updates replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded live plan update lifecycle",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563600000
+        }
+      ]
+    },
+    {
+      "id": "thread-list-2",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-live-plan-updates",
+          "title": "Live plan updates replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded live plan update lifecycle",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563600000
+        }
+      ]
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          }
+        ],
+        "lastAssistantMessage": "Ready for the next renderer check.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-live-plan-updates",
+        "runId": "turn-live-plan-1"
+      }
+    },
+    {
+      "id": "thread-read-2",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          }
+        ],
+        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
+        "lastAssistantMessage": "Ready for the next renderer check.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "status-active-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-live-plan-updates",
+          "status": {
+            "type": "active",
+            "activeFlags": []
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-live-plan-updates",
+          "turn": {
+            "id": "turn-live-plan-1",
+            "status": "inProgress"
+          }
+        }
+      }
+    },
+    {
+      "id": "plan-updated-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/plan/updated",
+        "params": {
+          "threadId": "thread-live-plan-updates",
+          "runId": "turn-live-plan-1",
+          "plan": {
+            "explanation": "Check the shared contract and transcript renderer before summarizing the dependency.",
+            "steps": [
+              {
+                "step": "Inspect AppServerThreadPlanEntry",
+                "status": "completed"
+              },
+              {
+                "step": "Inspect TranscriptPlan rendering",
+                "status": "in_progress"
+              },
+              {
+                "step": "Summarize renderer dependency",
+                "status": "pending"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-completed-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-live-plan-updates",
+          "turnId": "turn-live-plan-1"
+        }
+      }
+    },
+    {
+      "id": "thread-list-3",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-live-plan-updates",
+          "title": "Live plan updates replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded live plan update lifecycle",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563600000
+        }
+      ]
+    },
+    {
+      "id": "thread-list-4",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-live-plan-updates",
+          "title": "Live plan updates replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded live plan update lifecycle",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563600000
+        }
+      ]
+    },
+    {
+      "id": "skills-list-2",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
+    },
+    {
+      "id": "thread-read-3",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          },
+          {
+            "type": "plan",
+            "id": "persisted-plan-1",
+            "createdAt": 1776563601000,
+            "explanation": "Check the shared contract and transcript renderer before summarizing the dependency.",
+            "steps": [
+              {
+                "step": "Inspect AppServerThreadPlanEntry",
+                "status": "completed"
+              },
+              {
+                "step": "Inspect TranscriptPlan rendering",
+                "status": "in_progress"
+              },
+              {
+                "step": "Summarize renderer dependency",
+                "status": "pending"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "id": "message-3",
+            "role": "assistant",
+            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          },
+          {
+            "id": "message-3",
+            "role": "assistant",
+            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
+          }
+        ],
+        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
+        "lastAssistantMessage": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "thread-read-4",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          },
+          {
+            "type": "plan",
+            "id": "persisted-plan-1",
+            "createdAt": 1776563601000,
+            "explanation": "Check the shared contract and transcript renderer before summarizing the dependency.",
+            "steps": [
+              {
+                "step": "Inspect AppServerThreadPlanEntry",
+                "status": "completed"
+              },
+              {
+                "step": "Inspect TranscriptPlan rendering",
+                "status": "in_progress"
+              },
+              {
+                "step": "Summarize renderer dependency",
+                "status": "pending"
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "id": "message-3",
+            "role": "assistant",
+            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next renderer check."
+          },
+          {
+            "id": "message-2",
+            "role": "user",
+            "text": "Create a three-step task list before you inspect the renderer."
+          },
+          {
+            "id": "message-3",
+            "role": "assistant",
+            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
+          }
+        ],
+        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
+        "lastAssistantMessage": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/todo-list-rendering.spec.ts
+++ b/apps/desktop/e2e/todo-list-rendering.spec.ts
@@ -80,3 +80,41 @@ test("renders the Grok task plan contract with mixed step states", async () => {
     await app.close();
   }
 });
+
+test("renders live plan updates from turn/plan/updated notifications", async () => {
+  const app = await openThreadByTitle(
+    path.resolve(
+      todoListSpecDir,
+      "fixtures/live-plan-updates/replay.fixture.json"
+    ),
+    "Live plan updates replay"
+  );
+
+  try {
+    await app.window
+      .getByLabel("Reply")
+      .fill("Create a three-step task list before you inspect the renderer.");
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const planGroups = transcript.getByRole("group", { name: "Task plan" });
+
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "plan-updated-1" });
+
+    await expect(planGroups).toHaveCount(1);
+    await expect(planGroups.first()).toContainText("1 out of 3 tasks completed");
+    await expect(planGroups.first()).toContainText(
+      "Check the shared contract and transcript renderer before summarizing the dependency."
+    );
+    await expect(planGroups.first()).toContainText("Inspect AppServerThreadPlanEntry");
+    await expect(planGroups.first()).toContainText("Inspect TranscriptPlan rendering");
+    await expect(planGroups.first()).toContainText("Summarize renderer dependency");
+
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/todo-list-rendering.spec.ts
+++ b/apps/desktop/e2e/todo-list-rendering.spec.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const todoListSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function openThreadByTitle(
+  fixturePath: string,
+  threadTitle: string
+) {
+  const app = await launchElectronApp({ fixturePath });
+
+  await app.window.getByRole("button", { name: new RegExp(threadTitle, "i") }).first().click();
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: threadTitle
+    })
+  ).toBeVisible();
+
+  return app;
+}
+
+test("renders a persisted Codex task plan when the thread is selected", async () => {
+  const app = await openThreadByTitle(
+    path.resolve(
+      todoListSpecDir,
+      "fixtures/codex-todo-list/replay.fixture.json"
+    ),
+    "Add AGENTS docs for media VCL"
+  );
+
+  try {
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const plan = transcript.getByRole("group", { name: "Task plan" });
+
+    await expect(plan).toBeVisible();
+    await expect(plan).toContainText("0 out of 3 tasks completed");
+    await expect(plan).toContainText(
+      "Start the implementation by creating a local root plan file named `IMPLEMENTATION_PLAN.local.md` and add that exact filename to `.gitignore`."
+    );
+    await expect(plan).toContainText(
+      "The local plan file should begin with a short facts/goals section, followed by a `To-Do` section using Markdown checkboxes that get updated as work is completed."
+    );
+    await expect(plan).toContainText(
+      "Establish the repo pattern for scoped context, but implement it fully only for `gif-media` in this pass."
+    );
+    await expect(plan.getByText("Pending", { exact: true })).toHaveCount(3);
+  } finally {
+    await app.close();
+  }
+});
+
+test("renders the Grok task plan contract with mixed step states", async () => {
+  const app = await openThreadByTitle(
+    path.resolve(
+      todoListSpecDir,
+      "fixtures/grok-todo-list/replay.fixture.json"
+    ),
+    "Grok to-do list replay"
+  );
+
+  try {
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const plan = transcript.getByRole("group", { name: "Task plan" });
+
+    await expect(plan).toBeVisible();
+    await expect(plan).toContainText("1 out of 3 tasks completed");
+    await expect(plan).toContainText(
+      "Checking the shared contract and renderer before summarizing the dependency."
+    );
+    await expect(plan).toContainText("Inspect contract type");
+    await expect(plan).toContainText("Inspect renderer usage");
+    await expect(plan).toContainText("Summarize dependency");
+    await expect(plan.getByText("Completed", { exact: true })).toBeVisible();
+    await expect(plan.getByText("In progress", { exact: true })).toBeVisible();
+    await expect(plan.getByText("Pending", { exact: true })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1055,7 +1055,13 @@ describe("CodexAppServerClient", () => {
         id: "item-1",
         role: "user",
         text: "Plan the desktop transcript work.",
-        createdAt: 1_763_500_200_000
+        createdAt: 1_763_500_200_000,
+        parts: [
+          {
+            type: "text",
+            text: "Plan the desktop transcript work."
+          }
+        ]
       },
       {
         type: "plan",
@@ -1120,7 +1126,13 @@ describe("CodexAppServerClient", () => {
         id: "item-1",
         role: "user",
         text: "Build the task list rendering.",
-        createdAt: 1_763_500_300_000
+        createdAt: 1_763_500_300_000,
+        parts: [
+          {
+            type: "text",
+            text: "Build the task list rendering."
+          }
+        ]
       },
       {
         type: "plan",
@@ -1131,6 +1143,81 @@ describe("CodexAppServerClient", () => {
           { step: "Normalize replay", status: "pending" },
           { step: "Render plan cards", status: "pending" },
           { step: "Verify with tests", status: "pending" }
+        ]
+      }
+    ]);
+
+    await client.close();
+  });
+
+  it("extracts wrapped update_plan response items from thread/read", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-wrapped-plan-call", {
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            startedAt: 1_763_500_350,
+            items: [
+              {
+                type: "userMessage",
+                id: "item-1",
+                content: [{ type: "text", text: "Trace the image preview bug." }]
+              },
+              {
+                type: "response_item",
+                id: "item-2",
+                payload: {
+                  type: "function_call",
+                  name: "update_plan",
+                  arguments: JSON.stringify({
+                    explanation: "Verify the renderer path before changing it.",
+                    plan: [
+                      { step: "Read the replay normalizer", status: "completed" },
+                      { step: "Inspect the renderer", status: "in_progress" },
+                      { step: "Summarize the findings", status: "pending" }
+                    ]
+                  })
+                }
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-wrapped-plan-call"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "item-1",
+        role: "user",
+        text: "Trace the image preview bug.",
+        createdAt: 1_763_500_350_000,
+        parts: [
+          {
+            type: "text",
+            text: "Trace the image preview bug."
+          }
+        ]
+      },
+      {
+        type: "plan",
+        id: "item-2",
+        createdAt: 1_763_500_350_000,
+        explanation: "Verify the renderer path before changing it.",
+        steps: [
+          { step: "Read the replay normalizer", status: "completed" },
+          { step: "Inspect the renderer", status: "in_progress" },
+          { step: "Summarize the findings", status: "pending" }
         ]
       }
     ]);

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4,6 +4,7 @@ import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
   static readThreadErrorByThreadId = new Map<string, { code: number; message: string }>();
+  static readThreadResultByThreadId = new Map<string, unknown>();
   static threadStartResult: unknown = {
     thread: {
       id: "thread-3",
@@ -201,12 +202,26 @@ class MockTransport implements JsonRpcTransport {
       const readThreadError = threadId
         ? MockTransport.readThreadErrorByThreadId.get(threadId)
         : undefined;
+      const readThreadResult = threadId
+        ? MockTransport.readThreadResultByThreadId.get(threadId)
+        : undefined;
       if (readThreadError) {
         this.messageHandler(
           JSON.stringify({
             jsonrpc: "2.0",
             id: payload.id,
             error: readThreadError
+          })
+        );
+        return;
+      }
+
+      if (readThreadResult) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: readThreadResult
           })
         );
         return;
@@ -447,6 +462,7 @@ describe("CodexAppServerClient", () => {
   beforeEach(() => {
     MockTransport.instances.length = 0;
     MockTransport.readThreadErrorByThreadId.clear();
+    MockTransport.readThreadResultByThreadId.clear();
     MockTransport.threadStartResult = {
       thread: {
         id: "thread-3",
@@ -991,6 +1007,133 @@ describe("CodexAppServerClient", () => {
       }
     ]);
     expect(replay.lastUserMessage).toBe("Describe this image");
+
+    await client.close();
+  });
+
+  it("extracts structured plan items from thread/read", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-plan-item", {
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            startedAt: 1_763_500_200,
+            items: [
+              {
+                type: "userMessage",
+                id: "item-1",
+                content: [{ type: "text", text: "Plan the desktop transcript work." }]
+              },
+              {
+                type: "plan",
+                id: "plan-1",
+                explanation: "Keep the transcript contract stable.",
+                steps: [
+                  { step: "Normalize replay", status: "completed" },
+                  { step: "Render live plan progress", status: "in_progress" }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-plan-item"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "item-1",
+        role: "user",
+        text: "Plan the desktop transcript work.",
+        createdAt: 1_763_500_200_000
+      },
+      {
+        type: "plan",
+        id: "plan-1",
+        createdAt: 1_763_500_200_000,
+        explanation: "Keep the transcript contract stable.",
+        steps: [
+          { step: "Normalize replay", status: "completed" },
+          { step: "Render live plan progress", status: "in_progress" }
+        ]
+      }
+    ]);
+
+    await client.close();
+  });
+
+  it("extracts update_plan function calls from thread/read", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-plan-call", {
+      thread: {
+        turns: [
+          {
+            id: "turn-1",
+            startedAt: 1_763_500_300,
+            items: [
+              {
+                type: "userMessage",
+                id: "item-1",
+                content: [{ type: "text", text: "Build the task list rendering." }]
+              },
+              {
+                type: "function_call",
+                id: "item-2",
+                name: "update_plan",
+                arguments: JSON.stringify({
+                  explanation: "Track the desktop work in three steps.",
+                  plan: [
+                    { step: "Normalize replay", status: "pending" },
+                    { step: "Render plan cards", status: "pending" },
+                    { step: "Verify with tests", status: "pending" }
+                  ]
+                })
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-plan-call"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "item-1",
+        role: "user",
+        text: "Build the task list rendering.",
+        createdAt: 1_763_500_300_000
+      },
+      {
+        type: "plan",
+        id: "item-2",
+        createdAt: 1_763_500_300_000,
+        explanation: "Track the desktop work in three steps.",
+        steps: [
+          { step: "Normalize replay", status: "pending" },
+          { step: "Render plan cards", status: "pending" },
+          { step: "Verify with tests", status: "pending" }
+        ]
+      }
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -15,6 +15,9 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadPlanEntry,
+  AppServerThreadPlanStep,
+  AppServerThreadPlanStepStatus,
   AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadReplayPagination,
@@ -553,6 +556,192 @@ function normalizeActivityStatus(
   return undefined;
 }
 
+function normalizePlanStepStatus(
+  value: string | undefined
+): AppServerThreadPlanStepStatus | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (
+    normalized === "pending" ||
+    normalized === "in_progress" ||
+    normalized === "completed"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function collectPlanLines(text: string): AppServerThreadPlanStep[] {
+  const steps = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line): AppServerThreadPlanStep[] => {
+      const completedMatch = line.match(/^[-*]\s+\[(x|X)\]\s+(.+)$/);
+      if (completedMatch) {
+        return [{ step: completedMatch[2].trim(), status: "completed" }];
+      }
+
+      const pendingMatch = line.match(/^[-*]\s+\[\s?\]\s+(.+)$/);
+      if (pendingMatch) {
+        return [{ step: pendingMatch[1].trim(), status: "pending" }];
+      }
+
+      const bulletMatch = line.match(/^([-*]|\d+\.)\s+(.+)$/);
+      if (bulletMatch) {
+        return [{ step: bulletMatch[2].trim(), status: "pending" }];
+      }
+
+      return [];
+    })
+    .filter((step) => step.step.length > 0);
+
+  const deduped = new Map<string, AppServerThreadPlanStep>();
+  for (const step of steps) {
+    deduped.set(`${step.status}:${step.step}`, step);
+  }
+  return [...deduped.values()];
+}
+
+function normalizePlanSteps(value: unknown): AppServerThreadPlanStep[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry): AppServerThreadPlanStep[] => {
+    const record = asRecord(entry);
+    if (!record) {
+      return [];
+    }
+
+    const step = pickString(record, ["step", "title", "text", "label"]);
+    const status = normalizePlanStepStatus(pickString(record, ["status", "state"]));
+    if (!step || !status) {
+      return [];
+    }
+
+    return [{ step, status }];
+  });
+}
+
+function normalizePlanPayload(value: unknown): {
+  explanation?: string;
+  steps: AppServerThreadPlanStep[];
+} | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const directSteps = normalizePlanSteps(record.steps);
+  const nestedPlanRecord = asRecord(record.plan);
+  const nestedPlanSteps = normalizePlanSteps(record.plan);
+  const nestedRecordSteps = normalizePlanSteps(nestedPlanRecord?.steps);
+  const steps =
+    directSteps.length > 0
+      ? directSteps
+      : nestedPlanSteps.length > 0
+        ? nestedPlanSteps
+        : nestedRecordSteps;
+  const explanation =
+    pickString(record, ["explanation", "summary"]) ??
+    pickString(nestedPlanRecord ?? {}, ["explanation", "summary"]);
+
+  if (steps.length === 0 && !explanation) {
+    return undefined;
+  }
+
+  return {
+    ...(explanation ? { explanation } : {}),
+    steps,
+  };
+}
+
+function parseStructuredValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractPlanEntryFromItem(
+  item: Record<string, unknown>,
+  createdAt?: number
+): AppServerThreadPlanEntry | undefined {
+  const itemType = pickString(item, ["type"]);
+  const normalizedItemType = itemType?.trim().toLowerCase();
+  const itemId =
+    pickString(item, ["id", "itemId", "item_id", "call_id"]) ?? `plan-${createdAt ?? 0}`;
+
+  if (normalizedItemType === "plan") {
+    const normalizedPayload = normalizePlanPayload(item);
+    const textSteps = collectPlanLines(collectMessageText(item));
+    const steps = normalizedPayload?.steps.length
+      ? normalizedPayload.steps
+      : textSteps;
+    const explanation = normalizedPayload?.explanation;
+
+    if (steps.length === 0 && !explanation) {
+      return undefined;
+    }
+
+    return {
+      type: "plan",
+      id: itemId,
+      createdAt,
+      ...(explanation ? { explanation } : {}),
+      steps,
+    };
+  }
+
+  const functionLikeTypes = new Set([
+    "functioncall",
+    "function_call",
+    "dynamictoolcall",
+    "dynamic_tool_call",
+  ]);
+  const normalizedCollapsedType = normalizedItemType?.replace(/[-_\s]/g, "");
+  if (!normalizedCollapsedType || !functionLikeTypes.has(normalizedCollapsedType)) {
+    return undefined;
+  }
+
+  const functionName = pickString(item, ["name", "toolName", "tool_name", "text"]);
+  if (functionName !== "update_plan") {
+    return undefined;
+  }
+
+  const payload =
+    parseStructuredValue(item.arguments) ??
+    parseStructuredValue(item.input) ??
+    parseStructuredValue(item.output) ??
+    asRecord(item.arguments) ??
+    asRecord(item.input) ??
+    asRecord(item.output);
+  const normalizedPayload = normalizePlanPayload(payload);
+  if (!normalizedPayload) {
+    return undefined;
+  }
+
+  return {
+    type: "plan",
+    id: itemId,
+    createdAt,
+    ...(normalizedPayload.explanation
+      ? { explanation: normalizedPayload.explanation }
+      : {}),
+    steps: normalizedPayload.steps,
+  };
+}
+
 function pushActivityDetail(
   details: AppServerThreadActivityDetail[],
   detail: AppServerThreadActivityDetail
@@ -861,6 +1050,13 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
             ? { phase: "commentary" as const }
             : {})
         });
+        continue;
+      }
+
+      const planEntry = extractPlanEntryFromItem(item, createdAt);
+      if (planEntry) {
+        flushActivityItems();
+        entries.push(planEntry);
         continue;
       }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -673,6 +673,33 @@ function parseStructuredValue(value: unknown): unknown {
   }
 }
 
+function extractNestedPlanEntryFromItem(
+  item: Record<string, unknown>,
+  createdAt?: number
+): AppServerThreadPlanEntry | undefined {
+  for (const key of ["payload", "item", "responseItem", "response_item"]) {
+    const nestedItem = asRecord(item[key]);
+    if (!nestedItem) {
+      continue;
+    }
+
+    const nestedPlanEntry = extractPlanEntryFromItem(
+      {
+        ...nestedItem,
+        id:
+          pickString(item, ["id", "itemId", "item_id"]) ??
+          pickString(nestedItem, ["id", "itemId", "item_id", "call_id"])
+      },
+      createdAt
+    );
+    if (nestedPlanEntry) {
+      return nestedPlanEntry;
+    }
+  }
+
+  return undefined;
+}
+
 function extractPlanEntryFromItem(
   item: Record<string, unknown>,
   createdAt?: number
@@ -681,10 +708,14 @@ function extractPlanEntryFromItem(
   const normalizedItemType = itemType?.trim().toLowerCase();
   const itemId =
     pickString(item, ["id", "itemId", "item_id", "call_id"]) ?? `plan-${createdAt ?? 0}`;
+  const nestedPlanEntry = extractNestedPlanEntryFromItem(item, createdAt);
+  if (nestedPlanEntry) {
+    return nestedPlanEntry;
+  }
 
   if (normalizedItemType === "plan") {
     const normalizedPayload = normalizePlanPayload(item);
-    const textSteps = collectPlanLines(collectMessageText(item));
+    const textSteps = collectPlanLines(collectLegacyMessageText(item));
     const steps = normalizedPayload?.steps.length
       ? normalizedPayload.steps
       : textSteps;

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -55,6 +55,16 @@ describe("App", () => {
             text: "Open the desktop plan and build the Codex client."
           },
           {
+            type: "plan",
+            id: "plan-1",
+            explanation: "Track the desktop transcript work in three steps.",
+            steps: [
+              { step: "Normalize replay", status: "pending" },
+              { step: "Render plan card", status: "pending" },
+              { step: "Verify with tests", status: "pending" }
+            ]
+          },
+          {
             type: "activity",
             id: "activity-1",
             summary: "Explored 2 files, ran 1 command",
@@ -286,6 +296,8 @@ describe("App", () => {
     expect(
       screen.getByText("The Codex client is wired and the thread browser is live.")
     ).toBeInTheDocument();
+    expect(screen.getByText("0 out of 3 tasks completed")).toBeInTheDocument();
+    expect(screen.getByText("Render plan card")).toBeInTheDocument();
     expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();
     const openContextButton = screen.getByRole("button", { name: "Open context rail" });
     openContextButton.click();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -4,6 +4,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadPlanEntry,
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
   BackendSummary,
@@ -23,6 +24,24 @@ function formatRendererLogPayload(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function arePlanEntriesEquivalent(
+  left: AppServerThreadPlanEntry,
+  right: AppServerThreadPlanEntry
+): boolean {
+  if ((left.explanation ?? "").trim() !== (right.explanation ?? "").trim()) {
+    return false;
+  }
+
+  if (left.steps.length !== right.steps.length) {
+    return false;
+  }
+
+  return left.steps.every((step, index) => {
+    const other = right.steps[index];
+    return other?.status === step.status && other.step === step.step;
+  });
 }
 
 type ThreadViewProps = {
@@ -55,6 +74,8 @@ export function ThreadView(props: ThreadViewProps) {
   const [pendingStatusText, setPendingStatusText] = useState<string>();
   const [pendingAssistantMessage, setPendingAssistantMessage] =
     useState<AppServerThreadMessageEntry>();
+  const [pendingPlanEntry, setPendingPlanEntry] =
+    useState<AppServerThreadPlanEntry>();
   const [pendingRequest, setPendingRequest] =
     useState<AppServerPendingRequestNotification>();
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
@@ -63,6 +84,7 @@ export function ThreadView(props: ThreadViewProps) {
 
   useEffect(() => {
     setPendingAssistantMessage(undefined);
+    setPendingPlanEntry(undefined);
     setPendingRequest(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
@@ -70,6 +92,20 @@ export function ThreadView(props: ThreadViewProps) {
   }, [props.selectedThread?.id, props.selectedThread?.source]);
 
   const selectedThread = props.selectedThread;
+
+  useEffect(() => {
+    if (!pendingPlanEntry) {
+      return;
+    }
+
+    const persistedPlan = props.transcriptEntries.find(
+      (entry): entry is AppServerThreadPlanEntry =>
+        entry.type === "plan" && arePlanEntriesEquivalent(entry, pendingPlanEntry)
+    );
+    if (persistedPlan) {
+      setPendingPlanEntry(undefined);
+    }
+  }, [pendingPlanEntry, props.transcriptEntries]);
 
   useEffect(() => {
     if (!props.desktopApi?.onAgentEvent || !selectedThread) {
@@ -83,6 +119,15 @@ export function ThreadView(props: ThreadViewProps) {
         typeof event.notification.params.status === "object" &&
         event.notification.params.status !== null
           ? (event.notification.params.status as { type?: unknown })
+          : undefined;
+      const planRecord =
+        method === "turn/plan/updated" &&
+        typeof event.notification.params.plan === "object" &&
+        event.notification.params.plan !== null
+          ? (event.notification.params.plan as {
+              explanation?: unknown;
+              steps?: unknown;
+            })
           : undefined;
       if (
         event.backend !== selectedThread.source ||
@@ -101,6 +146,29 @@ export function ThreadView(props: ThreadViewProps) {
         setPendingRequestBusy(false);
         setPendingRequestError(undefined);
         setPendingStatusText("Waiting for approval");
+        return;
+      }
+
+      if (
+        method === "turn/plan/updated" &&
+        Array.isArray(planRecord?.steps)
+      ) {
+        const explanation =
+          typeof planRecord.explanation === "string" &&
+          planRecord.explanation.trim()
+            ? planRecord.explanation.trim()
+            : undefined;
+        setPendingPlanEntry({
+          type: "plan",
+          id: `live-plan-${
+            typeof event.notification.params.runId === "string"
+              ? event.notification.params.runId
+              : selectedThread.id
+          }`,
+          createdAt: Date.now(),
+          ...(explanation ? { explanation } : {}),
+          steps: planRecord.steps
+        });
         return;
       }
 
@@ -236,6 +304,7 @@ export function ThreadView(props: ThreadViewProps) {
             loading={props.loading}
             loadingMore={props.loadingMore}
             pendingAssistantMessage={pendingAssistantMessage}
+            pendingPlanEntry={pendingPlanEntry}
             pendingRequest={pendingRequest}
             pendingRequestBusy={pendingRequestBusy}
             pendingStatusText={pendingStatusText}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -4,12 +4,14 @@ import type {
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadPlanEntry,
   AppServerSkillSummary,
   AppServerThreadReplayPagination
 } from "@pwragnt/shared";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
+import { TranscriptPlan } from "./TranscriptPlan";
 
 type TranscriptListProps = {
   entries: AppServerThreadEntry[];
@@ -17,6 +19,7 @@ type TranscriptListProps = {
   loading: boolean;
   loadingMore: boolean;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingRequestBusy?: boolean;
   pendingStatusText?: string;
@@ -63,6 +66,7 @@ export function TranscriptList(props: TranscriptListProps) {
     const itemCount =
       props.entries.length +
       (props.pendingAssistantMessage ? 1 : 0) +
+      (props.pendingPlanEntry ? 1 : 0) +
       (props.pendingStatusText ? 1 : 0) +
       (props.pendingRequest ? 1 : 0);
     const distanceFromBottom = Math.max(
@@ -84,6 +88,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [
     props.entries,
     props.pendingAssistantMessage,
+    props.pendingPlanEntry,
     props.pendingRequest,
     props.pendingStatusText,
     props.threadId
@@ -149,6 +154,7 @@ export function TranscriptList(props: TranscriptListProps) {
           previousSnapshot.itemCount <
             props.entries.length +
               (props.pendingAssistantMessage ? 1 : 0) +
+              (props.pendingPlanEntry ? 1 : 0) +
               (props.pendingStatusText ? 1 : 0) +
               (props.pendingRequest ? 1 : 0))
     );
@@ -176,6 +182,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [
     props.entries,
     props.pendingAssistantMessage,
+    props.pendingPlanEntry,
     props.pendingRequest,
     props.pendingStatusText,
     props.threadId,
@@ -220,6 +227,8 @@ export function TranscriptList(props: TranscriptListProps) {
         {props.entries.map((entry) =>
           entry.type === "activity" ? (
             <TranscriptActivity key={entry.id} entry={entry} />
+          ) : entry.type === "plan" ? (
+            <TranscriptPlan key={entry.id} entry={entry} />
           ) : (
             <TranscriptMessage
               key={entry.id}
@@ -229,6 +238,9 @@ export function TranscriptList(props: TranscriptListProps) {
             />
           )
         )}
+        {props.pendingPlanEntry ? (
+          <TranscriptPlan key={props.pendingPlanEntry.id} entry={props.pendingPlanEntry} />
+        ) : null}
         {props.pendingAssistantMessage ? (
           <TranscriptMessage
             key={props.pendingAssistantMessage.id}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
@@ -1,0 +1,68 @@
+import type { AppServerThreadPlanEntry } from "@pwragnt/shared";
+
+type TranscriptPlanProps = {
+  entry: AppServerThreadPlanEntry;
+};
+
+function formatPlanSummary(completedCount: number, totalCount: number): string {
+  const taskLabel = totalCount === 1 ? "task" : "tasks";
+  return `${completedCount} out of ${totalCount} ${taskLabel} completed`;
+}
+
+function formatStepStatus(status: AppServerThreadPlanEntry["steps"][number]["status"]): string {
+  if (status === "in_progress") {
+    return "In progress";
+  }
+  return status[0].toUpperCase() + status.slice(1);
+}
+
+export function TranscriptPlan(props: TranscriptPlanProps) {
+  const completedCount = props.entry.steps.filter(
+    (step) => step.status === "completed"
+  ).length;
+
+  return (
+    <aside className="transcript-plan" role="group" aria-label="Task plan">
+      <header className="transcript-plan__header">
+        <div className="transcript-plan__copy">
+          <p className="transcript-plan__summary">
+            {props.entry.steps.length > 0
+              ? formatPlanSummary(completedCount, props.entry.steps.length)
+              : "Plan update"}
+          </p>
+          {props.entry.explanation ? (
+            <p className="transcript-plan__explanation">{props.entry.explanation}</p>
+          ) : null}
+        </div>
+        {props.entry.createdAt ? (
+          <time className="transcript-message__time">
+            {new Intl.DateTimeFormat(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit"
+            }).format(props.entry.createdAt)}
+          </time>
+        ) : null}
+      </header>
+
+      {props.entry.steps.length > 0 ? (
+        <ol className="transcript-plan__steps">
+          {props.entry.steps.map((step, index) => (
+            <li key={`${step.status}:${step.step}:${index}`} className="transcript-plan__step">
+              <span
+                className={`transcript-plan__step-status transcript-plan__step-status--${step.status}`}
+                aria-hidden="true"
+              />
+              <span className="transcript-plan__step-index">{index + 1}.</span>
+              <span className="transcript-plan__step-text">{step.step}</span>
+              <span className="transcript-plan__step-label">
+                {formatStepStatus(step.status)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppServerNotification } from "@pwragnt/shared";
 import { ThreadView } from "../ThreadView";
 
 afterEach(() => {
@@ -19,6 +20,10 @@ beforeEach(() => {
 });
 
 describe("ThreadView", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders a directory-less thread with transcript history and context", () => {
     render(
       <ThreadView
@@ -627,5 +632,200 @@ describe("ThreadView", () => {
     });
 
     expect(screen.queryByText("I ran")).not.toBeInTheDocument();
+  });
+
+  it("renders live plan progress from turn/plan/updated and clears it once replay catches up", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Plan the app-server protocol",
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    const livePlan = {
+      type: "plan" as const,
+      id: "persisted-plan-1",
+      explanation: "Track the desktop transcript work in three steps.",
+      steps: [
+        { step: "Normalize replay", status: "pending" as const },
+        { step: "Render plan card", status: "pending" as const },
+        { step: "Verify the thread view", status: "pending" as const }
+      ]
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    const { rerender } = render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Render the task list."
+          }
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={vi.fn(async () => undefined)}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/plan/updated",
+          params: {
+            threadId: "thread-2",
+            runId: "turn-1",
+            plan: {
+              explanation: livePlan.explanation,
+              steps: livePlan.steps
+            }
+          }
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/plan/updated",
+          params: {
+            threadId: "thread-other",
+            runId: "turn-2",
+            plan: {
+              explanation: "Ignore this other thread.",
+              steps: [{ step: "Ignore", status: "completed" }]
+            }
+          }
+        },
+      });
+    });
+
+    expect(screen.getByText("0 out of 3 tasks completed")).toBeInTheDocument();
+    expect(screen.getByText("Normalize replay")).toBeInTheDocument();
+    expect(screen.getByText("Render plan card")).toBeInTheDocument();
+    expect(screen.getByText("Verify the thread view")).toBeInTheDocument();
+    expect(screen.queryByText("Ignore this other thread.")).not.toBeInTheDocument();
+
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Render the task list."
+          },
+          livePlan
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={vi.fn(async () => undefined)}
+      />
+    );
+
+    expect(screen.getAllByText("0 out of 3 tasks completed")).toHaveLength(1);
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -638,6 +638,7 @@ describe("ThreadView", () => {
     const selectedThread = {
       id: "thread-2",
       title: "Plan the app-server protocol",
+      titleSource: "explicit" as const,
       source: "codex" as const,
       updatedAt: Date.now(),
       linkedDirectories: [],

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -295,6 +295,44 @@ describe("TranscriptList", () => {
     expect(screen.getByRole("status").querySelector(".thinking-scanner")).not.toBeNull();
   });
 
+  it("renders replayed plan progress inline in the transcript", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Show the desktop task list."
+          },
+          {
+            type: "plan",
+            id: "plan-1",
+            explanation: "Keep the renderer and replay contract aligned.",
+            steps: [
+              { step: "Normalize replay", status: "pending" },
+              { step: "Render transcript plan card", status: "pending" },
+              { step: "Verify with tests", status: "pending" }
+            ]
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByText("0 out of 3 tasks completed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keep the renderer and replay contract aligned.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Normalize replay")).toBeInTheDocument();
+    expect(screen.getByText("Render transcript plan card")).toBeInTheDocument();
+    expect(screen.getByText("Verify with tests")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending")).toHaveLength(3);
+  });
+
   it("renders a live assistant message before the turn is persisted", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -870,6 +870,102 @@ textarea {
   border-top: 1px solid var(--border-subtle);
 }
 
+.transcript-plan {
+  width: min(100%, 760px);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.transcript-plan__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.transcript-plan__copy {
+  min-width: 0;
+}
+
+.transcript-plan__summary,
+.transcript-plan__explanation {
+  margin: 0;
+}
+
+.transcript-plan__summary {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.transcript-plan__explanation {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.transcript-plan__steps {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.transcript-plan__step {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.transcript-plan__step:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.transcript-plan__step-status {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px;
+  border-radius: 999px;
+  background: var(--text-muted);
+}
+
+.transcript-plan__step-status--completed {
+  background: var(--accent);
+}
+
+.transcript-plan__step-status--in_progress {
+  background: #6fb7ff;
+}
+
+.transcript-plan__step-index,
+.transcript-plan__step-label {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.transcript-plan__step-text {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .transcript-list__items > .transcript-activity:first-child {
   padding-top: 0;
   border-top: 0;

--- a/docs/plans/2026-04-17-001-feat-desktop-plan-rendering-plan.md
+++ b/docs/plans/2026-04-17-001-feat-desktop-plan-rendering-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Render plan progress in the desktop thread transcript
 type: feat
-status: active
+status: completed
 date: 2026-04-17
 origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
 ---
@@ -142,7 +142,7 @@ Ship a dedicated transcript plan component, styling, and regression coverage for
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend transcript contracts and replay normalization for plans**
+- [x] **Unit 1: Extend transcript contracts and replay normalization for plans**
 
 **Goal:** Preserve plan/task-list artifacts when the desktop main process converts backend thread history into transcript entries.
 
@@ -176,7 +176,7 @@ Ship a dedicated transcript plan component, styling, and regression coverage for
 **Verification:**
 - `readThread(...)` returns replay entries that include plan artifacts instead of dropping them.
 
-- [ ] **Unit 2: Add live plan progress state for the selected thread**
+- [x] **Unit 2: Add live plan progress state for the selected thread**
 
 **Goal:** Let the open thread update immediately when a running turn emits structured plan progress.
 
@@ -209,7 +209,7 @@ Ship a dedicated transcript plan component, styling, and regression coverage for
 **Verification:**
 - A running turn can show evolving plan state in the thread detail view before the next manual refresh.
 
-- [ ] **Unit 3: Build the transcript-native plan card and lock down renderer regressions**
+- [x] **Unit 3: Build the transcript-native plan card and lock down renderer regressions**
 
 **Goal:** Present plan progress in a compact desktop transcript surface that matches the existing shell tone and remains testable.
 

--- a/docs/plans/2026-04-17-001-feat-desktop-plan-rendering-plan.md
+++ b/docs/plans/2026-04-17-001-feat-desktop-plan-rendering-plan.md
@@ -1,0 +1,247 @@
+---
+title: feat: Render plan progress in the desktop thread transcript
+type: feat
+status: active
+date: 2026-04-17
+origin: docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md
+---
+
+# feat: Render plan progress in the desktop thread transcript
+
+## Overview
+
+Add first-class transcript rendering for agent plans in the desktop app so historical replay and live updates can show the same task-list progress already present in the underlying app-server events. The immediate trigger is the Codex thread `019d99bf-f7f0-7531-99b9-850b300dde5a`, where around 2026-04-17 13:39 EDT another surface rendered a three-step task list while PwrAgnt showed only ordinary transcript content.
+
+## Problem Frame
+
+The desktop product direction says users should be able to inspect progress and results inside the app, with the thread as the primary surface (see origin: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`). The protocol layer is already close to supporting that:
+
+- `packages/shared/src/contracts/app-server.ts` already models `item/plan/delta` and `turn/plan/updated`
+- `packages/agent-core/src/app-server/turn-runner.ts` already emits those notifications
+- `packages/agent-core/src/app-server/session-state.ts` already persists replay items of type `plan`
+
+The missing behavior is in the desktop client and renderer:
+
+- `apps/desktop/src/main/codex-app-server/client.ts` only normalizes replay entries into `message` and `activity`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` only renders those two entry types
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` listens for live assistant deltas and approval requests, but not live plan updates
+
+As a result, plan state exists on the wire but disappears before it reaches the transcript UI. The desktop app therefore fails a concrete progress-inspection use case already happening in real threads.
+
+## Requirements Trace
+
+- R1-R4. Threads remain first-class even when work starts before a repo is chosen; transcript progress should belong to the thread, not to a directory-specific side surface.
+- R10-R11. When a thread is opened, users should see enough operational context to understand what the agent is doing.
+- R22. The first milestone must let users run agent work, inspect progress, and review results inside the app.
+- User requirement: when a thread contains plan/task-list progress like the example from `019d99bf-f7f0-7531-99b9-850b300dde5a`, the desktop transcript should render it instead of dropping it.
+- Compatibility requirement: consume the existing app-server replay and notification surfaces rather than introducing a desktop-only task system.
+
+## Scope Boundaries
+
+- In scope: replay normalization for plan-bearing thread history in the desktop main process.
+- In scope: live renderer updates for `turn/plan/updated` and related plan progress while a selected thread is open.
+- In scope: dedicated transcript UI for plan/task-list state, including completion counts and step statuses.
+- In scope: tolerant handling of both durable `plan` replay items and recognizable Codex `update_plan`-style replay shapes when they appear in `thread/read`.
+- Out of scope: changing `packages/agent-core` notification semantics unless desktop integration reveals a contract gap.
+- Out of scope: sidebar, inbox, or navigation changes.
+- Out of scope: creating a standalone task manager, editable checklist UI, or a new authoring flow for plans.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/shared/src/contracts/app-server.ts` currently defines only two transcript entry variants: `message` and `activity`. It already carries the live plan notification types the renderer needs.
+- `apps/desktop/src/main/codex-app-server/client.ts` contains the replay normalizer. `extractThreadEntries(...)` currently flushes message items and command/file activity only; everything else is ignored.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` is already the boundary where live `onAgentEvent` notifications are filtered by backend plus thread id and turned into transient transcript state.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` is the existing chronological transcript container with scroll anchoring, pending status rendering, and entry-type dispatch.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx` is the local pattern for a compact, transcript-native non-message artifact. It is useful as a structural reference, but plan state should not be squeezed into generic activity.
+- `apps/desktop/src/renderer/src/styles/app.css` is the renderer stylesheet source of truth for transcript surfaces.
+- `apps/desktop/src/main/__tests__/codex-client.test.ts`, `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`, `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`, and `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` already cover the relevant replay, transcript, and live-event seams.
+
+### Existing Protocol Evidence
+
+- `packages/agent-core/src/__tests__/codex-turn-progress.test.ts` proves the server emits `turn/plan/updated` before terminal completion.
+- `packages/agent-core/src/__tests__/codex-tool-progress.test.ts` proves replay can persist `plan` items with accumulated text.
+- The existing app-server compatibility plan in `docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md` already calls out that OpenClaw reconstructs plan artifacts from `turn/plan/updated`, `item/plan/delta`, and `item/completed`.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist yet for this area.
+
+### External Research Decision
+
+Skipped. The problem is local contract consumption and renderer presentation, and this repository already contains the protocol types, test coverage, and desktop patterns needed to plan the work.
+
+## Key Technical Decisions
+
+- Add a dedicated `plan` transcript entry type to `packages/shared/src/contracts/app-server.ts` instead of overloading `activity`. Plan progress is a first-class thread artifact with different semantics, status display, and live-update behavior.
+- Normalize plan replay in the desktop main process, not in the renderer. The renderer should consume a stable transcript contract, not parse raw Codex or Grok read payloads.
+- Keep live plan state at the `ThreadView` boundary beside the existing live assistant-delta and approval-request handling. That keeps backend/thread filtering in one place and avoids turning `useThreadTranscript.ts` into a second event bus.
+- Render plans inline in transcript chronology rather than in a side panel. This preserves the thread-first information hierarchy and keeps progress attached to the point in the conversation where it occurred.
+- Derive completion counts strictly from step statuses. Do not invent inferred completion or hide unknown states behind optimistic UI.
+- Be tolerant of replay shape differences. Directionally, the desktop client should map both explicit replay items of type `plan` and recognizable `update_plan`/plan-output records into the same transcript entry when those shapes are present.
+- Follow the desktop style guide: neutral surfaces, compact layout, one accent color, no nested decorative cards, and radius at or below `8px`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should plan progress be rendered as generic transcript activity? No. It needs a dedicated entry shape and component.
+- Should live updates wait for a manual refresh? No. The selected thread should update immediately on `turn/plan/updated`.
+- Where should plan parsing live? In the desktop main-process read normalizer, not the renderer.
+- Should the feature depend on new server work first? No. Existing server-side plan notifications and replay persistence are already sufficient for a desktop follow-on.
+
+### Deferred to Implementation
+
+- Whether incomplete plan replay that only has freeform delta text and no structured steps should render as a draft plan card or stay hidden until a structured update arrives.
+- Whether very long plans should gain a collapsed secondary state in the first pass or only after real usage shows they dominate transcript height.
+- Whether `item/completed` for plan items should alter the visible plan card in addition to `turn/plan/updated`, or only remain a replay detail for parity.
+
+## High-Level Technical Design
+
+> This is directional guidance for review, not implementation specification.
+
+```mermaid
+flowchart TB
+    READ["thread/read payload"]
+    NORMALIZE["Desktop main normalizer\ncodex-app-server/client.ts"]
+    CONTRACT["Shared transcript contract\nmessage | activity | plan"]
+    REPLAY["useThreadTranscript replay state"]
+    LIVE["ThreadView live agent-event state"]
+    LIST["TranscriptList"]
+    PLAN["TranscriptPlan"]
+
+    READ --> NORMALIZE
+    NORMALIZE --> CONTRACT
+    CONTRACT --> REPLAY
+    LIVE --> LIST
+    REPLAY --> LIST
+    LIST --> PLAN
+```
+
+### Compatibility Rules
+
+- The renderer should only depend on normalized `AppServerThreadEntry` values, never on raw backend payload shapes.
+- Live plan updates must be ignored unless both `backend` and `threadId` match the selected thread.
+- Replay and live plan rendering should converge on one visual component so historical and in-flight states do not drift.
+- Unknown or malformed plan payloads should fail soft by omission rather than corrupting the rest of the transcript.
+
+## Phased Delivery
+
+### Phase 1
+
+Extend the shared desktop transcript contract and desktop read normalizer so plan-bearing replay survives `thread/read`.
+
+### Phase 2
+
+Add live selected-thread plan state driven by app-server notifications.
+
+### Phase 3
+
+Ship a dedicated transcript plan component, styling, and regression coverage for replay plus live updates.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend transcript contracts and replay normalization for plans**
+
+**Goal:** Preserve plan/task-list artifacts when the desktop main process converts backend thread history into transcript entries.
+
+**Requirements:** R22, user requirement, compatibility requirement
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+
+**Approach:**
+- Add a `AppServerThreadPlanEntry` type that can carry an optional explanation, ordered steps, and summary counts needed by the renderer.
+- Update the desktop replay normalizer to emit `plan` entries from structured replay items when present.
+- Add tolerant parsing for recognizable Codex `update_plan`-style replay data when the read payload exposes plan state through function-call artifacts instead of explicit `plan` items.
+- Keep plan entries ordered within the same turn chronology as neighboring messages and activity summaries.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `packages/agent-core/src/__tests__/codex-turn-progress.test.ts`
+- `packages/agent-core/src/__tests__/codex-tool-progress.test.ts`
+
+**Test scenarios:**
+- Happy path: `thread/read` payload with a structured `plan` item becomes a `plan` transcript entry with step statuses preserved.
+- Happy path: `thread/read` payload with recognizable `update_plan` call output becomes the same `plan` transcript entry shape.
+- Edge case: malformed or unrelated function-call items do not produce false-positive plan entries.
+- Edge case: a turn containing message, activity, and plan artifacts preserves transcript ordering.
+- Error path: unknown plan statuses or missing step text are ignored or sanitized without throwing away the rest of the thread replay.
+
+**Verification:**
+- `readThread(...)` returns replay entries that include plan artifacts instead of dropping them.
+
+- [ ] **Unit 2: Add live plan progress state for the selected thread**
+
+**Goal:** Let the open thread update immediately when a running turn emits structured plan progress.
+
+**Requirements:** R22, user requirement
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Extend the existing `onAgentEvent` handling in `ThreadView.tsx` to track the latest plan state for the selected thread.
+- Listen for `turn/plan/updated` as the primary structured source of truth for live task-list progress.
+- Clear or reconcile the transient live plan state on thread switches and terminal turn events so stale progress does not bleed into another thread.
+- Keep the change additive and local; do not refactor message replay loading and live event handling into one large new hook in the first pass.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+
+**Test scenarios:**
+- Happy path: `turn/plan/updated` for the selected Codex thread renders live progress without a refresh.
+- Happy path: terminal completion leaves the latest visible plan intact until persisted replay catches up.
+- Edge case: plan notifications for a different backend or different thread id are ignored.
+- Edge case: selecting a new thread clears the previous thread's transient live plan state.
+- Integration: after refresh or replay reload, the persisted plan entry replaces the transient live version without duplication.
+
+**Verification:**
+- A running turn can show evolving plan state in the thread detail view before the next manual refresh.
+
+- [ ] **Unit 3: Build the transcript-native plan card and lock down renderer regressions**
+
+**Goal:** Present plan progress in a compact desktop transcript surface that matches the existing shell tone and remains testable.
+
+**Requirements:** R10-R11, R22, user requirement
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Add a dedicated `TranscriptPlan` component that renders plan title/explanation, completed-step count, and ordered step rows with stable status treatment.
+- Teach `TranscriptList.tsx` to dispatch `plan` entries alongside existing message and activity entries while preserving current scroll anchoring behavior.
+- Style the plan surface as transcript-native UI rather than a floating modal/card stack: compact spacing, subtle border treatment, and accent usage only for active/completed emphasis.
+- Cover both replayed and live plan rendering in renderer tests so future transcript work cannot silently regress this feature.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx`
+- `apps/desktop/src/renderer/src/styles/app.css`
+- `docs/design/desktop-style-guide.md`
+
+**Test scenarios:**
+- Happy path: a replayed plan entry renders `0 out of 3 tasks completed`-style summary plus ordered step rows.
+- Happy path: step statuses map to distinct but muted visual treatments for pending, in-progress, and completed.
+- Edge case: plans with explanation text but no steps still render cleanly without empty-list chrome.
+- Edge case: long step text wraps without changing surrounding transcript layout.
+- Edge case: transcript scroll anchoring still behaves correctly when a plan entry is appended or prepended.
+- Integration: the full app shell can read a thread containing plan replay and display it in the selected thread transcript.
+
+**Verification:**
+- The desktop transcript visibly renders the same class of plan/task-list progress that other app-server consumers already show.

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -120,9 +120,28 @@ export type AppServerThreadActivityEntry = {
   details: AppServerThreadActivityDetail[];
 };
 
+export type AppServerThreadPlanStepStatus =
+  | "pending"
+  | "in_progress"
+  | "completed";
+
+export type AppServerThreadPlanStep = {
+  step: string;
+  status: AppServerThreadPlanStepStatus;
+};
+
+export type AppServerThreadPlanEntry = {
+  type: "plan";
+  id: string;
+  createdAt?: number;
+  explanation?: string;
+  steps: AppServerThreadPlanStep[];
+};
+
 export type AppServerThreadEntry =
   | AppServerThreadMessageEntry
-  | AppServerThreadActivityEntry;
+  | AppServerThreadActivityEntry
+  | AppServerThreadPlanEntry;
 
 export type AppServerThreadReplayPagination = {
   supportsPagination: boolean;


### PR DESCRIPTION
## Summary
- normalize app-server plan updates from replayed thread entries and `update_plan` tool calls into transcript plan entries
- render plan cards in desktop thread transcripts and keep live pending plans visible until replay catches up
- add desktop main and renderer coverage for parsing, rendering, and pending-plan handoff behavior

## Testing
- `pnpm vitest apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm exec vitest run --environment jsdom apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project=desktop-main --project=desktop-renderer`

## Notes
- `pnpm --filter @pwragnt/desktop typecheck` still fails on pre-existing sidebar test prop mismatches in `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` at lines 163 and 230 (`creatingThreadBackend` vs `creatingThread`).
- I attempted to capture a live desktop screenshot for the new plan card, but the app's thread selection did not reliably follow automation, so I left the PR without a screenshot rather than attach something misleading.

## Validation
- Open the `Desktop App - To-Do Lists` thread in the desktop app and confirm replayed plan history and live `update_plan` events render as a task-progress card.
