### PR TITLE
feat(desktop): render transcript image previews in desktop chat

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -234,7 +234,7 @@ class MockTransport implements JsonRpcTransport {
                           },
                           {
                             type: "input_image",
-                            image_url: "file:///tmp/screenshot.png"
+                            image_url: "data:image/png;base64,aGVsbG8="
                           }
                         ]
                       },
@@ -940,7 +940,7 @@ describe("CodexAppServerClient", () => {
           },
           {
             type: "image",
-            url: "file:///tmp/screenshot.png"
+            url: "data:image/png;base64,aGVsbG8="
           }
         ]
       },
@@ -972,7 +972,7 @@ describe("CodexAppServerClient", () => {
           },
           {
             type: "image",
-            url: "file:///tmp/screenshot.png"
+            url: "data:image/png;base64,aGVsbG8="
           }
         ]
       },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -212,6 +212,53 @@ class MockTransport implements JsonRpcTransport {
         return;
       }
 
+      if (threadId === "thread-images") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              thread: {
+                turns: [
+                  {
+                    id: "turn-images",
+                    startedAt: 1_763_500_150,
+                    items: [
+                      {
+                        type: "userMessage",
+                        id: "item-image-1",
+                        content: [
+                          {
+                            type: "input_text",
+                            text: "Describe this image"
+                          },
+                          {
+                            type: "input_image",
+                            image_url: "file:///tmp/screenshot.png"
+                          }
+                        ]
+                      },
+                      {
+                        type: "userMessage",
+                        id: "item-image-2",
+                        content: [
+                          {
+                            type: "input_image",
+                            image_url: "https://example.com/thread-image.png",
+                            alt: "Thread image"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          })
+        );
+        return;
+      }
+
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -762,7 +809,13 @@ describe("CodexAppServerClient", () => {
           id: "item-1",
           role: "user",
           text: "Show me the current desktop thread shell",
-          createdAt: 1_763_500_100_000
+          createdAt: 1_763_500_100_000,
+          parts: [
+            {
+              type: "text",
+              text: "Show me the current desktop thread shell"
+            }
+          ]
         },
         {
           type: "message",
@@ -828,7 +881,13 @@ describe("CodexAppServerClient", () => {
           id: "item-1",
           role: "user",
           text: "Show me the current desktop thread shell",
-          createdAt: undefined
+          createdAt: undefined,
+          parts: [
+            {
+              type: "text",
+              text: "Show me the current desktop thread shell"
+            }
+          ]
         },
         {
           id: "item-2",
@@ -851,6 +910,87 @@ describe("CodexAppServerClient", () => {
         previousCursor: undefined
       }
     });
+
+    await client.close();
+  });
+
+  it("preserves image parts from Codex thread/read messages", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-images"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "item-image-1",
+        role: "user",
+        text: "Describe this image",
+        createdAt: 1_763_500_150_000,
+        parts: [
+          {
+            type: "text",
+            text: "Describe this image"
+          },
+          {
+            type: "image",
+            url: "file:///tmp/screenshot.png"
+          }
+        ]
+      },
+      {
+        type: "message",
+        id: "item-image-2",
+        role: "user",
+        text: "",
+        createdAt: 1_763_500_150_000,
+        parts: [
+          {
+            type: "image",
+            url: "https://example.com/thread-image.png",
+            alt: "Thread image"
+          }
+        ]
+      }
+    ]);
+    expect(replay.messages).toEqual([
+      {
+        id: "item-image-1",
+        role: "user",
+        text: "Describe this image",
+        createdAt: undefined,
+        parts: [
+          {
+            type: "text",
+            text: "Describe this image"
+          },
+          {
+            type: "image",
+            url: "file:///tmp/screenshot.png"
+          }
+        ]
+      },
+      {
+        id: "item-image-2",
+        role: "user",
+        text: "",
+        createdAt: undefined,
+        parts: [
+          {
+            type: "image",
+            url: "https://example.com/thread-image.png",
+            alt: "Thread image"
+          }
+        ]
+      }
+    ]);
+    expect(replay.lastUserMessage).toBe("Describe this image");
 
     await client.close();
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -12,6 +12,8 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadActivityStatus,
   AppServerThreadEntry,
+  AppServerThreadImagePart,
+  AppServerThreadMessagePart,
   AppServerThreadMessageEntry,
   AppServerSkillSummary,
   AppServerThreadReplay,
@@ -352,7 +354,7 @@ function normalizeConversationRole(
   return undefined;
 }
 
-function collectMessageText(record: Record<string, unknown>): string {
+function collectLegacyMessageText(record: Record<string, unknown>): string {
   return (
     dedupeJoinedText([
       ...collectText(record.content),
@@ -364,6 +366,116 @@ function collectMessageText(record: Record<string, unknown>): string {
       ...collectText(record.parts)
     ]) ?? ""
   );
+}
+
+function normalizeRenderableImageUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("file://")
+  ) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("/")) {
+    return `file://${trimmed}`;
+  }
+
+  return undefined;
+}
+
+function extractStructuredMessageParts(value: unknown): AppServerThreadMessagePart[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractStructuredMessageParts(entry));
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return [];
+  }
+
+  const normalizedType = pickString(record, ["type", "contentType", "content_type"])
+    ?.trim()
+    .toLowerCase();
+
+  if (
+    normalizedType === "text" ||
+    normalizedType === "input_text" ||
+    normalizedType === "output_text"
+  ) {
+    const text = pickString(record, ["text", "value", "content"]);
+    return text ? [{ type: "text", text }] : [];
+  }
+
+  const imageUrl = normalizeRenderableImageUrl(
+    pickString(record, [
+      "image_url",
+      "imageUrl",
+      "url",
+      "src",
+      "uri",
+      "path",
+      "localPath",
+      "local_path"
+    ])
+  );
+  if (
+    imageUrl &&
+    (normalizedType === "image" ||
+      normalizedType === "input_image" ||
+      normalizedType === "output_image" ||
+      normalizedType === "image_url" ||
+      "image_url" in record ||
+      "imageUrl" in record)
+  ) {
+    const part: AppServerThreadImagePart = {
+      type: "image",
+      url: imageUrl
+    };
+    const alt = pickString(record, ["alt", "altText", "alt_text", "title", "name"]);
+    if (alt) {
+      part.alt = alt;
+    }
+    return [part];
+  }
+
+  for (const nestedKey of ["content", "parts", "input", "output", "data"]) {
+    const nestedParts = extractStructuredMessageParts(record[nestedKey]);
+    if (nestedParts.length > 0) {
+      return nestedParts;
+    }
+  }
+
+  return [];
+}
+
+function buildMessageContent(record: Record<string, unknown>): {
+  parts?: AppServerThreadMessagePart[];
+  text: string;
+} {
+  const structuredParts = [
+    ...extractStructuredMessageParts(record.content),
+    ...extractStructuredMessageParts(record.parts)
+  ];
+
+  if (structuredParts.length > 0) {
+    const text = dedupeJoinedText(
+      structuredParts.flatMap((part) => (part.type === "text" ? [part.text] : []))
+    ) ?? "";
+
+    return {
+      parts: structuredParts,
+      text
+    };
+  }
+
+  const text = collectLegacyMessageText(record);
+  return { text };
 }
 
 function extractConversationMessages(
@@ -385,14 +497,15 @@ function extractConversationMessages(
     const role = normalizeConversationRole(
       pickString(record, ["role", "author", "speaker", "source", "type"])
     );
-    const text = collectMessageText(record);
-    if (role && text) {
+    const content = buildMessageContent(record);
+    if (role && (content.text || content.parts?.length)) {
       output.push({
         id:
           pickString(record, ["id", "messageId", "message_id", "itemId", "item_id"]) ??
           `message-${output.length + 1}`,
         role,
-        text,
+        text: content.text,
+        ...(content.parts ? { parts: content.parts } : {}),
         createdAt: normalizeEpochTimestamp(
           pickNumber(record, ["createdAt", "created_at", "timestamp", "time"])
         )
@@ -729,8 +842,8 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       const role = normalizeConversationRole(itemType);
       if (role) {
         flushActivityItems();
-        const text = collectMessageText(item);
-        if (!text) {
+        const content = buildMessageContent(item);
+        if (!content.text && !content.parts?.length) {
           continue;
         }
         entries.push({
@@ -739,7 +852,8 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
             pickString(item, ["id", "messageId", "message_id", "itemId", "item_id"]) ??
             `message-${entries.length + 1}`,
           role,
-          text,
+          text: content.text,
+          ...(content.parts ? { parts: content.parts } : {}),
           createdAt,
           ...(pickString(item, ["phase"]) === "commentary"
             ? { phase: "commentary" as const }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -377,7 +377,8 @@ function normalizeRenderableImageUrl(value: string | undefined): string | undefi
   if (
     trimmed.startsWith("http://") ||
     trimmed.startsWith("https://") ||
-    trimmed.startsWith("file://")
+    trimmed.startsWith("file://") ||
+    trimmed.startsWith("data:image/")
   ) {
     return trimmed;
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type {
   AppServerPendingRequestNotification,
   AppServerThreadEntry,
+  AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
@@ -13,6 +14,7 @@ import { Composer } from "../composer/Composer";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
+import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
 
 function formatRendererLogPayload(value: unknown): string {
@@ -57,12 +59,14 @@ export function ThreadView(props: ThreadViewProps) {
     useState<AppServerPendingRequestNotification>();
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
   const [pendingRequestError, setPendingRequestError] = useState<string>();
+  const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
 
   useEffect(() => {
     setPendingAssistantMessage(undefined);
     setPendingRequest(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
+    setExpandedImage(undefined);
   }, [props.selectedThread?.id, props.selectedThread?.source]);
 
   const selectedThread = props.selectedThread;
@@ -238,6 +242,7 @@ export function ThreadView(props: ThreadViewProps) {
             pagination={props.transcriptPagination}
             threadId={selectedThread.id}
             skills={props.skills}
+            onOpenImage={setExpandedImage}
             onRespondToPendingRequest={respondToPendingRequest}
             onLoadOlder={props.onLoadOlder}
           />
@@ -256,6 +261,15 @@ export function ThreadView(props: ThreadViewProps) {
           onSetExecutionMode={props.onSetExecutionMode}
         />
       </div>
+
+      {expandedImage ? (
+        <TranscriptImageLightbox
+          image={expandedImage}
+          onClose={() => {
+            setExpandedImage(undefined);
+          }}
+        />
+      ) : null}
 
       <Composer
         addOptimisticUserMessage={props.addOptimisticUserMessage}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImage.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import type { ImgHTMLAttributes } from "react";
+
+type TranscriptImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> & {
+  src: string;
+};
+
+export function TranscriptImage(props: TranscriptImageProps) {
+  const { src, ...imageProps } = props;
+  const resolvedSrc = useResolvedTranscriptImageSrc(src);
+
+  return <img {...imageProps} src={resolvedSrc} />;
+}
+
+function useResolvedTranscriptImageSrc(src: string): string {
+  const [resolvedSrc, setResolvedSrc] = useState(src);
+
+  useEffect(() => {
+    if (!isEmbeddedImageDataUrl(src) || typeof URL.createObjectURL !== "function") {
+      setResolvedSrc(src);
+      return;
+    }
+
+    const objectUrl = createObjectUrlFromDataUrl(src);
+    setResolvedSrc(objectUrl ?? src);
+
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [src]);
+
+  return resolvedSrc;
+}
+
+function isEmbeddedImageDataUrl(src: string): boolean {
+  return src.startsWith("data:image/");
+}
+
+function createObjectUrlFromDataUrl(src: string): string | undefined {
+  const commaIndex = src.indexOf(",");
+  if (commaIndex <= "data:".length) {
+    return undefined;
+  }
+
+  const metadata = src.slice("data:".length, commaIndex);
+  const payload = src.slice(commaIndex + 1);
+  if (!payload) {
+    return undefined;
+  }
+
+  const segments = metadata.split(";");
+  const mimeType = segments[0] || "application/octet-stream";
+  const isBase64 = segments.includes("base64");
+
+  try {
+    const bytes = isBase64
+      ? decodeBase64Payload(payload)
+      : new TextEncoder().encode(decodeURIComponent(payload));
+    return URL.createObjectURL(new Blob([toArrayBuffer(bytes)], { type: mimeType }));
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBase64Payload(payload: string): Uint8Array {
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImageLightbox.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import type { AppServerThreadImagePart } from "@pwragnt/shared";
+
+type TranscriptImageLightboxProps = {
+  image: AppServerThreadImagePart;
+  onClose: () => void;
+};
+
+export function TranscriptImageLightbox(props: TranscriptImageLightboxProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        props.onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [props.onClose]);
+
+  return (
+    <div
+      className="transcript-image-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Expanded transcript image"
+      onClick={props.onClose}
+    >
+      <div
+        className="transcript-image-lightbox__content"
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <button
+          type="button"
+          className="button button--ghost transcript-image-lightbox__close"
+          onClick={props.onClose}
+        >
+          Close
+        </button>
+        <img
+          className="transcript-image-lightbox__image"
+          src={props.image.url}
+          alt={props.image.alt ?? "Expanded transcript image"}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptImageLightbox.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { AppServerThreadImagePart } from "@pwragnt/shared";
+import { TranscriptImage } from "./TranscriptImage";
 
 type TranscriptImageLightboxProps = {
   image: AppServerThreadImagePart;
@@ -41,7 +42,7 @@ export function TranscriptImageLightbox(props: TranscriptImageLightboxProps) {
         >
           Close
         </button>
-        <img
+        <TranscriptImage
           className="transcript-image-lightbox__image"
           src={props.image.url}
           alt={props.image.alt ?? "Expanded transcript image"}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import type {
   AppServerPendingRequestNotification,
   AppServerThreadEntry,
+  AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerSkillSummary,
   AppServerThreadReplayPagination
@@ -22,6 +23,7 @@ type TranscriptListProps = {
   pagination?: AppServerThreadReplayPagination;
   threadId?: string;
   skills?: AppServerSkillSummary[];
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
   onRespondToPendingRequest?: (decision: "approve" | "decline" | "cancel") => Promise<void>;
   onLoadOlder: () => Promise<void>;
 };
@@ -219,7 +221,12 @@ export function TranscriptList(props: TranscriptListProps) {
           entry.type === "activity" ? (
             <TranscriptActivity key={entry.id} entry={entry} />
           ) : (
-            <TranscriptMessage key={entry.id} message={entry} skills={skills} />
+            <TranscriptMessage
+              key={entry.id}
+              message={entry}
+              skills={skills}
+              onOpenImage={props.onOpenImage}
+            />
           )
         )}
         {props.pendingAssistantMessage ? (
@@ -227,6 +234,7 @@ export function TranscriptList(props: TranscriptListProps) {
             key={props.pendingAssistantMessage.id}
             message={props.pendingAssistantMessage}
             skills={skills}
+            onOpenImage={props.onOpenImage}
           />
         ) : null}
         {props.pendingStatusText ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -50,9 +50,9 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
       </header>
       {contentParts.length > 0 ? (
         <div className="transcript-message__text">
-          {contentParts.map((part, index) =>
-            renderMessagePart({
-              part,
+          {groupMessageParts(contentParts).map((segment, index) =>
+            renderMessageSegment({
+              segment,
               index,
               onOpenImage: props.onOpenImage,
               skillsByPath
@@ -64,37 +64,75 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
   );
 }
 
-function renderMessagePart(params: {
-  part: AppServerThreadMessagePart;
+type MessagePartSegment =
+  | { type: "text"; part: Exclude<AppServerThreadMessagePart, AppServerThreadImagePart> }
+  | { type: "images"; parts: AppServerThreadImagePart[]; startIndex: number };
+
+function groupMessageParts(parts: AppServerThreadMessagePart[]): MessagePartSegment[] {
+  const segments: MessagePartSegment[] = [];
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (part.type === "image") {
+      const existingSegment = segments[segments.length - 1];
+      if (existingSegment?.type === "images") {
+        existingSegment.parts.push(part);
+        continue;
+      }
+
+      segments.push({
+        type: "images",
+        parts: [part],
+        startIndex: index
+      });
+      continue;
+    }
+
+    segments.push({
+      type: "text",
+      part
+    });
+  }
+
+  return segments;
+}
+
+function renderMessageSegment(params: {
+  segment: MessagePartSegment;
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   skillsByPath: Map<string, AppServerSkillSummary & { path: string }>;
 }): ReactNode {
-  if (params.part.type === "image") {
-    const imagePart = params.part;
+  if (params.segment.type === "images") {
+    const imageSegment = params.segment;
+
     return (
-      <button
-        key={`image:${params.index}`}
-        type="button"
-        className="transcript-message__image-button"
-        aria-label={`Expand transcript image ${params.index + 1}`}
-        onClick={() => {
-          params.onOpenImage?.(imagePart);
-        }}
-      >
-        <TranscriptImage
-          className="transcript-message__image-preview"
-          src={imagePart.url}
-          alt={imagePart.alt ?? "Transcript image"}
-          loading="lazy"
-        />
-      </button>
+      <div key={`images:${params.index}`} className="transcript-message__image-grid">
+        {imageSegment.parts.map((imagePart, imageIndex) => (
+          <button
+            key={`image:${imageSegment.startIndex + imageIndex}`}
+            type="button"
+            className="transcript-message__image-button"
+            aria-label={`Expand transcript image ${imageSegment.startIndex + imageIndex + 1}`}
+            onClick={() => {
+              params.onOpenImage?.(imagePart);
+            }}
+          >
+            <TranscriptImage
+              className="transcript-message__image-preview"
+              src={imagePart.url}
+              alt={imagePart.alt ?? "Transcript image"}
+              loading="lazy"
+            />
+          </button>
+        ))}
+      </div>
     );
   }
 
   return (
     <Fragment key={`text:${params.index}`}>
-      {renderTextPart(params.part.text, `part-${params.index}`, params.skillsByPath)}
+      {renderTextPart(params.segment.part.text, `part-${params.index}`, params.skillsByPath)}
     </Fragment>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,6 +1,9 @@
+import { Fragment, type ReactNode } from "react";
 import type {
   AppServerSkillSummary,
+  AppServerThreadImagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadMessagePart,
 } from "@pwragnt/shared";
 import { SkillChip } from "../composer/SkillChip";
 import { parseSkillMentionParts } from "../../lib/skill-mentions";
@@ -9,11 +12,10 @@ import { MarkdownText } from "./MarkdownText";
 type TranscriptMessageProps = {
   message: AppServerThreadMessageEntry;
   skills: AppServerSkillSummary[];
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
 };
 
 export function TranscriptMessage(props: TranscriptMessageProps) {
-  const parts = parseSkillMentionParts(props.message.text);
-  const hasSkillMention = parts.some((part) => part.type === "skill");
   const skillsByPath = new Map(
     props.skills
       .filter(
@@ -21,6 +23,12 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
       )
       .map((skill) => [skill.path, skill])
   );
+  const contentParts =
+    props.message.parts && props.message.parts.length > 0
+      ? props.message.parts
+      : props.message.text
+        ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
+        : [];
 
   return (
     <article
@@ -39,35 +47,94 @@ export function TranscriptMessage(props: TranscriptMessageProps) {
           </time>
         ) : null}
       </header>
-      {hasSkillMention ? (
+      {contentParts.length > 0 ? (
         <div className="transcript-message__text">
-          {parts.map((part, index) => {
-            if (part.type === "text") {
-              return (
-                <span key={`text:${index}`} className="transcript-message__text-part">
-                  {part.text}
-                </span>
-              );
-            }
-
-            return (
-              <SkillChip
-                key={`skill:${part.path}:${index}`}
-                label={part.label}
-                skill={
-                  skillsByPath.get(part.path) ?? {
-                    name: part.name,
-                    path: part.path,
-                  }
-                }
-              />
-            );
-          })}
+          {contentParts.map((part, index) =>
+            renderMessagePart({
+              part,
+              index,
+              onOpenImage: props.onOpenImage,
+              skillsByPath
+            })
+          )}
         </div>
-      ) : (
-        <MarkdownText className="transcript-message__text" text={props.message.text} />
-      )}
+      ) : null}
     </article>
+  );
+}
+
+function renderMessagePart(params: {
+  part: AppServerThreadMessagePart;
+  index: number;
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
+  skillsByPath: Map<string, AppServerSkillSummary & { path: string }>;
+}): ReactNode {
+  if (params.part.type === "image") {
+    const imagePart = params.part;
+    return (
+      <button
+        key={`image:${params.index}`}
+        type="button"
+        className="transcript-message__image-button"
+        aria-label={`Expand transcript image ${params.index + 1}`}
+        onClick={() => {
+          params.onOpenImage?.(imagePart);
+        }}
+      >
+        <img
+          className="transcript-message__image-preview"
+          src={imagePart.url}
+          alt={imagePart.alt ?? "Transcript image"}
+          loading="lazy"
+        />
+      </button>
+    );
+  }
+
+  return (
+    <Fragment key={`text:${params.index}`}>
+      {renderTextPart(params.part.text, `part-${params.index}`, params.skillsByPath)}
+    </Fragment>
+  );
+}
+
+function renderTextPart(
+  text: string,
+  keyPrefix: string,
+  skillsByPath: Map<string, AppServerSkillSummary & { path: string }>
+): ReactNode {
+  const parts = parseSkillMentionParts(text);
+  const hasSkillMention = parts.some((part) => part.type === "skill");
+
+  if (!hasSkillMention) {
+    return <MarkdownText className="transcript-message__text-block" text={text} />;
+  }
+
+  return (
+    <div className="transcript-message__text-block">
+      {parts.map((part, index) => {
+        if (part.type === "text") {
+          return (
+            <span key={`${keyPrefix}:text:${index}`} className="transcript-message__text-part">
+              {part.text}
+            </span>
+          );
+        }
+
+        return (
+          <SkillChip
+            key={`${keyPrefix}:skill:${part.path}:${index}`}
+            label={part.label}
+            skill={
+              skillsByPath.get(part.path) ?? {
+                name: part.name,
+                path: part.path,
+              }
+            }
+          />
+        );
+      })}
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -8,6 +8,7 @@ import type {
 import { SkillChip } from "../composer/SkillChip";
 import { parseSkillMentionParts } from "../../lib/skill-mentions";
 import { MarkdownText } from "./MarkdownText";
+import { TranscriptImage } from "./TranscriptImage";
 
 type TranscriptMessageProps = {
   message: AppServerThreadMessageEntry;
@@ -81,7 +82,7 @@ function renderMessagePart(params: {
           params.onOpenImage?.(imagePart);
         }}
       >
-        <img
+        <TranscriptImage
           className="transcript-message__image-preview"
           src={imagePart.url}
           alt={imagePart.alt ?? "Transcript image"}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadView } from "../ThreadView";
 
@@ -254,6 +254,202 @@ describe("ThreadView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy thread id" }));
 
     expect(copyText).toHaveBeenCalledWith("019d88a2-0e0b-77f0-bfce-130ae8e37d8f");
+  });
+
+  it("opens transcript image previews in a lightbox and dismisses them with Escape", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-images",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-images",
+          title: "Inspect image rendering",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-image-1",
+            role: "user",
+            text: "",
+            parts: [
+              {
+                type: "image",
+                url: "file:///tmp/screenshot.png",
+                alt: "Transcript screenshot"
+              }
+            ]
+          }
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand transcript image 1" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Expanded transcript image" });
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByAltText("Transcript screenshot")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("dialog", { name: "Expanded transcript image" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears an expanded transcript image when the selected thread changes", () => {
+    const viewProps = {
+      addOptimisticUserMessage: (_text: string) => "optimistic-1",
+      backends: [
+        {
+          kind: "codex" as const,
+          label: "Codex app server",
+          available: true,
+          methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+          capabilities: {
+            listThreads: true,
+            createThread: false,
+            resumeThread: true,
+            readThread: true,
+            startTurn: true,
+            interruptTurn: false,
+            steerTurn: false,
+            transcriptPagination: true,
+            toolUse: false,
+            approvalRequests: false,
+            multiDirectoryThreads: true
+          },
+          executionModes: [
+            {
+              mode: "default" as const,
+              label: "Default Access",
+              available: true,
+              isDefault: true,
+            },
+          ],
+        }
+      ],
+      composerDisabled: false,
+      desktopApi: {
+        startTurn: async () => ({
+          backend: "codex" as const,
+          threadId: "thread-images",
+          runId: "turn-1",
+        }),
+      },
+      loading: false,
+      loadingMore: false,
+      messageCount: 1,
+      skills: [],
+      transcriptEntries: [
+        {
+          type: "message" as const,
+          id: "message-image-1",
+          role: "user" as const,
+          text: "",
+          parts: [
+            {
+              type: "image" as const,
+              url: "file:///tmp/screenshot.png",
+              alt: "Transcript screenshot"
+            }
+          ]
+        }
+      ],
+      onLoadOlder: async () => undefined,
+      removeOptimisticMessage: (_id: string) => undefined,
+      onRefresh: async () => undefined,
+    };
+
+    const { rerender } = render(
+      <ThreadView
+        {...viewProps}
+        selectedThread={{
+          id: "thread-images",
+          title: "Inspect image rendering",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand transcript image 1" }));
+    expect(screen.getByRole("dialog", { name: "Expanded transcript image" })).toBeInTheDocument();
+
+    rerender(
+      <ThreadView
+        {...viewProps}
+        selectedThread={{
+          id: "thread-next",
+          title: "Another thread",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+      />
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: "Expanded transcript image" })
+    ).not.toBeInTheDocument();
   });
 
   it("renders live assistant commentary from item/agentMessage/delta notifications", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,10 +1,21 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThreadView } from "../ThreadView";
 
 afterEach(() => {
   cleanup();
+});
+
+beforeEach(() => {
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: vi.fn(() => "blob:expanded-transcript-image")
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: vi.fn()
+  });
 });
 
 describe("ThreadView", () => {
@@ -257,6 +268,8 @@ describe("ThreadView", () => {
   });
 
   it("opens transcript image previews in a lightbox and dismisses them with Escape", () => {
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+
     render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
@@ -321,7 +334,7 @@ describe("ThreadView", () => {
             parts: [
               {
                 type: "image",
-                url: "file:///tmp/screenshot.png",
+                url: dataUrl,
                 alt: "Transcript screenshot"
               }
             ]
@@ -337,7 +350,10 @@ describe("ThreadView", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Expanded transcript image" });
     expect(dialog).toBeInTheDocument();
-    expect(within(dialog).getByAltText("Transcript screenshot")).toBeInTheDocument();
+    expect(within(dialog).getByAltText("Transcript screenshot")).toHaveAttribute(
+      "src",
+      "blob:expanded-transcript-image"
+    );
 
     fireEvent.keyDown(window, { key: "Escape" });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptList } from "../TranscriptList";
 
@@ -45,6 +45,7 @@ describe("TranscriptList", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
   });
 
@@ -178,6 +179,64 @@ describe("TranscriptList", () => {
     expect(
       screen.getByText("$frontend-design").closest("article")
     ).toHaveClass("transcript-message--user");
+  });
+
+  it("renders inline image previews and opens them on demand", () => {
+    const onOpenImage = vi.fn();
+
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Describe this image",
+            parts: [
+              {
+                type: "text",
+                text: "Describe this image"
+              },
+              {
+                type: "image",
+                url: "file:///tmp/screenshot.png",
+                alt: "Transcript screenshot"
+              }
+            ]
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "",
+            parts: [
+              {
+                type: "image",
+                url: "https://example.com/thread-image.png",
+                alt: "Assistant image"
+              }
+            ]
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onOpenImage={onOpenImage}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByText("Describe this image")).toBeInTheDocument();
+    expect(screen.getByAltText("Transcript screenshot")).toBeInTheDocument();
+    expect(screen.getByAltText("Assistant image")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByAltText("Transcript screenshot").closest("button")!);
+
+    expect(onOpenImage).toHaveBeenCalledWith({
+      type: "image",
+      url: "file:///tmp/screenshot.png",
+      alt: "Transcript screenshot"
+    });
   });
 
   it("renders pending status inside the transcript list", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -197,6 +197,7 @@ describe("TranscriptList", () => {
   it("renders inline image previews and opens them on demand", () => {
     const onOpenImage = vi.fn();
     const dataUrl = "data:image/png;base64,aGVsbG8=";
+    const secondDataUrl = "data:image/png;base64,d29ybGQ=";
 
     render(
       <TranscriptList
@@ -215,6 +216,11 @@ describe("TranscriptList", () => {
                 type: "image",
                 url: dataUrl,
                 alt: "Transcript screenshot"
+              },
+              {
+                type: "image",
+                url: secondDataUrl,
+                alt: "Second transcript screenshot"
               }
             ]
           },
@@ -245,8 +251,17 @@ describe("TranscriptList", () => {
       "src",
       "blob:transcript-image"
     );
+    expect(screen.getByAltText("Second transcript screenshot")).toHaveAttribute(
+      "src",
+      "blob:transcript-image"
+    );
     expect(screen.getByAltText("Assistant image")).toBeInTheDocument();
-    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURLMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByAltText("Transcript screenshot").closest(".transcript-message__image-grid")
+    ).toBe(
+      screen.getByAltText("Second transcript screenshot").closest(".transcript-message__image-grid")
+    );
 
     fireEvent.click(screen.getByAltText("Transcript screenshot").closest("button")!);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -7,6 +7,8 @@ describe("TranscriptList", () => {
   let scrollHeight = 480;
   let clientHeight = 240;
   let scrollToMock: ReturnType<typeof vi.fn>;
+  let createObjectURLMock: ReturnType<typeof vi.fn>;
+  let revokeObjectURLMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     scrollHeight = 480;
@@ -41,6 +43,17 @@ describe("TranscriptList", () => {
     Object.defineProperty(HTMLElement.prototype, "scrollTo", {
       configurable: true,
       value: scrollToMock
+    });
+
+    createObjectURLMock = vi.fn(() => "blob:transcript-image");
+    revokeObjectURLMock = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURLMock
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURLMock
     });
   });
 
@@ -183,6 +196,7 @@ describe("TranscriptList", () => {
 
   it("renders inline image previews and opens them on demand", () => {
     const onOpenImage = vi.fn();
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
 
     render(
       <TranscriptList
@@ -199,7 +213,7 @@ describe("TranscriptList", () => {
               },
               {
                 type: "image",
-                url: "file:///tmp/screenshot.png",
+                url: dataUrl,
                 alt: "Transcript screenshot"
               }
             ]
@@ -227,14 +241,18 @@ describe("TranscriptList", () => {
     );
 
     expect(screen.getByText("Describe this image")).toBeInTheDocument();
-    expect(screen.getByAltText("Transcript screenshot")).toBeInTheDocument();
+    expect(screen.getByAltText("Transcript screenshot")).toHaveAttribute(
+      "src",
+      "blob:transcript-image"
+    );
     expect(screen.getByAltText("Assistant image")).toBeInTheDocument();
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByAltText("Transcript screenshot").closest("button")!);
 
     expect(onOpenImage).toHaveBeenCalledWith({
       type: "image",
-      url: "file:///tmp/screenshot.png",
+      url: dataUrl,
       alt: "Transcript screenshot"
     });
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -756,6 +756,12 @@ textarea {
   margin: 0;
 }
 
+.transcript-message__image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 10px;
+}
+
 .transcript-message__text-block > * {
   margin: 0;
 }
@@ -837,8 +843,7 @@ textarea {
 
 .transcript-message__image-button {
   display: block;
-  width: fit-content;
-  max-width: min(100%, 320px);
+  width: 100%;
   padding: 0;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -855,8 +860,7 @@ textarea {
 .transcript-message__image-preview {
   display: block;
   width: 100%;
-  max-width: 320px;
-  max-height: 240px;
+  aspect-ratio: 4 / 3;
   object-fit: cover;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -745,6 +745,9 @@ textarea {
 
 .transcript-message__text {
   margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   font-size: 14px;
   line-height: 1.55;
 }
@@ -753,12 +756,20 @@ textarea {
   margin: 0;
 }
 
-.transcript-message__text > * + * {
+.transcript-message__text-block > * {
+  margin: 0;
+}
+
+.transcript-message__text-block > * + * {
   margin-top: 10px;
 }
 
 .transcript-message__paragraph {
   white-space: normal;
+}
+
+.transcript-message__text-part {
+  white-space: pre-wrap;
 }
 
 .transcript-message__heading {
@@ -824,6 +835,31 @@ textarea {
   text-decoration-color: currentColor;
 }
 
+.transcript-message__image-button {
+  display: block;
+  width: fit-content;
+  max-width: min(100%, 320px);
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.transcript-message__image-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.transcript-message__image-preview {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  max-height: 240px;
+  object-fit: cover;
+}
+
 .transcript-activity {
   width: min(100%, 760px);
   padding: 12px 0 0;
@@ -855,6 +891,38 @@ textarea {
   border: 1px solid var(--accent-border);
   border-radius: 8px;
   background: rgba(184, 255, 77, 0.08);
+}
+
+.transcript-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(11, 13, 18, 0.88);
+}
+
+.transcript-image-lightbox__content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  max-width: min(100%, 960px);
+}
+
+.transcript-image-lightbox__close {
+  align-self: flex-end;
+}
+
+.transcript-image-lightbox__image {
+  display: block;
+  max-width: min(100vw - 48px, 960px);
+  max-height: min(100vh - 120px, 800px);
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .transcript-request__header,
@@ -1148,10 +1216,6 @@ textarea {
 
 .transcript-diff__separator {
   background: rgba(255, 255, 255, 0.02);
-}
-
-.transcript-message__text-part {
-  white-space: pre-wrap;
 }
 
 .skill-chip {

--- a/docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md
+++ b/docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Render transcript image previews in desktop chat
 type: fix
-status: active
+status: completed
 date: 2026-04-17
 ---
 
@@ -104,7 +104,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend transcript normalization to preserve image parts**
+- [x] **Unit 1: Extend transcript normalization to preserve image parts**
 
 **Goal:** Keep image-bearing Codex transcript messages in the replay instead of flattening them to text-only or dropping them outright.
 
@@ -138,7 +138,7 @@ flowchart TB
 **Verification:**
 - `readThread()` returns stable transcript entries for image-bearing Codex turns, and image-only messages no longer disappear from replay data.
 
-- [ ] **Unit 2: Render inline image previews inside transcript messages**
+- [x] **Unit 2: Render inline image previews inside transcript messages**
 
 **Goal:** Show image parts inside transcript bubbles without regressing existing text, markdown-like formatting, or skill-chip behavior.
 
@@ -173,7 +173,7 @@ flowchart TB
 **Verification:**
 - Transcript rows visibly include image previews wherever the normalized replay contains image parts, while text-only messages continue to render unchanged.
 
-- [ ] **Unit 3: Add thread-scoped image expansion and dismissal behavior**
+- [x] **Unit 3: Add thread-scoped image expansion and dismissal behavior**
 
 **Goal:** Let users enlarge transcript images from thread detail without leaving the conversation or destabilizing transcript state.
 

--- a/docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md
+++ b/docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md
@@ -1,0 +1,246 @@
+---
+title: fix: Render transcript image previews in desktop chat
+type: fix
+status: active
+date: 2026-04-17
+---
+
+# fix: Render transcript image previews in desktop chat
+
+## Overview
+
+Make desktop thread transcripts render user-posted images inline and allow them to be expanded from the thread-detail surface. The immediate repro is Codex session `019d9c9a-3ea6-70e3-a65c-4844b8ca859b`, where a user image is present in the source thread but the desktop transcript shows no image at all.
+
+## Problem Frame
+
+The desktop transcript pipeline currently assumes every transcript message is plain text. That assumption holds in the renderer, where `TranscriptMessage` only knows how to render `message.text`, but the failure starts earlier in the main-process Codex client. `apps/desktop/src/main/codex-app-server/client.ts` flattens `thread/read` payloads through `collectMessageText()`, which only collects text-like keys and silently ignores image payloads such as `input_image` / `image_url`. If a turn is image-only, the normalized text becomes empty and the message is dropped from `extractThreadEntries()` entirely.
+
+That produces two user-facing regressions:
+
+- image-only user turns disappear from the transcript
+- mixed text-plus-image turns lose the image, so the desktop transcript does not match the underlying thread
+
+The desktop already has the right product surface for this fix: thread transcripts are first-class, the shared contracts already model multimodal turn input, and the thread-detail renderer owns compact, inspectable interaction patterns like diff expansion. What is missing is a transcript content model that preserves image parts through normalization and a renderer path that can preview and enlarge them without breaking existing text, skill-chip, activity, and pagination behavior.
+
+## Requirements Trace
+
+- R1. A transcript message with one or more image parts renders a visible inline preview instead of disappearing or collapsing to text-only output.
+- R2. Image-only transcript turns still appear as messages and continue to count toward thread message totals and ordering.
+- R3. Mixed text-plus-image turns preserve message order and keep existing text rendering behavior for text segments.
+- R4. A user can expand a transcript image from the thread-detail surface and dismiss it without losing thread context.
+- R5. Existing transcript behaviors remain intact: skill chips, markdown-like text formatting, activity cards, approval cards, refresh, and pagination.
+- R6. The change is scoped to transcript read/render behavior; compose-side image attachment UI is not added by this fix.
+
+## Scope Boundaries
+
+- In scope: Codex `thread/read` normalization for image-bearing transcript messages, shared transcript message contract updates, inline transcript image previews, and image expansion inside thread detail.
+- In scope: support for both remote image URLs and local file-backed image references once they are normalized into renderable sources.
+- Out of scope: new composer UI for attaching images, drag-and-drop upload, or paste-to-attach flows.
+- Out of scope: replacing the current lightweight markdown renderer with a full markdown library.
+- Out of scope: generic non-image attachment rendering such as PDFs, audio, or arbitrary binary files.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/shared/src/contracts/app-server.ts` defines transcript message shapes and already exposes multimodal turn input item types, but transcript messages themselves remain text-only.
+- `apps/desktop/src/main/codex-app-server/client.ts` owns Codex `thread/read` normalization through `collectText()`, `collectMessageText()`, `extractConversationMessages()`, `extractThreadEntries()`, and `extractThreadReplayFromReadResult()`.
+- `apps/desktop/src/main/__tests__/codex-client.test.ts` already exercises `thread/read` normalization with realistic fixture payloads and is the natural place to pin multimodal transcript behavior.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx` is the message bubble renderer and currently assumes every message is reducible to `message.text`.
+- `apps/desktop/src/renderer/src/features/thread-detail/MarkdownText.tsx` should remain the text-only renderer for text parts; this fix should not force images through the markdown parser.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` is the natural owner for thread-scoped expansion state because it already manages pending assistant/request state for the selected thread.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx` shows the local pattern for transcript-local expansion controls that stay compact until the user asks for detail.
+- `apps/desktop/src/renderer/src/styles/app.css` already contains transcript bubble styling and should remain the single styling surface for preview and overlay states.
+
+### Institutional Learnings
+
+- No `docs/solutions/` artifacts exist yet for multimodal transcript rendering in this repository.
+- `docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md` established the current transcript surface and its renderer boundaries.
+- `docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md` already noted multimodal input shapes as part of backend compatibility work, which supports preserving image parts instead of flattening them away.
+
+### External References
+
+- None. The codebase already has strong local evidence for the affected surfaces, and this plan is grounded in current repo behavior rather than external framework guidance.
+
+## Key Technical Decisions
+
+- Preserve backward compatibility by extending transcript messages with structured `parts` rather than replacing the existing `text` field. `text` remains the textual projection for current consumers; `parts` becomes the source of truth for rich rendering.
+- Normalize image parts in the desktop Codex client, not in the renderer. The main-process client already owns unknown `thread/read` payload parsing, so the renderer should receive a stable, explicit transcript shape instead of re-parsing provider-specific JSON.
+- Emit image-only messages with empty textual projection rather than dropping them. Presence in the transcript is more important than forcing a placeholder string, and empty `text` is less misleading than synthetic copy.
+- Keep image expansion state thread-scoped in `ThreadView` so switching threads clears the overlay naturally and the feature does not leak into app-global shell state.
+- Reuse the existing compact transcript aesthetic: image previews should feel like part of the message bubble, not a separate card or gallery surface.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this fix replace `message.text` everywhere with rich content parts? No. That would create unnecessary churn across hooks and tests. A compatibility projection plus optional structured parts is the safer shape.
+- Should the normalization change happen in the renderer or the desktop backend client? In the desktop backend client. Provider-specific `thread/read` payload parsing already lives there.
+- Does this plan need to change Grok transcript normalization immediately? No. The current repro is Codex-backed, and the shared contract can be expanded in a backward-compatible way so Grok can adopt it later without blocking this fix.
+
+### Deferred to Implementation
+
+- Whether Codex `thread/read` emits any additional image metadata worth preserving beyond a renderable source and stable part ordering.
+- Whether the first pass should show image dimensions or source labels in the expansion overlay, or keep the overlay intentionally minimal.
+- Whether assistant-side future image outputs need separate affordances once a backend starts emitting them through the same contract.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+| Stage | Input shape | Normalized desktop shape | Renderer behavior |
+|---|---|---|---|
+| Codex `thread/read` user/assistant item with text only | `content[]` / `text` text entries | `message.text` plus `parts:[text]` | current text rendering path |
+| Codex item with text and image | mixed text and image records | `message.text` plus ordered `parts:[text,image]` | text block(s) plus inline preview button |
+| Codex item with image only | image record, no text | `message.text: ""` plus `parts:[image]` | image-only message bubble |
+
+```mermaid
+flowchart TB
+    A["Codex thread/read payload"] --> B["Desktop Codex client normalizer"]
+    B --> C["AppServerThreadMessageEntry { text, parts }"]
+    C --> D["TranscriptMessage renders text parts + image previews"]
+    D --> E["ThreadView expansion overlay for selected image"]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend transcript normalization to preserve image parts**
+
+**Goal:** Keep image-bearing Codex transcript messages in the replay instead of flattening them to text-only or dropping them outright.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+
+**Approach:**
+- Add an optional structured transcript-part model to `AppServerThreadMessage` / `AppServerThreadMessageEntry`, with enough information to distinguish text parts from image parts while keeping ordering stable.
+- Refactor the Codex desktop client so message extraction reads structured content arrays first and derives `message.text` from text parts instead of treating text flattening as the only representation.
+- Recognize image records from the Codex `thread/read` payload shapes already adjacent to current fixtures, including remote image URLs and local file-backed image references that can be normalized to a renderable source.
+- Keep activity-item extraction unchanged so file reads, commands, and diffs continue to group exactly as they do today.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- `packages/shared/src/contracts/app-server.ts`
+
+**Test scenarios:**
+- Happy path: a `userMessage` with ordered text and image content returns one transcript message entry with ordered text and image parts, plus the expected text projection.
+- Happy path: an image-only `userMessage` still produces a message entry and appears in both `entries` and `messages` with an empty text projection.
+- Edge case: a local file-backed image reference is normalized into a renderer-safe source instead of being discarded as unknown content.
+- Edge case: existing text-only commentary and final assistant messages still normalize exactly as before.
+- Error path: malformed image content is skipped without aborting the whole transcript read, and neighboring valid parts still render.
+
+**Verification:**
+- `readThread()` returns stable transcript entries for image-bearing Codex turns, and image-only messages no longer disappear from replay data.
+
+- [ ] **Unit 2: Render inline image previews inside transcript messages**
+
+**Goal:** Show image parts inside transcript bubbles without regressing existing text, markdown-like formatting, or skill-chip behavior.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Teach `TranscriptMessage` to render ordered message parts instead of assuming a single text blob. Text parts should continue to use the current text rendering path, while image parts render as compact inline previews inside the same message bubble.
+- Keep skill-chip handling compatible by applying it only to text parts that actually contain skill-mention syntax, rather than forcing the whole multimodal message through the skill-chip-only branch.
+- Pass preview activation through `TranscriptList` using a narrow callback surface so the list remains responsible for ordering and scrolling, not modal state.
+- Add transcript-specific preview styles that follow the desktop style guide: compact radius, neutral framing, and no gallery-card treatment.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/MarkdownText.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+
+**Test scenarios:**
+- Happy path: a message with text then image renders the text content first and a clickable preview beneath it in the same bubble.
+- Happy path: an image-only message renders a preview bubble with the correct role styling and timestamp chrome intact.
+- Edge case: a message with multiple image parts preserves part ordering and exposes a separate clickable preview for each image.
+- Edge case: a text part containing a skill mention still renders the skill chip while sibling image parts remain visible.
+- Error path: a message with empty `text` but valid image parts does not fall back to the transcript empty state or disappear from the list.
+
+**Verification:**
+- Transcript rows visibly include image previews wherever the normalized replay contains image parts, while text-only messages continue to render unchanged.
+
+- [ ] **Unit 3: Add thread-scoped image expansion and dismissal behavior**
+
+**Goal:** Let users enlarge transcript images from thread detail without leaving the conversation or destabilizing transcript state.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptImageLightbox.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Store the currently expanded transcript image in `ThreadView`, alongside other selected-thread transient UI state, and clear it when the selected thread changes.
+- Render a lightweight overlay/lightbox component from `ThreadView` so expansion is scoped to the thread-detail surface rather than to individual message bubbles.
+- Support mouse and keyboard dismissal paths that are standard for desktop inspection flows: explicit close control, backdrop click, and `Escape`.
+- Keep pagination, scroll anchoring, and pending-message behavior unchanged by ensuring image expansion state does not mutate transcript entry identity or ordering.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+
+**Test scenarios:**
+- Happy path: clicking a transcript image preview opens the enlarged image overlay for the selected thread.
+- Happy path: pressing `Escape` or activating the close control dismisses the overlay and leaves the transcript visible underneath.
+- Edge case: selecting another thread clears any open image overlay instead of carrying media state across threads.
+- Edge case: opening one image while another is already expanded swaps the selected image without duplicating overlays.
+- Integration: prepending older transcript pages still preserves scroll position and does not break preview click targets or overlay dismissal.
+
+**Verification:**
+- Users can inspect transcript images in place, then close the enlarged view and continue reading the same thread without losing context or transcript position.
+
+## System-Wide Impact
+
+- **Interaction graph:** `thread/read` -> desktop backend client normalization -> shared replay contract -> `useThreadTranscript` -> `TranscriptList` / `TranscriptMessage` -> thread-scoped image overlay.
+- **Error propagation:** malformed or unsupported image records should degrade by omission of that part, not by failing the entire transcript read or crashing the renderer.
+- **State lifecycle risks:** image expansion state must reset on thread changes; image-only messages must retain stable ids so pagination merging and list ordering still work.
+- **API surface parity:** the shared contract expansion should be backward-compatible so Grok can keep returning text-only messages until it adopts transcript parts.
+- **Integration coverage:** one end-to-end fixture path should prove that a Codex `thread/read` payload with image parts survives normalization and becomes a clickable preview in the renderer.
+- **Unchanged invariants:** activity grouping, approval prompts, markdown-like text rendering, optimistic text compose behavior, and transcript pagination mechanics should remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Codex `thread/read` may emit image references in more than one shape, causing partial support or brittle parsing. | Centralize image-part normalization in one helper and cover mixed, image-only, remote, and local-file fixtures in `codex-client.test.ts`. |
+| A contract change could force broad renderer churn if `text` stops being reliable for current consumers. | Keep `text` as a compatibility projection and add `parts` as optional structured data. |
+| Image-only messages could regress transcript counts, empty-state logic, or optimistic dedupe assumptions. | Emit stable message ids even with empty `text`, and add renderer tests that assert message presence and message-count behavior for image-only entries. |
+| Expansion UI could leak state across thread switches or interfere with transcript scrolling. | Keep the selected-image state in `ThreadView`, clear it on thread change, and cover scroll/pagination regression scenarios in renderer tests. |
+
+## Documentation / Operational Notes
+
+- No rollout or migration work is expected; this is a desktop-only behavior fix guarded by existing test suites.
+- No user-facing docs update is required for the first pass unless the product later adds composer-side image attachment UI.
+
+## Sources & References
+
+- Related code: `packages/shared/src/contracts/app-server.ts`
+- Related code: `apps/desktop/src/main/codex-app-server/client.ts`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Related tests: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Related tests: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Related plan: `docs/plans/2026-04-16-001-feat-thread-centric-agent-desktop-plan.md`
+- Related plan: `docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -61,8 +61,24 @@ export type AppServerThreadMessage = {
   id: string;
   role: "user" | "assistant";
   text: string;
+  parts?: AppServerThreadMessagePart[];
   createdAt?: number;
 };
+
+export type AppServerThreadTextPart = {
+  type: "text";
+  text: string;
+};
+
+export type AppServerThreadImagePart = {
+  type: "image";
+  url: string;
+  alt?: string;
+};
+
+export type AppServerThreadMessagePart =
+  | AppServerThreadTextPart
+  | AppServerThreadImagePart;
 
 export type AppServerTranscriptPhase = "commentary" | "final";
 


### PR DESCRIPTION
## Summary
- preserve image-bearing Codex `thread/read` messages as structured transcript parts instead of dropping image-only turns
- render inline image previews inside transcript bubbles and add a thread-scoped lightbox for expansion
- add regression coverage for Codex normalization, transcript previews, and lightbox dismissal, and mark the implementation plan complete

## Testing
- `pnpm test`
- `pnpm exec vitest run apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx --environment jsdom`
- `pnpm typecheck`

## Screenshots
- Screenshot capture was attempted, but this environment could not access macOS display capture and the available Playwright MCP could not initialize its scratch directory. No uploaded screenshot artifact is available from this run.

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required. This change is confined to the local Electron desktop transcript UI and shared desktop replay normalization, with no production service or deployment surface.