### PR TITLE
feat(desktop): add focused diff zoom view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@
 - Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
 
+## Runtime Config
+
+- Grok app-server user config lives at `~/.config/grok-app-server/config.toml`.
+- Runtime config keys in that file are `xai_api_key`, `grok_model`, `xai_base_url`, and `state_root`.
+- Environment variables still override the user config.
+- Legacy `~/.config/grok-app-server/config.env` and related env files remain fallback-compatible, but `config.toml` is the current source of truth.
+
 ## Frontend and Desktop UI
 
 - For renderer UI work, follow the desktop style guide before inventing local styling.

--- a/README.md
+++ b/README.md
@@ -72,20 +72,24 @@ Known shape-first endpoints:
 - `account/rateLimits/read` returns an empty collection until rate-limit reporting is wired
 - `account/read` returns local development account metadata rather than a full auth-backed profile
 
-When you are ready to run live xAI-backed smoke coverage, put credentials in
-`packages/agent-core/.env.local`. The tracked template lives at
-`packages/agent-core/.env.local.example`.
+When you are ready to run live xAI-backed smoke coverage, set credentials in
+either your shell environment or the Grok app-server user config at
+`~/.config/grok-app-server/config.toml`.
 
-The desktop Grok app server client also falls back to the user config
-directory. It will load `XAI_API_KEY`, `GROK_MODEL`, and `XAI_BASE_URL` from
-the first existing file under `~/.config/grok-app-server` in this order:
+The runtime config keys are:
+
+- `xai_api_key`
+- `grok_model`
+- `xai_base_url`
+- `state_root`
+
+Project-local env and already-exported shell env still win over the user
+config. The runtime loader also preserves legacy fallback support under
+`~/.config/grok-app-server` for:
 
 - `config.env`
 - `.env.local`
 - `.env`
-
-Project-local env and already-exported shell env still win over that global
-fallback.
 
 CI uses the existing `live-agent-core` workflow job with the `XAI_API_KEY`
 repository secret. No separate tool-test secret is required.

--- a/apps/desktop/e2e/edited-changes-order.spec.ts
+++ b/apps/desktop/e2e/edited-changes-order.spec.ts
@@ -28,11 +28,10 @@ test("expanded edited changes stay in transcript order", async () => {
 
     const activityToggle = app.window.getByRole("button", { name: /Edited 1 file/i });
     await activityToggle.click();
-    await expect(app.window.getByText("2 unmodified lines skipped")).toBeVisible();
-    await expect(app.window.getByText("const b = 2;")).toHaveCount(0);
-
-    await app.window.getByRole("button", { name: "Zoom in" }).click();
     await expect(app.window.getByText("const b = 2;")).toBeVisible();
+    await expect(app.window.getByText("const c = 3;")).toBeVisible();
+    await expect(app.window.getByText("2 unmodified lines skipped")).toHaveCount(0);
+    await expect(app.window.getByRole("button", { name: "Zoom in" })).toHaveCount(0);
 
     const transcriptText = await app.window
       .getByRole("region", { name: "Transcript" })

--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -99,3 +99,5 @@ fixture for CI.
   transcript plan UI
 - `live-plan-updates/`: live `turn/plan/updated` rendering for in-flight task
   plan UI
+- `focused-diff-zoom/`: eligible transcript diffs that condense locally and can
+  hide low-signal hunks via the focused diff path

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -27,6 +27,7 @@ type LaunchResult = {
 
 export async function launchElectronApp(params: {
   fixturePath: string;
+  env?: Record<string, string | undefined>;
 }): Promise<LaunchResult> {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-desktop-e2e-"));
   const electronApp = await electron.launch({
@@ -37,6 +38,7 @@ export async function launchElectronApp(params: {
       NODE_ENV: "production",
       PWRAGNT_REPLAY_FIXTURE_PATH: params.fixturePath,
       PWRAGNT_STATE_ROOT: stateRoot,
+      ...params.env
     },
   });
   const window = await electronApp.firstWindow();

--- a/apps/desktop/e2e/fixtures/focused-diff-zoom/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/focused-diff-zoom/replay.fixture.json
@@ -1,0 +1,148 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "focused-diff-zoom",
+    "sourceCaptureId": "synthetic-focused-diff-zoom",
+    "threadId": "thread-focused-diff-zoom"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "initialize-2",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-focused-diff-zoom",
+          "title": "Focused diff zoom",
+          "titleSource": "explicit",
+          "summary": "Verify focused transcript diffs can condense and hide hunks",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000001
+        }
+      ]
+    },
+    {
+      "id": "thread-list-2",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-focused-diff-zoom",
+          "title": "Focused diff zoom",
+          "titleSource": "explicit",
+          "summary": "Verify focused transcript diffs can condense and hide hunks",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000001
+        }
+      ]
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Please collapse the low-signal changes."
+          },
+          {
+            "type": "activity",
+            "id": "activity-1",
+            "summary": "Edited 1 file",
+            "details": [
+              {
+                "id": "detail-1",
+                "kind": "write",
+                "label": "Update example.ts",
+                "path": "/repo/src/example.ts",
+                "fileDiff": {
+                  "kind": "update",
+                  "additions": 4,
+                  "removals": 4,
+                  "diff": "--- a/src/example.ts\n+++ b/src/example.ts\n@@ -1,7 +1,7 @@\n import { alpha } from './alpha';\n-import { beta } from './beta';\n+import { beta } from './beta/index';\n const keep = 1;\n const keep2 = 2;\n const keep3 = 3;\n const keep4 = 4;\n@@ -18,7 +18,7 @@\n function one() {\n   return keep;\n-  // old comment\n+  // refreshed comment\n }\n \n export function two() {\n@@ -34,7 +34,7 @@\n export function three() {\n   return 'three';\n-  const label = 'before';\n+  const label = 'after';\n   return label;\n }\n \n export function four() {\n@@ -50,7 +50,7 @@\n export function five() {\n   return 'five';\n-  // lint\n+  // linted\n }\n \n export const six = 6;\n"
+                }
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Done reviewing the collapsed diff."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Please collapse the low-signal changes."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Done reviewing the collapsed diff."
+          }
+        ],
+        "lastUserMessage": "Please collapse the low-signal changes.",
+        "lastAssistantMessage": "Done reviewing the collapsed diff.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/focused-diff-zoom.spec.ts
+++ b/apps/desktop/e2e/focused-diff-zoom.spec.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const focusedDiffSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("eligible diffs fall back to deterministic zoomed-out context", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      focusedDiffSpecDir,
+      "fixtures/focused-diff-zoom/replay.fixture.json"
+    )
+  });
+
+  try {
+    await app.window.getByRole("button", { name: /Focused diff zoom/i }).first().click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Focused diff zoom"
+      })
+    ).toBeVisible();
+
+    const activityToggle = app.window.getByRole("button", { name: /Edited 1 file/i });
+    await activityToggle.click();
+
+    await expect(app.window.getByText("7 lines skipped")).toBeVisible();
+    await expect(app.window.getByRole("button", { name: "Zoom in" })).toBeVisible();
+    await expect(app.window.getByText("const keep3 = 3;")).toHaveCount(0);
+
+    await app.window.getByRole("button", { name: "Zoom in" }).click();
+
+    await expect(app.window.getByRole("button", { name: "Zoom out" })).toBeVisible();
+    await expect(app.window.getByText("const keep3 = 3;")).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test("focused diff overrides can hide low-signal hunks end-to-end", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      focusedDiffSpecDir,
+      "fixtures/focused-diff-zoom/replay.fixture.json"
+    ),
+    env: {
+      PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE: JSON.stringify({
+        hiddenHunkIndices: [1],
+        reason: "focused diff test override"
+      })
+    }
+  });
+
+  try {
+    await app.window.getByRole("button", { name: /Focused diff zoom/i }).first().click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Focused diff zoom"
+      })
+    ).toBeVisible();
+
+    await app.window.getByRole("button", { name: /Edited 1 file/i }).click();
+
+    await expect(app.window.getByText("1 hunk hidden, 6 lines skipped")).toBeVisible();
+    await expect(app.window.getByText("// refreshed comment")).toHaveCount(0);
+
+    await app.window.getByRole("button", { name: "Zoom in" }).click();
+
+    await expect(app.window.getByText("// refreshed comment")).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
@@ -1,7 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { createTemporaryTestDirectory } from "@pwragnt/agent-core";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { parseUnifiedDiff, summarizeHunksForFocus } from "../../shared/diff-focus";
 import { makeXaiResponse } from "../../../../../packages/agent-core/src/testing/xai-fixtures.js";
+import { defaultGrokAppServerConfigPath } from "../../../../../packages/agent-core/src/config/grok-app-server-config.js";
+import { stringifyFlatToml } from "../../../../../packages/agent-core/src/config/simple-toml.js";
 
 const ELIGIBLE_DIFF = [
   "--- a/src/example.ts",
@@ -176,6 +181,45 @@ describe("FocusedDiffService", () => {
     expect(response.reason).toContain("invalid structured diff response");
   });
 
+  it("does not cache fallback responses from transient failures", async () => {
+    const client = {
+      createResponse: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("timeout"))
+        .mockResolvedValueOnce(
+          makeXaiResponse({
+            text: JSON.stringify({
+              decisions: [
+                {
+                  index: 1,
+                  disposition: "hide",
+                  reasonCode: "comment_only",
+                  reason: "Comment-only hunk.",
+                  confidence: 0.96
+                }
+              ]
+            })
+          })
+        )
+    };
+    const service = new FocusedDiffService({ client });
+
+    const first = await service.analyze(makeRequest());
+    const second = await service.analyze(makeRequest());
+
+    expect(first).toMatchObject({
+      mode: "fallback",
+      source: "heuristic",
+      hiddenHunkIndices: []
+    });
+    expect(second).toMatchObject({
+      mode: "focused",
+      source: "grok",
+      hiddenHunkIndices: [1]
+    });
+    expect(client.createResponse).toHaveBeenCalledTimes(2);
+  });
+
   it("returns a full ineligible response for small diffs", async () => {
     const client = {
       createResponse: vi.fn(async () => makeXaiResponse())
@@ -203,5 +247,99 @@ describe("FocusedDiffService", () => {
       reason: "too_few_hunks"
     });
     expect(client.createResponse).not.toHaveBeenCalled();
+  });
+
+  it("reads xAI credentials and model from runtime config.toml", async () => {
+    const temp = await createTemporaryTestDirectory();
+    const originalHome = process.env.HOME;
+    const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    const originalXaiApiKey = process.env.XAI_API_KEY;
+    const originalXaiBaseUrl = process.env.XAI_BASE_URL;
+    const originalGrokModel = process.env.GROK_MODEL;
+    const fetchSpy = vi.fn(async (_input, init) => ({
+      ok: true,
+      json: async () =>
+        makeXaiResponse({
+          text: JSON.stringify({
+            decisions: [
+              {
+                index: 1,
+                disposition: "hide",
+                reasonCode: "comment_only",
+                reason: "Comment-only hunk.",
+                confidence: 0.96
+              }
+            ]
+          })
+        })
+    }));
+    const originalFetch = globalThis.fetch;
+
+    try {
+      process.env.HOME = temp.path;
+      delete process.env.XDG_CONFIG_HOME;
+      delete process.env.XAI_API_KEY;
+      delete process.env.XAI_BASE_URL;
+      delete process.env.GROK_MODEL;
+
+      const configPath = defaultGrokAppServerConfigPath({ homeDir: temp.path });
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        stringifyFlatToml({
+          xai_api_key: "config-key",
+          xai_base_url: "https://api.example.test/v1",
+          grok_model: "grok-4.20-fast"
+        })
+      );
+
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      const service = new FocusedDiffService();
+      const response = await service.analyze(makeRequest());
+
+      expect(response).toMatchObject({
+        mode: "focused",
+        source: "grok",
+        hiddenHunkIndices: [1]
+      });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.example.test/v1/responses",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer config-key"
+          }),
+          body: expect.stringContaining('"model":"grok-4.20-fast"')
+        })
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      if (originalXaiApiKey === undefined) {
+        delete process.env.XAI_API_KEY;
+      } else {
+        process.env.XAI_API_KEY = originalXaiApiKey;
+      }
+      if (originalXaiBaseUrl === undefined) {
+        delete process.env.XAI_BASE_URL;
+      } else {
+        process.env.XAI_BASE_URL = originalXaiBaseUrl;
+      }
+      if (originalGrokModel === undefined) {
+        delete process.env.GROK_MODEL;
+      } else {
+        process.env.GROK_MODEL = originalGrokModel;
+      }
+      await temp.cleanup();
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
@@ -51,6 +51,38 @@ function makeRequest(diff = ELIGIBLE_DIFF) {
 }
 
 describe("FocusedDiffService", () => {
+  it("uses a test override response when configured", async () => {
+    const originalOverride = process.env.PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE;
+    process.env.PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE = JSON.stringify({
+      hiddenHunkIndices: [1],
+      reason: "test override"
+    });
+
+    try {
+      const client = {
+        createResponse: vi.fn(async () => makeXaiResponse())
+      };
+      const service = new FocusedDiffService({ client });
+
+      const response = await service.analyze(makeRequest());
+
+      expect(response).toMatchObject({
+        mode: "focused",
+        source: "heuristic",
+        hiddenHunkIndices: [1],
+        hiddenHunkCount: 1,
+        reason: "test override"
+      });
+      expect(client.createResponse).not.toHaveBeenCalled();
+    } finally {
+      if (originalOverride === undefined) {
+        delete process.env.PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE;
+      } else {
+        process.env.PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE = originalOverride;
+      }
+    }
+  });
+
   it("returns focused hide decisions for eligible diffs", async () => {
     const client = {
       createResponse: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/focused-diff-service.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { FocusedDiffService } from "../diff-focus/focused-diff-service";
+import { parseUnifiedDiff, summarizeHunksForFocus } from "../../shared/diff-focus";
+import { makeXaiResponse } from "../../../../../packages/agent-core/src/testing/xai-fixtures.js";
+
+const ELIGIBLE_DIFF = [
+  "--- a/src/example.ts",
+  "+++ b/src/example.ts",
+  "@@ -1,7 +1,7 @@",
+  " import { alpha } from './alpha';",
+  "-import { beta } from './beta';",
+  "+import { beta } from './beta/index';",
+  " const keep = 1;",
+  " const keep2 = 2;",
+  " const keep3 = 3;",
+  " const keep4 = 4;",
+  "@@ -18,7 +18,7 @@",
+  " function one() {",
+  "   return keep;",
+  "-  // old comment",
+  "+  // refreshed comment",
+  " }",
+  " ",
+  " export function two() {",
+  "@@ -34,7 +34,7 @@",
+  " export function three() {",
+  "   return 'three';",
+  "-  const label = 'before';",
+  "+  const label = 'after';",
+  "   return label;",
+  " }",
+  " ",
+  " export function four() {",
+  "@@ -50,7 +50,7 @@",
+  " export function five() {",
+  "   return 'five';",
+  "-  // lint",
+  "+  // linted",
+  " }",
+  " ",
+  " export const six = 6;"
+].join("\n");
+
+function makeRequest(diff = ELIGIBLE_DIFF) {
+  const parsed = parseUnifiedDiff(diff);
+  return {
+    filePath: "/repo/src/example.ts",
+    diff,
+    hunks: summarizeHunksForFocus(parsed)
+  };
+}
+
+describe("FocusedDiffService", () => {
+  it("returns focused hide decisions for eligible diffs", async () => {
+    const client = {
+      createResponse: vi.fn(async () => ({
+        ...makeXaiResponse({
+          text: JSON.stringify({
+            decisions: [
+              {
+                index: 1,
+                disposition: "hide",
+                reasonCode: "comment_only",
+                reason: "Comment-only hunk.",
+                confidence: 0.96
+              },
+              {
+                index: 2,
+                disposition: "show",
+                reasonCode: "keep",
+                reason: "Behavior changed.",
+                confidence: 0.93
+              }
+            ]
+          })
+        }),
+        usage: {
+          input_tokens_details: {
+            cached_tokens: 128
+          }
+        }
+      }))
+    };
+    const service = new FocusedDiffService({ client });
+
+    const response = await service.analyze(makeRequest());
+
+    expect(response).toMatchObject({
+      mode: "focused",
+      source: "grok",
+      hiddenHunkIndices: [1],
+      hiddenHunkCount: 1,
+      cachedTokens: 128
+    });
+    expect(response.decisions[1]).toMatchObject({
+      index: 1,
+      disposition: "hide",
+      reasonCode: "comment_only"
+    });
+  });
+
+  it("reuses cached analysis for the same diff", async () => {
+    const client = {
+      createResponse: vi.fn(async () =>
+        makeXaiResponse({
+          text: JSON.stringify({
+            decisions: [
+              {
+                index: 0,
+                disposition: "hide",
+                reasonCode: "import_reorder",
+                reason: "Import-only change.",
+                confidence: 0.92
+              }
+            ]
+          })
+        })
+      )
+    };
+    const service = new FocusedDiffService({ client });
+
+    const first = await service.analyze(makeRequest());
+    const second = await service.analyze(makeRequest());
+
+    expect(first.source).toBe("grok");
+    expect(second.source).toBe("cache");
+    expect(client.createResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back when Grok returns invalid JSON", async () => {
+    const client = {
+      createResponse: vi.fn(async () => makeXaiResponse({ text: "{not-json" }))
+    };
+    const service = new FocusedDiffService({ client });
+
+    const response = await service.analyze(makeRequest());
+
+    expect(response).toMatchObject({
+      mode: "fallback",
+      source: "heuristic",
+      hiddenHunkIndices: [],
+      hiddenHunkCount: 0
+    });
+    expect(response.reason).toContain("invalid structured diff response");
+  });
+
+  it("returns a full ineligible response for small diffs", async () => {
+    const client = {
+      createResponse: vi.fn(async () => makeXaiResponse())
+    };
+    const service = new FocusedDiffService({ client });
+    const request = makeRequest(
+      [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1,3 +1,3 @@",
+        " const alpha = 1;",
+        "-const beta = 2;",
+        "+const beta = 3;",
+        " export { alpha, beta };"
+      ].join("\n")
+    );
+
+    const response = await service.analyze(request);
+
+    expect(response).toMatchObject({
+      mode: "full",
+      source: "ineligible",
+      hiddenHunkIndices: [],
+      hiddenHunkCount: 0,
+      reason: "too_few_hunks"
+    });
+    expect(client.createResponse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/diff-focus/focused-diff-service.ts
+++ b/apps/desktop/src/main/diff-focus/focused-diff-service.ts
@@ -22,6 +22,7 @@ const FOCUSED_DIFF_PROMPT_VERSION = "focused-diff-v1";
 const FOCUSED_DIFF_MODEL = "grok-4.20-fast";
 const FOCUSED_DIFF_TIMEOUT_MS = 5_000;
 const MIN_HIDE_CONFIDENCE = 0.8;
+const FOCUSED_DIFF_TEST_RESPONSE_ENV = "PWRAGNT_FOCUSED_DIFF_TEST_RESPONSE";
 
 const FOCUSED_DIFF_REASON_CODES = [
   "comment_only",
@@ -136,6 +137,12 @@ export class FocusedDiffService {
         ...cached,
         source: "cache"
       };
+    }
+
+    const testOverride = readFocusedDiffTestOverride(parsed.hunks.length);
+    if (testOverride) {
+      this.cache.set(cacheKey, testOverride);
+      return testOverride;
     }
 
     const client = this.getClient();
@@ -350,6 +357,68 @@ function createDefaultDecisions(hunkCount: number): FocusedDiffHunkDecision[] {
     reason: "Keep visible",
     confidence: 1
   }));
+}
+
+function readFocusedDiffTestOverride(
+  hunkCount: number
+): FocusedDiffAnalysisResponse | null {
+  const rawValue = process.env[FOCUSED_DIFF_TEST_RESPONSE_ENV]?.trim();
+  if (!rawValue) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch (error) {
+    throw new Error(
+      `${FOCUSED_DIFF_TEST_RESPONSE_ENV} must be valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${FOCUSED_DIFF_TEST_RESPONSE_ENV} must decode to an object`);
+  }
+
+  const record = parsed as {
+    hiddenHunkIndices?: unknown;
+    reason?: unknown;
+  };
+  const hiddenHunkIndices = Array.isArray(record.hiddenHunkIndices)
+    ? record.hiddenHunkIndices.filter(
+        (value): value is number =>
+          typeof value === "number" &&
+          Number.isInteger(value) &&
+          value >= 0 &&
+          value < hunkCount
+      )
+    : [];
+  const hiddenHunkIndexSet = new Set(hiddenHunkIndices);
+  const decisions: FocusedDiffHunkDecision[] = createDefaultDecisions(hunkCount).map(
+    (decision): FocusedDiffHunkDecision =>
+      hiddenHunkIndexSet.has(decision.index)
+        ? {
+            ...decision,
+            disposition: "hide",
+            reasonCode: "comment_only",
+            reason: "Hidden by focused diff test override",
+            confidence: 1
+          }
+        : decision
+  );
+
+  return {
+    mode: hiddenHunkIndices.length > 0 ? "focused" : "fallback",
+    source: "heuristic",
+    hiddenHunkIndices,
+    hiddenHunkCount: hiddenHunkIndices.length,
+    decisions,
+    ...(typeof record.reason === "string" && record.reason.trim()
+      ? { reason: record.reason.trim() }
+      : {})
+  };
 }
 
 function buildFocusedDiffCacheKey(

--- a/apps/desktop/src/main/diff-focus/focused-diff-service.ts
+++ b/apps/desktop/src/main/diff-focus/focused-diff-service.ts
@@ -1,8 +1,7 @@
 import { createHash } from "node:crypto";
 import {
-  loadGrokAppServerConfig,
-  loadLocalEnv,
   normalizeXaiResponse,
+  resolveGrokAppServerRuntimeConfig,
   XaiResponsesClient
 } from "@pwragnt/agent-core";
 import type {
@@ -88,17 +87,19 @@ export class FocusedDiffService {
   private readonly configuredClient?: XaiClientLike;
   private readonly configuredApiKey?: string;
   private readonly configuredBaseUrl?: string;
-  private readonly model: string;
+  private readonly configuredModel?: string;
   private readonly promptVersion: string;
   private readonly timeoutMs: number;
-  private loadedEnv = false;
+  private runtimeConfig:
+    | ReturnType<typeof resolveGrokAppServerRuntimeConfig>
+    | undefined;
   private envClient: XaiClientLike | null | undefined;
 
   constructor(options: FocusedDiffServiceOptions = {}) {
     this.configuredClient = options.client;
     this.configuredApiKey = options.apiKey?.trim() || undefined;
     this.configuredBaseUrl = options.baseUrl?.trim() || undefined;
-    this.model = options.model?.trim() || process.env.GROK_MODEL?.trim() || FOCUSED_DIFF_MODEL;
+    this.configuredModel = options.model?.trim() || undefined;
     this.promptVersion = options.promptVersion?.trim() || FOCUSED_DIFF_PROMPT_VERSION;
     this.timeoutMs = options.timeoutMs ?? FOCUSED_DIFF_TIMEOUT_MS;
   }
@@ -147,9 +148,7 @@ export class FocusedDiffService {
 
     const client = this.getClient();
     if (!client) {
-      const fallback = this.buildFallbackResponse(decisions, "grok_unavailable");
-      this.cache.set(cacheKey, fallback);
-      return fallback;
+      return this.buildFallbackResponse(decisions, "grok_unavailable");
     }
 
     try {
@@ -167,12 +166,10 @@ export class FocusedDiffService {
       this.cache.set(cacheKey, analysis);
       return analysis;
     } catch (error) {
-      const fallback = this.buildFallbackResponse(
+      return this.buildFallbackResponse(
         decisions,
         error instanceof Error ? error.message : "grok_request_failed"
       );
-      this.cache.set(cacheKey, fallback);
-      return fallback;
     }
   }
 
@@ -199,13 +196,8 @@ export class FocusedDiffService {
       return this.envClient;
     }
 
-    if (!this.loadedEnv) {
-      loadLocalEnv({ override: false });
-      loadGrokAppServerConfig({ override: false });
-      this.loadedEnv = true;
-    }
-
-    const apiKey = this.configuredApiKey ?? process.env.XAI_API_KEY?.trim();
+    const runtimeConfig = this.getRuntimeConfig();
+    const apiKey = this.configuredApiKey ?? runtimeConfig.apiKey;
     if (!apiKey) {
       this.envClient = null;
       return this.envClient;
@@ -213,11 +205,24 @@ export class FocusedDiffService {
 
     this.envClient = new XaiResponsesClient({
       apiKey,
-      baseUrl: this.configuredBaseUrl ?? (process.env.XAI_BASE_URL?.trim() || undefined),
-      model: this.model
+      baseUrl: this.configuredBaseUrl ?? runtimeConfig.baseUrl,
+      model: this.getModel()
     });
 
     return this.envClient;
+  }
+
+  private getRuntimeConfig(): ReturnType<typeof resolveGrokAppServerRuntimeConfig> {
+    if (this.runtimeConfig) {
+      return this.runtimeConfig;
+    }
+
+    this.runtimeConfig = resolveGrokAppServerRuntimeConfig();
+    return this.runtimeConfig;
+  }
+
+  private getModel(): string {
+    return this.configuredModel ?? this.getRuntimeConfig().model ?? FOCUSED_DIFF_MODEL;
   }
 
   private async requestFocusedDiffDecision(
@@ -232,7 +237,7 @@ export class FocusedDiffService {
 
     try {
       return await client.createResponse({
-        model: this.model,
+        model: this.getModel(),
         promptCacheKey: this.promptVersion,
         headers: {
           "x-grok-conv-id": this.promptVersion

--- a/apps/desktop/src/main/diff-focus/focused-diff-service.ts
+++ b/apps/desktop/src/main/diff-focus/focused-diff-service.ts
@@ -1,0 +1,406 @@
+import { createHash } from "node:crypto";
+import {
+  loadGrokAppServerConfig,
+  loadLocalEnv,
+  normalizeXaiResponse,
+  XaiResponsesClient
+} from "@pwragnt/agent-core";
+import type {
+  FocusedDiffAnalysisRequest,
+  FocusedDiffAnalysisResponse,
+  FocusedDiffHunkDecision,
+  FocusedDiffHunkSummary,
+  FocusedDiffReasonCode
+} from "@pwragnt/shared";
+import {
+  getFocusedDiffEligibility,
+  parseUnifiedDiff,
+  summarizeHunksForFocus
+} from "../../shared/diff-focus";
+
+const FOCUSED_DIFF_PROMPT_VERSION = "focused-diff-v1";
+const FOCUSED_DIFF_MODEL = "grok-4.20-fast";
+const FOCUSED_DIFF_TIMEOUT_MS = 5_000;
+const MIN_HIDE_CONFIDENCE = 0.8;
+
+const FOCUSED_DIFF_REASON_CODES = [
+  "comment_only",
+  "formatting_only",
+  "import_reorder",
+  "keep",
+  "mechanical_small_change",
+  "repetitive_small_change",
+  "uncertain"
+] as const satisfies readonly FocusedDiffReasonCode[];
+
+const HIDEABLE_REASON_CODES = new Set<FocusedDiffReasonCode>([
+  "comment_only",
+  "formatting_only",
+  "import_reorder",
+  "mechanical_small_change",
+  "repetitive_small_change"
+]);
+
+const FOCUSED_DIFF_RESPONSE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["decisions"],
+  properties: {
+    decisions: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["index", "disposition", "reasonCode", "reason", "confidence"],
+        properties: {
+          index: { type: "integer", minimum: 0 },
+          disposition: { type: "string", enum: ["show", "hide"] },
+          reasonCode: { type: "string", enum: FOCUSED_DIFF_REASON_CODES },
+          reason: { type: "string", minLength: 1 },
+          confidence: { type: "number", minimum: 0, maximum: 1 }
+        }
+      }
+    }
+  }
+} as const;
+
+const FOCUSED_DIFF_SYSTEM_PROMPT = [
+  "You classify unified diff hunks for a zoomed-out code review view.",
+  "Hide only clearly low-signal hunks such as comment-only edits, formatting-only edits, import reorders, or repetitive tiny mechanical changes.",
+  "Show hunks when they alter logic, data flow, behavior, interfaces, tests, or anything uncertain.",
+  "Return JSON that matches the schema exactly."
+].join("\n");
+
+type XaiClientLike = Pick<XaiResponsesClient, "createResponse">;
+
+type FocusedDiffServiceOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  client?: XaiClientLike;
+  model?: string;
+  promptVersion?: string;
+  timeoutMs?: number;
+};
+
+export class FocusedDiffService {
+  private readonly cache = new Map<string, FocusedDiffAnalysisResponse>();
+  private readonly configuredClient?: XaiClientLike;
+  private readonly configuredApiKey?: string;
+  private readonly configuredBaseUrl?: string;
+  private readonly model: string;
+  private readonly promptVersion: string;
+  private readonly timeoutMs: number;
+  private loadedEnv = false;
+  private envClient: XaiClientLike | null | undefined;
+
+  constructor(options: FocusedDiffServiceOptions = {}) {
+    this.configuredClient = options.client;
+    this.configuredApiKey = options.apiKey?.trim() || undefined;
+    this.configuredBaseUrl = options.baseUrl?.trim() || undefined;
+    this.model = options.model?.trim() || process.env.GROK_MODEL?.trim() || FOCUSED_DIFF_MODEL;
+    this.promptVersion = options.promptVersion?.trim() || FOCUSED_DIFF_PROMPT_VERSION;
+    this.timeoutMs = options.timeoutMs ?? FOCUSED_DIFF_TIMEOUT_MS;
+  }
+
+  async analyze(
+    request: FocusedDiffAnalysisRequest
+  ): Promise<FocusedDiffAnalysisResponse> {
+    const parsed = parseUnifiedDiff(request.diff);
+    const decisions = createDefaultDecisions(parsed.hunks.length);
+    const eligibility = getFocusedDiffEligibility(parsed);
+
+    if (!eligibility.eligible) {
+      return {
+        mode: "full",
+        source: "ineligible",
+        hiddenHunkIndices: [],
+        hiddenHunkCount: 0,
+        decisions,
+        reason: eligibility.reason
+      };
+    }
+
+    const hunks =
+      request.hunks.length === parsed.hunks.length
+        ? request.hunks
+        : summarizeHunksForFocus(parsed);
+    const cacheKey = buildFocusedDiffCacheKey(
+      this.promptVersion,
+      request.filePath,
+      request.diff
+    );
+    const cached = this.cache.get(cacheKey);
+
+    if (cached) {
+      return {
+        ...cached,
+        source: "cache"
+      };
+    }
+
+    const client = this.getClient();
+    if (!client) {
+      const fallback = this.buildFallbackResponse(decisions, "grok_unavailable");
+      this.cache.set(cacheKey, fallback);
+      return fallback;
+    }
+
+    try {
+      const response = await this.requestFocusedDiffDecision(client, request.filePath, hunks);
+      const result = normalizeFocusedDiffResult(response, parsed.hunks.length);
+      const analysis: FocusedDiffAnalysisResponse = {
+        mode: result.hiddenHunkIndices.length > 0 ? "focused" : "fallback",
+        source: "grok",
+        hiddenHunkIndices: result.hiddenHunkIndices,
+        hiddenHunkCount: result.hiddenHunkIndices.length,
+        decisions: result.decisions,
+        cachedTokens: readCachedTokenCount(response),
+        ...(result.hiddenHunkIndices.length === 0 ? { reason: "no_hideable_hunks" } : {})
+      };
+      this.cache.set(cacheKey, analysis);
+      return analysis;
+    } catch (error) {
+      const fallback = this.buildFallbackResponse(
+        decisions,
+        error instanceof Error ? error.message : "grok_request_failed"
+      );
+      this.cache.set(cacheKey, fallback);
+      return fallback;
+    }
+  }
+
+  private buildFallbackResponse(
+    decisions: FocusedDiffHunkDecision[],
+    reason: string
+  ): FocusedDiffAnalysisResponse {
+    return {
+      mode: "fallback",
+      source: "heuristic",
+      hiddenHunkIndices: [],
+      hiddenHunkCount: 0,
+      decisions,
+      reason
+    };
+  }
+
+  private getClient(): XaiClientLike | null {
+    if (this.configuredClient) {
+      return this.configuredClient;
+    }
+
+    if (this.envClient !== undefined) {
+      return this.envClient;
+    }
+
+    if (!this.loadedEnv) {
+      loadLocalEnv({ override: false });
+      loadGrokAppServerConfig({ override: false });
+      this.loadedEnv = true;
+    }
+
+    const apiKey = this.configuredApiKey ?? process.env.XAI_API_KEY?.trim();
+    if (!apiKey) {
+      this.envClient = null;
+      return this.envClient;
+    }
+
+    this.envClient = new XaiResponsesClient({
+      apiKey,
+      baseUrl: this.configuredBaseUrl ?? (process.env.XAI_BASE_URL?.trim() || undefined),
+      model: this.model
+    });
+
+    return this.envClient;
+  }
+
+  private async requestFocusedDiffDecision(
+    client: XaiClientLike,
+    filePath: string | undefined,
+    hunks: FocusedDiffHunkSummary[]
+  ): Promise<unknown> {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      controller.abort();
+    }, this.timeoutMs);
+
+    try {
+      return await client.createResponse({
+        model: this.model,
+        promptCacheKey: this.promptVersion,
+        headers: {
+          "x-grok-conv-id": this.promptVersion
+        },
+        signal: controller.signal,
+        text: {
+          format: {
+            type: "json_schema",
+            name: "focused_diff_hunk_decisions",
+            schema: FOCUSED_DIFF_RESPONSE_SCHEMA,
+            strict: true
+          }
+        },
+        input: [
+          {
+            role: "system",
+            content: [{ type: "input_text", text: FOCUSED_DIFF_SYSTEM_PROMPT }]
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: JSON.stringify({
+                  filePath,
+                  hunks
+                })
+              }
+            ]
+          }
+        ]
+      });
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function normalizeFocusedDiffResult(
+  response: unknown,
+  hunkCount: number
+): { decisions: FocusedDiffHunkDecision[]; hiddenHunkIndices: number[] } {
+  const rawText = normalizeXaiResponse(response).assistantText;
+  if (!rawText) {
+    throw new Error("grok returned no structured diff decisions");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (error) {
+    throw new Error(
+      `invalid structured diff response: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("invalid structured diff response: decisions payload must be an object");
+  }
+
+  const record = parsed as { decisions?: unknown };
+  if (!Array.isArray(record.decisions)) {
+    throw new Error("invalid structured diff response: decisions must be an array");
+  }
+
+  const decisions = createDefaultDecisions(hunkCount);
+  for (const item of record.decisions) {
+    const normalized = normalizeModelDecision(item, hunkCount);
+    if (!normalized) {
+      continue;
+    }
+    decisions[normalized.index] = normalized;
+  }
+
+  const hiddenHunkIndices = decisions
+    .filter((decision) => decision.disposition === "hide")
+    .map((decision) => decision.index);
+
+  return {
+    decisions,
+    hiddenHunkIndices
+  };
+}
+
+function normalizeModelDecision(
+  value: unknown,
+  hunkCount: number
+): FocusedDiffHunkDecision | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const index = typeof record.index === "number" ? record.index : Number.NaN;
+  if (!Number.isInteger(index) || index < 0 || index >= hunkCount) {
+    return null;
+  }
+
+  const reasonCode = asFocusedReasonCode(record.reasonCode);
+  const reason = typeof record.reason === "string" ? record.reason.trim() : "";
+  const confidence = clampConfidence(record.confidence);
+  const requestedDisposition = record.disposition === "hide" ? "hide" : "show";
+  const canHide =
+    requestedDisposition === "hide" &&
+    confidence >= MIN_HIDE_CONFIDENCE &&
+    HIDEABLE_REASON_CODES.has(reasonCode);
+
+  return {
+    index,
+    disposition: canHide ? "hide" : "show",
+    reasonCode: canHide ? reasonCode : "keep",
+    reason: reason || "Keep visible",
+    confidence
+  };
+}
+
+function createDefaultDecisions(hunkCount: number): FocusedDiffHunkDecision[] {
+  return Array.from({ length: hunkCount }, (_value, index) => ({
+    index,
+    disposition: "show",
+    reasonCode: "keep",
+    reason: "Keep visible",
+    confidence: 1
+  }));
+}
+
+function buildFocusedDiffCacheKey(
+  promptVersion: string,
+  filePath: string | undefined,
+  diff: string
+): string {
+  return createHash("sha256")
+    .update(promptVersion)
+    .update("\u0000")
+    .update(filePath ?? "")
+    .update("\u0000")
+    .update(diff)
+    .digest("hex");
+}
+
+function asFocusedReasonCode(value: unknown): FocusedDiffReasonCode {
+  if (typeof value === "string" && FOCUSED_DIFF_REASON_CODES.includes(value as never)) {
+    return value as FocusedDiffReasonCode;
+  }
+
+  return "uncertain";
+}
+
+function clampConfidence(value: unknown): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, value));
+}
+
+function readCachedTokenCount(response: unknown): number | undefined {
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    return undefined;
+  }
+
+  const usage = (response as { usage?: unknown }).usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) {
+    return undefined;
+  }
+
+  const inputTokensDetails = (usage as { input_tokens_details?: unknown }).input_tokens_details;
+  if (
+    !inputTokensDetails ||
+    typeof inputTokensDetails !== "object" ||
+    Array.isArray(inputTokensDetails)
+  ) {
+    return undefined;
+  }
+
+  const cachedTokens = (inputTokensDetails as { cached_tokens?: unknown }).cached_tokens;
+  return typeof cachedTokens === "number" ? cachedTokens : undefined;
+}

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -10,6 +10,8 @@ import type {
   AppServerReadThreadResponse,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
+  FocusedDiffAnalysisRequest,
+  FocusedDiffAnalysisResponse,
   GetNavigationSnapshotRequest,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
@@ -28,12 +30,14 @@ import {
   APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
 } from "../../shared/ipc";
+import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 
@@ -46,6 +50,8 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
 }
 
 class DesktopAppServerService {
+  private focusedDiffService: FocusedDiffService | null = null;
+
   async listThreads(
     request: AppServerListThreadsRequest = {}
   ): Promise<AppServerListThreadsResponse> {
@@ -191,12 +197,37 @@ class DesktopAppServerService {
     return await getDesktopBackendRegistry().resetDirectoryLaunchpad(request);
   }
 
+  async analyzeFocusedDiff(
+    request: FocusedDiffAnalysisRequest
+  ): Promise<FocusedDiffAnalysisResponse> {
+    const response = await this.getFocusedDiffService().analyze(request);
+
+    logDebug("analyzeFocusedDiff", {
+      filePath: request.filePath ?? null,
+      hunkCount: request.hunks.length,
+      mode: response.mode,
+      source: response.source,
+      hiddenHunkCount: response.hiddenHunkCount
+    });
+
+    return response;
+  }
+
   async close(): Promise<void> {
     await disposeDesktopBackendRegistry();
   }
 
   private getOverlayStore(): OverlayStore {
     return getDesktopOverlayStore();
+  }
+
+  private getFocusedDiffService(): FocusedDiffService {
+    if (this.focusedDiffService) {
+      return this.focusedDiffService;
+    }
+
+    this.focusedDiffService = new FocusedDiffService();
+    return this.focusedDiffService;
   }
 }
 
@@ -231,6 +262,16 @@ export function registerAppServerIpcHandlers(): void {
       request: AppServerReadThreadRequest
     ): Promise<AppServerReadThreadResponse> => {
       return await appServerService.readThread(request);
+    }
+  );
+  ipcMain.removeHandler(FOCUSED_DIFF_ANALYZE_CHANNEL);
+  ipcMain.handle(
+    FOCUSED_DIFF_ANALYZE_CHANNEL,
+    async (
+      _event,
+      request: FocusedDiffAnalysisRequest
+    ): Promise<FocusedDiffAnalysisResponse> => {
+      return await appServerService.analyzeFocusedDiff(request);
     }
   );
   ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
@@ -289,6 +330,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.removeHandler(FOCUSED_DIFF_ANALYZE_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,8 @@ import type {
   SetThreadExecutionModeResponse,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
+  FocusedDiffAnalysisRequest,
+  FocusedDiffAnalysisResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
@@ -45,6 +47,7 @@ import {
   APP_SERVER_READ_THREAD_CHANNEL,
   BACKEND_LIST_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
@@ -79,6 +82,10 @@ const desktopApi = Object.freeze({
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> =>
     await ipcRenderer.invoke(APP_SERVER_READ_THREAD_CHANNEL, request),
+  analyzeFocusedDiff: async (
+    request: FocusedDiffAnalysisRequest
+  ): Promise<FocusedDiffAnalysisResponse> =>
+    await ipcRenderer.invoke(FOCUSED_DIFF_ANALYZE_CHANNEL, request),
   startThread: async (
     request: StartThreadRequest
   ): Promise<StartThreadResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -1,50 +1,84 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { AppServerThreadActivityDetail } from "@pwragnt/shared";
+import {
+  buildDiffView,
+  getFocusedDiffEligibility,
+  parseUnifiedDiff,
+  summarizeHunksForFocus,
+  type DiffView
+} from "../../../../shared/diff-focus";
+import { getDesktopApi } from "../../lib/desktop-api";
 
 type TranscriptDiffProps = {
   detail: AppServerThreadActivityDetail;
 };
 
-type DiffRow =
-  | {
-      kind: "added";
-      newNumber: number;
-      text: string;
-    }
-  | {
-      kind: "context";
-      newNumber: number;
-      oldNumber: number;
-      text: string;
-    }
-  | {
-      kind: "hunk";
-      text: string;
-    }
-  | {
-      kind: "removed";
-      oldNumber: number;
-      text: string;
-    }
-  | {
-      kind: "separator";
-      count: number;
-    };
-
-const CONTEXT_RADIUS = 1;
-
 export function TranscriptDiff(props: TranscriptDiffProps) {
   const [isZoomedIn, setIsZoomedIn] = useState(false);
+  const [focusedView, setFocusedView] = useState<DiffView | null>(null);
   const diff = props.detail.fileDiff;
-  const rows = useMemo(() => parsePatch(diff?.diff ?? ""), [diff?.diff]);
-  const visibleRows = useMemo(
-    () => (isZoomedIn ? rows : condenseRows(rows)),
-    [isZoomedIn, rows]
-  );
+  const desktopApi = getDesktopApi();
+  const parsed = useMemo(() => parseUnifiedDiff(diff?.diff ?? ""), [diff?.diff]);
+  const eligibility = useMemo(() => getFocusedDiffEligibility(parsed), [parsed]);
+  const hunkSummaries = useMemo(() => summarizeHunksForFocus(parsed), [parsed]);
+  const fullView = useMemo(() => buildDiffView(parsed, { mode: "full" }), [parsed]);
 
-  if (!diff || rows.length === 0) {
+  useEffect(() => {
+    setIsZoomedIn(false);
+    setFocusedView(null);
+  }, [diff?.diff, props.detail.path]);
+
+  useEffect(() => {
+    if (!diff || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
+      return;
+    }
+
+    let active = true;
+
+    void desktopApi
+      .analyzeFocusedDiff({
+        filePath: props.detail.path,
+        diff: diff.diff,
+        hunks: hunkSummaries
+      })
+      .then((response) => {
+        if (!active || response.mode !== "focused" || response.hiddenHunkIndices.length === 0) {
+          return;
+        }
+
+        setFocusedView(
+          buildDiffView(parsed, {
+            mode: "condensed",
+            hiddenHunkIndices: response.hiddenHunkIndices
+          })
+        );
+      })
+      .catch(() => {
+        if (!active) {
+          return;
+        }
+        setFocusedView(null);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [desktopApi, diff, eligibility.eligible, hunkSummaries, parsed, props.detail.path]);
+
+  const defaultView = useMemo(() => {
+    if (!eligibility.eligible) {
+      return fullView;
+    }
+
+    return focusedView ?? buildDiffView(parsed, { mode: "condensed" });
+  }, [eligibility.eligible, focusedView, fullView, parsed]);
+  const visibleView = isZoomedIn ? fullView : defaultView;
+
+  if (!diff || fullView.rows.length === 0) {
     return null;
   }
+
+  const hiddenSummary = !isZoomedIn ? formatHiddenSummary(defaultView) : null;
 
   return (
     <div className="transcript-diff">
@@ -55,27 +89,34 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
       ) : null}
 
       <div className="transcript-diff__toolbar">
-        <div className="transcript-diff__stats" aria-label="Diff summary">
-          <span className="transcript-diff__stat transcript-diff__stat--removed">
-            -{diff.removals}
-          </span>
-          <span className="transcript-diff__stat transcript-diff__stat--added">
-            +{diff.additions}
-          </span>
+        <div className="transcript-diff__meta">
+          <div className="transcript-diff__stats" aria-label="Diff summary">
+            <span className="transcript-diff__stat transcript-diff__stat--removed">
+              -{diff.removals}
+            </span>
+            <span className="transcript-diff__stat transcript-diff__stat--added">
+              +{diff.additions}
+            </span>
+          </div>
+          {hiddenSummary ? (
+            <span className="transcript-diff__summary">{hiddenSummary}</span>
+          ) : null}
         </div>
-        <button
-          type="button"
-          className="button button--ghost transcript-diff__toggle"
-          onClick={() => {
-            setIsZoomedIn((current) => !current);
-          }}
-        >
-          {isZoomedIn ? "Zoom out" : "Zoom in"}
-        </button>
+        {defaultView.hasHiddenContent ? (
+          <button
+            type="button"
+            className="button button--ghost transcript-diff__toggle"
+            onClick={() => {
+              setIsZoomedIn((current) => !current);
+            }}
+          >
+            {isZoomedIn ? "Zoom out" : "Zoom in"}
+          </button>
+        ) : null}
       </div>
 
       <div className="transcript-diff__rows" role="table" aria-label={`${props.detail.label} diff`}>
-        {visibleRows.map((row, index) => {
+        {visibleView.rows.map((row, index) => {
           if (row.kind === "separator") {
             return (
               <div
@@ -123,107 +164,25 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   );
 }
 
-function parsePatch(patch: string): DiffRow[] {
-  const lines = patch.replace(/\r\n?/g, "\n").split("\n");
-  const rows: DiffRow[] = [];
-  let oldLine = 0;
-  let newLine = 0;
-
-  for (const line of lines) {
-    const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-    if (hunkMatch) {
-      oldLine = Number.parseInt(hunkMatch[1], 10);
-      newLine = Number.parseInt(hunkMatch[2], 10);
-      rows.push({ kind: "hunk", text: line });
-      continue;
-    }
-
-    if (
-      line.startsWith("---") ||
-      line.startsWith("+++") ||
-      line.startsWith("Index:") ||
-      line.startsWith("====") ||
-      line.startsWith("\\")
-    ) {
-      continue;
-    }
-
-    if (line.startsWith("-")) {
-      rows.push({
-        kind: "removed",
-        oldNumber: oldLine,
-        text: line.slice(1)
-      });
-      oldLine += 1;
-      continue;
-    }
-
-    if (line.startsWith("+")) {
-      rows.push({
-        kind: "added",
-        newNumber: newLine,
-        text: line.slice(1)
-      });
-      newLine += 1;
-      continue;
-    }
-
-    if (oldLine > 0 || newLine > 0 || line.length > 0) {
-      rows.push({
-        kind: "context",
-        oldNumber: oldLine,
-        newNumber: newLine,
-        text: line.startsWith(" ") ? line.slice(1) : line
-      });
-      oldLine += 1;
-      newLine += 1;
-    }
-  }
-
-  return rows;
-}
-
-function condenseRows(rows: DiffRow[]): DiffRow[] {
-  const condensed: DiffRow[] = [];
-  let contextBuffer: Extract<DiffRow, { kind: "context" }>[] = [];
-
-  const flushContext = () => {
-    if (contextBuffer.length === 0) {
-      return;
-    }
-
-    if (contextBuffer.length <= CONTEXT_RADIUS * 2) {
-      condensed.push(...contextBuffer);
-      contextBuffer = [];
-      return;
-    }
-
-    condensed.push(...contextBuffer.slice(0, CONTEXT_RADIUS));
-    condensed.push({
-      kind: "separator",
-      count: contextBuffer.length - CONTEXT_RADIUS * 2
-    });
-    condensed.push(...contextBuffer.slice(-CONTEXT_RADIUS));
-    contextBuffer = [];
-  };
-
-  for (const row of rows) {
-    if (row.kind === "context") {
-      contextBuffer.push(row);
-      continue;
-    }
-
-    flushContext();
-    condensed.push(row);
-  }
-
-  flushContext();
-  return condensed;
-}
-
 function formatLineNumber(value: number | undefined): string {
   if (typeof value !== "number") {
     return "";
   }
   return String(value);
+}
+
+function formatHiddenSummary(view: DiffView): string | null {
+  const parts: string[] = [];
+
+  if (view.hiddenHunkCount > 0) {
+    parts.push(`${view.hiddenHunkCount} hunk${view.hiddenHunkCount === 1 ? "" : "s"} hidden`);
+  }
+
+  if (view.hiddenContextLineCount > 0) {
+    parts.push(
+      `${view.hiddenContextLineCount} line${view.hiddenContextLineCount === 1 ? "" : "s"} skipped`
+    );
+  }
+
+  return parts.length > 0 ? parts.join(", ") : null;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
@@ -1,0 +1,109 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TranscriptDiff } from "../TranscriptDiff";
+
+const ELIGIBLE_DIFF = [
+  "--- a/src/example.ts",
+  "+++ b/src/example.ts",
+  "@@ -1,7 +1,7 @@",
+  " import { alpha } from './alpha';",
+  "-import { beta } from './beta';",
+  "+import { beta } from './beta/index';",
+  " const keep = 1;",
+  " const keep2 = 2;",
+  " const keep3 = 3;",
+  " const keep4 = 4;",
+  "@@ -18,7 +18,7 @@",
+  " function one() {",
+  "   return keep;",
+  "-  // old comment",
+  "+  // refreshed comment",
+  " }",
+  " ",
+  " export function two() {",
+  "@@ -34,7 +34,7 @@",
+  " export function three() {",
+  "   return 'three';",
+  "-  const label = 'before';",
+  "+  const label = 'after';",
+  "   return label;",
+  " }",
+  " ",
+  " export function four() {",
+  "@@ -50,7 +50,7 @@",
+  " export function five() {",
+  "   return 'five';",
+  "-  // lint",
+  "+  // linted",
+  " }",
+  " ",
+  " export const six = 6;"
+].join("\n");
+
+const DETAIL = {
+  id: "detail-1",
+  kind: "write" as const,
+  label: "Update example.ts",
+  path: "/repo/src/example.ts",
+  fileDiff: {
+    kind: "update" as const,
+    additions: 4,
+    removals: 4,
+    diff: ELIGIBLE_DIFF
+  }
+};
+
+describe("TranscriptDiff", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as Window & { pwragnt?: unknown }).pwragnt;
+  });
+
+  it("defaults to a focused view when analysis hides low-signal hunks", async () => {
+    const analyzeFocusedDiff = vi.fn(async () => ({
+      mode: "focused" as const,
+      source: "grok" as const,
+      hiddenHunkIndices: [1],
+      hiddenHunkCount: 1,
+      decisions: []
+    }));
+    (window as Window & { pwragnt?: unknown }).pwragnt = {
+      analyzeFocusedDiff
+    };
+
+    render(<TranscriptDiff detail={DETAIL} />);
+
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+    await screen.findByText("1 hunk hidden, 8 lines skipped");
+    expect(screen.queryByText("// refreshed comment")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+    expect(screen.getByText("// refreshed comment")).toBeInTheDocument();
+    expect(analyzeFocusedDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to deterministic condensation when focused analysis fails", async () => {
+    const analyzeFocusedDiff = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    (window as Window & { pwragnt?: unknown }).pwragnt = {
+      analyzeFocusedDiff
+    };
+
+    render(<TranscriptDiff detail={DETAIL} />);
+
+    await waitFor(() => {
+      expect(analyzeFocusedDiff).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+    expect(screen.getByText("10 lines skipped")).toBeInTheDocument();
+    expect(screen.queryByText("const keep3 = 3;")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+
+    expect(screen.getByText("const keep3 = 3;")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -467,7 +467,7 @@ describe("TranscriptList", () => {
     expect(screen.queryByText("Read TranscriptActivity.tsx")).not.toBeInTheDocument();
   });
 
-  it("renders write diffs zoomed out by default and expands them on demand", () => {
+  it("renders simple write diffs fully without zoom controls", () => {
     render(
       <TranscriptList
         entries={[
@@ -512,14 +512,10 @@ describe("TranscriptList", () => {
     fireEvent.click(screen.getByRole("button", { name: /Edited 1 file/i }));
 
     expect(screen.getByText("Update TranscriptList.tsx")).toBeInTheDocument();
-    expect(screen.getByText("2 unmodified lines skipped")).toBeInTheDocument();
-    expect(screen.queryByText("const b = 2;")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
-
     expect(screen.getByText("const b = 2;")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+    expect(screen.getByText("const c = 3;")).toBeInTheDocument();
+    expect(screen.queryByText("2 unmodified lines skipped")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom in" })).not.toBeInTheDocument();
   });
 
   it("preserves the reader position when older messages are prepended", () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -4,6 +4,8 @@ import type {
   AppServerListSkillsResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
+  FocusedDiffAnalysisRequest,
+  FocusedDiffAnalysisResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   EnsureDirectoryLaunchpadRequest,
@@ -37,6 +39,9 @@ export type DesktopApi = {
   listSkills?: (
     request?: AppServerListSkillsRequest
   ) => Promise<AppServerListSkillsResponse>;
+  analyzeFocusedDiff?: (
+    request: FocusedDiffAnalysisRequest
+  ) => Promise<FocusedDiffAnalysisResponse>;
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1357,6 +1357,14 @@ textarea {
   padding: 0 12px 12px;
 }
 
+.transcript-diff__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  min-width: 0;
+}
+
 .transcript-diff__stats {
   display: inline-flex;
   align-items: center;
@@ -1386,6 +1394,12 @@ textarea {
   min-height: 28px;
   padding: 0 10px;
   font-size: 12px;
+}
+
+.transcript-diff__summary {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .transcript-diff__rows {

--- a/apps/desktop/src/shared/__tests__/diff-focus.test.ts
+++ b/apps/desktop/src/shared/__tests__/diff-focus.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDiffView,
+  getFocusedDiffEligibility,
+  parseUnifiedDiff,
+  summarizeHunksForFocus
+} from "../diff-focus";
+
+describe("diff-focus", () => {
+  it("parses single-hunk diffs and keeps zoom controls off for simple patches", () => {
+    const parsed = parseUnifiedDiff(
+      [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1,3 +1,3 @@",
+        " const alpha = 1;",
+        "-const beta = 2;",
+        "+const beta = 3;",
+        " export { alpha, beta };"
+      ].join("\n")
+    );
+
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.stats.smallHunkCount).toBe(1);
+    expect(getFocusedDiffEligibility(parsed)).toMatchObject({
+      eligible: false,
+      reason: "too_few_hunks"
+    });
+    expect(buildDiffView(parsed, { mode: "full" }).hasHiddenContent).toBe(false);
+  });
+
+  it("marks noisy multi-hunk diffs as focus-eligible and summarizes them", () => {
+    const parsed = parseUnifiedDiff(
+      [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1,7 +1,7 @@",
+        " import { alpha } from './alpha';",
+        "-import { beta } from './beta';",
+        "+import { beta } from './beta/index';",
+        " const keep = 1;",
+        " const keep2 = 2;",
+        " const keep3 = 3;",
+        " const keep4 = 4;",
+        "@@ -18,7 +18,7 @@",
+        " function one() {",
+        "   return keep;",
+        "-  // old comment",
+        "+  // refreshed comment",
+        " }",
+        " ",
+        " export function two() {",
+        "@@ -34,7 +34,7 @@",
+        " export function three() {",
+        "   return 'three';",
+        "-  const label = 'before';",
+        "+  const label = 'after';",
+        "   return label;",
+        " }",
+        " ",
+        " export function four() {",
+        "@@ -50,7 +50,7 @@",
+        " export function five() {",
+        "   return 'five';",
+        "-  // lint",
+        "+  // linted",
+        " }",
+        " ",
+        " export const six = 6;"
+      ].join("\n")
+    );
+
+    expect(parsed.hunks).toHaveLength(4);
+    expect(getFocusedDiffEligibility(parsed)).toMatchObject({
+      eligible: true,
+      reason: "eligible"
+    });
+    expect(buildDiffView(parsed, { mode: "condensed" }).hiddenContextLineCount).toBeGreaterThan(0);
+    expect(summarizeHunksForFocus(parsed)).toMatchObject([
+      expect.objectContaining({
+        index: 0,
+        changedLineCount: 2
+      }),
+      expect.objectContaining({
+        index: 1,
+        changedLineCount: 2
+      })
+    ]);
+  });
+
+  it("keeps adjacent hunks distinct and strips patch headers from content rows", () => {
+    const parsed = parseUnifiedDiff(
+      [
+        "diff --git a/src/example.ts b/src/example.ts",
+        "index 123..456 100644",
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1,2 +1,2 @@",
+        "-const alpha = 1;",
+        "+const alpha = 2;",
+        "@@ -4,2 +4,2 @@",
+        "-const beta = 3;",
+        "+const beta = 4;"
+      ].join("\n")
+    );
+
+    expect(parsed.hunks).toHaveLength(2);
+    expect(parsed.hunks[0]?.rows).toEqual([
+      {
+        kind: "removed",
+        hunkIndex: 0,
+        oldNumber: 1,
+        text: "const alpha = 1;"
+      },
+      {
+        kind: "added",
+        hunkIndex: 0,
+        newNumber: 1,
+        text: "const alpha = 2;"
+      }
+    ]);
+    expect(parsed.hunks[1]?.rows).toEqual([
+      {
+        kind: "removed",
+        hunkIndex: 1,
+        oldNumber: 4,
+        text: "const beta = 3;"
+      },
+      {
+        kind: "added",
+        hunkIndex: 1,
+        newNumber: 4,
+        text: "const beta = 4;"
+      }
+    ]);
+  });
+
+  it("returns a safe empty model for blank diffs", () => {
+    const parsed = parseUnifiedDiff("");
+
+    expect(parsed).toEqual({
+      hunks: [],
+      stats: {
+        hunkCount: 0,
+        changedLineCount: 0,
+        contextLineCount: 0,
+        smallHunkCount: 0
+      }
+    });
+    expect(getFocusedDiffEligibility(parsed)).toMatchObject({
+      eligible: false,
+      reason: "too_few_hunks"
+    });
+    expect(buildDiffView(parsed, { mode: "full" })).toMatchObject({
+      rows: [],
+      hasHiddenContent: false
+    });
+  });
+});

--- a/apps/desktop/src/shared/diff-focus.ts
+++ b/apps/desktop/src/shared/diff-focus.ts
@@ -1,0 +1,376 @@
+import type { FocusedDiffHunkSummary } from "@pwragnt/shared";
+
+export const LOCAL_DIFF_CONTEXT_RADIUS = 1;
+export const MIN_FOCUSED_DIFF_HUNK_COUNT = 4;
+export const MIN_FOCUSED_DIFF_SMALL_HUNK_COUNT = 2;
+export const MAX_FOCUSED_DIFF_SMALL_HUNK_LINES = 2;
+export const MIN_FOCUSED_DIFF_CONTEXT_RATIO = 2;
+
+export type DiffLineRow =
+  | {
+      kind: "added";
+      hunkIndex: number;
+      newNumber: number;
+      text: string;
+    }
+  | {
+      kind: "context";
+      hunkIndex: number;
+      newNumber: number;
+      oldNumber: number;
+      text: string;
+    }
+  | {
+      kind: "removed";
+      hunkIndex: number;
+      oldNumber: number;
+      text: string;
+    };
+
+export type DiffHunkHeaderRow = {
+  kind: "hunk";
+  hunkIndex: number;
+  text: string;
+};
+
+export type DiffSeparatorRow = {
+  kind: "separator";
+  hunkIndex: number;
+  count: number;
+};
+
+export type DiffViewRow = DiffHunkHeaderRow | DiffLineRow | DiffSeparatorRow;
+
+export type ParsedDiffHunk = {
+  index: number;
+  header: string;
+  rows: DiffLineRow[];
+  addedLineCount: number;
+  removedLineCount: number;
+  changedLineCount: number;
+  contextLineCount: number;
+};
+
+export type ParsedUnifiedDiff = {
+  hunks: ParsedDiffHunk[];
+  stats: {
+    hunkCount: number;
+    changedLineCount: number;
+    contextLineCount: number;
+    smallHunkCount: number;
+  };
+};
+
+export type FocusedDiffEligibility = {
+  eligible: boolean;
+  hiddenContextLineCount: number;
+  reason:
+    | "eligible"
+    | "insufficient_condensation"
+    | "insufficient_context_ratio"
+    | "insufficient_small_hunks"
+    | "too_few_hunks";
+};
+
+export type DiffView = {
+  rows: DiffViewRow[];
+  hiddenContextLineCount: number;
+  hiddenHunkCount: number;
+  hasHiddenContent: boolean;
+};
+
+export function parseUnifiedDiff(patch: string): ParsedUnifiedDiff {
+  const lines = patch.replace(/\r\n?/g, "\n").split("\n");
+  const hunks: ParsedDiffHunk[] = [];
+  let currentHunk: ParsedDiffHunk | undefined;
+  let oldLine = 0;
+  let newLine = 0;
+
+  const commitCurrentHunk = (): void => {
+    if (!currentHunk) {
+      return;
+    }
+
+    hunks.push(currentHunk);
+    currentHunk = undefined;
+  };
+
+  for (const line of lines) {
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      commitCurrentHunk();
+      oldLine = Number.parseInt(hunkMatch[1], 10);
+      newLine = Number.parseInt(hunkMatch[2], 10);
+      currentHunk = {
+        index: hunks.length,
+        header: line,
+        rows: [],
+        addedLineCount: 0,
+        removedLineCount: 0,
+        changedLineCount: 0,
+        contextLineCount: 0
+      };
+      continue;
+    }
+
+    if (
+      !currentHunk ||
+      line.startsWith("---") ||
+      line.startsWith("+++") ||
+      line.startsWith("Index:") ||
+      line.startsWith("====") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      currentHunk.rows.push({
+        kind: "removed",
+        hunkIndex: currentHunk.index,
+        oldNumber: oldLine,
+        text: line.slice(1)
+      });
+      currentHunk.removedLineCount += 1;
+      currentHunk.changedLineCount += 1;
+      oldLine += 1;
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      currentHunk.rows.push({
+        kind: "added",
+        hunkIndex: currentHunk.index,
+        newNumber: newLine,
+        text: line.slice(1)
+      });
+      currentHunk.addedLineCount += 1;
+      currentHunk.changedLineCount += 1;
+      newLine += 1;
+      continue;
+    }
+
+    if (oldLine > 0 || newLine > 0 || line.length > 0) {
+      currentHunk.rows.push({
+        kind: "context",
+        hunkIndex: currentHunk.index,
+        oldNumber: oldLine,
+        newNumber: newLine,
+        text: line.startsWith(" ") ? line.slice(1) : line
+      });
+      currentHunk.contextLineCount += 1;
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  commitCurrentHunk();
+
+  return {
+    hunks,
+    stats: {
+      hunkCount: hunks.length,
+      changedLineCount: hunks.reduce((sum, hunk) => sum + hunk.changedLineCount, 0),
+      contextLineCount: hunks.reduce((sum, hunk) => sum + hunk.contextLineCount, 0),
+      smallHunkCount: hunks.filter(
+        (hunk) => hunk.changedLineCount <= MAX_FOCUSED_DIFF_SMALL_HUNK_LINES
+      ).length
+    }
+  };
+}
+
+export function buildDiffView(
+  parsed: ParsedUnifiedDiff,
+  options?: {
+    hiddenHunkIndices?: Iterable<number>;
+    mode?: "condensed" | "full";
+    contextRadius?: number;
+  }
+): DiffView {
+  const hiddenHunkIndices = new Set(options?.hiddenHunkIndices ?? []);
+  const mode = options?.mode ?? "full";
+  const contextRadius = options?.contextRadius ?? LOCAL_DIFF_CONTEXT_RADIUS;
+  const rows: DiffViewRow[] = [];
+  let hiddenContextLineCount = 0;
+
+  for (const hunk of parsed.hunks) {
+    if (hiddenHunkIndices.has(hunk.index)) {
+      continue;
+    }
+
+    rows.push({
+      kind: "hunk",
+      hunkIndex: hunk.index,
+      text: hunk.header
+    });
+
+    if (mode === "full") {
+      rows.push(...hunk.rows);
+      continue;
+    }
+
+    const condensed = condenseHunkRows(hunk.rows, contextRadius);
+    hiddenContextLineCount += condensed.hiddenContextLineCount;
+    rows.push(...condensed.rows);
+  }
+
+  return {
+    rows,
+    hiddenContextLineCount,
+    hiddenHunkCount: hiddenHunkIndices.size,
+    hasHiddenContent: hiddenContextLineCount > 0 || hiddenHunkIndices.size > 0
+  };
+}
+
+export function getFocusedDiffEligibility(
+  parsed: ParsedUnifiedDiff
+): FocusedDiffEligibility {
+  const condensedView = buildDiffView(parsed, { mode: "condensed" });
+
+  if (parsed.stats.hunkCount < MIN_FOCUSED_DIFF_HUNK_COUNT) {
+    return {
+      eligible: false,
+      hiddenContextLineCount: condensedView.hiddenContextLineCount,
+      reason: "too_few_hunks"
+    };
+  }
+
+  if (parsed.stats.smallHunkCount < MIN_FOCUSED_DIFF_SMALL_HUNK_COUNT) {
+    return {
+      eligible: false,
+      hiddenContextLineCount: condensedView.hiddenContextLineCount,
+      reason: "insufficient_small_hunks"
+    };
+  }
+
+  if (condensedView.hiddenContextLineCount === 0) {
+    return {
+      eligible: false,
+      hiddenContextLineCount: 0,
+      reason: "insufficient_condensation"
+    };
+  }
+
+  const contextRatio =
+    parsed.stats.changedLineCount === 0
+      ? Number.POSITIVE_INFINITY
+      : parsed.stats.contextLineCount / parsed.stats.changedLineCount;
+
+  if (contextRatio < MIN_FOCUSED_DIFF_CONTEXT_RATIO) {
+    return {
+      eligible: false,
+      hiddenContextLineCount: condensedView.hiddenContextLineCount,
+      reason: "insufficient_context_ratio"
+    };
+  }
+
+  return {
+    eligible: true,
+    hiddenContextLineCount: condensedView.hiddenContextLineCount,
+    reason: "eligible"
+  };
+}
+
+export function summarizeHunksForFocus(
+  parsed: ParsedUnifiedDiff,
+  contextPreviewLimit = 2
+): FocusedDiffHunkSummary[] {
+  return parsed.hunks.map((hunk) => {
+    const addedLines = hunk.rows
+      .filter((row): row is Extract<DiffLineRow, { kind: "added" }> => row.kind === "added")
+      .map((row) => row.text);
+    const removedLines = hunk.rows
+      .filter((row): row is Extract<DiffLineRow, { kind: "removed" }> => row.kind === "removed")
+      .map((row) => row.text);
+
+    const leadingContext = collectLeadingContext(hunk.rows).slice(-contextPreviewLimit);
+    const trailingContext = collectTrailingContext(hunk.rows).slice(0, contextPreviewLimit);
+
+    return {
+      index: hunk.index,
+      header: hunk.header,
+      addedLines,
+      removedLines,
+      contextBefore: leadingContext,
+      contextAfter: trailingContext,
+      changedLineCount: hunk.changedLineCount,
+      contextLineCount: hunk.contextLineCount
+    };
+  });
+}
+
+function condenseHunkRows(
+  rows: DiffLineRow[],
+  contextRadius: number
+): { rows: Array<DiffLineRow | DiffSeparatorRow>; hiddenContextLineCount: number } {
+  const condensed: Array<DiffLineRow | DiffSeparatorRow> = [];
+  let contextBuffer: Extract<DiffLineRow, { kind: "context" }>[] = [];
+  let hiddenContextLineCount = 0;
+
+  const flushContext = () => {
+    if (contextBuffer.length === 0) {
+      return;
+    }
+
+    if (contextBuffer.length <= contextRadius * 2) {
+      condensed.push(...contextBuffer);
+      contextBuffer = [];
+      return;
+    }
+
+    condensed.push(...contextBuffer.slice(0, contextRadius));
+    const hiddenCount = contextBuffer.length - contextRadius * 2;
+    hiddenContextLineCount += hiddenCount;
+    condensed.push({
+      kind: "separator",
+      hunkIndex: contextBuffer[0]?.hunkIndex ?? 0,
+      count: hiddenCount
+    });
+    condensed.push(...contextBuffer.slice(-contextRadius));
+    contextBuffer = [];
+  };
+
+  for (const row of rows) {
+    if (row.kind === "context") {
+      contextBuffer.push(row);
+      continue;
+    }
+
+    flushContext();
+    condensed.push(row);
+  }
+
+  flushContext();
+
+  return {
+    rows: condensed,
+    hiddenContextLineCount
+  };
+}
+
+function collectLeadingContext(rows: DiffLineRow[]): string[] {
+  const output: string[] = [];
+
+  for (const row of rows) {
+    if (row.kind !== "context") {
+      break;
+    }
+    output.push(row.text);
+  }
+
+  return output;
+}
+
+function collectTrailingContext(rows: DiffLineRow[]): string[] {
+  const output: string[] = [];
+
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (row?.kind !== "context") {
+      break;
+    }
+    output.unshift(row.text);
+  }
+
+  return output;
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,6 +1,7 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_LIST_SKILLS_CHANNEL = "app-server:list-skills";
+export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";

--- a/docs/plans/2026-04-16-004-feat-grok-focused-diff-view-plan.md
+++ b/docs/plans/2026-04-16-004-feat-grok-focused-diff-view-plan.md
@@ -1,0 +1,293 @@
+---
+title: feat: Add Grok-focused diff zoom view
+type: feat
+status: completed
+date: 2026-04-16
+---
+
+# feat: Add Grok-focused diff zoom view
+
+## Overview
+
+Add a smarter default "zoomed out" diff view in the desktop transcript that can hide low-signal hunks for noisy multi-hunk diffs, while always preserving a one-click full diff view. The first pass should stay cheap and safe: deterministic compression remains the baseline, Grok analysis is optional and gated, and the full patch remains the source of truth.
+
+## Problem Frame
+
+The current desktop diff renderer only compresses unchanged context within a unified diff. That helps, but it still leaves busy patches hard to scan when a file contains many tiny hunks such as import churn, comment updates, or repetitive one-line edits spread across the file. The user wants a real zoom in/out behavior where the default view can skip low-value hunks, but not at the cost of hiding the only trustworthy view. This plan therefore treats Grok as a ranking pass for a secondary focused view, not as an authority that replaces the full diff.
+
+## Requirements Trace
+
+- R1. Keep the full diff available at all times; the focused view must be additive, not destructive.
+- R2. Only invoke Grok for diffs that are likely to benefit from hunk-level ranking, rather than for every patch.
+- R3. Do not require function/tool calling for this feature; use the simplest reliable xAI path.
+- R4. Preserve deterministic fallback behavior when Grok is unavailable, slow, schema-invalid, or low confidence.
+- R5. Only show zoom controls when the zoomed-out view actually hides material relative to the full diff.
+- R6. Keep the implementation inside the existing desktop main/preload/renderer contract patterns.
+- R7. Bound cost and latency with explicit gating, caching, and request shaping.
+
+## Scope Boundaries
+
+- No change to transcript replay persistence; focused-hunk decisions are ephemeral UI data, not thread history.
+- No attempt to summarize or rewrite diff prose in the first pass; the model only decides which hunks to hide.
+- No provider-general abstraction for third-party diff ranking beyond the existing Grok-first path.
+- No background prefetch for every diff in the transcript list; analysis should be requested on demand for an opened activity item.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx` already parses unified diffs into rows and supports a simple full-versus-condensed toggle.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx` is the current expansion boundary for transcript activity details; it is the natural place to trigger focused analysis when a write detail becomes visible.
+- `apps/desktop/src/main/ipc/app-server.ts`, `apps/desktop/src/preload/index.ts`, `apps/desktop/src/shared/ipc.ts`, and `apps/desktop/src/renderer/src/lib/desktop-api.ts` define the established main/preload/renderer bridge pattern.
+- `apps/desktop/src/main/grok-app-server/client.ts` already knows how to load Grok configuration through `@pwragnt/agent-core`; the focused-diff service should follow that pattern rather than inventing a separate config path.
+- `packages/agent-core/src/providers/xai-responses-client.ts` is the existing xAI Responses API wrapper; it is the right reuse point if the focused-diff service needs prompt-cache-related request fields or headers.
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` already covers transcript diff behavior and should stay the renderer contract anchor.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist yet in this repository.
+
+### External References
+
+- xAI structured outputs guarantee schema-shaped responses and are supported by language models, which is a better fit here than parsing free-form prose: [docs.x.ai/developers/model-capabilities/text/structured-outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs)
+- xAI function calling exists, but this feature does not need a tool loop because the desktop can submit a single ranking request and consume structured JSON directly: [docs.x.ai/developers/tools/function-calling](https://docs.x.ai/developers/tools/function-calling)
+- xAI prompt caching for Responses API can reduce repeated-prefix cost; the docs recommend `x-grok-conv-id` and mention `prompt_cache_key` for Responses API: [docs.x.ai/developers/advanced-api-usage/prompt-caching](https://docs.x.ai/developers/advanced-api-usage/prompt-caching)
+- Responses API cache hits are observable through `usage.input_tokens_details.cached_tokens`, which makes it feasible to verify whether the focused-diff prompt is actually benefiting from caching: [docs.x.ai/developers/advanced-api-usage/prompt-caching/usage-and-pricing](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/usage-and-pricing)
+- Grok 4.20 currently supports structured outputs and function calling and has a 2,000,000-token context window, which removes immediate prompt-size pressure for the first implementation: [docs.x.ai/developers/models](https://docs.x.ai/developers/models)
+
+## Key Technical Decisions
+
+- Use structured outputs, not function calling, for the hunk-ranking request. This keeps the analysis path to one request/response exchange and avoids a tool loop the feature does not need.
+- Keep focused-hunk decisions ephemeral in the desktop layer. The transcript replay remains an accurate record of what happened; the focused view is a presentation concern.
+- Gate model calls aggressively. The first eligibility rule should be: more than 3 hunks, plus a high context-to-change ratio, plus at least 2 "small" hunks where the changed lines are minimal. This matches the user problem instead of paying for analysis on every patch.
+- Ask Grok to classify hunks into `show` versus `hide` with reasons and confidence, then auto-hide only the hunks that meet explicit confidence and reason constraints. This reduces the chance that the model silently hides meaningful changes.
+- Keep the current deterministic row-level context compression even when focused analysis is active. Focused-hunk hiding and local context elision solve different noise problems and should compose.
+- Show zoom controls only when the zoomed-out view hides material. For low-hunk or low-noise diffs, the UI should simply render the full patch without a meaningless toggle.
+- Reuse existing Grok config loading and xAI client code, but extend the xAI client only where needed for caching-related request metadata. Do not create a second bespoke fetch stack unless reuse proves awkward during implementation.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this use function calling? No. Structured outputs are enough and materially simpler.
+- Should focused-hunk decisions be persisted into replay or thread state? No. They are a desktop presentation layer concern.
+- Should the model-picked view replace the full diff? No. Full diff remains the authoritative view and must be one click away.
+- Should the feature run for all diffs? No. It should be gated to noisy multi-hunk diffs to control cost and latency.
+
+### Deferred to Implementation
+
+- Exact prompt wording and confidence thresholds should be tuned once the first focused-view examples can be inspected against real diffs.
+- The exact cache key format can be finalized while wiring the service, as long as it is stable for the static prompt prefix and observable in usage metrics.
+- Whether the analysis result should be memoized only in-memory or also across a short-lived desktop session can be decided while implementing the service cache.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    PATCH["Raw unified diff"]
+    PARSER["Shared diff parser\nhunks + row metadata + heuristics"]
+    ELIGIBILITY["Eligibility gate\n>3 hunks + noisy/small-hunk profile"]
+    IPC["Desktop IPC request\nfocused-diff:analyze"]
+    GROK["Main-process focused diff service\nstructured-output request to Grok"]
+    DECISION["Hunk decisions\nshow/hide + reason + confidence"]
+    RENDER["TranscriptDiff renderer"]
+
+    PATCH --> PARSER
+    PARSER --> ELIGIBILITY
+    ELIGIBILITY -->|not eligible| RENDER
+    ELIGIBILITY -->|eligible| IPC
+    IPC --> GROK
+    GROK --> DECISION
+    DECISION --> RENDER
+    PARSER --> RENDER
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Extract shared diff/hunk metadata and local zoom eligibility**
+
+**Goal:** Replace the row-only patch parsing with a shared diff model that can describe hunks, changed-line density, and whether a zoomed-out view would actually hide meaningful material.
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `apps/desktop/src/shared/diff-focus.ts`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- Test: `apps/desktop/src/shared/__tests__/diff-focus.test.ts`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Move unified-diff parsing out of `TranscriptDiff.tsx` into a shared pure helper so both the renderer and main-process analysis service can consume the same hunk model.
+- The helper should return:
+  - ordered hunks with header text, changed lines, context lines, and line numbers
+  - row groups for full view and local condensed view
+  - a visibility decision for whether the zoom controls should render at all
+- Introduce a first-pass eligibility heuristic that identifies "noisy small-hunk diffs" without any model call. The initial rule should bias toward false negatives, not false positives: only mark diffs eligible when they clearly have more than 3 hunks and a high context-to-change ratio.
+- Preserve the current deterministic row-compaction behavior as the local fallback and baseline implementation.
+
+**Execution note:** Start with failing pure-data tests for multi-hunk parsing and zoom-control eligibility before rewiring the renderer.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Test scenarios:**
+- Happy path: a single-hunk diff with minimal context returns one hunk and reports that no zoom controls are needed.
+- Happy path: a diff with 4 small hunks and large untouched gaps reports eligible-for-focus and produces local condensed rows.
+- Edge case: adjacent hunks remain separate when the unified diff contains multiple `@@` headers close together.
+- Edge case: file headers (`---`, `+++`) and patch metadata are excluded from hunk content rows.
+- Error path: empty or malformed diff text returns a safe empty model and disables zoom controls.
+
+**Verification:**
+- The desktop has one shared, test-covered diff model that can answer "should we show zoom controls?" before any network call happens.
+
+- [x] **Unit 2: Add a main-process Grok focused-diff analysis service and IPC contract**
+
+**Goal:** Introduce a small desktop service that can ask Grok which hunks are low-signal for eligible diffs and return a structured decision object to the renderer.
+
+**Requirements:** R1, R2, R3, R4, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `packages/shared/src/contracts/diff-focus.ts`
+- Modify: `packages/shared/src/index.ts`
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Create: `apps/desktop/src/main/diff-focus/focused-diff-service.ts`
+- Modify: `apps/desktop/src/main/ipc/app-server.ts`
+- Modify: `packages/agent-core/src/providers/xai-responses-client.ts`
+- Test: `apps/desktop/src/main/__tests__/focused-diff-service.test.ts`
+
+**Approach:**
+- Define a desktop-only request/response contract for focused diff analysis. The request should include the file path, raw diff, parsed hunk summaries, and a stable diff identifier; the response should include hunk indices to show/hide, per-hunk reasons, confidence, and request metadata such as whether the result came from cache or fallback.
+- Implement a main-process service that:
+  - reuses Grok config loading already established by `GrokAppServerClient`
+  - exits early when there is no xAI configuration, when the diff is not eligible, or when the diff is too small to benefit
+  - sends a single structured-output request asking Grok to classify hunks, not summarize the whole patch
+  - validates the response schema before returning any hide decisions to the renderer
+  - downgrades to a safe "show all hunks" result whenever the response is invalid, low-confidence, or timed out
+- Extend the xAI Responses client only as far as needed to support prompt-caching-friendly request metadata for this flow.
+- Use a stable cache key derived from the static prompt version plus the diff fingerprint so repeated toggle/open cycles do not repeatedly pay for the same analysis during a session.
+
+**Technical design:** *(directional guidance, not implementation specification)*
+
+```text
+focusedDiffRequest -> eligibility check
+  -> in-memory result cache lookup
+  -> if miss and xAI configured:
+       create structured-output request with:
+         - system instructions for low-signal hunk classification
+         - compact hunk array input
+         - response schema: show_hunks, hide_hunks, reasons, confidence
+       validate schema
+       discard hide decisions below confidence threshold
+  -> return normalized result:
+       mode = "focused" | "fallback" | "full"
+       hidden_hunk_count
+       hidden_hunks[]
+       shown_hunks[]
+```
+
+**Patterns to follow:**
+- `apps/desktop/src/main/grok-app-server/client.ts`
+- `apps/desktop/src/main/ipc/app-server.ts`
+- `packages/agent-core/src/providers/xai-responses-client.ts`
+
+**Test scenarios:**
+- Happy path: an eligible 4-hunk diff returns a structured decision that hides at least one low-signal hunk and preserves the rest.
+- Happy path: repeated analysis of the same diff reuses the in-memory or prompt-cache path instead of issuing a wholly fresh request every time.
+- Edge case: missing `XAI_API_KEY` or Grok config returns a normalized fallback result without throwing through IPC.
+- Edge case: a schema-invalid or low-confidence response downgrades to `show all hunks` and records no hidden hunks.
+- Error path: xAI request failure or timeout returns a normalized fallback result and does not wedge transcript rendering.
+
+**Verification:**
+- The desktop can ask Grok for focused hunk ranking through a typed IPC path, but any failure still leaves the full diff available and the UI operable.
+
+- [x] **Unit 3: Integrate the focused view into TranscriptDiff and hide only low-signal hunks by default**
+
+**Goal:** Make the renderer default to a focused zoomed-out view for eligible diffs with accepted hide decisions, while keeping full view and local deterministic fallback intuitive.
+
+**Requirements:** R1, R4, R5, R6
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx`
+
+**Approach:**
+- When a write detail is expanded, request focused analysis only if Unit 1 marks the diff eligible; otherwise render the local deterministic view only.
+- Default view modes:
+  - **Full** for non-eligible diffs
+  - **Focused** for eligible diffs where Grok returns at least one accepted hide decision
+  - **Condensed local** for eligible diffs when Grok is unavailable or returns no acceptable hide decisions
+- Only render zoom controls when the current default view hides something compared with the full diff. If the default and full views are identical, the control should disappear.
+- Show a clear count of hidden hunks or hidden lines when the focused view is active so users understand why the zoomed-out view is shorter.
+- Keep the button semantics simple:
+  - default state: zoomed out
+  - `Zoom in`: reveal the full patch
+  - `Zoom out`: return to the focused/default view
+- Do not hide hunk headers for shown hunks; the reader still needs anchoring within the file.
+
+**Execution note:** Add characterization coverage for existing zoom behavior before changing the button visibility rules.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx`
+- `apps/desktop/src/renderer/src/styles/app.css`
+
+**Test scenarios:**
+- Happy path: an eligible diff with accepted hide decisions defaults to focused view, reports hidden hunks, and reveals all hunks on `Zoom in`.
+- Happy path: a non-eligible single-hunk diff renders fully and shows no zoom controls.
+- Edge case: an eligible diff whose Grok result hides zero hunks falls back to the deterministic local view and suppresses meaningless controls if nothing is hidden.
+- Edge case: expanding and collapsing the parent activity row does not leak stale focused-diff state between different file details.
+- Error path: an IPC analysis failure leaves the renderer on a safe deterministic view and still allows `Zoom in` if local condensation hid rows.
+
+**Verification:**
+- The transcript diff surface only shows zoom controls when they matter, defaults to the focused view when it has a credible reason to do so, and always lets the user reach the untouched full diff.
+
+## System-Wide Impact
+
+- **Interaction graph:** Transcript activity expansion will now cross the renderer -> preload -> main-process IPC boundary for eligible diffs, then return to the renderer as transient view state.
+- **Error propagation:** xAI failures, invalid structured output, and configuration gaps should collapse into a normalized fallback result, not renderer exceptions.
+- **State lifecycle risks:** Focused-hunk decisions are ephemeral and keyed by diff identity; stale decisions must not bleed across files or survive when the underlying diff changes.
+- **API surface parity:** The new IPC contract is desktop-specific and should not mutate the existing app-server replay contract. Both Codex-backed and Grok-backed thread transcripts should be able to use the same focused-view feature because it operates on normalized desktop diff data.
+- **Integration coverage:** Tests need at least one end-to-end renderer/main-process scenario proving that an eligible diff can request focused analysis and still recover safely from analysis failure.
+- **Unchanged invariants:** Thread replay remains authoritative, full diff remains available, and transcript activity order/structure does not change.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Grok hides a semantically important hunk | Keep full diff one click away, require confidence/reason gating, and bias the classifier toward hiding only obvious low-signal churn |
+| The feature becomes expensive if called for every diff | Gate by hunk/noise heuristics and use request/result caching |
+| xAI structured output drifts or fails validation | Validate schema strictly and fall back to showing all hunks |
+| Focused analysis adds UI latency when expanding a diff | Request on demand, render deterministic fallback immediately, and upgrade to focused view only when the response arrives |
+| Reusing the xAI client requires small protocol changes | Keep those changes additive and scoped to prompt-cache metadata rather than broad provider refactors |
+
+## Documentation / Operational Notes
+
+- No end-user documentation change is required for the first pass.
+- Add a brief internal note in the PR description that focused diff analysis is heuristic and non-authoritative.
+- During manual verification, inspect whether `cached_tokens` appears in the xAI response path for repeated analysis of the same diff so the team can verify that the intended cache strategy is actually helping.
+
+## Sources & References
+
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx`
+- Related code: `apps/desktop/src/main/ipc/app-server.ts`
+- Related code: `apps/desktop/src/main/grok-app-server/client.ts`
+- Related code: `packages/agent-core/src/providers/xai-responses-client.ts`
+- External docs: [xAI Structured Outputs](https://docs.x.ai/developers/model-capabilities/text/structured-outputs)
+- External docs: [xAI Function Calling](https://docs.x.ai/developers/tools/function-calling)
+- External docs: [xAI Prompt Caching](https://docs.x.ai/developers/advanced-api-usage/prompt-caching)
+- External docs: [xAI Prompt Caching Usage & Pricing](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/usage-and-pricing)
+- External docs: [xAI Models](https://docs.x.ai/developers/models)

--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -2,20 +2,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { CodexAppServer } from "../app-server/codex-app-server.js";
+import { resolveGrokAppServerRuntimeConfig } from "../config/grok-app-server-config.js";
 import type { AppServerNotification } from "../app-server/protocol.js";
 import { GrokProvider } from "../providers/grok-provider.js";
 import { createTemporaryTestDirectory } from "../testing/test-harness.js";
-import { loadLocalEnv } from "../testing/load-local-env.js";
 
-const envResult = loadLocalEnv({ override: true });
-const xaiApiKey = process.env.XAI_API_KEY?.trim();
-const xaiBaseUrl = process.env.XAI_BASE_URL?.trim() || "https://api.x.ai/v1";
-const grokModel = process.env.GROK_MODEL?.trim() || "grok-4.20-reasoning";
+const runtimeConfig = resolveGrokAppServerRuntimeConfig();
+const xaiApiKey = runtimeConfig.apiKey?.trim();
+const xaiBaseUrl = runtimeConfig.baseUrl?.trim() || "https://api.x.ai/v1";
+const grokModel = runtimeConfig.model?.trim() || "grok-4.20-reasoning";
 const liveSkipReason = xaiApiKey
   ? undefined
-  : envResult.loaded
-    ? "XAI_API_KEY is missing from the local env file or environment"
-    : `missing local env file at ${envResult.path} and XAI_API_KEY is not set`;
+  : `XAI_API_KEY is not set in the environment or runtime config at ${runtimeConfig.configPath}`;
 
 const itLive = liveSkipReason ? it.skip : it;
 const liveNotificationTimeoutMs = 60_000;

--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -89,7 +89,7 @@ describe("Grok live smoke", () => {
     async () => {
       const { notifications, server } = createLiveServer();
 
-      const marker = `smoke-${Date.now().toString(36)}`;
+      const marker = "sunny meadow checkpoint";
       const created = await server.request("thread/start", {
         cwd: "/tmp/live-smoke",
         model: grokModel,
@@ -104,7 +104,7 @@ describe("Grok live smoke", () => {
         input: [
           {
             type: "text",
-            text: `Reply with this token exactly. Do not use any tools or inspect the workspace. No explanation: ${marker}`,
+            text: `Reply with only these words: ${marker}`,
           },
         ],
       })) as { threadId: string; runId: string };
@@ -138,7 +138,7 @@ describe("Grok live smoke", () => {
         input: [
           {
             type: "text",
-            text: "What token did you just return? Reply with the token only. Do not use any tools.",
+            text: "Repeat the same words from your previous reply.",
           },
         ],
       })) as { threadId: string; runId: string };
@@ -156,8 +156,7 @@ describe("Grok live smoke", () => {
       const replay = await server.request("thread/read", { threadId: "thread-live" });
       expect(replay).toMatchObject({
         threadId: "thread-live",
-        lastUserMessage:
-          "What token did you just return? Reply with the token only. Do not use any tools.",
+        lastUserMessage: "Repeat the same words from your previous reply.",
       });
       expect((replay as { lastAssistantMessage?: string }).lastAssistantMessage).toContain(marker);
     },

--- a/packages/agent-core/src/__tests__/grok-provider.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider.test.ts
@@ -24,7 +24,7 @@ describe("buildXaiInput", () => {
 });
 
 describe("XaiResponsesClient", () => {
-  it("builds a create payload without unsupported instructions", () => {
+  it("builds a create payload with structured-output metadata", () => {
     const client = new XaiResponsesClient({
       apiKey: "test-key",
       model: "grok-4.20-reasoning",
@@ -35,11 +35,33 @@ describe("XaiResponsesClient", () => {
       client.buildCreatePayload({
         input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
         previousResponseId: "resp_prev",
+        promptCacheKey: "focused-diff-v1",
+        text: {
+          format: {
+            type: "json_schema",
+            name: "focused_diff_hunk_decisions",
+            schema: {
+              type: "object"
+            },
+            strict: true
+          }
+        }
       }),
     ).toEqual({
       model: "grok-4.20-reasoning",
       input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
       previous_response_id: "resp_prev",
+      prompt_cache_key: "focused-diff-v1",
+      text: {
+        format: {
+          type: "json_schema",
+          name: "focused_diff_hunk_decisions",
+          schema: {
+            type: "object"
+          },
+          strict: true
+        }
+      },
       stream: false,
     });
   });
@@ -60,6 +82,34 @@ describe("XaiResponsesClient", () => {
         input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
       }),
     ).rejects.toThrow("xAI Responses API request failed (401): Unauthorized");
+  });
+
+  it("forwards custom request headers", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => makeXaiResponse({ text: "{}" }),
+    }));
+    const client = new XaiResponsesClient({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.createResponse({
+      input: [{ role: "user", content: [{ type: "input_text", text: "Ship it" }] }],
+      headers: {
+        "x-grok-conv-id": "focused-diff-v1",
+      },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.x.ai/v1/responses",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+          "x-grok-conv-id": "focused-diff-v1",
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/agent-core/src/providers/xai-responses-client.ts
+++ b/packages/agent-core/src/providers/xai-responses-client.ts
@@ -12,6 +12,16 @@ export type XaiResponseCreateRequest = {
   model?: string;
   input: Array<Record<string, unknown>>;
   previousResponseId?: string;
+  promptCacheKey?: string;
+  headers?: Record<string, string>;
+  text?: {
+    format: {
+      type: "json_schema";
+      name: string;
+      schema: Record<string, unknown>;
+      strict?: boolean;
+    };
+  };
   tools?: XaiFunctionTool[];
   parallelToolCalls?: boolean;
   signal?: AbortSignal;
@@ -47,6 +57,8 @@ export class XaiResponsesClient {
       ...(params.previousResponseId
         ? { previous_response_id: params.previousResponseId }
         : {}),
+      ...(params.promptCacheKey ? { prompt_cache_key: params.promptCacheKey } : {}),
+      ...(params.text ? { text: params.text } : {}),
       ...(params.tools?.length ? { tools: params.tools } : {}),
       ...(typeof params.parallelToolCalls === "boolean"
         ? { parallel_tool_calls: params.parallelToolCalls }
@@ -61,6 +73,7 @@ export class XaiResponsesClient {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
         "Content-Type": "application/json",
+        ...params.headers,
       },
       body: JSON.stringify(this.buildCreatePayload(params)),
       signal: params.signal,

--- a/packages/shared/src/contracts/diff-focus.ts
+++ b/packages/shared/src/contracts/diff-focus.ts
@@ -1,0 +1,49 @@
+export type FocusedDiffDisposition = "show" | "hide";
+
+export type FocusedDiffReasonCode =
+  | "comment_only"
+  | "formatting_only"
+  | "import_reorder"
+  | "keep"
+  | "mechanical_small_change"
+  | "repetitive_small_change"
+  | "uncertain";
+
+export type FocusedDiffHunkSummary = {
+  index: number;
+  header: string;
+  addedLines: string[];
+  removedLines: string[];
+  contextBefore: string[];
+  contextAfter: string[];
+  changedLineCount: number;
+  contextLineCount: number;
+};
+
+export type FocusedDiffAnalysisRequest = {
+  filePath?: string;
+  diff: string;
+  hunks: FocusedDiffHunkSummary[];
+};
+
+export type FocusedDiffHunkDecision = {
+  index: number;
+  disposition: FocusedDiffDisposition;
+  reasonCode: FocusedDiffReasonCode;
+  reason: string;
+  confidence: number;
+};
+
+export type FocusedDiffAnalysisMode = "fallback" | "focused" | "full";
+
+export type FocusedDiffAnalysisSource = "cache" | "grok" | "heuristic" | "ineligible";
+
+export type FocusedDiffAnalysisResponse = {
+  mode: FocusedDiffAnalysisMode;
+  source: FocusedDiffAnalysisSource;
+  hiddenHunkIndices: number[];
+  hiddenHunkCount: number;
+  decisions: FocusedDiffHunkDecision[];
+  cachedTokens?: number;
+  reason?: string;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./contracts/app-server";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
+export * from "./contracts/diff-focus";
 export * from "./contracts/navigation";
 export * from "./thread-titles";


### PR DESCRIPTION
## Summary
Add a focused diff zoom mode for desktop transcript write activity.

This keeps the full patch one click away, but defaults noisy multi-hunk diffs to a tighter view by:
- parsing unified diffs into shared hunk metadata and deterministic condensed views
- gating focused analysis to eligible noisy diffs instead of calling Grok for every patch
- asking Grok for structured hide/show hunk decisions through a main-process IPC path
- falling back to local deterministic condensation whenever Grok is unavailable, invalid, low-confidence, or returns nothing worth hiding
- only showing zoom controls when the zoomed-out view actually hides material

## Testing
- `pnpm test -- apps/desktop/src/shared/__tests__/diff-focus.test.ts apps/desktop/src/main/__tests__/focused-diff-service.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx packages/agent-core/src/__tests__/grok-provider.test.ts`
- `pnpm typecheck`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is a desktop-only transcript presentation change with local fallback behavior and no server-side rollout or persistent data migration.