### PR TITLE
feat(desktop): add directory launchpad workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-results/
 packages/agent-core/.env.local
 .env.local
 excalidraw.log
+.worktrees/

--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -5,7 +5,7 @@ import { launchElectronApp } from "./fixtures/electron-app";
 
 const approvalPendingSpecDir = path.dirname(fileURLToPath(import.meta.url));
 
-test("shows pending approval UI without duplicating the turn elsewhere", async () => {
+async function openApprovalPendingReplay() {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
       approvalPendingSpecDir,
@@ -13,35 +13,57 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
     )
   });
 
+  await app.window
+    .getByRole("button", { name: /Approval pending replay/i })
+    .first()
+    .click();
+
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: "Approval pending replay"
+    })
+  ).toBeVisible();
+
+  await app.window
+    .getByLabel("Reply")
+    .fill("Read /etc/hosts and tell me the first three lines.");
+  await app.window.getByRole("button", { name: "Send" }).click();
+
+  await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+  await expect(
+    app.window
+      .getByRole("region", { name: "Transcript" })
+      .getByText("Read /etc/hosts and tell me the first three lines.")
+  ).toBeVisible();
+
+  await app.advance({ stepId: "status-active-1" });
+  await app.advance({ stepId: "turn-started-1" });
+  await app.advance({ stepId: "request-approval-1" });
+
+  await expect(
+    app.window.getByRole("group", { name: "Pending approval" })
+  ).toBeVisible();
+  await expect(app.window.getByText("Approval needed")).toBeVisible();
+  await expect(
+    app.window
+      .getByRole("group", { name: "Pending approval" })
+      .getByText("Read /etc/hosts and tell me the first three lines.")
+  ).toBeVisible();
+  await expect(
+    app.window.getByText("Waiting for approval before this turn can continue.")
+  ).toBeVisible();
+  await expect(
+    app.window.getByRole("button", { name: "Approve" })
+  ).toBeVisible();
+
+  return app;
+}
+
+test("shows pending approval UI without duplicating the turn elsewhere", async () => {
+  const app = await openApprovalPendingReplay();
+
   try {
-    await app.window
-      .getByRole("button", { name: /Approval pending replay/i })
-      .first()
-      .click();
-
-    await expect(
-      app.window.getByRole("heading", {
-        level: 2,
-        name: "Approval pending replay"
-      })
-    ).toBeVisible();
-
-    await app.window
-      .getByLabel("Reply")
-      .fill("Read /etc/hosts and tell me the first three lines.");
-    await app.window.getByRole("button", { name: "Send" }).click();
-
-    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
-    await expect(
-      app.window
-        .getByRole("region", { name: "Transcript" })
-        .getByText("Read /etc/hosts and tell me the first three lines.")
-    ).toBeVisible();
-
-    await app.advance({ stepId: "status-active-1" });
-    await app.advance({ stepId: "turn-started-1" });
-    await app.advance({ stepId: "request-approval-1" });
-
     await expect(
       app.window.getByRole("group", { name: "Pending approval" })
     ).toBeVisible();
@@ -57,6 +79,33 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
     await expect(
       app.window.getByRole("button", { name: "Approve" })
     ).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test("dismisses the pending approval UI after approval", async () => {
+  const app = await openApprovalPendingReplay();
+
+  try {
+    await app.window.getByRole("button", { name: "Approve" }).click();
+
+    await expect(
+      app.window.getByRole("group", { name: "Pending approval" })
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByText("Waiting for approval before this turn can continue.")
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Decline" })
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Cancel turn" })
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Stop" })
+    ).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ThreadExecutionMode } from "@pwragnt/shared";
@@ -26,6 +28,7 @@ type LaunchResult = {
 export async function launchElectronApp(params: {
   fixturePath: string;
 }): Promise<LaunchResult> {
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-desktop-e2e-"));
   const electronApp = await electron.launch({
     args: [path.resolve(fixtureDir, "../../out/main/index.js")],
     cwd: path.resolve(fixtureDir, "../.."),
@@ -33,6 +36,7 @@ export async function launchElectronApp(params: {
       ...process.env,
       NODE_ENV: "production",
       PWRAGNT_REPLAY_FIXTURE_PATH: params.fixturePath,
+      PWRAGNT_STATE_ROOT: stateRoot,
     },
   });
   const window = await electronApp.firstWindow();
@@ -66,6 +70,7 @@ export async function launchElectronApp(params: {
     },
     close: async () => {
       await electronApp.close();
+      await rm(stateRoot, { recursive: true, force: true });
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentEvent,
   InterruptTurnRequest,
   ListBackendsRequest,
+  MaterializeDirectoryLaunchpadRequest,
   StartThreadRequest,
   StartTurnRequest,
 } from "@pwragnt/shared";
@@ -36,6 +37,15 @@ const registry = {
     threadId: request.threadId,
     runId: request.runId,
   })),
+  materializeDirectoryLaunchpad: vi.fn(
+    async (request: MaterializeDirectoryLaunchpadRequest) => ({
+      backend: "codex" as const,
+      threadId: `materialized:${request.directoryKey}`,
+      executionMode: "default" as const,
+      workMode: "local" as const,
+      runId: "turn-2",
+    }),
+  ),
 };
 
 vi.mock("electron", () => ({
@@ -70,6 +80,7 @@ describe("agent ipc", () => {
     registry.startThread.mockClear();
     registry.startTurn.mockClear();
     registry.interruptTurn.mockClear();
+    registry.materializeDirectoryLaunchpad.mockClear();
     registryListener = undefined;
   });
 
@@ -81,6 +92,7 @@ describe("agent ipc", () => {
     const {
       AGENT_EVENT_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
+      AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
       AGENT_START_THREAD_CHANNEL,
       AGENT_START_TURN_CHANNEL,
       BACKEND_LIST_CHANNEL,
@@ -119,6 +131,17 @@ describe("agent ipc", () => {
       backend: "grok",
       threadId: "thread-1",
       runId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL)?.({}, {
+        directoryKey: "directory:/repo/app",
+      }),
+    ).toEqual({
+      backend: "codex",
+      threadId: "materialized:directory:/repo/app",
+      executionMode: "default",
+      workMode: "local",
+      runId: "turn-2",
     });
 
     await registryListener?.({

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -37,6 +37,31 @@ const reconcileNavigationSnapshot = vi.fn(async (params: unknown) => ({
   unchanged: false,
   threads: (params as { threads: unknown[] }).threads,
   inboxThreadKeys: ["grok:thread-1"],
+  directories: [
+    {
+      key: "directory:/repo/app",
+      kind: "directory" as const,
+      label: "app",
+      path: "/repo/app",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 1,
+      latestUpdatedAt: 2000,
+    },
+  ],
+  launchpadDefaults: {
+    backend: "codex" as const,
+    executionMode: "default" as const,
+  },
+}));
+const readDirectoryStatuses = vi.fn(async () => ({
+  "directory:/repo/app": {
+    currentBranch: "main",
+    upstreamBranch: "origin/main",
+    ahead: 0,
+    behind: 0,
+    syncState: "in-sync" as const,
+    branches: ["main"],
+  },
 }));
 const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   backend: request.backend ?? "codex",
@@ -71,6 +96,7 @@ vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: () => ({
     listThreads,
     readThread,
+    readDirectoryStatuses,
   }),
 }));
 
@@ -80,6 +106,7 @@ describe("app server ipc", () => {
     listThreads.mockClear();
     readThread.mockClear();
     reconcileNavigationSnapshot.mockClear();
+    readDirectoryStatuses.mockClear();
     markThreadSeen.mockClear();
   });
 
@@ -112,6 +139,29 @@ describe("app server ipc", () => {
         expect.objectContaining({ source: "grok", id: "thread-1" }),
       ],
       inboxThreadKeys: ["grok:thread-1"],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory",
+          label: "app",
+          path: "/repo/app",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 1,
+          latestUpdatedAt: 2000,
+          gitStatus: {
+            currentBranch: "main",
+            upstreamBranch: "origin/main",
+            ahead: 0,
+            behind: 0,
+            syncState: "in-sync",
+            branches: ["main"],
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
     });
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9,9 +9,17 @@ import type {
 } from "@pwragnt/shared";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 
-function createOverlayStoreMock() {
+function createOverlayStoreMock(params?: { executionMode?: "default" | "full-access" }) {
   return {
-    getThreadOverlayState: async () => undefined,
+    getThreadOverlayState: async () =>
+      params?.executionMode
+        ? {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: params.executionMode,
+            extraLinkedDirectories: [],
+          }
+        : undefined,
     setThreadExecutionMode: async ({
       backend,
       threadId,
@@ -46,6 +54,15 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
   };
+  lastSetThreadPermissionsParams?: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  };
 
   constructor(
     private readonly options: {
@@ -60,6 +77,7 @@ class MockBackendClient {
       threads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
       skills?: Array<{ cwd?: string; skills: AppServerSkillSummary[] }>;
+      setThreadPermissionsError?: Error;
     }
   ) {}
 
@@ -122,6 +140,23 @@ class MockBackendClient {
 
   async startTurn(): Promise<{ threadId: string; runId: string }> {
     return { threadId: "thread-1", runId: "turn-1" };
+  }
+
+  async setThreadPermissions(params: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    this.lastSetThreadPermissionsParams = params;
+    if (this.options.setThreadPermissionsError) {
+      throw this.options.setThreadPermissionsError;
+    }
+
+    return { threadId: params.threadId };
   }
 
   async interruptTurn(): Promise<{ threadId: string; runId: string }> {
@@ -375,6 +410,44 @@ describe("DesktopBackendRegistry", () => {
       before: "cursor-1",
       limit: 25,
     });
+
+    await registry.close();
+  });
+
+  it("updates execution mode through the current Codex thread owner", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read", "thread/resume"] },
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read", "thread/resume"] },
+      setThreadPermissionsError: new Error("thread not found on full-access client"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({ executionMode: "default" }),
+    });
+
+    const response = await registry.setThreadExecutionMode({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+    expect(codexClient.lastSetThreadPermissionsParams).toEqual({
+      threadId: "thread-1",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    expect(codexFullAccessClient.lastSetThreadPermissionsParams).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -444,6 +444,10 @@ class MockTransport implements JsonRpcTransport {
   setCloseHandler(handler: (error?: Error) => void): void {
     this.closeHandler = handler;
   }
+
+  emitInbound(payload: unknown): void {
+    this.messageHandler(JSON.stringify(payload));
+  }
 }
 
 vi.mock("../codex-app-server/stdio-transport", () => {
@@ -1421,6 +1425,59 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       runId: "turn-1"
     });
+
+    await client.close();
+  });
+
+  it("normalizes approval requests from rpc envelope ids and nested thread metadata", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onRequest((request) => {
+      requests.push(request as { method: string; params: Record<string, unknown> });
+      return { decision: "decline" };
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      id: "rpc-approval-1",
+      method: "turn/requestApproval",
+      params: {
+        thread: {
+          id: "thread-2"
+        },
+        turn: {
+          id: "turn-7"
+        },
+        reason: "command requires approval: npm view dive",
+        command: "npm view dive"
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requests).toEqual([
+      {
+        method: "turn/requestApproval",
+        params: expect.objectContaining({
+          threadId: "thread-2",
+          runId: "turn-7",
+          requestId: "rpc-approval-1",
+          reason: "command requires approval: npm view dive",
+          command: "npm view dive"
+        })
+      }
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-state-root.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-state-root.test.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_STATE_ROOT_ENV,
+  defaultDesktopStateRoot,
+  resolveDesktopOverlayStorePath,
+  resolveDesktopStateRoot,
+} from "../app-server/desktop-state-root";
+
+describe("desktop state root", () => {
+  it("defaults to an XDG-style state directory under the home directory", () => {
+    expect(
+      defaultDesktopStateRoot({
+        env: {} as NodeJS.ProcessEnv,
+        homeDir: "/Users/tester",
+      }),
+    ).toBe("/Users/tester/.local/state/pwragnt");
+  });
+
+  it("prefers XDG_STATE_HOME when present", () => {
+    expect(
+      defaultDesktopStateRoot({
+        env: {} as NodeJS.ProcessEnv,
+        homeDir: "/Users/tester",
+        xdgStateHome: "/tmp/xdg-state",
+      }),
+    ).toBe("/tmp/xdg-state/pwragnt");
+  });
+
+  it("allows an explicit desktop state root override", () => {
+    expect(
+      resolveDesktopStateRoot({
+        env: {
+          [DESKTOP_STATE_ROOT_ENV]: "/tmp/pwragnt-state",
+        } as NodeJS.ProcessEnv,
+        homeDir: "/Users/tester",
+      }),
+    ).toBe("/tmp/pwragnt-state");
+  });
+
+  it("derives the overlay store path from the resolved state root", () => {
+    expect(
+      resolveDesktopOverlayStorePath({
+        env: {
+          [DESKTOP_STATE_ROOT_ENV]: "/tmp/pwragnt-state",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.join("/tmp/pwragnt-state", "overlay-state.json"));
+  });
+});

--- a/apps/desktop/src/main/__tests__/replay-client.test.ts
+++ b/apps/desktop/src/main/__tests__/replay-client.test.ts
@@ -119,6 +119,57 @@ function buildInterleavedFixture() {
   };
 }
 
+function buildConcurrentResponseFixture() {
+  return {
+    metadata: {
+      backend: "codex" as const,
+      scenario: "replay-client-concurrent-response-test"
+    },
+    steps: [
+      {
+        id: "initialize-1",
+        kind: "response" as const,
+        method: "initialize" as const,
+        result: {
+          serverInfo: {
+            name: "Replay Codex",
+            version: "1.0.0"
+          },
+          methods: ["thread/read", "skills/list", "turn/start"]
+        }
+      },
+      {
+        id: "skills-list-1",
+        kind: "response" as const,
+        method: "skills/list" as const,
+        result: []
+      },
+      {
+        id: "thread-read-1",
+        kind: "response" as const,
+        method: "thread/read" as const,
+        result: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false
+          }
+        }
+      },
+      {
+        id: "turn-start-1",
+        kind: "response" as const,
+        method: "turn/start" as const,
+        result: {
+          threadId: "thread-1",
+          runId: "turn-1"
+        }
+      }
+    ]
+  };
+}
+
 describe("ReplayClient", () => {
   it("consumes response steps and advances live replay deterministically", async () => {
     const client = ReplayClient.fromFixture(buildFixture());
@@ -194,5 +245,53 @@ describe("ReplayClient", () => {
         id: "thread-1"
       })
     ]);
+  });
+
+  it("allows concurrent response steps to resolve in either order before the next live step", async () => {
+    const client = ReplayClient.fromFixture(buildConcurrentResponseFixture());
+
+    await expect(client.getInitializeResult()).resolves.toMatchObject({
+      methods: ["thread/read", "skills/list", "turn/start"]
+    });
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [],
+      messages: []
+    });
+
+    await expect(client.listSkills()).resolves.toEqual([]);
+
+    await expect(
+      client.startTurn({
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Need approval coverage." }]
+      })
+    ).resolves.toEqual({
+      threadId: "thread-1",
+      runId: "turn-1"
+    });
+  });
+
+  it("reuses stable read responses when the desktop shell asks again", async () => {
+    const client = ReplayClient.fromFixture(buildConcurrentResponseFixture());
+
+    await expect(client.getInitializeResult()).resolves.toMatchObject({
+      methods: ["thread/read", "skills/list", "turn/start"]
+    });
+    await expect(client.getInitializeResult()).resolves.toMatchObject({
+      methods: ["thread/read", "skills/list", "turn/start"]
+    });
+
+    await expect(client.listSkills()).resolves.toEqual([]);
+    await expect(client.listSkills()).resolves.toEqual([]);
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [],
+      messages: []
+    });
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [],
+      messages: []
+    });
   });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -430,26 +430,27 @@ export class DesktopBackendRegistry {
     }
 
     const modeSettings = EXECUTION_MODE_SUMMARIES[params.executionMode];
-    const client = this.getClient("codex", params.executionMode);
-    if (!client.setThreadPermissions) {
-      throw new Error("Selected backend does not support execution mode updates");
-    }
+    const result = await this.withCodexThreadClient(params.threadId, async (client) => {
+      if (!client.setThreadPermissions) {
+        throw new Error("Selected backend does not support execution mode updates");
+      }
 
-    await client.setThreadPermissions({
-      threadId: params.threadId,
-      approvalPolicy: modeSettings.approvalPolicy,
-      sandbox: modeSettings.sandbox,
+      return await client.setThreadPermissions({
+        threadId: params.threadId,
+        approvalPolicy: modeSettings.approvalPolicy,
+        sandbox: modeSettings.sandbox,
+      });
     });
 
     await this.overlayStore.setThreadExecutionMode({
       backend: "codex",
-      threadId: params.threadId,
+      threadId: result.threadId,
       executionMode: params.executionMode,
     });
 
     return {
       backend: params.backend,
-      threadId: params.threadId,
+      threadId: result.threadId,
       executionMode: params.executionMode,
     };
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14,12 +14,24 @@ import type {
   BackendSummary,
   ListBackendsRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
+  NavigationDirectoryGitStatus,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
+  NavigationLaunchpadDefaults,
+  ResetDirectoryLaunchpadRequest,
+  ResetDirectoryLaunchpadResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   StartThreadResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadExecutionMode,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
+  EnsureDirectoryLaunchpadRequest,
+  EnsureDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
@@ -28,6 +40,7 @@ import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
+import { GitDirectoryService } from "./git-directory-service";
 
 type InitializeResult = {
   serverInfo?: {
@@ -171,6 +184,7 @@ export class DesktopBackendRegistry {
   private readonly codexFullAccessClient: BackendClient;
   private readonly grokClient: BackendClient;
   private readonly overlayStore: OverlayStore;
+  private readonly gitDirectoryService: GitDirectoryService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
@@ -184,6 +198,7 @@ export class DesktopBackendRegistry {
     codexFullAccessClient?: BackendClient;
     grokClient?: BackendClient;
     overlayStore?: OverlayStore;
+    gitDirectoryService?: GitDirectoryService;
     createScratchProjectDirectory?: () => Promise<string>;
   }) {
     const replayClients = createReplayClientsFromEnv();
@@ -228,6 +243,7 @@ export class DesktopBackendRegistry {
         connectionObserver: grokCapture?.observer,
       });
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
+    this.gitDirectoryService = options?.gitDirectoryService ?? new GitDirectoryService();
     this.createScratchProjectDirectory =
       options?.createScratchProjectDirectory ?? createScratchProjectDirectory;
 
@@ -293,6 +309,12 @@ export class DesktopBackendRegistry {
     });
 
     return { data };
+  }
+
+  async readDirectoryStatuses(directories: NavigationDirectorySummary[]): Promise<
+    Record<string, NavigationDirectoryGitStatus | undefined>
+  > {
+    return await this.gitDirectoryService.readDirectoryStatuses(directories);
   }
 
   async readThread(
@@ -449,6 +471,157 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       runId: params.runId,
       requestId: params.requestId,
+    };
+  }
+
+  async ensureDirectoryLaunchpad(
+    request: EnsureDirectoryLaunchpadRequest,
+  ): Promise<EnsureDirectoryLaunchpadResponse> {
+    const existing = await this.overlayStore.getDirectoryLaunchpad({
+      directoryKey: request.directoryKey,
+    });
+    const defaults = await this.overlayStore.getLaunchpadDefaults();
+    if (existing) {
+      return {
+        launchpad: existing,
+        defaults,
+      };
+    }
+
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: request.directoryKey,
+      directoryKind: request.directoryKind,
+      directoryLabel: request.directoryLabel,
+      directoryPath: request.directoryPath,
+      backend: request.preferredBackend ?? defaults.backend,
+      executionMode: defaults.executionMode,
+      model: defaults.model,
+      reasoningEffort: defaults.reasoningEffort,
+      serviceTier: defaults.serviceTier,
+      fastMode: defaults.fastMode,
+      prompt: "",
+      workMode: "local",
+      branchName: request.currentBranch,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    const persisted = await this.overlayStore.upsertDirectoryLaunchpad(launchpad);
+    return {
+      launchpad: persisted,
+      defaults,
+    };
+  }
+
+  async updateDirectoryLaunchpad(
+    request: UpdateDirectoryLaunchpadRequest,
+  ): Promise<UpdateDirectoryLaunchpadResponse> {
+    const current =
+      (await this.overlayStore.getDirectoryLaunchpad({
+        directoryKey: request.directoryKey,
+      })) ??
+      (await this.ensureDirectoryLaunchpad({
+        directoryKey: request.directoryKey,
+        directoryKind: "directory",
+        directoryLabel: request.directoryKey,
+      })).launchpad;
+
+    const nextLaunchpad: NavigationLaunchpadDraft = {
+      ...current,
+      ...request.patch,
+      directoryKey: request.directoryKey,
+      updatedAt: Date.now(),
+    };
+    const persisted = await this.overlayStore.upsertDirectoryLaunchpad(nextLaunchpad);
+
+    const stickyPatch: Partial<NavigationLaunchpadDefaults> = {};
+    if (request.patch.backend) {
+      stickyPatch.backend = request.patch.backend;
+    }
+    if (request.patch.executionMode) {
+      stickyPatch.executionMode = request.patch.executionMode;
+    }
+    if (request.patch.model !== undefined) {
+      stickyPatch.model = request.patch.model;
+    }
+    if (request.patch.reasoningEffort !== undefined) {
+      stickyPatch.reasoningEffort = request.patch.reasoningEffort;
+    }
+    if (request.patch.serviceTier !== undefined) {
+      stickyPatch.serviceTier = request.patch.serviceTier;
+    }
+    if (request.patch.fastMode !== undefined) {
+      stickyPatch.fastMode = request.patch.fastMode;
+    }
+
+    const defaults =
+      Object.keys(stickyPatch).length > 0
+        ? await this.overlayStore.setLaunchpadDefaults(stickyPatch)
+        : await this.overlayStore.getLaunchpadDefaults();
+
+    return {
+      launchpad: persisted,
+      defaults,
+    };
+  }
+
+  async resetDirectoryLaunchpad(
+    request: ResetDirectoryLaunchpadRequest,
+  ): Promise<ResetDirectoryLaunchpadResponse> {
+    await this.overlayStore.resetDirectoryLaunchpad({
+      directoryKey: request.directoryKey,
+    });
+    return {
+      directoryKey: request.directoryKey,
+      defaults: await this.overlayStore.getLaunchpadDefaults(),
+    };
+  }
+
+  async materializeDirectoryLaunchpad(
+    request: MaterializeDirectoryLaunchpadRequest,
+  ): Promise<MaterializeDirectoryLaunchpadResponse> {
+    const launchpad = await this.overlayStore.getDirectoryLaunchpad({
+      directoryKey: request.directoryKey,
+    });
+    if (!launchpad) {
+      throw new Error(`No launchpad found for ${request.directoryKey}`);
+    }
+
+    const workspace = await this.gitDirectoryService.prepareLaunchpadWorkspace(launchpad);
+    const startThreadResponse = await this.startThread({
+      backend: launchpad.backend,
+      executionMode: launchpad.executionMode,
+      cwd: workspace.cwd,
+      model: launchpad.model,
+      reasoningEffort: launchpad.reasoningEffort,
+      serviceTier: launchpad.serviceTier,
+    });
+
+    const input =
+      request.input ??
+      (launchpad.prompt.trim()
+        ? [{ type: "text", text: launchpad.prompt } as const]
+        : []);
+    let runId: string | undefined;
+    if (input.length > 0) {
+      const turnResponse = await this.startTurn({
+        backend: launchpad.backend,
+        threadId: startThreadResponse.threadId,
+        input,
+        model: launchpad.model,
+      });
+      runId = turnResponse.runId;
+    }
+
+    await this.overlayStore.resetDirectoryLaunchpad({
+      directoryKey: request.directoryKey,
+    });
+
+    return {
+      backend: startThreadResponse.backend,
+      threadId: startThreadResponse.threadId,
+      runId,
+      executionMode: startThreadResponse.executionMode,
+      workMode: workspace.workMode,
     };
   }
 

--- a/apps/desktop/src/main/app-server/desktop-overlay-store.ts
+++ b/apps/desktop/src/main/app-server/desktop-overlay-store.ts
@@ -1,14 +1,11 @@
-import { app } from "electron";
-import path from "node:path";
 import { OverlayStore } from "@pwragnt/agent-core";
+import { resolveDesktopOverlayStorePath } from "./desktop-state-root";
 
 let overlayStore: OverlayStore | null = null;
 
 export function getDesktopOverlayStore(): OverlayStore {
   if (!overlayStore) {
-    overlayStore = new OverlayStore(
-      path.join(app.getPath("userData"), "overlay-state.json"),
-    );
+    overlayStore = new OverlayStore(resolveDesktopOverlayStorePath());
   }
 
   return overlayStore;

--- a/apps/desktop/src/main/app-server/desktop-state-root.ts
+++ b/apps/desktop/src/main/app-server/desktop-state-root.ts
@@ -1,0 +1,37 @@
+import os from "node:os";
+import path from "node:path";
+
+export const DESKTOP_STATE_ROOT_ENV = "PWRAGNT_STATE_ROOT";
+
+type DesktopStatePathOptions = {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  xdgStateHome?: string;
+};
+
+export function defaultDesktopStateRoot(
+  options?: DesktopStatePathOptions,
+): string {
+  const env = options?.env ?? process.env;
+  const homeDir = options?.homeDir ?? os.homedir();
+  const xdgStateHome =
+    options?.xdgStateHome?.trim() || env.XDG_STATE_HOME?.trim();
+
+  return path.join(
+    xdgStateHome || path.join(homeDir, ".local", "state"),
+    "pwragnt",
+  );
+}
+
+export function resolveDesktopStateRoot(
+  options?: DesktopStatePathOptions,
+): string {
+  const env = options?.env ?? process.env;
+  return env[DESKTOP_STATE_ROOT_ENV]?.trim() || defaultDesktopStateRoot(options);
+}
+
+export function resolveDesktopOverlayStorePath(
+  options?: DesktopStatePathOptions,
+): string {
+  return path.join(resolveDesktopStateRoot(options), "overlay-state.json");
+}

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,0 +1,166 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type {
+  LaunchpadWorkMode,
+  NavigationDirectoryGitStatus,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
+} from "@pwragnt/shared";
+
+const execFile = promisify(execFileCallback);
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFile("git", ["-C", cwd, ...args], {
+    env: process.env,
+  });
+  return stdout.trim();
+}
+
+function sanitizeBranchName(value: string): string {
+  return value
+    .trim()
+    .replace(/^refs\/heads\//, "")
+    .replace(/[^a-zA-Z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/^-+|-+$/g, "");
+}
+
+function buildWorktreeBranchName(params: {
+  baseBranch: string;
+  directoryLabel: string;
+  timestamp?: number;
+}): string {
+  const base = sanitizeBranchName(params.baseBranch) || "main";
+  const label = sanitizeBranchName(params.directoryLabel.toLowerCase()) || "launchpad";
+  const suffix = (params.timestamp ?? Date.now()).toString(36);
+  return `pwragnt/${label}-${base.replace(/\//g, "-")}-${suffix}`;
+}
+
+function buildWorktreePath(repoRoot: string, branchName: string): string {
+  return path.join(repoRoot, ".worktrees", branchName.replace(/[\\/]/g, "-"));
+}
+
+export class GitDirectoryService {
+  async readDirectoryStatuses(
+    directories: NavigationDirectorySummary[],
+  ): Promise<Record<string, NavigationDirectoryGitStatus | undefined>> {
+    const statuses = await Promise.all(
+      directories.map(async (directory) => [
+        directory.key,
+        await this.readDirectoryStatus(directory),
+      ] as const),
+    );
+    return Object.fromEntries(statuses);
+  }
+
+  async readDirectoryStatus(
+    directory: Pick<NavigationDirectorySummary, "path">,
+  ): Promise<NavigationDirectoryGitStatus | undefined> {
+    const cwd = directory.path?.trim();
+    if (!cwd) {
+      return undefined;
+    }
+
+    try {
+      const [currentBranch, branches] = await Promise.all([
+        runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
+        runGit(cwd, ["for-each-ref", "refs/heads", "--format=%(refname:short)"]).catch(
+          () => "",
+        ),
+      ]);
+      const upstreamBranch = await runGit(cwd, [
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+      ]).catch(() => "");
+      if (!currentBranch) {
+        return undefined;
+      }
+
+      if (!upstreamBranch) {
+        return {
+          currentBranch,
+          branches: branches ? branches.split("\n").filter(Boolean) : [],
+          syncState: "untracked",
+        };
+      }
+
+      const counts = await runGit(cwd, [
+        "rev-list",
+        "--left-right",
+        "--count",
+        `HEAD...${upstreamBranch}`,
+      ]).catch(() => "");
+      const [aheadValue, behindValue] = counts
+        .split(/\s+/)
+        .map((value) => Number.parseInt(value, 10));
+      const ahead = Number.isFinite(aheadValue) ? aheadValue : 0;
+      const behind = Number.isFinite(behindValue) ? behindValue : 0;
+      const syncState =
+        ahead > 0 && behind > 0
+          ? "diverged"
+          : ahead > 0
+            ? "ahead"
+            : behind > 0
+              ? "behind"
+              : "in-sync";
+
+      return {
+        currentBranch,
+        upstreamBranch,
+        ahead,
+        behind,
+        branches: branches ? branches.split("\n").filter(Boolean) : [],
+        syncState,
+      };
+    } catch (error) {
+      return {
+        syncState: "status-unavailable",
+        statusUnavailableReason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async prepareLaunchpadWorkspace(
+    launchpad: Pick<
+      NavigationLaunchpadDraft,
+      "branchName" | "directoryLabel" | "directoryPath" | "workMode"
+    >,
+  ): Promise<{ cwd?: string; workMode: LaunchpadWorkMode }> {
+    const directoryPath = launchpad.directoryPath?.trim();
+    if (!directoryPath) {
+      return {
+        cwd: undefined,
+        workMode: launchpad.workMode,
+      };
+    }
+
+    if (launchpad.workMode !== "worktree") {
+      return {
+        cwd: directoryPath,
+        workMode: "local",
+      };
+    }
+
+    const repoRoot = await runGit(directoryPath, ["rev-parse", "--show-toplevel"]);
+    const baseBranch =
+      sanitizeBranchName(launchpad.branchName ?? "") ||
+      sanitizeBranchName(await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"])) ||
+      "main";
+    const worktreeBranch = buildWorktreeBranchName({
+      baseBranch,
+      directoryLabel: launchpad.directoryLabel,
+    });
+    const worktreePath = buildWorktreePath(repoRoot, worktreeBranch);
+    await mkdir(path.dirname(worktreePath), { recursive: true });
+    await runGit(repoRoot, ["worktree", "add", "-b", worktreeBranch, worktreePath, baseBranch]);
+
+    return {
+      cwd: worktreePath,
+      workMode: "worktree",
+    };
+  }
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -26,7 +26,11 @@ import type {
   AppServerTurnInputItem,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
-import { JsonRpcConnection, type JsonRpcObserver } from "./json-rpc";
+import {
+  JsonRpcConnection,
+  type JsonRpcId,
+  type JsonRpcObserver,
+} from "./json-rpc";
 import { StdioJsonRpcTransport } from "./stdio-transport";
 
 const DEFAULT_PROTOCOL_VERSION = "1.0";
@@ -174,6 +178,51 @@ function pickBoolean(
     }
   }
   return undefined;
+}
+
+function extractRequestMetadata(value: unknown): {
+  threadId?: string;
+  runId?: string;
+  requestId?: string;
+} {
+  const record = asRecord(value);
+  if (!record) {
+    return {};
+  }
+
+  const threadRecord = asRecord(record.thread) ?? asRecord(record.session);
+  const turnRecord = asRecord(record.turn) ?? asRecord(record.run);
+
+  return {
+    threadId:
+      pickString(record, ["threadId", "thread_id", "conversationId", "conversation_id"]) ??
+      pickString(threadRecord ?? {}, ["id", "threadId", "thread_id", "conversationId"]),
+    runId:
+      pickString(record, ["turnId", "turn_id", "runId", "run_id"]) ??
+      pickString(turnRecord ?? {}, ["id", "turnId", "turn_id", "runId", "run_id"]),
+    requestId:
+      pickString(record, ["requestId", "request_id", "serverRequestId"]) ??
+      pickString(asRecord(record.serverRequest) ?? {}, ["id", "requestId", "request_id"]),
+  };
+}
+
+function normalizePendingRequestNotification(
+  method: string,
+  params: unknown,
+  rpcId?: JsonRpcId,
+): AppServerPendingRequestNotification {
+  const record = asRecord(params) ?? {};
+  const metadata = extractRequestMetadata(params);
+
+  return {
+    method,
+    params: {
+      ...record,
+      ...(metadata.threadId ? { threadId: metadata.threadId } : {}),
+      ...(metadata.runId ? { runId: metadata.runId } : {}),
+      requestId: metadata.requestId ?? String(rpcId ?? `${method}-request`),
+    } as AppServerPendingRequestNotification["params"],
+  };
 }
 
 function normalizeEpochTimestamp(value: number | undefined): number | undefined {
@@ -1656,11 +1705,8 @@ export class CodexAppServerClient {
         } as AppServerNotification);
       }
     });
-    this.connection.setRequestHandler(async (method, params) => {
-      const request = {
-        method,
-        params: (params ?? {}) as AppServerPendingRequestNotification["params"],
-      } satisfies AppServerPendingRequestNotification;
+    this.connection.setRequestHandler(async (method, params, rpcId) => {
+      const request = normalizePendingRequestNotification(method, params, rpcId);
 
       const listeners = [...this.requestListeners];
       if (listeners.length === 0) {

--- a/apps/desktop/src/main/codex-app-server/json-rpc.ts
+++ b/apps/desktop/src/main/codex-app-server/json-rpc.ts
@@ -26,7 +26,8 @@ export type JsonRpcNotificationHandler = (
 
 export type JsonRpcRequestHandler = (
   method: string,
-  params: unknown
+  params: unknown,
+  id?: JsonRpcId,
 ) => Promise<unknown>;
 
 export interface JsonRpcTransport {
@@ -184,7 +185,7 @@ export class JsonRpcConnection {
     }
 
     try {
-      const result = await this.requestHandler(method, envelope.params);
+      const result = await this.requestHandler(method, envelope.params, envelope.id);
       await this.sendEnvelope({
         jsonrpc: "2.0",
         id: envelope.id,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, ipcMain } from "electron";
 import type {
   AgentEvent,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
   ListBackendsRequest,
@@ -18,6 +20,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import {
   AGENT_EVENT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_TURN_CHANNEL,
@@ -104,6 +107,17 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.handle(
+    AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
+    async (
+      _event,
+      request: MaterializeDirectoryLaunchpadRequest
+    ): Promise<MaterializeDirectoryLaunchpadResponse> => {
+      return await registry.materializeDirectoryLaunchpad(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
   ipcMain.handle(
     AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
@@ -124,5 +138,6 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
+  ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -8,10 +8,16 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  EnsureDirectoryLaunchpadRequest,
+  EnsureDirectoryLaunchpadResponse,
   GetNavigationSnapshotRequest,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   NavigationSnapshot,
+  ResetDirectoryLaunchpadRequest,
+  ResetDirectoryLaunchpadResponse,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
 import {
   disposeDesktopBackendRegistry,
@@ -23,7 +29,10 @@ import {
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
+  NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
 } from "../../shared/ipc";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -120,6 +129,12 @@ class DesktopAppServerService {
       fetchedAt: Date.now(),
       threads,
     });
+    const directoryStatuses =
+      await getDesktopBackendRegistry().readDirectoryStatuses(snapshot.directories);
+    const directories = snapshot.directories.map((directory) => ({
+      ...directory,
+      gitStatus: directoryStatuses[directory.key],
+    }));
 
     logDebug("getNavigationSnapshot", {
       backend,
@@ -128,7 +143,13 @@ class DesktopAppServerService {
       unchanged: snapshot.unchanged,
     });
 
-    return snapshot;
+    return {
+      ...snapshot,
+      directories,
+      unchanged:
+        snapshot.unchanged &&
+        !directories.some((directory) => directory.gitStatus !== undefined),
+    };
   }
 
   async markThreadSeen(
@@ -150,6 +171,24 @@ class DesktopAppServerService {
     });
 
     return response;
+  }
+
+  async ensureDirectoryLaunchpad(
+    request: EnsureDirectoryLaunchpadRequest,
+  ): Promise<EnsureDirectoryLaunchpadResponse> {
+    return await getDesktopBackendRegistry().ensureDirectoryLaunchpad(request);
+  }
+
+  async updateDirectoryLaunchpad(
+    request: UpdateDirectoryLaunchpadRequest,
+  ): Promise<UpdateDirectoryLaunchpadResponse> {
+    return await getDesktopBackendRegistry().updateDirectoryLaunchpad(request);
+  }
+
+  async resetDirectoryLaunchpad(
+    request: ResetDirectoryLaunchpadRequest,
+  ): Promise<ResetDirectoryLaunchpadResponse> {
+    return await getDesktopBackendRegistry().resetDirectoryLaunchpad(request);
   }
 
   async close(): Promise<void> {
@@ -214,6 +253,36 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.markThreadSeen(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+    async (
+      _event,
+      request: EnsureDirectoryLaunchpadRequest,
+    ): Promise<EnsureDirectoryLaunchpadResponse> => {
+      return await appServerService.ensureDirectoryLaunchpad(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
+    async (
+      _event,
+      request: UpdateDirectoryLaunchpadRequest,
+    ): Promise<UpdateDirectoryLaunchpadResponse> => {
+      return await appServerService.updateDirectoryLaunchpad(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
+    async (
+      _event,
+      request: ResetDirectoryLaunchpadRequest,
+    ): Promise<ResetDirectoryLaunchpadResponse> => {
+      return await appServerService.resetDirectoryLaunchpad(request);
+    },
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
@@ -222,6 +291,9 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/main/testing/replay-controller.ts
+++ b/apps/desktop/src/main/testing/replay-controller.ts
@@ -1,10 +1,21 @@
 import type { ReplayFixture, ReplayRequestStep, ReplayResponseMethod, ReplayResponseStep, ReplayStep, ReplayStepOverride } from "./replay-fixture";
 import { validateReplayFixture } from "./replay-fixture";
 
+const REUSABLE_RESPONSE_METHODS = new Set<ReplayResponseMethod>([
+  "initialize",
+  "thread/list",
+  "thread/read",
+  "skills/list",
+]);
+
 export class ReplayController {
   private readonly steps: ReplayStep[];
   private index = 0;
   private pendingRequest?: ReplayRequestStep;
+  private readonly reusableResponses = new Map<
+    ReplayResponseMethod,
+    ReplayResponseStep
+  >();
 
   constructor(private readonly fixture: ReplayFixture) {
     validateReplayFixture(fixture);
@@ -13,31 +24,46 @@ export class ReplayController {
 
   consumeResponse(method: ReplayResponseMethod): ReplayResponseStep {
     const nextStep = this.steps[this.index];
+    const matchIndex = this.findResponseIndex(method);
+    if (matchIndex !== -1) {
+      const [matchedStep] = this.steps.splice(matchIndex, 1);
+      if (!matchedStep || matchedStep.kind !== "response") {
+        throw new Error(`Replay fixture could not resolve response ${method}`);
+      }
+
+      if (REUSABLE_RESPONSE_METHODS.has(method)) {
+        this.reusableResponses.set(method, matchedStep);
+      }
+
+      if (matchedStep.error) {
+        throw new Error(
+          `Replay response error (${matchedStep.error.code ?? "unknown"}): ${
+            matchedStep.error.message ?? "unknown error"
+          }`
+        );
+      }
+
+      return matchedStep;
+    }
+
+    const cachedResponse = this.reusableResponses.get(method);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
     if (!nextStep) {
       throw new Error(`Replay fixture exhausted before ${method}`);
     }
+
     if (nextStep.kind !== "response") {
       throw new Error(
         `Replay fixture expected live step ${nextStep.id} before response ${method}`
       );
     }
-    if (nextStep.method !== method) {
-      throw new Error(
-        `Replay fixture expected ${nextStep.method} before ${method}`
-      );
-    }
 
-    this.index += 1;
-
-    if (nextStep.error) {
-      throw new Error(
-        `Replay response error (${nextStep.error.code ?? "unknown"}): ${
-          nextStep.error.message ?? "unknown error"
-        }`
-      );
-    }
-
-    return nextStep;
+    throw new Error(
+      `Replay fixture expected ${nextStep.method} before ${method}`
+    );
   }
 
   advance(params: {
@@ -85,6 +111,20 @@ export class ReplayController {
     const current = this.pendingRequest;
     this.pendingRequest = undefined;
     return current;
+  }
+
+  private findResponseIndex(method: ReplayResponseMethod): number {
+    for (let candidateIndex = this.index; candidateIndex < this.steps.length; candidateIndex += 1) {
+      const step = this.steps[candidateIndex];
+      if (step.kind !== "response") {
+        break;
+      }
+      if (step.method === method) {
+        return candidateIndex;
+      }
+    }
+
+    return -1;
   }
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,10 +1,14 @@
 import { clipboard, contextBridge, ipcRenderer } from "electron";
 import type {
   AgentEvent,
+  EnsureDirectoryLaunchpadRequest,
+  EnsureDirectoryLaunchpadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   AppServerListSkillsRequest,
@@ -17,16 +21,21 @@ import type {
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   NavigationSnapshot,
+  ResetDirectoryLaunchpadRequest,
+  ResetDirectoryLaunchpadResponse,
   StartThreadRequest,
   StartThreadResponse,
   StartTurnRequest,
   StartTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
 import {
   AGENT_EVENT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_TURN_CHANNEL,
@@ -35,8 +44,11 @@ import {
   APP_SERVER_LIST_THREADS_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   BACKEND_LIST_CHANNEL,
+  NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
+  NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
 } from "../shared/ipc";
 
@@ -83,6 +95,10 @@ const desktopApi = Object.freeze({
     request: SetThreadExecutionModeRequest
   ): Promise<SetThreadExecutionModeResponse> =>
     await ipcRenderer.invoke(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL, request),
+  materializeDirectoryLaunchpad: async (
+    request: MaterializeDirectoryLaunchpadRequest
+  ): Promise<MaterializeDirectoryLaunchpadResponse> =>
+    await ipcRenderer.invoke(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL, request),
   submitServerRequest: async (
     request: SubmitServerRequestRequest
   ): Promise<SubmitServerRequestResponse> =>
@@ -95,6 +111,18 @@ const desktopApi = Object.freeze({
     request: MarkThreadSeenRequest,
   ): Promise<MarkThreadSeenResponse> =>
     await ipcRenderer.invoke(NAVIGATION_MARK_THREAD_SEEN_CHANNEL, request),
+  ensureDirectoryLaunchpad: async (
+    request: EnsureDirectoryLaunchpadRequest,
+  ): Promise<EnsureDirectoryLaunchpadResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  updateDirectoryLaunchpad: async (
+    request: UpdateDirectoryLaunchpadRequest,
+  ): Promise<UpdateDirectoryLaunchpadResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  resetDirectoryLaunchpad: async (
+    request: ResetDirectoryLaunchpadRequest,
+  ): Promise<ResetDirectoryLaunchpadResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL, request),
   onWindowFocus: (callback: () => void): (() => void) => {
     const listener = () => callback();
     ipcRenderer.on(WINDOW_FOCUS_SYNC_CHANNEL, listener);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -16,6 +16,7 @@ export function App() {
   });
   const skills = useThreadSkills({
     desktopApi,
+    launchpad: navigation.selectedLaunchpad,
     thread: navigation.selectedThread,
   });
 
@@ -25,16 +26,19 @@ export function App() {
         browseMode={navigation.browseMode}
         backends={backendSummaries.backends}
         createThreadError={navigation.createThreadError}
+        directories={navigation.directories}
         error={navigation.error}
         fetchedAt={navigation.snapshot?.fetchedAt}
         inboxThreads={navigation.inboxThreads}
+        launchpadError={navigation.launchpadError}
         loading={navigation.loading}
         creatingThread={navigation.creatingThread}
         refreshing={navigation.refreshing}
-        selectedThreadKey={navigation.selectedThreadKey}
+        selectedItemKey={navigation.selectedItemKey}
         threads={navigation.threads}
         onBrowseModeChange={navigation.setBrowseMode}
         onCreateThread={navigation.createThread}
+        onOpenLaunchpad={navigation.openDirectoryLaunchpad}
         onRefresh={navigation.refresh}
         onSelectThread={navigation.selectThread}
       />
@@ -58,6 +62,8 @@ export function App() {
           }
           desktopApi={desktopApi}
           platform={desktopApi?.platform}
+          selectedDirectory={navigation.selectedDirectory}
+          selectedLaunchpad={navigation.selectedLaunchpad}
           selectedThread={navigation.selectedThread}
           setExecutionModeError={navigation.setThreadExecutionModeError}
           skillError={skills.error}
@@ -67,7 +73,9 @@ export function App() {
           transcriptEntries={transcript.entries}
           transcriptPagination={transcript.response?.replay.pagination}
           updatingExecutionMode={navigation.updatingThreadExecutionMode}
+          launchpadError={navigation.launchpadError}
           onLoadOlder={transcript.loadOlder}
+          onMaterializeLaunchpad={navigation.materializeDirectoryLaunchpad}
           onSetExecutionMode={
             navigation.selectedThread
               ? async (executionMode) =>
@@ -77,8 +85,11 @@ export function App() {
                   )
               : undefined
           }
+          onUpdateLaunchpad={navigation.updateDirectoryLaunchpad}
           removeOptimisticMessage={transcript.removeOptimisticMessage}
-          onRefresh={transcript.refresh}
+          onRefresh={
+            navigation.selectedThread ? transcript.refresh : navigation.refresh
+          }
         />
       </main>
     </div>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5,6 +5,7 @@ import type {
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
+  ThreadExecutionMode,
 } from "@pwragnt/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
@@ -51,10 +52,13 @@ type ComposerProps = {
     >
   ) => Promise<void>;
   removeOptimisticMessage?: (id: string) => void;
+  setExecutionModeError?: string;
   skillError?: string;
   skillLoading?: boolean;
   skills: AppServerSkillSummary[];
   thread?: NavigationThreadSummary;
+  updatingExecutionMode?: ThreadExecutionMode;
+  onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
 };
 
 export function Composer(props: ComposerProps) {
@@ -383,9 +387,11 @@ export function Composer(props: ComposerProps) {
     currentModelOption?.supportsFast ??
     backend?.launchpadOptions?.supportsFastMode ??
     false;
-  const canChooseWorktree = Boolean(
-    props.directory?.gitStatus?.currentBranch || props.directory?.gitStatus?.branches?.length
-  );
+  const availableExecutionModes =
+    backend?.executionModes.filter((mode) => mode.available) ?? [];
+  const workspaceLabel = isLaunchpad
+    ? formatLaunchpadWorkspaceLabel(props.launchpad, props.directory)
+    : formatThreadWorkspaceLabel(props.thread);
 
   return (
     <form
@@ -487,100 +493,85 @@ export function Composer(props: ComposerProps) {
         ) : null}
       </div>
 
-      {props.launchpad ? (
-        <div className="composer__setup" aria-label="New thread settings">
-          <div className="composer__control-group">
-            <span className="composer__control-label">Access</span>
-            <div className="composer__segmented" role="group" aria-label="Access mode">
-              {(backend?.executionModes ?? []).filter((mode) => mode.available).map((mode) => (
-                <button
-                  key={mode.mode}
-                  aria-pressed={props.launchpad?.executionMode === mode.mode}
-                  className={`composer__segmented-button${
-                    props.launchpad?.executionMode === mode.mode ? " is-active" : ""
-                  }`}
-                  type="button"
-                  onClick={() => {
-                    if (props.launchpad?.executionMode !== mode.mode) {
-                      handleLaunchpadPatch({ executionMode: mode.mode });
-                    }
-                  }}
-                >
-                  {formatExecutionModeLabel(mode.mode)}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {canChooseWorktree ? (
-            <div className="composer__control-group">
-              <span className="composer__control-label">Workspace</span>
-              <div className="composer__segmented" role="group" aria-label="Workspace mode">
-                <button
-                  aria-pressed={props.launchpad.workMode === "local"}
-                  className={`composer__segmented-button${
-                    props.launchpad.workMode === "local" ? " is-active" : ""
-                  }`}
-                  type="button"
-                  onClick={() => {
-                    if (props.launchpad?.workMode !== "local") {
-                      handleLaunchpadPatch({ workMode: "local" });
-                    }
-                  }}
-                >
-                  Local {props.directory?.gitStatus?.currentBranch ? `(${props.directory.gitStatus.currentBranch})` : ""}
-                </button>
-                <button
-                  aria-pressed={props.launchpad.workMode === "worktree"}
-                  className={`composer__segmented-button${
-                    props.launchpad.workMode === "worktree" ? " is-active" : ""
-                  }`}
-                  type="button"
-                  onClick={() => {
-                    if (props.launchpad?.workMode !== "worktree") {
-                      handleLaunchpadPatch({
-                        workMode: "worktree",
-                        branchName:
-                          launchpad?.branchName ??
-                          props.directory?.gitStatus?.currentBranch,
-                      });
-                    }
-                  }}
-                >
-                  New worktree
-                </button>
-              </div>
-            </div>
-          ) : null}
-
-          {props.launchpad.workMode === "worktree" &&
-          (props.directory?.gitStatus?.branches?.length ?? 0) > 0 ? (
-            <div className="composer__control-group">
-              <label className="composer__control-label" htmlFor="launchpad-branch">
-                Base branch
-              </label>
-              <select
-                id="launchpad-branch"
-                className="composer__select"
-                value={
-                  props.launchpad.branchName ??
-                  props.directory?.gitStatus?.currentBranch ??
-                  ""
+      {props.launchpad || props.thread ? (
+        <div
+          className="composer__setup"
+          aria-label={props.launchpad ? "New thread settings" : "Thread settings"}
+        >
+          {availableExecutionModes.length > 0 &&
+          (props.launchpad || (props.thread?.source === "codex" && props.onSetExecutionMode)) ? (
+            <select
+              aria-label="Access mode"
+              className="composer__select composer__select--compact"
+              disabled={Boolean(props.updatingExecutionMode)}
+              value={
+                props.launchpad?.executionMode ??
+                props.thread?.executionMode ??
+                "default"
+              }
+              onChange={(event) => {
+                const executionMode = event.target.value as ThreadExecutionMode;
+                if (props.launchpad) {
+                  if (props.launchpad.executionMode !== executionMode) {
+                    handleLaunchpadPatch({ executionMode });
+                  }
+                  return;
                 }
-                onChange={(event) => {
-                  handleLaunchpadPatch({ branchName: event.target.value || undefined });
-                }}
-              >
-                {(props.directory?.gitStatus?.branches ?? []).map((branch) => (
-                  <option key={branch} value={branch}>
-                    {branch}
-                  </option>
-                ))}
-              </select>
-            </div>
+
+                if (
+                  props.thread &&
+                  props.thread.executionMode !== executionMode &&
+                  !props.updatingExecutionMode
+                ) {
+                  void props.onSetExecutionMode?.(executionMode);
+                }
+              }}
+            >
+              {availableExecutionModes.map((mode) => (
+                <option key={mode.mode} value={mode.mode}>
+                  {formatExecutionModeLabel(mode.mode)}
+                </option>
+              ))}
+            </select>
           ) : null}
 
-          {backend?.launchpadOptions?.models?.length ? (
+          {workspaceLabel ? (
+            <select
+              aria-label="Workspace mode"
+              className="composer__select composer__select--compact"
+              disabled
+              value={workspaceLabel}
+              onChange={() => undefined}
+            >
+              <option value={workspaceLabel}>{workspaceLabel}</option>
+            </select>
+          ) : null}
+
+          {props.launchpad &&
+          props.launchpad.workMode === "worktree" &&
+          (props.directory?.gitStatus?.branches?.length ?? 0) > 0 ? (
+            <select
+              aria-label="Base branch"
+              id="launchpad-branch"
+              className="composer__select composer__select--compact"
+              value={
+                props.launchpad.branchName ??
+                props.directory?.gitStatus?.currentBranch ??
+                ""
+              }
+              onChange={(event) => {
+                handleLaunchpadPatch({ branchName: event.target.value || undefined });
+              }}
+            >
+              {(props.directory?.gitStatus?.branches ?? []).map((branch) => (
+                <option key={branch} value={branch}>
+                  {branch}
+                </option>
+              ))}
+            </select>
+          ) : null}
+
+          {props.launchpad && backend?.launchpadOptions?.models?.length ? (
             <div className="composer__control-group">
               <label className="composer__control-label" htmlFor="launchpad-model">
                 Model
@@ -603,7 +594,9 @@ export function Composer(props: ComposerProps) {
             </div>
           ) : null}
 
-          {supportsReasoning && backend?.launchpadOptions?.reasoningEfforts?.length ? (
+          {props.launchpad &&
+          supportsReasoning &&
+          backend?.launchpadOptions?.reasoningEfforts?.length ? (
             <div className="composer__control-group">
               <label className="composer__control-label" htmlFor="launchpad-reasoning">
                 Reasoning
@@ -628,7 +621,7 @@ export function Composer(props: ComposerProps) {
             </div>
           ) : null}
 
-          {backend?.launchpadOptions?.serviceTiers?.length ? (
+          {props.launchpad && backend?.launchpadOptions?.serviceTiers?.length ? (
             <div className="composer__control-group">
               <label className="composer__control-label" htmlFor="launchpad-service-tier">
                 Service tier
@@ -653,7 +646,7 @@ export function Composer(props: ComposerProps) {
             </div>
           ) : null}
 
-          {supportsFast ? (
+          {props.launchpad && supportsFast ? (
             <label className="composer__checkbox">
               <input
                 checked={Boolean(props.launchpad.fastMode)}
@@ -673,8 +666,18 @@ export function Composer(props: ComposerProps) {
         <p className="composer__meta composer__meta--error">{props.launchpadError}</p>
       ) : null}
       {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
+      {props.setExecutionModeError ? (
+        <p className="composer__meta composer__meta--error">
+          {props.setExecutionModeError}
+        </p>
+      ) : null}
       {!props.skillError && props.skillLoading ? (
         <p className="composer__meta">Loading skills…</p>
+      ) : null}
+      {props.updatingExecutionMode ? (
+        <p className="composer__meta">
+          Switching to {formatExecutionModeLabel(props.updatingExecutionMode)}…
+        </p>
       ) : null}
       {props.disabled ? (
         <p className="composer__meta">
@@ -721,4 +724,40 @@ export function Composer(props: ComposerProps) {
       </div>
     </form>
   );
+}
+
+function formatLaunchpadWorkspaceLabel(
+  launchpad?: NavigationLaunchpadDraft,
+  directory?: NavigationDirectorySummary,
+): string | undefined {
+  if (!launchpad) {
+    return undefined;
+  }
+
+  if (launchpad.workMode === "worktree") {
+    return "New worktree";
+  }
+
+  return directory?.gitStatus?.currentBranch
+    ? `Local (${directory.gitStatus.currentBranch})`
+    : "Local";
+}
+
+function formatThreadWorkspaceLabel(thread?: NavigationThreadSummary): string | undefined {
+  if (!thread) {
+    return undefined;
+  }
+
+  if (thread.linkedDirectories.some((directory) => directory.kind === "worktree")) {
+    return "Worktree";
+  }
+
+  if (
+    thread.linkedDirectories.some((directory) => directory.kind === "local") ||
+    thread.projectKey
+  ) {
+    return thread.gitBranch ? `Local (${thread.gitBranch})` : "Local";
+  }
+
+  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { AppServerSkillSummary, NavigationThreadSummary } from "@pwragnt/shared";
+import type {
+  AppServerSkillSummary,
+  BackendSummary,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
+  NavigationThreadSummary,
+} from "@pwragnt/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import {
   findSkillTrigger,
   hydrateSkillLabelsWithMarkdown,
@@ -11,11 +18,38 @@ import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
   addOptimisticUserMessage?: (text: string) => string;
+  backends?: BackendSummary[];
   desktopApi?: DesktopApi;
+  directory?: NavigationDirectorySummary;
   disabled?: boolean;
+  launchpad?: NavigationLaunchpadDraft;
+  launchpadError?: string;
   pendingRequestActive?: boolean;
+  onMaterializeLaunchpad?: (
+    directoryKey: string,
+    input?: Array<{ type: "text"; text: string }>
+  ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onRefresh: () => Promise<void>;
+  onUpdateLaunchpad?: (
+    directoryKey: string,
+    patch: Partial<
+      Pick<
+        NavigationLaunchpadDraft,
+        | "prompt"
+        | "backend"
+        | "executionMode"
+        | "model"
+        | "reasoningEffort"
+        | "serviceTier"
+        | "fastMode"
+        | "workMode"
+        | "branchName"
+        | "directoryLabel"
+        | "directoryPath"
+      >
+    >
+  ) => Promise<void>;
   removeOptimisticMessage?: (id: string) => void;
   skillError?: string;
   skillLoading?: boolean;
@@ -33,9 +67,17 @@ export function Composer(props: ComposerProps) {
   const [sendError, setSendError] = useState<string>();
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
+  const isLaunchpad = Boolean(props.launchpad && props.directory);
+  const launchpad = props.launchpad;
+  const backend = useMemo(
+    () =>
+      props.backends?.find((candidate) =>
+        candidate.kind === (props.launchpad?.backend ?? props.thread?.source)
+      ),
+    [props.backends, props.launchpad?.backend, props.thread?.source]
+  );
 
   const selectionStart = inputRef.current?.selectionStart ?? draft.length;
-  const selectionEnd = inputRef.current?.selectionEnd ?? draft.length;
   const updateActiveRunId = (nextRunId?: string): void => {
     activeRunIdRef.current = nextRunId;
     setActiveRunId(nextRunId);
@@ -71,9 +113,31 @@ export function Composer(props: ComposerProps) {
 
   useEffect(() => {
     setActiveSkillIndex(0);
-  }, [trigger?.query, props.thread?.id]);
+  }, [trigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
+    if (!isLaunchpad) {
+      setDraft("");
+      setSending(false);
+      setInterrupting(false);
+      updateActiveRunId(undefined);
+      setActiveOptimisticMessageId(undefined);
+      return;
+    }
+
+    setDraft(props.launchpad?.prompt ?? "");
+    setSending(false);
+    setInterrupting(false);
+    updateActiveRunId(undefined);
+    setActiveOptimisticMessageId(undefined);
+  }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.updatedAt]);
+
+  useEffect(() => {
+    if (!props.thread) {
+      return;
+    }
+
+    setDraft("");
     setSending(false);
     setInterrupting(false);
     updateActiveRunId(undefined);
@@ -161,14 +225,53 @@ export function Composer(props: ComposerProps) {
     props.thread
   ]);
 
+  useEffect(() => {
+    if (!launchpad || !props.onUpdateLaunchpad) {
+      return;
+    }
+
+    if (draft === launchpad.prompt) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void props.onUpdateLaunchpad?.(launchpad.directoryKey, {
+        prompt: draft,
+      });
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [draft, launchpad, props.onUpdateLaunchpad]);
+
   const submitTurn = async (): Promise<void> => {
     const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
-    if (!text || !props.thread || !props.desktopApi?.startTurn || props.disabled) {
+    if (!text || props.disabled) {
       return;
     }
 
     setSendError(undefined);
     setSending(true);
+
+    if (props.launchpad && props.onMaterializeLaunchpad) {
+      try {
+        await props.onMaterializeLaunchpad(props.launchpad.directoryKey, [
+          { type: "text", text },
+        ]);
+      } catch (error) {
+        setSendError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setSending(false);
+      }
+      return;
+    }
+
+    if (!props.thread || !props.desktopApi?.startTurn) {
+      setSending(false);
+      return;
+    }
+
     props.onPendingStatusChange?.("Thinking");
     const optimisticMessageId = props.addOptimisticUserMessage?.(text);
     setActiveOptimisticMessageId(optimisticMessageId);
@@ -248,6 +351,42 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  const handleLaunchpadPatch = (
+    patch: Partial<
+      Pick<
+        NavigationLaunchpadDraft,
+        | "executionMode"
+        | "model"
+        | "reasoningEffort"
+        | "serviceTier"
+        | "fastMode"
+        | "workMode"
+        | "branchName"
+      >
+    >
+  ): void => {
+    if (!props.launchpad || !props.onUpdateLaunchpad) {
+      return;
+    }
+
+    setSendError(undefined);
+    void props.onUpdateLaunchpad(props.launchpad.directoryKey, patch);
+  };
+
+  const currentModelOption = backend?.launchpadOptions?.models?.find(
+    (option) => option.id === props.launchpad?.model
+  );
+  const supportsReasoning =
+    currentModelOption?.supportsReasoning ??
+    Boolean(backend?.launchpadOptions?.reasoningEfforts?.length);
+  const supportsFast =
+    currentModelOption?.supportsFast ??
+    backend?.launchpadOptions?.supportsFastMode ??
+    false;
+  const canChooseWorktree = Boolean(
+    props.directory?.gitStatus?.currentBranch || props.directory?.gitStatus?.branches?.length
+  );
+
   return (
     <form
       className="composer"
@@ -257,7 +396,7 @@ export function Composer(props: ComposerProps) {
       }}
     >
       <label className="composer__label" htmlFor="thread-composer">
-        Reply
+        {isLaunchpad ? "New thread" : "Reply"}
       </label>
 
       {mentionedSkills.length > 0 ? (
@@ -273,8 +412,12 @@ export function Composer(props: ComposerProps) {
           ref={inputRef}
           id="thread-composer"
           className="composer__input"
-          disabled={sending}
-          placeholder="Reply to this thread"
+          disabled={Boolean(props.thread && sending)}
+          placeholder={
+            isLaunchpad
+              ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
+              : "Reply to this thread"
+          }
           value={draft}
           onChange={(event) => {
             setDraft(event.target.value);
@@ -344,18 +487,208 @@ export function Composer(props: ComposerProps) {
         ) : null}
       </div>
 
+      {props.launchpad ? (
+        <div className="composer__setup" aria-label="New thread settings">
+          <div className="composer__control-group">
+            <span className="composer__control-label">Access</span>
+            <div className="composer__segmented" role="group" aria-label="Access mode">
+              {(backend?.executionModes ?? []).filter((mode) => mode.available).map((mode) => (
+                <button
+                  key={mode.mode}
+                  aria-pressed={props.launchpad?.executionMode === mode.mode}
+                  className={`composer__segmented-button${
+                    props.launchpad?.executionMode === mode.mode ? " is-active" : ""
+                  }`}
+                  type="button"
+                  onClick={() => {
+                    if (props.launchpad?.executionMode !== mode.mode) {
+                      handleLaunchpadPatch({ executionMode: mode.mode });
+                    }
+                  }}
+                >
+                  {formatExecutionModeLabel(mode.mode)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {canChooseWorktree ? (
+            <div className="composer__control-group">
+              <span className="composer__control-label">Workspace</span>
+              <div className="composer__segmented" role="group" aria-label="Workspace mode">
+                <button
+                  aria-pressed={props.launchpad.workMode === "local"}
+                  className={`composer__segmented-button${
+                    props.launchpad.workMode === "local" ? " is-active" : ""
+                  }`}
+                  type="button"
+                  onClick={() => {
+                    if (props.launchpad?.workMode !== "local") {
+                      handleLaunchpadPatch({ workMode: "local" });
+                    }
+                  }}
+                >
+                  Local {props.directory?.gitStatus?.currentBranch ? `(${props.directory.gitStatus.currentBranch})` : ""}
+                </button>
+                <button
+                  aria-pressed={props.launchpad.workMode === "worktree"}
+                  className={`composer__segmented-button${
+                    props.launchpad.workMode === "worktree" ? " is-active" : ""
+                  }`}
+                  type="button"
+                  onClick={() => {
+                    if (props.launchpad?.workMode !== "worktree") {
+                      handleLaunchpadPatch({
+                        workMode: "worktree",
+                        branchName:
+                          launchpad?.branchName ??
+                          props.directory?.gitStatus?.currentBranch,
+                      });
+                    }
+                  }}
+                >
+                  New worktree
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {props.launchpad.workMode === "worktree" &&
+          (props.directory?.gitStatus?.branches?.length ?? 0) > 0 ? (
+            <div className="composer__control-group">
+              <label className="composer__control-label" htmlFor="launchpad-branch">
+                Base branch
+              </label>
+              <select
+                id="launchpad-branch"
+                className="composer__select"
+                value={
+                  props.launchpad.branchName ??
+                  props.directory?.gitStatus?.currentBranch ??
+                  ""
+                }
+                onChange={(event) => {
+                  handleLaunchpadPatch({ branchName: event.target.value || undefined });
+                }}
+              >
+                {(props.directory?.gitStatus?.branches ?? []).map((branch) => (
+                  <option key={branch} value={branch}>
+                    {branch}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {backend?.launchpadOptions?.models?.length ? (
+            <div className="composer__control-group">
+              <label className="composer__control-label" htmlFor="launchpad-model">
+                Model
+              </label>
+              <select
+                id="launchpad-model"
+                className="composer__select"
+                value={props.launchpad.model ?? ""}
+                onChange={(event) => {
+                  handleLaunchpadPatch({ model: event.target.value || undefined });
+                }}
+              >
+                <option value="">Default</option>
+                {backend.launchpadOptions.models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.label ?? model.id}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {supportsReasoning && backend?.launchpadOptions?.reasoningEfforts?.length ? (
+            <div className="composer__control-group">
+              <label className="composer__control-label" htmlFor="launchpad-reasoning">
+                Reasoning
+              </label>
+              <select
+                id="launchpad-reasoning"
+                className="composer__select"
+                value={props.launchpad.reasoningEffort ?? ""}
+                onChange={(event) => {
+                  handleLaunchpadPatch({
+                    reasoningEffort: event.target.value || undefined,
+                  });
+                }}
+              >
+                <option value="">Default</option>
+                {backend.launchpadOptions.reasoningEfforts.map((effort) => (
+                  <option key={effort} value={effort}>
+                    {effort}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {backend?.launchpadOptions?.serviceTiers?.length ? (
+            <div className="composer__control-group">
+              <label className="composer__control-label" htmlFor="launchpad-service-tier">
+                Service tier
+              </label>
+              <select
+                id="launchpad-service-tier"
+                className="composer__select"
+                value={props.launchpad.serviceTier ?? ""}
+                onChange={(event) => {
+                  handleLaunchpadPatch({
+                    serviceTier: event.target.value || undefined,
+                  });
+                }}
+              >
+                <option value="">Default</option>
+                {backend.launchpadOptions.serviceTiers.map((tier) => (
+                  <option key={tier} value={tier}>
+                    {tier}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {supportsFast ? (
+            <label className="composer__checkbox">
+              <input
+                checked={Boolean(props.launchpad.fastMode)}
+                type="checkbox"
+                onChange={(event) => {
+                  handleLaunchpadPatch({ fastMode: event.target.checked });
+                }}
+              />
+              <span>Fast mode</span>
+            </label>
+          ) : null}
+        </div>
+      ) : null}
+
       {props.skillError ? <p className="composer__meta composer__meta--error">{props.skillError}</p> : null}
+      {props.launchpadError ? (
+        <p className="composer__meta composer__meta--error">{props.launchpadError}</p>
+      ) : null}
       {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
       {!props.skillError && props.skillLoading ? (
         <p className="composer__meta">Loading skills…</p>
       ) : null}
       {props.disabled ? (
         <p className="composer__meta">
-          This thread's backend is unavailable right now. You can keep drafting, but send is unavailable.
+          {props.launchpad
+            ? "This backend is unavailable right now. Your draft stays here until send is available again."
+            : "This thread's backend is unavailable right now. You can keep drafting, but send is unavailable."}
         </p>
       ) : props.pendingRequestActive ? (
         <p className="composer__meta">
           Waiting for approval before this turn can continue.
+        </p>
+      ) : props.launchpad ? (
+        <p className="composer__meta">
+          Changes here become the default for future new-thread launchpads. Existing threads keep their current settings.
         </p>
       ) : null}
 
@@ -377,7 +710,13 @@ export function Composer(props: ComposerProps) {
           disabled={props.disabled || sending || !draft.trim()}
           type="submit"
         >
-          {sending ? "Sending…" : "Send"}
+          {sending
+            ? props.launchpad
+              ? "Starting…"
+              : "Sending…"
+            : props.launchpad
+              ? "Start thread"
+              : "Send"}
         </button>
       </div>
     </form>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -8,6 +8,90 @@ afterEach(() => {
 });
 
 describe("Composer", () => {
+  it("shows thread access in the composer and updates it from the select", async () => {
+    const onSetExecutionMode = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            runId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        onRefresh={async () => undefined}
+        onSetExecutionMode={onSetExecutionMode}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "main",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "local",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText("Access mode")).toHaveValue("default");
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("Local (main)");
+    expect(screen.getByLabelText("Workspace mode")).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Access mode"), {
+      target: { value: "full-access" },
+    });
+
+    await waitFor(() => {
+      expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -5,7 +5,6 @@ import type {
   NavigationThreadSummary,
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
-import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 
 type DirectoriesListProps = {
@@ -138,40 +137,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
             {expanded ? (
               <div className="directory-row__details">
-                <div className="directory-row__details-meta">
-                  {directory.path ? (
-                    <button
-                      aria-label={`Copy path for ${directory.label}`}
-                      className="directory-row__detail-chip directory-row__detail-chip--path path-copy-target tooltip-target"
-                      data-tooltip={formatCopyTooltip(directory.path)}
-                      type="button"
-                      onClick={() => {
-                        if (directory.path) {
-                          void copyText(directory.path);
-                        }
-                      }}
-                    >
-                      {directory.path}
-                    </button>
-                  ) : null}
-                  {directory.gitStatus?.currentBranch ? (
-                    <span className="directory-row__detail-chip thread-row__chip--mono">
-                      🌿 {directory.gitStatus.currentBranch}
-                    </span>
-                  ) : null}
-                  {formatSyncLabel(directory) ? (
-                    <span className="directory-row__detail-chip">{formatSyncLabel(directory)}</span>
-                  ) : null}
-                  <span className="directory-row__detail-chip">
-                    {visibleThreads.length} thread{visibleThreads.length === 1 ? "" : "s"}
-                  </span>
-                  {directory.launchpad ? (
-                    <span className="directory-row__detail-chip directory-row__detail-chip--draft">
-                      Draft
-                    </span>
-                  ) : null}
-                </div>
-
                 {visibleThreads.length > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {visibleThreads.map((thread) => {
@@ -239,32 +204,4 @@ function formatRelativeTime(timestamp?: number): string {
     month: "short",
     day: "numeric"
   }).format(timestamp);
-}
-
-function formatSyncLabel(directory: NavigationDirectorySummary): string | undefined {
-  const status = directory.gitStatus;
-  if (!status) {
-    return undefined;
-  }
-
-  if (status.syncState === "in-sync") {
-    return "Up to date";
-  }
-  if (status.syncState === "ahead") {
-    return `${status.ahead ?? 0} ahead`;
-  }
-  if (status.syncState === "behind") {
-    return `${status.behind ?? 0} behind`;
-  }
-  if (status.syncState === "diverged") {
-    return `${status.ahead ?? 0} ahead · ${status.behind ?? 0} behind`;
-  }
-  if (status.syncState === "untracked") {
-    return "No upstream";
-  }
-  if (status.syncState === "status-unavailable") {
-    return "Status unavailable";
-  }
-
-  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,270 +1,211 @@
-import type { LinkedDirectorySummary, NavigationThreadSummary } from "@pwragnt/shared";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  AppServerBackendKind,
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 
 type DirectoriesListProps = {
-  selectedThreadKey?: string;
+  directories: NavigationDirectorySummary[];
+  selectedItemKey?: string;
   threads: NavigationThreadSummary[];
+  onOpenLaunchpad: (
+    directory: NavigationDirectorySummary,
+    preferredBackend?: AppServerBackendKind
+  ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
 
-type DirectoryGroup = {
-  id: string;
-  icon: string;
-  label: string;
-  path?: string;
-  threads: NavigationThreadSummary[];
-};
-
-type DirectoryGroupDescriptor = Omit<DirectoryGroup, "threads">;
-type DirectoryIdentity =
-  | {
-      kind: "scratch-workspaces";
-      path: string;
-    }
-  | {
-      kind: "stable";
-      label: string;
-      path: string;
-    }
-  | {
-      kind: "codex-worktree";
-      label: string;
-    };
-
-const DIRECTORY_THREAD_AGE_OUT_MS = 30 * 24 * 60 * 60 * 1000;
+function buildLaunchpadSelectionKey(directoryKey: string): string {
+  return `launchpad:${directoryKey}`;
+}
 
 export function DirectoriesList(props: DirectoriesListProps) {
-  const groups = groupThreadsByDirectory(props.threads);
+  const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>({});
+  const threadsByKey = useMemo(
+    () =>
+      new Map(
+        props.threads.map((thread) => [
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread,
+        ]),
+      ),
+    [props.threads]
+  );
 
-  if (groups.length === 0) {
+  useEffect(() => {
+    const selectedItemKey = props.selectedItemKey;
+    if (!selectedItemKey) {
+      return;
+    }
+
+    setExpandedByKey((current) => {
+      for (const directory of props.directories) {
+        if (
+          selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
+          directory.threadKeys.includes(selectedItemKey)
+        ) {
+          if (current[directory.key]) {
+            return current;
+          }
+
+          return {
+            ...current,
+            [directory.key]: true,
+          };
+        }
+      }
+
+      return current;
+    });
+  }, [props.directories, props.selectedItemKey]);
+
+  if (props.directories.length === 0) {
     return <p className="sidebar-empty">No directory-linked threads.</p>;
   }
 
   return (
-    <div className="directory-groups">
-      {groups.map((group) => (
-        <section key={group.id} className="directory-group">
-          <header className="directory-group__header">
-            <h3 className="directory-group__title">
+    <div className="directory-list sidebar-list sidebar-list--dense">
+      {props.directories.map((directory) => {
+        const selectedLaunchpad =
+          props.selectedItemKey === buildLaunchpadSelectionKey(directory.key);
+        const selectedThreadInDirectory = directory.threadKeys.includes(
+          props.selectedItemKey ?? ""
+        );
+        const expanded =
+          expandedByKey[directory.key] ??
+          (selectedLaunchpad || selectedThreadInDirectory);
+        const visibleThreads = directory.threadKeys
+          .map((threadKey) => threadsByKey.get(threadKey))
+          .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
+
+        return (
+          <section key={directory.key} className="directory-row">
+            <div className="directory-row__header">
               <button
-                aria-label={`Copy path for ${group.label}`}
-                className="directory-group__button path-copy-target tooltip-target"
-                data-tooltip={group.path ? formatCopyTooltip(group.path) : undefined}
+                aria-expanded={expanded}
+                className={`thread-row thread-row--compact directory-row__summary${
+                  selectedLaunchpad ? " is-selected" : ""
+                }`}
                 type="button"
                 onClick={() => {
-                  if (group.path) {
-                    void copyText(group.path);
-                  }
+                  setExpandedByKey((current) => ({
+                    ...current,
+                    [directory.key]: !expanded,
+                  }));
                 }}
               >
-                <span aria-hidden="true" className="directory-group__icon">
-                  {group.icon}
-                </span>
-                {group.label}
-              </button>
-            </h3>
-            <span className="directory-group__count">
-              {group.threads.length} thread{group.threads.length === 1 ? "" : "s"}
-            </span>
-          </header>
-
-          <div className="sidebar-list sidebar-list--compact" role="list">
-            {group.threads.map((thread) => {
-              const selected =
-                buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
-              return (
-                <button
-                  key={`${group.id}:${buildThreadIdentityKey(thread.source, thread.id)}`}
-                  aria-pressed={selected}
-                  className={`thread-row${selected ? " is-selected" : ""}`}
-                  type="button"
-                  onClick={() => props.onSelectThread(thread)}
-                >
-                  <span className="thread-row__header">
-                    <span className="thread-row__title">{thread.title}</span>
-                    <span className="thread-row__time">
-                      {formatRelativeTime(thread.updatedAt)}
-                    </span>
+                <span className="directory-row__summary-main">
+                  <span aria-hidden="true" className="directory-row__icon">
+                    {directory.kind === "workspace" ? "🗂" : directory.kind === "unlinked" ? "•" : "📁"}
                   </span>
-                  <ThreadMetaChips thread={thread} />
-                </button>
-              );
-            })}
-          </div>
-        </section>
-      ))}
+                  <span className="directory-row__title-wrap">
+                    <span className="thread-row__title">{directory.label}</span>
+                  </span>
+                </span>
+
+                <span className="directory-row__summary-meta">
+                  {directory.needsAttentionCount > 0 ? (
+                    <span className="count-pill directory-row__attention">
+                      {directory.needsAttentionCount}
+                    </span>
+                  ) : null}
+                  <span
+                    aria-hidden="true"
+                    className={`directory-row__chevron${expanded ? " is-open" : ""}`}
+                  >
+                    ▾
+                  </span>
+                </span>
+              </button>
+
+              <button
+                aria-label={`Open new thread launchpad for ${directory.label}`}
+                className={`directory-row__launchpad-button${
+                  directory.launchpad ? " has-draft" : ""
+                }`}
+                type="button"
+                onClick={() => {
+                  void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
+                }}
+              >
+                +
+              </button>
+            </div>
+
+            {expanded ? (
+              <div className="directory-row__details">
+                <div className="directory-row__details-meta">
+                  {directory.path ? (
+                    <button
+                      aria-label={`Copy path for ${directory.label}`}
+                      className="directory-row__detail-chip directory-row__detail-chip--path path-copy-target tooltip-target"
+                      data-tooltip={formatCopyTooltip(directory.path)}
+                      type="button"
+                      onClick={() => {
+                        if (directory.path) {
+                          void copyText(directory.path);
+                        }
+                      }}
+                    >
+                      {directory.path}
+                    </button>
+                  ) : null}
+                  {directory.gitStatus?.currentBranch ? (
+                    <span className="directory-row__detail-chip thread-row__chip--mono">
+                      🌿 {directory.gitStatus.currentBranch}
+                    </span>
+                  ) : null}
+                  {formatSyncLabel(directory) ? (
+                    <span className="directory-row__detail-chip">{formatSyncLabel(directory)}</span>
+                  ) : null}
+                  <span className="directory-row__detail-chip">
+                    {visibleThreads.length} thread{visibleThreads.length === 1 ? "" : "s"}
+                  </span>
+                  {directory.launchpad ? (
+                    <span className="directory-row__detail-chip directory-row__detail-chip--draft">
+                      Draft
+                    </span>
+                  ) : null}
+                </div>
+
+                {visibleThreads.length > 0 ? (
+                  <div className="sidebar-list sidebar-list--compact directory-row__threads">
+                    {visibleThreads.map((thread) => {
+                      const selected =
+                        buildThreadIdentityKey(thread.source, thread.id) === props.selectedItemKey;
+                      return (
+                        <button
+                          key={`${directory.key}:${buildThreadIdentityKey(thread.source, thread.id)}`}
+                          aria-pressed={selected}
+                          className={`thread-row${selected ? " is-selected" : ""}`}
+                          type="button"
+                          onClick={() => props.onSelectThread(thread)}
+                        >
+                          <span className="thread-row__header">
+                            <span className="thread-row__title">{thread.title}</span>
+                            <span className="thread-row__time">
+                              {formatRelativeTime(thread.updatedAt)}
+                            </span>
+                          </span>
+                          <ThreadMetaChips thread={thread} />
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="sidebar-empty directory-row__empty">No threads in this directory yet.</p>
+                )}
+              </div>
+            ) : null}
+          </section>
+        );
+      })}
     </div>
   );
-}
-
-function groupThreadsByDirectory(threads: NavigationThreadSummary[]): DirectoryGroup[] {
-  const groups = new Map<string, DirectoryGroup>();
-  const visibleThreads = threads.filter((thread) => shouldShowThreadInDirectories(thread));
-  const stablePathByLabel = collectStablePathByLabel(visibleThreads);
-
-  for (const thread of visibleThreads) {
-    if (thread.linkedDirectories.length === 0) {
-      if (thread.projectKey?.trim()) {
-        continue;
-      }
-
-      const unlinked = groups.get("unlinked");
-      if (unlinked) {
-        unlinked.threads.push(thread);
-      } else {
-        groups.set("unlinked", {
-          id: "unlinked",
-          icon: "•",
-          label: "No linked directory",
-          threads: [thread]
-        });
-      }
-      continue;
-    }
-
-    for (const directory of thread.linkedDirectories) {
-      const descriptor = getDirectoryGroupDescriptor(directory, stablePathByLabel);
-      const existing = groups.get(descriptor.id);
-      if (existing) {
-        existing.threads.push(thread);
-        continue;
-      }
-
-      groups.set(descriptor.id, {
-        ...descriptor,
-        threads: [thread]
-      });
-    }
-  }
-
-  return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
-}
-
-function shouldShowThreadInDirectories(thread: NavigationThreadSummary): boolean {
-  if (thread.inbox.inInbox) {
-    return true;
-  }
-
-  if (!thread.updatedAt) {
-    return true;
-  }
-
-  return Date.now() - thread.updatedAt < DIRECTORY_THREAD_AGE_OUT_MS;
-}
-
-function collectStablePathByLabel(
-  threads: NavigationThreadSummary[]
-): Map<string, string | undefined> {
-  const pathsByLabel = new Map<string, Set<string>>();
-
-  for (const thread of threads) {
-    for (const directory of thread.linkedDirectories) {
-      const identity = classifyDirectory(directory);
-      if (identity.kind !== "stable") {
-        continue;
-      }
-
-      const paths = pathsByLabel.get(identity.label) ?? new Set<string>();
-      paths.add(identity.path);
-      pathsByLabel.set(identity.label, paths);
-    }
-  }
-
-  return new Map(
-    [...pathsByLabel.entries()].map(([label, paths]) => [
-      label,
-      paths.size === 1 ? [...paths][0] : undefined
-    ])
-  );
-}
-
-function getDirectoryGroupDescriptor(
-  directory: LinkedDirectorySummary,
-  stablePathByLabel: Map<string, string | undefined>
-): DirectoryGroupDescriptor {
-  const identity = classifyDirectory(directory);
-
-  if (identity.kind === "scratch-workspaces") {
-    return {
-      id: `workspaces:${identity.path}`,
-      icon: "📁",
-      label: "Workspaces",
-      path: identity.path
-    };
-  }
-
-  if (identity.kind === "codex-worktree") {
-    const stablePath = stablePathByLabel.get(identity.label);
-    if (stablePath) {
-      return {
-        id: `directory:${stablePath}`,
-        icon: "📁",
-        label: identity.label,
-        path: stablePath
-      };
-    }
-
-    return {
-      id: `codex-worktree:${identity.label}`,
-      icon: "📁",
-      label: identity.label
-    };
-  }
-
-  return {
-    id: `directory:${identity.path}`,
-    icon: "📁",
-    label: identity.label,
-    path: identity.path
-  };
-}
-
-function classifyDirectory(directory: LinkedDirectorySummary): DirectoryIdentity {
-  const scratchWorkspaceMatch = directory.path.match(
-    /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/
-  );
-  if (scratchWorkspaceMatch) {
-    return {
-      kind: "scratch-workspaces",
-      path: scratchWorkspaceMatch[1]
-    };
-  }
-
-  const repoWorktreeMatch = directory.path.match(
-    /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/].*)?$/
-  );
-  if (repoWorktreeMatch) {
-    const canonicalPath = repoWorktreeMatch[1];
-    return {
-      kind: "stable",
-      label: pathBaseName(canonicalPath),
-      path: canonicalPath
-    };
-  }
-
-  const codexWorktreeMatch = directory.path.match(
-    /^[\\/].*[\\/]\.codex[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/
-  );
-  if (codexWorktreeMatch) {
-    return {
-      kind: "codex-worktree",
-      label: codexWorktreeMatch[1]
-    };
-  }
-
-  return {
-    kind: "stable",
-    label: directory.label,
-    path: directory.path
-  };
-}
-
-function pathBaseName(pathname: string): string {
-  const normalized = pathname.replace(/[\\/]+$/, "");
-  const segments = normalized.split(/[\\/]/).filter(Boolean);
-  return segments.at(-1) ?? pathname;
 }
 
 function formatRelativeTime(timestamp?: number): string {
@@ -298,4 +239,32 @@ function formatRelativeTime(timestamp?: number): string {
     month: "short",
     day: "numeric"
   }).format(timestamp);
+}
+
+function formatSyncLabel(directory: NavigationDirectorySummary): string | undefined {
+  const status = directory.gitStatus;
+  if (!status) {
+    return undefined;
+  }
+
+  if (status.syncState === "in-sync") {
+    return "Up to date";
+  }
+  if (status.syncState === "ahead") {
+    return `${status.ahead ?? 0} ahead`;
+  }
+  if (status.syncState === "behind") {
+    return `${status.behind ?? 0} behind`;
+  }
+  if (status.syncState === "diverged") {
+    return `${status.ahead ?? 0} ahead · ${status.behind ?? 0} behind`;
+  }
+  if (status.syncState === "untracked") {
+    return "No upstream";
+  }
+  if (status.syncState === "status-unavailable") {
+    return "Status unavailable";
+  }
+
+  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
+  NavigationDirectorySummary,
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
@@ -16,6 +17,7 @@ type SidebarProps = {
   backends: BackendSummary[];
   browseMode: BrowseMode;
   createThreadError?: string;
+  directories: NavigationDirectorySummary[];
   error?: string;
   fetchedAt?: number;
   inboxThreads: NavigationThreadSummary[];
@@ -24,13 +26,18 @@ type SidebarProps = {
     backend: AppServerBackendKind;
     executionMode: ThreadExecutionMode;
   };
+  launchpadError?: string;
   refreshing: boolean;
-  selectedThreadKey?: string;
+  selectedItemKey?: string;
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: (
     backend: AppServerBackendKind,
     executionMode?: ThreadExecutionMode
+  ) => Promise<void>;
+  onOpenLaunchpad: (
+    directory: NavigationDirectorySummary,
+    preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
   onRefresh: () => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
@@ -129,6 +136,8 @@ export function Sidebar(props: SidebarProps) {
 
       {props.createThreadError ? (
         <p className="sidebar-error sidebar-error--masthead">{props.createThreadError}</p>
+      ) : props.launchpadError ? (
+        <p className="sidebar-error sidebar-error--masthead">{props.launchpadError}</p>
       ) : null}
 
       <section className="sidebar__section">
@@ -137,7 +146,7 @@ export function Sidebar(props: SidebarProps) {
           <span className="count-pill">{props.inboxThreads.length}</span>
         </div>
         <InboxList
-          selectedThreadKey={props.selectedThreadKey}
+          selectedThreadKey={props.selectedItemKey}
           threads={props.inboxThreads}
           onSelectThread={props.onSelectThread}
         />
@@ -179,13 +188,15 @@ export function Sidebar(props: SidebarProps) {
             <p className="sidebar-empty">No threads yet.</p>
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
-              selectedThreadKey={props.selectedThreadKey}
+              directories={props.directories}
+              selectedItemKey={props.selectedItemKey}
               threads={props.threads}
+              onOpenLaunchpad={props.onOpenLaunchpad}
               onSelectThread={props.onSelectThread}
             />
           ) : (
             <RecentsList
-              selectedThreadKey={props.selectedThreadKey}
+              selectedThreadKey={props.selectedItemKey}
               threads={props.threads}
               onSelectThread={props.onSelectThread}
             />

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -145,8 +145,6 @@ describe("Sidebar", () => {
       "true"
     );
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
-    expect(screen.getByText("Up to date")).toBeInTheDocument();
-    expect(screen.getByText("1 thread")).toBeInTheDocument();
     expect(screen.getAllByText("Cross-project cleanup").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
   });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1,8 +1,7 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BackendSummary } from "@pwragnt/shared";
+import type { BackendSummary, NavigationDirectorySummary } from "@pwragnt/shared";
 import { Sidebar } from "../Sidebar";
 
 const backends: BackendSummary[] = [
@@ -76,10 +75,11 @@ const sharedThread = {
   summary: "Line up the desktop shell with the app server",
   source: "codex" as const,
   gitBranch: "codex/thread-centric-ui",
+  executionMode: "default" as const,
   updatedAt: Date.now(),
   inbox: {
     inInbox: true,
-    reason: "new-thread" as const
+    reason: "new-thread" as const,
   },
   linkedDirectories: [
     {
@@ -87,51 +87,52 @@ const sharedThread = {
       label: "PwrAgnt",
       path: "/Users/huntharo/pwrdrvr/PwrAgnt",
       worktreePath: "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt",
-      kind: "local" as const
+      kind: "local" as const,
     },
-    {
-      id: "dir-b",
-      label: "openclaw-codex-app-server",
-      path: "/Users/huntharo/pwrdrvr/openclaw-codex-app-server",
-      kind: "worktree" as const
-    }
-  ]
+  ],
 };
+
+const directories: NavigationDirectorySummary[] = [
+  {
+    key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+    kind: "directory",
+    label: "PwrAgnt",
+    path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+    threadKeys: ["codex:thread-1"],
+    needsAttentionCount: 1,
+    latestUpdatedAt: sharedThread.updatedAt,
+    gitStatus: {
+      currentBranch: "main",
+      upstreamBranch: "origin/main",
+      syncState: "in-sync",
+      branches: ["main", "release"],
+    },
+  },
+];
 
 afterEach(() => {
   cleanup();
 });
 
 describe("Sidebar", () => {
-  it("keeps Inbox first and groups a thread under each linked directory lens", () => {
+  it("keeps Inbox first and renders compact directory rows from directory summaries", () => {
     render(
       <Sidebar
         backends={backends}
         browseMode="directories"
         createThreadError={undefined}
+        directories={directories}
         fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
+        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         refreshing={false}
-        selectedThreadKey="codex:thread-1"
-        threads={[
-          sharedThread,
-          {
-            id: "thread-2",
-            title: "Unlinked planning thread",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: []
-          }
-        ]}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
         onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
@@ -143,305 +144,45 @@ describe("Sidebar", () => {
       "aria-pressed",
       "true"
     );
-    expect(screen.getByRole("heading", { level: 3, name: "PwrAgnt" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 3, name: "openclaw-codex-app-server" })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 3, name: "No linked directory" })
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByRole("heading", { level: 3, name: "PwrAgnt" })).getByText("📁")
-    ).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: /Cross-project cleanup/i }).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
-    const pwrAgntSection = screen
-      .getByRole("heading", { level: 3, name: "PwrAgnt" })
-      .closest("section");
-    expect(pwrAgntSection).not.toBeNull();
-    const groupedThread = within(pwrAgntSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
-    expect(groupedThread).toHaveClass("thread-row");
-    expect(groupedThread).not.toHaveClass("thread-row--compact");
-    expect(within(groupedThread).getByText("Codex")).toBeInTheDocument();
-    expect(within(groupedThread).getByText("codex/thread-centric-ui")).toBeInTheDocument();
-  });
-
-  it("lumps scratch workspaces under a shared Workspaces directory group", () => {
-    render(
-      <Sidebar
-        backends={backends}
-        browseMode="directories"
-        createThreadError={undefined}
-        fetchedAt={Date.now()}
-        inboxThreads={[]}
-        loading={false}
-        creatingThread={undefined}
-        refreshing={false}
-        selectedThreadKey={undefined}
-        threads={[
-          {
-            id: "thread-3",
-            title: "Untitled thread",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: [
-              {
-                id: "scratch-1",
-                label: "2026-04-17-a15d5e",
-                path: "/Users/huntharo/.pwragnt/projects/2026-04-17-a15d5e",
-                kind: "local"
-              }
-            ]
-          },
-          {
-            id: "thread-4",
-            title: "Second untitled thread",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: [
-              {
-                id: "scratch-2",
-                label: "2026-04-17-b83f91",
-                path: "/Users/huntharo/.pwragnt/projects/2026-04-17-b83f91",
-                kind: "local"
-              }
-            ]
-          }
-        ]}
-        onBrowseModeChange={() => undefined}
-        onCreateThread={async () => undefined}
-        onRefresh={async () => undefined}
-        onSelectThread={() => undefined}
-      />
-    );
-
-    expect(screen.getByRole("heading", { level: 3, name: "Workspaces" })).toBeInTheDocument();
-    expect(screen.getByText("2 threads")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("heading", { level: 3, name: "2026-04-17-a15d5e" })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("heading", { level: 3, name: "2026-04-17-b83f91" })
-    ).not.toBeInTheDocument();
-  });
-
-  it("merges codex worktree paths into the stable repo directory group", () => {
-    render(
-      <Sidebar
-        backends={backends}
-        browseMode="directories"
-        createThreadError={undefined}
-        fetchedAt={Date.now()}
-        inboxThreads={[]}
-        loading={false}
-        creatingThread={undefined}
-        refreshing={false}
-        selectedThreadKey={undefined}
-        threads={[
-          {
-            id: "thread-5",
-            title: "Check web API proxy support",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: [
-              {
-                id: "web-app-root",
-                label: "web-app",
-                path: "/Users/huntharo/GIPHY/web-app",
-                kind: "local"
-              }
-            ]
-          },
-          {
-            id: "thread-6",
-            title: "Explain web app login flow",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: [
-              {
-                id: "web-app-worktree-1",
-                label: "web-app",
-                path: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
-                kind: "local"
-              }
-            ]
-          },
-          {
-            id: "thread-7",
-            title: "Investigate chunk file errors",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: [
-              {
-                id: "web-app-worktree-2",
-                label: "web-app",
-                path: "/Users/huntharo/.codex/worktrees/1f9a/web-app",
-                kind: "local"
-              }
-            ]
-          }
-        ]}
-        onBrowseModeChange={() => undefined}
-        onCreateThread={async () => undefined}
-        onRefresh={async () => undefined}
-        onSelectThread={() => undefined}
-      />
-    );
-
-    expect(screen.getAllByRole("heading", { level: 3, name: "web-app" })).toHaveLength(1);
-    expect(screen.getByText("3 threads")).toBeInTheDocument();
-  });
-
-  it("ages old non-inbox threads out of directory groups", () => {
-    const now = new Date("2026-04-17T13:00:00.000Z").getTime();
-    vi.useFakeTimers();
-    vi.setSystemTime(now);
-
-    try {
-      render(
-        <Sidebar
-          backends={backends}
-          browseMode="directories"
-          createThreadError={undefined}
-          fetchedAt={now}
-          inboxThreads={[]}
-          loading={false}
-          creatingThread={undefined}
-          refreshing={false}
-          selectedThreadKey={undefined}
-          threads={[
-            {
-              id: "thread-recent",
-              title: "Check web API proxy support",
-              titleSource: "explicit",
-              summary: undefined,
-              source: "codex",
-              updatedAt: now - 5 * 24 * 60 * 60 * 1000,
-              inbox: {
-                inInbox: false
-              },
-              linkedDirectories: [
-                {
-                  id: "web-app-root",
-                  label: "web-app",
-                  path: "/Users/huntharo/GIPHY/web-app",
-                  kind: "local"
-                }
-              ]
-            },
-            {
-              id: "thread-old",
-              title: "Explain web app login flow",
-              titleSource: "explicit",
-              summary: undefined,
-              source: "codex",
-              updatedAt: now - 38 * 24 * 60 * 60 * 1000,
-              inbox: {
-                inInbox: false
-              },
-              linkedDirectories: [
-                {
-                  id: "web-app-root-2",
-                  label: "web-app",
-                  path: "/Users/huntharo/GIPHY/web-app",
-                  kind: "local"
-                }
-              ]
-            }
-          ]}
-          onBrowseModeChange={() => undefined}
-          onCreateThread={async () => undefined}
-          onRefresh={async () => undefined}
-          onSelectThread={() => undefined}
-        />
-      );
-
-      expect(screen.getByRole("heading", { level: 3, name: "web-app" })).toBeInTheDocument();
-      expect(screen.getByText("1 thread")).toBeInTheDocument();
-      expect(screen.getByText("Check web API proxy support")).toBeInTheDocument();
-      expect(screen.queryByText("Explain web app login flow")).not.toBeInTheDocument();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("does not place unresolved worktree threads under No linked directory", () => {
-    render(
-      <Sidebar
-        backends={backends}
-        browseMode="directories"
-        createThreadError={undefined}
-        fetchedAt={Date.now()}
-        inboxThreads={[]}
-        loading={false}
-        creatingThread={undefined}
-        refreshing={false}
-        selectedThreadKey={undefined}
-        threads={[
-          {
-            id: "thread-missing-cwd",
-            title: "Plan Slidev theme extraction",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "codex",
-            projectKey: "/Users/huntharo/.codex/worktrees/be87/search-product",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: []
-          },
-          {
-            id: "thread-unlinked",
-            title: "Untitled thread",
-            titleSource: "explicit",
-            summary: undefined,
-            source: "grok",
-            updatedAt: Date.now(),
-            inbox: {
-              inInbox: false
-            },
-            linkedDirectories: []
-          }
-        ]}
-        onBrowseModeChange={() => undefined}
-        onCreateThread={async () => undefined}
-        onRefresh={async () => undefined}
-        onSelectThread={() => undefined}
-      />
-    );
-
-    expect(screen.getByRole("heading", { level: 3, name: "No linked directory" })).toBeInTheDocument();
+    expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
+    expect(screen.getByText("Up to date")).toBeInTheDocument();
     expect(screen.getByText("1 thread")).toBeInTheDocument();
-    expect(screen.getByText("Untitled thread")).toBeInTheDocument();
-    expect(screen.queryByText("Plan Slidev theme extraction")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Cross-project cleanup").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
+  });
+
+  it("opens the directory launchpad from the plus button", () => {
+    const onOpenLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        fetchedAt={Date.now()}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        refreshing={false}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={onOpenLaunchpad}
+        onRefresh={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open new thread launchpad for PwrAgnt",
+      })
+    );
+
+    expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
 
   it("copies a linked directory path from the recents chip", () => {
@@ -449,8 +190,8 @@ describe("Sidebar", () => {
     Object.defineProperty(window, "pwragnt", {
       configurable: true,
       value: {
-        copyText
-      }
+        copyText,
+      },
     });
 
     render(
@@ -458,15 +199,18 @@ describe("Sidebar", () => {
         backends={backends}
         browseMode="recents"
         createThreadError={undefined}
+        directories={directories}
         fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
+        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         refreshing={false}
-        selectedThreadKey="codex:thread-1"
+        selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
         onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
@@ -488,15 +232,18 @@ describe("Sidebar", () => {
         backends={backends}
         browseMode="recents"
         createThreadError={undefined}
+        directories={directories}
         fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
+        launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
         refreshing={false}
-        selectedThreadKey="codex:thread-1"
+        selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={onCreateThread}
+        onOpenLaunchpad={async () => undefined}
         onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
@@ -504,29 +251,22 @@ describe("Sidebar", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "New thread" }));
 
-    expect(screen.getByRole("menu", { name: "New thread backend" })).toBeInTheDocument();
+    const menu = screen.getByRole("menu", { name: "New thread backend" });
+    expect(menu).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", {
+      within(menu).getByRole("menuitem", {
         name: "Create thread with Codex in Default Access",
       })
     ).toBeEnabled();
     expect(
-      screen.getByRole("menuitem", {
+      within(menu).getByRole("menuitem", {
         name: "Create thread with Codex in Full Access",
       })
     ).toBeEnabled();
     expect(
-      screen.getByRole("menuitem", {
+      within(menu).getByRole("menuitem", {
         name: "Create thread with Grok in Default Access",
       })
     ).toBeDisabled();
-
-    fireEvent.click(
-      screen.getByRole("menuitem", {
-        name: "Create thread with Codex in Default Access",
-      })
-    );
-
-    expect(onCreateThread).toHaveBeenCalledWith("codex", "default");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,9 +1,5 @@
 import { useState, type KeyboardEvent, type MouseEvent } from "react";
-import type {
-  BackendSummary,
-  NavigationThreadSummary,
-  ThreadExecutionMode,
-} from "@pwragnt/shared";
+import type { BackendSummary, NavigationThreadSummary } from "@pwragnt/shared";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 
@@ -12,20 +8,12 @@ type ThreadContextPanelProps = {
   backends: BackendSummary[];
   platform?: string;
   thread: NavigationThreadSummary;
-  setExecutionModeError?: string;
-  updatingExecutionMode?: ThreadExecutionMode;
-  onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
 };
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const [pinned, setPinned] = useState(false);
   const [revealed, setRevealed] = useState(false);
   const open = pinned || revealed;
-  const threadBackend = props.backends.find(
-    (backend) => backend.kind === props.thread.source
-  );
-  const executionModes =
-    threadBackend?.executionModes.filter((mode) => mode.available) ?? [];
 
   return (
     <aside
@@ -218,41 +206,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               </div>
             </dl>
 
-            {props.thread.source === "codex" && executionModes.length > 0 ? (
-              <div className="context-mode-switch">
-                {executionModes.map((mode) => {
-                  const active = (props.thread.executionMode ?? "default") === mode.mode;
-                  return (
-                    <button
-                      key={mode.mode}
-                      aria-pressed={active}
-                      className={`context-mode-switch__button${
-                        active ? " is-active" : ""
-                      }`}
-                      disabled={Boolean(props.updatingExecutionMode)}
-                      type="button"
-                      onClick={() => {
-                        if (!active) {
-                          void props.onSetExecutionMode?.(mode.mode);
-                        }
-                      }}
-                    >
-                      {formatExecutionModeLabel(mode.mode)}
-                    </button>
-                  );
-                })}
-              </div>
-            ) : null}
-
-            {props.setExecutionModeError ? (
-              <p className="context-empty context-empty--error">
-                {props.setExecutionModeError}
-              </p>
-            ) : props.updatingExecutionMode ? (
-              <p className="context-empty">
-                Switching to {formatExecutionModeLabel(props.updatingExecutionMode)}…
-              </p>
-            ) : null}
           </section>
 
           <section className="context-panel__section context-panel__section--status">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -209,6 +209,10 @@ export function ThreadView(props: ThreadViewProps) {
         typeof event.notification.params.itemId === "string" &&
         typeof event.notification.params.delta === "string"
       ) {
+        setPendingRequest(undefined);
+        setPendingRequestBusy(false);
+        setPendingRequestError(undefined);
+        setPendingStatusText("Thinking");
         const { itemId, delta } = event.notification.params;
         setPendingAssistantMessage((current) => ({
           type: "message",
@@ -240,6 +244,12 @@ export function ThreadView(props: ThreadViewProps) {
         (method === "thread/status/changed" && statusRecord?.type === "idle")
       ) {
         setPendingAssistantMessage(undefined);
+        setPendingRequest(undefined);
+        setPendingRequestBusy(false);
+        setPendingRequestError(undefined);
+        if (method !== "turn/completed") {
+          setPendingStatusText(undefined);
+        }
       }
 
       if (method.includes("/request")) {
@@ -275,12 +285,10 @@ export function ThreadView(props: ThreadViewProps) {
             ? pendingRequest.params.runId
             : undefined,
         requestId: pendingRequest.params.requestId,
-        response: { decision },
+        response: buildPendingRequestResponse(pendingRequest, decision),
       });
+      setPendingRequest(undefined);
       setPendingStatusText(decision === "approve" ? "Thinking" : undefined);
-      if (decision !== "approve") {
-        setPendingRequest(undefined);
-      }
     } catch (error) {
       setPendingRequestError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -489,6 +497,87 @@ export function ThreadView(props: ThreadViewProps) {
       />
     </section>
   );
+}
+
+function buildPendingRequestResponse(
+  request: AppServerPendingRequestNotification,
+  decision: "approve" | "decline" | "cancel",
+): { decision: string } {
+  const availableDecision = selectAvailableDecision(request.params, decision);
+  if (availableDecision) {
+    return { decision: availableDecision };
+  }
+
+  if (request.method.includes("commandExecution/requestApproval")) {
+    return {
+      decision:
+        decision === "approve"
+          ? "accept"
+          : decision === "decline"
+            ? "decline"
+            : "cancel",
+    };
+  }
+
+  if (request.method.includes("fileChange/requestApproval")) {
+    return {
+      decision:
+        decision === "approve"
+          ? "accept"
+          : decision === "decline"
+            ? "decline"
+            : "cancel",
+    };
+  }
+
+  return { decision };
+}
+
+function selectAvailableDecision(
+  params: AppServerPendingRequestNotification["params"],
+  decision: "approve" | "decline" | "cancel",
+): string | undefined {
+  const rawDecisions =
+    readDecisionStrings(params.availableDecisions) ?? readDecisionStrings(params.decisions);
+  if (!rawDecisions?.length) {
+    return undefined;
+  }
+
+  const acceptedAliases =
+    decision === "approve"
+      ? ["accept", "approve", "allow"]
+      : decision === "decline"
+        ? ["decline", "deny", "reject"]
+        : ["cancel", "abort", "stop"];
+
+  return rawDecisions.find((value) =>
+    acceptedAliases.some((alias) => value.toLowerCase().includes(alias)),
+  );
+}
+
+function readDecisionStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return entry.trim();
+      }
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return undefined;
+      }
+      const record = entry as Record<string, unknown>;
+      for (const key of ["decision", "value", "name", "id"]) {
+        const raw = record[key];
+        if (typeof raw === "string" && raw.trim()) {
+          return raw.trim();
+        }
+      }
+      return undefined;
+    })
+    .filter((entry): entry is string => Boolean(entry));
 }
 
 function formatDirectorySync(directory: NavigationDirectorySummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -457,10 +457,7 @@ export function ThreadView(props: ThreadViewProps) {
           backendError={props.backendError}
           backends={props.backends}
           platform={props.platform}
-          setExecutionModeError={props.setExecutionModeError}
           thread={selectedThread!}
-          updatingExecutionMode={props.updatingExecutionMode}
-          onSetExecutionMode={props.onSetExecutionMode}
         />
       </div>
 
@@ -475,16 +472,20 @@ export function ThreadView(props: ThreadViewProps) {
 
       <Composer
         addOptimisticUserMessage={props.addOptimisticUserMessage}
+        backends={props.backends}
         desktopApi={props.desktopApi}
         disabled={props.composerDisabled}
         pendingRequestActive={Boolean(pendingRequest)}
         onPendingStatusChange={setPendingStatusText}
         onRefresh={props.onRefresh}
+        onSetExecutionMode={props.onSetExecutionMode}
         removeOptimisticMessage={props.removeOptimisticMessage}
+        setExecutionModeError={props.setExecutionModeError}
         skillError={props.skillError}
         skillLoading={props.skillLoading}
         skills={props.skills}
         thread={selectedThread!}
+        updatingExecutionMode={props.updatingExecutionMode}
       />
     </section>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -8,11 +8,15 @@ import type {
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
   BackendSummary,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
 import { Composer } from "../composer/Composer";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { formatBackendLabel } from "../../lib/backend-label";
+import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
@@ -51,10 +55,13 @@ type ThreadViewProps = {
   composerDisabled: boolean;
   desktopApi?: DesktopApi;
   fetchedAt?: number;
+  launchpadError?: string;
   loading: boolean;
   loadingMore: boolean;
   messageCount: number;
   platform?: string;
+  selectedDirectory?: NavigationDirectorySummary;
+  selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
   setExecutionModeError?: string;
   skillError?: string;
@@ -65,7 +72,30 @@ type ThreadViewProps = {
   transcriptPagination?: AppServerThreadReplayPagination;
   updatingExecutionMode?: ThreadExecutionMode;
   onLoadOlder: () => Promise<void>;
+  onMaterializeLaunchpad?: (
+    directoryKey: string,
+    input?: Array<{ type: "text"; text: string }>
+  ) => Promise<void>;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
+  onUpdateLaunchpad?: (
+    directoryKey: string,
+    patch: Partial<
+      Pick<
+        NavigationLaunchpadDraft,
+        | "prompt"
+        | "backend"
+        | "executionMode"
+        | "model"
+        | "reasoningEffort"
+        | "serviceTier"
+        | "fastMode"
+        | "workMode"
+        | "branchName"
+        | "directoryLabel"
+        | "directoryPath"
+      >
+    >
+  ) => Promise<void>;
   removeOptimisticMessage: (id: string) => void;
   onRefresh: () => Promise<void>;
 };
@@ -89,9 +119,10 @@ export function ThreadView(props: ThreadViewProps) {
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
     setExpandedImage(undefined);
-  }, [props.selectedThread?.id, props.selectedThread?.source]);
+  }, [props.selectedThread?.id, props.selectedThread?.source, props.selectedLaunchpad?.directoryKey]);
 
   const selectedThread = props.selectedThread;
+  const selectedLaunchpad = props.selectedLaunchpad;
 
   useEffect(() => {
     if (!pendingPlanEntry) {
@@ -257,15 +288,117 @@ export function ThreadView(props: ThreadViewProps) {
     }
   }
 
-  if (!selectedThread) {
+  if (!selectedThread && !selectedLaunchpad) {
     return (
       <section className="thread-empty-state">
         <p className="eyebrow">Thread detail</p>
         <h2>Select a thread</h2>
         <p>
           Inbox stays above every other lens. Pick a thread to read the full
-          transcript and inspect its linked directories.
+          transcript, or open a project launchpad from Directories.
         </p>
+      </section>
+    );
+  }
+
+  if (selectedLaunchpad && props.selectedDirectory) {
+    const launchpadBackend = props.backends.find(
+      (backend) => backend.kind === selectedLaunchpad.backend
+    );
+    const syncLabel = formatDirectorySync(props.selectedDirectory);
+
+    return (
+      <section className="thread-view">
+        <header className="thread-header">
+          <div>
+            <div className="thread-header__eyebrow-row">
+              <p className="eyebrow">New thread</p>
+              <span className="thread-row__chip thread-row__chip--backend">
+                {formatBackendLabel(selectedLaunchpad.backend)}
+              </span>
+              <span className="thread-row__chip thread-row__chip--mode">
+                {formatExecutionModeLabel(selectedLaunchpad.executionMode)}
+              </span>
+            </div>
+            <h2 className="thread-header__title">{selectedLaunchpad.directoryLabel}</h2>
+            <p className="thread-header__summary">
+              Start a thread in this directory. Unsent prompt and setup changes stay attached to this launchpad until the first send.
+            </p>
+          </div>
+
+          <div className="thread-header__stats">
+            <div>
+              <span className="thread-header__stat-label">Workspace</span>
+              <strong>
+                {selectedLaunchpad.workMode === "worktree" ? "New worktree" : "Local checkout"}
+              </strong>
+            </div>
+            <div>
+              <span className="thread-header__stat-label">Branch</span>
+              <strong>
+                {selectedLaunchpad.workMode === "worktree"
+                  ? selectedLaunchpad.branchName ?? props.selectedDirectory.gitStatus?.currentBranch ?? "Pick one"
+                  : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached"}
+              </strong>
+            </div>
+          </div>
+        </header>
+
+        <div className="launchpad-panel">
+          <div className="launchpad-panel__header">
+            <div>
+              <h3>Directory</h3>
+              <p>
+                {props.selectedDirectory.threadKeys.length} thread
+                {props.selectedDirectory.threadKeys.length === 1 ? "" : "s"}
+                {syncLabel ? ` • ${syncLabel}` : ""}
+              </p>
+            </div>
+            <button
+              className="button button--ghost"
+              type="button"
+              onClick={() => {
+                void props.onRefresh();
+              }}
+            >
+              Refresh
+            </button>
+          </div>
+
+          <dl className="launchpad-grid">
+            <div>
+              <dt>Path</dt>
+              <dd>{props.selectedDirectory.path ?? "Not recorded"}</dd>
+            </div>
+            <div>
+              <dt>Current branch</dt>
+              <dd>{props.selectedDirectory.gitStatus?.currentBranch ?? "Not a Git repo"}</dd>
+            </div>
+            <div>
+              <dt>Upstream</dt>
+              <dd>{props.selectedDirectory.gitStatus?.upstreamBranch ?? "Not tracking"}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{syncLabel ?? "Directory context only"}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <Composer
+          backends={props.backends}
+          desktopApi={props.desktopApi}
+          directory={props.selectedDirectory}
+          disabled={!launchpadBackend?.available}
+          launchpad={selectedLaunchpad}
+          launchpadError={props.launchpadError}
+          onMaterializeLaunchpad={props.onMaterializeLaunchpad}
+          onRefresh={props.onRefresh}
+          onUpdateLaunchpad={props.onUpdateLaunchpad}
+          skillError={props.skillError}
+          skillLoading={props.skillLoading}
+          skills={props.skills}
+        />
       </section>
     );
   }
@@ -275,7 +408,7 @@ export function ThreadView(props: ThreadViewProps) {
       <ThreadHeader
         fetchedAt={props.fetchedAt}
         messageCount={props.messageCount}
-        thread={selectedThread}
+        thread={selectedThread!}
       />
 
       <div className="thread-view__layout">
@@ -309,7 +442,7 @@ export function ThreadView(props: ThreadViewProps) {
             pendingRequestBusy={pendingRequestBusy}
             pendingStatusText={pendingStatusText}
             pagination={props.transcriptPagination}
-            threadId={selectedThread.id}
+            threadId={selectedThread!.id}
             skills={props.skills}
             onOpenImage={setExpandedImage}
             onRespondToPendingRequest={respondToPendingRequest}
@@ -325,7 +458,7 @@ export function ThreadView(props: ThreadViewProps) {
           backends={props.backends}
           platform={props.platform}
           setExecutionModeError={props.setExecutionModeError}
-          thread={selectedThread}
+          thread={selectedThread!}
           updatingExecutionMode={props.updatingExecutionMode}
           onSetExecutionMode={props.onSetExecutionMode}
         />
@@ -351,8 +484,36 @@ export function ThreadView(props: ThreadViewProps) {
         skillError={props.skillError}
         skillLoading={props.skillLoading}
         skills={props.skills}
-        thread={selectedThread}
+        thread={selectedThread!}
       />
     </section>
   );
+}
+
+function formatDirectorySync(directory: NavigationDirectorySummary): string | undefined {
+  const status = directory.gitStatus;
+  if (!status) {
+    return undefined;
+  }
+
+  if (status.syncState === "in-sync") {
+    return "Up to date";
+  }
+  if (status.syncState === "ahead") {
+    return `${status.ahead ?? 0} ahead`;
+  }
+  if (status.syncState === "behind") {
+    return `${status.behind ?? 0} behind`;
+  }
+  if (status.syncState === "diverged") {
+    return `${status.ahead ?? 0} ahead · ${status.behind ?? 0} behind`;
+  }
+  if (status.syncState === "untracked") {
+    return "No upstream";
+  }
+  if (status.syncState === "status-unavailable") {
+    return "Status unavailable";
+  }
+
+  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -829,4 +829,252 @@ describe("ThreadView", () => {
 
     expect(screen.getAllByText("0 out of 3 tasks completed")).toHaveLength(1);
   });
+
+  it("maps command approval actions to native decision values and dismisses the approval card", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const submitServerRequest = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-2",
+      requestId: "req-1",
+    }));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+          submitServerRequest,
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-2",
+          title: "Plan the app-server protocol",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Run npm view dive"
+          }
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={vi.fn(async () => undefined)}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-2",
+            requestId: "req-1",
+            availableDecisions: ["accept", "decline", "cancel"],
+            command: "npm view dive",
+          },
+        },
+      });
+    });
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(submitServerRequest).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-2",
+        runId: undefined,
+        requestId: "req-1",
+        response: { decision: "accept" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("group", { name: "Pending approval" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears a stale approval card when assistant output resumes", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-2",
+          title: "Plan the app-server protocol",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Run npm view dive"
+          }
+        ]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        onRefresh={vi.fn(async () => undefined)}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-2",
+            requestId: "req-1",
+            command: "npm view dive",
+          },
+        },
+      });
+    });
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText("Waiting for approval")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-2",
+            itemId: "msg-1",
+            delta: "The request was handled.",
+          },
+        },
+      });
+    });
+
+    expect(
+      screen.queryByRole("group", { name: "Pending approval" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(screen.getByText("The request was handled.")).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerNotification } from "@pwragnt/shared";
 import { ThreadView } from "../ThreadView";

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -6,13 +6,19 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  EnsureDirectoryLaunchpadRequest,
+  EnsureDirectoryLaunchpadResponse,
   GetNavigationSnapshotRequest,
   InterruptTurnRequest,
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
   MarkThreadSeenRequest,
   NavigationSnapshot,
+  ResetDirectoryLaunchpadRequest,
+  ResetDirectoryLaunchpadResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   StartThreadRequest,
@@ -21,6 +27,8 @@ import type {
   StartTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
 
 export type DesktopApi = {
@@ -40,6 +48,9 @@ export type DesktopApi = {
   setThreadExecutionMode?: (
     request: SetThreadExecutionModeRequest
   ) => Promise<SetThreadExecutionModeResponse>;
+  materializeDirectoryLaunchpad?: (
+    request: MaterializeDirectoryLaunchpadRequest
+  ) => Promise<MaterializeDirectoryLaunchpadResponse>;
   submitServerRequest?: (
     request: SubmitServerRequestRequest
   ) => Promise<SubmitServerRequestResponse>;
@@ -53,6 +64,15 @@ export type DesktopApi = {
     request?: AppServerListThreadsRequest
   ) => Promise<AppServerListThreadsResponse>;
   markThreadSeen?: (request: MarkThreadSeenRequest) => Promise<unknown>;
+  ensureDirectoryLaunchpad?: (
+    request: EnsureDirectoryLaunchpadRequest
+  ) => Promise<EnsureDirectoryLaunchpadResponse>;
+  updateDirectoryLaunchpad?: (
+    request: UpdateDirectoryLaunchpadRequest
+  ) => Promise<UpdateDirectoryLaunchpadResponse>;
+  resetDirectoryLaunchpad?: (
+    request: ResetDirectoryLaunchpadRequest
+  ) => Promise<ResetDirectoryLaunchpadResponse>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
+  AppServerTurnInputItem,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
   NavigationSnapshot,
   NavigationThreadSummary,
   ThreadExecutionMode,
@@ -16,6 +19,18 @@ type NavigationState = {
   error?: string;
   response?: NavigationSnapshot;
 };
+
+function buildLaunchpadSelectionKey(directoryKey: string): string {
+  return `launchpad:${directoryKey}`;
+}
+
+function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | undefined {
+  if (!selectionKey?.startsWith("launchpad:")) {
+    return undefined;
+  }
+
+  return selectionKey.slice("launchpad:".length);
+}
 
 function applyThreadNameUpdate(
   snapshot: NavigationSnapshot | undefined,
@@ -52,6 +67,145 @@ function applyThreadNameUpdate(
     : snapshot;
 }
 
+function applyLaunchpadUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  launchpad: NavigationLaunchpadDraft,
+  defaults: NavigationSnapshot["launchpadDefaults"]
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let foundDirectory = false;
+  const directories = snapshot.directories.map((directory) => {
+    if (directory.key !== launchpad.directoryKey) {
+      return directory;
+    }
+
+    foundDirectory = true;
+    return {
+      ...directory,
+      kind: launchpad.directoryKind,
+      label: launchpad.directoryLabel,
+      path: launchpad.directoryPath ?? directory.path,
+      launchpad,
+    };
+  });
+
+  return {
+    ...snapshot,
+    directories: foundDirectory
+      ? directories
+      : [
+          {
+            key: launchpad.directoryKey,
+            kind: launchpad.directoryKind,
+            label: launchpad.directoryLabel,
+            path: launchpad.directoryPath,
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad,
+          },
+          ...directories,
+        ],
+    launchpadDefaults: defaults,
+  };
+}
+
+function applyLaunchpadReset(
+  snapshot: NavigationSnapshot | undefined,
+  directoryKey: string,
+  defaults: NavigationSnapshot["launchpadDefaults"]
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    directories: snapshot.directories.map((directory) =>
+      directory.key === directoryKey ? { ...directory, launchpad: undefined } : directory
+    ),
+    launchpadDefaults: defaults,
+  };
+}
+
+function hasSelectionKey(
+  response: NavigationSnapshot,
+  selectionKey: string,
+  optimisticThreadKey?: string
+): boolean {
+  const launchpadDirectoryKey = getDirectoryKeyFromLaunchpadSelection(selectionKey);
+  if (launchpadDirectoryKey) {
+    return response.directories.some(
+      (directory) =>
+        directory.key === launchpadDirectoryKey && Boolean(directory.launchpad),
+    );
+  }
+
+  return (
+    response.threads.some(
+      (thread) => buildThreadIdentityKey(thread.source, thread.id) === selectionKey,
+    ) || selectionKey === optimisticThreadKey
+  );
+}
+
+function getFallbackSelectionKey(
+  response: NavigationSnapshot,
+  optimisticThreadKey?: string
+): string | undefined {
+  if (optimisticThreadKey) {
+    return optimisticThreadKey;
+  }
+
+  if (response.threads[0]) {
+    return buildThreadIdentityKey(response.threads[0].source, response.threads[0].id);
+  }
+
+  const firstLaunchpadDirectory = response.directories.find((directory) => directory.launchpad);
+  return firstLaunchpadDirectory
+    ? buildLaunchpadSelectionKey(firstLaunchpadDirectory.key)
+    : undefined;
+}
+
+function buildOptimisticThreadFromLaunchpad(params: {
+  directory?: NavigationDirectorySummary;
+  launchpad: NavigationLaunchpadDraft;
+  backend: AppServerBackendKind;
+  threadId: string;
+  executionMode: ThreadExecutionMode;
+  workMode: NavigationLaunchpadDraft["workMode"];
+}): NavigationThreadSummary {
+  return {
+    id: params.threadId,
+    title: "Untitled thread",
+    titleSource: "fallback",
+    summary: params.launchpad.prompt.trim() || undefined,
+    projectKey: params.launchpad.directoryPath,
+    source: params.backend,
+    executionMode: params.executionMode,
+    linkedDirectories: params.launchpad.directoryPath
+      ? [
+          {
+            id: `launchpad:${params.launchpad.directoryKey}`,
+            label: params.launchpad.directoryLabel,
+            path: params.launchpad.directoryPath,
+            kind: params.workMode === "worktree" ? "worktree" : "local",
+          },
+        ]
+      : [],
+    gitBranch:
+      params.workMode === "worktree"
+        ? params.launchpad.branchName
+        : params.directory?.gitStatus?.currentBranch ?? params.launchpad.branchName,
+    updatedAt: Date.now(),
+    inbox: {
+      inInbox: true,
+      reason: "new-thread",
+    },
+  };
+}
+
 export function useThreadNavigation(desktopApi?: DesktopApi): {
   browseMode: BrowseMode;
   createThread: (
@@ -63,11 +217,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     backend: AppServerBackendKind;
     executionMode: ThreadExecutionMode;
   };
+  directories: NavigationDirectorySummary[];
   error?: string;
   inboxThreads: NavigationThreadSummary[];
+  launchpadError?: string;
   loading: boolean;
   refreshing: boolean;
   refresh: () => Promise<void>;
+  materializeDirectoryLaunchpad: (
+    directoryKey: string,
+    input?: AppServerTurnInputItem[]
+  ) => Promise<void>;
+  openDirectoryLaunchpad: (
+    directory: NavigationDirectorySummary,
+    preferredBackend?: AppServerBackendKind
+  ) => Promise<void>;
+  resetDirectoryLaunchpad: (directoryKey: string) => Promise<void>;
+  selectedDirectory?: NavigationDirectorySummary;
+  selectedItemKey?: string;
+  selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
   selectedThreadKey?: string;
   setThreadExecutionMode: (
@@ -76,6 +244,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   ) => Promise<void>;
   setThreadExecutionModeError?: string;
   updatingThreadExecutionMode?: ThreadExecutionMode;
+  updateDirectoryLaunchpad: (
+    directoryKey: string,
+    patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"]
+  ) => Promise<void>;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
   snapshot?: NavigationSnapshot;
@@ -85,7 +257,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const startThread = desktopApi?.startThread;
   const setThreadExecutionMode = desktopApi?.setThreadExecutionMode;
   const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
-  const [selectedThreadKey, setSelectedThreadKey] = useState<string>();
+  const [selectedItemKey, setSelectedItemKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
   const [optimisticThread, setOptimisticThread] = useState<NavigationThreadSummary>();
   const [creatingThread, setCreatingThread] = useState<{
@@ -93,6 +265,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     executionMode: ThreadExecutionMode;
   }>();
   const [createThreadError, setCreateThreadError] = useState<string>();
+  const [launchpadError, setLaunchpadError] = useState<string>();
   const [updatingThreadExecutionMode, setUpdatingThreadExecutionMode] =
     useState<ThreadExecutionMode>();
   const [setThreadExecutionModeError, setSetThreadExecutionModeError] =
@@ -103,7 +276,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   });
 
   const refresh = useCallback(async (
-    preferredThreadKey?: string,
+    preferredSelectionKey?: string,
     preferredOptimisticThread?: NavigationThreadSummary
   ): Promise<void> => {
     if (!desktopApi?.getNavigationSnapshot) {
@@ -129,23 +302,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       const optimisticThreadKey = optimisticSelection
         ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
         : undefined;
-      const hasPreferredThread = Boolean(
-        preferredThreadKey &&
-          response.threads.some(
-            (thread) =>
-              buildThreadIdentityKey(thread.source, thread.id) === preferredThreadKey,
-          )
-      );
-      const hasOptimisticThread = Boolean(
-        optimisticThreadKey &&
-          response.threads.some(
-            (thread) =>
-              buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey,
-          )
-      );
+      const effectivePreferredSelectionKey = preferredSelectionKey ?? selectedItemKey;
 
       setState((current) => {
-        if (current.response && response.unchanged) {
+        if (current.response && response.unchanged && !preferredSelectionKey) {
           return {
             ...current,
             loading: false,
@@ -162,40 +322,23 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         };
       });
 
-      if (hasOptimisticThread) {
+      if (
+        optimisticThreadKey &&
+        response.threads.some(
+          (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey,
+        )
+      ) {
         setOptimisticThread(undefined);
       }
 
-      if (!response.unchanged || preferredThreadKey) {
-        setSelectedThreadKey((current) => {
-          if (
-            preferredThreadKey &&
-            (hasPreferredThread || preferredThreadKey === optimisticThreadKey)
-          ) {
-            return preferredThreadKey;
-          }
+      setSelectedItemKey((current) => {
+        const candidate = preferredSelectionKey ?? current ?? effectivePreferredSelectionKey;
+        if (candidate && hasSelectionKey(response, candidate, optimisticThreadKey)) {
+          return candidate;
+        }
 
-          if (
-            current &&
-            (
-              response.threads.some(
-                (thread) => buildThreadIdentityKey(thread.source, thread.id) === current,
-              ) ||
-              current === optimisticThreadKey
-            )
-          ) {
-            return current;
-          }
-
-          if (optimisticThreadKey) {
-            return optimisticThreadKey;
-          }
-
-          return response.threads[0]
-            ? buildThreadIdentityKey(response.threads[0].source, response.threads[0].id)
-            : undefined;
-        });
-      }
+        return getFallbackSelectionKey(response, optimisticThreadKey);
+      });
     } catch (error) {
       setState((current) => ({
         loading: false,
@@ -204,7 +347,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         error: error instanceof Error ? error.message : String(error)
       }));
     }
-  }, [desktopApi, optimisticThread]);
+  }, [desktopApi, optimisticThread, selectedItemKey]);
 
   useEffect(() => {
     void refresh();
@@ -291,6 +434,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return [optimisticThread, ...currentThreads];
   }, [optimisticThread, state.response?.threads]);
 
+  const directories = state.response?.directories ?? [];
+
   const inboxThreads = useMemo(() => {
     const inboxThreadKeys = new Set(state.response?.inboxThreadKeys ?? []);
     return threads.filter((thread) =>
@@ -299,14 +444,35 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     );
   }, [state.response?.inboxThreadKeys, threads]);
 
+  const selectedThreadKey = useMemo(() => {
+    if (selectedItemKey && !getDirectoryKeyFromLaunchpadSelection(selectedItemKey)) {
+      return selectedItemKey;
+    }
+
+    return undefined;
+  }, [selectedItemKey]);
+
   const selectedThread = useMemo(
     () =>
-      threads.find(
-        (thread) =>
-          buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey,
-      ) ?? threads[0],
+      selectedThreadKey
+        ? threads.find(
+            (thread) =>
+              buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey,
+          )
+        : undefined,
     [selectedThreadKey, threads]
   );
+
+  const selectedDirectory = useMemo(() => {
+    const launchpadDirectoryKey = getDirectoryKeyFromLaunchpadSelection(selectedItemKey);
+    if (!launchpadDirectoryKey) {
+      return undefined;
+    }
+
+    return directories.find((directory) => directory.key === launchpadDirectoryKey);
+  }, [directories, selectedItemKey]);
+
+  const selectedLaunchpad = selectedDirectory?.launchpad;
 
   useEffect(() => {
     const submitMarkThreadSeen = markThreadSeen;
@@ -321,14 +487,16 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       return;
     }
 
+    const markThreadSeenRequest = submitMarkThreadSeen;
+    const threadToMarkSeen = selectedThread;
     let cancelled = false;
 
     async function markSeen(): Promise<void> {
       try {
-        await submitMarkThreadSeen!({
-          backend: selectedThread.source,
-          threadId: selectedThread.id,
-          seenUpdatedAt: selectedThread.updatedAt
+        await markThreadSeenRequest({
+          backend: threadToMarkSeen.source,
+          threadId: threadToMarkSeen.id,
+          seenUpdatedAt: threadToMarkSeen.updatedAt
         });
         if (!cancelled) {
           await refresh();
@@ -350,8 +518,9 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
     setCreateThreadError(undefined);
+    setLaunchpadError(undefined);
     setSetThreadExecutionModeError(undefined);
-    setSelectedThreadKey(threadKey);
+    setSelectedItemKey(threadKey);
     setPendingSeenThreadKey(threadKey);
   }, []);
 
@@ -367,6 +536,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
 
       setCreatingThread({ backend, executionMode });
       setCreateThreadError(undefined);
+      setLaunchpadError(undefined);
 
       try {
         const response = await startThread({ backend, executionMode });
@@ -387,7 +557,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           }
         };
         setOptimisticThread(nextOptimisticThread);
-        setSelectedThreadKey(nextThreadKey);
+        setSelectedItemKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);
         await refresh(nextThreadKey, nextOptimisticThread);
       } catch (error) {
@@ -397,6 +567,177 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       }
     },
     [refresh, startThread],
+  );
+
+  const openDirectoryLaunchpad = useCallback(
+    async (
+      directory: NavigationDirectorySummary,
+      preferredBackend?: AppServerBackendKind
+    ): Promise<void> => {
+      if (!desktopApi?.ensureDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
+        return;
+      }
+
+      setLaunchpadError(undefined);
+      setCreateThreadError(undefined);
+      setSetThreadExecutionModeError(undefined);
+
+      try {
+        const response = await desktopApi.ensureDirectoryLaunchpad({
+          directoryKey: directory.key,
+          directoryKind: directory.kind,
+          directoryLabel: directory.label,
+          directoryPath: directory.path,
+          currentBranch: directory.gitStatus?.currentBranch,
+          preferredBackend,
+        });
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdate(
+            current.response,
+            response.launchpad,
+            response.defaults,
+          ),
+        }));
+        setSelectedItemKey(buildLaunchpadSelectionKey(directory.key));
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi],
+  );
+
+  const updateDirectoryLaunchpad = useCallback(
+    async (
+      directoryKey: string,
+      patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"]
+    ): Promise<void> => {
+      if (!desktopApi?.updateDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing updateDirectoryLaunchpad().");
+        return;
+      }
+
+      setLaunchpadError(undefined);
+
+      try {
+        const response = await desktopApi.updateDirectoryLaunchpad({
+          directoryKey,
+          patch,
+        });
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdate(
+            current.response,
+            response.launchpad,
+            response.defaults,
+          ),
+        }));
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi],
+  );
+
+  const resetDirectoryLaunchpad = useCallback(
+    async (directoryKey: string): Promise<void> => {
+      if (!desktopApi?.resetDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing resetDirectoryLaunchpad().");
+        return;
+      }
+
+      setLaunchpadError(undefined);
+
+      try {
+        const response = await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadReset(
+            current.response,
+            response.directoryKey,
+            response.defaults,
+          ),
+        }));
+        setSelectedItemKey((current) =>
+          current === buildLaunchpadSelectionKey(directoryKey)
+            ? getFallbackSelectionKey(
+                state.response
+                  ? applyLaunchpadReset(state.response, response.directoryKey, response.defaults)!
+                  : {
+                      backend: "all",
+                      fetchedAt: Date.now(),
+                      unchanged: false,
+                      threads,
+                      inboxThreadKeys: [],
+                      directories,
+                      launchpadDefaults: response.defaults,
+                    },
+                optimisticThread
+                  ? buildThreadIdentityKey(optimisticThread.source, optimisticThread.id)
+                  : undefined,
+              )
+            : current
+        );
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi, directories, optimisticThread, state.response, threads],
+  );
+
+  const materializeDirectoryLaunchpad = useCallback(
+    async (
+      directoryKey: string,
+      input?: AppServerTurnInputItem[]
+    ): Promise<void> => {
+      if (!desktopApi?.materializeDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
+        return;
+      }
+
+      const directory = directories.find((candidate) => candidate.key === directoryKey);
+      const launchpad = directory?.launchpad;
+      if (!launchpad) {
+        setLaunchpadError(`No launchpad found for ${directoryKey}.`);
+        return;
+      }
+
+      setLaunchpadError(undefined);
+
+      try {
+        const response = await desktopApi.materializeDirectoryLaunchpad({
+          directoryKey,
+          input,
+        });
+        const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
+          directory,
+          launchpad,
+          backend: response.backend,
+          threadId: response.threadId,
+          executionMode: response.executionMode,
+          workMode: response.workMode,
+        });
+        const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        setOptimisticThread(optimisticMaterializedThread);
+        setSelectedItemKey(nextThreadKey);
+        setPendingSeenThreadKey(nextThreadKey);
+        setState((current) => ({
+          ...current,
+          response: current.response
+            ? applyLaunchpadReset(
+                current.response,
+                directoryKey,
+                current.response.launchpadDefaults,
+              )
+            : current.response,
+        }));
+        await refresh(nextThreadKey, optimisticMaterializedThread);
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [desktopApi, directories, refresh],
   );
 
   const updateThreadExecutionMode = useCallback(
@@ -456,16 +797,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     createThread,
     createThreadError,
     creatingThread,
+    directories,
     error: state.error,
     inboxThreads,
+    launchpadError,
     loading: state.loading,
     refreshing: state.refreshing,
-    refresh,
+    refresh: async () => await refresh(),
+    materializeDirectoryLaunchpad,
+    openDirectoryLaunchpad,
+    resetDirectoryLaunchpad,
+    selectedDirectory,
+    selectedItemKey,
+    selectedLaunchpad,
     selectedThread,
     selectedThreadKey,
     setThreadExecutionMode: updateThreadExecutionMode,
     setThreadExecutionModeError,
     updatingThreadExecutionMode,
+    updateDirectoryLaunchpad,
     setBrowseMode,
     selectThread,
     snapshot: state.response,

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerListSkillsResponse,
   AppServerSkillSummary,
+  NavigationLaunchpadDraft,
   NavigationThreadSummary,
 } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
@@ -14,6 +15,7 @@ type SkillState = {
 
 export function useThreadSkills(params: {
   desktopApi?: DesktopApi;
+  launchpad?: NavigationLaunchpadDraft;
   thread?: NavigationThreadSummary;
 }): {
   error?: string;
@@ -21,12 +23,13 @@ export function useThreadSkills(params: {
   response?: AppServerListSkillsResponse;
   skills: AppServerSkillSummary[];
 } {
-  const { desktopApi, thread } = params;
+  const { desktopApi, launchpad, thread } = params;
   const [state, setState] = useState<SkillState>({ loading: false });
   const requestVersionRef = useRef(0);
 
   useEffect(() => {
-    if (!thread || thread.source !== "codex") {
+    const backend = thread?.source ?? launchpad?.backend;
+    if (!backend || backend !== "codex") {
       setState({ loading: false, error: undefined, response: undefined });
       return;
     }
@@ -42,11 +45,15 @@ export function useThreadSkills(params: {
 
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
-    const cwds = [...new Set(
-      thread.linkedDirectories
-        .map((directory) => directory.worktreePath ?? directory.path)
-        .filter(Boolean)
-    )];
+    const cwds = thread
+      ? [...new Set(
+          thread.linkedDirectories
+            .map((directory) => directory.worktreePath ?? directory.path)
+            .filter(Boolean)
+        )]
+      : launchpad?.directoryPath
+        ? [launchpad.directoryPath]
+        : [];
 
     setState((current) => ({
       ...current,
@@ -56,7 +63,8 @@ export function useThreadSkills(params: {
 
     void desktopApi
       .listSkills({
-        backend: thread.source,
+        backend,
+        cwd: !thread && cwds.length === 1 ? cwds[0] : undefined,
         cwds: cwds.length > 0 ? cwds : undefined,
       })
       .then((response) => {
@@ -81,7 +89,7 @@ export function useThreadSkills(params: {
           response: undefined,
         });
       });
-  }, [desktopApi, thread]);
+  }, [desktopApi, launchpad, thread]);
 
   const skills = useMemo(() => {
     const deduped = new Map<string, AppServerSkillSummary>();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1791,8 +1791,8 @@ textarea {
 .composer__setup {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 10px 18px;
+  align-items: center;
+  gap: 8px;
 }
 
 .composer__control-group {
@@ -1810,33 +1810,6 @@ textarea {
   text-transform: uppercase;
 }
 
-.composer__segmented {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.composer__segmented-button {
-  min-height: 34px;
-  padding: 0 12px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.composer__segmented-button:hover {
-  background: var(--bg-panel-hover);
-}
-
-.composer__segmented-button.is-active {
-  border-color: var(--accent-border);
-  background: rgba(184, 255, 77, 0.08);
-  color: var(--text-primary);
-}
-
 .composer__select {
   min-width: 168px;
   min-height: 34px;
@@ -1845,6 +1818,18 @@ textarea {
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.03);
   color: var(--text-primary);
+}
+
+.composer__select:disabled {
+  opacity: 1;
+  color: var(--text-secondary);
+  cursor: default;
+}
+
+.composer__select--compact {
+  min-width: 0;
+  width: auto;
+  max-width: 220px;
 }
 
 .composer__checkbox {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -607,55 +607,17 @@ textarea {
 .directory-row__details {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px 0 14px 0;
-}
-
-.directory-row__details-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding-left: 12px;
-}
-
-.directory-row__detail-chip {
-  display: inline-flex;
-  min-width: 0;
-  max-width: 100%;
-  align-items: center;
-  gap: 6px;
-  height: 24px;
-  padding: 0 8px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.directory-row__detail-chip--draft {
-  border-color: var(--accent-border);
-  background: rgba(184, 255, 77, 0.08);
-  color: var(--text-primary);
-}
-
-.directory-row__detail-chip--path {
-  max-width: min(100%, 420px);
-  background: transparent;
-  text-align: left;
+  gap: 8px;
+  padding: 8px 0 14px 0;
 }
 
 .directory-row__threads {
-  padding-left: 12px;
+  padding-left: 8px;
 }
 
 .directory-row__empty {
   margin-top: 0;
-  padding-left: 12px;
+  padding-left: 8px;
 }
 
 .directory-group {
@@ -1829,36 +1791,40 @@ textarea {
 .composer__setup {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  align-items: flex-end;
+  gap: 10px 18px;
 }
 
 .composer__control-group {
   display: flex;
-  min-width: min(100%, 220px);
-  flex: 1 1 220px;
+  min-width: 0;
+  flex: 0 0 auto;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .composer__control-label {
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
+  text-transform: uppercase;
 }
 
 .composer__segmented {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 4px;
 }
 
 .composer__segmented-button {
-  min-height: 30px;
-  padding: 0 10px;
+  min-height: 34px;
+  padding: 0 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   background: transparent;
   color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .composer__segmented-button:hover {
@@ -1872,7 +1838,7 @@ textarea {
 }
 
 .composer__select {
-  width: 100%;
+  min-width: 168px;
   min-height: 34px;
   padding: 0 10px;
   border: 1px solid var(--border-subtle);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -514,6 +514,150 @@ textarea {
   font-family: "IBM Plex Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
 }
 
+.directory-list {
+  gap: 0;
+  padding-top: 0;
+}
+
+.directory-row {
+  padding: 10px 0 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.directory-row:first-child {
+  border-top: 0;
+}
+
+.directory-row__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.directory-row__summary {
+  min-height: 44px;
+  padding: 10px 12px;
+}
+
+.directory-row__summary-main,
+.directory-row__summary-meta,
+.directory-row__title-wrap {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.directory-row__summary-main {
+  gap: 8px;
+}
+
+.directory-row__summary-meta {
+  gap: 10px;
+}
+
+.directory-row__icon {
+  flex: 0 0 auto;
+  line-height: 1;
+}
+
+.directory-row__title-wrap {
+  min-width: 0;
+}
+
+.directory-row__attention {
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  font-size: 11px;
+}
+
+.directory-row__chevron {
+  color: var(--text-muted);
+  font-size: 12px;
+  transition: transform 120ms ease;
+}
+
+.directory-row__chevron.is-open {
+  transform: rotate(180deg);
+}
+
+.directory-row__launchpad-button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.directory-row__launchpad-button:hover {
+  background: var(--bg-panel-hover);
+}
+
+.directory-row__launchpad-button.has-draft {
+  border-color: var(--accent-border);
+  background: rgba(184, 255, 77, 0.08);
+  color: var(--accent);
+}
+
+.directory-row__details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 0 14px 0;
+}
+
+.directory-row__details-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-left: 12px;
+}
+
+.directory-row__detail-chip {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.directory-row__detail-chip--draft {
+  border-color: var(--accent-border);
+  background: rgba(184, 255, 77, 0.08);
+  color: var(--text-primary);
+}
+
+.directory-row__detail-chip--path {
+  max-width: min(100%, 420px);
+  background: transparent;
+  text-align: left;
+}
+
+.directory-row__threads {
+  padding-left: 12px;
+}
+
+.directory-row__empty {
+  margin-top: 0;
+  padding-left: 12px;
+}
+
 .directory-group {
   padding-top: 12px;
   border-top: 1px solid var(--border-subtle);
@@ -638,6 +782,49 @@ textarea {
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel);
+}
+
+.launchpad-panel {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.launchpad-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.launchpad-panel__header p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.launchpad-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px;
+}
+
+.launchpad-grid dt {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.launchpad-grid dd {
+  margin: 4px 0 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.45;
+  word-break: break-word;
 }
 
 .transcript-panel {
@@ -1639,6 +1826,69 @@ textarea {
   gap: 8px;
 }
 
+.composer__setup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.composer__control-group {
+  display: flex;
+  min-width: min(100%, 220px);
+  flex: 1 1 220px;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.composer__control-label {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.composer__segmented {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.composer__segmented-button {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.composer__segmented-button:hover {
+  background: var(--bg-panel-hover);
+}
+
+.composer__segmented-button.is-active {
+  border-color: var(--accent-border);
+  background: rgba(184, 255, 77, 0.08);
+  color: var(--text-primary);
+}
+
+.composer__select {
+  width: 100%;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+}
+
+.composer__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
 .composer__autocomplete {
   position: absolute;
   right: 0;
@@ -1730,6 +1980,10 @@ textarea {
   .transcript-list__scroll-bottom {
     left: 50%;
     bottom: 16px;
+  }
+
+  .launchpad-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .context-rail,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -6,8 +6,16 @@ export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
+export const AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL =
+  "agent:materialize-directory-launchpad";
 export const AGENT_SUBMIT_SERVER_REQUEST_CHANNEL = "agent:submit-server-request";
 export const AGENT_EVENT_CHANNEL = "agent:event";
 export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
+export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
+  "navigation:ensure-directory-launchpad";
+export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =
+  "navigation:update-directory-launchpad";
+export const NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL =
+  "navigation:reset-directory-launchpad";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";

--- a/docs/brainstorms/2026-04-18-directories-launchpad-requirements.md
+++ b/docs/brainstorms/2026-04-18-directories-launchpad-requirements.md
@@ -1,0 +1,101 @@
+---
+date: 2026-04-18
+topic: directories-launchpad
+---
+
+# Directories Launchpad
+
+## Problem Frame
+
+The current Directories lens spends too much vertical space on each project, uses a header-and-count pattern that does not align with Recents, and treats "new thread" like a one-shot action instead of durable project-scoped work in progress. That makes directory browsing feel less dense, less operational, and less consistent with the thread-first product direction.
+
+The Directories lens should become a compact project browser that stays visually close to Recents while giving users a better way to start work from a directory. Instead of exposing a large section header plus a raw thread count, each directory should collapse to a dense row with a needs-attention signal. Expanding that row should reveal existing threads plus a persistent launchpad draft that reopens when the user clicks `+`, preserves unsent work, and only becomes a real thread when the user sends the first message.
+
+```mermaid
+flowchart TB
+    A["Directories collapsed row"] --> B["Show project label + unread/needs-attention count"]
+    B --> C["User expands project"]
+    C --> D["Expanded view shows existing threads and + launchpad entrypoint"]
+    D --> E["User clicks +"]
+    E --> F["Persistent project launchpad reopens with unsent prompt and retained context"]
+    F --> G["User navigates away and returns"]
+    G --> F
+    F --> H["User sends first message"]
+    H --> I["Launchpad becomes a real thread"]
+    I --> J["Project returns to detached reusable launchpad state for next +"]
+```
+
+## Requirements
+
+**Directory List Density and Structure**
+- R1. The Directories lens uses compact per-directory rows rather than tall section headers with detached thread-count labels.
+- R2. The collapsed directory row should stay stylistically close to the Recents row pattern rather than introducing a separate visual language.
+- R3. The collapsed directory row should prioritize an unread or needs-attention count over a raw thread count as its primary summary signal.
+- R4. Expanding a directory row reveals the threads for that directory inline beneath the directory summary row.
+
+**Directory Status and Git Context**
+- R5. For Git directories, the expanded row should show informational repository context including the current branch and whether it is in sync, ahead, or behind the default pull remote for that branch.
+- R6. Repository status shown in the Directories row is informational; the Directories lens must not directly switch the checked-out branch from that row.
+- R7. For non-Git directories, the expanded row should expose the directory's threads and the `+` entrypoint without a Git-status control area.
+- R8. Branch, access mode, model, reasoning, fast mode, and similar thread-setup controls do not live in the expanded directory row itself.
+
+**Launchpad Draft Model**
+- R9. Clicking `+` on a directory opens a project-scoped launchpad that appears as a thread draft for that directory rather than immediately creating a full thread.
+- R10. Each directory has exactly one persistent unsent launchpad draft.
+- R11. Re-clicking `+` for a directory reopens that same unsent launchpad draft until the draft is sent.
+- R12. If the user types a prompt without sending it, the launchpad must retain that unsent prompt when the user leaves and later reopens the launchpad.
+- R13. If the user changes launchpad context such as local versus worktree execution, branch choice, access mode, model, reasoning, or fast mode, the launchpad must retain that unsent context when the user leaves and later reopens it.
+- R14. The launchpad should snapshot the current sticky defaults for new-thread setup as soon as the user changes a relevant setting or begins composing the prompt, so reopening it restores the in-progress setup rather than re-reading newer defaults.
+- R15. Sending the launchpad's first message converts the launchpad into a real thread in that directory.
+- R16. After the first send, the project returns to a detached reusable launchpad state so a future `+` opens a fresh draft rather than reopening the already-created thread.
+
+**Thread Setup Controls**
+- R17. Access mode is surfaced with the composer area below the thread reply box rather than in the Directories row.
+- R18. Changing access mode updates the sticky default used for future new launchpads and new threads, but it does not rewrite the settings of existing threads.
+- R19. Model, reasoning, and later fast-mode controls are surfaced with the composer area below the thread reply box rather than in the Directories row.
+- R20. Changing model, reasoning, or fast mode updates the sticky default used for future new launchpads and new threads, but it does not rewrite the settings of existing threads.
+- R21. Branch selection is part of launchpad context, but branch choice is not a global sticky default that automatically changes future launchpads unless the user explicitly sets it in that launchpad.
+
+## Success Criteria
+
+- The Directories lens feels visibly denser and more consistent with Recents without losing scannability.
+- Users can tell which directories need attention without relying on a detached raw thread-count label.
+- Users can start drafting work from a directory, navigate away, return via `+`, and find the draft unchanged.
+- A project launchpad only becomes a real thread when the user sends the first message.
+- Git directories surface enough status to orient the user without turning the Directories lens into a full branch-management UI.
+- Access mode and later model/reasoning controls are easier to discover during composition because they live with the reply workflow instead of being hidden in a distant footer-only control.
+
+## Scope Boundaries
+
+- This change does not turn the Directories lens into a direct branch-switching surface.
+- This change does not keep multiple unsent launchpad drafts per directory.
+- This change does not make access mode, model, reasoning, or branch selectors permanent controls in the expanded directory row.
+- This change does not require raw thread count to remain the dominant collapsed-row summary signal.
+
+## Key Decisions
+
+- Recents-aligned density: Directories should adopt the calmer, denser thread-row language already used by Recents instead of maintaining a tall grouped-section layout.
+- Needs-attention over raw count: the collapsed row should summarize urgency, not just container size.
+- Launchpad instead of instant thread creation: `+` reopens persistent project-scoped draft work rather than firing an immediate create-thread action.
+- One draft per directory: launchpad state stays simple and predictable by limiting each directory to one unsent draft.
+- Repo status is informational in Directories: branch and ahead/behind indicators help orientation, but editing repo state belongs elsewhere.
+- Composer-owned setup controls: access mode, model, reasoning, fast mode, and launchpad context belong near the reply workflow rather than in the directory list row.
+
+## Dependencies / Assumptions
+
+- The product can distinguish unread or needs-attention state for directory-linked threads well enough to summarize that state at the directory row level.
+- Git metadata can be read reliably enough to surface current branch and ahead/behind status for Git directories.
+- The product can persist unsent launchpad drafts independently from fully created threads.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R3][Technical] What exact rules compute the collapsed-row unread or needs-attention count for a directory when a thread may appear in Inbox, Recents, and multiple linked directories?
+- [Affects R5][Technical] What exact remote-selection rule defines the "default pull remote" for ahead/behind status when Git config is ambiguous?
+- [Affects R9][Technical] Where and how should persistent unsent launchpad state be stored so it survives navigation and restart without colliding with real thread identity?
+- [Affects R14][Technical] What exact event boundary should freeze launchpad defaults into a project draft: first keystroke, first non-empty prompt, first setting change, or all of the above?
+- [Affects R17][Technical] How should composer-area controls differ between a detached launchpad draft and an already-created thread so users understand which settings are still draft context versus thread state?
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-04-18-001-feat-directories-launchpad-plan.md
+++ b/docs/plans/2026-04-18-001-feat-directories-launchpad-plan.md
@@ -1,0 +1,354 @@
+---
+title: feat: Add Directories launchpad flow
+type: feat
+status: active
+date: 2026-04-18
+origin: docs/brainstorms/2026-04-18-directories-launchpad-requirements.md
+deepened: 2026-04-18
+---
+
+# feat: Add Directories launchpad flow
+
+## Overview
+
+Rework the Directories lens from a tall grouped-thread list into a compact project browser with inline expansion, a per-directory needs-attention badge, informational Git status, and a persistent launchpad draft that only becomes a real thread on first send. The implementation should preserve the repo's existing thread-first model by keeping launchpads separate from thread identity, routing thread creation through the current desktop backend registry, and moving new-thread setup ownership into the launchpad composer surface instead of the directory row.
+
+## Problem Frame
+
+The origin requirements define a denser Directories experience that stays visually aligned with Recents, replaces detached thread counts with a needs-attention signal, and turns `+` into a durable project-scoped launchpad rather than an immediate create-thread action (see origin: `docs/brainstorms/2026-04-18-directories-launchpad-requirements.md`). The current desktop code does not have a place to represent a non-thread draft: [`apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx) derives grouped sections directly from thread summaries, [`apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts) only selects real threads, and [`apps/desktop/src/renderer/src/features/composer/Composer.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/composer/Composer.tsx) only knows how to submit turns against an existing thread id.
+
+At the same time, the current stack already has most of the infrastructure the launchpad needs:
+- [`packages/agent-core/src/persistence/overlay-store.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts) persists desktop-only state keyed outside the backing app server
+- [`packages/agent-core/src/domain/navigation-state.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/domain/navigation-state.ts) already materializes navigation snapshots from thread summaries plus overlay data
+- [`apps/desktop/src/main/app-server/backend-registry.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/app-server/backend-registry.ts) already owns thread creation, execution-mode routing, and request/response orchestration
+- [`apps/desktop/src/main/codex-app-server/client.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/codex-app-server/client.ts) already resolves Git roots, worktrees, and thread-level branch metadata
+
+This plan extends those boundaries rather than replacing them.
+
+## Requirements Trace
+
+- R1-R4. Replace tall grouped directory sections with compact expandable directory rows that stay visually consistent with Recents.
+- R5-R8. Surface Git branch and ahead/behind context in Directories as informational metadata only, while keeping branch- and setup-editing controls out of the directory row itself.
+- R9-R16. Add one persistent unsent launchpad draft per directory that retains prompt and setup context across navigation until the first send materializes a real thread.
+- R17-R18. Move new-thread access-mode ownership into the launchpad composer workflow and make it a sticky default for future launchpads without rewriting existing thread state.
+- R19-R20. Carry model/reasoning/fast-mode setup through the same launchpad-owned sticky-default mechanism when backend metadata can support real choices, without inventing unsupported values.
+- R21. Treat branch choice as launchpad-local context, not a global sticky default.
+
+## Scope Boundaries
+
+- Do not turn the Directories lens into a branch-switching UI.
+- Do not create multiple concurrent unsent launchpads per directory.
+- Do not redefine existing thread ids or merge launchpad drafts into thread identity.
+- Do not move thread-specific execution-mode controls out of the thread detail context rail in this pass; the new composer-owned controls apply to launchpad/new-thread setup.
+- Do not invent hard-coded model or reasoning taxonomies for backends that cannot advertise valid options yet.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- [`docs/design/desktop-style-guide.md`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/design/desktop-style-guide.md) explicitly calls for calm, dense sidebar rows and warns against ad hoc grouped-card styling.
+- [`docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md) already establishes directory view as an alternate lens over thread-first navigation, not a replacement object model.
+- [`apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx) currently groups threads client-side and is the main renderer entry point that needs restructuring.
+- [`apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx) already owns the browse-lens switch and current sidebar creation affordances.
+- [`apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts) is the current selection, snapshot refresh, and optimistic-thread boundary.
+- [`apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx) and [`apps/desktop/src/renderer/src/features/composer/Composer.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/composer/Composer.tsx) define the current thread-detail and reply workflow that the launchpad needs to mirror.
+- [`packages/shared/src/contracts/navigation.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/shared/src/contracts/navigation.ts) and [`packages/shared/src/contracts/agent.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/shared/src/contracts/agent.ts) are the shared contract boundaries for navigation snapshots and desktop IPC.
+- [`packages/agent-core/src/persistence/migrations.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/persistence/migrations.ts) and [`packages/agent-core/src/persistence/overlay-store.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts) are the persistence path for desktop-owned state and already handle versioned overlay migrations.
+- [`apps/desktop/src/main/ipc/app-server.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts) currently builds navigation snapshots from `listThreads()` plus overlay reconciliation, which is the natural place to add directory summaries.
+- [`docs/plans/2026-04-16-004-feat-codex-access-mode-toggle-plan.md`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/plans/2026-04-16-004-feat-codex-access-mode-toggle-plan.md) already established execution-mode persistence in the overlay store and current renderer exposure for existing threads.
+- [`docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md) confirms `model/list` is part of the longer-term protocol surface, which matters for how aggressively this plan should promise model/reasoning UI.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist yet in this repository.
+
+### External References
+
+- None. The repo already has strong local patterns for navigation snapshots, overlay persistence, desktop IPC, and thread/composer rendering, so additional external research would add little practical value here.
+
+## Key Technical Decisions
+
+- Represent launchpads as persisted directory-scoped drafts, not optimistic placeholder threads. This preserves thread identity and avoids mixing unsent draft state into thread lists that are sourced from the app server.
+- Build stable directory summaries in the main process rather than re-deriving groups purely in the renderer. The renderer needs directory-level state that threads alone cannot provide: needs-attention counts, repo status, and launchpad presence.
+- Persist launchpad drafts in the overlay store under a dedicated `directoryLaunchpads` map keyed by a stable directory key derived from the canonical Git root when available, otherwise the directory path. This keeps launchpad state durable across navigation and restart without colliding with thread ids.
+- Compute the collapsed-row needs-attention badge from the count of distinct grouped threads whose `inbox.inInbox` flag is true. That reuses the existing desktop attention signal instead of inventing a second unread system.
+- Use the Git upstream branch as the only ahead/behind source. If a directory has no upstream tracking branch, show branch information but omit sync-state claims rather than guessing a “default pull remote.”
+- Treat launchpad send as one desktop-orchestrated materialization flow that prepares the working directory, starts the thread with the launchpad settings, and starts the first turn. This keeps the draft-to-thread transition coherent and minimizes renderer half-states.
+- Keep composer-owned setup controls launchpad-specific in this pass. Existing threads retain their current thread-state controls, while launchpads own sticky defaults for future new threads. This honors the requirement that sticky changes should not rewrite existing thread settings.
+- Make model/reasoning/fast-mode controls capability-driven. Persist those fields generically in launchpad state, but only render editable controls when the selected backend can advertise safe options or defaults; do not hard-code speculative model catalogs.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How should the collapsed-row attention badge be computed? Count distinct grouped threads where `thread.inbox.inInbox === true`.
+- What remote should define sync state? Use the branch upstream when configured; otherwise mark sync status unavailable.
+- Where should launchpad drafts live? In the desktop overlay store under a directory-keyed draft map separate from thread overlay records.
+- When should sticky defaults freeze into a draft? Create or update the persisted launchpad draft on the first non-empty prompt input or any setup-field mutation, and from then on treat the draft as the source of truth until materialization or reset.
+- How should launchpad controls differ from an existing thread? The launchpad composer owns editable setup fields; existing threads keep their current thread-state behavior and do not inherit later sticky-default edits.
+
+### Deferred to Implementation
+
+- What autosave debounce interval feels responsive without writing overlay state on every keystroke? This depends on the final renderer update pattern and can be tuned during implementation.
+- How should the branch picker behave for very large repositories with many local branches? The implementation can choose between a simple select and a searchable list once the actual branch counts are visible.
+- What path-naming strategy should new worktrees use when the preferred branch-slug path already exists? The implementation should settle the collision strategy once the worktree-preparation helper exists.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    THREADS["BackendRegistry.listThreads()"]
+    GIT["GitDirectoryService\ncanonical root / branch / upstream / branches / worktree prep"]
+    OVERLAY["OverlayStore\nthread overlays + directoryLaunchpads"]
+    SNAP["Navigation snapshot builder\nthreads + directory summaries + launchpads"]
+    UI["Sidebar / DirectoriesList"]
+    DETAIL["Launchpad detail + composer"]
+    MATERIALIZE["materializeDirectoryLaunchpad"]
+    REALTHREAD["Real thread selected"]
+
+    THREADS --> SNAP
+    GIT --> SNAP
+    OVERLAY --> SNAP
+    SNAP --> UI
+    UI --> DETAIL
+    DETAIL --> OVERLAY
+    DETAIL --> MATERIALIZE
+    MATERIALIZE --> GIT
+    MATERIALIZE --> THREADS
+    MATERIALIZE --> OVERLAY
+    MATERIALIZE --> REALTHREAD
+```
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1\nContracts + overlay draft state"] --> U2["Unit 2\nMain-process directory metadata + launchpad IPC"]
+    U1 --> U3["Unit 3\nRenderer navigation + compact Directories rows"]
+    U2 --> U4["Unit 4\nLaunchpad detail/composer materialization flow"]
+    U3 --> U4
+```
+
+- [ ] **Unit 1: Add directory launchpad contracts and persistence**
+
+**Goal:** Introduce shared types and overlay-store structures for directory summaries, launchpad drafts, and launchpad-owned sticky setup fields without changing thread identity.
+
+**Requirements:** R1-R4, R9-R16, R17-R21
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `packages/shared/src/contracts/navigation.ts`
+- Modify: `packages/shared/src/contracts/agent.ts`
+- Modify: `packages/shared/src/contracts/backend.ts`
+- Create: `packages/agent-core/src/domain/directory-navigation.ts`
+- Modify: `packages/agent-core/src/domain/navigation-state.ts`
+- Modify: `packages/agent-core/src/persistence/migrations.ts`
+- Modify: `packages/agent-core/src/persistence/overlay-store.ts`
+- Test: `packages/agent-core/src/__tests__/overlay-store.test.ts`
+- Test: `packages/agent-core/src/__tests__/directory-navigation.test.ts`
+
+**Approach:**
+- Add shared navigation types for directory summaries and launchpad drafts, including stable directory keys, needs-attention counts, optional Git status metadata, and launchpad-owned setup fields such as backend, execution mode, branch choice, worktree/local choice, and optional model/reasoning/service-tier values.
+- Extend overlay persistence with a dedicated directory-launchpad map instead of stuffing launchpad state into `ThreadOverlayState`.
+- Split directory aggregation logic into a focused domain helper so directory-level grouping, needs-attention counting, and launchpad attachment stay testable outside the Electron layer.
+- Extend desktop IPC request/response types for “ensure/update/materialize/reset directory launchpad” so the renderer has explicit draft operations rather than piggybacking on `startThread`.
+- Extend backend summary metadata only enough to expose launchpad-setup options safely. If a backend cannot advertise a real option list yet, the contract should allow omission rather than fake data.
+
+**Execution note:** Start with migration and aggregation tests before changing the renderer shape.
+
+**Patterns to follow:**
+- [`packages/shared/src/contracts/navigation.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/shared/src/contracts/navigation.ts)
+- [`packages/agent-core/src/persistence/migrations.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/persistence/migrations.ts)
+- [`packages/agent-core/src/domain/navigation-state.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/domain/navigation-state.ts)
+
+**Test scenarios:**
+- Happy path: a persisted launchpad draft rehydrates after restart with prompt text, execution mode, branch choice, and worktree/local preference intact.
+- Happy path: directory aggregation produces one stable directory summary with the correct needs-attention count even when the same thread appears in multiple views.
+- Happy path: a launchpad draft and a real thread with the same directory key coexist without key collisions.
+- Edge case: older overlay data with no `directoryLaunchpads` field migrates cleanly with existing thread overlays preserved.
+- Edge case: a directory with no Git metadata still materializes a summary and can own a launchpad draft.
+- Error path: invalid persisted execution/model/reasoning values normalize to safe defaults or absent metadata rather than crashing snapshot generation.
+
+**Verification:**
+- Navigation snapshots can carry directory summaries plus launchpad drafts without inventing synthetic thread ids.
+
+- [ ] **Unit 2: Add main-process directory metadata and launchpad orchestration**
+
+**Goal:** Teach the main process to build directory-level Git metadata, persist/reopen launchpads, and materialize a launchpad into a real thread on first send.
+
+**Requirements:** R3-R8, R9-R16, R17-R21
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/git-directory-service.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/ipc/app-server.ts`
+- Modify: `apps/desktop/src/main/ipc/agent-ipc.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+
+**Approach:**
+- Add a main-process Git directory service that can canonicalize a directory key, detect whether the directory is a Git repo, read current branch/upstream status, list branch choices for launchpads, and prepare a working directory for “local” versus “new worktree” launchpad materialization.
+- Move directory-summary assembly to the navigation snapshot path so the renderer receives precomputed directory rows instead of having to infer them from thread arrays alone.
+- Add explicit launchpad IPC methods:
+  - ensure/open a directory launchpad
+  - update autosaved launchpad state
+  - discard/reset the directory launchpad after materialization
+  - materialize the launchpad into a thread + first turn
+- Keep `materializeDirectoryLaunchpad` in the main process so it can sequence worktree preparation, `startThread`, and `startTurn`, then clear/reset the draft only after the transition is coherent.
+- Extend backend metadata enough to expose launchpad setup options when available. Use current backend defaults as the floor, but avoid shipping made-up lists for unsupported backends.
+
+**Patterns to follow:**
+- [`apps/desktop/src/main/ipc/app-server.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/ipc/app-server.ts)
+- [`apps/desktop/src/main/ipc/agent-ipc.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/ipc/agent-ipc.ts)
+- [`apps/desktop/src/main/app-server/backend-registry.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/app-server/backend-registry.ts)
+- [`apps/desktop/src/main/codex-app-server/client.ts`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/codex-app-server/client.ts)
+
+**Test scenarios:**
+- Happy path: a Git directory summary reports its current branch plus `ahead/behind` counts when an upstream branch exists.
+- Happy path: a directory without an upstream branch reports branch information but omits sync-state claims.
+- Happy path: opening a launchpad for a directory with no existing draft returns the sticky defaults seeded from current backend availability.
+- Happy path: re-opening a directory launchpad returns the persisted unsent prompt and setup fields unchanged.
+- Happy path: materializing a “local” launchpad starts the thread against the repo root and clears the directory draft after the first turn starts.
+- Happy path: materializing a “new worktree” launchpad prepares a worktree cwd, starts the thread there, and preserves the canonical git-root directory summary.
+- Error path: if Git status probing fails, the directory summary degrades to “status unavailable” without breaking the rest of the snapshot.
+- Error path: if worktree creation fails, the draft remains intact and the user-visible error is returned without creating a thread.
+- Error path: if `startThread` succeeds but `startTurn` fails, the created thread is still selectable and the original launchpad prompt is preserved for retry in the materialized thread surface rather than being lost.
+
+**Verification:**
+- The main process can return directory summaries and launchpad data in one snapshot and can materialize a launchpad into a working thread without dropping unsent user input.
+
+- [ ] **Unit 3: Replace grouped Directories sections with compact expandable rows**
+
+**Goal:** Rebuild the renderer’s Directories lens around stable directory summaries, inline expansion, and launchpad selection while keeping Recents and Inbox behavior intact.
+
+**Requirements:** R1-R8, R9-R11
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Stop grouping threads on the fly inside `DirectoriesList`; consume server-provided directory summaries with stable keys, launchpad metadata, and directory-level Git status.
+- Change navigation selection from “selected thread only” to a small union of “selected thread” or “selected launchpad,” preserving the existing thread-key format for real threads so Recents and Inbox do not need a parallel rewrite.
+- Add local expansion state per directory row in the renderer and render existing threads inline under the compact summary row.
+- Replace the detached thread-count label with a compact needs-attention badge, while keeping the row styling aligned with the existing Recents row tokens and density.
+- Keep Git status informational in the expanded row only: branch text, sync status when known, and `+` entrypoint. Do not add branch-switching actions here.
+
+**Patterns to follow:**
+- [`apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx)
+- [`apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx)
+- [`docs/design/desktop-style-guide.md`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/design/desktop-style-guide.md)
+
+**Test scenarios:**
+- Happy path: the collapsed directory row shows label plus needs-attention badge and no detached raw thread-count label.
+- Happy path: expanding a Git directory reveals inline threads, informational branch/sync metadata, and a `+` entrypoint.
+- Happy path: expanding a non-Git directory reveals inline threads and `+` but no Git-status area.
+- Happy path: clicking `+` on a directory selects the existing launchpad draft when one already exists instead of creating a second draft.
+- Edge case: a directory with zero needs-attention threads renders without a badge but remains expandable.
+- Edge case: selecting a launchpad does not mark any real thread as seen or disturb Inbox bookkeeping.
+- Integration: Recents and Inbox continue to render real threads off the same navigation snapshot without being polluted by launchpad-only rows.
+
+**Verification:**
+- The sidebar shows compact directory rows with inline expansion and can target either a real thread or a launchpad without regressions in Recents/Inbox.
+
+- [ ] **Unit 4: Add launchpad detail and composer-owned setup workflow**
+
+**Goal:** Render the launchpad as a thread-like draft surface, autosave prompt/setup edits, and materialize it into a real thread on send while keeping existing-thread behavior predictable.
+
+**Requirements:** R9-R21
+
+**Dependencies:** Unit 2, Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSkills.ts`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Teach `ThreadView` to render either a real thread or a selected launchpad draft. The launchpad should reuse the thread detail layout enough to “look like a thread in that project” while clearly remaining a pre-thread draft.
+- Update transcript and skill-loading hooks so launchpad selection does not trigger `thread/read` for a non-existent thread id and so skill lookup can key off the draft's directory/worktree context instead of an existing thread summary.
+- Extend the composer to support two modes:
+  - real-thread reply mode, preserving existing behavior
+  - launchpad mode, where text entry and setup controls autosave into the persisted draft
+- Move new-thread setup ownership into the launchpad composer: access mode is editable here and updates sticky defaults for future launchpads; model/reasoning/fast-mode controls render here only when the selected backend advertises valid options.
+- Keep branch choice and local/worktree mode as launchpad-local context fields that are retained in the draft but do not become global sticky defaults.
+- On send from a launchpad, call the materialization API, transition selection to the created thread, and reset the directory launchpad to a detached fresh state for the next `+`.
+- Leave current thread-specific execution-mode switching in the context rail for existing threads so sticky launchpad defaults are not confused with retroactive thread edits.
+
+**Patterns to follow:**
+- [`apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx)
+- [`apps/desktop/src/renderer/src/features/composer/Composer.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/composer/Composer.tsx)
+- [`apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx)
+
+**Test scenarios:**
+- Happy path: editing a launchpad prompt autosaves it, navigating away, and reopening the launchpad restores the draft unchanged.
+- Happy path: changing launchpad access mode updates the persisted draft and the sticky default used for the next new launchpad, while an existing thread’s execution mode remains unchanged.
+- Happy path: changing launchpad branch or local/worktree choice affects only that launchpad draft and is restored when the draft is reopened.
+- Happy path: sending a launchpad materializes a real thread, selects it, and resets the directory’s next launchpad to a fresh detached draft.
+- Happy path: when backend setup options are advertised, model/reasoning/fast-mode controls render in the launchpad composer and persist their selections.
+- Happy path: selecting a launchpad skips transcript fetches for real-thread history and loads skills using the launchpad's current directory/worktree context.
+- Edge case: when backend setup options are not advertised, the launchpad composer remains layout-stable and does not invent unsupported selectors.
+- Error path: a failed materialization leaves the launchpad prompt and settings available for retry if no thread was created, or hands them off to the created thread surface if thread creation already succeeded.
+- Integration: existing thread reply behavior, optimistic user messages, approval handling, and interrupt controls continue to work unchanged outside launchpad mode.
+
+**Verification:**
+- Users can treat `+` as a durable per-directory launchpad, leave mid-composition, return later, and only create a real thread when they actually send.
+
+## System-Wide Impact
+
+- **Interaction graph:** `DesktopAppServerService.getNavigationSnapshot()` must now combine backend thread lists, overlay draft state, and Git-directory metadata before the renderer can build the Directories lens.
+- **Error propagation:** Git metadata failures should degrade to missing status on a row, not break navigation. Launchpad materialization failures should preserve recoverable user input instead of dropping the draft silently.
+- **State lifecycle risks:** Launchpad drafts and thread overlays now evolve independently. Clearing a draft at the wrong moment or keying it inconsistently with directory summaries would create lost work or duplicate drafts.
+- **API surface parity:** Preload, shared IPC constants, desktop API types, and main-process handlers all need to evolve together for launchpad operations and directory summaries.
+- **Integration coverage:** Cross-layer tests need to prove autosave persistence, directory summary assembly, launchpad materialization, and selection transitions; unit tests alone will not catch those seams.
+- **Unchanged invariants:** Real thread ids, Inbox semantics, Recents ordering, and thread-specific transcript/reply behavior remain the existing source of truth and must not be rewritten around launchpad state.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Launchpad drafts collide when the same repo appears through multiple worktree paths | Key drafts and directory summaries by canonical git root when available, with path fallback for non-Git directories |
+| Git shellouts slow down snapshot refresh | Scope status lookup to visible/stable directory roots and cache per refresh cycle; degrade gracefully to “status unavailable” on failure |
+| A send path creates a thread but loses the draft text on later failure | Centralize materialization in the main process and explicitly preserve the prompt until the created thread can own it |
+| Model/reasoning controls drift from real backend support | Make those controls capability-driven and allow omission when backend metadata is unavailable |
+
+## Documentation / Operational Notes
+
+- Overlay persistence will require a versioned migration and restart-safe tests because launchpad drafts are stored in `overlay-state.json`.
+- The resulting interaction model should be reflected in the desktop app guidance and any future contributor docs once implementation lands, because Directories will no longer be “threads grouped by path.”
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-18-directories-launchpad-requirements.md](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/brainstorms/2026-04-18-directories-launchpad-requirements.md)
+- Related requirements: [docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md)
+- Related design: [docs/design/desktop-style-guide.md](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/design/desktop-style-guide.md)
+- Related plan: [docs/plans/2026-04-16-004-feat-codex-access-mode-toggle-plan.md](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/plans/2026-04-16-004-feat-codex-access-mode-toggle-plan.md)
+- Related plan: [docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md)
+- Related code: [apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx)
+- Related code: [apps/desktop/src/renderer/src/lib/useThreadNavigation.ts](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts)
+- Related code: [apps/desktop/src/main/app-server/backend-registry.ts](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/apps/desktop/src/main/app-server/backend-registry.ts)
+- Related code: [packages/agent-core/src/persistence/overlay-store.ts](/Users/huntharo/.codex/worktrees/c913/PwrAgnt/packages/agent-core/src/persistence/overlay-store.ts)

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { buildDirectorySummaries } from "../domain/directory-navigation";
+
+function buildThread(
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Desktop App",
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: {
+      inInbox: false,
+    },
+    updatedAt: 1_000,
+    executionMode: "default",
+    ...overrides,
+  };
+}
+
+describe("buildDirectorySummaries", () => {
+  it("groups linked threads under stable directory rows and counts needs-attention threads", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          inbox: { inInbox: true },
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-2",
+          inbox: { inInbox: false },
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "local",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+        label: "PwrAgnt",
+        threadKeys: ["codex:thread-1", "codex:thread-2"],
+        needsAttentionCount: 1,
+        latestUpdatedAt: 2_000,
+      }),
+    ]);
+  });
+
+  it("includes launchpad-only directories even when no current thread is linked", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/pwrdrvr/PwrAgnt": {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Draft prompt",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        launchpad: expect.objectContaining({
+          prompt: "Draft prompt",
+        }),
+      }),
+    ]);
+  });
+});

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -93,4 +93,52 @@ describe("buildDirectorySummaries", () => {
       }),
     ]);
   });
+
+  it("keeps same-named Codex worktrees as separate directory rows", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/repo-one/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-2",
+          linkedDirectories: [
+            {
+              id: "dir-2",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/repo-two/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toHaveLength(2);
+    expect(directories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "directory:/Users/huntharo/.codex/worktrees/repo-one/PwrAgnt",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/.codex/worktrees/repo-one/PwrAgnt",
+          threadKeys: ["codex:thread-1"],
+        }),
+        expect.objectContaining({
+          key: "directory:/Users/huntharo/.codex/worktrees/repo-two/PwrAgnt",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/.codex/worktrees/repo-two/PwrAgnt",
+          threadKeys: ["codex:thread-2"],
+        }),
+      ]),
+    );
+  });
 });

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -135,4 +135,53 @@ describe("OverlayStore", () => {
       lastSeenUpdatedAt: 2500,
     });
   });
+
+  it("persists directory launchpad drafts separately from real threads", async () => {
+    const store = await createStore();
+
+    await store.upsertDirectoryLaunchpad({
+      directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgnt",
+      directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+      backend: "codex",
+      executionMode: "full-access",
+      prompt: "Investigate the directories launchpad flow",
+      workMode: "worktree",
+      branchName: "main",
+      createdAt: 1000,
+      updatedAt: 2000,
+    });
+
+    const raw = JSON.parse(
+      await readFile(path.join(tempDirs[0]!, "overlay-state.json"), "utf8"),
+    ) as {
+      directoryLaunchpads: Record<string, { prompt?: string; executionMode?: string }>;
+      threads: Record<string, unknown>;
+    };
+
+    expect(raw.directoryLaunchpads["directory:/Users/huntharo/pwrdrvr/PwrAgnt"]).toMatchObject({
+      prompt: "Investigate the directories launchpad flow",
+      executionMode: "full-access",
+    });
+    expect(raw.threads).toEqual({});
+  });
+
+  it("persists launchpad defaults for future directory drafts", async () => {
+    const store = await createStore();
+
+    await store.setLaunchpadDefaults({
+      backend: "grok",
+      executionMode: "full-access",
+      reasoningEffort: "high",
+      fastMode: true,
+    });
+
+    expect(await store.getLaunchpadDefaults()).toEqual({
+      backend: "grok",
+      executionMode: "full-access",
+      reasoningEffort: "high",
+      fastMode: true,
+    });
+  });
 });

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -52,10 +52,12 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
     /^[\\/].*[\\/]\.codex[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
   );
   if (codexWorktreeMatch) {
+    const canonicalPath = directory.path.replace(/[\\/]+$/, "");
     return {
-      key: `directory:${codexWorktreeMatch[1]}`,
+      key: `directory:${canonicalPath}`,
       kind: "directory",
       label: codexWorktreeMatch[1],
+      path: canonicalPath,
     };
   }
 

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -1,0 +1,199 @@
+import type {
+  DirectoryLaunchpadOverlayState,
+  LinkedDirectorySummary,
+  NavigationDirectoryGitStatus,
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+
+type DirectoryDescriptor = Pick<
+  NavigationDirectorySummary,
+  "key" | "kind" | "label" | "path"
+>;
+
+function pathBaseName(value?: string): string {
+  if (!value) {
+    return value ?? "";
+  }
+
+  const normalized = value.replace(/[\\/]+$/, "");
+  const parts = normalized.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) ?? normalized;
+}
+
+function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
+  const scratchWorkspaceMatch = directory.path.match(
+    /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/,
+  );
+  if (scratchWorkspaceMatch) {
+    return {
+      key: `workspace:${scratchWorkspaceMatch[1]}`,
+      kind: "workspace",
+      label: "Workspaces",
+      path: scratchWorkspaceMatch[1],
+    };
+  }
+
+  const repoWorktreeMatch = directory.path.match(
+    /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/].*)?$/,
+  );
+  if (repoWorktreeMatch) {
+    const canonicalPath = repoWorktreeMatch[1];
+    return {
+      key: `directory:${canonicalPath}`,
+      kind: "directory",
+      label: pathBaseName(canonicalPath),
+      path: canonicalPath,
+    };
+  }
+
+  const codexWorktreeMatch = directory.path.match(
+    /^[\\/].*[\\/]\.codex[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
+  );
+  if (codexWorktreeMatch) {
+    return {
+      key: `directory:${codexWorktreeMatch[1]}`,
+      kind: "directory",
+      label: codexWorktreeMatch[1],
+    };
+  }
+
+  return {
+    key: `directory:${directory.path}`,
+    kind: "directory",
+    label: directory.label,
+    path: directory.path,
+  };
+}
+
+function collectStablePathByLabel(
+  threads: NavigationThreadSummary[],
+): Map<string, string | undefined> {
+  const pathsByLabel = new Map<string, Set<string>>();
+
+  for (const thread of threads) {
+    for (const directory of thread.linkedDirectories) {
+      const descriptor = classifyDirectory(directory);
+      if (!descriptor.path || descriptor.kind !== "directory") {
+        continue;
+      }
+
+      const paths = pathsByLabel.get(descriptor.label) ?? new Set<string>();
+      paths.add(descriptor.path);
+      pathsByLabel.set(descriptor.label, paths);
+    }
+  }
+
+  return new Map(
+    [...pathsByLabel.entries()].map(([label, paths]) => [
+      label,
+      paths.size === 1 ? [...paths][0] : undefined,
+    ]),
+  );
+}
+
+function ensureSummary(
+  summaries: Map<string, NavigationDirectorySummary>,
+  descriptor: DirectoryDescriptor,
+): NavigationDirectorySummary {
+  const existing = summaries.get(descriptor.key);
+  if (existing) {
+    return existing;
+  }
+
+  const created: NavigationDirectorySummary = {
+    key: descriptor.key,
+    kind: descriptor.kind,
+    label: descriptor.label,
+    path: descriptor.path,
+    threadKeys: [],
+    needsAttentionCount: 0,
+  };
+  summaries.set(descriptor.key, created);
+  return created;
+}
+
+export function buildDirectorySummaries(params: {
+  threads: NavigationThreadSummary[];
+  launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
+  gitStatusByKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
+}): NavigationDirectorySummary[] {
+  const summaries = new Map<string, NavigationDirectorySummary>();
+  const stablePathByLabel = collectStablePathByLabel(params.threads);
+
+  for (const thread of params.threads) {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+
+    if (thread.linkedDirectories.length === 0) {
+      if (!thread.projectKey?.trim()) {
+        const summary = ensureSummary(summaries, {
+          key: "unlinked",
+          kind: "unlinked",
+          label: "No linked directory",
+        });
+        if (!summary.threadKeys.includes(threadKey)) {
+          summary.threadKeys.push(threadKey);
+        }
+        if (thread.inbox.inInbox) {
+          summary.needsAttentionCount += 1;
+        }
+        summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, thread.updatedAt ?? 0);
+      }
+      continue;
+    }
+
+    const seenDescriptors = new Set<string>();
+    for (const directory of thread.linkedDirectories) {
+      const descriptor = classifyDirectory(directory);
+      const normalizedDescriptor =
+        descriptor.path || descriptor.kind !== "directory"
+          ? descriptor
+          : stablePathByLabel.get(descriptor.label)
+            ? {
+                ...descriptor,
+                key: `directory:${stablePathByLabel.get(descriptor.label)}`,
+                path: stablePathByLabel.get(descriptor.label),
+              }
+            : descriptor;
+      if (seenDescriptors.has(normalizedDescriptor.key)) {
+        continue;
+      }
+      seenDescriptors.add(normalizedDescriptor.key);
+      const summary = ensureSummary(summaries, normalizedDescriptor);
+      if (!summary.threadKeys.includes(threadKey)) {
+        summary.threadKeys.push(threadKey);
+      }
+      if (thread.inbox.inInbox) {
+        summary.needsAttentionCount += 1;
+      }
+      summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, thread.updatedAt ?? 0);
+    }
+  }
+
+  for (const [directoryKey, launchpad] of Object.entries(params.launchpadsByKey ?? {})) {
+    if (!launchpad) {
+      continue;
+    }
+    const summary = ensureSummary(summaries, {
+      key: directoryKey,
+      kind: launchpad.directoryKind,
+      label: launchpad.directoryLabel,
+      path: launchpad.directoryPath,
+    });
+    summary.launchpad = launchpad;
+    summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, launchpad.updatedAt);
+  }
+
+  for (const [directoryKey, gitStatus] of Object.entries(params.gitStatusByKey ?? {})) {
+    if (!gitStatus) {
+      continue;
+    }
+    const summary = summaries.get(directoryKey);
+    if (summary) {
+      summary.gitStatus = gitStatus;
+    }
+  }
+
+  return [...summaries.values()].sort((left, right) => left.label.localeCompare(right.label));
+}

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -1,13 +1,17 @@
 import type {
+  DirectoryLaunchpadOverlayState,
+  NavigationDirectoryGitStatus,
   AppServerBackendScope,
   AppServerThreadSummary,
   LinkedDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
+  NavigationLaunchpadDefaults,
   ThreadOverlayState,
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { deriveInboxState, rankInboxThreadKeys } from "./inbox";
+import { buildDirectorySummaries } from "./directory-navigation";
 
 function dedupeLinkedDirectories(
   directories: LinkedDirectorySummary[],
@@ -60,6 +64,9 @@ export function buildNavigationSnapshot(params: {
   fetchedAt: number;
   firstSnapshot: boolean;
   now?: number;
+  gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
+  launchpadDefaults?: NavigationLaunchpadDefaults;
+  launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
@@ -79,11 +86,22 @@ export function buildNavigationSnapshot(params: {
     unchanged: params.unchanged,
     threads,
     inboxThreadKeys: rankInboxThreadKeys(threads),
+    directories: buildDirectorySummaries({
+      threads,
+      launchpadsByKey: params.launchpadsByKey,
+      gitStatusByKey: params.gitStatusByDirectoryKey,
+    }),
+    launchpadDefaults: params.launchpadDefaults ?? {
+      backend: "codex",
+      executionMode: "default",
+    },
   };
 }
 
 export function buildNavigationSnapshotHash(params: {
   backend: AppServerBackendScope;
+  directories?: NavigationSnapshot["directories"];
+  launchpadDefaults?: NavigationLaunchpadDefaults;
   threads: NavigationThreadSummary[];
 }): string {
   return JSON.stringify({
@@ -109,5 +127,38 @@ export function buildNavigationSnapshotHash(params: {
         lastSeenUpdatedAt: thread.inbox.lastSeenUpdatedAt ?? null,
       },
     })),
+    directories: (params.directories ?? []).map((directory) => ({
+      key: directory.key,
+      kind: directory.kind,
+      label: directory.label,
+      path: directory.path ?? null,
+      threadKeys: directory.threadKeys,
+      needsAttentionCount: directory.needsAttentionCount,
+      latestUpdatedAt: directory.latestUpdatedAt ?? null,
+      launchpad: directory.launchpad
+        ? {
+            backend: directory.launchpad.backend,
+            executionMode: directory.launchpad.executionMode,
+            prompt: directory.launchpad.prompt,
+            workMode: directory.launchpad.workMode,
+            branchName: directory.launchpad.branchName ?? null,
+            updatedAt: directory.launchpad.updatedAt,
+          }
+        : null,
+      gitStatus: directory.gitStatus
+        ? {
+            currentBranch: directory.gitStatus.currentBranch ?? null,
+            upstreamBranch: directory.gitStatus.upstreamBranch ?? null,
+            ahead: directory.gitStatus.ahead ?? null,
+            behind: directory.gitStatus.behind ?? null,
+            branches: directory.gitStatus.branches ?? [],
+            syncState: directory.gitStatus.syncState ?? null,
+          }
+        : null,
+    })),
+    launchpadDefaults: params.launchpadDefaults ?? {
+      backend: "codex",
+      executionMode: "default",
+    },
   });
 }

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -1,12 +1,14 @@
 import type {
   AppServerBackendKind,
   AppServerBackendScope,
+  DirectoryLaunchpadOverlayState,
+  NavigationLaunchpadDefaults,
   ThreadExecutionMode,
   ThreadOverlayState,
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 
-export const CURRENT_OVERLAY_STORE_VERSION = 3;
+export const CURRENT_OVERLAY_STORE_VERSION = 4;
 
 export type OverlayStoreData = {
   version: number;
@@ -28,6 +30,8 @@ export type OverlayStoreData = {
         >
       >
   >;
+  launchpadDefaults: NavigationLaunchpadDefaults;
+  directoryLaunchpads: Record<string, DirectoryLaunchpadOverlayState>;
   threads: Record<string, ThreadOverlayState>;
 };
 
@@ -60,6 +64,11 @@ function migrateBackendState(
 const EMPTY_OVERLAY_STORE_DATA: OverlayStoreData = {
   version: CURRENT_OVERLAY_STORE_VERSION,
   backends: {},
+  launchpadDefaults: {
+    backend: "codex",
+    executionMode: "default",
+  },
+  directoryLaunchpads: {},
   threads: {},
 };
 
@@ -84,6 +93,8 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
   const version =
     typeof record.version === "number" ? record.version : CURRENT_OVERLAY_STORE_VERSION;
   const backendsRecord = asRecord(record.backends) ?? {};
+  const launchpadDefaultsRecord = asRecord(record.launchpadDefaults) ?? {};
+  const directoryLaunchpadsRecord = asRecord(record.directoryLaunchpads) ?? {};
   const threadsRecord = asRecord(record.threads) ?? {};
 
   return {
@@ -93,6 +104,92 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
       grok: migrateBackendState("grok", backendsRecord.grok),
       all: migrateBackendState("all", backendsRecord.all),
     },
+    launchpadDefaults: {
+      backend:
+        launchpadDefaultsRecord.backend === "grok" ||
+        launchpadDefaultsRecord.backend === "codex"
+          ? (launchpadDefaultsRecord.backend as AppServerBackendKind)
+          : "codex",
+      executionMode: normalizeExecutionMode(launchpadDefaultsRecord.executionMode),
+      model:
+        typeof launchpadDefaultsRecord.model === "string"
+          ? launchpadDefaultsRecord.model
+          : undefined,
+      reasoningEffort:
+        typeof launchpadDefaultsRecord.reasoningEffort === "string"
+          ? launchpadDefaultsRecord.reasoningEffort
+          : undefined,
+      serviceTier:
+        typeof launchpadDefaultsRecord.serviceTier === "string"
+          ? launchpadDefaultsRecord.serviceTier
+          : undefined,
+      fastMode:
+        typeof launchpadDefaultsRecord.fastMode === "boolean"
+          ? launchpadDefaultsRecord.fastMode
+          : undefined,
+    },
+    directoryLaunchpads: Object.fromEntries(
+      Object.entries(directoryLaunchpadsRecord).map(([directoryKey, value]) => {
+        const launchpadRecord = asRecord(value) ?? {};
+        const now = Date.now();
+        return [
+          directoryKey,
+          {
+            directoryKey,
+            directoryKind:
+              launchpadRecord.directoryKind === "workspace" ||
+              launchpadRecord.directoryKind === "unlinked"
+                ? launchpadRecord.directoryKind
+                : "directory",
+            directoryLabel:
+              typeof launchpadRecord.directoryLabel === "string"
+                ? launchpadRecord.directoryLabel
+                : directoryKey,
+            directoryPath:
+              typeof launchpadRecord.directoryPath === "string"
+                ? launchpadRecord.directoryPath
+                : undefined,
+            backend:
+              launchpadRecord.backend === "grok" || launchpadRecord.backend === "codex"
+                ? (launchpadRecord.backend as AppServerBackendKind)
+                : "codex",
+            executionMode: normalizeExecutionMode(launchpadRecord.executionMode),
+            prompt:
+              typeof launchpadRecord.prompt === "string" ? launchpadRecord.prompt : "",
+            workMode:
+              launchpadRecord.workMode === "worktree" ? "worktree" : "local",
+            branchName:
+              typeof launchpadRecord.branchName === "string"
+                ? launchpadRecord.branchName
+                : undefined,
+            model:
+              typeof launchpadRecord.model === "string"
+                ? launchpadRecord.model
+                : undefined,
+            reasoningEffort:
+              typeof launchpadRecord.reasoningEffort === "string"
+                ? launchpadRecord.reasoningEffort
+                : undefined,
+            serviceTier:
+              typeof launchpadRecord.serviceTier === "string"
+                ? launchpadRecord.serviceTier
+                : undefined,
+            fastMode:
+              typeof launchpadRecord.fastMode === "boolean"
+                ? launchpadRecord.fastMode
+                : undefined,
+            createdAt:
+              typeof launchpadRecord.createdAt === "number"
+                ? launchpadRecord.createdAt
+                : now,
+            updatedAt:
+              typeof launchpadRecord.updatedAt === "number"
+                ? launchpadRecord.updatedAt
+                : now,
+          } satisfies DirectoryLaunchpadOverlayState,
+        ];
+      }),
+    ),
     threads: Object.fromEntries(
       Object.entries(threadsRecord).map(([rawKey, value]) => {
         const threadRecord = asRecord(value) ?? {};

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -3,8 +3,11 @@ import path from "node:path";
 import type {
   AppServerBackendScope,
   AppServerThreadSummary,
+  DirectoryLaunchpadOverlayState,
   LinkedDirectorySummary,
   MarkThreadSeenResponse,
+  NavigationDirectoryGitStatus,
+  NavigationLaunchpadDefaults,
   NavigationSnapshot,
   ThreadExecutionMode,
   ThreadOverlayState,
@@ -28,6 +31,7 @@ export class OverlayStore {
   async reconcileNavigationSnapshot(params: {
     backend: AppServerBackendScope;
     fetchedAt: number;
+    gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
     threads: AppServerThreadSummary[];
   }): Promise<NavigationSnapshot> {
     return await this.withData(async (data) => {
@@ -61,6 +65,9 @@ export class OverlayStore {
         backend: params.backend,
         fetchedAt: params.fetchedAt,
         firstSnapshot,
+        gitStatusByDirectoryKey: params.gitStatusByDirectoryKey,
+        launchpadDefaults: data.launchpadDefaults,
+        launchpadsByKey: data.directoryLaunchpads,
         overlayByThreadKey,
         previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
         threads: params.threads,
@@ -69,6 +76,8 @@ export class OverlayStore {
 
       const nextHash = buildNavigationSnapshotHash({
         backend: params.backend,
+        directories: snapshot.directories,
+        launchpadDefaults: snapshot.launchpadDefaults,
         threads: snapshot.threads,
       });
       const unchanged = backendState?.lastSnapshotHash === nextHash;
@@ -189,6 +198,55 @@ export class OverlayStore {
     });
   }
 
+  async getLaunchpadDefaults(): Promise<NavigationLaunchpadDefaults> {
+    return await this.withData(async (data) => data.launchpadDefaults);
+  }
+
+  async setLaunchpadDefaults(
+    patch: Partial<NavigationLaunchpadDefaults>,
+  ): Promise<NavigationLaunchpadDefaults> {
+    return await this.withData(async (data) => {
+      data.launchpadDefaults = {
+        ...data.launchpadDefaults,
+        ...patch,
+      };
+      return data.launchpadDefaults;
+    });
+  }
+
+  async getDirectoryLaunchpad(params: {
+    directoryKey: string;
+  }): Promise<DirectoryLaunchpadOverlayState | undefined> {
+    return await this.withData(async (data) => data.directoryLaunchpads[params.directoryKey]);
+  }
+
+  async listDirectoryLaunchpads(): Promise<DirectoryLaunchpadOverlayState[]> {
+    return await this.withData(async (data) => Object.values(data.directoryLaunchpads));
+  }
+
+  async upsertDirectoryLaunchpad(
+    launchpad: DirectoryLaunchpadOverlayState,
+  ): Promise<DirectoryLaunchpadOverlayState> {
+    return await this.withData(async (data) => {
+      const current = data.directoryLaunchpads[launchpad.directoryKey];
+      const nextLaunchpad: DirectoryLaunchpadOverlayState = {
+        ...current,
+        ...launchpad,
+        createdAt: current?.createdAt ?? launchpad.createdAt,
+      };
+      data.directoryLaunchpads[launchpad.directoryKey] = nextLaunchpad;
+      return nextLaunchpad;
+    });
+  }
+
+  async resetDirectoryLaunchpad(params: {
+    directoryKey: string;
+  }): Promise<void> {
+    await this.withData(async (data) => {
+      delete data.directoryLaunchpads[params.directoryKey];
+    });
+  }
+
   private async withData<T>(
     operation: (data: OverlayStoreData) => Promise<T> | T,
   ): Promise<T> {
@@ -216,6 +274,11 @@ export class OverlayStore {
         return migrateOverlayStoreData({
           version: CURRENT_OVERLAY_STORE_VERSION,
           backends: {},
+          launchpadDefaults: {
+            backend: "codex",
+            executionMode: "default",
+          },
+          directoryLaunchpads: {},
           threads: {},
         });
       }

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -5,6 +5,12 @@ import type {
   AppServerTurnInputItem,
   ThreadIdentifier,
 } from "./app-server";
+import type {
+  DirectorySummaryKind,
+  LaunchpadWorkMode,
+  NavigationLaunchpadDraft,
+  NavigationLaunchpadDefaults,
+} from "./navigation";
 
 export type StartThreadRequest = {
   backend: AppServerBackendKind;
@@ -75,6 +81,67 @@ export type SubmitServerRequestResponse = {
   threadId: ThreadIdentifier;
   runId?: string;
   requestId: string;
+};
+
+export type EnsureDirectoryLaunchpadRequest = {
+  directoryKey: string;
+  directoryKind: DirectorySummaryKind;
+  directoryLabel: string;
+  directoryPath?: string;
+  currentBranch?: string;
+  preferredBackend?: AppServerBackendKind;
+};
+
+export type EnsureDirectoryLaunchpadResponse = {
+  launchpad: NavigationLaunchpadDraft;
+  defaults: NavigationLaunchpadDefaults;
+};
+
+export type UpdateDirectoryLaunchpadRequest = {
+  directoryKey: string;
+  patch: Partial<
+    Pick<
+      NavigationLaunchpadDraft,
+      | "prompt"
+      | "backend"
+      | "executionMode"
+      | "model"
+      | "reasoningEffort"
+      | "serviceTier"
+      | "fastMode"
+      | "workMode"
+      | "branchName"
+      | "directoryLabel"
+      | "directoryPath"
+    >
+  >;
+};
+
+export type UpdateDirectoryLaunchpadResponse = {
+  launchpad: NavigationLaunchpadDraft;
+  defaults: NavigationLaunchpadDefaults;
+};
+
+export type ResetDirectoryLaunchpadRequest = {
+  directoryKey: string;
+};
+
+export type ResetDirectoryLaunchpadResponse = {
+  directoryKey: string;
+  defaults: NavigationLaunchpadDefaults;
+};
+
+export type MaterializeDirectoryLaunchpadRequest = {
+  directoryKey: string;
+  input?: AppServerTurnInputItem[];
+};
+
+export type MaterializeDirectoryLaunchpadResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  runId?: string;
+  executionMode: ThreadExecutionMode;
+  workMode: LaunchpadWorkMode;
 };
 
 export type AgentEvent = {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -71,9 +71,7 @@ export type SubmitServerRequestRequest = {
   threadId: ThreadIdentifier;
   runId?: string;
   requestId: string;
-  response: {
-    decision: "approve" | "decline" | "cancel";
-  };
+  response: Record<string, unknown>;
 };
 
 export type SubmitServerRequestResponse = {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -14,6 +14,21 @@ export type BackendCapabilities = {
   multiDirectoryThreads: boolean;
 };
 
+export type BackendModelOption = {
+  id: string;
+  label?: string;
+  current?: boolean;
+  supportsReasoning?: boolean;
+  supportsFast?: boolean;
+};
+
+export type BackendLaunchpadOptions = {
+  models?: BackendModelOption[];
+  reasoningEfforts?: string[];
+  serviceTiers?: string[];
+  supportsFastMode?: boolean;
+};
+
 export type BackendSummary = {
   kind: AppServerBackendKind;
   label: string;
@@ -29,6 +44,7 @@ export type BackendSummary = {
     isDefault?: boolean;
     unavailableReason?: string;
   }>;
+  launchpadOptions?: BackendLaunchpadOptions;
   unavailableReason?: string;
 };
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -20,6 +20,58 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
 };
 
+export type DirectorySummaryKind = "directory" | "workspace" | "unlinked";
+export type LaunchpadWorkMode = "local" | "worktree";
+
+export type NavigationLaunchpadDefaults = {
+  backend: AppServerBackendKind;
+  executionMode: ThreadExecutionMode;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+};
+
+export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
+  directoryKey: string;
+  directoryKind: DirectorySummaryKind;
+  directoryLabel: string;
+  directoryPath?: string;
+  prompt: string;
+  workMode: LaunchpadWorkMode;
+  branchName?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type NavigationDirectoryGitStatus = {
+  currentBranch?: string;
+  upstreamBranch?: string;
+  ahead?: number;
+  behind?: number;
+  branches?: string[];
+  syncState?:
+    | "in-sync"
+    | "ahead"
+    | "behind"
+    | "diverged"
+    | "untracked"
+    | "status-unavailable";
+  statusUnavailableReason?: string;
+};
+
+export type NavigationDirectorySummary = {
+  key: string;
+  kind: DirectorySummaryKind;
+  label: string;
+  path?: string;
+  threadKeys: string[];
+  needsAttentionCount: number;
+  latestUpdatedAt?: number;
+  gitStatus?: NavigationDirectoryGitStatus;
+  launchpad?: NavigationLaunchpadDraft;
+};
+
 export function buildThreadIdentityKey(
   backend: AppServerBackendKind,
   threadId: ThreadIdentifier,
@@ -33,6 +85,8 @@ export type NavigationSnapshot = {
   unchanged: boolean;
   threads: NavigationThreadSummary[];
   inboxThreadKeys: string[];
+  directories: NavigationDirectorySummary[];
+  launchpadDefaults: NavigationLaunchpadDefaults;
 };
 
 export type GetNavigationSnapshotRequest = {
@@ -64,3 +118,5 @@ export type ThreadOverlayState = {
   snoozedUntil?: number;
   extraLinkedDirectories: LinkedDirectorySummary[];
 };
+
+export type DirectoryLaunchpadOverlayState = NavigationLaunchpadDraft;


### PR DESCRIPTION
## Summary
Rework the desktop Directories flow around persistent per-directory launchpads, move thread setup controls into the composer, and fix Codex exec approval handling end to end.

## What changed
- persist one launchpad draft per directory in overlay state so unsent prompt text and sticky defaults survive navigation until first send materializes a real thread
- rebuild the Directories lens into denser expandable rows that stay visually closer to Recents, add the `+` launchpad entrypoint, tighten unread/thread counts, and surface Git directory metadata needed for local-vs-worktree planning
- move access and workspace context into the composer and thread detail flow, including sticky launchpad defaults, compact selectors, and thread execution mode wiring through the desktop IPC and backend registry
- add Git-aware directory status plumbing for branch, upstream, and sync state so launchpads and directory rows can show the current checkout context without inventing a separate workflow yet
- fix approval request normalization in the Codex JSON-RPC client so desktop receives stable request ids and thread/run metadata even when the app server uses native RPC envelope ids
- fix approval response handling in thread detail so command execution approvals map to the native decision values, dismiss correctly after approval, and clear stale approval UI when assistant output resumes
- harden the replay harness for concurrent and repeated read-only responses, add replay-client regression coverage, and add replay-backed desktop E2E coverage for the approval pending and approval dismissal flows
- ignore local `.worktrees/` directories

## Verification
- `pnpm typecheck`
- `pnpm vitest run packages/agent-core/src/__tests__/overlay-store.test.ts packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/replay-client.test.ts`
- `pnpm vitest run --environment jsdom apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragnt/desktop test:e2e -- approval-pending.spec.ts`
