### PR TITLE
fix(desktop): rebuild thread refresh model and lazy skill loading

### DIFF
--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -24,23 +24,6 @@
       }
     },
     {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": [
-          "thread/list",
-          "thread/read",
-          "skills/list",
-          "turn/start"
-        ]
-      }
-    },
-    {
       "id": "thread-list-1",
       "kind": "response",
       "method": "thread/list",
@@ -60,33 +43,6 @@
           "updatedAt": 1760000001000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-approval-pending",
-          "title": "Approval pending replay",
-          "titleSource": "explicit",
-          "summary": "Replay seeded approval request",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1760000001000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",
@@ -134,56 +90,6 @@
       "result": {
         "threadId": "thread-approval-pending",
         "runId": "turn-approval-2"
-      }
-    },
-    {
-      "id": "thread-read-2",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "user",
-            "text": "Need approval coverage."
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "assistant",
-            "text": "Ready for approval coverage."
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "user",
-            "text": "Read /etc/hosts and tell me the first three lines."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "user",
-            "text": "Need approval coverage."
-          },
-          {
-            "id": "message-2",
-            "role": "assistant",
-            "text": "Ready for approval coverage."
-          },
-          {
-            "id": "message-3",
-            "role": "user",
-            "text": "Read /etc/hosts and tell me the first three lines."
-          }
-        ],
-        "lastUserMessage": "Read /etc/hosts and tell me the first three lines.",
-        "lastAssistantMessage": "Ready for approval coverage.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
-        }
       }
     },
     {

--- a/apps/desktop/e2e/fixtures/codex-todo-list/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/codex-todo-list/replay.fixture.json
@@ -15,19 +15,11 @@
           "name": "Replay Codex",
           "version": "1.0.0"
         },
-        "methods": ["thread/list", "thread/read", "skills/list"]
-      }
-    },
-    {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": ["thread/list", "thread/read", "skills/list"]
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
       }
     },
     {
@@ -50,33 +42,6 @@
           "updatedAt": 1776562836000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "019ce224-97ac-7c01-a2ae-55da8b7a4006",
-          "title": "Add AGENTS docs for media VCL",
-          "titleSource": "explicit",
-          "summary": "Captured Codex thread with a persisted task plan",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1776562836000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",

--- a/apps/desktop/e2e/fixtures/edited-changes-order/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/edited-changes-order/replay.fixture.json
@@ -23,6 +23,22 @@
       }
     },
     {
+      "id": "initialize-2",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
       "id": "thread-list-1",
       "kind": "response",
       "method": "thread/list",
@@ -42,6 +58,33 @@
           "updatedAt": 1760000000000
         }
       ]
+    },
+    {
+      "id": "thread-list-2",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-edited-changes",
+          "title": "Edited changes ordering",
+          "titleSource": "explicit",
+          "summary": "Verify expanded diffs stay in transcript order",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": []
     },
     {
       "id": "thread-read-1",

--- a/apps/desktop/e2e/fixtures/edited-changes-order/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/edited-changes-order/replay.fixture.json
@@ -23,22 +23,6 @@
       }
     },
     {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": [
-          "thread/list",
-          "thread/read",
-          "skills/list"
-        ]
-      }
-    },
-    {
       "id": "thread-list-1",
       "kind": "response",
       "method": "thread/list",
@@ -58,33 +42,6 @@
           "updatedAt": 1760000000000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-edited-changes",
-          "title": "Edited changes ordering",
-          "titleSource": "explicit",
-          "summary": "Verify expanded diffs stay in transcript order",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1760000000000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",

--- a/apps/desktop/e2e/fixtures/grok-todo-list/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/grok-todo-list/replay.fixture.json
@@ -14,44 +14,15 @@
           "name": "Replay Grok",
           "version": "1.0.0"
         },
-        "methods": ["thread/list", "thread/read", "skills/list"]
-      }
-    },
-    {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Grok",
-          "version": "1.0.0"
-        },
-        "methods": ["thread/list", "thread/read", "skills/list"]
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
       }
     },
     {
       "id": "thread-list-1",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-3mefc6i7",
-          "title": "Grok to-do list replay",
-          "titleSource": "explicit",
-          "summary": "Contract fixture for Grok-backed task plan rendering",
-          "source": "grok",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1776563200000
-        }
-      ]
-    },
-    {
-      "id": "thread-list-2",
       "kind": "response",
       "method": "thread/list",
       "result": [

--- a/apps/desktop/e2e/fixtures/live-plan-updates/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/live-plan-updates/replay.fixture.json
@@ -14,19 +14,12 @@
           "name": "Replay Codex",
           "version": "1.0.0"
         },
-        "methods": ["thread/list", "thread/read", "skills/list", "turn/start"]
-      }
-    },
-    {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": ["thread/list", "thread/read", "skills/list", "turn/start"]
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start"
+        ]
       }
     },
     {
@@ -49,33 +42,6 @@
           "updatedAt": 1776563600000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-live-plan-updates",
-          "title": "Live plan updates replay",
-          "titleSource": "explicit",
-          "summary": "Replay seeded live plan update lifecycle",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1776563600000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",
@@ -111,45 +77,6 @@
       "result": {
         "threadId": "thread-live-plan-updates",
         "runId": "turn-live-plan-1"
-      }
-    },
-    {
-      "id": "thread-read-2",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          }
-        ],
-        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
-        "lastAssistantMessage": "Ready for the next renderer check.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
-        }
       }
     },
     {
@@ -216,194 +143,6 @@
         "params": {
           "threadId": "thread-live-plan-updates",
           "turnId": "turn-live-plan-1"
-        }
-      }
-    },
-    {
-      "id": "thread-list-3",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-live-plan-updates",
-          "title": "Live plan updates replay",
-          "titleSource": "explicit",
-          "summary": "Replay seeded live plan update lifecycle",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1776563600000
-        }
-      ]
-    },
-    {
-      "id": "thread-list-4",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-live-plan-updates",
-          "title": "Live plan updates replay",
-          "titleSource": "explicit",
-          "summary": "Replay seeded live plan update lifecycle",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1776563600000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-2",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
-    },
-    {
-      "id": "thread-read-3",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          },
-          {
-            "type": "plan",
-            "id": "persisted-plan-1",
-            "createdAt": 1776563601000,
-            "explanation": "Check the shared contract and transcript renderer before summarizing the dependency.",
-            "steps": [
-              {
-                "step": "Inspect AppServerThreadPlanEntry",
-                "status": "completed"
-              },
-              {
-                "step": "Inspect TranscriptPlan rendering",
-                "status": "in_progress"
-              },
-              {
-                "step": "Summarize renderer dependency",
-                "status": "pending"
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "assistant",
-            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          },
-          {
-            "id": "message-3",
-            "role": "assistant",
-            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
-          }
-        ],
-        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
-        "lastAssistantMessage": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
-        }
-      }
-    },
-    {
-      "id": "thread-read-4",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          },
-          {
-            "type": "plan",
-            "id": "persisted-plan-1",
-            "createdAt": 1776563601000,
-            "explanation": "Check the shared contract and transcript renderer before summarizing the dependency.",
-            "steps": [
-              {
-                "step": "Inspect AppServerThreadPlanEntry",
-                "status": "completed"
-              },
-              {
-                "step": "Inspect TranscriptPlan rendering",
-                "status": "in_progress"
-              },
-              {
-                "step": "Summarize renderer dependency",
-                "status": "pending"
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "assistant",
-            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "assistant",
-            "text": "Ready for the next renderer check."
-          },
-          {
-            "id": "message-2",
-            "role": "user",
-            "text": "Create a three-step task list before you inspect the renderer."
-          },
-          {
-            "id": "message-3",
-            "role": "assistant",
-            "text": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting."
-          }
-        ],
-        "lastUserMessage": "Create a three-step task list before you inspect the renderer.",
-        "lastAssistantMessage": "The renderer is using the same normalized plan contract the backend emits, so the UI depends on that shared shape rather than backend-specific formatting.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
         }
       }
     }

--- a/apps/desktop/e2e/fixtures/smoke/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/smoke/replay.fixture.json
@@ -14,19 +14,11 @@
           "name": "Replay Codex",
           "version": "1.0.0"
         },
-        "methods": ["thread/list", "thread/read", "skills/list"]
-      }
-    },
-    {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": ["thread/list", "thread/read", "skills/list"]
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
       }
     },
     {
@@ -49,33 +41,6 @@
           "updatedAt": 1760000000000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-smoke",
-          "title": "Replay smoke thread",
-          "titleSource": "explicit",
-          "summary": "Desktop replay smoke test",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1760000000000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",

--- a/apps/desktop/e2e/fixtures/turn-lifecycle/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/turn-lifecycle/replay.fixture.json
@@ -24,23 +24,6 @@
       }
     },
     {
-      "id": "initialize-2",
-      "kind": "response",
-      "method": "initialize",
-      "result": {
-        "serverInfo": {
-          "name": "Replay Codex",
-          "version": "1.0.0"
-        },
-        "methods": [
-          "thread/list",
-          "thread/read",
-          "skills/list",
-          "turn/start"
-        ]
-      }
-    },
-    {
       "id": "thread-list-1",
       "kind": "response",
       "method": "thread/list",
@@ -60,33 +43,6 @@
           "updatedAt": 1760000000000
         }
       ]
-    },
-    {
-      "id": "thread-list-2",
-      "kind": "response",
-      "method": "thread/list",
-      "result": [
-        {
-          "id": "thread-turn-lifecycle",
-          "title": "Turn lifecycle replay",
-          "titleSource": "explicit",
-          "summary": "Replay seeded turn lifecycle",
-          "source": "codex",
-          "executionMode": "default",
-          "linkedDirectories": [],
-          "inbox": {
-            "inInbox": true,
-            "reason": "new-thread"
-          },
-          "updatedAt": 1760000000000
-        }
-      ]
-    },
-    {
-      "id": "skills-list-1",
-      "kind": "response",
-      "method": "skills/list",
-      "result": []
     },
     {
       "id": "thread-read-1",
@@ -134,56 +90,6 @@
       "result": {
         "threadId": "thread-turn-lifecycle",
         "runId": "turn-turn-lifecycle-2"
-      }
-    },
-    {
-      "id": "thread-read-2",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "lastUserMessage": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn.",
-        "lastAssistantMessage": "lifecycle baseline ready",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
-        }
       }
     },
     {
@@ -271,128 +177,6 @@
               }
             ]
           }
-        }
-      }
-    },
-    {
-      "id": "thread-read-3",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          },
-          {
-            "type": "message",
-            "id": "message-4",
-            "role": "assistant",
-            "text": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          },
-          {
-            "id": "message-4",
-            "role": "assistant",
-            "text": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "lastUserMessage": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn.",
-        "lastAssistantMessage": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
-        }
-      }
-    },
-    {
-      "id": "thread-read-4",
-      "kind": "response",
-      "method": "thread/read",
-      "result": {
-        "entries": [
-          {
-            "type": "message",
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "type": "message",
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          },
-          {
-            "type": "message",
-            "id": "message-4",
-            "role": "assistant",
-            "text": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "messages": [
-          {
-            "id": "message-1",
-            "role": "user",
-            "text": "Reply exactly with: lifecycle baseline ready"
-          },
-          {
-            "id": "message-2",
-            "role": "assistant",
-            "text": "lifecycle baseline ready"
-          },
-          {
-            "id": "message-3",
-            "role": "user",
-            "text": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          },
-          {
-            "id": "message-4",
-            "role": "assistant",
-            "text": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
-          }
-        ],
-        "lastUserMessage": "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn.",
-        "lastAssistantMessage": "Created /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn.",
-        "pagination": {
-          "supportsPagination": false,
-          "hasPreviousPage": false
         }
       }
     }

--- a/apps/desktop/e2e/smoke.spec.ts
+++ b/apps/desktop/e2e/smoke.spec.ts
@@ -5,7 +5,7 @@ import { launchElectronApp } from "./fixtures/electron-app";
 
 const smokeSpecDir = path.dirname(fileURLToPath(import.meta.url));
 
-test("loads the desktop shell from a replay fixture", async () => {
+test("loads the desktop shell without eager skill or manual refresh requests", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
       smokeSpecDir,
@@ -22,6 +22,12 @@ test("loads the desktop shell from a replay fixture", async () => {
       })
     ).toBeVisible();
     await expect(app.window.getByText("The replay harness is live.")).toBeVisible();
+    await expect(
+      app.window.getByRole("button", { name: /Refresh threads/i })
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: /^Refresh$/i })
+    ).toHaveCount(0);
     await expect(
       app.window.getByRole("button", {
         name: "Open context rail"

--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -166,6 +166,18 @@ describe("DesktopBackendRegistry replay isolation", () => {
       },
       steps: [
         {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: {
+              name: "Replay Codex",
+              version: "1.0.0"
+            },
+            methods: ["thread/list"]
+          }
+        },
+        {
           id: "list-1",
           kind: "response",
           method: "thread/list",
@@ -192,6 +204,18 @@ describe("DesktopBackendRegistry replay isolation", () => {
         scenario: "registry-replay-grok"
       },
       steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: {
+              name: "Replay Grok",
+              version: "1.0.0"
+            },
+            methods: ["thread/list"]
+          }
+        },
         {
           id: "list-1",
           kind: "response",

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -52,6 +52,18 @@ describe("DesktopBackendRegistry replay integration", () => {
       },
       steps: [
         {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: {
+              name: "Replay Codex",
+              version: "1.0.0"
+            },
+            methods: ["thread/read"]
+          }
+        },
+        {
           id: "read-1",
           kind: "response",
           method: "thread/read",

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -33,6 +33,8 @@ export class ReplayClient {
       request: AppServerPendingRequestNotification
     ) => Promise<unknown> | unknown
   >();
+  private initializeResult?: InitializeResult;
+  private initializePromise?: Promise<InitializeResult>;
 
   constructor(private readonly controller: ReplayController) {}
 
@@ -45,10 +47,11 @@ export class ReplayClient {
   }
 
   async getInitializeResult(): Promise<InitializeResult> {
-    return asInitializeResult(this.controller.consumeResponse("initialize").result);
+    return await this.ensureInitialized();
   }
 
   async listThreads(_params?: { filter?: string }): Promise<AppServerThreadSummary[]> {
+    await this.ensureInitialized();
     return asThreadList(this.controller.consumeResponse("thread/list").result);
   }
 
@@ -56,6 +59,7 @@ export class ReplayClient {
     cwd?: string;
     cwds?: string[];
   }): Promise<AppServerListSkillsResponse["data"]> {
+    await this.ensureInitialized();
     return asSkillList(this.controller.consumeResponse("skills/list").result);
   }
 
@@ -84,6 +88,7 @@ export class ReplayClient {
     before?: string;
     limit?: number;
   }): Promise<AppServerReadThreadResponse["replay"]> {
+    await this.ensureInitialized();
     return asThreadReplay(this.controller.consumeResponse("thread/read").result);
   }
 
@@ -95,6 +100,7 @@ export class ReplayClient {
     serviceTier?: string;
     reasoningEffort?: string;
   }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
     return this.controller.consumeResponse("thread/start").result as {
       threadId: string;
     };
@@ -105,6 +111,7 @@ export class ReplayClient {
     input: AppServerTurnInputItem[];
     model?: string;
   }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
     return this.controller.consumeResponse("turn/start").result as {
       threadId: string;
       runId: string;
@@ -115,6 +122,7 @@ export class ReplayClient {
     threadId: string;
     runId: string;
   }): Promise<{ threadId: string; runId: string }> {
+    await this.ensureInitialized();
     return this.controller.consumeResponse("turn/interrupt").result as {
       threadId: string;
       runId: string;
@@ -147,5 +155,22 @@ export class ReplayClient {
 
   async respondToPendingRequest(requestId: string): Promise<void> {
     this.controller.resolvePendingRequest(requestId);
+  }
+
+  private async ensureInitialized(): Promise<InitializeResult> {
+    if (this.initializeResult) {
+      return this.initializeResult;
+    }
+
+    if (!this.initializePromise) {
+      this.initializePromise = Promise.resolve(
+        asInitializeResult(this.controller.consumeResponse("initialize").result)
+      ).then((result) => {
+        this.initializeResult = result;
+        return result;
+      });
+    }
+
+    return await this.initializePromise;
   }
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,13 +1,13 @@
 import { Sidebar } from "./features/navigation/Sidebar";
 import { ThreadView } from "./features/thread-detail/ThreadView";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
-import { getDesktopApi } from "./lib/desktop-api";
+import { useDesktopApi } from "./lib/desktop-api";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
 
 export function App() {
-  const desktopApi = getDesktopApi();
+  const desktopApi = useDesktopApi();
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
   const session = useThreadSessionState({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,18 +1,18 @@
-import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { ThreadView } from "./features/thread-detail/ThreadView";
+import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { getDesktopApi } from "./lib/desktop-api";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
+import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
-import { useThreadTranscript } from "./lib/useThreadTranscript";
 
 export function App() {
   const desktopApi = getDesktopApi();
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
-  const transcript = useThreadTranscript({
+  const session = useThreadSessionState({
     desktopApi,
-    thread: navigation.selectedThread
+    thread: navigation.selectedThread,
   });
   const skills = useThreadSkills({
     desktopApi,
@@ -23,35 +23,31 @@ export function App() {
   return (
     <div className="app-shell">
       <Sidebar
-        browseMode={navigation.browseMode}
         backends={backendSummaries.backends}
+        browseMode={navigation.browseMode}
         createThreadError={navigation.createThreadError}
+        creatingThread={navigation.creatingThread}
         directories={navigation.directories}
         error={navigation.error}
         fetchedAt={navigation.snapshot?.fetchedAt}
         inboxThreads={navigation.inboxThreads}
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
-        creatingThread={navigation.creatingThread}
-        refreshing={navigation.refreshing}
         selectedItemKey={navigation.selectedItemKey}
         threads={navigation.threads}
         onBrowseModeChange={navigation.setBrowseMode}
         onCreateThread={navigation.createThread}
         onOpenLaunchpad={navigation.openDirectoryLaunchpad}
-        onRefresh={navigation.refresh}
         onSelectThread={navigation.selectThread}
       />
 
       <main className="app-main">
         <ThreadView
-          addOptimisticUserMessage={transcript.addOptimisticUserMessage}
+          activeRunId={session.activeRunId}
+          addOptimisticUserMessage={session.addOptimisticUserMessage}
           backendError={backendSummaries.error}
           backends={backendSummaries.backends}
-          fetchedAt={transcript.response?.fetchedAt}
-          loading={transcript.loading}
-          loadingMore={transcript.loadingMore}
-          messageCount={transcript.messages.length}
+          clearPendingRequest={session.clearPendingRequest}
           composerDisabled={
             !navigation.selectedThread ||
             !backendSummaries.backends.some(
@@ -61,6 +57,14 @@ export function App() {
             )
           }
           desktopApi={desktopApi}
+          fetchedAt={session.response?.fetchedAt}
+          launchpadError={navigation.launchpadError}
+          loading={session.loading}
+          loadingMore={session.loadingMore}
+          messageCount={session.messages.length}
+          pendingAssistantMessage={session.pendingAssistantMessage}
+          pendingRequest={session.pendingRequest}
+          pendingStatusText={session.pendingStatusText}
           platform={desktopApi?.platform}
           selectedDirectory={navigation.selectedDirectory}
           selectedLaunchpad={navigation.selectedLaunchpad}
@@ -69,13 +73,15 @@ export function App() {
           skillError={skills.error}
           skillLoading={skills.loading}
           skills={skills.skills}
-          transcriptError={transcript.error}
-          transcriptEntries={transcript.entries}
-          transcriptPagination={transcript.response?.replay.pagination}
+          transcriptEntries={session.entries}
+          transcriptError={session.error}
+          transcriptPagination={session.response?.replay.pagination}
           updatingExecutionMode={navigation.updatingThreadExecutionMode}
-          launchpadError={navigation.launchpadError}
-          onLoadOlder={transcript.loadOlder}
+          onActiveRunIdChange={session.setActiveRunId}
+          onEnsureSkillsLoaded={skills.ensureLoaded}
+          onLoadOlder={session.loadOlder}
           onMaterializeLaunchpad={navigation.materializeDirectoryLaunchpad}
+          onPendingStatusChange={session.setPendingStatusText}
           onSetExecutionMode={
             navigation.selectedThread
               ? async (executionMode) =>
@@ -86,10 +92,7 @@ export function App() {
               : undefined
           }
           onUpdateLaunchpad={navigation.updateDirectoryLaunchpad}
-          removeOptimisticMessage={transcript.removeOptimisticMessage}
-          onRefresh={
-            navigation.selectedThread ? transcript.refresh : navigation.refresh
-          }
+          removeOptimisticMessage={session.removeOptimisticMessage}
         />
       </main>
     </div>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -18,6 +18,28 @@ describe("App", () => {
 
   it("renders the live thread shell with transcript history", async () => {
     const copyText = vi.fn(async () => undefined);
+    const listSkills = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      data: [
+        {
+          cwd: "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt",
+          skills: [
+            {
+              name: "frontend-design",
+              description: "Design and verify renderer UI work.",
+              path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+              enabled: true
+            }
+          ]
+        }
+      ]
+    }));
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1"
+    }));
     const interruptTurn = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
@@ -120,23 +142,7 @@ describe("App", () => {
       value: {
         copyText,
         ping: () => "pong",
-        listSkills: async () => ({
-          backend: "codex",
-          fetchedAt: Date.now(),
-          data: [
-            {
-              cwd: "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt",
-              skills: [
-                {
-                  name: "frontend-design",
-                  description: "Design and verify renderer UI work.",
-                  path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
-                  enabled: true
-                }
-              ]
-            }
-          ]
-        }),
+        listSkills,
         listBackends: async () => ({
           fetchedAt: Date.now(),
           backends: [
@@ -249,11 +255,7 @@ describe("App", () => {
           });
         },
         platform: "darwin",
-        startTurn: async () => ({
-          backend: "codex",
-          threadId: "thread-1",
-          runId: "turn-1"
-        }),
+        startTurn,
         interruptTurn,
         onAgentEvent: () => () => undefined,
         versions: {
@@ -272,9 +274,6 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "recents" })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Refresh threads" })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New thread" })).toBeInTheDocument();
     expect(
@@ -327,12 +326,23 @@ describe("App", () => {
     fireEvent.change(reply, {
       target: { value: "$frontend-design what can this skill do" }
     });
+    reply.setSelectionRange(reply.value.length, reply.value.length);
+    fireEvent.click(reply);
+
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("what can this skill do").closest("article")
-      ).toHaveClass("transcript-message--user");
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    expect(startTurn.mock.calls[0]?.[0]).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [
+        {
+          type: "text",
+          text: expect.stringContaining("what can this skill do")
+        }
+      ]
     });
     expect(
       screen.getByText("The Codex client is wired and the thread browser is live.")
@@ -345,7 +355,6 @@ describe("App", () => {
         selector: ".composer__meta"
       })
     ).not.toBeInTheDocument();
-    expect(screen.getAllByText("$frontend-design").length).toBeGreaterThan(0);
     expect(screen.getByText("3 messages")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
   within
 } from "@testing-library/react";
+import type { StartTurnRequest, StartTurnResponse } from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "../App";
 
@@ -35,7 +36,9 @@ describe("App", () => {
         }
       ]
     }));
-    const startTurn = vi.fn(async () => ({
+    const startTurn = vi.fn<
+      (request: StartTurnRequest) => Promise<StartTurnResponse>
+    >(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
       runId: "turn-1"
@@ -322,7 +325,7 @@ describe("App", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
 
-    const reply = screen.getByLabelText("Reply");
+    const reply = screen.getByLabelText("Reply") as HTMLTextAreaElement;
     fireEvent.change(reply, {
       target: { value: "$frontend-design what can this skill do" }
     });

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -167,6 +167,8 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    const thread = props.thread;
+
     return props.desktopApi.onAgentEvent((event) => {
       const notificationThreadId =
         "threadId" in event.notification.params &&
@@ -186,7 +188,7 @@ export function Composer(props: ComposerProps) {
           ? (event.notification.params.turn as { id?: unknown })
           : undefined;
 
-      if (event.backend !== props.thread.source || notificationThreadId !== props.thread.id) {
+      if (event.backend !== thread.source || notificationThreadId !== thread.id) {
         return;
       }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -18,6 +18,7 @@ import {
 import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
+  activeRunId?: string;
   addOptimisticUserMessage?: (text: string) => string;
   backends?: BackendSummary[];
   desktopApi?: DesktopApi;
@@ -25,13 +26,14 @@ type ComposerProps = {
   disabled?: boolean;
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
+  onActiveRunIdChange?: (runId?: string) => void;
+  onEnsureSkillsLoaded?: () => void | Promise<void>;
   pendingRequestActive?: boolean;
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: Array<{ type: "text"; text: string }>
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
-  onRefresh: () => Promise<void>;
   onUpdateLaunchpad?: (
     directoryKey: string,
     patch: Partial<
@@ -120,12 +122,15 @@ export function Composer(props: ComposerProps) {
   }, [trigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
+    if (!trigger) {
+      return;
+    }
+
+    void props.onEnsureSkillsLoaded?.();
+  }, [props.onEnsureSkillsLoaded, trigger]);
+
+  useEffect(() => {
     if (!isLaunchpad) {
-      setDraft("");
-      setSending(false);
-      setInterrupting(false);
-      updateActiveRunId(undefined);
-      setActiveOptimisticMessageId(undefined);
       return;
     }
 
@@ -147,6 +152,15 @@ export function Composer(props: ComposerProps) {
     updateActiveRunId(undefined);
     setActiveOptimisticMessageId(undefined);
   }, [props.thread?.id, props.thread?.source]);
+
+  useEffect(() => {
+    updateActiveRunId(props.activeRunId);
+
+    if (!props.activeRunId) {
+      setSending(false);
+      setInterrupting(false);
+    }
+  }, [props.activeRunId]);
 
   useEffect(() => {
     if (!props.desktopApi?.onAgentEvent || !props.thread) {
@@ -172,11 +186,7 @@ export function Composer(props: ComposerProps) {
           ? (event.notification.params.turn as { id?: unknown })
           : undefined;
 
-      if (event.backend !== props.thread?.source) {
-        return;
-      }
-
-      if (notificationThreadId !== props.thread.id) {
+      if (event.backend !== props.thread.source || notificationThreadId !== props.thread.id) {
         return;
       }
 
@@ -185,6 +195,7 @@ export function Composer(props: ComposerProps) {
         typeof startedTurnRecord?.id === "string"
       ) {
         updateActiveRunId(startedTurnRecord.id);
+        props.onActiveRunIdChange?.(startedTurnRecord.id);
       }
 
       if (
@@ -203,8 +214,8 @@ export function Composer(props: ComposerProps) {
         setSending(false);
         setInterrupting(false);
         updateActiveRunId(undefined);
+        props.onActiveRunIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
-        void props.onRefresh();
         return;
       }
 
@@ -216,17 +227,17 @@ export function Composer(props: ComposerProps) {
         setSending(false);
         setInterrupting(false);
         updateActiveRunId(undefined);
+        props.onActiveRunIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
-        void props.onRefresh();
       }
     });
   }, [
     activeOptimisticMessageId,
     props.desktopApi,
+    props.onActiveRunIdChange,
     props.onPendingStatusChange,
-    props.onRefresh,
     props.removeOptimisticMessage,
-    props.thread
+    props.thread,
   ]);
 
   useEffect(() => {
@@ -287,8 +298,8 @@ export function Composer(props: ComposerProps) {
         input: [{ type: "text", text }],
       });
       updateActiveRunId(response.runId);
+      props.onActiveRunIdChange?.(response.runId);
       setDraft("");
-      await props.onRefresh();
     } catch (error) {
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);
@@ -297,6 +308,7 @@ export function Composer(props: ComposerProps) {
       setSending(false);
       setInterrupting(false);
       updateActiveRunId(undefined);
+      props.onActiveRunIdChange?.(undefined);
       setActiveOptimisticMessageId(undefined);
       setSendError(error instanceof Error ? error.message : String(error));
     }
@@ -418,7 +430,7 @@ export function Composer(props: ComposerProps) {
           ref={inputRef}
           id="thread-composer"
           className="composer__input"
-          disabled={Boolean(props.thread && sending)}
+          disabled={sending}
           placeholder={
             isLaunchpad
               ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
@@ -728,7 +740,7 @@ export function Composer(props: ComposerProps) {
 
 function formatLaunchpadWorkspaceLabel(
   launchpad?: NavigationLaunchpadDraft,
-  directory?: NavigationDirectorySummary,
+  directory?: NavigationDirectorySummary
 ): string | undefined {
   if (!launchpad) {
     return undefined;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -56,7 +56,6 @@ describe("Composer", () => {
           }),
         }}
         disabled={false}
-        onRefresh={async () => undefined}
         onSetExecutionMode={onSetExecutionMode}
         skills={[]}
         thread={{
@@ -98,8 +97,6 @@ describe("Composer", () => {
       threadId: "thread-1",
       runId: "turn-1",
     }));
-    const refresh = vi.fn(async () => undefined);
-
     render(
       <Composer
         desktopApi={{
@@ -107,7 +104,6 @@ describe("Composer", () => {
           startTurn,
         }}
         disabled={false}
-        onRefresh={refresh}
         skills={[
           {
             name: "frontend-design",
@@ -150,7 +146,6 @@ describe("Composer", () => {
         ],
       });
     });
-    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("applies the focused skill option when activated from the keyboard", async () => {
@@ -165,7 +160,6 @@ describe("Composer", () => {
           }),
         }}
         disabled={false}
-        onRefresh={async () => undefined}
         skills={[
           {
             name: "ce:plan",
@@ -233,7 +227,6 @@ describe("Composer", () => {
           }),
         }}
         disabled={false}
-        onRefresh={async () => undefined}
         skills={[]}
         thread={{
           id: "thread-1",
@@ -316,8 +309,6 @@ describe("Composer", () => {
       threadId: "thread-1",
       runId: "turn-99",
     }));
-    const refresh = vi.fn(async () => undefined);
-
     render(
       <Composer
         desktopApi={{
@@ -333,7 +324,6 @@ describe("Composer", () => {
           }),
         }}
         disabled={false}
-        onRefresh={refresh}
         skills={[]}
         thread={{
           id: "thread-1",
@@ -397,6 +387,5 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     });
-    expect(refresh).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -27,7 +27,6 @@ type SidebarProps = {
     executionMode: ThreadExecutionMode;
   };
   launchpadError?: string;
-  refreshing: boolean;
   selectedItemKey?: string;
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
@@ -39,7 +38,6 @@ type SidebarProps = {
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
-  onRefresh: () => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
 
@@ -63,9 +61,9 @@ export function Sidebar(props: SidebarProps) {
               : backend.available
                 ? "Thread creation unavailable"
                 : backend.unavailableReason ?? "Unavailable",
-        })),
+        }))
       ),
-    [props.backends],
+    [props.backends]
   );
   const hasCreateThreadOptions = createThreadOptions.some((option) => option.enabled);
 
@@ -120,17 +118,6 @@ export function Sidebar(props: SidebarProps) {
               </div>
             ) : null}
           </div>
-
-          <button
-            aria-label="Refresh threads"
-            className="button button--ghost"
-            type="button"
-            onClick={() => {
-              void props.onRefresh();
-            }}
-          >
-            {props.refreshing ? "Syncing" : "Refresh"}
-          </button>
         </div>
       </header>
 
@@ -212,6 +199,6 @@ function formatTimestamp(timestamp: number): string {
     month: "short",
     day: "numeric",
     hour: "numeric",
-    minute: "2-digit"
+    minute: "2-digit",
   }).format(timestamp);
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -127,13 +127,11 @@ describe("Sidebar", () => {
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        refreshing={false}
         selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
-        onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
     );
@@ -163,13 +161,11 @@ describe("Sidebar", () => {
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        refreshing={false}
         selectedItemKey={undefined}
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={onOpenLaunchpad}
-        onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
     );
@@ -203,13 +199,11 @@ describe("Sidebar", () => {
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        refreshing={false}
         selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
-        onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
     );
@@ -236,13 +230,11 @@ describe("Sidebar", () => {
         launchpadError={undefined}
         loading={false}
         creatingThread={undefined}
-        refreshing={false}
         selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={onCreateThread}
         onOpenLaunchpad={async () => undefined}
-        onRefresh={async () => undefined}
         onSelectThread={() => undefined}
       />
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -5,30 +5,22 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
-  AppServerSkillSummary,
   AppServerThreadReplayPagination,
+  AppServerSkillSummary,
   BackendSummary,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
-import { Composer } from "../composer/Composer";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { Composer } from "../composer/Composer";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
-
-function formatRendererLogPayload(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
 
 function arePlanEntriesEquivalent(
   left: AppServerThreadPlanEntry,
@@ -49,9 +41,11 @@ function arePlanEntriesEquivalent(
 }
 
 type ThreadViewProps = {
+  activeRunId?: string;
   addOptimisticUserMessage: (text: string) => string;
   backendError?: string;
   backends: BackendSummary[];
+  clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   composerDisabled: boolean;
   desktopApi?: DesktopApi;
   fetchedAt?: number;
@@ -59,6 +53,9 @@ type ThreadViewProps = {
   loading: boolean;
   loadingMore: boolean;
   messageCount: number;
+  pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingRequest?: AppServerPendingRequestNotification;
+  pendingStatusText?: string;
   platform?: string;
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
@@ -67,15 +64,18 @@ type ThreadViewProps = {
   skillError?: string;
   skillLoading?: boolean;
   skills: AppServerSkillSummary[];
-  transcriptError?: string;
   transcriptEntries: AppServerThreadEntry[];
+  transcriptError?: string;
   transcriptPagination?: AppServerThreadReplayPagination;
   updatingExecutionMode?: ThreadExecutionMode;
+  onActiveRunIdChange?: (runId?: string) => void;
+  onEnsureSkillsLoaded?: () => void | Promise<void>;
   onLoadOlder: () => Promise<void>;
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: Array<{ type: "text"; text: string }>
   ) => Promise<void>;
+  onPendingStatusChange?: (status?: string) => void;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
   onUpdateLaunchpad?: (
     directoryKey: string,
@@ -97,29 +97,25 @@ type ThreadViewProps = {
     >
   ) => Promise<void>;
   removeOptimisticMessage: (id: string) => void;
-  onRefresh: () => Promise<void>;
 };
 
 export function ThreadView(props: ThreadViewProps) {
-  const [pendingStatusText, setPendingStatusText] = useState<string>();
-  const [pendingAssistantMessage, setPendingAssistantMessage] =
-    useState<AppServerThreadMessageEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
-  const [pendingRequest, setPendingRequest] =
-    useState<AppServerPendingRequestNotification>();
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
   const [pendingRequestError, setPendingRequestError] = useState<string>();
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
 
   useEffect(() => {
-    setPendingAssistantMessage(undefined);
     setPendingPlanEntry(undefined);
-    setPendingRequest(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
     setExpandedImage(undefined);
-  }, [props.selectedThread?.id, props.selectedThread?.source, props.selectedLaunchpad?.directoryKey]);
+  }, [
+    props.selectedLaunchpad?.directoryKey,
+    props.selectedThread?.id,
+    props.selectedThread?.source,
+  ]);
 
   const selectedThread = props.selectedThread;
   const selectedLaunchpad = props.selectedLaunchpad;
@@ -144,15 +140,15 @@ export function ThreadView(props: ThreadViewProps) {
     }
 
     return props.desktopApi.onAgentEvent((event) => {
-      const method = event.notification.method;
-      const statusRecord =
-        method === "thread/status/changed" &&
-        typeof event.notification.params.status === "object" &&
-        event.notification.params.status !== null
-          ? (event.notification.params.status as { type?: unknown })
-          : undefined;
+      if (
+        event.notification.method !== "turn/plan/updated" ||
+        event.backend !== selectedThread.source ||
+        event.notification.params.threadId !== selectedThread.id
+      ) {
+        return;
+      }
+
       const planRecord =
-        method === "turn/plan/updated" &&
         typeof event.notification.params.plan === "object" &&
         event.notification.params.plan !== null
           ? (event.notification.params.plan as {
@@ -160,115 +156,34 @@ export function ThreadView(props: ThreadViewProps) {
               steps?: unknown;
             })
           : undefined;
-      if (
-        event.backend !== selectedThread.source ||
-        event.notification.params.threadId !== selectedThread.id
-      ) {
+
+      if (!Array.isArray(planRecord?.steps)) {
         return;
       }
 
-      if (
-        method.endsWith("/requestApproval") &&
-        "requestId" in event.notification.params
-      ) {
-        setPendingRequest(
-          event.notification as AppServerPendingRequestNotification
-        );
-        setPendingRequestBusy(false);
-        setPendingRequestError(undefined);
-        setPendingStatusText("Waiting for approval");
-        return;
-      }
+      const explanation =
+        typeof planRecord.explanation === "string" && planRecord.explanation.trim()
+          ? planRecord.explanation.trim()
+          : undefined;
 
-      if (
-        method === "turn/plan/updated" &&
-        Array.isArray(planRecord?.steps)
-      ) {
-        const explanation =
-          typeof planRecord.explanation === "string" &&
-          planRecord.explanation.trim()
-            ? planRecord.explanation.trim()
-            : undefined;
-        setPendingPlanEntry({
-          type: "plan",
-          id: `live-plan-${
-            typeof event.notification.params.runId === "string"
-              ? event.notification.params.runId
-              : selectedThread.id
-          }`,
-          createdAt: Date.now(),
-          ...(explanation ? { explanation } : {}),
-          steps: planRecord.steps
-        });
-        return;
-      }
-
-      if (
-        method === "item/agentMessage/delta" &&
-        "itemId" in event.notification.params &&
-        typeof event.notification.params.itemId === "string" &&
-        typeof event.notification.params.delta === "string"
-      ) {
-        setPendingRequest(undefined);
-        setPendingRequestBusy(false);
-        setPendingRequestError(undefined);
-        setPendingStatusText("Thinking");
-        const { itemId, delta } = event.notification.params;
-        setPendingAssistantMessage((current) => ({
-          type: "message",
-          id: itemId,
-          role: "assistant",
-          text: current?.id === itemId ? `${current.text}${delta}` : delta,
-        }));
-        return;
-      }
-
-      if (
-        method === "serverRequest/resolved" &&
-        "requestId" in event.notification.params
-      ) {
-        const requestId = event.notification.params.requestId;
-        setPendingRequest((current) =>
-          current?.params.requestId === requestId ? undefined : current
-        );
-        setPendingRequestBusy(false);
-        setPendingRequestError(undefined);
-        setPendingStatusText("Thinking");
-        return;
-      }
-
-      if (
-        method === "turn/completed" ||
-        method === "turn/failed" ||
-        method === "turn/cancelled" ||
-        (method === "thread/status/changed" && statusRecord?.type === "idle")
-      ) {
-        setPendingAssistantMessage(undefined);
-        setPendingRequest(undefined);
-        setPendingRequestBusy(false);
-        setPendingRequestError(undefined);
-        if (method !== "turn/completed") {
-          setPendingStatusText(undefined);
-        }
-      }
-
-      if (method.includes("/request")) {
-        console.error(
-          `[pwragnt:thread-view] unhandled thread request event ${formatRendererLogPayload({
-            backend: event.backend,
-            threadId: selectedThread.id,
-            method,
-            params: event.notification.params,
-          })}`
-        );
-      }
+      setPendingPlanEntry({
+        type: "plan",
+        id: `live-plan-${
+          typeof event.notification.params.runId === "string"
+            ? event.notification.params.runId
+            : selectedThread.id
+        }`,
+        createdAt: Date.now(),
+        ...(explanation ? { explanation } : {}),
+        steps: planRecord.steps,
+      });
     });
   }, [props.desktopApi, selectedThread]);
 
   async function respondToPendingRequest(
     decision: "approve" | "decline" | "cancel"
   ): Promise<void> {
-    if (!props.desktopApi?.submitServerRequest || !selectedThread || !pendingRequest) {
+    if (!props.desktopApi?.submitServerRequest || !selectedThread || !props.pendingRequest) {
       setPendingRequestError("Desktop bridge is missing submitServerRequest().");
       return;
     }
@@ -281,14 +196,16 @@ export function ThreadView(props: ThreadViewProps) {
         backend: selectedThread.source,
         threadId: selectedThread.id,
         runId:
-          typeof pendingRequest.params.runId === "string"
-            ? pendingRequest.params.runId
+          typeof props.pendingRequest.params.runId === "string"
+            ? props.pendingRequest.params.runId
             : undefined,
-        requestId: pendingRequest.params.requestId,
-        response: buildPendingRequestResponse(pendingRequest, decision),
+        requestId: props.pendingRequest.params.requestId,
+        response: buildPendingRequestResponse(props.pendingRequest, decision),
       });
-      setPendingRequest(undefined);
-      setPendingStatusText(decision === "approve" ? "Thinking" : undefined);
+      props.clearPendingRequest(
+        props.pendingRequest.params.requestId,
+        decision === "approve" ? "Thinking" : undefined
+      );
     } catch (error) {
       setPendingRequestError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -345,7 +262,9 @@ export function ThreadView(props: ThreadViewProps) {
               <span className="thread-header__stat-label">Branch</span>
               <strong>
                 {selectedLaunchpad.workMode === "worktree"
-                  ? selectedLaunchpad.branchName ?? props.selectedDirectory.gitStatus?.currentBranch ?? "Pick one"
+                  ? selectedLaunchpad.branchName ??
+                    props.selectedDirectory.gitStatus?.currentBranch ??
+                    "Pick one"
                   : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached"}
               </strong>
             </div>
@@ -362,15 +281,6 @@ export function ThreadView(props: ThreadViewProps) {
                 {syncLabel ? ` • ${syncLabel}` : ""}
               </p>
             </div>
-            <button
-              className="button button--ghost"
-              type="button"
-              onClick={() => {
-                void props.onRefresh();
-              }}
-            >
-              Refresh
-            </button>
           </div>
 
           <dl className="launchpad-grid">
@@ -400,8 +310,8 @@ export function ThreadView(props: ThreadViewProps) {
           disabled={!launchpadBackend?.available}
           launchpad={selectedLaunchpad}
           launchpadError={props.launchpadError}
+          onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
           onMaterializeLaunchpad={props.onMaterializeLaunchpad}
-          onRefresh={props.onRefresh}
           onUpdateLaunchpad={props.onUpdateLaunchpad}
           skillError={props.skillError}
           skillLoading={props.skillLoading}
@@ -428,33 +338,24 @@ export function ThreadView(props: ThreadViewProps) {
                 {props.messageCount} message{props.messageCount === 1 ? "" : "s"}
               </p>
             </div>
-            <button
-              className="button button--ghost"
-              type="button"
-              onClick={() => {
-                void props.onRefresh();
-              }}
-            >
-              Refresh
-            </button>
           </div>
 
           <TranscriptList
-            error={props.transcriptError}
             entries={props.transcriptEntries}
+            error={props.transcriptError}
             loading={props.loading}
             loadingMore={props.loadingMore}
-            pendingAssistantMessage={pendingAssistantMessage}
-            pendingPlanEntry={pendingPlanEntry}
-            pendingRequest={pendingRequest}
-            pendingRequestBusy={pendingRequestBusy}
-            pendingStatusText={pendingStatusText}
             pagination={props.transcriptPagination}
-            threadId={selectedThread!.id}
+            pendingAssistantMessage={props.pendingAssistantMessage}
+            pendingPlanEntry={pendingPlanEntry}
+            pendingRequest={props.pendingRequest}
+            pendingRequestBusy={pendingRequestBusy}
+            pendingStatusText={props.pendingStatusText}
             skills={props.skills}
+            threadId={selectedThread!.id}
+            onLoadOlder={props.onLoadOlder}
             onOpenImage={setExpandedImage}
             onRespondToPendingRequest={respondToPendingRequest}
-            onLoadOlder={props.onLoadOlder}
           />
           {pendingRequestError ? (
             <p className="transcript-error">{pendingRequestError}</p>
@@ -479,14 +380,16 @@ export function ThreadView(props: ThreadViewProps) {
       ) : null}
 
       <Composer
+        activeRunId={props.activeRunId}
         addOptimisticUserMessage={props.addOptimisticUserMessage}
         backends={props.backends}
         desktopApi={props.desktopApi}
         disabled={props.composerDisabled}
-        pendingRequestActive={Boolean(pendingRequest)}
-        onPendingStatusChange={setPendingStatusText}
-        onRefresh={props.onRefresh}
+        onActiveRunIdChange={props.onActiveRunIdChange}
+        onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+        onPendingStatusChange={props.onPendingStatusChange}
         onSetExecutionMode={props.onSetExecutionMode}
+        pendingRequestActive={Boolean(props.pendingRequest)}
         removeOptimisticMessage={props.removeOptimisticMessage}
         setExecutionModeError={props.setExecutionModeError}
         skillError={props.skillError}
@@ -501,7 +404,7 @@ export function ThreadView(props: ThreadViewProps) {
 
 function buildPendingRequestResponse(
   request: AppServerPendingRequestNotification,
-  decision: "approve" | "decline" | "cancel",
+  decision: "approve" | "decline" | "cancel"
 ): { decision: string } {
   const availableDecision = selectAvailableDecision(request.params, decision);
   if (availableDecision) {
@@ -535,7 +438,7 @@ function buildPendingRequestResponse(
 
 function selectAvailableDecision(
   params: AppServerPendingRequestNotification["params"],
-  decision: "approve" | "decline" | "cancel",
+  decision: "approve" | "decline" | "cancel"
 ): string | undefined {
   const rawDecisions =
     readDecisionStrings(params.availableDecisions) ?? readDecisionStrings(params.decisions);
@@ -551,7 +454,7 @@ function selectAvailableDecision(
         : ["cancel", "abort", "stop"];
 
   return rawDecisions.find((value) =>
-    acceptedAliases.some((alias) => value.toLowerCase().includes(alias)),
+    acceptedAliases.some((alias) => value.toLowerCase().includes(alias))
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -7,7 +7,7 @@ import {
   summarizeHunksForFocus,
   type DiffView
 } from "../../../../shared/diff-focus";
-import { getDesktopApi } from "../../lib/desktop-api";
+import { useDesktopApi } from "../../lib/desktop-api";
 
 type TranscriptDiffProps = {
   detail: AppServerThreadActivityDetail;
@@ -17,7 +17,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   const [isZoomedIn, setIsZoomedIn] = useState(false);
   const [focusedView, setFocusedView] = useState<DiffView | null>(null);
   const diff = props.detail.fileDiff;
-  const desktopApi = getDesktopApi();
+  const desktopApi = useDesktopApi();
   const parsed = useMemo(() => parseUnifiedDiff(diff?.diff ?? ""), [diff?.diff]);
   const eligibility = useMemo(() => getFocusedDiffEligibility(parsed), [parsed]);
   const hunkSummaries = useMemo(() => summarizeHunksForFocus(parsed), [parsed]);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -157,9 +157,9 @@ describe("ThreadView", () => {
             text: "The desktop client now reads the full transcript."
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={async () => undefined}
         skillLoading={false}
       />
     );
@@ -265,9 +265,9 @@ describe("ThreadView", () => {
             text: "The thread still loads."
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 
@@ -354,9 +354,9 @@ describe("ThreadView", () => {
             ]
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={async () => undefined}
       />
     );
 
@@ -435,9 +435,9 @@ describe("ThreadView", () => {
           ]
         }
       ],
+      clearPendingRequest: () => undefined,
       onLoadOlder: async () => undefined,
       removeOptimisticMessage: (_id: string) => undefined,
-      onRefresh: async () => undefined,
     };
 
     const { rerender } = render(
@@ -580,9 +580,9 @@ describe("ThreadView", () => {
             text: "Run npm view dive"
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 
@@ -729,9 +729,9 @@ describe("ThreadView", () => {
             text: "Render the task list."
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 
@@ -830,9 +830,9 @@ describe("ThreadView", () => {
           },
           livePlan
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 
@@ -923,9 +923,9 @@ describe("ThreadView", () => {
             text: "Run npm view dive"
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 
@@ -1043,9 +1043,9 @@ describe("ThreadView", () => {
             text: "Run npm view dive"
           }
         ]}
+        clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
-        onRefresh={vi.fn(async () => undefined)}
       />
     );
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppServerNotification } from "@pwragnt/shared";
+import type { AppServerNotification, AppServerPendingRequestNotification } from "@pwragnt/shared";
 import { ThreadView } from "../ThreadView";
 
 afterEach(() => {
@@ -482,38 +482,20 @@ describe("ThreadView", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders live assistant commentary from item/agentMessage/delta notifications", async () => {
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification:
-            | {
-                method: "item/agentMessage/delta";
-                params: {
-                  threadId: string;
-                  itemId: string;
-                  delta: string;
-                };
-              }
-            | {
-                method: "turn/completed";
-                params: {
-                  threadId: string;
-                  runId: string;
-                  turn: {
-                    id: string;
-                    status: "completed";
-                    output: Array<{
-                      type: "text";
-                      text: string;
-                    }>;
-                  };
-                };
-              };
-        }) => void)
-      | undefined;
+  it("renders live assistant commentary passed in from session state", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Plan the app-server protocol",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
 
-    render(
+    const { rerender } = render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
@@ -547,10 +529,6 @@ describe("ThreadView", () => {
         ]}
         composerDisabled={false}
         desktopApi={{
-          onAgentEvent: (callback) => {
-            agentEventHandler = callback as typeof agentEventHandler;
-            return () => undefined;
-          },
           startTurn: async () => ({
             backend: "codex",
             threadId: "thread-2",
@@ -560,17 +538,7 @@ describe("ThreadView", () => {
         loading={false}
         loadingMore={false}
         messageCount={1}
-        selectedThread={{
-          id: "thread-2",
-          title: "Plan the app-server protocol",
-          titleSource: "explicit",
-          source: "codex",
-          updatedAt: Date.now(),
-          linkedDirectories: [],
-          inbox: {
-            inInbox: false
-          }
-        }}
+        selectedThread={selectedThread}
         skills={[]}
         transcriptEntries={[
           {
@@ -586,30 +554,71 @@ describe("ThreadView", () => {
       />
     );
 
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/agentMessage/delta",
-          params: {
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
             threadId: "thread-2",
-            itemId: "msg-1",
-            delta: "I ran ",
-          },
-        },
-      });
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/agentMessage/delta",
-          params: {
-            threadId: "thread-2",
-            itemId: "msg-1",
-            delta: "`npm view dive`",
-          },
-        },
-      });
-    });
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "msg-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "I ran `npm view dive`"
+        }}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Run npm view dive"
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
 
     expect(screen.getByText("I ran")).toBeInTheDocument();
     expect(screen.getByText("npm view dive")).toBeInTheDocument();
@@ -617,28 +626,64 @@ describe("ThreadView", () => {
       "transcript-message--assistant"
     );
 
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "turn/completed",
-          params: {
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
             threadId: "thread-2",
             runId: "turn-1",
-            turn: {
-              id: "turn-1",
-              status: "completed",
-              output: [
-                {
-                  type: "text",
-                  text: "done",
-                },
-              ],
-            },
-          },
-        },
-      });
-    });
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Run npm view dive"
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
 
     expect(screen.queryByText("I ran")).not.toBeInTheDocument();
   });
@@ -840,22 +885,28 @@ describe("ThreadView", () => {
   });
 
   it("maps command approval actions to native decision values and dismisses the approval card", async () => {
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: {
-            method: string;
-            params: Record<string, unknown>;
-          };
-        }) => void)
-      | undefined;
     const submitServerRequest = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-2",
       requestId: "req-1",
     }));
+    let currentPendingRequest: AppServerPendingRequestNotification | undefined = {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-2",
+        requestId: "req-1",
+        availableDecisions: ["accept", "decline", "cancel"],
+        command: "npm view dive",
+      },
+    };
+    let currentPendingStatus: string | undefined = "Waiting for approval";
+    const clearPendingRequest = vi.fn((_requestId: string, nextStatus?: string) => {
+      currentPendingRequest = undefined;
+      currentPendingStatus = nextStatus;
+      rerenderThreadView();
+    });
 
-    render(
+    const { rerender } = render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
@@ -889,10 +940,6 @@ describe("ThreadView", () => {
         ]}
         composerDisabled={false}
         desktopApi={{
-          onAgentEvent: (callback) => {
-            agentEventHandler = callback as typeof agentEventHandler;
-            return () => undefined;
-          },
           startTurn: async () => ({
             backend: "codex",
             threadId: "thread-2",
@@ -903,6 +950,8 @@ describe("ThreadView", () => {
         loading={false}
         loadingMore={false}
         messageCount={1}
+        pendingRequest={currentPendingRequest}
+        pendingStatusText={currentPendingStatus}
         selectedThread={{
           id: "thread-2",
           title: "Plan the app-server protocol",
@@ -923,26 +972,85 @@ describe("ThreadView", () => {
             text: "Run npm view dive"
           }
         ]}
-        clearPendingRequest={() => undefined}
+        clearPendingRequest={clearPendingRequest}
         onLoadOlder={async () => undefined}
         removeOptimisticMessage={(_id) => undefined}
       />
     );
 
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/commandExecution/requestApproval",
-          params: {
-            threadId: "thread-2",
-            requestId: "req-1",
-            availableDecisions: ["accept", "decline", "cancel"],
-            command: "npm view dive",
-          },
-        },
-      });
-    });
+    const rerenderThreadView = () => {
+      rerender(
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: true,
+                multiDirectoryThreads: true
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            }
+          ]}
+          composerDisabled={false}
+          desktopApi={{
+            startTurn: async () => ({
+              backend: "codex",
+              threadId: "thread-2",
+              runId: "turn-1",
+            }),
+            submitServerRequest,
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          pendingRequest={currentPendingRequest}
+          pendingStatusText={currentPendingStatus}
+          selectedThread={{
+            id: "thread-2",
+            title: "Plan the app-server protocol",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false
+            }
+          }}
+          skills={[]}
+          transcriptEntries={[
+            {
+              type: "message",
+              id: "message-1",
+              role: "user",
+              text: "Run npm view dive"
+            }
+          ]}
+          clearPendingRequest={clearPendingRequest}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    };
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
 
@@ -963,20 +1071,23 @@ describe("ThreadView", () => {
         screen.queryByRole("group", { name: "Pending approval" })
       ).not.toBeInTheDocument();
     });
+    expect(clearPendingRequest).toHaveBeenCalledWith("req-1", "Thinking");
   });
 
   it("clears a stale approval card when assistant output resumes", async () => {
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: {
-            method: string;
-            params: Record<string, unknown>;
-          };
-        }) => void)
-      | undefined;
+    const selectedThread = {
+      id: "thread-2",
+      title: "Plan the app-server protocol",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
 
-    render(
+    const { rerender } = render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
@@ -1010,10 +1121,6 @@ describe("ThreadView", () => {
         ]}
         composerDisabled={false}
         desktopApi={{
-          onAgentEvent: (callback) => {
-            agentEventHandler = callback as typeof agentEventHandler;
-            return () => undefined;
-          },
           startTurn: async () => ({
             backend: "codex",
             threadId: "thread-2",
@@ -1023,17 +1130,16 @@ describe("ThreadView", () => {
         loading={false}
         loadingMore={false}
         messageCount={1}
-        selectedThread={{
-          id: "thread-2",
-          title: "Plan the app-server protocol",
-          titleSource: "explicit",
-          source: "codex",
-          updatedAt: Date.now(),
-          linkedDirectories: [],
-          inbox: {
-            inInbox: false
-          }
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-2",
+            requestId: "req-1",
+            command: "npm view dive",
+          },
         }}
+        pendingStatusText="Waiting for approval"
+        selectedThread={selectedThread}
         skills={[]}
         transcriptEntries={[
           {
@@ -1049,36 +1155,75 @@ describe("ThreadView", () => {
       />
     );
 
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/commandExecution/requestApproval",
-          params: {
-            threadId: "thread-2",
-            requestId: "req-1",
-            command: "npm view dive",
-          },
-        },
-      });
-    });
-
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
     expect(screen.getByText("Waiting for approval")).toBeInTheDocument();
 
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/agentMessage/delta",
-          params: {
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
             threadId: "thread-2",
-            itemId: "msg-1",
-            delta: "The request was handled.",
-          },
-        },
-      });
-    });
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "msg-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "The request was handled."
+        }}
+        pendingStatusText="Thinking"
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Run npm view dive"
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
 
     expect(
       screen.queryByRole("group", { name: "Pending approval" })

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type {
   AgentEvent,
   AppServerListSkillsRequest,
@@ -90,4 +91,42 @@ export type DesktopApi = {
 
 export function getDesktopApi(): DesktopApi | undefined {
   return (window as Window & { pwragnt?: DesktopApi }).pwragnt;
+}
+
+export function useDesktopApi(): DesktopApi | undefined {
+  const [desktopApi, setDesktopApi] = useState<DesktopApi | undefined>(() =>
+    getDesktopApi()
+  );
+
+  useEffect(() => {
+    if (desktopApi) {
+      return;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    const refresh = (): void => {
+      const nextDesktopApi = getDesktopApi();
+      if (nextDesktopApi) {
+        setDesktopApi(nextDesktopApi);
+        return;
+      }
+
+      if (!cancelled) {
+        timeoutId = setTimeout(refresh, 16);
+      }
+    };
+
+    refresh();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [desktopApi]);
+
+  return desktopApi;
 }

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -41,15 +41,5 @@ export function useBackendSummaries(desktopApi?: DesktopApi): BackendSummaryStat
     void refresh();
   }, [refresh]);
 
-  useEffect(() => {
-    if (!desktopApi?.onWindowFocus) {
-      return;
-    }
-
-    return desktopApi.onWindowFocus(() => {
-      void refresh();
-    });
-  }, [desktopApi, refresh]);
-
   return state;
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -402,7 +402,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     refreshing: false,
   });
 
-  const optimisticThreadRef = useRef<NavigationThreadSummary>();
+  const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
 
   optimisticThreadRef.current = optimisticThread;
 
@@ -575,7 +575,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return undefined;
   }, [selectedItemKey]);
 
-  const selectedThread = useMemo(
+  const selectedThread = useMemo<NavigationThreadSummary | undefined>(
     () =>
       selectedThreadKey
         ? threads.find(
@@ -610,12 +610,13 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       return;
     }
 
+    const markThreadSeenRequest = submitMarkThreadSeen;
     const threadToMarkSeen = selectedThread;
     let cancelled = false;
 
     async function markSeen(): Promise<void> {
       try {
-        await submitMarkThreadSeen({
+        await markThreadSeenRequest({
           backend: threadToMarkSeen.source,
           threadId: threadToMarkSeen.id,
           seenUpdatedAt: threadToMarkSeen.updatedAt,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
   AppServerTurnInputItem,
@@ -30,6 +30,133 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
   }
 
   return selectionKey.slice("launchpad:".length);
+}
+
+function linkedDirectoriesEqual(
+  left: NavigationThreadSummary["linkedDirectories"],
+  right: NavigationThreadSummary["linkedDirectories"]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((directory, index) => {
+    const candidate = right[index];
+    return (
+      directory?.id === candidate?.id &&
+      directory?.label === candidate?.label &&
+      directory?.path === candidate?.path &&
+      directory?.worktreePath === candidate?.worktreePath &&
+      directory?.kind === candidate?.kind
+    );
+  });
+}
+
+function threadInboxEqual(
+  left: NavigationThreadSummary["inbox"],
+  right: NavigationThreadSummary["inbox"]
+): boolean {
+  return (
+    left.inInbox === right.inInbox &&
+    left.reason === right.reason &&
+    left.lastSeenAt === right.lastSeenAt &&
+    left.lastSeenUpdatedAt === right.lastSeenUpdatedAt
+  );
+}
+
+function threadSummariesEqual(
+  left: NavigationThreadSummary,
+  right: NavigationThreadSummary
+): boolean {
+  return (
+    left.id === right.id &&
+    left.source === right.source &&
+    left.title === right.title &&
+    left.titleSource === right.titleSource &&
+    left.summary === right.summary &&
+    left.projectKey === right.projectKey &&
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt &&
+    left.gitBranch === right.gitBranch &&
+    left.executionMode === right.executionMode &&
+    linkedDirectoriesEqual(left.linkedDirectories, right.linkedDirectories) &&
+    threadInboxEqual(left.inbox, right.inbox)
+  );
+}
+
+function reconcileNavigationSnapshot(
+  previous: NavigationSnapshot | undefined,
+  next: NavigationSnapshot
+): NavigationSnapshot {
+  if (!previous) {
+    return next;
+  }
+
+  const previousByThreadKey = new Map(
+    previous.threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ])
+  );
+
+  return {
+    ...next,
+    threads: next.threads.map((thread) => {
+      const previousThread = previousByThreadKey.get(
+        buildThreadIdentityKey(thread.source, thread.id)
+      );
+      return previousThread && threadSummariesEqual(previousThread, thread)
+        ? previousThread
+        : thread;
+    }),
+  };
+}
+
+function markThreadSeenInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    seenUpdatedAt?: number;
+  }
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (buildThreadIdentityKey(thread.source, thread.id) !== threadKey) {
+      return thread;
+    }
+
+    if (!thread.inbox.inInbox && thread.inbox.lastSeenUpdatedAt === params.seenUpdatedAt) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      inbox: {
+        ...thread.inbox,
+        inInbox: false,
+        reason: undefined,
+        lastSeenAt: Date.now(),
+        lastSeenUpdatedAt: params.seenUpdatedAt,
+      },
+    };
+  });
+
+  if (!changed) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    inboxThreadKeys: snapshot.inboxThreadKeys.filter((candidate) => candidate !== threadKey),
+    threads,
+  };
 }
 
 function applyThreadNameUpdate(
@@ -139,13 +266,13 @@ function hasSelectionKey(
   if (launchpadDirectoryKey) {
     return response.directories.some(
       (directory) =>
-        directory.key === launchpadDirectoryKey && Boolean(directory.launchpad),
+        directory.key === launchpadDirectoryKey && Boolean(directory.launchpad)
     );
   }
 
   return (
     response.threads.some(
-      (thread) => buildThreadIdentityKey(thread.source, thread.id) === selectionKey,
+      (thread) => buildThreadIdentityKey(thread.source, thread.id) === selectionKey
     ) || selectionKey === optimisticThreadKey
   );
 }
@@ -272,96 +399,92 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     useState<string>();
   const [state, setState] = useState<NavigationState>({
     loading: true,
-    refreshing: false
+    refreshing: false,
   });
 
-  const refresh = useCallback(async (
-    preferredSelectionKey?: string,
-    preferredOptimisticThread?: NavigationThreadSummary
-  ): Promise<void> => {
-    if (!desktopApi?.getNavigationSnapshot) {
-      setState({
-        loading: false,
-        refreshing: false,
-        error: "Desktop bridge is missing getNavigationSnapshot().",
-        response: undefined
-      });
-      return;
-    }
+  const optimisticThreadRef = useRef<NavigationThreadSummary>();
 
-    setState((current) => ({
-      ...current,
-      loading: !current.response,
-      refreshing: Boolean(current.response),
-      error: undefined
-    }));
+  optimisticThreadRef.current = optimisticThread;
 
-    try {
-      const response = await desktopApi.getNavigationSnapshot();
-      const optimisticSelection = preferredOptimisticThread ?? optimisticThread;
-      const optimisticThreadKey = optimisticSelection
-        ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
-        : undefined;
-      const effectivePreferredSelectionKey = preferredSelectionKey ?? selectedItemKey;
-
-      setState((current) => {
-        if (current.response && response.unchanged && !preferredSelectionKey) {
-          return {
-            ...current,
-            loading: false,
-            refreshing: false,
-            error: undefined
-          };
-        }
-
-        return {
+  const refresh = useCallback(
+    async (
+      preferredSelectionKey?: string,
+      preferredOptimisticThread?: NavigationThreadSummary
+    ): Promise<void> => {
+      if (!desktopApi?.getNavigationSnapshot) {
+        setState({
           loading: false,
           refreshing: false,
-          error: undefined,
-          response
-        };
-      });
-
-      if (
-        optimisticThreadKey &&
-        response.threads.some(
-          (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey,
-        )
-      ) {
-        setOptimisticThread(undefined);
+          error: "Desktop bridge is missing getNavigationSnapshot().",
+          response: undefined,
+        });
+        return;
       }
 
-      setSelectedItemKey((current) => {
-        const candidate = preferredSelectionKey ?? current ?? effectivePreferredSelectionKey;
-        if (candidate && hasSelectionKey(response, candidate, optimisticThreadKey)) {
-          return candidate;
+      setState((current) => ({
+        ...current,
+        loading: !current.response,
+        refreshing: Boolean(current.response),
+        error: undefined,
+      }));
+
+      try {
+        const response = await desktopApi.getNavigationSnapshot();
+        const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
+        const optimisticThreadKey = optimisticSelection
+          ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
+          : undefined;
+
+        setState((current) => {
+          if (current.response && response.unchanged && !preferredSelectionKey) {
+            return {
+              ...current,
+              loading: false,
+              refreshing: false,
+              error: undefined,
+            };
+          }
+
+          return {
+            loading: false,
+            refreshing: false,
+            error: undefined,
+            response: reconcileNavigationSnapshot(current.response, response),
+          };
+        });
+
+        if (
+          optimisticThreadKey &&
+          response.threads.some(
+            (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+          )
+        ) {
+          setOptimisticThread(undefined);
         }
 
-        return getFallbackSelectionKey(response, optimisticThreadKey);
-      });
-    } catch (error) {
-      setState((current) => ({
-        loading: false,
-        refreshing: false,
-        response: current.response,
-        error: error instanceof Error ? error.message : String(error)
-      }));
-    }
-  }, [desktopApi, optimisticThread, selectedItemKey]);
+        setSelectedItemKey((current) => {
+          const candidate = preferredSelectionKey ?? current;
+          if (candidate && hasSelectionKey(response, candidate, optimisticThreadKey)) {
+            return candidate;
+          }
+
+          return getFallbackSelectionKey(response, optimisticThreadKey);
+        });
+      } catch (error) {
+        setState((current) => ({
+          loading: false,
+          refreshing: false,
+          response: current.response,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    },
+    [desktopApi]
+  );
 
   useEffect(() => {
     void refresh();
-  }, [desktopApi, refresh]);
-
-  useEffect(() => {
-    if (!desktopApi?.onWindowFocus) {
-      return;
-    }
-
-    return desktopApi.onWindowFocus(() => {
-      void refresh();
-    });
-  }, [desktopApi, refresh]);
+  }, [refresh]);
 
   useEffect(() => {
     if (!desktopApi?.onAgentEvent) {
@@ -440,7 +563,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     const inboxThreadKeys = new Set(state.response?.inboxThreadKeys ?? []);
     return threads.filter((thread) =>
       inboxThreadKeys.has(buildThreadIdentityKey(thread.source, thread.id)) ||
-      thread.inbox.inInbox,
+      thread.inbox.inInbox
     );
   }, [state.response?.inboxThreadKeys, threads]);
 
@@ -457,7 +580,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       selectedThreadKey
         ? threads.find(
             (thread) =>
-              buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey,
+              buildThreadIdentityKey(thread.source, thread.id) === selectedThreadKey
           )
         : undefined,
     [selectedThreadKey, threads]
@@ -487,19 +610,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       return;
     }
 
-    const markThreadSeenRequest = submitMarkThreadSeen;
     const threadToMarkSeen = selectedThread;
     let cancelled = false;
 
     async function markSeen(): Promise<void> {
       try {
-        await markThreadSeenRequest({
+        await submitMarkThreadSeen({
           backend: threadToMarkSeen.source,
           threadId: threadToMarkSeen.id,
-          seenUpdatedAt: threadToMarkSeen.updatedAt
+          seenUpdatedAt: threadToMarkSeen.updatedAt,
         });
         if (!cancelled) {
-          await refresh();
+          setState((current) => ({
+            ...current,
+            response: markThreadSeenInSnapshot(current.response, {
+              backend: threadToMarkSeen.source,
+              threadId: threadToMarkSeen.id,
+              seenUpdatedAt: threadToMarkSeen.updatedAt,
+            }),
+          }));
         }
       } finally {
         if (!cancelled) {
@@ -513,7 +642,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return () => {
       cancelled = true;
     };
-  }, [markThreadSeen, pendingSeenThreadKey, refresh, selectedThread]);
+  }, [markThreadSeen, pendingSeenThreadKey, selectedThread]);
 
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
@@ -553,8 +682,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           updatedAt: optimisticUpdatedAt,
           inbox: {
             inInbox: true,
-            reason: "new-thread"
-          }
+            reason: "new-thread",
+          },
         };
         setOptimisticThread(nextOptimisticThread);
         setSelectedItemKey(nextThreadKey);
@@ -566,7 +695,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         setCreatingThread(undefined);
       }
     },
-    [refresh, startThread],
+    [refresh, startThread]
   );
 
   const openDirectoryLaunchpad = useCallback(
@@ -597,7 +726,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           response: applyLaunchpadUpdate(
             current.response,
             response.launchpad,
-            response.defaults,
+            response.defaults
           ),
         }));
         setSelectedItemKey(buildLaunchpadSelectionKey(directory.key));
@@ -605,7 +734,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi],
+    [desktopApi]
   );
 
   const updateDirectoryLaunchpad = useCallback(
@@ -630,14 +759,14 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           response: applyLaunchpadUpdate(
             current.response,
             response.launchpad,
-            response.defaults,
+            response.defaults
           ),
         }));
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi],
+    [desktopApi]
   );
 
   const resetDirectoryLaunchpad = useCallback(
@@ -656,7 +785,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           response: applyLaunchpadReset(
             current.response,
             response.directoryKey,
-            response.defaults,
+            response.defaults
           ),
         }));
         setSelectedItemKey((current) =>
@@ -675,7 +804,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
                     },
                 optimisticThread
                   ? buildThreadIdentityKey(optimisticThread.source, optimisticThread.id)
-                  : undefined,
+                  : undefined
               )
             : current
         );
@@ -683,7 +812,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, optimisticThread, state.response, threads],
+    [desktopApi, directories, optimisticThread, state.response, threads]
   );
 
   const materializeDirectoryLaunchpad = useCallback(
@@ -728,7 +857,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
             ? applyLaunchpadReset(
                 current.response,
                 directoryKey,
-                current.response.launchpadDefaults,
+                current.response.launchpadDefaults
               )
             : current.response,
         }));
@@ -737,7 +866,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, refresh],
+    [desktopApi, directories, refresh]
   );
 
   const updateThreadExecutionMode = useCallback(
@@ -819,6 +948,6 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     setBrowseMode,
     selectThread,
     snapshot: state.response,
-    threads
+    threads,
   };
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1,0 +1,699 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AppServerPendingRequestNotification,
+  AppServerReadThreadResponse,
+  AppServerThreadEntry,
+  AppServerThreadMessage,
+  AppServerThreadMessageEntry,
+  NavigationThreadSummary,
+} from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import type { DesktopApi } from "./desktop-api";
+
+const MAX_VIEW_ONLY_THREADS = 10;
+
+type ThreadSessionEntry = {
+  activeRunId?: string;
+  error?: string;
+  expectOwnUpdate: boolean;
+  hydratedUpdatedAt?: number;
+  interacted: boolean;
+  lastTouchedAt: number;
+  loading: boolean;
+  loadingMore: boolean;
+  optimisticEntries: AppServerThreadMessageEntry[];
+  pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingRequest?: AppServerPendingRequestNotification;
+  pendingStatusText?: string;
+  response?: AppServerReadThreadResponse;
+};
+
+type ThreadSessionState = Record<string, ThreadSessionEntry>;
+
+function createEmptyThreadSessionEntry(): ThreadSessionEntry {
+  return {
+    expectOwnUpdate: false,
+    interacted: false,
+    lastTouchedAt: Date.now(),
+    loading: false,
+    loadingMore: false,
+    optimisticEntries: [],
+  };
+}
+
+function mergeItems<T extends { id: string }>(olderItems: T[], newerItems: T[]): T[] {
+  const deduped = new Map<string, T>();
+
+  for (const item of [...olderItems, ...newerItems]) {
+    deduped.set(item.id, item);
+  }
+
+  return [...deduped.values()];
+}
+
+function buildEmptyResponse(params: {
+  backend: NavigationThreadSummary["source"];
+  threadId: NavigationThreadSummary["id"];
+}): AppServerReadThreadResponse {
+  return {
+    backend: params.backend,
+    fetchedAt: Date.now(),
+    threadId: params.threadId,
+    replay: {
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    },
+  };
+}
+
+function pruneOptimisticEntries(
+  optimisticEntries: AppServerThreadMessageEntry[],
+  response: AppServerReadThreadResponse | undefined
+): AppServerThreadMessageEntry[] {
+  if (!response) {
+    return optimisticEntries;
+  }
+
+  return optimisticEntries.filter(
+    (entry) =>
+      !response.replay.messages.some(
+        (message) => message.role === entry.role && message.text === entry.text
+      )
+  );
+}
+
+function appendAssistantMessage(
+  response: AppServerReadThreadResponse | undefined,
+  params: {
+    backend: NavigationThreadSummary["source"];
+    threadId: NavigationThreadSummary["id"];
+  },
+  message: AppServerThreadMessageEntry
+): AppServerReadThreadResponse {
+  const baseResponse = response ?? buildEmptyResponse(params);
+  const assistantMessage: AppServerThreadMessage = {
+    id: message.id,
+    role: message.role,
+    text: message.text,
+    parts: message.parts,
+    createdAt: message.createdAt,
+  };
+
+  return {
+    ...baseResponse,
+    fetchedAt: Date.now(),
+    replay: {
+      ...baseResponse.replay,
+      entries: mergeItems(baseResponse.replay.entries, [message]),
+      messages: mergeItems(baseResponse.replay.messages, [assistantMessage]),
+      lastAssistantMessage: message.text,
+    },
+  };
+}
+
+function retainSessionCache(
+  sessions: ThreadSessionState,
+  selectedThreadKey?: string
+): ThreadSessionState {
+  const interactedEntries: Array<[string, ThreadSessionEntry]> = [];
+  const viewOnlyEntries: Array<[string, ThreadSessionEntry]> = [];
+
+  for (const entry of Object.entries(sessions)) {
+    const [threadKey, session] = entry;
+    if (threadKey === selectedThreadKey || session.interacted) {
+      interactedEntries.push(entry);
+    } else {
+      viewOnlyEntries.push(entry);
+    }
+  }
+
+  viewOnlyEntries.sort((left, right) => right[1].lastTouchedAt - left[1].lastTouchedAt);
+
+  return Object.fromEntries([
+    ...interactedEntries,
+    ...viewOnlyEntries.slice(0, MAX_VIEW_ONLY_THREADS),
+  ]);
+}
+
+function readCompletedTurnText(
+  notification: AppServerPendingRequestNotification | AppServerReadThreadResponse["backend"] | unknown
+): string | undefined {
+  if (
+    typeof notification !== "object" ||
+    notification === null ||
+    !("turn" in notification)
+  ) {
+    return undefined;
+  }
+
+  const turnRecord = (notification as { turn?: { output?: Array<{ type: string; text?: string }> } })
+    .turn;
+  const text = turnRecord?.output
+    ?.filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text!.trim())
+    .filter(Boolean)
+    .join("\n\n");
+
+  return text || undefined;
+}
+
+export function useThreadSessionState(params: {
+  desktopApi?: DesktopApi;
+  thread?: NavigationThreadSummary;
+}): {
+  activeRunId?: string;
+  addOptimisticUserMessage: (text: string) => string;
+  clearPendingRequest: (requestId: string, nextStatus?: string) => void;
+  entries: AppServerThreadEntry[];
+  error?: string;
+  loading: boolean;
+  loadingMore: boolean;
+  loadOlder: () => Promise<void>;
+  messages: AppServerThreadMessage[];
+  pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingRequest?: AppServerPendingRequestNotification;
+  pendingStatusText?: string;
+  removeOptimisticMessage: (id: string) => void;
+  response?: AppServerReadThreadResponse;
+  setActiveRunId: (runId?: string) => void;
+  setPendingStatusText: (status?: string) => void;
+} {
+  const { desktopApi, thread } = params;
+  const threadKey = thread
+    ? buildThreadIdentityKey(thread.source, thread.id)
+    : undefined;
+  const selectedThreadKeyRef = useRef<string>();
+  const requestVersionsRef = useRef<Record<string, number>>({});
+  const [sessions, setSessions] = useState<ThreadSessionState>({});
+
+  selectedThreadKeyRef.current = threadKey;
+
+  const updateSession = useCallback(
+    (
+      targetThreadKey: string,
+      updater: (current: ThreadSessionEntry) => ThreadSessionEntry
+    ): void => {
+      setSessions((current) => {
+        const previous = current[targetThreadKey] ?? createEmptyThreadSessionEntry();
+        const next = updater(previous);
+        if (next === previous) {
+          return current;
+        }
+
+        return retainSessionCache(
+          {
+            ...current,
+            [targetThreadKey]: next,
+          },
+          selectedThreadKeyRef.current
+        );
+      });
+    },
+    []
+  );
+
+  const loadLatest = useCallback(
+    async (targetThread: NavigationThreadSummary): Promise<void> => {
+      const readThread = desktopApi?.readThread;
+      const targetThreadKey = buildThreadIdentityKey(targetThread.source, targetThread.id);
+
+      if (!readThread) {
+        updateSession(targetThreadKey, (current) => ({
+          ...current,
+          error: "Desktop bridge is missing readThread().",
+          lastTouchedAt: Date.now(),
+          loading: false,
+          loadingMore: false,
+        }));
+        return;
+      }
+
+      const requestVersion = (requestVersionsRef.current[targetThreadKey] ?? 0) + 1;
+      requestVersionsRef.current[targetThreadKey] = requestVersion;
+
+      updateSession(targetThreadKey, (current) => ({
+        ...current,
+        error: undefined,
+        lastTouchedAt: Date.now(),
+        loading: true,
+      }));
+
+      try {
+        const response = await readThread({
+          backend: targetThread.source,
+          threadId: targetThread.id,
+        });
+
+        if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
+          return;
+        }
+
+        updateSession(targetThreadKey, (current) => ({
+          ...current,
+          error: undefined,
+          expectOwnUpdate: false,
+          hydratedUpdatedAt: targetThread.updatedAt,
+          lastTouchedAt: Date.now(),
+          loading: false,
+          optimisticEntries: pruneOptimisticEntries(current.optimisticEntries, response),
+          response,
+        }));
+      } catch (error) {
+        if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
+          return;
+        }
+
+        updateSession(targetThreadKey, (current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : String(error),
+          lastTouchedAt: Date.now(),
+          loading: false,
+        }));
+      }
+    },
+    [desktopApi?.readThread, updateSession]
+  );
+
+  useEffect(() => {
+    if (!threadKey) {
+      return;
+    }
+
+    updateSession(threadKey, (current) => ({
+      ...current,
+      lastTouchedAt: Date.now(),
+    }));
+  }, [threadKey, updateSession]);
+
+  useEffect(() => {
+    if (!thread || !threadKey) {
+      return;
+    }
+
+    const session = sessions[threadKey];
+    if (!session?.response) {
+      if (!session?.loading) {
+        void loadLatest(thread);
+      }
+      return;
+    }
+
+    if (session.loading || session.activeRunId) {
+      return;
+    }
+
+    if (thread.updatedAt == null || session.hydratedUpdatedAt === thread.updatedAt) {
+      return;
+    }
+
+    if (session.expectOwnUpdate) {
+      updateSession(threadKey, (current) => ({
+        ...current,
+        expectOwnUpdate: false,
+        hydratedUpdatedAt: thread.updatedAt,
+        lastTouchedAt: Date.now(),
+      }));
+      return;
+    }
+
+    void loadLatest(thread);
+  }, [loadLatest, sessions, thread, threadKey, updateSession]);
+
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
+
+    return desktopApi.onAgentEvent((event) => {
+      const notificationThreadId =
+        "threadId" in event.notification.params &&
+        typeof event.notification.params.threadId === "string"
+          ? event.notification.params.threadId
+          : undefined;
+
+      if (!notificationThreadId) {
+        return;
+      }
+
+      const targetThreadKey = buildThreadIdentityKey(event.backend, notificationThreadId);
+
+      updateSession(targetThreadKey, (current) => {
+        const nextLastTouchedAt = Date.now();
+
+        if (
+          (event.notification.method === "turn/requestApproval" ||
+            event.notification.method === "review/requestApproval") &&
+          "requestId" in event.notification.params
+        ) {
+          return {
+            ...current,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingRequest:
+              event.notification as AppServerPendingRequestNotification,
+            pendingStatusText: "Waiting for approval",
+          };
+        }
+
+        if (
+          event.notification.method === "item/agentMessage/delta" &&
+          typeof event.notification.params.itemId === "string" &&
+          typeof event.notification.params.delta === "string"
+        ) {
+          const { itemId, delta } = event.notification.params;
+          return {
+            ...current,
+            expectOwnUpdate: true,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingAssistantMessage: {
+              type: "message",
+              id: itemId,
+              role: "assistant",
+              text:
+                current.pendingAssistantMessage?.id === itemId
+                  ? `${current.pendingAssistantMessage.text}${delta}`
+                  : delta,
+            },
+          };
+        }
+
+        if (event.notification.method === "turn/started") {
+          const runId =
+            typeof event.notification.params.turn?.id === "string"
+              ? event.notification.params.turn.id
+              : event.notification.params.runId;
+
+          return {
+            ...current,
+            activeRunId: runId,
+            expectOwnUpdate: true,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+          };
+        }
+
+        if (
+          event.notification.method === "serverRequest/resolved" &&
+          "requestId" in event.notification.params
+        ) {
+          return {
+            ...current,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingRequest:
+              current.pendingRequest?.params.requestId === event.notification.params.requestId
+                ? undefined
+                : current.pendingRequest,
+            pendingStatusText: "Thinking",
+          };
+        }
+
+        if (event.notification.method === "turn/completed") {
+          const completedText =
+            readCompletedTurnText(event.notification.params) ??
+            current.pendingAssistantMessage?.text;
+
+          return {
+            ...current,
+            activeRunId: undefined,
+            error: undefined,
+            expectOwnUpdate: true,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingAssistantMessage: undefined,
+            pendingRequest: undefined,
+            pendingStatusText: undefined,
+            response:
+              completedText
+                ? appendAssistantMessage(current.response, {
+                    backend: event.backend,
+                    threadId: notificationThreadId,
+                  }, {
+                    type: "message",
+                    id:
+                      current.pendingAssistantMessage?.id ??
+                      `${event.notification.params.runId}:assistant`,
+                    role: "assistant",
+                    text: completedText,
+                    createdAt: Date.now(),
+                  })
+                : current.response,
+          };
+        }
+
+        if (
+          event.notification.method === "turn/failed" ||
+          event.notification.method === "turn/cancelled"
+        ) {
+          return {
+            ...current,
+            activeRunId: undefined,
+            error: undefined,
+            expectOwnUpdate: false,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingAssistantMessage: undefined,
+            pendingRequest: undefined,
+            pendingStatusText: undefined,
+          };
+        }
+
+        if (event.notification.method === "thread/status/changed") {
+          const statusType =
+            typeof event.notification.params.status === "object" &&
+            event.notification.params.status !== null &&
+            "type" in event.notification.params.status
+              ? event.notification.params.status.type
+              : undefined;
+
+          if (statusType === "idle") {
+            return {
+              ...current,
+              activeRunId: undefined,
+              lastTouchedAt: nextLastTouchedAt,
+              pendingStatusText: undefined,
+            };
+          }
+        }
+
+        if (event.notification.method === "thread/compacted") {
+          return {
+            ...current,
+            hydratedUpdatedAt: undefined,
+            lastTouchedAt: nextLastTouchedAt,
+            response: undefined,
+          };
+        }
+
+        return current;
+      });
+    });
+  }, [desktopApi, thread, threadKey, updateSession]);
+
+  const selectedSession = threadKey ? sessions[threadKey] : undefined;
+
+  const loadOlder = useCallback(async (): Promise<void> => {
+    if (
+      !thread ||
+      !threadKey ||
+      !desktopApi?.readThread ||
+      !selectedSession?.response?.replay.pagination.supportsPagination ||
+      !selectedSession.response.replay.pagination.hasPreviousPage ||
+      !selectedSession.response.replay.pagination.previousCursor
+    ) {
+      return;
+    }
+
+    const requestVersion = requestVersionsRef.current[threadKey] ?? 0;
+    updateSession(threadKey, (current) => ({
+      ...current,
+      error: undefined,
+      lastTouchedAt: Date.now(),
+      loadingMore: true,
+    }));
+
+    try {
+      const olderResponse = await desktopApi.readThread({
+        backend: thread.source,
+        threadId: thread.id,
+        before: selectedSession.response.replay.pagination.previousCursor,
+      });
+
+      if ((requestVersionsRef.current[threadKey] ?? 0) !== requestVersion) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        lastTouchedAt: Date.now(),
+        loadingMore: false,
+        response: current.response
+          ? {
+              ...olderResponse,
+              replay: {
+                ...olderResponse.replay,
+                entries: mergeItems(
+                  olderResponse.replay.entries,
+                  current.response.replay.entries
+                ),
+                messages: mergeItems(
+                  olderResponse.replay.messages,
+                  current.response.replay.messages
+                ),
+              },
+            }
+          : olderResponse,
+      }));
+    } catch (error) {
+      if ((requestVersionsRef.current[threadKey] ?? 0) !== requestVersion) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        error: error instanceof Error ? error.message : String(error),
+        lastTouchedAt: Date.now(),
+        loadingMore: false,
+      }));
+    }
+  }, [desktopApi, selectedSession?.response, thread, threadKey, updateSession]);
+
+  const addOptimisticUserMessage = useCallback(
+    (text: string): string => {
+      if (!thread || !threadKey) {
+        return `optimistic-${Date.now()}`;
+      }
+
+      const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      updateSession(threadKey, (current) => ({
+        ...current,
+        expectOwnUpdate: true,
+        interacted: true,
+        lastTouchedAt: Date.now(),
+        optimisticEntries: [
+          ...current.optimisticEntries,
+          {
+            type: "message",
+            id,
+            role: "user",
+            text,
+            createdAt: Date.now(),
+          },
+        ],
+      }));
+      return id;
+    },
+    [thread, threadKey, updateSession]
+  );
+
+  const removeOptimisticMessage = useCallback(
+    (id: string): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        lastTouchedAt: Date.now(),
+        optimisticEntries: current.optimisticEntries.filter((entry) => entry.id !== id),
+      }));
+    },
+    [threadKey, updateSession]
+  );
+
+  const setPendingStatusText = useCallback(
+    (status?: string): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        lastTouchedAt: Date.now(),
+        pendingStatusText: status,
+      }));
+    },
+    [threadKey, updateSession]
+  );
+
+  const setActiveRunId = useCallback(
+    (runId?: string): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        activeRunId: runId,
+        expectOwnUpdate: Boolean(runId) || current.expectOwnUpdate,
+        interacted: Boolean(runId) || current.interacted,
+        lastTouchedAt: Date.now(),
+      }));
+    },
+    [threadKey, updateSession]
+  );
+
+  const clearPendingRequest = useCallback(
+    (requestId: string, nextStatus?: string): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        lastTouchedAt: Date.now(),
+        pendingRequest:
+          current.pendingRequest?.params.requestId === requestId
+            ? undefined
+            : current.pendingRequest,
+        pendingStatusText: nextStatus,
+      }));
+    },
+    [threadKey, updateSession]
+  );
+
+  const visibleOptimisticEntries = useMemo(
+    () =>
+      pruneOptimisticEntries(
+        selectedSession?.optimisticEntries ?? [],
+        selectedSession?.response
+      ),
+    [selectedSession?.optimisticEntries, selectedSession?.response]
+  );
+
+  const entries = useMemo(
+    () => mergeItems(selectedSession?.response?.replay.entries ?? [], visibleOptimisticEntries),
+    [selectedSession?.response?.replay.entries, visibleOptimisticEntries]
+  );
+
+  const messages = useMemo(
+    () =>
+      mergeItems(
+        selectedSession?.response?.replay.messages ?? [],
+        visibleOptimisticEntries.map(({ type: _type, ...message }) => message)
+      ),
+    [selectedSession?.response?.replay.messages, visibleOptimisticEntries]
+  );
+
+  return {
+    activeRunId: selectedSession?.activeRunId,
+    addOptimisticUserMessage,
+    clearPendingRequest,
+    entries,
+    error: selectedSession?.error,
+    loading: selectedSession?.loading ?? false,
+    loadingMore: selectedSession?.loadingMore ?? false,
+    loadOlder,
+    messages,
+    pendingAssistantMessage: selectedSession?.pendingAssistantMessage,
+    pendingRequest: selectedSession?.pendingRequest,
+    pendingStatusText: selectedSession?.pendingStatusText,
+    removeOptimisticMessage,
+    response: selectedSession?.response,
+    setActiveRunId,
+    setPendingStatusText,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -474,6 +474,7 @@ export function useThreadSessionState(params: {
               ...current,
               activeRunId: undefined,
               lastTouchedAt: nextLastTouchedAt,
+              pendingAssistantMessage: undefined,
               pendingStatusText: undefined,
             };
           }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -186,7 +186,7 @@ export function useThreadSessionState(params: {
   const threadKey = thread
     ? buildThreadIdentityKey(thread.source, thread.id)
     : undefined;
-  const selectedThreadKeyRef = useRef<string>();
+  const selectedThreadKeyRef = useRef<string | undefined>(undefined);
   const requestVersionsRef = useRef<Record<string, number>>({});
   const [sessions, setSessions] = useState<ThreadSessionState>({});
 
@@ -383,9 +383,14 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "turn/started") {
+          const startedTurnRecord =
+            typeof event.notification.params.turn === "object" &&
+            event.notification.params.turn !== null
+              ? (event.notification.params.turn as { id?: unknown })
+              : undefined;
           const runId =
-            typeof event.notification.params.turn?.id === "string"
-              ? event.notification.params.turn.id
+            typeof startedTurnRecord?.id === "string"
+              ? startedTurnRecord.id
               : event.notification.params.runId;
 
           return {

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type {
   AppServerListSkillsResponse,
   AppServerSkillSummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
 } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
 type SkillState = {
@@ -13,88 +14,109 @@ type SkillState = {
   response?: AppServerListSkillsResponse;
 };
 
+function createEmptySkillState(): SkillState {
+  return { loading: false };
+}
+
 export function useThreadSkills(params: {
   desktopApi?: DesktopApi;
   launchpad?: NavigationLaunchpadDraft;
   thread?: NavigationThreadSummary;
 }): {
+  ensureLoaded: () => Promise<void>;
   error?: string;
   loading: boolean;
   response?: AppServerListSkillsResponse;
   skills: AppServerSkillSummary[];
 } {
-  const { desktopApi, launchpad, thread } = params;
-  const [state, setState] = useState<SkillState>({ loading: false });
-  const requestVersionRef = useRef(0);
+  const { desktopApi, thread } = params;
+  const requestVersionsRef = useRef<Record<string, number>>({});
+  const [stateByThreadKey, setStateByThreadKey] = useState<Record<string, SkillState>>({});
+  const threadKey =
+    thread && thread.source === "codex"
+      ? buildThreadIdentityKey(thread.source, thread.id)
+      : undefined;
+  const state = threadKey ? stateByThreadKey[threadKey] : undefined;
 
-  useEffect(() => {
-    const backend = thread?.source ?? launchpad?.backend;
-    if (!backend || backend !== "codex") {
-      setState({ loading: false, error: undefined, response: undefined });
+  const ensureLoaded = useCallback(async (): Promise<void> => {
+    if (!thread || thread.source !== "codex" || !threadKey) {
       return;
     }
 
     if (!desktopApi?.listSkills) {
-      setState({
-        loading: false,
-        error: "Desktop bridge is missing listSkills().",
-        response: undefined,
-      });
+      setStateByThreadKey((current) => ({
+        ...current,
+        [threadKey]: {
+          error: "Desktop bridge is missing listSkills().",
+          loading: false,
+          response: undefined,
+        },
+      }));
       return;
     }
 
-    const requestVersion = requestVersionRef.current + 1;
-    requestVersionRef.current = requestVersion;
-    const cwds = thread
-      ? [...new Set(
-          thread.linkedDirectories
-            .map((directory) => directory.worktreePath ?? directory.path)
-            .filter(Boolean)
-        )]
-      : launchpad?.directoryPath
-        ? [launchpad.directoryPath]
-        : [];
+    const currentState = stateByThreadKey[threadKey];
+    if (currentState?.loading || currentState?.response) {
+      return;
+    }
 
-    setState((current) => ({
+    const requestVersion = (requestVersionsRef.current[threadKey] ?? 0) + 1;
+    requestVersionsRef.current[threadKey] = requestVersion;
+    const cwds = [
+      ...new Set(
+        thread.linkedDirectories
+          .map((directory) => directory.worktreePath ?? directory.path)
+          .filter(Boolean)
+      ),
+    ];
+
+    setStateByThreadKey((current) => ({
       ...current,
-      loading: true,
-      error: undefined,
+      [threadKey]: {
+        ...createEmptySkillState(),
+        loading: true,
+      },
     }));
 
-    void desktopApi
-      .listSkills({
-        backend,
-        cwd: !thread && cwds.length === 1 ? cwds[0] : undefined,
+    try {
+      const response = await desktopApi.listSkills({
+        backend: thread.source,
+        cwd: cwds.length === 1 ? cwds[0] : undefined,
         cwds: cwds.length > 0 ? cwds : undefined,
-      })
-      .then((response) => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-
-        setState({
-          loading: false,
-          error: undefined,
-          response,
-        });
-      })
-      .catch((error: unknown) => {
-        if (requestVersionRef.current !== requestVersion) {
-          return;
-        }
-
-        setState({
-          loading: false,
-          error: error instanceof Error ? error.message : String(error),
-          response: undefined,
-        });
       });
-  }, [desktopApi, launchpad, thread]);
+
+      if (requestVersionsRef.current[threadKey] !== requestVersion) {
+        return;
+      }
+
+      setStateByThreadKey((current) => ({
+        ...current,
+        [threadKey]: {
+          error: undefined,
+          loading: false,
+          response,
+        },
+      }));
+    } catch (error) {
+      if (requestVersionsRef.current[threadKey] !== requestVersion) {
+        return;
+      }
+
+      setStateByThreadKey((current) => ({
+        ...current,
+        [threadKey]: {
+          error: error instanceof Error ? error.message : String(error),
+          loading: false,
+          response: undefined,
+        },
+      }));
+    }
+  }, [desktopApi, stateByThreadKey, thread, threadKey]);
 
   const skills = useMemo(() => {
     const deduped = new Map<string, AppServerSkillSummary>();
 
-    for (const entry of state.response?.data ?? []) {
+    for (const entry of state?.response?.data ?? []) {
       for (const skill of entry.skills) {
         const key = skill.path ?? `${entry.cwd ?? "global"}:${skill.name}`;
         deduped.set(key, skill);
@@ -104,12 +126,13 @@ export function useThreadSkills(params: {
     return [...deduped.values()].sort((left, right) =>
       left.name.localeCompare(right.name)
     );
-  }, [state.response?.data]);
+  }, [state?.response?.data]);
 
   return {
-    error: state.error,
-    loading: state.loading,
-    response: state.response,
+    ensureLoaded,
+    error: state?.error,
+    loading: state?.loading ?? false,
+    response: state?.response,
     skills,
   };
 }

--- a/docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md
+++ b/docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md
@@ -1,0 +1,110 @@
+---
+date: 2026-04-18
+topic: desktop-thread-refresh-model
+---
+
+# Desktop Thread Refresh Model
+
+## Problem Frame
+
+The current desktop refresh behavior is too broad and too eager. Navigation refreshes, transcript rereads, and skill reloads are coupled tightly enough that normal activity can cause the open thread view to jump, the composer to show repeated skill-loading states, and unrelated thread updates to perturb the currently focused conversation. The result is a UI that feels unstable and likely does more work than needed.
+
+This feature should replace broad refresh behavior with thread-scoped, event-driven updates. The selected thread should remain visually stable unless that thread itself changed, while the sidebar may continue to reflect unread and ordering changes. The model should favor cached thread state, append-only updates for active conversations, and targeted stale checks when a thread is revisited.
+
+```mermaid
+flowchart TB
+    A["User opens thread"] --> B{"Cached in this app session?"}
+    B -- "No" --> C["Load current thread state once"]
+    B -- "Yes" --> D{"Turn active for this thread?"}
+    D -- "Yes" --> E["Reuse cached state; accept live append events"]
+    D -- "No" --> F["Check lightweight thread freshness"]
+    F --> G{"Thread changed elsewhere?"}
+    G -- "No" --> H["Keep cached state unchanged"]
+    G -- "Yes" --> I["Reload current thread state once"]
+    C --> J["Render thread from cached state"]
+    E --> J
+    H --> J
+    I --> J
+    J --> K{"New activity for open thread?"}
+    K -- "No" --> L["Keep viewport stable"]
+    K -- "Yes, user at bottom" --> M["Append and auto-scroll"]
+    K -- "Yes, user scrolled up" --> N["Append without pulling scroll"]
+```
+
+## Requirements
+
+**Refresh Ownership**
+- R1. The thread detail view must not expose a manual `Refresh` button.
+- R2. The app must not perform automatic whole-window refreshes on desktop window focus in this iteration.
+- R3. The open thread view must update automatically only for activity that belongs to the selected thread.
+- R4. Activity on non-selected threads may update inbox state, unread state, and sidebar ordering, but must not cause the selected thread transcript or composer state to jump or rerender unnecessarily.
+
+**Open Thread Update Model**
+- R5. Live updates for the selected thread must be append-driven from thread events rather than driven by repeated full transcript rereads during an active turn.
+- R6. When a user selects a thread that is not already cached in the current app session, the app must load that thread's current state once before rendering it as the active conversation.
+- R7. When a user re-selects a thread that is already cached and that thread currently has an active turn in this app instance, the app must reuse the cached state without performing a freshness reload.
+- R8. When a user re-selects a thread that is already cached and does not have an active turn, the app must perform a lightweight freshness check before deciding whether to reload the full thread state.
+- R9. If the freshness check indicates that the thread was changed elsewhere, the app must reload the current thread state once and reconcile the cache.
+- R10. If the freshness check indicates that nothing materially changed, the app must preserve the cached thread state without visible transcript repaint.
+
+**Scroll and Viewport Stability**
+- R11. When new activity is appended to the selected thread while the user is reading the bottom of the conversation, the thread view must follow the new bottom content automatically.
+- R12. When new activity is appended to the selected thread while the user has scrolled up away from the bottom, the thread view must preserve the reader's current viewport and must not pull the scroll position to the newest message.
+- R13. Appending new activity to the selected thread must not repaint the entire transcript when an incremental append is sufficient.
+
+**Skills Loading**
+- R14. Skills are treated as thread-scoped state in the desktop UI.
+- R15. The app must not load skills automatically when a thread becomes selected.
+- R16. The app must load skills lazily the first time the user types a skill trigger in that thread.
+- R17. After skills have been loaded once for a thread during the current app session, the app must reuse the cached skill list for that thread and must not reload it again automatically.
+- R18. Reloading skills manually is out of scope for this iteration and may be added later as a separate feature.
+
+**In-Memory Thread Retention**
+- R19. The app must retain in memory any thread that the user sent a message in during the current app session.
+- R20. For retained interacted threads, the app must track at least the last time the user sent a message and whether the latest assistant response has been read.
+- R21. Threads that were only opened and viewed, but never sent a message in this app session, must still be eligible for short-term in-memory reuse.
+- R22. The app must distinguish between interacted retained threads and view-only retained threads so that future eviction logic can treat them differently.
+- R23. The app must keep no more than ten view-only retained threads in memory at a time.
+- R24. View-only retained threads are the first candidates for eviction when the app needs to reduce memory usage.
+
+## Success Criteria
+
+- The open thread view no longer jumps when unrelated threads receive updates.
+- The composer no longer shows repeated skill-loading states for the same thread during normal use.
+- During an active turn, the selected thread can continue to stream or append activity without relying on repeated full transcript reloads.
+- Re-entering an unchanged cached thread is visually stable and does not trigger unnecessary transcript repaint.
+- Re-entering a cached thread that changed elsewhere refreshes correctly and only when needed.
+- Sidebar unread and ordering changes remain functional without destabilizing the active thread view.
+
+## Scope Boundaries
+
+- This iteration does not reintroduce any automatic refresh-on-window-focus behavior.
+- This iteration does not add a manual skill reload control.
+- This iteration does not require a full memory-pressure sweeper implementation; it only defines retention and eviction priority rules.
+- This iteration does not require a broader protocol redesign, though planning may propose a minimal freshness mechanism if the current app-server surface is insufficient.
+
+## Key Decisions
+
+- Event-driven append is the default model for the selected thread during active work.
+- Selection-time freshness checks replace broad refresh behavior for cached threads without active turns.
+- Skills move from eager thread-selection loading to lazy first-use loading per thread.
+- Sidebar freshness is allowed to move independently from transcript freshness.
+- Interacted threads are treated as more valuable session state than threads that were only viewed.
+
+## Dependencies / Assumptions
+
+- The current desktop app server surface includes `thread/list`, `thread/read`, and `skills/list`, and does not currently expose a dedicated lightweight per-thread freshness RPC.
+- Existing thread metadata such as `updatedAt`, `lastUserMessage`, and `lastAssistantMessage` may be sufficient for a first stale-check design, but that must be validated during planning.
+- The selected thread view can receive enough thread-local events to support append-driven updates without periodic full rereads during active turns.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R8][Technical] What concrete freshness signal should the app use for cached threads without active turns: existing thread-list metadata, an augmented summary response, or a new lightweight RPC?
+- [Affects R11][Technical] What scroll-anchoring approach will preserve viewport stability while still following new content when the user is at the bottom?
+- [Affects R20][Technical] What exact state transition marks the latest assistant response as "read" for retention and future eviction decisions?
+- [Affects R23][Technical] Where should per-thread cached transcript, skill, and retention metadata live so sidebar updates do not invalidate the active thread view?
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md
+++ b/docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md
@@ -1,0 +1,322 @@
+---
+title: fix: Stabilize desktop thread refresh and session state
+type: fix
+status: active
+date: 2026-04-18
+origin: docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md
+---
+
+# fix: Stabilize desktop thread refresh and session state
+
+## Overview
+
+Replace the desktop app's eager refresh model with a thread-keyed session model. Sidebar metadata can keep updating for inbox and ordering behavior, but the selected thread transcript, composer, and skill state should remain stable unless that specific thread changed.
+
+## Problem Frame
+
+The current renderer splits refresh ownership across `useThreadNavigation`, `useThreadTranscript`, `useThreadSkills`, `ThreadView`, and `Composer`. That split makes normal lifecycle events fan out into broad list refreshes, full transcript rereads, and repeated skill fetches. The result matches the origin requirements doc: UI jumpiness, unnecessary loading states, and avoidable memory churn. This plan keeps the thread-detail surface calm by separating summary refresh from thread runtime state and by making the selected thread event-driven during active work. (see origin: `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`)
+
+## Requirements Trace
+
+- R1, R2. Remove manual and focus-driven refresh surfaces from the thread UI.
+- R3, R4. Keep non-selected thread updates confined to sidebar metadata and unread ordering.
+- R5, R11, R12, R13. Drive selected-thread updates from events and preserve transcript scroll behavior.
+- R6, R7, R8, R9, R10. Use cached thread state plus lightweight freshness checks before deciding to reread the full thread.
+- R14, R15, R16, R17, R18. Convert skills loading to lazy, per-thread, session-cached behavior.
+- R19, R20, R21, R22, R23, R24. Track thread retention state in memory and distinguish interacted threads from view-only threads.
+
+## Scope Boundaries
+
+- No window-focus auto-refresh behavior in this pass.
+- No manual thread refresh button or manual skill reload control in this pass.
+- No broader app-server protocol redesign in this pass.
+- No memory-pressure sweeper implementation in this pass beyond storing eviction priority metadata and enforcing the 10-thread cap for view-only cached threads.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/App.tsx` currently composes `useThreadNavigation`, `useThreadTranscript`, and `useThreadSkills` independently, which is the root of selected-thread invalidation fan-out.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` owns selection, `markThreadSeen`, focus refresh, and turn-complete navigation refresh. It currently rebuilds selected thread objects whenever a snapshot changes.
+- `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts` eagerly rereads `thread/read` whenever the selected `thread` object changes.
+- `apps/desktop/src/renderer/src/lib/useThreadSkills.ts` eagerly calls `listSkills` whenever the selected `thread` object changes.
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` currently calls `props.onRefresh()` on turn lifecycle events, which forces full transcript rereads after active turns.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` currently exposes a thread-level `Refresh` button and holds live assistant/pending-request state locally instead of in a thread-keyed session cache.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` already has the right scroll-anchoring pattern for append vs prepend behavior; the plan should preserve that component's assumptions by stabilizing entry identity and limiting full transcript resets.
+- `packages/shared/src/contracts/app-server.ts` already exposes enough turn and item notifications (`turn/started`, `item/agentMessage/delta`, `item/started`, `item/completed`, `turn/completed`, `thread/status/changed`) to support a renderer-side event reducer for selected-thread runtime state.
+- `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` is the best integration seam to prove that sidebar refreshes no longer perturb the open thread, while feature-level tests in `composer`, `thread-detail`, and `navigation` remain the right place for focused behavior coverage.
+
+### Institutional Learnings
+
+- No `docs/solutions/` artifacts exist yet for desktop refresh ownership or thread session caching in this repository.
+- `docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md` already identified that metadata correctness should not rely on window-focus refresh and that refresh churn should stay contained.
+- `docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md` shows the current plan format and confirms `ThreadView` plus `TranscriptList` as the thread-detail ownership boundary.
+
+### External References
+
+- None. The affected behavior is driven by current repo architecture, and the local renderer/main patterns are strong enough for planning without external framework research.
+
+## Key Technical Decisions
+
+- **Separate summary state from thread runtime state:** `useThreadNavigation` remains responsible for sidebar metadata and selection, while a new renderer-local session hook becomes the source of truth for transcript cache, active-turn state, pending approval state, lazy skill state, and retention metadata. This directly addresses the current invalidation fan-out.
+- **Use navigation `updatedAt` as the first-pass freshness token:** on re-selecting a cached thread without an active turn, refresh the navigation snapshot as the lightweight summary source, compare the selected thread's `updatedAt` to the cached hydration token, and only call `readThread` when that summary changed. This keeps the first pass inside the current repo surface and avoids inventing a new app-server method prematurely.
+- **Preserve object identity for unchanged thread summaries in the renderer:** `useThreadNavigation` should reconcile incoming snapshot rows by thread key so unrelated sidebar changes do not manufacture a new selected-thread object unnecessarily.
+- **Make active-thread transcript updates event-driven:** selected-thread turns should mutate cached transcript state from agent events and finalize assistant output from `turn/completed`, instead of treating turn completion as a cue to reread the full transcript immediately.
+- **Keep skills on the existing `skills/list(cwds)` path, but cache by thread key:** the protocol is currently cwd-scoped, so the desktop app should treat the result as thread-scoped session state and load it lazily on first `$` trigger within that thread.
+
+## Alternative Approaches Considered
+
+- **Add a new per-thread summary RPC immediately:** rejected for this pass because the current repo already has a workable summary signal (`updatedAt`) and the user-facing problem is UI invalidation more than transport cost. A narrower protocol method remains a fallback if `updatedAt` proves too coarse in implementation.
+- **Keep the existing split hooks and only tweak dependencies:** rejected because it leaves refresh ownership distributed across `App`, `Composer`, and `ThreadView`, which is the core reason the current behavior is hard to reason about and easy to re-break.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this first pass add a new protocol method for lightweight stale checks?** No. Use navigation snapshot metadata as the lightweight summary source first and keep protocol expansion as a fallback if implementation proves `updatedAt` is insufficient.
+- **Should the selected thread runtime continue to live in `ThreadView` and `Composer` local state?** No. Those components should become renderers/dispatchers over thread-keyed session state so unrelated thread updates cannot perturb the current thread view.
+- **Should skill caching be global or thread-keyed?** Thread-keyed. The desktop behavior should stay per-thread even though the transport call is currently cwd-based.
+
+### Deferred to Implementation
+
+- What exact reducer/action split best expresses transcript cache mutations without making the new session hook too opaque.
+- Whether the first pass should render live `item/started` / `item/completed` entries as full activity cards immediately or keep them as lightweight pending activity state until a later follow-up.
+- The exact heuristic that marks "latest assistant response has been read" for retention metadata, especially when the user is scrolled away from bottom.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    A["Sidebar / selection"] --> B["useThreadNavigation"]
+    B --> C["Selected thread summary"]
+    C --> D["useThreadSessionState"]
+    D --> E["Cached transcript by thread key"]
+    D --> F["Retention metadata by thread key"]
+    D --> G["Pending run / approval / live assistant state"]
+    C --> H["useThreadSkills"]
+    H --> I["Lazy per-thread skills cache"]
+    J["desktopApi.onAgentEvent"] --> D
+    K["desktopApi.getNavigationSnapshot"] --> B
+    L["desktopApi.readThread"] --> D
+    M["desktopApi.listSkills"] --> H
+```
+
+| Selection state | Active turn? | Summary changed? | Expected behavior |
+|---|---|---|---|
+| Uncached thread | N/A | N/A | Load `readThread` once, cache result, render thread |
+| Cached thread | Yes | Any | Reuse cached transcript and continue event-driven updates |
+| Cached thread | No | No | Reuse cached transcript with no visible repaint |
+| Cached thread | No | Yes | Read fresh transcript once and replace that thread's cached state |
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Stabilize navigation refresh ownership"] --> U2["Unit 2: Add thread session cache and stale-check hydration"]
+    U1 --> U4["Unit 4: Make skills lazy and per-thread cached"]
+    U2 --> U3["Unit 3: Move live thread updates to event-driven cache mutations"]
+    U2 --> U4
+```
+
+- [ ] **Unit 1: Stabilize navigation refresh ownership**
+
+**Goal:** Remove refresh surfaces that destabilize the UI and make navigation updates preserve unchanged thread identity.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useBackendSummaries.ts`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Remove the thread-detail and sidebar refresh buttons from the renderer surface and stop passing refresh callbacks into those views as user-facing controls.
+- Drop the `onWindowFocus` subscriptions in `useThreadNavigation` and `useBackendSummaries` so focus changes no longer trigger broad refreshes.
+- Reconcile incoming navigation snapshot rows by thread key inside `useThreadNavigation`, reusing prior `NavigationThreadSummary` objects when their relevant metadata has not changed. This protects the selected thread summary from unrelated sidebar reordering or unread-state churn.
+- When a thread selection needs both `markThreadSeen` and a lightweight stale-check summary refresh, coalesce them onto one navigation refresh path instead of issuing separate broad summary refreshes for the same interaction.
+- Keep navigation refresh on meaningful data changes such as `markThreadSeen`, thread creation, execution mode changes, and thread lifecycle agent events, but let those updates stay in the summary lane rather than driving transcript rereads directly.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- `packages/agent-core/src/domain/navigation-state.ts`
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+
+**Test scenarios:**
+- Happy path: the sidebar renders without `Refresh threads`, and the thread detail header renders without the thread-level `Refresh` button.
+- Happy path: a navigation snapshot update that changes inbox ordering for another thread preserves the selected thread summary identity and does not trigger a new selected-thread transcript fetch.
+- Edge case: `markThreadSeen` still updates inbox state correctly after selection without requiring focus refresh support.
+- Edge case: creating a thread or changing execution mode still refreshes navigation metadata and keeps the intended thread selected.
+- Integration: a non-selected thread receiving a completion event updates sidebar ordering/unread state while the open thread transcript remains unchanged.
+
+**Verification:**
+- Sidebar and thread-detail metadata can refresh in normal lifecycle paths, but focus regain and unrelated thread churn no longer manufacture visible thread-detail resets.
+
+- [ ] **Unit 2: Add thread-keyed session cache and stale-check hydration**
+
+**Goal:** Make the selected thread read from a renderer-local cache first, then conditionally reread from `thread/read` only when the cached thread is stale.
+
+**Requirements:** R6, R7, R8, R9, R10, R19, R20, R21, R22, R23, R24
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Create: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Introduce a thread-keyed session cache hook that stores hydrated transcript state, the `updatedAt` value observed when that transcript was loaded, active-turn markers, pending approval state, and retention metadata for each visited thread.
+- On selecting an uncached thread, hydrate from `readThread` once and mark the cache entry as either interacted or view-only depending on whether the user later sends a message.
+- On selecting a cached thread with no active turn, invoke the existing navigation refresh as the lightweight summary source, compare the selected summary's `updatedAt` against the cached hydration token, and only call `readThread` if it changed.
+- Move optimistic local user messages into the same thread-keyed cache entry so a thread the user just sent in can be revisited without losing in-flight local state.
+- Enforce the view-only retention cap by evicting the oldest clean/view-only cache entries once more than ten are retained, while preserving interacted threads for the session.
+- Track the metadata needed for later sweep logic now: last local send time, whether the latest assistant response has been read, and whether the thread was ever interacted with in this session.
+
+**Execution note:** Add focused hook-level coverage before rewiring `App.tsx` so cache and stale-check behavior is pinned independently from UI chrome.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- `apps/desktop/src/renderer/src/App.tsx`
+- `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Test scenarios:**
+- Happy path: selecting an uncached thread triggers one `readThread` call, caches the transcript, and renders the loaded state.
+- Happy path: re-selecting a cached thread with matching `updatedAt` reuses the cached transcript without issuing another `readThread`.
+- Happy path: re-selecting a cached thread whose summary `updatedAt` increased issues one fresh `readThread` and replaces only that thread's cached transcript.
+- Edge case: a cached thread with an active local turn skips the summary stale-check path and continues from the cached active-turn state.
+- Edge case: after a local send, switching away from the thread and back again preserves the optimistic user message and interacted-thread retention metadata.
+- Edge case: opening more than ten view-only threads evicts the oldest clean entries first while leaving interacted-thread cache entries intact.
+- Error path: a stale-check summary refresh failure leaves the last known cached transcript visible instead of blanking the open thread.
+- Integration: switching between two cached threads where only one changed elsewhere reloads only the changed thread and preserves the other thread's in-memory state.
+
+**Verification:**
+- Thread selection becomes cache-first and only performs `readThread` when the selected thread is uncached or actually stale.
+
+- [ ] **Unit 3: Move live selected-thread updates to event-driven cache mutations**
+
+**Goal:** Stop treating turn lifecycle events as cues to reread the transcript and instead fold them directly into the selected thread's cached runtime state.
+
+**Requirements:** R3, R4, R5, R11, R12, R13
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Move live assistant delta, pending approval, and turn lifecycle handling out of `ThreadView`/`Composer` local refresh loops and into the new session hook so those events mutate one thread-keyed cache entry instead of asking the whole app to refresh.
+- Finalize assistant output on `turn/completed` by promoting the accumulated delta or `turn.output` into the cached transcript entry rather than clearing transient UI state and forcing `readThread`.
+- Keep event application scoped by thread key so non-selected thread events can update sidebar metadata or off-screen cache state without perturbing the current thread view.
+- Preserve `TranscriptList`'s scroll assumptions by appending new entries in place, keeping existing ids stable, and only resetting list state when a true stale reload replaces the selected thread transcript.
+- Continue clearing or downgrading transient pending state on failure, cancellation, or idle transitions, but do so in cache state rather than through component-local resets.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+
+**Test scenarios:**
+- Happy path: `item/agentMessage/delta` notifications append live assistant text to the selected thread without issuing `readThread`.
+- Happy path: `turn/completed` finalizes the assistant reply into the cached transcript and leaves the message visible after pending state clears.
+- Edge case: when the selected thread is scrolled to bottom, appended live activity auto-scrolls to the new bottom.
+- Edge case: when the user is scrolled away from bottom, appended live activity does not pull the viewport to the latest message.
+- Edge case: non-selected thread lifecycle events do not change the selected thread transcript entries, pending state, or scroll position.
+- Error path: `turn/failed` or `turn/cancelled` clears transient pending state without wiping the previously cached transcript.
+- Integration: sending a message in one thread, switching away, and returning before completion preserves the active-turn cache and resumes from live events instead of rereading immediately.
+
+**Verification:**
+- Selected-thread transcript changes are driven by thread-local events and preserve scroll stability, with no full reread on every turn completion.
+
+- [ ] **Unit 4: Make skills lazy and per-thread cached**
+
+**Goal:** Stop eager skill loading on thread selection and load skills only on first skill-trigger use within a thread.
+
+**Requirements:** R14, R15, R16, R17, R18
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSkills.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Replace the current selected-thread effect in `useThreadSkills` with a thread-keyed cache and an explicit `ensureSkillsLoaded(thread)` entry point that loads only once per thread per app session.
+- Trigger `ensureSkillsLoaded` from `Composer` when the user first enters a skill trigger for a Codex-backed thread, rather than on thread selection.
+- Continue using the existing `listSkills({ backend, cwds })` transport path, but store the result under the selected thread key so repeated visits to the same thread do not re-fetch skills.
+- Keep the loading and error surface local to skill-trigger use so the composer does not show `Loading skills…` during ordinary thread selection or unrelated sidebar activity.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/useThreadSkills.ts`
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Test scenarios:**
+- Happy path: selecting a Codex thread does not call `listSkills` until the user types `$`.
+- Happy path: the first `$` trigger in a thread calls `listSkills` once and enables autocomplete for subsequent trigger edits in that thread.
+- Edge case: revisiting a thread whose skills were already loaded does not call `listSkills` again.
+- Edge case: switching to a different thread keeps its skills unloaded until the first trigger in that thread.
+- Edge case: non-Codex threads never attempt to load skills, even if the user types `$`.
+- Error path: a failed skill load surfaces an error only for that thread and does not poison already cached skill lists for other threads.
+
+**Verification:**
+- Skill loading becomes lazy, thread-keyed, and invisible during ordinary navigation.
+
+## System-Wide Impact
+
+- **Interaction graph:** `getNavigationSnapshot` updates sidebar summary state; `useThreadSessionState` owns selected-thread runtime; `readThread` hydrates or rehydrates individual thread cache entries; `onAgentEvent` mutates cache entries for the affected thread; `useThreadSkills` handles lazy thread-keyed autocomplete data.
+- **Error propagation:** summary refresh failures should preserve existing cached thread content; `readThread` failures should leave the last known transcript visible with an error state instead of blanking the entire view; skill-load failures should stay scoped to the requesting thread.
+- **State lifecycle risks:** thread-keyed cache entries need explicit ownership boundaries so interacted-thread retention does not accidentally pin ephemeral pending state forever; view-only eviction must not remove the currently selected thread.
+- **API surface parity:** the plan intentionally keeps the existing desktop-to-app-server method surface (`getNavigationSnapshot`, `readThread`, `listSkills`) for the first pass, so no cross-repo protocol rollout is required.
+- **Integration coverage:** the app-shell tests need to prove that sidebar reorder, thread selection, active turns, and lazy skills can all coexist without the selected thread rereading or jumping unexpectedly.
+- **Unchanged invariants:** inbox semantics, thread creation flow, execution-mode toggling, transcript pagination, and markdown/image transcript rendering should continue to work as they do today.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `updatedAt` may be too coarse as the only stale-check signal for all backends. | Build the first pass around `updatedAt`, but isolate the stale-check decision in the session hook so a minimal thread-summary protocol can be added later without another renderer rewrite. |
+| Moving turn lifecycle state into a session hook could make the new logic harder to understand if reducer boundaries are vague. | Keep cache mutations grouped by concern (hydration, active-turn events, retention metadata, skill cache) and pin the selection/stale-check logic with focused hook tests. |
+| Sidebar metadata refreshes may still cause thread-detail rerenders if summary identity reconciliation is incomplete. | Reconcile rows by thread key and compare the exact fields that matter to thread-detail consumers before replacing an existing summary object. |
+| View-only cache eviction could accidentally evict a thread the user is actively reading. | Exclude the selected thread and active-turn threads from the view-only eviction pool and cover this behavior in hook tests. |
+| Lazy skill loading could regress autocomplete UX if trigger detection fires too often. | Trigger the load only on the first unresolved skill request per thread and keep the loaded result cached for the rest of the session. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation update is required for this pass; the behavior change is internal to the desktop experience.
+- If implementation reveals that `updatedAt` is not a reliable stale-check token, capture that as a follow-on protocol task rather than widening this fix mid-stream.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md](/Users/huntharo/pwrdrvr/PwrAgnt/docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md)
+- Related code: `apps/desktop/src/renderer/src/App.tsx`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadSkills.ts`
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Related tests: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Related plan: `docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md`
+- Related plan: `docs/plans/2026-04-17-001-fix-transcript-image-preview-plan.md`


### PR DESCRIPTION
## Summary
- replace the desktop thread refresh path with per-thread cached session state instead of repeated transcript reloads
- remove the manual refresh UI and lazy-load Codex skills per thread only when skill mention autocomplete is triggered
- preserve directory launchpad behavior while avoiding focused-thread repaint churn and refresh-driven UI jumps
- update replay fixtures and E2E coverage to match the new append-only thread behavior
- include the requirements and implementation plan docs for the refresh-model rewrite

## Testing
- pnpm --filter @pwragnt/desktop build
- pnpm --filter @pwragnt/desktop test:e2e