### PR TITLE
fix(desktop): align renderer transcript test assertions

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -290,12 +290,13 @@ describe("App", () => {
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
     expect(screen.getAllByText("codex/build-codex-client").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { level: 3, name: "Transcript" })).toBeInTheDocument();
-    expect(
-      await screen.findByText("Open the desktop plan and build the Codex client.")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("The Codex client is wired and the thread browser is live.")
-    ).toBeInTheDocument();
+    const transcript = screen.getByRole("region", { name: "Transcript" });
+    await waitFor(() => {
+      expect(transcript).toHaveTextContent("Open the desktop plan and build the Codex client.");
+    });
+    expect(transcript).toHaveTextContent(
+      "The Codex client is wired and the thread browser is live."
+    );
     expect(screen.getByText("0 out of 3 tasks completed")).toBeInTheDocument();
     expect(screen.getByText("Render plan card")).toBeInTheDocument();
     expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
@@ -75,7 +75,7 @@ describe("TranscriptDiff", () => {
     render(<TranscriptDiff detail={DETAIL} />);
 
     expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
-    await screen.findByText("1 hunk hidden, 8 lines skipped");
+    await screen.findByText("1 hunk hidden, 5 lines skipped");
     expect(screen.queryByText("// refreshed comment")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
@@ -99,7 +99,7 @@ describe("TranscriptDiff", () => {
       expect(analyzeFocusedDiff).toHaveBeenCalledTimes(1);
     });
     expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
-    expect(screen.getByText("10 lines skipped")).toBeInTheDocument();
+    expect(screen.getByText("6 lines skipped")).toBeInTheDocument();
     expect(screen.queryByText("const keep3 = 3;")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));


### PR DESCRIPTION
## Summary
The desktop markdown renderer work changed how transcript content is split across DOM nodes and how focused diff summaries report hidden hunks versus skipped context lines. These two renderer tests were still asserting the old shapes, which is why the `Test` job started failing on `main` after the markdown-renderer merge.

This updates the assertions to match the current renderer behavior instead of changing the production diff logic.

## What changed
- update `transcript-diff.test.tsx` to assert the current focused diff summary counts
- update `app-shell.test.tsx` to assert transcript text from the transcript region instead of a brittle single-node text lookup

## Verification
- `pnpm run test`
