### PR TITLE
fix(desktop): submit thread reply on enter

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -448,6 +448,10 @@ export function Composer(props: ComposerProps) {
           }}
           onKeyDown={(event) => {
             if (!hasAutocomplete) {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                void submitTurn();
+              }
               return;
             }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -148,6 +148,87 @@ describe("Composer", () => {
     });
   });
 
+  it("sends the reply when Enter is pressed without Shift", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Ship it" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Ship it" }],
+      });
+    });
+  });
+
+  it("keeps Shift+Enter available for a newline", () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Line one" } });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    const defaultWasPrevented = !textarea.dispatchEvent(event);
+
+    expect(defaultWasPrevented).toBe(false);
+    expect(startTurn).not.toHaveBeenCalled();
+  });
+
   it("applies the focused skill option when activated from the keyboard", async () => {
     render(
       <Composer


### PR DESCRIPTION
## Summary
- make the thread composer submit on Enter when skill autocomplete is inactive
- preserve Shift+Enter so multiline replies still work in the reply box
- add focused composer tests for Enter submit and Shift+Enter newline behavior

## Testing
- pnpm exec vitest run --environment jsdom src/renderer/src/features/composer/__tests__/composer.test.tsx
- pnpm typecheck
