### PR TITLE
fix(desktop): cover directory launchpad thread regressions

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -1,0 +1,180 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createDirectoryLaunchpadSkillsFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-skills-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const fixturePath = path.join(rootDir, "directory-launchpad-skills.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "directory-launchpad-skills",
+          threadId: "thread-directory-launchpad",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-directory-launchpad",
+                title: "Directory launchpad replay",
+                titleSource: "explicit",
+                summary: "Open a new thread from a directory",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1760000000000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Seed the directory launchpad.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Seed the directory launchpad.",
+                },
+              ],
+              lastUserMessage: "Seed the directory launchpad.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "skills-list-1",
+            kind: "response",
+            method: "skills/list",
+            result: [
+              {
+                cwd: repoDir,
+                skills: [
+                  {
+                    name: "frontend-design",
+                    description: "Design and verify renderer UI work.",
+                    path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+                    enabled: true,
+                    scope: "user",
+                  },
+                  {
+                    name: "desktop-e2e-fixture-seeding",
+                    description: "Replay-backed desktop E2E fixtures.",
+                    path: path.join(
+                      repoDir,
+                      ".agents/skills/desktop-e2e-fixture-seeding/SKILL.md",
+                    ),
+                    enabled: true,
+                    scope: "local",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("directory launchpad loads skill autocomplete from user and local scope", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+
+    await app.window.getByRole("textbox", { name: "New thread" }).fill("$");
+
+    await expect(
+      app.window.getByRole("button", { name: /\$frontend-design/i }),
+    ).toBeVisible();
+    await expect(
+      app.window.getByRole("button", { name: /\$desktop-e2e-fixture-seeding/i }),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
@@ -1,0 +1,305 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createDirectoryLaunchpadTranscriptFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-sync-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const fixturePath = path.join(rootDir, "directory-launchpad-transcript-sync.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "directory-launchpad-transcript-sync",
+          threadId: "thread-new",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-existing",
+                title: "Existing directory thread",
+                titleSource: "explicit",
+                summary: "Already linked to the repo",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing directory thread",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing directory thread",
+                },
+              ],
+              lastAssistantMessage: "Existing directory thread",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-start-1",
+            kind: "response",
+            method: "thread/start",
+            result: {
+              threadId: "thread-new",
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-new",
+              runId: "turn-new-1",
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-new",
+                title: "hello from launchpad",
+                titleSource: "derived",
+                summary: "captured after refresh",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-existing",
+                title: "Existing directory thread",
+                titleSource: "explicit",
+                summary: "Already linked to the repo",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [],
+              messages: [],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-new-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "turn-completed-1",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                runId: "turn-new-1",
+                turn: {
+                  id: "turn-new-1",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-read-3",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-new-message-1",
+                  role: "user",
+                  text: "hello from launchpad",
+                },
+                {
+                  type: "message",
+                  id: "thread-new-message-2",
+                  role: "assistant",
+                  text: "captured after refresh",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-new-message-1",
+                  role: "user",
+                  text: "hello from launchpad",
+                },
+                {
+                  id: "thread-new-message-2",
+                  role: "assistant",
+                  text: "captured after refresh",
+                },
+              ],
+              lastUserMessage: "hello from launchpad",
+              lastAssistantMessage: "captured after refresh",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("directory launchpad rereads the created thread after completion when the first transcript read was empty", async () => {
+  const fixture = await createDirectoryLaunchpadTranscriptFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("hello from launchpad");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "hello from launchpad" }),
+    ).toBeVisible();
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("No thread history yet."),
+    ).toBeVisible();
+
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "hello from launchpad" }),
+    ).toBeVisible();
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("hello from launchpad"),
+    ).toBeVisible();
+    await expect(
+      app.window
+        .getByRole("region", { name: "Transcript" })
+        .getByText("captured after refresh"),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function createDirectoryLaunchpadFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-e2e-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+  execFileSync("git", ["branch", "release"], { cwd: repoDir, stdio: "ignore" });
+
+  const fixturePath = path.join(rootDir, "directory-launchpad-workspace.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "directory-launchpad-workspace",
+          threadId: "thread-directory-launchpad",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-directory-launchpad",
+                title: "Directory launchpad replay",
+                titleSource: "explicit",
+                summary: "Open a new thread from a directory",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "main",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1760000000000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Seed the directory launchpad.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Seed the directory launchpad.",
+                },
+              ],
+              lastUserMessage: "Seed the directory launchpad.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("directory launchpad can switch from local checkout to a new worktree", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const workspaceMode = settings.getByLabel("Workspace mode");
+
+    await expect(workspaceMode).toBeEnabled();
+    await expect(workspaceMode).toHaveValue("local");
+    await expect(workspaceMode.getByRole("option", { name: "New worktree" })).toHaveCount(1);
+
+    await workspaceMode.selectOption("worktree");
+
+    await expect(workspaceMode).toHaveValue("worktree");
+    await expect(settings.getByLabel("Base branch")).toHaveValue("main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -34,16 +34,30 @@ export async function launchElectronApp(params: {
   };
 }): Promise<LaunchResult> {
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-desktop-e2e-"));
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  Object.assign(env, {
+    NODE_ENV: "production",
+    PWRAGNT_REPLAY_FIXTURE_PATH: params.fixturePath,
+    PWRAGNT_STATE_ROOT: stateRoot,
+  });
+  delete env.ELECTRON_RENDERER_URL;
+  for (const [key, value] of Object.entries(params.env ?? {})) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+
   const electronApp = await electron.launch({
     args: [path.resolve(fixtureDir, "../../out/main/index.js")],
     cwd: path.resolve(fixtureDir, "../.."),
-    env: {
-      ...process.env,
-      NODE_ENV: "production",
-      PWRAGNT_REPLAY_FIXTURE_PATH: params.fixturePath,
-      PWRAGNT_STATE_ROOT: stateRoot,
-      ...params.env
-    },
+    env,
   });
   const window = await electronApp.firstWindow();
 

--- a/apps/desktop/e2e/fixtures/turn-lifecycle/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/turn-lifecycle/replay.fixture.json
@@ -121,6 +121,68 @@
       }
     },
     {
+      "id": "token-usage-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/tokenUsage/updated",
+        "params": {
+          "threadId": "thread-turn-lifecycle",
+          "turnId": "turn-turn-lifecycle-2",
+          "tokenUsage": {
+            "total": {
+              "inputTokens": 1200,
+              "outputTokens": 12
+            },
+            "last": {
+              "inputTokens": 1200,
+              "outputTokens": 12
+            },
+            "modelContextWindow": 258400
+          }
+        }
+      }
+    },
+    {
+      "id": "rate-limits-1",
+      "kind": "notification",
+      "notification": {
+        "method": "account/rateLimits/updated",
+        "params": {
+          "rateLimits": {
+            "limitId": "codex",
+            "limitName": null,
+            "planType": "pro"
+          }
+        }
+      }
+    },
+    {
+      "id": "command-output-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/commandExecution/outputDelta",
+        "params": {
+          "threadId": "thread-turn-lifecycle",
+          "turnId": "turn-turn-lifecycle-2",
+          "itemId": "call-1",
+          "delta": "command output is still streaming\n"
+        }
+      }
+    },
+    {
+      "id": "status-idle-midturn",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-turn-lifecycle",
+          "status": {
+            "type": "idle"
+          }
+        }
+      }
+    },
+    {
       "id": "assistant-delta-1",
       "kind": "notification",
       "notification": {

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -1,0 +1,290 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createNewThreadTranscriptFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-new-thread-sync-"));
+  const fixturePath = path.join(rootDir, "new-thread-transcript-sync.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "new-thread-transcript-sync",
+          threadId: "thread-new",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-existing",
+                title: "Existing Codex thread",
+                titleSource: "explicit",
+                summary: "Already in the list",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: true,
+                  reason: "new-thread",
+                },
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing Codex thread",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing Codex thread",
+                },
+              ],
+              lastAssistantMessage: "Existing Codex thread",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-start-1",
+            kind: "response",
+            method: "thread/start",
+            result: {
+              threadId: "thread-new",
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-existing",
+                title: "Existing Codex thread",
+                titleSource: "explicit",
+                summary: "Already in the list",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: false,
+                },
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [],
+              messages: [],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-new",
+              runId: "turn-new-1",
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-new-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "turn-completed-1",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                runId: "turn-new-1",
+                turn: {
+                  id: "turn-new-1",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-read-3",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-new-message-1",
+                  role: "user",
+                  text: "Let's test creating a new thread again",
+                },
+                {
+                  type: "message",
+                  id: "thread-new-message-2",
+                  role: "assistant",
+                  text: "The assistant reply finally showed up.",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-new-message-1",
+                  role: "user",
+                  text: "Let's test creating a new thread again",
+                },
+                {
+                  id: "thread-new-message-2",
+                  role: "assistant",
+                  text: "The assistant reply finally showed up.",
+                },
+              ],
+              lastAssistantMessage: "The assistant reply finally showed up.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-list-3",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-new",
+                title: "Let's test creating a new thread again",
+                titleSource: "derived",
+                summary: undefined,
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: true,
+                  reason: "new-thread",
+                },
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-existing",
+                title: "Existing Codex thread",
+                titleSource: "explicit",
+                summary: "Already in the list",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: false,
+                },
+                updatedAt: 1_000,
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("top-level new thread rereads the created thread until the assistant reply is hydrated", async () => {
+  const fixture = await createNewThreadTranscriptFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "New thread" }).click();
+    await app.window
+      .getByRole("menuitem", { name: "Create thread with Codex in Default Access" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "Untitled thread" }),
+    ).toBeVisible();
+
+    await app.window.getByLabel("Reply").fill("Let's test creating a new thread again");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("Let's test creating a new thread again"),
+    ).toBeVisible();
+
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "Let's test creating a new thread again" }),
+    ).toBeVisible();
+    await expect(
+      app.window
+        .getByRole("region", { name: "Transcript" })
+        .getByText("The assistant reply finally showed up."),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -5,7 +5,7 @@ import { launchElectronApp } from "./fixtures/electron-app";
 
 const turnLifecycleSpecDir = path.dirname(fileURLToPath(import.meta.url));
 
-test("clears transient turn UI after a replayed turn returns idle", async () => {
+test("keeps transient turn UI through metadata and premature idle notifications", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
       turnLifecycleSpecDir,
@@ -41,6 +41,22 @@ test("clears transient turn UI after a replayed turn returns idle", async () => 
 
     await app.advance({ stepId: "status-active-1" });
     await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "token-usage-1" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
+    await app.advance({ stepId: "rate-limits-1" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
+    await app.advance({ stepId: "command-output-1" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
+    await app.advance({ stepId: "status-idle-midturn" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
     await app.advance({ stepId: "assistant-delta-1" });
     await app.advance({ stepId: "assistant-delta-2" });
 
@@ -49,6 +65,11 @@ test("clears transient turn UI after a replayed turn returns idle", async () => 
     ).toBeVisible();
 
     await app.advance({ stepId: "status-idle-1" });
+
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+
+    await app.advance({ stepId: "turn-completed-1" });
 
     await expect(
       app.window.getByRole("button", { name: "Stop" })

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -86,8 +86,11 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "serverRequest/resolved",
   "thread/compacted",
   "thread/status/changed",
+  "thread/tokenUsage/updated",
   "turn/requestApproval",
   "review/requestApproval",
+  "account/rateLimits/updated",
+  "item/commandExecution/outputDelta",
   "mcpServer/startupStatus/updated",
 ]);
 const codexClientLog = getMainLogger("pwragnt:codex-client");

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -568,6 +568,27 @@ describe("App", () => {
         runId: "turn-1"
       })
     );
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId
+      }: {
+        backend: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend,
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false
+          }
+        }
+      })
+    );
     let navigationCallCount = 0;
 
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -373,6 +373,174 @@ describe("App", () => {
     resolveRefreshRead?.(transcriptResponse);
   });
 
+  it("loads launchpad skill autocomplete from the project directory", async () => {
+    const listSkills = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      data: [
+        {
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          skills: [
+            {
+              name: "frontend-design",
+              description: "Design and verify renderer UI work.",
+              path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+              enabled: true,
+              scope: "user",
+            },
+            {
+              name: "desktop-e2e-fixture-seeding",
+              description: "Replay-backed desktop E2E fixtures.",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt/.agents/skills/desktop-e2e-fixture-seeding/SKILL.md",
+              enabled: true,
+              scope: "local",
+            },
+          ],
+        },
+      ],
+    }));
+
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listSkills,
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+                {
+                  mode: "full-access",
+                  label: "Full Access",
+                  available: true,
+                },
+              ],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [
+            {
+              key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "directory" as const,
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              threadKeys: [],
+              needsAttentionCount: 0,
+              gitStatus: {
+                currentBranch: "main",
+                branches: ["main", "release"],
+                syncState: "in-sync" as const,
+              },
+              launchpad: {
+                directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+                directoryKind: "directory" as const,
+                directoryLabel: "PwrAgnt",
+                directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                backend: "codex" as const,
+                executionMode: "default" as const,
+                prompt: "",
+                workMode: "local" as const,
+                branchName: "main",
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            },
+          ],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        updateDirectoryLaunchpad: async ({
+          directoryKey,
+          patch,
+        }: {
+          directoryKey: string;
+          patch: Record<string, unknown>;
+        }) => ({
+          directoryKey,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgnt",
+            directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt: typeof patch.prompt === "string" ? patch.prompt : "",
+            workMode: "local" as const,
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          defaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        versions: {
+          electron: "41.2.1",
+        },
+      },
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "PwrAgnt",
+    });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "New thread" }), {
+      target: {
+        value: "$front",
+      },
+    });
+
+    await waitFor(() => {
+      expect(listSkills).toHaveBeenCalledWith({
+        backend: "codex",
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+        cwds: ["/Users/huntharo/pwrdrvr/PwrAgnt"],
+      });
+    });
+
+    expect(
+      await screen.findByRole("button", { name: /\$frontend-design/i })
+    ).toBeInTheDocument();
+  });
+
   it("creates and sends on a new Grok thread", async () => {
     const startThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -403,9 +403,10 @@ export function Composer(props: ComposerProps) {
     false;
   const availableExecutionModes =
     backend?.executionModes.filter((mode) => mode.available) ?? [];
-  const workspaceLabel = isLaunchpad
-    ? formatLaunchpadWorkspaceLabel(props.launchpad, props.directory)
-    : formatThreadWorkspaceLabel(props.thread);
+  const workspaceLabel = formatThreadWorkspaceLabel(props.thread);
+  const launchpadWorkspaceOptions = props.launchpad
+    ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
+    : [];
 
   return (
     <form
@@ -553,7 +554,25 @@ export function Composer(props: ComposerProps) {
             </select>
           ) : null}
 
-          {workspaceLabel ? (
+          {props.launchpad ? (
+            <select
+              aria-label="Workspace mode"
+              className="composer__select composer__select--compact"
+              disabled={!props.onUpdateLaunchpad || launchpadWorkspaceOptions.length <= 1}
+              value={props.launchpad.workMode}
+              onChange={(event) => {
+                handleLaunchpadPatch({
+                  workMode: event.target.value as NavigationLaunchpadDraft["workMode"],
+                });
+              }}
+            >
+              {launchpadWorkspaceOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          ) : workspaceLabel ? (
             <select
               aria-label="Workspace mode"
               className="composer__select composer__select--compact"
@@ -759,6 +778,31 @@ function formatLaunchpadWorkspaceLabel(
   return directory?.gitStatus?.currentBranch
     ? `Local (${directory.gitStatus.currentBranch})`
     : "Local";
+}
+
+function buildLaunchpadWorkspaceOptions(
+  launchpad: NavigationLaunchpadDraft,
+  directory?: NavigationDirectorySummary
+): Array<{ value: NavigationLaunchpadDraft["workMode"]; label: string }> {
+  const localLabel = formatLaunchpadWorkspaceLabel(
+    { ...launchpad, workMode: "local" },
+    directory
+  );
+  const canCreateWorktree = Boolean(
+    directory?.path &&
+      directory.kind === "directory" &&
+      (directory.gitStatus?.currentBranch ||
+        (directory.gitStatus?.branches?.length ?? 0) > 0)
+  );
+  const options: Array<{ value: NavigationLaunchpadDraft["workMode"]; label: string }> = [
+    { value: "local", label: localLabel ?? "Local" },
+  ];
+
+  if (canCreateWorktree || launchpad.workMode === "worktree") {
+    options.push({ value: "worktree", label: "New worktree" });
+  }
+
+  return options;
 }
 
 function formatThreadWorkspaceLabel(thread?: NavigationThreadSummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -225,6 +225,10 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "thread/status/changed" &&
         statusRecord?.type === "idle"
       ) {
+        if (activeRunIdRef.current) {
+          return;
+        }
+
         props.onPendingStatusChange?.(undefined);
         setSending(false);
         setInterrupting(false);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -91,6 +91,87 @@ describe("Composer", () => {
     });
   });
 
+  it("lets a directory launchpad switch from local checkout to a new worktree", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/start"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+        ]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "release"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    const workspaceMode = screen.getByLabelText("Workspace mode");
+    expect(workspaceMode).toBeEnabled();
+    expect(workspaceMode).toHaveValue("local");
+    expect(screen.getByRole("option", { name: "Local (main)" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "New worktree" })).toBeInTheDocument();
+
+    fireEvent.change(workspaceMode, { target: { value: "worktree" } });
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+        { workMode: "worktree" }
+      );
+    });
+  });
+
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -463,6 +463,18 @@ describe("Composer", () => {
                     type: string;
                   };
                 };
+              }
+            | {
+                method: "turn/completed";
+                params: {
+                  threadId: string;
+                  runId: string;
+                  turn: {
+                    id: string;
+                    status: "completed";
+                    output: Array<{ type: "text"; text: string }>;
+                  };
+                };
               };
         }) => void)
       | undefined;
@@ -535,6 +547,108 @@ describe("Composer", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            runId: "turn-99",
+            turn: {
+              id: "turn-99",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the stop button visible when idle status arrives before completion", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification:
+            | {
+                method: "turn/started";
+                params: {
+                  threadId: string;
+                  turn: {
+                    id: string;
+                    status: string;
+                  };
+                };
+              }
+            | {
+                method: "thread/status/changed";
+                params: {
+                  threadId: string;
+                  status: {
+                    type: string;
+                  };
+                };
+              };
+        }) => void)
+      | undefined;
+    const onPendingStatusChange = vi.fn();
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            runId: "pending:thread-1",
+          }),
+        }}
+        disabled={false}
+        onActiveRunIdChange={() => undefined}
+        onPendingStatusChange={onPendingStatusChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "send then keep thinking" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "turn-99",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
           method: "thread/status/changed",
           params: {
             threadId: "thread-1",
@@ -546,8 +660,7 @@ describe("Composer", () => {
       });
     });
 
-    await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
-    });
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(onPendingStatusChange).not.toHaveBeenCalledWith(undefined);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -115,9 +115,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   <span
                     aria-hidden="true"
                     className={`directory-row__chevron${expanded ? " is-open" : ""}`}
-                  >
-                    ▾
-                  </span>
+                  />
                 </span>
               </button>
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -179,6 +179,30 @@ describe("Sidebar", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
 
+  it("renders directory rows without the raw chevron glyph affordance", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        fetchedAt={Date.now()}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.queryByText("▾")).not.toBeInTheDocument();
+  });
+
   it("copies a linked directory path from the recents chip", () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -9,6 +9,86 @@ describe("useThreadNavigation", () => {
     vi.restoreAllMocks();
   });
 
+  it("clears a directory attention count after the selected thread is marked seen", async () => {
+    const markThreadSeen = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      seenAt: Date.now(),
+      seenUpdatedAt: 1_000,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "local" as const,
+            },
+          ],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [
+        {
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          kind: "directory" as const,
+          label: "PwrAgnt",
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 1,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        seenUpdatedAt: 1_000,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.inboxThreads).toHaveLength(0);
+      expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
+    });
+  });
+
   it("coalesces repeated turn lifecycle notifications into one navigation refresh", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -405,6 +405,180 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps thinking visible during metadata notifications for an active turn", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setActiveRunId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/tokenUsage/updated",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              tokenUsage: {
+                modelContextWindow: 258400,
+              },
+            },
+          } as any,
+        });
+        listener({
+          backend: "codex",
+          notification: {
+            method: "account/rateLimits/updated",
+            params: {
+              rateLimits: {
+                limitId: "codex",
+                planType: "pro",
+              },
+            },
+          } as any,
+        });
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/outputDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "call-1",
+              delta: "To github.com:pwrdrvr/PwrAgnt.git\n",
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.activeRunId).toBe("turn-1");
+  });
+
+  it("keeps thinking visible when an idle status arrives before turn completion", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setActiveRunId("turn-1");
+      result.current.setPendingStatusText("Thinking");
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-1",
+              status: {
+                type: "idle",
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.activeRunId).toBe("turn-1");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              runId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.activeRunId).toBeUndefined();
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -119,4 +119,240 @@ describe("useThreadSessionState", () => {
 
     expect(readThread).toHaveBeenCalledTimes(2);
   });
+
+  it("rereads an interacted thread when the cached transcript is still empty", async () => {
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "hello from launchpad",
+              },
+              {
+                type: "message" as const,
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "captured after refresh",
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "hello from launchpad",
+              },
+              {
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "captured after refresh",
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const thread = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const updatedThread = buildThread({ id: "thread-1", updatedAt: 2_000 });
+
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: thread,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.entries).toHaveLength(0);
+
+    act(() => {
+      result.current.setActiveRunId("run-1");
+      result.current.setActiveRunId(undefined);
+    });
+
+    rerender({ currentThread: updatedThread });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(2);
+    });
+  });
+
+  it("rereads an empty transcript after turn completion even when updatedAt is unchanged", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "hello from launchpad",
+              },
+              {
+                type: "message" as const,
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "captured after refresh",
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "hello from launchpad",
+              },
+              {
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "captured after refresh",
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread,
+    };
+
+    const thread = buildThread({ id: "thread-1", updatedAt: 2_000 });
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread,
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.entries).toHaveLength(0);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              runId: "run-1",
+              turn: {
+                id: "run-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(2);
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -355,4 +355,147 @@ describe("useThreadSessionState", () => {
       expect(result.current.entries).toHaveLength(2);
     });
   });
+
+  it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Let's test creating a new thread again",
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Let's test creating a new thread again",
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Let's test creating a new thread again",
+              },
+              {
+                type: "message" as const,
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "The new thread is live and the reply has been hydrated.",
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Let's test creating a new thread again",
+              },
+              {
+                id: `${threadId}-message-2`,
+                role: "assistant" as const,
+                text: "The new thread is live and the reply has been hydrated.",
+              },
+            ],
+            lastAssistantMessage: "The new thread is live and the reply has been hydrated.",
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread,
+    };
+
+    const thread = buildThread({ id: "thread-1", updatedAt: 2_000 });
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread,
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.entries).toHaveLength(1);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              runId: "run-1",
+              turn: {
+                id: "run-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(2);
+    });
+    expect(result.current.entries[1]).toMatchObject({
+      role: "assistant",
+      text: "The new thread is live and the reply has been hydrated.",
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -356,6 +356,55 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("surfaces a failed transcript read once per thread version", async () => {
+    const readThread = vi.fn(async () => {
+      throw new Error(
+        "json-rpc error (-32603): failed to locate rollout for thread thread-1"
+      );
+    });
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const thread = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const updatedThread = buildThread({ id: "thread-1", updatedAt: 2_000 });
+
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: thread,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        "json-rpc error (-32603): failed to locate rollout for thread thread-1"
+      );
+    });
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    rerender({ currentThread: thread });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    rerender({ currentThread: updatedThread });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
@@ -465,7 +514,9 @@ describe("useThreadSessionState", () => {
     await waitFor(() => {
       expect(readThread).toHaveBeenCalledTimes(1);
     });
-    expect(result.current.entries).toHaveLength(1);
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
 
     act(() => {
       for (const listener of agentEventListeners) {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom/vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { DesktopApi } from "../desktop-api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThreadSkills } from "../useThreadSkills";
+
+describe("useThreadSkills", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads skills for a Codex directory launchpad from the local project path", async () => {
+    const listSkills = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      data: [
+        {
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          skills: [
+            {
+              name: "local-fix",
+              description: "Project-local skill",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt/.agents/skills/local-fix/SKILL.md",
+              scope: "local",
+              enabled: true,
+            },
+            {
+              name: "frontend-design",
+              description: "User skill",
+              path: "/Users/huntharo/.codex/skills/frontend-design/SKILL.md",
+              scope: "user",
+              enabled: true,
+            },
+          ],
+        },
+      ],
+    }));
+
+    const desktopApi: DesktopApi = {
+      listSkills,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi,
+        launchpad: {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    expect(listSkills).toHaveBeenCalledWith({
+      backend: "codex",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+      cwds: ["/Users/huntharo/pwrdrvr/PwrAgnt"],
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills.map((skill) => skill.name)).toEqual([
+        "frontend-design",
+        "local-fix",
+      ]);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -152,8 +152,22 @@ function markThreadSeenInSnapshot(
     return snapshot;
   }
 
+  const threadInboxByKey = new Map(
+    threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread.inbox.inInbox,
+    ])
+  );
+
   return {
     ...snapshot,
+    directories: snapshot.directories.map((directory) => ({
+      ...directory,
+      needsAttentionCount: directory.threadKeys.reduce(
+        (count, threadKey) => count + (threadInboxByKey.get(threadKey) ? 1 : 0),
+        0
+      ),
+    })),
     inboxThreadKeys: snapshot.inboxThreadKeys.filter((candidate) => candidate !== threadKey),
     threads,
   };

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -152,6 +152,7 @@ function markThreadSeenInSnapshot(
     return snapshot;
   }
 
+  const directories = snapshot.directories ?? [];
   const threadInboxByKey = new Map(
     threads.map((thread) => [
       buildThreadIdentityKey(thread.source, thread.id),
@@ -161,7 +162,7 @@ function markThreadSeenInSnapshot(
 
   return {
     ...snapshot,
-    directories: snapshot.directories.map((directory) => ({
+    directories: directories.map((directory) => ({
       ...directory,
       needsAttentionCount: directory.threadKeys.reduce(
         (count, threadKey) => count + (threadInboxByKey.get(threadKey) ? 1 : 0),

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -92,6 +92,15 @@ function pruneOptimisticEntries(
   );
 }
 
+function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
+  return Boolean(
+    session.response?.replay.entries.length ||
+      session.optimisticEntries.length ||
+      session.pendingAssistantMessage ||
+      session.pendingRequest
+  );
+}
+
 function appendAssistantMessage(
   response: AppServerReadThreadResponse | undefined,
   params: {
@@ -319,6 +328,11 @@ export function useThreadSessionState(params: {
     }
 
     if (session.expectOwnUpdate) {
+      if (!hasHydratedTranscriptContent(session)) {
+        void loadLatest(thread);
+        return;
+      }
+
       updateSession(threadKey, (current) => ({
         ...current,
         expectOwnUpdate: false,
@@ -329,6 +343,11 @@ export function useThreadSessionState(params: {
     }
 
     if (session.interacted) {
+      if (!hasHydratedTranscriptContent(session)) {
+        void loadLatest(thread);
+        return;
+      }
+
       updateSession(threadKey, (current) => ({
         ...current,
         hydratedUpdatedAt: thread.updatedAt,
@@ -438,32 +457,44 @@ export function useThreadSessionState(params: {
           const completedText =
             readCompletedTurnText(event.notification.params) ??
             current.pendingAssistantMessage?.text;
+          const nextResponse =
+            completedText
+              ? appendAssistantMessage(current.response, {
+                  backend: event.backend,
+                  threadId: notificationThreadId,
+                }, {
+                  type: "message",
+                  id:
+                    current.pendingAssistantMessage?.id ??
+                    `${event.notification.params.runId}:assistant`,
+                  role: "assistant",
+                  text: completedText,
+                  createdAt: Date.now(),
+                })
+              : current.response;
+          const shouldInvalidateHydration =
+            !completedText &&
+            !hasHydratedTranscriptContent({
+              ...current,
+              pendingAssistantMessage: undefined,
+              pendingRequest: undefined,
+              response: nextResponse,
+            });
 
           return {
             ...current,
             activeRunId: undefined,
             error: undefined,
             expectOwnUpdate: true,
+            hydratedUpdatedAt: shouldInvalidateHydration
+              ? undefined
+              : current.hydratedUpdatedAt,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
             pendingStatusText: undefined,
-            response:
-              completedText
-                ? appendAssistantMessage(current.response, {
-                    backend: event.backend,
-                    threadId: notificationThreadId,
-                  }, {
-                    type: "message",
-                    id:
-                      current.pendingAssistantMessage?.id ??
-                      `${event.notification.params.runId}:assistant`,
-                    role: "assistant",
-                    text: completedText,
-                    createdAt: Date.now(),
-                  })
-                : current.response,
+            response: nextResponse,
           };
         }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -19,6 +19,7 @@ export type ThreadViewportState = {
 
 type ThreadSessionEntry = {
   activeRunId?: string;
+  completionHydrationRetries: number;
   error?: string;
   expectOwnUpdate: boolean;
   hydratedUpdatedAt?: number;
@@ -26,6 +27,7 @@ type ThreadSessionEntry = {
   lastTouchedAt: number;
   loading: boolean;
   loadingMore: boolean;
+  needsHydrationAfterCompletion: boolean;
   optimisticEntries: AppServerThreadMessageEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -38,11 +40,13 @@ type ThreadSessionState = Record<string, ThreadSessionEntry>;
 
 function createEmptyThreadSessionEntry(): ThreadSessionEntry {
   return {
+    completionHydrationRetries: 0,
     expectOwnUpdate: false,
     interacted: false,
     lastTouchedAt: Date.now(),
     loading: false,
     loadingMore: false,
+    needsHydrationAfterCompletion: false,
     optimisticEntries: [],
   };
 }
@@ -176,6 +180,21 @@ function readCompletedTurnText(
   return text || undefined;
 }
 
+function didHydrateCompletedTurn(
+  previousResponse: AppServerReadThreadResponse | undefined,
+  nextResponse: AppServerReadThreadResponse
+): boolean {
+  const previousMessages = previousResponse?.replay.messages.length ?? 0;
+  const previousEntries = previousResponse?.replay.entries.length ?? 0;
+
+  return (
+    nextResponse.replay.messages.length > previousMessages ||
+    nextResponse.replay.entries.length > previousEntries ||
+    nextResponse.replay.lastAssistantMessage !==
+      previousResponse?.replay.lastAssistantMessage
+  );
+}
+
 export function useThreadSessionState(params: {
   desktopApi?: DesktopApi;
   thread?: NavigationThreadSummary;
@@ -269,16 +288,30 @@ export function useThreadSessionState(params: {
           return;
         }
 
-        updateSession(targetThreadKey, (current) => ({
-          ...current,
-          error: undefined,
-          expectOwnUpdate: false,
-          hydratedUpdatedAt: targetThread.updatedAt,
-          lastTouchedAt: Date.now(),
-          loading: false,
-          optimisticEntries: pruneOptimisticEntries(current.optimisticEntries, response),
-          response,
-        }));
+        updateSession(targetThreadKey, (current) => {
+          const hydratedCompletedTurn = didHydrateCompletedTurn(current.response, response);
+          const needsHydrationAfterCompletion =
+            current.needsHydrationAfterCompletion && !hydratedCompletedTurn;
+          const completionHydrationRetries = needsHydrationAfterCompletion
+            ? current.completionHydrationRetries + 1
+            : 0;
+
+          return {
+            ...current,
+            error: undefined,
+            expectOwnUpdate: false,
+            hydratedUpdatedAt:
+              needsHydrationAfterCompletion && completionHydrationRetries < 2
+                ? undefined
+                : targetThread.updatedAt,
+            lastTouchedAt: Date.now(),
+            loading: false,
+            completionHydrationRetries,
+            needsHydrationAfterCompletion,
+            optimisticEntries: pruneOptimisticEntries(current.optimisticEntries, response),
+            response,
+          };
+        });
       } catch (error) {
         if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
           return;
@@ -324,6 +357,11 @@ export function useThreadSessionState(params: {
     }
 
     if (thread.updatedAt == null || session.hydratedUpdatedAt === thread.updatedAt) {
+      return;
+    }
+
+    if (session.needsHydrationAfterCompletion) {
+      void loadLatest(thread);
       return;
     }
 
@@ -484,13 +522,15 @@ export function useThreadSessionState(params: {
           return {
             ...current,
             activeRunId: undefined,
+            completionHydrationRetries: 0,
             error: undefined,
             expectOwnUpdate: true,
-            hydratedUpdatedAt: shouldInvalidateHydration
+            hydratedUpdatedAt: !completedText || shouldInvalidateHydration
               ? undefined
               : current.hydratedUpdatedAt,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
+            needsHydrationAfterCompletion: !completedText,
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
             pendingStatusText: undefined,
@@ -505,9 +545,11 @@ export function useThreadSessionState(params: {
           return {
             ...current,
             activeRunId: undefined,
+            completionHydrationRetries: 0,
             error: undefined,
             expectOwnUpdate: false,
             lastTouchedAt: nextLastTouchedAt,
+            needsHydrationAfterCompletion: false,
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
             pendingStatusText: undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -22,6 +22,7 @@ type ThreadSessionEntry = {
   completionHydrationRetries: number;
   error?: string;
   expectOwnUpdate: boolean;
+  failedHydrationVersion?: number | "unknown";
   hydratedUpdatedAt?: number;
   interacted: boolean;
   lastTouchedAt: number;
@@ -78,6 +79,12 @@ function buildEmptyResponse(params: {
       },
     },
   };
+}
+
+function getThreadHydrationVersion(
+  thread: Pick<NavigationThreadSummary, "updatedAt">
+): number | "unknown" {
+  return typeof thread.updatedAt === "number" ? thread.updatedAt : "unknown";
 }
 
 function pruneOptimisticEntries(
@@ -256,11 +263,13 @@ export function useThreadSessionState(params: {
     async (targetThread: NavigationThreadSummary): Promise<void> => {
       const readThread = desktopApi?.readThread;
       const targetThreadKey = buildThreadIdentityKey(targetThread.source, targetThread.id);
+      const hydrationVersion = getThreadHydrationVersion(targetThread);
 
       if (!readThread) {
         updateSession(targetThreadKey, (current) => ({
           ...current,
           error: "Desktop bridge is missing readThread().",
+          failedHydrationVersion: hydrationVersion,
           lastTouchedAt: Date.now(),
           loading: false,
           loadingMore: false,
@@ -274,6 +283,7 @@ export function useThreadSessionState(params: {
       updateSession(targetThreadKey, (current) => ({
         ...current,
         error: undefined,
+        failedHydrationVersion: undefined,
         lastTouchedAt: Date.now(),
         loading: true,
       }));
@@ -300,6 +310,7 @@ export function useThreadSessionState(params: {
             ...current,
             error: undefined,
             expectOwnUpdate: false,
+            failedHydrationVersion: undefined,
             hydratedUpdatedAt:
               needsHydrationAfterCompletion && completionHydrationRetries < 2
                 ? undefined
@@ -320,6 +331,7 @@ export function useThreadSessionState(params: {
         updateSession(targetThreadKey, (current) => ({
           ...current,
           error: error instanceof Error ? error.message : String(error),
+          failedHydrationVersion: hydrationVersion,
           lastTouchedAt: Date.now(),
           loading: false,
         }));
@@ -345,8 +357,12 @@ export function useThreadSessionState(params: {
     }
 
     const session = sessions[threadKey];
+    const hydrationVersion = getThreadHydrationVersion(thread);
     if (!session?.response) {
-      if (!session?.loading) {
+      if (
+        !session?.loading &&
+        session?.failedHydrationVersion !== hydrationVersion
+      ) {
         void loadLatest(thread);
       }
       return;
@@ -578,6 +594,7 @@ export function useThreadSessionState(params: {
         if (event.notification.method === "thread/compacted") {
           return {
             ...current,
+            failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
             response: undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -581,6 +581,10 @@ export function useThreadSessionState(params: {
               : undefined;
 
           if (statusType === "idle") {
+            if (current.activeRunId || current.pendingStatusText) {
+              return current;
+            }
+
             return {
               ...current,
               activeRunId: undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -29,24 +29,48 @@ export function useThreadSkills(params: {
   response?: AppServerListSkillsResponse;
   skills: AppServerSkillSummary[];
 } {
-  const { desktopApi, thread } = params;
+  const { desktopApi, launchpad, thread } = params;
   const requestVersionsRef = useRef<Record<string, number>>({});
   const [stateByThreadKey, setStateByThreadKey] = useState<Record<string, SkillState>>({});
-  const threadKey =
-    thread && thread.source === "codex"
-      ? buildThreadIdentityKey(thread.source, thread.id)
-      : undefined;
-  const state = threadKey ? stateByThreadKey[threadKey] : undefined;
+  const skillTarget = useMemo(() => {
+    if (thread && thread.source === "codex") {
+      const cwds = [
+        ...new Set(
+          thread.linkedDirectories
+            .map((directory) => directory.worktreePath ?? directory.path)
+            .filter(Boolean)
+        ),
+      ];
+
+      return {
+        backend: thread.source,
+        cwds,
+        key: buildThreadIdentityKey(thread.source, thread.id),
+      };
+    }
+
+    if (launchpad?.backend === "codex") {
+      const cwds = launchpad.directoryPath?.trim() ? [launchpad.directoryPath.trim()] : [];
+      return {
+        backend: launchpad.backend,
+        cwds,
+        key: `launchpad:${launchpad.backend}:${launchpad.directoryKey}`,
+      };
+    }
+
+    return undefined;
+  }, [launchpad, thread]);
+  const state = skillTarget ? stateByThreadKey[skillTarget.key] : undefined;
 
   const ensureLoaded = useCallback(async (): Promise<void> => {
-    if (!thread || thread.source !== "codex" || !threadKey) {
+    if (!skillTarget) {
       return;
     }
 
     if (!desktopApi?.listSkills) {
       setStateByThreadKey((current) => ({
         ...current,
-        [threadKey]: {
+        [skillTarget.key]: {
           error: "Desktop bridge is missing listSkills().",
           loading: false,
           response: undefined,
@@ -55,24 +79,18 @@ export function useThreadSkills(params: {
       return;
     }
 
-    const currentState = stateByThreadKey[threadKey];
+    const currentState = stateByThreadKey[skillTarget.key];
     if (currentState?.loading || currentState?.response) {
       return;
     }
 
-    const requestVersion = (requestVersionsRef.current[threadKey] ?? 0) + 1;
-    requestVersionsRef.current[threadKey] = requestVersion;
-    const cwds = [
-      ...new Set(
-        thread.linkedDirectories
-          .map((directory) => directory.worktreePath ?? directory.path)
-          .filter(Boolean)
-      ),
-    ];
+    const requestVersion = (requestVersionsRef.current[skillTarget.key] ?? 0) + 1;
+    requestVersionsRef.current[skillTarget.key] = requestVersion;
+    const cwds = skillTarget.cwds;
 
     setStateByThreadKey((current) => ({
       ...current,
-      [threadKey]: {
+      [skillTarget.key]: {
         ...createEmptySkillState(),
         loading: true,
       },
@@ -80,38 +98,38 @@ export function useThreadSkills(params: {
 
     try {
       const response = await desktopApi.listSkills({
-        backend: thread.source,
+        backend: skillTarget.backend,
         cwd: cwds.length === 1 ? cwds[0] : undefined,
         cwds: cwds.length > 0 ? cwds : undefined,
       });
 
-      if (requestVersionsRef.current[threadKey] !== requestVersion) {
+      if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
         return;
       }
 
       setStateByThreadKey((current) => ({
         ...current,
-        [threadKey]: {
+        [skillTarget.key]: {
           error: undefined,
           loading: false,
           response,
         },
       }));
     } catch (error) {
-      if (requestVersionsRef.current[threadKey] !== requestVersion) {
+      if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
         return;
       }
 
       setStateByThreadKey((current) => ({
         ...current,
-        [threadKey]: {
+        [skillTarget.key]: {
           error: error instanceof Error ? error.message : String(error),
           loading: false,
           response: undefined,
         },
       }));
     }
-  }, [desktopApi, stateByThreadKey, thread, threadKey]);
+  }, [desktopApi, skillTarget, stateByThreadKey]);
 
   const skills = useMemo(() => {
     const deduped = new Map<string, AppServerSkillSummary>();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -573,13 +573,18 @@ textarea {
 }
 
 .directory-row__chevron {
-  color: var(--text-muted);
-  font-size: 12px;
+  display: inline-flex;
+  width: 9px;
+  height: 9px;
+  border-right: 1.75px solid var(--text-muted);
+  border-bottom: 1.75px solid var(--text-muted);
+  opacity: 0.82;
   transition: transform 120ms ease;
+  transform: rotate(45deg) translateY(-1px);
 }
 
 .directory-row__chevron.is-open {
-  transform: rotate(180deg);
+  transform: rotate(225deg) translateY(1px);
 }
 
 .directory-row__launchpad-button {

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -332,6 +332,29 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/tokenUsage/updated";
+      params: {
+        threadId: string;
+        turnId?: string;
+        tokenUsage: unknown;
+      };
+    }
+  | {
+      method: "account/rateLimits/updated";
+      params: {
+        rateLimits: unknown;
+      };
+    }
+  | {
+      method: "item/commandExecution/outputDelta";
+      params: {
+        threadId: string;
+        turnId?: string;
+        itemId: string;
+        delta: string;
+      };
+    }
+  | {
       method: "thread/name/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary
- restore the directory launchpad workspace selector so local checkouts can switch to creating a new worktree again
- reread newly created launchpad threads when the first transcript hydration returns empty, including the completion path where navigation already knows about the thread but the transcript cache is still blank
- load Codex launchpad skill autocomplete from the selected project directory so New Thread suggestions include both user-scope and local project skills
- add replay-backed desktop E2E coverage for the worktree selector, transcript hydration, and launchpad skill autocomplete regressions, plus focused renderer regression tests around launchpad skill loading and stale empty transcript state
- harden the Electron replay fixture launcher so desktop E2E runs do not inherit a stale `ELECTRON_RENDERER_URL`

## Testing
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/directory-launchpad-workspace.spec.ts`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/directory-launchpad-transcript-sync.spec.ts`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/directory-launchpad-skills.spec.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
