### PR TITLE
feat(desktop): support pasted chat images

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type ClipboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerSkillSummary,
+  AppServerThreadImagePart,
+  AppServerTurnInputItem,
   BackendSummary,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -19,7 +21,10 @@ import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
   activeRunId?: string;
-  addOptimisticUserMessage?: (text: string) => string;
+  addOptimisticUserMessage?: (
+    text: string,
+    imageParts?: AppServerThreadImagePart[]
+  ) => string;
   backends?: BackendSummary[];
   desktopApi?: DesktopApi;
   directory?: NavigationDirectorySummary;
@@ -31,7 +36,7 @@ type ComposerProps = {
   pendingRequestActive?: boolean;
   onMaterializeLaunchpad?: (
     directoryKey: string,
-    input?: Array<{ type: "text"; text: string }>
+    input?: AppServerTurnInputItem[]
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onUpdateLaunchpad?: (
@@ -63,6 +68,19 @@ type ComposerProps = {
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
 };
 
+type ComposerImageAttachment = {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+  url: string;
+};
+
+type PastedImageFile = {
+  file: File;
+  type: string;
+};
+
 export function Composer(props: ComposerProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const activeRunIdRef = useRef<string | undefined>(undefined);
@@ -71,6 +89,7 @@ export function Composer(props: ComposerProps) {
   const [interrupting, setInterrupting] = useState(false);
   const [activeRunId, setActiveRunId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
+  const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
@@ -142,6 +161,10 @@ export function Composer(props: ComposerProps) {
   }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.updatedAt]);
 
   useEffect(() => {
+    setImageAttachments([]);
+  }, [props.launchpad?.directoryKey]);
+
+  useEffect(() => {
     if (!props.thread) {
       return;
     }
@@ -151,6 +174,7 @@ export function Composer(props: ComposerProps) {
     setInterrupting(false);
     updateActiveRunId(undefined);
     setActiveOptimisticMessageId(undefined);
+    setImageAttachments([]);
   }, [props.thread?.id, props.thread?.source]);
 
   useEffect(() => {
@@ -268,7 +292,17 @@ export function Composer(props: ComposerProps) {
 
   const submitTurn = async (): Promise<void> => {
     const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
-    if (!text || props.disabled) {
+    const imageParts = imageAttachments.map((attachment, index) => ({
+      type: "image" as const,
+      url: attachment.url,
+      alt: formatPastedImageAlt(attachment, index),
+    }));
+    const input: AppServerTurnInputItem[] = [
+      ...(text ? [{ type: "text" as const, text }] : []),
+      ...imageParts.map(({ url }) => ({ type: "image" as const, url })),
+    ];
+
+    if (input.length === 0 || props.disabled) {
       return;
     }
 
@@ -277,9 +311,9 @@ export function Composer(props: ComposerProps) {
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
       try {
-        await props.onMaterializeLaunchpad(props.launchpad.directoryKey, [
-          { type: "text", text },
-        ]);
+        await props.onMaterializeLaunchpad(props.launchpad.directoryKey, input);
+        setDraft("");
+        setImageAttachments([]);
       } catch (error) {
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
@@ -294,18 +328,19 @@ export function Composer(props: ComposerProps) {
     }
 
     props.onPendingStatusChange?.("Thinking");
-    const optimisticMessageId = props.addOptimisticUserMessage?.(text);
+    const optimisticMessageId = props.addOptimisticUserMessage?.(text, imageParts);
     setActiveOptimisticMessageId(optimisticMessageId);
 
     try {
       const response = await props.desktopApi.startTurn({
         backend: props.thread.source,
         threadId: props.thread.id,
-        input: [{ type: "text", text }],
+        input,
       });
       updateActiveRunId(response.runId);
       props.onActiveRunIdChange?.(response.runId);
       setDraft("");
+      setImageAttachments([]);
     } catch (error) {
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);
@@ -371,6 +406,43 @@ export function Composer(props: ComposerProps) {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(inserted.nextSelection, inserted.nextSelection);
     });
+  };
+
+  const removeImageAttachment = (id: string): void => {
+    setImageAttachments((current) =>
+      current.filter((attachment) => attachment.id !== id)
+    );
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>): void => {
+    const pastedFiles = getPastedImageFiles(event.clipboardData);
+    if (pastedFiles.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    setSendError(undefined);
+    void attachPastedImages(pastedFiles);
+  };
+
+  const attachPastedImages = async (files: PastedImageFile[]): Promise<void> => {
+    try {
+      const nextAttachments = await Promise.all(
+        files.map(async ({ file, type }, index) => ({
+          id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+          name: file.name || formatPastedImageName(type, index),
+          size: file.size,
+          type,
+          url: await readFileAsDataUrl(file, type),
+        }))
+      );
+
+      setImageAttachments((current) => [...current, ...nextAttachments]);
+    } catch (error) {
+      setSendError(
+        error instanceof Error ? error.message : "The pasted image could not be read."
+      );
+    }
   };
 
   const handleLaunchpadPatch = (
@@ -448,6 +520,7 @@ export function Composer(props: ComposerProps) {
             setDraft(event.target.value);
             setSendError(undefined);
           }}
+          onPaste={handlePaste}
           onClick={() => {
             setActiveSkillIndex(0);
           }}
@@ -515,6 +588,38 @@ export function Composer(props: ComposerProps) {
           </div>
         ) : null}
       </div>
+
+      {imageAttachments.length > 0 ? (
+        <div className="composer__attachments" aria-label="Pasted images">
+          {imageAttachments.map((attachment, index) => (
+            <div className="composer__attachment" key={attachment.id}>
+              <img
+                className="composer__attachment-preview"
+                src={attachment.url}
+                alt={formatPastedImageAlt(attachment, index)}
+              />
+              <div className="composer__attachment-copy">
+                <span className="composer__attachment-name">
+                  {attachment.name}
+                </span>
+                <span className="composer__attachment-meta">
+                  {formatImageType(attachment.type)} · {formatBytes(attachment.size)}
+                </span>
+              </div>
+              <button
+                aria-label={`Remove ${attachment.name}`}
+                className="composer__attachment-remove"
+                type="button"
+                onClick={() => {
+                  removeImageAttachment(attachment.id);
+                }}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {props.launchpad || props.thread ? (
         <div
@@ -751,7 +856,7 @@ export function Composer(props: ComposerProps) {
         ) : null}
         <button
           className="button button--primary"
-          disabled={props.disabled || sending || !draft.trim()}
+          disabled={props.disabled || sending || (!draft.trim() && imageAttachments.length === 0)}
           type="submit"
         >
           {sending
@@ -765,6 +870,105 @@ export function Composer(props: ComposerProps) {
       </div>
     </form>
   );
+}
+
+function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
+  const files: PastedImageFile[] = [];
+  const seenFiles = new Set<string>();
+
+  for (const item of Array.from(clipboardData.items)) {
+    if (item.kind !== "file" || !item.type.startsWith("image/")) {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (!file) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push({ file, type: item.type });
+      seenFiles.add(key);
+    }
+  }
+
+  for (const file of Array.from(clipboardData.files)) {
+    if (!file.type.startsWith("image/")) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push({ file, type: file.type });
+      seenFiles.add(key);
+    }
+  }
+
+  return files;
+}
+
+function buildFileKey(file: File): string {
+  return `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
+}
+
+function readFileAsDataUrl(file: File, mimeType: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string" && reader.result.startsWith("data:image/")) {
+        resolve(reader.result);
+        return;
+      }
+
+      if (typeof reader.result === "string") {
+        const dataSeparatorIndex = reader.result.indexOf(",");
+        if (mimeType.startsWith("image/") && dataSeparatorIndex >= 0) {
+          resolve(`data:${mimeType};base64,${reader.result.slice(dataSeparatorIndex + 1)}`);
+          return;
+        }
+      }
+
+      reject(new Error("The pasted image did not produce an image data URL."));
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("The pasted image could not be read."));
+    });
+    reader.readAsDataURL(file);
+  });
+}
+
+function formatPastedImageName(type: string, index: number): string {
+  const extension = type.split("/")[1] || "png";
+  return `pasted-image-${index + 1}.${extension}`;
+}
+
+function formatPastedImageAlt(
+  attachment: Pick<ComposerImageAttachment, "name">,
+  index: number
+): string {
+  return attachment.name || `Pasted image ${index + 1}`;
+}
+
+function formatImageType(type: string): string {
+  const subtype = type.split("/")[1];
+  return subtype ? subtype.toUpperCase() : "Image";
+}
+
+function formatBytes(size: number): string {
+  if (!Number.isFinite(size) || size <= 0) {
+    return "Unknown size";
+  }
+
+  if (size < 1024) {
+    return `${size} B`;
+  }
+
+  if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatLaunchpadWorkspaceLabel(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -268,6 +268,142 @@ describe("Composer", () => {
     });
   });
 
+  it("sends pasted images with the reply", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1",
+    }));
+    const addOptimisticUserMessage = vi.fn(() => "optimistic-1");
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "screenshot.jpeg", {
+      type: "image/jpeg",
+    });
+
+    render(
+      <Composer
+        addOptimisticUserMessage={addOptimisticUserMessage}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/jpeg",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+    fireEvent.change(textarea, { target: { value: "Describe this screenshot" } });
+
+    expect(await screen.findByAltText("screenshot.jpeg")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          { type: "text", text: "Describe this screenshot" },
+          {
+            type: "image",
+            url: expect.stringMatching(/^data:image\/jpeg;base64,/),
+          },
+        ],
+      });
+    });
+    expect(addOptimisticUserMessage).toHaveBeenCalledWith(
+      "Describe this screenshot",
+      [
+        {
+          type: "image",
+          url: expect.stringMatching(/^data:image\/jpeg;base64,/),
+          alt: "screenshot.jpeg",
+        },
+      ]
+    );
+  });
+
+  it("allows pasted image-only replies", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      runId: "turn-1",
+    }));
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "diagram.png");
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("diagram.png")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "image",
+            url: expect.stringMatching(/^data:image\/png;base64,/),
+          },
+        ],
+      });
+    });
+  });
+
   it("keeps Shift+Enter available for a newline", () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -5,6 +5,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
+  AppServerTurnInputItem,
   AppServerThreadReplayPagination,
   AppServerSkillSummary,
   BackendSummary,
@@ -73,7 +74,7 @@ type ThreadViewProps = {
   onLoadOlder: () => Promise<void>;
   onMaterializeLaunchpad?: (
     directoryKey: string,
-    input?: Array<{ type: "text"; text: string }>
+    input?: AppServerTurnInputItem[]
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -5,6 +5,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  AppServerThreadImagePart,
   NavigationThreadSummary,
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
@@ -98,7 +99,7 @@ function pruneOptimisticEntries(
   return optimisticEntries.filter(
     (entry) =>
       !response.replay.messages.some(
-        (message) => message.role === entry.role && message.text === entry.text
+        (message) => messageMatchesOptimisticEntry(message, entry)
       )
   );
 }
@@ -109,6 +110,26 @@ function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
       session.optimisticEntries.length ||
       session.pendingAssistantMessage ||
       session.pendingRequest
+  );
+}
+
+function messageMatchesOptimisticEntry(
+  message: AppServerThreadMessage,
+  entry: AppServerThreadMessageEntry
+): boolean {
+  if (message.role !== entry.role || message.text !== entry.text) {
+    return false;
+  }
+
+  const entryImages = (entry.parts ?? []).filter((part) => part.type === "image");
+  if (entryImages.length === 0) {
+    return true;
+  }
+
+  const messageImages = (message.parts ?? []).filter((part) => part.type === "image");
+  return (
+    messageImages.length === entryImages.length &&
+    entryImages.every((image, index) => messageImages[index]?.url === image.url)
   );
 }
 
@@ -215,7 +236,10 @@ export function useThreadSessionState(params: {
   thread?: NavigationThreadSummary;
 }): {
   activeRunId?: string;
-  addOptimisticUserMessage: (text: string) => string;
+  addOptimisticUserMessage: (
+    text: string,
+    imageParts?: AppServerThreadImagePart[]
+  ) => string;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   entries: AppServerThreadEntry[];
   error?: string;
@@ -695,12 +719,16 @@ export function useThreadSessionState(params: {
   }, [desktopApi, selectedSession?.response, thread, threadKey, updateSession]);
 
   const addOptimisticUserMessage = useCallback(
-    (text: string): string => {
+    (text: string, imageParts: AppServerThreadImagePart[] = []): string => {
       if (!thread || !threadKey) {
         return `optimistic-${Date.now()}`;
       }
 
       const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const parts: AppServerThreadMessageEntry["parts"] = [
+        ...(text ? [{ type: "text" as const, text }] : []),
+        ...imageParts,
+      ];
       updateSession(threadKey, (current) => ({
         ...current,
         expectOwnUpdate: true,
@@ -713,6 +741,7 @@ export function useThreadSessionState(params: {
             id,
             role: "user",
             text,
+            parts,
             createdAt: Date.now(),
           },
         ],

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerReadThreadResponse,
   AppServerThreadEntry,
+  AppServerThreadImagePart,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
   NavigationThreadSummary
@@ -21,11 +22,34 @@ function mergeItems<T extends { id: string }>(
   return [...deduped.values()];
 }
 
+function messageMatchesOptimisticEntry(
+  message: AppServerThreadMessage,
+  entry: AppServerThreadMessageEntry
+): boolean {
+  if (message.role !== entry.role || message.text !== entry.text) {
+    return false;
+  }
+
+  const entryImages = (entry.parts ?? []).filter((part) => part.type === "image");
+  if (entryImages.length === 0) {
+    return true;
+  }
+
+  const messageImages = (message.parts ?? []).filter((part) => part.type === "image");
+  return (
+    messageImages.length === entryImages.length &&
+    entryImages.every((image, index) => messageImages[index]?.url === image.url)
+  );
+}
+
 export function useThreadTranscript(params: {
   desktopApi?: DesktopApi;
   thread?: NavigationThreadSummary;
 }): {
-  addOptimisticUserMessage: (text: string) => string;
+  addOptimisticUserMessage: (
+    text: string,
+    imageParts?: AppServerThreadImagePart[]
+  ) => string;
   error?: string;
   entries: AppServerThreadEntry[];
   loading: boolean;
@@ -150,8 +174,15 @@ export function useThreadTranscript(params: {
     }
   }, [desktopApi, response, thread]);
 
-  const addOptimisticUserMessage = useCallback((text: string): string => {
+  const addOptimisticUserMessage = useCallback((
+    text: string,
+    imageParts: AppServerThreadImagePart[] = []
+  ): string => {
     const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const parts: AppServerThreadMessageEntry["parts"] = [
+      ...(text ? [{ type: "text" as const, text }] : []),
+      ...imageParts
+    ];
     setOptimisticEntries((current) => [
       ...current,
       {
@@ -159,6 +190,7 @@ export function useThreadTranscript(params: {
         id,
         role: "user",
         text,
+        parts,
         createdAt: Date.now()
       }
     ]);
@@ -174,7 +206,7 @@ export function useThreadTranscript(params: {
       optimisticEntries.filter(
         (entry) =>
           !response?.replay.messages.some(
-            (message) => message.role === entry.role && message.text === entry.text
+            (message) => messageMatchesOptimisticEntry(message, entry)
           )
       ),
     [optimisticEntries, response?.replay.messages]

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -250,7 +250,8 @@ textarea {
 .lens-switch__button:focus-visible,
 .thread-row:focus-visible,
 .transcript-activity__toggle:focus-visible,
-.composer__input:focus-visible {
+.composer__input:focus-visible,
+.composer__attachment-remove:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -1827,6 +1828,71 @@ textarea {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.composer__attachments {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  gap: 8px;
+}
+
+.composer__attachment {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.composer__attachment-preview {
+  width: 56px;
+  aspect-ratio: 1;
+  border-radius: 6px;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.composer__attachment-copy {
+  min-width: 0;
+}
+
+.composer__attachment-name,
+.composer__attachment-meta {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer__attachment-name {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.composer__attachment-meta {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.composer__attachment-remove {
+  min-height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.composer__attachment-remove:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
 }
 
 .composer__setup {


### PR DESCRIPTION
## Summary

Allows users to paste screenshots and other image clipboard items directly into the desktop chat composer. Pasted images are read as image data URLs, previewed inline with a remove action, and sent through the existing image turn-input protocol alongside optional text.

## Details

- Adds composer attachment state for pasted `image/*` clipboard files, including PNG, JPEG, GIF, WebP, and clipboard items with missing `File.type` metadata.
- Enables image-only sends by treating attachments as valid turn input even when the reply text is empty.
- Includes pasted image parts in optimistic user messages so the transcript reflects the submitted image immediately.
- Extends launchpad materialization typing to accept the full turn-input item union instead of text-only input.

## Verification

- `pnpm vitest run apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx --config vitest.workspace.ts`
- `pnpm vitest run apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx --config vitest.workspace.ts`
- `pnpm vitest run --project desktop-renderer --config vitest.workspace.ts`
- `pnpm --filter @pwragnt/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 via [Codex](https://openai.com/codex)