### PR TITLE
fix(desktop): preserve transcript order after live turns

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -27,6 +27,196 @@ describe("useThreadSessionState", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps the optimistic user message ahead of the completed assistant reply", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.addOptimisticUserMessage("Please fix transcript ordering.");
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            runId: "run-1",
+            turn: {
+              output: [{ type: "text", text: "Transcript ordering is fixed." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "assistant:Loaded thread-1",
+        "user:Please fix transcript ordering.",
+        "assistant:Transcript ordering is fixed.",
+      ]);
+    });
+
+    expect(
+      result.current.response?.replay.messages.map(
+        (message) => `${message.role}:${message.text}`
+      )
+    ).toEqual([
+      "assistant:Loaded thread-1",
+      "user:Please fix transcript ordering.",
+      "assistant:Transcript ordering is fixed.",
+    ]);
+  });
+
+  it("materializes a new thread in user-then-assistant order on completion", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-empty", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      result.current.addOptimisticUserMessage("Start a new ordered thread.");
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-empty",
+            runId: "run-2",
+            turn: {
+              output: [{ type: "text", text: "The new thread is ordered." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "user:Start a new ordered thread.",
+        "assistant:The new thread is ordered.",
+      ]);
+    });
+  });
+
   it("does not reread an interacted thread when only updatedAt changed on reselect", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -112,31 +112,39 @@ function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
   );
 }
 
-function appendAssistantMessage(
+function appendMessageEntries(
   response: AppServerReadThreadResponse | undefined,
   params: {
     backend: NavigationThreadSummary["source"];
     threadId: NavigationThreadSummary["id"];
   },
-  message: AppServerThreadMessageEntry
+  entries: AppServerThreadMessageEntry[]
 ): AppServerReadThreadResponse {
   const baseResponse = response ?? buildEmptyResponse(params);
-  const assistantMessage: AppServerThreadMessage = {
-    id: message.id,
-    role: message.role,
-    text: message.text,
-    parts: message.parts,
-    createdAt: message.createdAt,
-  };
+  const nextMessages: AppServerThreadMessage[] = entries.map(
+    ({ type: _type, ...message }) => message
+  );
+  let lastUserMessage = baseResponse.replay.lastUserMessage;
+  let lastAssistantMessage = baseResponse.replay.lastAssistantMessage;
+
+  for (const message of nextMessages) {
+    if (message.role === "user") {
+      lastUserMessage = message.text;
+      continue;
+    }
+
+    lastAssistantMessage = message.text;
+  }
 
   return {
     ...baseResponse,
     fetchedAt: Date.now(),
     replay: {
       ...baseResponse.replay,
-      entries: mergeItems(baseResponse.replay.entries, [message]),
-      messages: mergeItems(baseResponse.replay.messages, [assistantMessage]),
-      lastAssistantMessage: message.text,
+      entries: mergeItems(baseResponse.replay.entries, entries),
+      messages: mergeItems(baseResponse.replay.messages, nextMessages),
+      lastUserMessage,
+      lastAssistantMessage,
     },
   };
 }
@@ -511,25 +519,32 @@ export function useThreadSessionState(params: {
           const completedText =
             readCompletedTurnText(event.notification.params) ??
             current.pendingAssistantMessage?.text;
+          const nextEntries = [...current.optimisticEntries];
+
+          if (completedText) {
+            nextEntries.push({
+              type: "message",
+              id:
+                current.pendingAssistantMessage?.id ??
+                `${event.notification.params.runId}:assistant`,
+              role: "assistant",
+              text: completedText,
+              createdAt: Date.now(),
+            });
+          }
+
           const nextResponse =
-            completedText
-              ? appendAssistantMessage(current.response, {
+            nextEntries.length > 0
+              ? appendMessageEntries(current.response, {
                   backend: event.backend,
                   threadId: notificationThreadId,
-                }, {
-                  type: "message",
-                  id:
-                    current.pendingAssistantMessage?.id ??
-                    `${event.notification.params.runId}:assistant`,
-                  role: "assistant",
-                  text: completedText,
-                  createdAt: Date.now(),
-                })
+                }, nextEntries)
               : current.response;
           const shouldInvalidateHydration =
             !completedText &&
             !hasHydratedTranscriptContent({
               ...current,
+              optimisticEntries: [],
               pendingAssistantMessage: undefined,
               pendingRequest: undefined,
               response: nextResponse,
@@ -547,6 +562,7 @@ export function useThreadSessionState(params: {
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion: !completedText,
+            optimisticEntries: [],
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
             pendingStatusText: undefined,


### PR DESCRIPTION
## Summary
Fix the desktop transcript reducer so a completed assistant reply cannot render above the user message that triggered it.

## What changed
- fold optimistic user entries into the hydrated replay before appending the terminal assistant message on `turn/completed`
- clear the optimistic buffer once those entries are materialized into replay state
- add focused hook regressions for both hydrated-thread and empty-thread completion paths

## Why it matters
The thread history stored by Codex is already in the right order, but the desktop app was merging live turn completion state in a way that produced `assistant final` before `optimistic user`. This PR fixes the live reducer path that caused the 6:50 PM / 6:41 PM inversion in thread `019da718-0aee-7d51-9b19-1400b2a7ce5a`.

## Verification
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
