### PR TITLE
feat(desktop): handle live turn diff notifications

### DIFF
--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -83,6 +83,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "item/completed",
   "item/plan/delta",
   "turn/plan/updated",
+  "turn/diff/updated",
   "serverRequest/resolved",
   "thread/compacted",
   "thread/status/changed",

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import type {
   AppServerPendingRequestNotification,
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
@@ -38,6 +40,160 @@ function arePlanEntriesEquivalent(
   return left.steps.every((step, index) => {
     const other = right.steps[index];
     return other?.status === step.status && other.step === step.step;
+  });
+}
+
+function summarizeDiff(diff: string): { additions: number; removals: number } {
+  let additions = 0;
+  let removals = 0;
+
+  for (const line of diff.split("\n")) {
+    if (
+      !line ||
+      line.startsWith("+++") ||
+      line.startsWith("---") ||
+      line.startsWith("@@") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      additions += 1;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+
+  return { additions, removals };
+}
+
+function getBasename(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments[segments.length - 1] || path;
+}
+
+function normalizeDiffPath(path: string | undefined): string | undefined {
+  if (!path || path === "/dev/null") {
+    return undefined;
+  }
+
+  return path.replace(/^[ab]\//, "");
+}
+
+function inferDiffKind(lines: string[]): "add" | "delete" | "update" {
+  const beforeLine = lines.find((line) => line.startsWith("--- "));
+  const afterLine = lines.find((line) => line.startsWith("+++ "));
+
+  if (beforeLine?.slice(4).trim() === "/dev/null") {
+    return "add";
+  }
+
+  if (afterLine?.slice(4).trim() === "/dev/null") {
+    return "delete";
+  }
+
+  return "update";
+}
+
+function buildDiffLabel(kind: "add" | "delete" | "update", path?: string): string {
+  const verb = kind[0]?.toUpperCase() + kind.slice(1);
+  return `${verb} ${path ? getBasename(path) : "file"}`;
+}
+
+function extractDiffDetails(
+  diff: string,
+  entryId: string
+): AppServerThreadActivityDetail[] {
+  const lines = diff.replace(/\r\n?/g, "\n").split("\n");
+  const sections: Array<{ lines: string[] }> = [];
+  let currentSection: { lines: string[] } | undefined;
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      if (currentSection?.lines.length) {
+        sections.push(currentSection);
+      }
+      currentSection = { lines: [line] };
+      continue;
+    }
+
+    if (!currentSection) {
+      currentSection = { lines: [] };
+    }
+
+    currentSection.lines.push(line);
+  }
+
+  if (currentSection?.lines.length) {
+    sections.push(currentSection);
+  }
+
+  const normalizedSections = sections.length > 0 ? sections : [{ lines }];
+  const details: AppServerThreadActivityDetail[] = [];
+
+  for (const [index, section] of normalizedSections.entries()) {
+    const rawBefore = section.lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
+    const rawAfter = section.lines.find((line) => line.startsWith("+++ "))?.slice(4).trim();
+    const path = normalizeDiffPath(rawAfter) ?? normalizeDiffPath(rawBefore);
+    const diffText = section.lines.join("\n").trim();
+
+    if (!diffText) {
+      continue;
+    }
+
+    const kind = inferDiffKind(section.lines);
+    const diffSummary = summarizeDiff(diffText);
+
+    details.push({
+      id: `${entryId}-${index + 1}`,
+      kind: "write",
+      label: buildDiffLabel(kind, path),
+      ...(path ? { path } : {}),
+      fileDiff: {
+        kind,
+        diff: diffText,
+        additions: diffSummary.additions,
+        removals: diffSummary.removals,
+      },
+    });
+  }
+
+  return details;
+}
+
+function buildPendingDiffEntry(params: {
+  diff: string;
+  id: string;
+}): AppServerThreadActivityEntry | undefined {
+  const details = extractDiffDetails(params.diff, params.id);
+  if (details.length === 0) {
+    return undefined;
+  }
+
+  return {
+    type: "activity",
+    id: params.id,
+    createdAt: Date.now(),
+    summary: `Edited ${details.length} file${details.length === 1 ? "" : "s"}`,
+    details,
+  };
+}
+
+function activityContainsDiff(
+  candidate: AppServerThreadActivityEntry,
+  pendingEntry: AppServerThreadActivityEntry
+): boolean {
+  return pendingEntry.details.every((pendingDetail) => {
+    const pendingDiff = pendingDetail.fileDiff?.diff;
+    if (!pendingDiff) {
+      return false;
+    }
+
+    return candidate.details.some((detail) => detail.fileDiff?.diff === pendingDiff);
   });
 }
 
@@ -109,6 +265,8 @@ type ThreadViewProps = {
 };
 
 export function ThreadView(props: ThreadViewProps) {
+  const [pendingActivityEntry, setPendingActivityEntry] =
+    useState<AppServerThreadActivityEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
@@ -116,6 +274,7 @@ export function ThreadView(props: ThreadViewProps) {
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
 
   useEffect(() => {
+    setPendingActivityEntry(undefined);
     setPendingPlanEntry(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
@@ -128,6 +287,20 @@ export function ThreadView(props: ThreadViewProps) {
 
   const selectedThread = props.selectedThread;
   const selectedLaunchpad = props.selectedLaunchpad;
+
+  useEffect(() => {
+    if (!pendingActivityEntry) {
+      return;
+    }
+
+    const persistedActivity = props.transcriptEntries.find(
+      (entry): entry is AppServerThreadActivityEntry =>
+        entry.type === "activity" && activityContainsDiff(entry, pendingActivityEntry)
+    );
+    if (persistedActivity) {
+      setPendingActivityEntry(undefined);
+    }
+  }, [pendingActivityEntry, props.transcriptEntries]);
 
   useEffect(() => {
     if (!pendingPlanEntry) {
@@ -149,11 +322,48 @@ export function ThreadView(props: ThreadViewProps) {
     }
 
     return props.desktopApi.onAgentEvent((event) => {
+      const notificationThreadId =
+        "threadId" in event.notification.params &&
+        typeof event.notification.params.threadId === "string"
+          ? event.notification.params.threadId
+          : undefined;
+
       if (
-        event.notification.method !== "turn/plan/updated" ||
         event.backend !== selectedThread.source ||
-        event.notification.params.threadId !== selectedThread.id
+        notificationThreadId !== selectedThread.id
       ) {
+        return;
+      }
+
+      if (
+        event.notification.method === "turn/failed" ||
+        event.notification.method === "turn/cancelled"
+      ) {
+        setPendingActivityEntry(undefined);
+        return;
+      }
+
+      if (event.notification.method === "turn/diff/updated") {
+        if (typeof event.notification.params.diff !== "string") {
+          return;
+        }
+
+        setPendingActivityEntry(
+          buildPendingDiffEntry({
+            diff: event.notification.params.diff,
+            id: `live-diff-${
+              typeof event.notification.params.turnId === "string"
+                ? event.notification.params.turnId
+                : typeof event.notification.params.runId === "string"
+                  ? event.notification.params.runId
+                  : selectedThread.id
+            }`,
+          })
+        );
+        return;
+      }
+
+      if (event.notification.method !== "turn/plan/updated") {
         return;
       }
 
@@ -355,6 +565,7 @@ export function ThreadView(props: ThreadViewProps) {
             loading={props.loading}
             loadingMore={props.loadingMore}
             pagination={props.transcriptPagination}
+            pendingActivityEntry={pendingActivityEntry}
             pendingAssistantMessage={props.pendingAssistantMessage}
             pendingPlanEntry={pendingPlanEntry}
             pendingRequest={props.pendingRequest}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   AppServerPendingRequestNotification,
+  AppServerThreadActivityEntry,
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
@@ -18,6 +19,7 @@ type TranscriptListProps = {
   error?: string;
   loading: boolean;
   loadingMore: boolean;
+  pendingActivityEntry?: AppServerThreadActivityEntry;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -77,6 +79,7 @@ export function TranscriptList(props: TranscriptListProps) {
     const lastMessageId = props.entries[props.entries.length - 1]?.id;
     const itemCount =
       props.entries.length +
+      (props.pendingActivityEntry ? 1 : 0) +
       (props.pendingAssistantMessage ? 1 : 0) +
       (props.pendingPlanEntry ? 1 : 0) +
       (props.pendingStatusText ? 1 : 0) +
@@ -99,6 +102,7 @@ export function TranscriptList(props: TranscriptListProps) {
     };
   }, [
     props.entries,
+    props.pendingActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
@@ -182,6 +186,7 @@ export function TranscriptList(props: TranscriptListProps) {
           previousSnapshot.pendingStatusText !== props.pendingStatusText ||
       previousSnapshot.itemCount <
             props.entries.length +
+              (props.pendingActivityEntry ? 1 : 0) +
               (props.pendingAssistantMessage ? 1 : 0) +
               (props.pendingPlanEntry ? 1 : 0) +
               (props.pendingStatusText ? 1 : 0) +
@@ -227,6 +232,7 @@ export function TranscriptList(props: TranscriptListProps) {
     syncScrollState();
   }, [
     props.entries,
+    props.pendingActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
@@ -287,6 +293,12 @@ export function TranscriptList(props: TranscriptListProps) {
         )}
         {props.pendingPlanEntry ? (
           <TranscriptPlan key={props.pendingPlanEntry.id} entry={props.pendingPlanEntry} />
+        ) : null}
+        {props.pendingActivityEntry ? (
+          <TranscriptActivity
+            key={props.pendingActivityEntry.id}
+            entry={props.pendingActivityEntry}
+          />
         ) : null}
         {props.pendingAssistantMessage ? (
           <TranscriptMessage

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -879,6 +879,216 @@ describe("ThreadView", () => {
     expect(screen.getAllByText("0 out of 3 tasks completed")).toHaveLength(1);
   });
 
+  it("renders live diff activity from turn/diff/updated and clears it once replay catches up", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Fix the transcript merge markers",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    const liveDiff = [
+      "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "@@ -113,2 +113,1 @@",
+      "-<<<<<<< HEAD",
+      "-function appendMessageEntries(",
+      "+function messageMatchesOptimisticEntry("
+    ].join("\n");
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    const { rerender } = render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Fix the merge markers."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/diff/updated",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            diff: liveDiff
+          }
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/diff/updated",
+          params: {
+            threadId: "thread-other",
+            turnId: "turn-2",
+            diff: "diff --git a/ignored.ts b/ignored.ts"
+          }
+        },
+      });
+    });
+
+    const toggle = screen.getByRole("button", { name: /Edited 1 file/i });
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("Update useThreadSessionState.ts")).toBeInTheDocument();
+    expect(screen.getByText("function messageMatchesOptimisticEntry(")).toBeInTheDocument();
+    expect(screen.queryByText("ignored.ts")).not.toBeInTheDocument();
+
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={2}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Fix the merge markers."
+          },
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Edited 1 file",
+            details: [
+              {
+                id: "detail-1",
+                kind: "write",
+                label: "Update useThreadSessionState.ts",
+                path: "/repo/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+                fileDiff: {
+                  kind: "update",
+                  additions: 1,
+                  removals: 2,
+                  diff: liveDiff
+                }
+              }
+            ]
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(1);
+  });
+
   it("maps command approval actions to native decision values and dismisses the approval card", async () => {
     const submitServerRequest = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -365,6 +365,59 @@ describe("TranscriptList", () => {
     );
   });
 
+  it("renders a live activity entry before the turn is persisted", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Fix the merge markers"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "pending-activity-1",
+          summary: "Edited 1 file",
+          details: [
+            {
+              id: "pending-detail-1",
+              kind: "write",
+              label: "Update useThreadSessionState.ts",
+              path: "/repo/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+              fileDiff: {
+                kind: "update",
+                additions: 1,
+                removals: 2,
+                diff: [
+                  "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+                  "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+                  "@@ -1,3 +1,2 @@",
+                  "-<<<<<<< HEAD",
+                  "-function appendMessageEntries(",
+                  "+function messageMatchesOptimisticEntry("
+                ].join("\n")
+              }
+            }
+          ]
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const toggle = screen.getByRole("button", { name: /Edited 1 file/i });
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("Update useThreadSessionState.ts")).toBeInTheDocument();
+    expect(screen.getByText("function messageMatchesOptimisticEntry(")).toBeInTheDocument();
+  });
+
   it("anchors a freshly loaded transcript to the newest entry", () => {
     render(
       <TranscriptList

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -255,6 +255,15 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "turn/diff/updated";
+      params: {
+        threadId: string;
+        turnId?: string;
+        runId?: string;
+        diff: string;
+      };
+    }
+  | {
       method: "serverRequest/resolved";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -311,6 +311,15 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "turn/diff/updated";
+      params: {
+        threadId: string;
+        turnId?: string;
+        runId?: string;
+        diff: string;
+      };
+    }
+  | {
       method: "turn/requestApproval" | "review/requestApproval";
       params: AppServerPendingRequestNotification["params"];
     }


### PR DESCRIPTION
## Summary
- recognize `turn/diff/updated` as a first-class app-server notification instead of logging it as unknown
- render live diff notifications as pending transcript activity so file changes are visible before replay persistence catches up
- extend the shared notification contract and add renderer coverage for the pending diff path

## Testing
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm typecheck`
