### PR TITLE
feat(desktop): Show active thread row indicators

### DIFF
--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -1,0 +1,246 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createThreadRowStatusFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-thread-row-status-"));
+  const fixturePath = path.join(rootDir, "thread-row-status.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-row-status",
+          threadId: "thread-initiated",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-initiated",
+                title: "Initiated thread",
+                titleSource: "explicit",
+                summary: "A thread we start from the app",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+              {
+                id: "thread-reference",
+                title: "Reference thread",
+                titleSource: "explicit",
+                summary: "A thread we switch to while the first one runs",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_500,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "initiated-message-1",
+                  role: "assistant",
+                  text: "Initiated thread baseline",
+                },
+              ],
+              messages: [
+                {
+                  id: "initiated-message-1",
+                  role: "assistant",
+                  text: "Initiated thread baseline",
+                },
+              ],
+              lastAssistantMessage: "Initiated thread baseline",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-initiated",
+              runId: "turn-initiated-1",
+            },
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "reference-message-1",
+                  role: "assistant",
+                  text: "Reference thread baseline",
+                },
+              ],
+              messages: [
+                {
+                  id: "reference-message-1",
+                  role: "assistant",
+                  text: "Reference thread baseline",
+                },
+              ],
+              lastAssistantMessage: "Reference thread baseline",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-initiated",
+                turn: {
+                  id: "turn-initiated-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "turn-completed-1",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-initiated",
+                runId: "turn-initiated-1",
+                turn: {
+                  id: "turn-initiated-1",
+                  status: "completed",
+                  output: [
+                    {
+                      type: "text",
+                      text: "Finished the initiated turn.",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-initiated",
+                title: "Initiated thread",
+                titleSource: "explicit",
+                summary: "A thread we start from the app",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-reference",
+                title: "Reference thread",
+                titleSource: "explicit",
+                summary: "A thread we switch to while the first one runs",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_500,
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
+test("shows initiated background turns as thinking, then unread once they finish", async () => {
+  const fixture = await createThreadRowStatusFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    const browseSection = app.window.locator(".sidebar__section--fill");
+    const initiatedRow = browseSection.getByRole("button", {
+      name: /Initiated thread/i,
+    });
+
+    await initiatedRow.click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Initiated thread",
+      })
+    ).toBeVisible();
+
+    await app.window.getByLabel("Reply").fill("Keep working on this thread.");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await browseSection.getByRole("button", { name: /Reference thread/i }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Reference thread",
+      })
+    ).toBeVisible();
+
+    await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toBeVisible();
+    await expect(initiatedRow.locator('[data-thread-status="unread"]')).toHaveCount(0);
+
+    await app.advance({ stepId: "turn-started-1" });
+    await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toBeVisible();
+
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toHaveCount(0);
+    await expect(initiatedRow.locator('[data-thread-status="unread"]')).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ export function App() {
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
         selectedItemKey={navigation.selectedItemKey}
+        thinkingThreadKeys={session.thinkingThreadKeys}
         threads={navigation.threads}
         onBrowseModeChange={navigation.setBrowseMode}
         onCreateThread={navigation.createThread}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -6,10 +6,12 @@ import type {
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThreadMetaChips } from "./ThreadMetaChips";
+import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
 type DirectoriesListProps = {
   directories: NavigationDirectorySummary[];
   selectedItemKey?: string;
+  thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -140,6 +142,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     {visibleThreads.map((thread) => {
                       const selected =
                         buildThreadIdentityKey(thread.source, thread.id) === props.selectedItemKey;
+                      const status = getThreadRowStatus(thread, props.thinkingThreadKeys);
                       return (
                         <button
                           key={`${directory.key}:${buildThreadIdentityKey(thread.source, thread.id)}`}
@@ -149,7 +152,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onClick={() => props.onSelectThread(thread)}
                         >
                           <span className="thread-row__header">
-                            <span className="thread-row__title">{thread.title}</span>
+                            <span className="thread-row__heading">
+                              <ThreadRowStatus status={status} />
+                              <span className="thread-row__title">{thread.title}</span>
+                            </span>
                             <span className="thread-row__time">
                               {formatRelativeTime(thread.updatedAt)}
                             </span>

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,9 +1,11 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThreadMetaChips } from "./ThreadMetaChips";
+import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
 type RecentsListProps = {
   selectedThreadKey?: string;
+  thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -14,6 +16,7 @@ export function RecentsList(props: RecentsListProps) {
       {props.threads.map((thread) => {
         const selected =
           buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
+        const status = getThreadRowStatus(thread, props.thinkingThreadKeys);
         return (
           <button
             key={buildThreadIdentityKey(thread.source, thread.id)}
@@ -23,7 +26,10 @@ export function RecentsList(props: RecentsListProps) {
             onClick={() => props.onSelectThread(thread)}
           >
             <span className="thread-row__header">
-              <span className="thread-row__title">{thread.title}</span>
+              <span className="thread-row__heading">
+                <ThreadRowStatus status={status} />
+                <span className="thread-row__title">{thread.title}</span>
+              </span>
               <span className="thread-row__time">
                 {formatRelativeTime(thread.updatedAt)}
               </span>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -28,6 +28,7 @@ type SidebarProps = {
   };
   launchpadError?: string;
   selectedItemKey?: string;
+  thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: (
@@ -177,6 +178,7 @@ export function Sidebar(props: SidebarProps) {
             <DirectoriesList
               directories={props.directories}
               selectedItemKey={props.selectedItemKey}
+              thinkingThreadKeys={props.thinkingThreadKeys}
               threads={props.threads}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onSelectThread={props.onSelectThread}
@@ -184,6 +186,7 @@ export function Sidebar(props: SidebarProps) {
           ) : (
             <RecentsList
               selectedThreadKey={props.selectedItemKey}
+              thinkingThreadKeys={props.thinkingThreadKeys}
               threads={props.threads}
               onSelectThread={props.onSelectThread}
             />

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -1,0 +1,53 @@
+import type { NavigationThreadSummary } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
+
+export type ThreadRowStatusKind = "thinking" | "unread";
+
+export function getThreadRowStatus(
+  thread: NavigationThreadSummary,
+  thinkingThreadKeys?: Record<string, boolean>
+): ThreadRowStatusKind | undefined {
+  const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+  if (thinkingThreadKeys?.[threadKey]) {
+    return "thinking";
+  }
+
+  if (thread.inbox.inInbox) {
+    return "unread";
+  }
+
+  return undefined;
+}
+
+type ThreadRowStatusProps = {
+  status?: ThreadRowStatusKind;
+};
+
+export function ThreadRowStatus(props: ThreadRowStatusProps) {
+  if (!props.status) {
+    return null;
+  }
+
+  if (props.status === "thinking") {
+    return (
+      <span
+        aria-hidden="true"
+        className="thread-row__status-indicator thread-row__status-indicator--thinking"
+        data-thread-status="thinking"
+      >
+        <ThinkingScanner compact />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="thread-row__status-indicator thread-row__status-indicator--unread"
+      data-thread-status="unread"
+    >
+      <span className="thread-row__status-dot" />
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -179,6 +179,69 @@ describe("Sidebar", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
 
+  it("shows the thinking indicator instead of unread for an active initiated turn", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        fetchedAt={Date.now()}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        thinkingThreadKeys={{ "codex:thread-1": true }}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
+    expect(browseSection).not.toBeNull();
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    expect(threadButton.querySelector('[data-thread-status="thinking"]')).not.toBeNull();
+    expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
+  });
+
+  it("falls back to the unread indicator in recents once the turn is done", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        fetchedAt={Date.now()}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
+    expect(browseSection).not.toBeNull();
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
+    expect(threadButton.querySelector('[data-thread-status="unread"]')).not.toBeNull();
+  });
+
   it("renders directory rows without the raw chevron glyph affordance", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -1,8 +1,12 @@
-export function ThinkingScanner() {
+type ThinkingScannerProps = {
+  compact?: boolean;
+};
+
+export function ThinkingScanner(props: ThinkingScannerProps = {}) {
   return (
     <div
       aria-hidden="true"
-      className="thinking-scanner"
+      className={`thinking-scanner${props.compact ? " thinking-scanner--mini" : ""}`}
     >
       <div className="thinking-scanner__beam" />
     </div>

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -217,6 +217,98 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("tracks thinking state for a nonselected thread until the turn completes", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-2", updatedAt: 1_500 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.threadId).toBe("thread-2");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "run-1",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            runId: "run-1",
+            turn: {
+              id: "run-1",
+              status: "completed",
+              output: [{ type: "text", text: "Finished background work." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+    });
+  });
+
   it("does not reread an interacted thread when only updatedAt changed on reselect", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -113,6 +113,16 @@ function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
   );
 }
 
+function hasThinkingState(session: ThreadSessionEntry): boolean {
+  return Boolean(
+    session.activeRunId ||
+      session.pendingStatusText ||
+      session.pendingAssistantMessage ||
+      session.pendingRequest ||
+      (session.expectOwnUpdate && session.optimisticEntries.length > 0)
+  );
+}
+
 function messageMatchesOptimisticEntry(
   message: AppServerThreadMessage,
   entry: AppServerThreadMessageEntry
@@ -254,6 +264,7 @@ export function useThreadSessionState(params: {
   response?: AppServerReadThreadResponse;
   setActiveRunId: (runId?: string) => void;
   setPendingStatusText: (status?: string) => void;
+  thinkingThreadKeys: Record<string, boolean>;
   setViewport: (viewport?: ThreadViewportState) => void;
   viewport?: ThreadViewportState;
 } {
@@ -874,6 +885,16 @@ export function useThreadSessionState(params: {
     [selectedSession?.response?.replay.messages, visibleOptimisticEntries]
   );
 
+  const thinkingThreadKeys = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(sessions)
+          .filter(([, session]) => hasThinkingState(session))
+          .map(([sessionThreadKey]) => [sessionThreadKey, true])
+      ),
+    [sessions]
+  );
+
   return {
     activeRunId: selectedSession?.activeRunId,
     addOptimisticUserMessage,
@@ -891,6 +912,7 @@ export function useThreadSessionState(params: {
     response: selectedSession?.response,
     setActiveRunId,
     setPendingStatusText,
+    thinkingThreadKeys,
     setViewport,
     viewport: selectedSession?.viewport,
   };

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -367,6 +367,14 @@ textarea {
   gap: 12px;
 }
 
+.thread-row__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+}
+
 .thread-row__title,
 .directory-group__title,
 .context-list__label {
@@ -389,6 +397,23 @@ textarea {
   color: var(--text-muted);
   font-size: 12px;
   font-weight: 500;
+}
+
+.thread-row__status-indicator {
+  display: inline-flex;
+  width: 14px;
+  min-width: 14px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+}
+
+.thread-row__status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 10px rgba(184, 255, 77, 0.42);
 }
 
 .thread-row__summary {
@@ -1252,6 +1277,11 @@ textarea {
   box-shadow: inset 0 0 0 1px rgba(255, 106, 94, 0.14);
 }
 
+.thinking-scanner--mini {
+  width: 14px;
+  height: 6px;
+}
+
 .thinking-scanner__beam {
   position: absolute;
   top: 0;
@@ -1271,6 +1301,13 @@ textarea {
   animation:
     pwragnt-kitt-scan 1.35s cubic-bezier(0.4, 0, 0.2, 1) infinite,
     pwragnt-kitt-glow 0.7s ease-in-out infinite;
+}
+
+.thinking-scanner--mini .thinking-scanner__beam {
+  width: 8px;
+  box-shadow:
+    0 0 8px rgba(255, 106, 94, 0.55),
+    0 0 14px rgba(255, 78, 68, 0.24);
 }
 
 .transcript-activity__header {


### PR DESCRIPTION
## Summary
- Add a compact thread-row status indicator for Recents and directory thread rows.
- Reuse the KITT thinking scanner while a locally initiated turn is active, then fall back to an unread dot when the completed thread is still unseen.
- Expose per-thread thinking state from the session hook so active turns remain visible after switching away.

## Testing
- pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
- pnpm --filter @pwragnt/desktop typecheck
- pnpm --filter @pwragnt/desktop build
- pnpm --filter @pwragnt/desktop test:e2e -- thread-row-status.spec.ts