### PR TITLE
fix(desktop): simplify Codex listing and keep thinking visible

### DIFF
--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -1,9 +1,126 @@
 import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const turnLifecycleSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function createActiveRunThinkingFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-active-run-thinking-"));
+  const fixturePath = path.join(rootDir, "active-run-thinking.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "active-run-thinking",
+          threadId: "thread-active-run-thinking",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-active-run-thinking",
+                title: "Active run thinking replay",
+                titleSource: "explicit",
+                summary: "Replay seeded active run thinking state",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Keep working while I watch the transcript footer.",
+                },
+                {
+                  type: "message",
+                  id: "message-2",
+                  role: "assistant",
+                  text: "Baseline transcript is ready.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Keep working while I watch the transcript footer.",
+                },
+                {
+                  id: "message-2",
+                  role: "assistant",
+                  text: "Baseline transcript is ready.",
+                },
+              ],
+              lastUserMessage: "Keep working while I watch the transcript footer.",
+              lastAssistantMessage: "Baseline transcript is ready.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-active-run-thinking",
+                runId: "turn-active-run-thinking-1",
+                turn: {
+                  id: "turn-active-run-thinking-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
 
 test("keeps transient turn UI through metadata and premature idle notifications", async () => {
   const app = await launchElectronApp({
@@ -85,5 +202,43 @@ test("keeps transient turn UI through metadata and premature idle notifications"
     ).toBeVisible();
   } finally {
     await app.close();
+  }
+});
+
+test("keeps the in-thread thinking indicator visible for active runs without pending text", async () => {
+  const fixture = await createActiveRunThinkingFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Active run thinking replay/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Active run thinking replay",
+      })
+    ).toBeVisible();
+    await expect(
+      app.window.getByText("Baseline transcript is ready.", { exact: true })
+    ).toBeVisible();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    await expect(transcript.getByRole("status")).toHaveCount(0);
+
+    await app.advance({ stepId: "turn-started-1" });
+
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(transcript.getByRole("status")).toContainText("Thinking");
+    await expect(
+      app.window
+        .getByRole("button", { name: /Active run thinking replay/i })
+        .locator('[data-thread-status="thinking"]')
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
   }
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -66,6 +66,10 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
   };
+  listThreadsCallCount = 0;
+  lastListThreadsParams?: {
+    filter?: string;
+  };
 
   constructor(
     private readonly options: {
@@ -96,7 +100,9 @@ class MockBackendClient {
     return this.options.initializeResult ?? {};
   }
 
-  async listThreads(): Promise<AppServerThreadSummary[]> {
+  async listThreads(params?: { filter?: string }): Promise<AppServerThreadSummary[]> {
+    this.listThreadsCallCount += 1;
+    this.lastListThreadsParams = params;
     return this.options.threads ?? [];
   }
 
@@ -451,6 +457,69 @@ describe("DesktopBackendRegistry", () => {
       sandbox: "danger-full-access",
     });
     expect(codexFullAccessClient.lastSetThreadPermissionsParams).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("lists Codex threads only through the default client and reapplies overlay execution mode", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-1",
+          title: "Thread one",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 2,
+        },
+        {
+          id: "thread-2",
+          title: "Thread two",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 1,
+        },
+      ],
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-3",
+          title: "Should not appear",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+          updatedAt: 3,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({ executionMode: "full-access" }),
+    });
+
+    const threads = await registry.listThreads({ backend: "codex", filter: "thread" });
+
+    expect(threads).toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        executionMode: "full-access",
+      }),
+      expect.objectContaining({
+        id: "thread-2",
+        executionMode: "default",
+      }),
+    ]);
+    expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(codexClient.lastListThreadsParams).toEqual({ filter: "thread" });
+    expect(codexFullAccessClient.listThreadsCallCount).toBe(0);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -670,54 +670,26 @@ export class DesktopBackendRegistry {
   }
 
   private async listCodexThreads(filter?: string): Promise<AppServerThreadSummary[]> {
-    const [defaultThreads, fullAccessThreads] = await Promise.all([
-      this.codexDefaultClient.listThreads({ filter }).catch(() => []),
-      this.codexFullAccessClient.listThreads({ filter }).catch(() => []),
-    ]);
-
-    const threadsById = new Map<string, AppServerThreadSummary>();
-    const allThreads = [
-      ...defaultThreads.map((thread) => ({
-        ...thread,
-        executionMode: "default" as const,
-      })),
-      ...fullAccessThreads.map((thread) => ({
-        ...thread,
-        executionMode: "full-access" as const,
-      })),
-    ];
+    const defaultThreads = await this.codexDefaultClient.listThreads({ filter }).catch(() => []);
+    const allThreads = defaultThreads.map((thread) => ({
+      ...thread,
+      executionMode: "default" as const,
+    }));
 
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
-      threadIds: [...new Set(allThreads.map((thread) => thread.id))],
+      threadIds: allThreads.map((thread) => thread.id),
     });
 
-    for (const thread of allThreads) {
-      const overlay = overlaysByThreadId[thread.id];
-      const preferredMode = overlay?.executionMode;
-      const existing = threadsById.get(thread.id);
-      const normalizedThread = {
-        ...thread,
-        executionMode: preferredMode ?? thread.executionMode,
-      };
-
-      if (!existing) {
-        threadsById.set(thread.id, normalizedThread);
-        continue;
-      }
-
-      if (
-        preferredMode
-          ? normalizedThread.executionMode === preferredMode
-          : normalizedThread.executionMode === "default"
-      ) {
-        threadsById.set(thread.id, normalizedThread);
-      }
-    }
-
-    return [...threadsById.values()].sort(
-      (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
-    );
+    return allThreads
+      .map((thread) => {
+        const overlay = overlaysByThreadId[thread.id];
+        return {
+          ...thread,
+          executionMode: overlay?.executionMode ?? thread.executionMode,
+        };
+      })
+      .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
   }
 
   private async describeCodexBackend(): Promise<BackendSummary> {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -775,6 +775,45 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeRunId).toBe("turn-1");
   });
 
+  it("derives the transcript thinking status from an active run when status text is cleared", async () => {
+    const desktopApi: DesktopApi = {
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setPendingStatusText("Thinking");
+      result.current.setActiveRunId("turn-1");
+      result.current.setPendingStatusText(undefined);
+    });
+
+    expect(result.current.activeRunId).toBe("turn-1");
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+  });
+
   it("keeps thinking visible when an idle status arrives before turn completion", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -894,6 +894,9 @@ export function useThreadSessionState(params: {
       ),
     [sessions]
   );
+  const pendingStatusText =
+    selectedSession?.pendingStatusText ??
+    (selectedSession?.activeRunId ? "Thinking" : undefined);
 
   return {
     activeRunId: selectedSession?.activeRunId,
@@ -907,7 +910,7 @@ export function useThreadSessionState(params: {
     messages,
     pendingAssistantMessage: selectedSession?.pendingAssistantMessage,
     pendingRequest: selectedSession?.pendingRequest,
-    pendingStatusText: selectedSession?.pendingStatusText,
+    pendingStatusText,
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveRunId,


### PR DESCRIPTION
## Summary
- use the default Codex app-server instance as the sole source of truth for desktop thread listing, while preserving overlay-based access-mode restoration for listed threads
- keep the in-thread transcript Thinking indicator visible whenever the selected thread still has an active run, even if transient pending status text is cleared
- add regression coverage for both behaviors: backend-registry unit coverage for default-only listing, hook coverage for active-run-derived thinking state, and replay-backed Electron coverage for the transcript indicator

## Testing
- `pnpm vitest run apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
- `pnpm vitest run apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx --config vitest.workspace.ts`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop test:e2e -- turn-lifecycle.spec.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
