### PR TITLE
feat(desktop): handle approval and plan input requests

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -48,8 +48,9 @@ async function openApprovalPendingReplay() {
   await expect(
     app.window
       .getByRole("group", { name: "Pending approval" })
-      .getByText("Read /etc/hosts and tell me the first three lines.")
+      .getByText("Command: npm view dive")
   ).toBeVisible();
+  await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
   await expect(
     app.window.getByText("Waiting for approval before this turn can continue.")
   ).toBeVisible();
@@ -71,8 +72,9 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
     await expect(
       app.window
         .getByRole("group", { name: "Pending approval" })
-        .getByText("Read /etc/hosts and tell me the first three lines.")
+        .getByText("Command: npm view dive")
     ).toBeVisible();
+    await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
     await expect(
       app.window.getByText("Waiting for approval before this turn can continue.")
     ).toBeVisible();

--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -45,11 +45,11 @@ async function openApprovalPendingReplay() {
     app.window.getByRole("group", { name: "Pending approval" })
   ).toBeVisible();
   await expect(app.window.getByText("Approval needed")).toBeVisible();
+  const pendingApproval = app.window.getByRole("group", { name: "Pending approval" });
+  await expect(pendingApproval.getByText("Command:")).toBeVisible();
   await expect(
-    app.window
-      .getByRole("group", { name: "Pending approval" })
-      .getByText("Command: npm view dive")
-  ).toBeVisible();
+    pendingApproval.locator("pre code")
+  ).toHaveText("npm view dive");
   await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
   await expect(
     app.window.getByText("Waiting for approval before this turn can continue.")
@@ -69,11 +69,11 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
       app.window.getByRole("group", { name: "Pending approval" })
     ).toBeVisible();
     await expect(app.window.getByText("Approval needed")).toBeVisible();
+    const pendingApproval = app.window.getByRole("group", { name: "Pending approval" });
+    await expect(pendingApproval.getByText("Command:")).toBeVisible();
     await expect(
-      app.window
-        .getByRole("group", { name: "Pending approval" })
-        .getByText("Command: npm view dive")
-    ).toBeVisible();
+      pendingApproval.locator("pre code")
+    ).toHaveText("npm view dive");
     await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
     await expect(
       app.window.getByText("Waiting for approval before this turn can continue.")

--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -124,12 +124,14 @@
       "id": "request-approval-1",
       "kind": "request",
       "request": {
-        "method": "turn/requestApproval",
+        "method": "item/commandExecution/requestApproval",
         "params": {
           "threadId": "thread-approval-pending",
-          "runId": "turn-approval-2",
+          "turnId": "turn-approval-2",
+          "itemId": "call-npm-view-dive",
           "requestId": "approval-request-1",
-          "prompt": "Read /etc/hosts and tell me the first three lines."
+          "reason": "Do you want to allow network access so I can query npm metadata for the `dive` package?",
+          "command": "/bin/zsh -lc 'npm view dive'"
         }
       }
     }

--- a/apps/desktop/e2e/fixtures/request-user-input/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/request-user-input/replay.fixture.json
@@ -1,0 +1,174 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "request-user-input",
+    "sourceCaptureId": "synthetic-request-user-input",
+    "threadId": "thread-request-user-input"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-request-user-input",
+          "title": "Request user input replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded request_user_input prompt",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000002000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Need plan questionnaire coverage."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for plan questionnaire coverage."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Need plan questionnaire coverage."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for plan questionnaire coverage."
+          }
+        ],
+        "lastUserMessage": "Need plan questionnaire coverage.",
+        "lastAssistantMessage": "Ready for plan questionnaire coverage.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-request-user-input",
+        "runId": "turn-input-2"
+      }
+    },
+    {
+      "id": "status-active-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-request-user-input",
+          "status": {
+            "type": "active",
+            "activeFlags": []
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-request-user-input",
+          "turn": {
+            "id": "turn-input-2",
+            "status": "inProgress"
+          }
+        }
+      }
+    },
+    {
+      "id": "request-user-input-1",
+      "kind": "request",
+      "request": {
+        "method": "item/tool/requestUserInput",
+        "params": {
+          "threadId": "thread-request-user-input",
+          "turnId": "turn-input-2",
+          "runId": "turn-input-2",
+          "itemId": "request-user-input-call",
+          "requestId": "user-input-request-1",
+          "questions": [
+            {
+              "id": "scope",
+              "header": "Scope",
+              "question": "How much should change?",
+              "isOther": false,
+              "isSecret": false,
+              "options": [
+                {
+                  "label": "Small patch (Recommended)",
+                  "description": "Keep this scoped."
+                },
+                {
+                  "label": "Large refactor",
+                  "description": "Touch adjacent flows."
+                }
+              ]
+            },
+            {
+              "id": "tests",
+              "header": "Tests",
+              "question": "Which test path?",
+              "isOther": false,
+              "isSecret": false,
+              "options": [
+                {
+                  "label": "Unit only",
+                  "description": "Fast coverage."
+                },
+                {
+                  "label": "Unit and E2E",
+                  "description": "Full path."
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/request-user-input.spec.ts
+++ b/apps/desktop/e2e/request-user-input.spec.ts
@@ -28,6 +28,7 @@ async function openRequestUserInputReplay() {
   await app.window
     .getByLabel("Reply")
     .fill("Ask the plan questionnaire.");
+  await app.window.getByLabel("Plan mode").check();
   await app.window.getByRole("button", { name: "Send" }).click();
 
   await app.advance({ stepId: "status-active-1" });

--- a/apps/desktop/e2e/request-user-input.spec.ts
+++ b/apps/desktop/e2e/request-user-input.spec.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const requestUserInputSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function openRequestUserInputReplay() {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      requestUserInputSpecDir,
+      "fixtures/request-user-input/replay.fixture.json"
+    )
+  });
+
+  await app.window
+    .getByRole("button", { name: /Request user input replay/i })
+    .first()
+    .click();
+
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: "Request user input replay"
+    })
+  ).toBeVisible();
+
+  await app.window
+    .getByLabel("Reply")
+    .fill("Ask the plan questionnaire.");
+  await app.window.getByRole("button", { name: "Send" }).click();
+
+  await app.advance({ stepId: "status-active-1" });
+  await app.advance({ stepId: "turn-started-1" });
+  await app.advance({ stepId: "request-user-input-1" });
+
+  await expect(app.window.getByRole("group", { name: "Pending input" })).toBeVisible();
+  await expect(app.window.getByText("Question 1 of 2")).toBeVisible();
+  await expect(app.window.getByRole("button", { name: "Approve" })).toHaveCount(0);
+  await expect(app.window.getByRole("button", { name: "Decline" })).toHaveCount(0);
+
+  return app;
+}
+
+test("answers request_user_input questionnaires with back and next navigation", async () => {
+  const app = await openRequestUserInputReplay();
+
+  try {
+    const pendingInput = app.window.getByRole("group", { name: "Pending input" });
+
+    await pendingInput.getByRole("button", { name: /Large refactor/ }).click();
+    await pendingInput.getByRole("button", { name: "Next" }).click();
+    await expect(pendingInput.getByText("Question 2 of 2")).toBeVisible();
+
+    await pendingInput.getByRole("button", { name: /Unit only/ }).click();
+    await pendingInput.getByRole("button", { name: "Back" }).click();
+    await expect(pendingInput.getByText("Question 1 of 2")).toBeVisible();
+    await expect(
+      pendingInput.getByRole("button", { name: /Large refactor/ })
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await pendingInput.getByRole("button", { name: "Next" }).click();
+    await pendingInput.getByRole("button", { name: "Submit" }).click();
+
+    await expect(app.window.getByRole("group", { name: "Pending input" })).toHaveCount(0);
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+    await expect
+      .poll(async () => await app.getPendingRequest())
+      .toBeUndefined();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -156,4 +156,134 @@ describe("DesktopBackendRegistry replay integration", () => {
     expect(replayClient.getPendingRequest()).toBeUndefined();
     await registry.close();
   });
+
+  it("preserves request_user_input question payloads through registry events", async () => {
+    const replayClient = ReplayClient.fromFixture({
+      metadata: {
+        backend: "codex",
+        scenario: "registry-user-input-replay"
+      },
+      steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: {
+              name: "Replay Codex",
+              version: "1.0.0"
+            },
+            methods: ["thread/read"]
+          }
+        },
+        {
+          id: "read-1",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          }
+        },
+        {
+          id: "req-input-1",
+          kind: "request",
+          request: {
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              runId: "turn-1",
+              itemId: "input-1",
+              requestId: "input-request-1",
+              questions: [
+                {
+                  id: "approach",
+                  header: "Approach",
+                  question: "Which implementation path should I take?",
+                  isOther: false,
+                  isSecret: false,
+                  options: [
+                    {
+                      label: "Small patch (Recommended)",
+                      description: "Keep this scoped."
+                    },
+                    {
+                      label: "Large refactor",
+                      description: "Touch adjacent flows."
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    });
+
+    const registry = new DesktopBackendRegistry({
+      codexClient: replayClient,
+      codexFullAccessClient: createPassiveClient() as any,
+      grokClient: createPassiveClient() as any,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: Array<{ method: string; params: Record<string, unknown> }> = [];
+    registry.onEvent((event) => {
+      events.push({
+        method: event.notification.method,
+        params: event.notification.params as Record<string, unknown>,
+      });
+    });
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1"
+    });
+    await replayClient.advance({ stepId: "req-input-1" });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        method: "item/tool/requestUserInput",
+        params: expect.objectContaining({
+          requestId: "input-request-1",
+          itemId: "input-1",
+          questions: [
+            expect.objectContaining({
+              id: "approach",
+              options: [
+                expect.objectContaining({
+                  label: "Small patch (Recommended)"
+                }),
+                expect.objectContaining({
+                  label: "Large refactor"
+                })
+              ]
+            })
+          ]
+        })
+      })
+    );
+
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      runId: "turn-1",
+      requestId: "input-request-1",
+      response: {
+        answers: {
+          approach: {
+            answers: ["Small patch (Recommended)"]
+          }
+        }
+      }
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(replayClient.getPendingRequest()).toBeUndefined();
+    await registry.close();
+  });
 });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1311,6 +1311,7 @@ describe("CodexAppServerClient", () => {
                 type: "plan",
                 id: "plan-1",
                 explanation: "Keep the transcript contract stable.",
+                markdown: "## Final plan\n\nShip the transcript renderer in small steps.",
                 steps: [
                   { step: "Normalize replay", status: "completed" },
                   { step: "Render live plan progress", status: "in_progress" }
@@ -1350,12 +1351,98 @@ describe("CodexAppServerClient", () => {
         id: "plan-1",
         createdAt: 1_763_500_200_000,
         explanation: "Keep the transcript contract stable.",
+        markdown: "## Final plan\n\nShip the transcript renderer in small steps.",
         steps: [
           { step: "Normalize replay", status: "completed" },
           { step: "Render live plan progress", status: "in_progress" }
         ]
       }
     ]);
+
+    await client.close();
+  });
+
+  it("normalizes request_user_input requests from rpc envelope ids", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onRequest((request) => {
+      requests.push(request as { method: string; params: Record<string, unknown> });
+      return {
+        answers: {
+          breakfast: {
+            answers: ["Bagels"]
+          }
+        }
+      };
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      id: "rpc-input-1",
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-7",
+        itemId: "call-1",
+        questions: [
+          {
+            id: "breakfast",
+            header: "Breakfast",
+            question: "What should we eat?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: "Bagels",
+                description: "Good with cream cheese."
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requests).toEqual([
+      {
+        method: "item/tool/requestUserInput",
+        params: expect.objectContaining({
+          threadId: "thread-2",
+          runId: "turn-7",
+          turnId: "turn-7",
+          itemId: "call-1",
+          requestId: "rpc-input-1",
+          questions: expect.any(Array)
+        })
+      }
+    ]);
+    expect(
+      transport!.sentMessages
+        .map((message) => JSON.parse(message) as { id?: string; result?: unknown })
+        .find((message) => message.id === "rpc-input-1")
+    ).toEqual({
+      jsonrpc: "2.0",
+      id: "rpc-input-1",
+      result: {
+        answers: {
+          breakfast: {
+            answers: ["Bagels"]
+          }
+        }
+      }
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1624,6 +1624,59 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("starts plan-mode turns with a collaboration mode payload", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadResumeResult = {
+      thread: {
+        id: "thread-2"
+      },
+      model: "gpt-5.4",
+      reasoningEffort: "high"
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Plan the fix" }],
+      collaborationMode: {
+        mode: "plan",
+        settings: {
+          developerInstructions: null
+        }
+      }
+    });
+
+    expect(result).toEqual({
+      threadId: "thread-2",
+      runId: "turn-1"
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const startPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "turn/start");
+
+    expect(startPayload?.params).toMatchObject({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Plan the fix" }],
+      collaborationMode: {
+        mode: "plan",
+        settings: {
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+          developerInstructions: null
+        }
+      }
+    });
+
+    await client.close();
+  });
+
   it("falls back to the requested thread and a pending run id when turn/start omits ids", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.turnStartResult = {};

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10,6 +10,7 @@ import type {
   AppServerThreadSummary,
   AppServerTurnInputItem,
   AppServerBackendKind,
+  AppServerCollaborationModeRequest,
   BackendCapabilities,
   BackendSummary,
   ListBackendsRequest,
@@ -83,6 +84,7 @@ type BackendClient = {
     threadId: string;
     input: AppServerTurnInputItem[];
     model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
   }): Promise<{ threadId: string; runId: string }>;
   interruptTurn(params: {
     threadId: string;
@@ -388,13 +390,18 @@ export class DesktopBackendRegistry {
     threadId: string;
     input: AppServerTurnInputItem[];
     model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; runId: string }> {
     const result =
       params.backend === "codex"
         ? await this.withCodexThreadClient(params.threadId, async (client) =>
             await client.startTurn(params),
           )
-        : await this.grokClient.startTurn(params);
+        : await this.grokClient.startTurn({
+            threadId: params.threadId,
+            input: params.input,
+            model: params.model,
+          });
 
     return {
       backend: params.backend,
@@ -609,6 +616,7 @@ export class DesktopBackendRegistry {
         threadId: startThreadResponse.threadId,
         input,
         model: launchpad.model,
+        collaborationMode: request.collaborationMode,
       });
       runId = turnResponse.runId;
     }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -102,6 +102,10 @@ function isApprovalLikeMethod(method: string): boolean {
   return method.endsWith("/requestApproval");
 }
 
+function isHandledServerRequestMethod(method: string): boolean {
+  return isApprovalLikeMethod(method) || method === "item/tool/requestUserInput";
+}
+
 function isRequestLikeMethod(method: string): boolean {
   return method.includes("/request");
 }
@@ -152,6 +156,19 @@ function pickString(
     const trimmed = value.trim();
     if (trimmed) {
       return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function pickRawString(
+  record: Record<string, unknown>,
+  keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
     }
   }
   return undefined;
@@ -626,6 +643,7 @@ function normalizePlanSteps(value: unknown): AppServerThreadPlanStep[] {
 
 function normalizePlanPayload(value: unknown): {
   explanation?: string;
+  markdown?: string;
   steps: AppServerThreadPlanStep[];
 } | undefined {
   const record = asRecord(value);
@@ -646,13 +664,18 @@ function normalizePlanPayload(value: unknown): {
   const explanation =
     pickString(record, ["explanation", "summary"]) ??
     pickString(nestedPlanRecord ?? {}, ["explanation", "summary"]);
+  const markdown =
+    pickRawString(record, ["markdown"]) ??
+    pickRawString(nestedPlanRecord ?? {}, ["markdown"]) ??
+    collectLegacyMessageText(record);
 
-  if (steps.length === 0 && !explanation) {
+  if (steps.length === 0 && !explanation && !markdown.trim()) {
     return undefined;
   }
 
   return {
     ...(explanation ? { explanation } : {}),
+    ...(markdown.trim() ? { markdown: markdown.trim() } : {}),
     steps,
   };
 }
@@ -731,6 +754,7 @@ function extractPlanEntryFromItem(
       id: itemId,
       createdAt,
       ...(explanation ? { explanation } : {}),
+      ...(normalizedPayload?.markdown ? { markdown: normalizedPayload.markdown } : {}),
       steps,
     };
   }
@@ -770,6 +794,7 @@ function extractPlanEntryFromItem(
     ...(normalizedPayload.explanation
       ? { explanation: normalizedPayload.explanation }
       : {}),
+    ...(normalizedPayload.markdown ? { markdown: normalizedPayload.markdown } : {}),
     steps: normalizedPayload.steps,
   };
 }
@@ -1761,7 +1786,7 @@ export class CodexAppServerClient {
         throw new Error(`No desktop request handler registered for ${method}`);
       }
 
-      if (!isApprovalLikeMethod(method)) {
+      if (!isHandledServerRequestMethod(method)) {
         logUnhandledCodexMessage({
           kind: "request",
           method,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -21,6 +21,7 @@ import type {
   AppServerThreadTitleSource,
   AppServerThreadSummary,
   AppServerTurnInputItem,
+  AppServerCollaborationModeRequest,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
 import { getMainLogger } from "../log";
@@ -37,6 +38,7 @@ import { StdioJsonRpcTransport } from "./stdio-transport";
 
 const DEFAULT_PROTOCOL_VERSION = "1.0";
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.4";
 
 type CodexClientOptions = {
   command?: string;
@@ -1592,6 +1594,85 @@ function buildThreadResumePayloads(params: {
   return [base];
 }
 
+function extractStringProperty(value: unknown, ...keys: string[]): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return undefined;
+}
+
+function buildCollaborationModePayload(params: {
+  collaborationMode?: AppServerCollaborationModeRequest;
+  fallbackModel?: string;
+  fallbackReasoningEffort?: string;
+}): Record<string, unknown> | undefined {
+  if (!params.collaborationMode) {
+    return undefined;
+  }
+
+  const settings = params.collaborationMode.settings ?? {};
+  const model =
+    settings.model?.trim() ||
+    params.fallbackModel?.trim() ||
+    DEFAULT_CODEX_COLLABORATION_MODEL;
+  const reasoningEffort =
+    settings.reasoningEffort?.trim() || params.fallbackReasoningEffort?.trim();
+  const developerInstructions = Object.hasOwn(settings, "developerInstructions")
+    ? settings.developerInstructions
+    : params.collaborationMode.mode === "plan"
+      ? null
+      : undefined;
+
+  return {
+    mode: params.collaborationMode.mode,
+    settings: {
+      model,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+      ...(developerInstructions !== undefined
+        ? { developerInstructions }
+        : {}),
+    },
+  };
+}
+
+function buildTurnStartPayload(params: {
+  threadId: string;
+  input: AppServerTurnInputItem[];
+  model?: string;
+  collaborationMode?: AppServerCollaborationModeRequest;
+  collaborationFallbackModel?: string;
+  collaborationFallbackReasoningEffort?: string;
+}): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    threadId: params.threadId,
+    input: params.input,
+  };
+
+  if (params.model?.trim()) {
+    base.model = params.model.trim();
+  }
+
+  const collaborationMode = buildCollaborationModePayload({
+    collaborationMode: params.collaborationMode,
+    fallbackModel: params.collaborationFallbackModel ?? params.model,
+    fallbackReasoningEffort: params.collaborationFallbackReasoningEffort,
+  });
+  if (collaborationMode) {
+    base.collaborationMode = collaborationMode;
+  }
+
+  return base;
+}
+
 async function requestWithFallbacks(params: {
   client: JsonRpcConnection;
   methods: string[];
@@ -1854,10 +1935,11 @@ export class CodexAppServerClient {
     threadId: string;
     input: AppServerTurnInputItem[];
     model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
   }): Promise<{ threadId: string; runId: string }> {
     await this.ensureInitialized();
 
-    await requestWithFallbacks({
+    const resumeResult = await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/resume"],
       payloads: buildThreadResumePayloads({
@@ -1870,7 +1952,21 @@ export class CodexAppServerClient {
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["turn/start"],
-      payloads: [params],
+      payloads: [
+        buildTurnStartPayload({
+          threadId: params.threadId,
+          input: params.input,
+          model: params.model,
+          collaborationMode: params.collaborationMode,
+          collaborationFallbackModel:
+            params.model?.trim() || extractStringProperty(resumeResult, "model"),
+          collaborationFallbackReasoningEffort: extractStringProperty(
+            resumeResult,
+            "reasoningEffort",
+            "reasoning_effort"
+          ),
+        }),
+      ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -1,4 +1,5 @@
 import type {
+  AppServerCollaborationModeRequest,
   AppServerListSkillsResponse,
   AppServerNotification,
   AppServerPendingRequestNotification,
@@ -110,6 +111,7 @@ export class ReplayClient {
     threadId: string;
     input: AppServerTurnInputItem[];
     model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
   }): Promise<{ threadId: string; runId: string }> {
     await this.ensureInitialized();
     return this.controller.consumeResponse("turn/start").result as {

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type {
   AppServerBackendKind,
+  AppServerCollaborationModeRequest,
   AppServerListSkillsResponse,
   AppServerNotification,
   AppServerPendingRequestNotification,
@@ -77,6 +78,7 @@ type ReplayRuntimeClient = {
     threadId: string;
     input: AppServerTurnInputItem[];
     model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
   }): Promise<{ threadId: string; runId: string }>;
   interruptTurn(params: {
     threadId: string;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -65,6 +65,7 @@ export function App() {
           messageCount={session.messages.length}
           pendingAssistantMessage={session.pendingAssistantMessage}
           pendingRequest={session.pendingRequest}
+          pendingUserInput={session.pendingUserInput}
           pendingStatusText={session.pendingStatusText}
           platform={desktopApi?.platform}
           selectedDirectory={navigation.selectedDirectory}
@@ -94,6 +95,7 @@ export function App() {
           }
           onTranscriptViewportChange={session.setViewport}
           onUpdateLaunchpad={navigation.updateDirectoryLaunchpad}
+          onUpdatePendingUserInput={session.updatePendingUserInput}
           removeOptimisticMessage={session.removeOptimisticMessage}
           transcriptViewport={session.viewport}
         />

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -330,6 +330,9 @@ export function Composer(props: ComposerProps) {
         );
         setDraft("");
         setImageAttachments([]);
+        if (collaborationMode) {
+          setPlanModeEnabled(false);
+        }
       } catch (error) {
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
@@ -358,6 +361,9 @@ export function Composer(props: ComposerProps) {
       props.onActiveRunIdChange?.(response.runId);
       setDraft("");
       setImageAttachments([]);
+      if (collaborationMode) {
+        setPlanModeEnabled(false);
+      }
     } catch (error) {
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,5 +1,6 @@
 import { type ClipboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AppServerCollaborationModeRequest,
   AppServerSkillSummary,
   AppServerThreadImagePart,
   AppServerTurnInputItem,
@@ -37,7 +38,8 @@ type ComposerProps = {
   pendingUserInputActive?: boolean;
   onMaterializeLaunchpad?: (
     directoryKey: string,
-    input?: AppServerTurnInputItem[]
+    input?: AppServerTurnInputItem[],
+    collaborationMode?: AppServerCollaborationModeRequest
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onUpdateLaunchpad?: (
@@ -91,6 +93,7 @@ export function Composer(props: ComposerProps) {
   const [activeRunId, setActiveRunId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
+  const [planModeEnabled, setPlanModeEnabled] = useState(false);
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
@@ -302,6 +305,14 @@ export function Composer(props: ComposerProps) {
       ...(text ? [{ type: "text" as const, text }] : []),
       ...imageParts.map(({ url }) => ({ type: "image" as const, url })),
     ];
+    const collaborationMode = planModeEnabled && supportsPlanMode
+      ? ({
+          mode: "plan",
+          settings: {
+            developerInstructions: null,
+          },
+        } satisfies AppServerCollaborationModeRequest)
+      : undefined;
 
     if (input.length === 0 || props.disabled) {
       return;
@@ -312,7 +323,11 @@ export function Composer(props: ComposerProps) {
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
       try {
-        await props.onMaterializeLaunchpad(props.launchpad.directoryKey, input);
+        await props.onMaterializeLaunchpad(
+          props.launchpad.directoryKey,
+          input,
+          collaborationMode
+        );
         setDraft("");
         setImageAttachments([]);
       } catch (error) {
@@ -328,7 +343,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    props.onPendingStatusChange?.("Thinking");
+    props.onPendingStatusChange?.(collaborationMode ? "Planning" : "Thinking");
     const optimisticMessageId = props.addOptimisticUserMessage?.(text, imageParts);
     setActiveOptimisticMessageId(optimisticMessageId);
 
@@ -337,6 +352,7 @@ export function Composer(props: ComposerProps) {
         backend: props.thread.source,
         threadId: props.thread.id,
         input,
+        collaborationMode,
       });
       updateActiveRunId(response.runId);
       props.onActiveRunIdChange?.(response.runId);
@@ -485,6 +501,8 @@ export function Composer(props: ComposerProps) {
   const availableExecutionModes =
     backend?.executionModes.filter((mode) => mode.available) ?? [];
   const workspaceLabel = formatThreadWorkspaceLabel(props.thread);
+  const supportsPlanMode =
+    (props.launchpad?.backend ?? props.thread?.source) === "codex";
   const launchpadWorkspaceOptions = props.launchpad
     ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
     : [];
@@ -807,6 +825,20 @@ export function Composer(props: ComposerProps) {
                 }}
               />
               <span>Fast mode</span>
+            </label>
+          ) : null}
+
+          {supportsPlanMode ? (
+            <label className="composer__checkbox">
+              <input
+                checked={planModeEnabled}
+                disabled={sending}
+                type="checkbox"
+                onChange={(event) => {
+                  setPlanModeEnabled(event.target.checked);
+                }}
+              />
+              <span>Plan mode</span>
             </label>
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -34,6 +34,7 @@ type ComposerProps = {
   onActiveRunIdChange?: (runId?: string) => void;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
   pendingRequestActive?: boolean;
+  pendingUserInputActive?: boolean;
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: AppServerTurnInputItem[]
@@ -379,7 +380,11 @@ export function Composer(props: ComposerProps) {
     } catch (error) {
       setInterrupting(false);
       props.onPendingStatusChange?.(
-        props.pendingRequestActive ? "Waiting for approval" : "Thinking"
+        props.pendingRequestActive
+          ? "Waiting for approval"
+          : props.pendingUserInputActive
+            ? "Waiting for input"
+            : "Thinking"
       );
       setSendError(error instanceof Error ? error.message : String(error));
     }
@@ -834,6 +839,10 @@ export function Composer(props: ComposerProps) {
       ) : props.pendingRequestActive ? (
         <p className="composer__meta">
           Waiting for approval before this turn can continue.
+        </p>
+      ) : props.pendingUserInputActive ? (
+        <p className="composer__meta">
+          Waiting for input before this turn can continue.
         </p>
       ) : props.launchpad ? (
         <p className="composer__meta">

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { StartTurnRequest } from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Composer } from "../Composer";
 
@@ -798,5 +799,86 @@ describe("Composer", () => {
 
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
     expect(onPendingStatusChange).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it("sends Codex turns with plan collaboration mode when plan mode is enabled", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      runId: "turn-1",
+    }));
+    const onPendingStatusChange = vi.fn();
+
+    render(
+      <Composer
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/read", "turn/start"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        onPendingStatusChange={onPendingStatusChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Plan mode",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Plan this change" },
+    });
+    fireEvent.click(screen.getByLabelText("Plan mode"));
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    expect(startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Plan this change" }],
+      collaborationMode: {
+        mode: "plan",
+        settings: {
+          developerInstructions: null,
+        },
+      },
+    });
+    expect(onPendingStatusChange).toHaveBeenCalledWith("Planning");
   });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -880,5 +880,8 @@ describe("Composer", () => {
       },
     });
     expect(onPendingStatusChange).toHaveBeenCalledWith("Planning");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Plan mode")).not.toBeChecked();
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
@@ -1,0 +1,137 @@
+import {
+  answerQuestionnaireOption,
+  answerQuestionnaireText,
+  canAdvanceQuestionnaire,
+  canSubmitQuestionnaire,
+  goToNextQuestion,
+  goToPreviousQuestion,
+  type PendingQuestionnaireState,
+} from "./questionnaire";
+
+type PendingQuestionnaireProps = {
+  busy?: boolean;
+  state: PendingQuestionnaireState;
+  onChange: (state: PendingQuestionnaireState) => void;
+  onSubmit: (state: PendingQuestionnaireState) => Promise<void> | void;
+};
+
+export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
+  const question = props.state.questions[props.state.currentIndex];
+  const answer = props.state.answers[props.state.currentIndex];
+  if (!question) {
+    return null;
+  }
+
+  const isLastQuestion = props.state.currentIndex === props.state.questions.length - 1;
+  const canMoveNext = canAdvanceQuestionnaire(props.state);
+  const canSubmit = canSubmitQuestionnaire(props.state);
+  const textAnswer = answer?.kind === "text" ? answer.value : "";
+
+  return (
+    <div className="transcript-questionnaire" role="group" aria-label="Pending input">
+      <div className="transcript-questionnaire__header">
+        <span className="thread-row__chip thread-row__chip--mode">
+          Input needed
+        </span>
+        <span className="transcript-message__time">
+          Question {props.state.currentIndex + 1} of {props.state.questions.length}
+        </span>
+      </div>
+
+      <div className="transcript-questionnaire__prompt">
+        {question.header ? <p className="eyebrow">{question.header}</p> : null}
+        <h3>{question.question}</h3>
+      </div>
+
+      {question.options.length > 0 ? (
+        <div className="transcript-questionnaire__options">
+          {question.options.map((option) => {
+            const selected =
+              answer?.kind === "option" && answer.optionKey === option.key;
+            return (
+              <button
+                key={option.key}
+                className={`transcript-questionnaire__option${
+                  selected ? " is-selected" : ""
+                }`}
+                type="button"
+                aria-pressed={selected}
+                disabled={props.busy}
+                onClick={() => {
+                  props.onChange(answerQuestionnaireOption(props.state, option.key));
+                }}
+              >
+                <span className="transcript-questionnaire__option-label">
+                  <span className="transcript-questionnaire__option-key">
+                    {option.key}
+                  </span>
+                  <span>{option.label}</span>
+                  {option.recommended ? (
+                    <span className="transcript-questionnaire__recommended">
+                      Recommended
+                    </span>
+                  ) : null}
+                </span>
+                {option.description ? (
+                  <span className="transcript-questionnaire__option-description">
+                    {option.description}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {question.allowFreeform ? (
+        <label className="transcript-questionnaire__freeform">
+          <span>Other answer</span>
+          <textarea
+            value={textAnswer}
+            disabled={props.busy}
+            rows={3}
+            onChange={(event) => {
+              props.onChange(answerQuestionnaireText(props.state, event.target.value));
+            }}
+          />
+        </label>
+      ) : null}
+
+      <div className="transcript-questionnaire__actions">
+        <button
+          className="button button--ghost"
+          disabled={props.busy || props.state.currentIndex === 0}
+          type="button"
+          onClick={() => {
+            props.onChange(goToPreviousQuestion(props.state));
+          }}
+        >
+          Back
+        </button>
+        {isLastQuestion ? (
+          <button
+            className="button button--primary"
+            disabled={props.busy || !canSubmit}
+            type="button"
+            onClick={() => {
+              void props.onSubmit(props.state);
+            }}
+          >
+            Submit
+          </button>
+        ) : (
+          <button
+            className="button button--primary"
+            disabled={props.busy || !canMoveNext}
+            type="button"
+            onClick={() => {
+              props.onChange(goToNextQuestion(props.state));
+            }}
+          >
+            Next
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -24,6 +24,10 @@ import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
+import {
+  buildQuestionnaireResponse,
+  type PendingQuestionnaireState,
+} from "./questionnaire";
 
 function arePlanEntriesEquivalent(
   left: AppServerThreadPlanEntry,
@@ -212,6 +216,7 @@ type ThreadViewProps = {
   messageCount: number;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingRequest?: AppServerPendingRequestNotification;
+  pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   platform?: string;
   selectedDirectory?: NavigationDirectorySummary;
@@ -233,6 +238,10 @@ type ThreadViewProps = {
     input?: AppServerTurnInputItem[]
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
+  onUpdatePendingUserInput?: (
+    requestId: string,
+    updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+  ) => void;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
   onTranscriptViewportChange?: (viewport?: {
     distanceFromBottom: number;
@@ -432,6 +441,33 @@ export function ThreadView(props: ThreadViewProps) {
     }
   }
 
+  async function submitPendingUserInput(
+    pendingUserInput: PendingQuestionnaireState
+  ): Promise<void> {
+    if (!props.desktopApi?.submitServerRequest || !selectedThread) {
+      setPendingRequestError("Desktop bridge is missing submitServerRequest().");
+      return;
+    }
+
+    setPendingRequestBusy(true);
+    setPendingRequestError(undefined);
+
+    try {
+      await props.desktopApi.submitServerRequest({
+        backend: selectedThread.source,
+        threadId: selectedThread.id,
+        runId: pendingUserInput.runId,
+        requestId: pendingUserInput.requestId,
+        response: buildQuestionnaireResponse(pendingUserInput),
+      });
+      props.clearPendingRequest(pendingUserInput.requestId, "Thinking");
+    } catch (error) {
+      setPendingRequestError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPendingRequestBusy(false);
+    }
+  }
+
   if (!selectedThread && !selectedLaunchpad) {
     return (
       <section className="thread-empty-state">
@@ -570,14 +606,19 @@ export function ThreadView(props: ThreadViewProps) {
             pendingPlanEntry={pendingPlanEntry}
             pendingRequest={props.pendingRequest}
             pendingRequestBusy={pendingRequestBusy}
+            pendingUserInput={props.pendingUserInput}
             pendingStatusText={props.pendingStatusText}
             restoredViewport={props.transcriptViewport}
             skills={props.skills}
             threadId={`${selectedThread!.source}:${selectedThread!.id}`}
             onLoadOlder={props.onLoadOlder}
             onOpenImage={setExpandedImage}
-            onViewportChange={props.onTranscriptViewportChange}
             onRespondToPendingRequest={respondToPendingRequest}
+            onPendingUserInputChange={(state) => {
+              props.onUpdatePendingUserInput?.(state.requestId, () => state);
+            }}
+            onSubmitPendingUserInput={submitPendingUserInput}
+            onViewportChange={props.onTranscriptViewportChange}
           />
           {pendingRequestError ? (
             <p className="transcript-error">{pendingRequestError}</p>
@@ -612,6 +653,7 @@ export function ThreadView(props: ThreadViewProps) {
         onPendingStatusChange={props.onPendingStatusChange}
         onSetExecutionMode={props.onSetExecutionMode}
         pendingRequestActive={Boolean(props.pendingRequest)}
+        pendingUserInputActive={Boolean(props.pendingUserInput)}
         removeOptimisticMessage={props.removeOptimisticMessage}
         setExecutionModeError={props.setExecutionModeError}
         skillError={props.skillError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type {
+  AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
@@ -235,7 +236,8 @@ type ThreadViewProps = {
   onLoadOlder: () => Promise<void>;
   onMaterializeLaunchpad?: (
     directoryKey: string,
-    input?: AppServerTurnInputItem[]
+    input?: AppServerTurnInputItem[],
+    collaborationMode?: AppServerCollaborationModeRequest
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onUpdatePendingUserInput?: (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -8,6 +8,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
+  AppServerThreadPlanStep,
   AppServerTurnInputItem,
   AppServerThreadReplayPagination,
   AppServerSkillSummary,
@@ -34,11 +35,17 @@ function arePlanEntriesEquivalent(
   left: AppServerThreadPlanEntry,
   right: AppServerThreadPlanEntry
 ): boolean {
-  if ((left.explanation ?? "").trim() !== (right.explanation ?? "").trim()) {
-    return false;
+  const leftMarkdown = (left.markdown ?? "").trim();
+  const rightMarkdown = (right.markdown ?? "").trim();
+  if (leftMarkdown || rightMarkdown) {
+    return leftMarkdown === rightMarkdown;
   }
 
   if (left.steps.length !== right.steps.length) {
+    return false;
+  }
+
+  if ((left.explanation ?? "").trim() !== (right.explanation ?? "").trim()) {
     return false;
   }
 
@@ -74,6 +81,87 @@ function summarizeDiff(diff: string): { additions: number; removals: number } {
   }
 
   return { additions, removals };
+}
+
+function getPlanNotificationItemId(params: Record<string, unknown>): string | undefined {
+  if (typeof params.itemId === "string") {
+    return params.itemId;
+  }
+
+  if (
+    typeof params.item === "object" &&
+    params.item !== null &&
+    "id" in params.item &&
+    typeof params.item.id === "string"
+  ) {
+    return params.item.id;
+  }
+
+  return undefined;
+}
+
+function getPlanNotificationRunId(params: Record<string, unknown>): string | undefined {
+  return typeof params.runId === "string"
+    ? params.runId
+    : typeof params.turnId === "string"
+      ? params.turnId
+      : undefined;
+}
+
+function isCompletedPlanItem(params: Record<string, unknown>): params is {
+  item: { type: string; text?: unknown; markdown?: unknown };
+} {
+  return (
+    typeof params.item === "object" &&
+    params.item !== null &&
+    "type" in params.item &&
+    typeof params.item.type === "string" &&
+    params.item.type.trim().toLowerCase() === "plan"
+  );
+}
+
+function readCompletedPlanMarkdown(params: Record<string, unknown>): string | undefined {
+  if (!isCompletedPlanItem(params)) {
+    return undefined;
+  }
+
+  const markdown =
+    typeof params.item.markdown === "string"
+      ? params.item.markdown
+      : typeof params.item.text === "string"
+        ? params.item.text
+        : "";
+  const trimmed = markdown.trim();
+  return trimmed || undefined;
+}
+
+function normalizeLivePlanSteps(value: unknown): AppServerThreadPlanStep[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry): AppServerThreadPlanStep[] => {
+    if (typeof entry !== "object" || entry === null) {
+      return [];
+    }
+
+    const stepRecord = entry as Record<string, unknown>;
+    const step = typeof stepRecord.step === "string" ? stepRecord.step.trim() : "";
+    if (!step) {
+      return [];
+    }
+
+    const rawStatus =
+      typeof stepRecord.status === "string" ? stepRecord.status.trim().toLowerCase() : "";
+    const status: AppServerThreadPlanStep["status"] =
+      rawStatus === "completed"
+        ? "completed"
+        : rawStatus === "in_progress" || rawStatus === "inprogress"
+          ? "in_progress"
+          : "pending";
+
+    return [{ step, status }];
+  });
 }
 
 function getBasename(path: string): string {
@@ -374,6 +462,46 @@ export function ThreadView(props: ThreadViewProps) {
         return;
       }
 
+      if (event.notification.method === "item/plan/delta") {
+        const params = event.notification.params as Record<string, unknown>;
+        const delta = typeof params.delta === "string" ? params.delta : "";
+        if (!delta) {
+          return;
+        }
+
+        const itemId = getPlanNotificationItemId(params);
+        const runId = getPlanNotificationRunId(params) ?? itemId ?? selectedThread.id;
+        setPendingPlanEntry((current) => ({
+          type: "plan",
+          id: `live-plan-${runId}`,
+          createdAt: current?.createdAt ?? Date.now(),
+          ...(current?.explanation ? { explanation: current.explanation } : {}),
+          markdown: `${current?.markdown ?? ""}${delta}`,
+          steps: current?.steps ?? [],
+        }));
+        return;
+      }
+
+      if (event.notification.method === "item/completed") {
+        const params = event.notification.params as Record<string, unknown>;
+        const markdown = readCompletedPlanMarkdown(params);
+        if (!markdown) {
+          return;
+        }
+
+        const itemId = getPlanNotificationItemId(params);
+        const runId = getPlanNotificationRunId(params) ?? itemId ?? selectedThread.id;
+        setPendingPlanEntry((current) => ({
+          type: "plan",
+          id: `live-plan-${runId}`,
+          createdAt: current?.createdAt ?? Date.now(),
+          ...(current?.explanation ? { explanation: current.explanation } : {}),
+          markdown,
+          steps: current?.steps ?? [],
+        }));
+        return;
+      }
+
       if (event.notification.method !== "turn/plan/updated") {
         return;
       }
@@ -395,18 +523,20 @@ export function ThreadView(props: ThreadViewProps) {
         typeof planRecord.explanation === "string" && planRecord.explanation.trim()
           ? planRecord.explanation.trim()
           : undefined;
+      const steps = normalizeLivePlanSteps(planRecord.steps);
 
-      setPendingPlanEntry({
+      const runId =
+        typeof event.notification.params.runId === "string"
+          ? event.notification.params.runId
+          : selectedThread.id;
+      setPendingPlanEntry((current) => ({
         type: "plan",
-        id: `live-plan-${
-          typeof event.notification.params.runId === "string"
-            ? event.notification.params.runId
-            : selectedThread.id
-        }`,
-        createdAt: Date.now(),
+        id: `live-plan-${runId}`,
+        createdAt: current?.createdAt ?? Date.now(),
         ...(explanation ? { explanation } : {}),
-        steps: planRecord.steps,
-      });
+        ...(current?.markdown ? { markdown: current.markdown } : {}),
+        steps,
+      }));
     });
   }, [props.desktopApi, selectedThread]);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -56,13 +56,73 @@ type ScrollSnapshot = {
 const BOTTOM_THRESHOLD_PX = 24;
 type ScrollBottomMode = "instant" | "smooth";
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function firstStringByKeys(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return "";
+}
+
+function stripShellLauncher(command: string): string {
+  const match = command.match(
+    /^(?:\/[/\w]*\/)?(?:bash|zsh|sh|dash|ksh|tcsh|fish)\s+-lc\s+(['"])([\s\S]*)\1\s*$/
+  );
+
+  return match ? match[2] : command;
+}
+
+function commandFromActions(params: Record<string, unknown>): string {
+  const actions = params.commandActions;
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return "";
+  }
+
+  return actions
+    .map((action) => {
+      const record = asRecord(action);
+      const command = record?.command;
+      return typeof command === "string" && command.trim() ? command.trim() : undefined;
+    })
+    .filter((command): command is string => Boolean(command))
+    .join(" && ");
+}
+
+function approvalDisplayCommand(params: Record<string, unknown>): string {
+  const parsedCommand = commandFromActions(params);
+  if (parsedCommand) {
+    return parsedCommand;
+  }
+
+  const rawCommand = firstStringByKeys(params, [
+    "command",
+    "cmd",
+    "displayCommand",
+    "rawCommand",
+    "shellCommand",
+  ]);
+
+  return rawCommand ? stripShellLauncher(rawCommand) : "";
+}
+
 function pendingRequestPrompt(request: AppServerPendingRequestNotification): string {
   if (typeof request.params.prompt === "string" && request.params.prompt.trim()) {
     return request.params.prompt.trim();
   }
 
   const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
-  const command = typeof request.params.command === "string" ? request.params.command.trim() : "";
+  const command = approvalDisplayCommand(request.params);
 
   if (reason && command) {
     return `${reason}\n\nCommand: ${command}`;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -56,6 +56,27 @@ type ScrollSnapshot = {
 const BOTTOM_THRESHOLD_PX = 24;
 type ScrollBottomMode = "instant" | "smooth";
 
+function pendingRequestPrompt(request: AppServerPendingRequestNotification): string {
+  if (typeof request.params.prompt === "string" && request.params.prompt.trim()) {
+    return request.params.prompt.trim();
+  }
+
+  const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
+  const command = typeof request.params.command === "string" ? request.params.command.trim() : "";
+
+  if (reason && command) {
+    return `${reason}\n\nCommand: ${command}`;
+  }
+  if (command) {
+    return `Command: ${command}`;
+  }
+  if (reason) {
+    return reason;
+  }
+
+  return "This turn is waiting for approval before it can continue.";
+}
+
 export function TranscriptList(props: TranscriptListProps) {
   const skills = props.skills ?? [];
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -67,6 +88,13 @@ export function TranscriptList(props: TranscriptListProps) {
   const [hasContentBelow, setHasContentBelow] = useState(false);
   const canLoadOlder = Boolean(
     props.pagination?.supportsPagination && props.pagination.hasPreviousPage
+  );
+  const hasPendingContent = Boolean(
+    props.pendingActivityEntry ||
+      props.pendingAssistantMessage ||
+      props.pendingPlanEntry ||
+      props.pendingRequest ||
+      props.pendingStatusText
   );
 
   const captureSnapshot = useCallback((): ScrollSnapshot | undefined => {
@@ -243,15 +271,15 @@ export function TranscriptList(props: TranscriptListProps) {
     syncScrollState,
   ]);
 
-  if (props.loading && props.entries.length === 0) {
+  if (props.loading && props.entries.length === 0 && !hasPendingContent) {
     return <p className="transcript-empty">Loading transcript…</p>;
   }
 
-  if (props.error && props.entries.length === 0) {
+  if (props.error && props.entries.length === 0 && !hasPendingContent) {
     return <p className="transcript-error">{props.error}</p>;
   }
 
-  if (props.entries.length === 0) {
+  if (props.entries.length === 0 && !hasPendingContent) {
     return <p className="transcript-empty">No thread history yet.</p>;
   }
 
@@ -325,9 +353,7 @@ export function TranscriptList(props: TranscriptListProps) {
               </span>
             </div>
             <p className="transcript-request__prompt">
-              {typeof props.pendingRequest.params.prompt === "string"
-                ? props.pendingRequest.params.prompt
-                : "This turn is waiting for approval before it can continue."}
+              {pendingRequestPrompt(props.pendingRequest)}
             </p>
             <div className="transcript-request__actions">
               <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@pwragnt/shared";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { TranscriptActivity } from "./TranscriptActivity";
+import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
 
@@ -83,6 +84,18 @@ function stripShellLauncher(command: string): string {
   return match ? match[2] : command;
 }
 
+function markdownCodeBlock(text: string, language: string): string {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const longestFence = [...normalized.matchAll(/`{3,}/g)].reduce(
+    (max, match) => Math.max(max, match[0].length),
+    2
+  );
+  const fence = "`".repeat(longestFence + 1);
+  const languageTag = language.trim();
+
+  return `${fence}${languageTag}\n${normalized}\n${fence}`;
+}
+
 function commandFromActions(params: Record<string, unknown>): string {
   const actions = params.commandActions;
   if (!Array.isArray(actions) || actions.length === 0) {
@@ -123,12 +136,13 @@ function pendingRequestPrompt(request: AppServerPendingRequestNotification): str
 
   const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
   const command = approvalDisplayCommand(request.params);
+  const commandBlock = command ? `Command:\n\n${markdownCodeBlock(command, "sh")}` : "";
 
-  if (reason && command) {
-    return `${reason}\n\nCommand: ${command}`;
+  if (reason && commandBlock) {
+    return `${reason}\n\n${commandBlock}`;
   }
-  if (command) {
-    return `Command: ${command}`;
+  if (commandBlock) {
+    return commandBlock;
   }
   if (reason) {
     return reason;
@@ -412,9 +426,10 @@ export function TranscriptList(props: TranscriptListProps) {
                 {props.pendingRequest.method}
               </span>
             </div>
-            <p className="transcript-request__prompt">
-              {pendingRequestPrompt(props.pendingRequest)}
-            </p>
+            <ThreadMarkdown
+              className="transcript-request__prompt"
+              text={pendingRequestPrompt(props.pendingRequest)}
+            />
             <div className="transcript-request__actions">
               <button
                 className="button button--primary"

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -10,10 +10,12 @@ import type {
   AppServerThreadReplayPagination
 } from "@pwragnt/shared";
 import { ThinkingScanner } from "./ThinkingScanner";
+import { PendingQuestionnaire } from "./PendingQuestionnaire";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
+import type { PendingQuestionnaireState } from "./questionnaire";
 
 type TranscriptListProps = {
   entries: AppServerThreadEntry[];
@@ -25,6 +27,7 @@ type TranscriptListProps = {
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingRequestBusy?: boolean;
+  pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   pagination?: AppServerThreadReplayPagination;
   restoredViewport?: {
@@ -39,6 +42,8 @@ type TranscriptListProps = {
     scrollTop: number;
   }) => void;
   onRespondToPendingRequest?: (decision: "approve" | "decline" | "cancel") => Promise<void>;
+  onPendingUserInputChange?: (state: PendingQuestionnaireState) => void;
+  onSubmitPendingUserInput?: (state: PendingQuestionnaireState) => Promise<void>;
   onLoadOlder: () => Promise<void>;
 };
 
@@ -168,6 +173,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingAssistantMessage ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
+      props.pendingUserInput ||
       props.pendingStatusText
   );
 
@@ -185,7 +191,8 @@ export function TranscriptList(props: TranscriptListProps) {
       (props.pendingAssistantMessage ? 1 : 0) +
       (props.pendingPlanEntry ? 1 : 0) +
       (props.pendingStatusText ? 1 : 0) +
-      (props.pendingRequest ? 1 : 0);
+      (props.pendingRequest ? 1 : 0) +
+      (props.pendingUserInput ? 1 : 0);
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
       0
@@ -208,6 +215,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
+    props.pendingUserInput,
     props.pendingStatusText,
     props.threadId
   ]);
@@ -292,7 +300,8 @@ export function TranscriptList(props: TranscriptListProps) {
               (props.pendingAssistantMessage ? 1 : 0) +
               (props.pendingPlanEntry ? 1 : 0) +
               (props.pendingStatusText ? 1 : 0) +
-              (props.pendingRequest ? 1 : 0))
+              (props.pendingRequest ? 1 : 0) +
+              (props.pendingUserInput ? 1 : 0))
     );
 
     if (hasPrependedMessages && previousSnapshot) {
@@ -338,6 +347,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
+    props.pendingUserInput,
     props.pendingStatusText,
     props.restoredViewport,
     props.threadId,
@@ -415,6 +425,18 @@ export function TranscriptList(props: TranscriptListProps) {
             <ThinkingScanner />
             <span>{props.pendingStatusText}</span>
           </div>
+        ) : null}
+        {props.pendingUserInput ? (
+          <PendingQuestionnaire
+            busy={props.pendingRequestBusy}
+            state={props.pendingUserInput}
+            onChange={(state) => {
+              props.onPendingUserInputChange?.(state);
+            }}
+            onSubmit={async (state) => {
+              await props.onSubmitPendingUserInput?.(state);
+            }}
+          />
         ) : null}
         {props.pendingRequest ? (
           <div className="transcript-request" role="group" aria-label="Pending approval">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
@@ -1,4 +1,5 @@
 import type { AppServerThreadPlanEntry } from "@pwragnt/shared";
+import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptPlanProps = {
   entry: AppServerThreadPlanEntry;
@@ -62,6 +63,13 @@ export function TranscriptPlan(props: TranscriptPlanProps) {
             </li>
           ))}
         </ol>
+      ) : null}
+
+      {props.entry.markdown ? (
+        <ThreadMarkdown
+          className="transcript-plan__markdown"
+          text={props.entry.markdown}
+        />
       ) : null}
     </aside>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
@@ -1,0 +1,120 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PendingQuestionnaireState } from "../questionnaire";
+import { PendingQuestionnaire } from "../PendingQuestionnaire";
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildState(): PendingQuestionnaireState {
+  return {
+    method: "item/tool/requestUserInput",
+    threadId: "thread-1",
+    runId: "turn-1",
+    turnId: "turn-1",
+    itemId: "input-1",
+    requestId: "input-request-1",
+    currentIndex: 0,
+    answers: [null, null],
+    questions: [
+      {
+        id: "scope",
+        header: "Scope",
+        question: "How much should change?",
+        options: [
+          {
+            key: "A",
+            label: "Small patch (Recommended)",
+            description: "Keep this scoped.",
+            recommended: true,
+          },
+          {
+            key: "B",
+            label: "Large refactor",
+            description: "Touch adjacent flows.",
+            recommended: false,
+          },
+        ],
+        allowFreeform: false,
+        secret: false,
+      },
+      {
+        id: "tests",
+        header: "Tests",
+        question: "Which test path?",
+        options: [
+          {
+            key: "A",
+            label: "Unit only",
+            description: "Fast coverage.",
+            recommended: false,
+          },
+          {
+            key: "B",
+            label: "Unit and E2E",
+            description: "Full path.",
+            recommended: false,
+          },
+        ],
+        allowFreeform: false,
+        secret: false,
+      },
+    ],
+  };
+}
+
+describe("PendingQuestionnaire", () => {
+  it("renders plan questions without approval controls", () => {
+    render(
+      <PendingQuestionnaire
+        state={buildState()}
+        onChange={() => undefined}
+        onSubmit={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending input" })).toBeInTheDocument();
+    expect(screen.getByText("Question 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Small patch (Recommended)")).toBeInTheDocument();
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Decline" })).not.toBeInTheDocument();
+  });
+
+  it("emits changed state for option selection and navigation", () => {
+    let state = buildState();
+    const onChange = vi.fn((next: PendingQuestionnaireState) => {
+      state = next;
+      rerenderQuestionnaire();
+    });
+    const onSubmit = vi.fn(async () => undefined);
+    const { rerender } = render(
+      <PendingQuestionnaire state={state} onChange={onChange} onSubmit={onSubmit} />
+    );
+    const rerenderQuestionnaire = () => {
+      rerender(
+        <PendingQuestionnaire state={state} onChange={onChange} onSubmit={onSubmit} />
+      );
+    };
+
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Large refactor/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: /Unit only/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByText("Question 1 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Large refactor/ })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerToolRequestUserInputNotification } from "@pwragnt/shared";
+import {
+  answerQuestionnaireOption,
+  answerQuestionnaireText,
+  buildQuestionnaireResponse,
+  canAdvanceQuestionnaire,
+  canSubmitQuestionnaire,
+  createQuestionnaireState,
+  goToNextQuestion,
+  goToPreviousQuestion,
+} from "../questionnaire";
+
+function buildRequest(
+  questions: AppServerToolRequestUserInputNotification["params"]["questions"]
+): AppServerToolRequestUserInputNotification {
+  return {
+    method: "item/tool/requestUserInput",
+    params: {
+      threadId: "thread-1",
+      runId: "turn-1",
+      turnId: "turn-1",
+      itemId: "input-1",
+      requestId: "input-request-1",
+      questions,
+    },
+  };
+}
+
+describe("questionnaire helpers", () => {
+  it("formats selected option answers for the Codex request_user_input response shape", () => {
+    const state = createQuestionnaireState(
+      buildRequest([
+        {
+          id: "approach",
+          header: "Approach",
+          question: "Which path should I take?",
+          isOther: false,
+          isSecret: false,
+          options: [
+            {
+              label: "Small patch (Recommended)",
+              description: "Keep this scoped."
+            },
+            {
+              label: "Large refactor",
+              description: "Touch adjacent flows."
+            }
+          ]
+        }
+      ])
+    );
+
+    expect(state).toBeDefined();
+    const answered = answerQuestionnaireOption(state!, "A");
+
+    expect(canSubmitQuestionnaire(answered)).toBe(true);
+    expect(buildQuestionnaireResponse(answered)).toEqual({
+      answers: {
+        approach: {
+          answers: ["Small patch (Recommended)"]
+        }
+      }
+    });
+  });
+
+  it("preserves answers while navigating backward and forward", () => {
+    const state = createQuestionnaireState(
+      buildRequest([
+        {
+          id: "scope",
+          header: "Scope",
+          question: "How much should change?",
+          isOther: false,
+          isSecret: false,
+          options: [
+            { label: "Small", description: "One component." },
+            { label: "Large", description: "Multiple components." }
+          ]
+        },
+        {
+          id: "tests",
+          header: "Tests",
+          question: "Which test path?",
+          isOther: false,
+          isSecret: false,
+          options: [
+            { label: "Unit only", description: "Fast coverage." },
+            { label: "Unit and E2E", description: "Full path." }
+          ]
+        }
+      ])
+    );
+
+    const firstAnswer = answerQuestionnaireOption(state!, "B");
+    expect(canAdvanceQuestionnaire(firstAnswer)).toBe(true);
+
+    const secondQuestion = goToNextQuestion(firstAnswer);
+    const secondAnswer = answerQuestionnaireOption(secondQuestion, "A");
+    const backToFirst = goToPreviousQuestion(secondAnswer);
+    const forwardAgain = goToNextQuestion(backToFirst);
+
+    expect(backToFirst.answers[0]).toMatchObject({
+      kind: "option",
+      optionKey: "B",
+      value: "Large"
+    });
+    expect(forwardAgain.answers[1]).toMatchObject({
+      kind: "option",
+      optionKey: "A",
+      value: "Unit only"
+    });
+    expect(canSubmitQuestionnaire(forwardAgain)).toBe(true);
+  });
+
+  it("requires non-empty free-form answers before submitting", () => {
+    const state = createQuestionnaireState(
+      buildRequest([
+        {
+          id: "other",
+          header: "Other",
+          question: "What should I do instead?",
+          isOther: true,
+          isSecret: false,
+          options: null
+        }
+      ])
+    );
+
+    expect(state).toBeDefined();
+    expect(canSubmitQuestionnaire(state!)).toBe(false);
+    expect(canSubmitQuestionnaire(answerQuestionnaireText(state!, "   "))).toBe(false);
+
+    const answered = answerQuestionnaireText(state!, "Use the smaller implementation.");
+    expect(canSubmitQuestionnaire(answered)).toBe(true);
+    expect(buildQuestionnaireResponse(answered)).toEqual({
+      answers: {
+        other: {
+          answers: ["Use the smaller implementation."]
+        }
+      }
+    });
+  });
+
+  it("rejects malformed requests without valid questions", () => {
+    expect(createQuestionnaireState(buildRequest([]))).toBeUndefined();
+    expect(
+      createQuestionnaireState(
+        buildRequest([
+          {
+            id: "missing-options",
+            header: "Missing options",
+            question: "This cannot be answered.",
+            isOther: false,
+            isSecret: false,
+            options: null
+          }
+        ])
+      )
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerNotification, AppServerPendingRequestNotification } from "@pwragnt/shared";
+import type { PendingQuestionnaireState } from "../questionnaire";
 import { ThreadView } from "../ThreadView";
 
 afterEach(() => {
@@ -1277,6 +1278,241 @@ describe("ThreadView", () => {
       ).not.toBeInTheDocument();
     });
     expect(clearPendingRequest).toHaveBeenCalledWith("req-1", "Thinking");
+  });
+
+  it("submits pending questionnaire answers with the request_user_input response shape", async () => {
+    const submitServerRequest = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-2",
+      requestId: "input-request-1",
+    }));
+    let currentPendingUserInput: PendingQuestionnaireState | undefined = {
+      method: "item/tool/requestUserInput",
+      threadId: "thread-2",
+      runId: "turn-1",
+      turnId: "turn-1",
+      itemId: "input-1",
+      requestId: "input-request-1",
+      currentIndex: 0,
+      answers: [null],
+      questions: [
+        {
+          id: "approach",
+          header: "Approach",
+          question: "Which implementation path should I take?",
+          options: [
+            {
+              key: "A",
+              label: "Small patch (Recommended)",
+              description: "Keep this scoped.",
+              recommended: true,
+            },
+            {
+              key: "B",
+              label: "Large refactor",
+              description: "Touch adjacent flows.",
+              recommended: false,
+            },
+          ],
+          allowFreeform: false,
+          secret: false,
+        },
+      ],
+    };
+    let currentPendingStatus: string | undefined = "Waiting for input";
+    const clearPendingRequest = vi.fn((_requestId: string, nextStatus?: string) => {
+      currentPendingUserInput = undefined;
+      currentPendingStatus = nextStatus;
+      rerenderThreadView();
+    });
+    const updatePendingUserInput = vi.fn(
+      (
+        requestId: string,
+        updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+      ) => {
+        if (currentPendingUserInput?.requestId === requestId) {
+          currentPendingUserInput = updater(currentPendingUserInput);
+          rerenderThreadView();
+        }
+      }
+    );
+
+    const { rerender } = render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+          submitServerRequest,
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        pendingStatusText={currentPendingStatus}
+        pendingUserInput={currentPendingUserInput}
+        selectedThread={{
+          id: "thread-2",
+          title: "Plan the app-server protocol",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Ask me a plan question"
+          }
+        ]}
+        clearPendingRequest={clearPendingRequest}
+        onLoadOlder={async () => undefined}
+        onUpdatePendingUserInput={updatePendingUserInput}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    const rerenderThreadView = () => {
+      rerender(
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: true,
+                multiDirectoryThreads: true
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            }
+          ]}
+          composerDisabled={false}
+          desktopApi={{
+            startTurn: async () => ({
+              backend: "codex",
+              threadId: "thread-2",
+              runId: "turn-1",
+            }),
+            submitServerRequest,
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          pendingStatusText={currentPendingStatus}
+          pendingUserInput={currentPendingUserInput}
+          selectedThread={{
+            id: "thread-2",
+            title: "Plan the app-server protocol",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false
+            }
+          }}
+          skills={[]}
+          transcriptEntries={[
+            {
+              type: "message",
+              id: "message-1",
+              role: "user",
+              text: "Ask me a plan question"
+            }
+          ]}
+          clearPendingRequest={clearPendingRequest}
+          onLoadOlder={async () => undefined}
+          onUpdatePendingUserInput={updatePendingUserInput}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    };
+
+    expect(screen.getByRole("group", { name: "Pending input" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Small patch/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(submitServerRequest).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-2",
+        runId: "turn-1",
+        requestId: "input-request-1",
+        response: {
+          answers: {
+            approach: {
+              answers: ["Small patch (Recommended)"]
+            }
+          }
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("group", { name: "Pending input" })
+      ).not.toBeInTheDocument();
+    });
+    expect(clearPendingRequest).toHaveBeenCalledWith("input-request-1", "Thinking");
   });
 
   it("clears a stale approval card when assistant output resumes", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -26,7 +26,7 @@ describe("ThreadView", () => {
   });
 
   it("renders a directory-less thread with transcript history and context", () => {
-    render(
+    const { rerender } = render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
@@ -197,7 +197,7 @@ describe("ThreadView", () => {
       }
     });
 
-    render(
+    const { rerender } = render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
@@ -878,6 +878,221 @@ describe("ThreadView", () => {
     );
 
     expect(screen.getAllByText("0 out of 3 tasks completed")).toHaveLength(1);
+  });
+
+  it("renders live plan markdown from item plan notifications", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Plan breakfast",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    const { rerender } = render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Make a breakfast plan."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/plan/delta",
+          params: {
+            threadId: "thread-2",
+            runId: "turn-1",
+            item: {
+              id: "plan-item-1",
+              type: "plan"
+            },
+            delta: "## Breakfast plan\n\n"
+          }
+        } as AppServerNotification,
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/plan/delta",
+          params: {
+            threadId: "thread-2",
+            runId: "turn-1",
+            item: {
+              id: "plan-item-1",
+              type: "plan"
+            },
+            delta: "Choose bagels after checking the cream cheese."
+          }
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByRole("heading", { name: "Breakfast plan" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Choose bagels after checking the cream cheese.")
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-2",
+            runId: "turn-1",
+            item: {
+              id: "plan-item-1",
+              type: "plan",
+              text: "## Final breakfast plan\n\nEat bagels if the cream cheese passes inspection."
+            }
+          }
+        },
+      });
+    });
+
+    expect(screen.getByRole("heading", { name: "Final breakfast plan" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Eat bagels if the cream cheese passes inspection.")
+    ).toBeInTheDocument();
+
+    rerender(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            runId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Make a breakfast plan."
+          },
+          {
+            type: "plan",
+            id: "persisted-plan-item-1",
+            markdown: "## Final breakfast plan\n\nEat bagels if the cream cheese passes inspection.",
+            steps: []
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole("heading", { name: "Final breakfast plan" })).toHaveLength(1);
   });
 
   it("renders live diff activity from turn/diff/updated and clears it once replay catches up", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -905,7 +905,7 @@ describe("TranscriptList", () => {
   });
 
   it("shows command approval reason and command when no prompt is provided", () => {
-    render(
+    const { container } = render(
       <TranscriptList
         entries={[]}
         loading={false}
@@ -926,12 +926,15 @@ describe("TranscriptList", () => {
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
     expect(screen.getByText(/Network access is required/)).toBeInTheDocument();
-    expect(screen.getByText(/Command: npm view dive/)).toBeInTheDocument();
+    expect(screen.getByText("Command:")).toBeInTheDocument();
+    expect(container.querySelector(".transcript-request pre code")).toHaveTextContent(
+      "npm view dive"
+    );
     expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
 
   it("prefers parsed command actions for command approval display", () => {
-    render(
+    const { container } = render(
       <TranscriptList
         entries={[]}
         loading={false}
@@ -957,7 +960,10 @@ describe("TranscriptList", () => {
     );
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
-    expect(screen.getByText(/Command: npm view dive/)).toBeInTheDocument();
+    expect(screen.getByText("Command:")).toBeInTheDocument();
+    expect(container.querySelector(".transcript-request pre code")).toHaveTextContent(
+      "npm view dive"
+    );
     expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -916,7 +916,7 @@ describe("TranscriptList", () => {
             threadId: "thread-1",
             requestId: "approval-1",
             reason: "Network access is required.",
-            command: "npm view dive",
+            command: "/bin/zsh -lc 'npm view dive'",
           },
         }}
         threadId="thread-1"
@@ -927,5 +927,37 @@ describe("TranscriptList", () => {
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
     expect(screen.getByText(/Network access is required/)).toBeInTheDocument();
     expect(screen.getByText(/Command: npm view dive/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
+  });
+
+  it("prefers parsed command actions for command approval display", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            reason: "Network access is required.",
+            command: "/bin/zsh -lc 'npm view dive'",
+            commandActions: [
+              {
+                type: "search",
+                command: "npm view dive",
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Command: npm view dive/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -966,4 +966,45 @@ describe("TranscriptList", () => {
     );
     expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
+
+  it("renders pending user input without approval actions", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingUserInput={{
+          method: "item/tool/requestUserInput",
+          threadId: "thread-1",
+          requestId: "input-request-1",
+          currentIndex: 0,
+          answers: [null],
+          questions: [
+            {
+              id: "approach",
+              header: "Approach",
+              question: "Which path should I take?",
+              options: [
+                {
+                  key: "A",
+                  label: "Small patch (Recommended)",
+                  description: "Keep this scoped.",
+                  recommended: true,
+                },
+              ],
+              allowFreeform: false,
+              secret: false,
+            },
+          ],
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending input" })).toBeInTheDocument();
+    expect(screen.getByText("Question 1 of 1")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Decline" })).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -310,6 +310,7 @@ describe("TranscriptList", () => {
             type: "plan",
             id: "plan-1",
             explanation: "Keep the renderer and replay contract aligned.",
+            markdown: "## Final plan\n\nUse the transcript plan renderer for durable output.",
             steps: [
               { step: "Normalize replay", status: "pending" },
               { step: "Render transcript plan card", status: "pending" },
@@ -331,6 +332,10 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Normalize replay")).toBeInTheDocument();
     expect(screen.getByText("Render transcript plan card")).toBeInTheDocument();
     expect(screen.getByText("Verify with tests")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Final plan" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Use the transcript plan renderer for durable output.")
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Pending")).toHaveLength(3);
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -903,4 +903,29 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(72);
     expect(scrollToMock).not.toHaveBeenCalled();
   });
+
+  it("shows command approval reason and command when no prompt is provided", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            reason: "Network access is required.",
+            command: "npm view dive",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Network access is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Command: npm view dive/)).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
@@ -1,0 +1,220 @@
+import type {
+  AppServerToolRequestUserInputNotification,
+  AppServerToolRequestUserInputResponse,
+} from "@pwragnt/shared";
+
+export type PendingQuestionnaireOption = {
+  key: string;
+  label: string;
+  description: string;
+  recommended: boolean;
+};
+
+export type PendingQuestionnaireQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  options: PendingQuestionnaireOption[];
+  allowFreeform: boolean;
+  secret: boolean;
+};
+
+export type PendingQuestionnaireAnswer =
+  | {
+      kind: "option";
+      optionKey: string;
+      value: string;
+    }
+  | {
+      kind: "text";
+      value: string;
+    };
+
+export type PendingQuestionnaireState = {
+  method: "item/tool/requestUserInput";
+  requestId: string;
+  threadId: string;
+  runId?: string;
+  turnId?: string;
+  itemId?: string;
+  questions: PendingQuestionnaireQuestion[];
+  currentIndex: number;
+  answers: Array<PendingQuestionnaireAnswer | null>;
+};
+
+export function createQuestionnaireState(
+  request: AppServerToolRequestUserInputNotification
+): PendingQuestionnaireState | undefined {
+  const questions = request.params.questions
+    .map((question) => {
+      const rawOptions = Array.isArray(question.options) ? question.options : [];
+      const options: PendingQuestionnaireOption[] = [];
+      for (const option of rawOptions) {
+        const label = trimString(option.label);
+        if (!label) {
+          continue;
+        }
+
+        options.push({
+          key: String.fromCharCode(65 + options.length),
+          label,
+          description: trimString(option.description),
+          recommended: /\(recommended\)/i.test(label),
+        });
+      }
+      const allowFreeform = question.isOther === true;
+
+      if (options.length === 0 && !allowFreeform) {
+        return undefined;
+      }
+
+      const prompt = trimString(question.question);
+      const header = trimString(question.header);
+      const id = trimString(question.id);
+      if (!id || (!prompt && !header)) {
+        return undefined;
+      }
+
+      return {
+        id,
+        header,
+        question: prompt || header,
+        options,
+        allowFreeform,
+        secret: question.isSecret === true,
+      };
+    })
+    .filter((question): question is PendingQuestionnaireQuestion => Boolean(question));
+
+  if (questions.length === 0) {
+    return undefined;
+  }
+
+  return {
+    method: request.method,
+    requestId: request.params.requestId,
+    threadId: request.params.threadId,
+    ...(request.params.runId ? { runId: request.params.runId } : {}),
+    ...(request.params.turnId ? { turnId: request.params.turnId } : {}),
+    ...(request.params.itemId ? { itemId: request.params.itemId } : {}),
+    questions,
+    currentIndex: 0,
+    answers: questions.map(() => null),
+  };
+}
+
+export function answerQuestionnaireOption(
+  state: PendingQuestionnaireState,
+  optionKey: string
+): PendingQuestionnaireState {
+  const question = state.questions[state.currentIndex];
+  const option = question?.options.find((candidate) => candidate.key === optionKey);
+  if (!question || !option) {
+    return state;
+  }
+
+  return answerCurrentQuestion(state, {
+    kind: "option",
+    optionKey: option.key,
+    value: option.label,
+  });
+}
+
+export function answerQuestionnaireText(
+  state: PendingQuestionnaireState,
+  value: string
+): PendingQuestionnaireState {
+  const question = state.questions[state.currentIndex];
+  if (!question?.allowFreeform) {
+    return state;
+  }
+
+  return answerCurrentQuestion(state, {
+    kind: "text",
+    value,
+  });
+}
+
+export function goToNextQuestion(
+  state: PendingQuestionnaireState
+): PendingQuestionnaireState {
+  if (!canAdvanceQuestionnaire(state)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    currentIndex: Math.min(state.currentIndex + 1, state.questions.length - 1),
+  };
+}
+
+export function goToPreviousQuestion(
+  state: PendingQuestionnaireState
+): PendingQuestionnaireState {
+  if (state.currentIndex <= 0) {
+    return state;
+  }
+
+  return {
+    ...state,
+    currentIndex: state.currentIndex - 1,
+  };
+}
+
+export function canAdvanceQuestionnaire(state: PendingQuestionnaireState): boolean {
+  return (
+    state.currentIndex < state.questions.length - 1 &&
+    isAnswerComplete(state.answers[state.currentIndex])
+  );
+}
+
+export function canSubmitQuestionnaire(state: PendingQuestionnaireState): boolean {
+  return state.answers.every(isAnswerComplete);
+}
+
+export function buildQuestionnaireResponse(
+  state: PendingQuestionnaireState
+): AppServerToolRequestUserInputResponse {
+  return {
+    answers: Object.fromEntries(
+      state.questions.map((question, index) => [
+        question.id,
+        {
+          answers: answerValue(state.answers[index]),
+        },
+      ])
+    ),
+  };
+}
+
+function answerCurrentQuestion(
+  state: PendingQuestionnaireState,
+  answer: PendingQuestionnaireAnswer
+): PendingQuestionnaireState {
+  const answers = [...state.answers];
+  answers[state.currentIndex] = answer;
+
+  return {
+    ...state,
+    answers,
+  };
+}
+
+function isAnswerComplete(
+  answer: PendingQuestionnaireAnswer | null | undefined
+): boolean {
+  return Boolean(answer && answerValue(answer).length > 0);
+}
+
+function answerValue(answer: PendingQuestionnaireAnswer | null | undefined): string[] {
+  if (!answer) {
+    return [];
+  }
+
+  const value = answer.value.trim();
+  return value ? [value] : [];
+}
+
+function trimString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1028,6 +1028,123 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingRequest).toBeUndefined();
   });
 
+  it("surfaces request_user_input as pending user input instead of approval", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              runId: "turn-1",
+              itemId: "input-1",
+              requestId: "input-request-1",
+              questions: [
+                {
+                  id: "approach",
+                  header: "Approach",
+                  question: "Which path should I take?",
+                  isOther: false,
+                  isSecret: false,
+                  options: [
+                    {
+                      label: "Small patch (Recommended)",
+                      description: "Keep this scoped.",
+                    },
+                    {
+                      label: "Large refactor",
+                      description: "Touch adjacent flows.",
+                    },
+                  ],
+                },
+              ],
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Waiting for input");
+    expect(result.current.pendingRequest).toBeUndefined();
+    expect(result.current.pendingUserInput).toMatchObject({
+      method: "item/tool/requestUserInput",
+      requestId: "input-request-1",
+      questions: [
+        {
+          id: "approach",
+          options: [
+            {
+              key: "A",
+              label: "Small patch (Recommended)",
+              recommended: true,
+            },
+            {
+              key: "B",
+              label: "Large refactor",
+              recommended: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "serverRequest/resolved",
+            params: {
+              threadId: "thread-1",
+              requestId: "input-request-1",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingUserInput).toBeUndefined();
+    expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -900,6 +900,72 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeRunId).toBeUndefined();
   });
 
+  it("surfaces command execution approval requests from app-server events", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/commandExecution/requestApproval",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "call-1",
+              requestId: "approval-1",
+              reason: "Network access is required.",
+              command: "npm view dive",
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Waiting for approval");
+    expect(result.current.pendingRequest).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+      params: {
+        requestId: "approval-1",
+        command: "npm view dive",
+      },
+    });
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -966,6 +966,68 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("does not surface permissions approvals as command approval requests", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/permissions/requestApproval",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "call-1",
+              requestId: "approval-1",
+              reason: "Additional permissions are required.",
+              permissions: {
+                type: "full-access",
+              },
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.pendingRequest).toBeUndefined();
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
+  AppServerCollaborationModeRequest,
   AppServerTurnInputItem,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -368,7 +369,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   refresh: () => Promise<void>;
   materializeDirectoryLaunchpad: (
     directoryKey: string,
-    input?: AppServerTurnInputItem[]
+    input?: AppServerTurnInputItem[],
+    collaborationMode?: AppServerCollaborationModeRequest
   ) => Promise<void>;
   openDirectoryLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -918,7 +920,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const materializeDirectoryLaunchpad = useCallback(
     async (
       directoryKey: string,
-      input?: AppServerTurnInputItem[]
+      input?: AppServerTurnInputItem[],
+      collaborationMode?: AppServerCollaborationModeRequest
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -938,6 +941,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         const response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
           input,
+          collaborationMode,
         });
         const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
           directory,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -204,6 +204,15 @@ function retainSessionCache(
   ]);
 }
 
+function isApprovalRequestNotification(
+  notification: { method: string; params: Record<string, unknown> }
+): notification is AppServerPendingRequestNotification {
+  return (
+    notification.method.endsWith("/requestApproval") &&
+    typeof notification.params.requestId === "string"
+  );
+}
+
 function readCompletedTurnText(
   notification: AppServerPendingRequestNotification | AppServerReadThreadResponse["backend"] | unknown
 ): string | undefined {
@@ -477,17 +486,12 @@ export function useThreadSessionState(params: {
       updateSession(targetThreadKey, (current) => {
         const nextLastTouchedAt = Date.now();
 
-        if (
-          (event.notification.method === "turn/requestApproval" ||
-            event.notification.method === "review/requestApproval") &&
-          "requestId" in event.notification.params
-        ) {
+        if (isApprovalRequestNotification(event.notification)) {
           return {
             ...current,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
-            pendingRequest:
-              event.notification as AppServerPendingRequestNotification,
+            pendingRequest: event.notification,
             pendingStatusText: "Waiting for approval",
           };
         }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -12,6 +12,12 @@ import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
 const MAX_VIEW_ONLY_THREADS = 10;
+const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
+  "turn/requestApproval",
+  "review/requestApproval",
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+]);
 
 export type ThreadViewportState = {
   distanceFromBottom: number;
@@ -208,7 +214,7 @@ function isApprovalRequestNotification(
   notification: { method: string; params: Record<string, unknown> }
 ): notification is AppServerPendingRequestNotification {
   return (
-    notification.method.endsWith("/requestApproval") &&
+    SUPPORTED_APPROVAL_REQUEST_METHODS.has(notification.method) &&
     typeof notification.params.requestId === "string"
   );
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerPendingRequestNotification,
   AppServerReadThreadResponse,
+  AppServerToolRequestUserInputNotification,
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
@@ -10,6 +11,10 @@ import type {
 } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
+import {
+  createQuestionnaireState,
+  type PendingQuestionnaireState,
+} from "../features/thread-detail/questionnaire";
 
 const MAX_VIEW_ONLY_THREADS = 10;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
@@ -39,6 +44,7 @@ type ThreadSessionEntry = {
   optimisticEntries: AppServerThreadMessageEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingRequest?: AppServerPendingRequestNotification;
+  pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   response?: AppServerReadThreadResponse;
   viewport?: ThreadViewportState;
@@ -115,7 +121,8 @@ function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
     session.response?.replay.entries.length ||
       session.optimisticEntries.length ||
       session.pendingAssistantMessage ||
-      session.pendingRequest
+      session.pendingRequest ||
+      session.pendingUserInput
   );
 }
 
@@ -125,6 +132,7 @@ function hasThinkingState(session: ThreadSessionEntry): boolean {
       session.pendingStatusText ||
       session.pendingAssistantMessage ||
       session.pendingRequest ||
+      session.pendingUserInput ||
       (session.expectOwnUpdate && session.optimisticEntries.length > 0)
   );
 }
@@ -219,6 +227,17 @@ function isApprovalRequestNotification(
   );
 }
 
+function isRequestUserInputNotification(
+  notification: { method: string; params: Record<string, unknown> }
+): notification is AppServerToolRequestUserInputNotification {
+  return (
+    notification.method === "item/tool/requestUserInput" &&
+    typeof notification.params.threadId === "string" &&
+    typeof notification.params.requestId === "string" &&
+    Array.isArray(notification.params.questions)
+  );
+}
+
 function readCompletedTurnText(
   notification: AppServerPendingRequestNotification | AppServerReadThreadResponse["backend"] | unknown
 ): string | undefined {
@@ -274,10 +293,15 @@ export function useThreadSessionState(params: {
   messages: AppServerThreadMessage[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingRequest?: AppServerPendingRequestNotification;
+  pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   removeOptimisticMessage: (id: string) => void;
   response?: AppServerReadThreadResponse;
   setActiveRunId: (runId?: string) => void;
+  updatePendingUserInput: (
+    requestId: string,
+    updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+  ) => void;
   setPendingStatusText: (status?: string) => void;
   thinkingThreadKeys: Record<string, boolean>;
   setViewport: (viewport?: ThreadViewportState) => void;
@@ -502,6 +526,21 @@ export function useThreadSessionState(params: {
           };
         }
 
+        if (isRequestUserInputNotification(event.notification)) {
+          const pendingUserInput = createQuestionnaireState(event.notification);
+          if (!pendingUserInput) {
+            return current;
+          }
+
+          return {
+            ...current,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingStatusText: "Waiting for input",
+            pendingUserInput,
+          };
+        }
+
         if (
           event.notification.method === "item/agentMessage/delta" &&
           typeof event.notification.params.itemId === "string" &&
@@ -556,6 +595,10 @@ export function useThreadSessionState(params: {
               current.pendingRequest?.params.requestId === event.notification.params.requestId
                 ? undefined
                 : current.pendingRequest,
+            pendingUserInput:
+              current.pendingUserInput?.requestId === event.notification.params.requestId
+                ? undefined
+                : current.pendingUserInput,
             pendingStatusText: "Thinking",
           };
         }
@@ -592,6 +635,7 @@ export function useThreadSessionState(params: {
               optimisticEntries: [],
               pendingAssistantMessage: undefined,
               pendingRequest: undefined,
+              pendingUserInput: undefined,
               response: nextResponse,
             });
 
@@ -610,6 +654,7 @@ export function useThreadSessionState(params: {
             optimisticEntries: [],
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
+            pendingUserInput: undefined,
             pendingStatusText: undefined,
             response: nextResponse,
           };
@@ -629,6 +674,7 @@ export function useThreadSessionState(params: {
             needsHydrationAfterCompletion: false,
             pendingAssistantMessage: undefined,
             pendingRequest: undefined,
+            pendingUserInput: undefined,
             pendingStatusText: undefined,
           };
         }
@@ -832,8 +878,36 @@ export function useThreadSessionState(params: {
           current.pendingRequest?.params.requestId === requestId
             ? undefined
             : current.pendingRequest,
+        pendingUserInput:
+          current.pendingUserInput?.requestId === requestId
+            ? undefined
+            : current.pendingUserInput,
         pendingStatusText: nextStatus,
       }));
+    },
+    [threadKey, updateSession]
+  );
+
+  const updatePendingUserInput = useCallback(
+    (
+      requestId: string,
+      updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+    ): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => {
+        if (current.pendingUserInput?.requestId !== requestId) {
+          return current;
+        }
+
+        return {
+          ...current,
+          lastTouchedAt: Date.now(),
+          pendingUserInput: updater(current.pendingUserInput),
+        };
+      });
     },
     [threadKey, updateSession]
   );
@@ -920,10 +994,12 @@ export function useThreadSessionState(params: {
     messages,
     pendingAssistantMessage: selectedSession?.pendingAssistantMessage,
     pendingRequest: selectedSession?.pendingRequest,
+    pendingUserInput: selectedSession?.pendingUserInput,
     pendingStatusText,
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveRunId,
+    updatePendingUserInput,
     setPendingStatusText,
     thinkingThreadKeys,
     setViewport,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1195,6 +1195,17 @@ textarea {
   background: rgba(184, 255, 77, 0.08);
 }
 
+.transcript-questionnaire {
+  width: min(100%, 760px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: rgba(184, 255, 77, 0.08);
+}
+
 .transcript-image-lightbox {
   position: fixed;
   inset: 0;
@@ -1229,6 +1240,8 @@ textarea {
 
 .transcript-request__header,
 .transcript-request__actions,
+.transcript-questionnaire__header,
+.transcript-questionnaire__actions,
 .context-mode-switch {
   display: flex;
   align-items: center;
@@ -1236,11 +1249,13 @@ textarea {
 }
 
 .transcript-request__header,
+.transcript-questionnaire__header,
 .context-mode-switch {
   flex-wrap: wrap;
 }
 
-.transcript-request__header {
+.transcript-request__header,
+.transcript-questionnaire__header {
   justify-content: space-between;
 }
 
@@ -1252,8 +1267,119 @@ textarea {
   white-space: pre-wrap;
 }
 
-.transcript-request__actions {
+.transcript-request__actions,
+.transcript-questionnaire__actions {
   justify-content: flex-start;
+}
+
+.transcript-questionnaire__prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.transcript-questionnaire__prompt .eyebrow {
+  margin: 0;
+}
+
+.transcript-questionnaire__prompt h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.transcript-questionnaire__options {
+  display: grid;
+  gap: 8px;
+}
+
+.transcript-questionnaire__option {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.transcript-questionnaire__option:hover:not(:disabled),
+.transcript-questionnaire__option:focus-visible,
+.transcript-questionnaire__option.is-selected {
+  border-color: var(--accent-border);
+  background: rgba(184, 255, 77, 0.12);
+  outline: none;
+}
+
+.transcript-questionnaire__option-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.transcript-questionnaire__option-key {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.transcript-questionnaire__recommended {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.transcript-questionnaire__option-description {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.transcript-questionnaire__freeform {
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.transcript-questionnaire__freeform textarea {
+  min-height: 84px;
+  resize: vertical;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font: inherit;
+  line-height: 1.45;
+  padding: 10px 12px;
+}
+
+.transcript-questionnaire__freeform textarea:focus {
+  border-color: var(--accent-border);
+  outline: none;
 }
 
 @keyframes pwragnt-kitt-scan {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1249,6 +1249,7 @@ textarea {
   color: var(--text-primary);
   font-size: 14px;
   line-height: 1.55;
+  white-space: pre-wrap;
 }
 
 .transcript-request__actions {

--- a/docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md
+++ b/docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md
@@ -1,0 +1,373 @@
+---
+title: feat: Add Plan questionnaire navigation to the desktop app
+type: feat
+status: completed
+date: 2026-04-20
+origin: docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md
+---
+
+# feat: Add Plan questionnaire navigation to the desktop app
+
+## Overview
+
+Bring Codex `request_user_input` Plan-mode questionnaires into the desktop thread view as a first-class pending-input surface with Back, Next, and Submit navigation. This is separate from command/file approval prompts: questionnaire requests must never appear as Approve/Decline cards and must respond with the Codex app-server `ToolRequestUserInputResponse` shape.
+
+This plan treats `/Users/huntharo/pwrdrvr/openclaw-codex-app-server` as prior art and this PwrAgnt desktop app as the target. OpenClaw already has useful questionnaire state and response-formatting concepts, but its chat callback queue is platform-specific and should not be copied into the Electron renderer.
+
+## Problem Frame
+
+The recent approval work restored command/file approval cards and intentionally excluded `item/permissions/requestApproval` from the generic approval matcher. That avoids invalid approval responses, but it does not solve Plan-mode questions. Codex plan questionnaires arrive as `item/tool/requestUserInput` JSON-RPC requests with structured `questions`, `options`, and an expected response payload of `{ answers: { [questionId]: { answers: string[] } } }`.
+
+Without a dedicated UI and response path, the desktop app either ignores those requests or risks routing future input prompts through approval-shaped decisions. Plan mode needs a compact, thread-native questionnaire card that can show one question at a time, preserve answers while navigating backward and forward, handle recommended and free-form options, and submit the exact app-server response contract.
+
+## Requirements Trace
+
+- R1, R2, R4 from the origin parity requirements: match supported Codex Desktop protocol behavior and treat real app-server traffic as the source of truth.
+- R3, R4 from the origin parity requirements: do not recover this from rollout files or private session artifacts.
+- R15, R16 from the origin parity requirements: close the behavior with targeted unit, replay, and E2E coverage.
+
+Derived requirements for this feature:
+
+- RQ1. Surface `item/tool/requestUserInput` as pending user input, not as pending approval.
+- RQ2. Preserve Codex response compatibility by submitting `{ answers: Record<string, { answers: string[] }> }`.
+- RQ3. Render structured questions with headers, prompt text, option labels, descriptions, recommended labels, and optional free-form/Other input.
+- RQ4. Support Back and Next navigation across multi-question questionnaires while preserving answers.
+- RQ5. Gate Submit until every question has a valid answer; gate Next until the current question is answered.
+- RQ6. Keep pending questionnaire state scoped to backend, thread id, and request id, and clear it on successful submit, server resolution, turn cancellation, turn failure, or thread change.
+- RQ7. Cover the behavior with failing-first unit tests and a replay-backed Electron E2E test.
+
+## Scope Boundaries
+
+- In scope: Codex `item/tool/requestUserInput` structured Plan-mode questionnaires.
+- In scope: renderer state, thread UI, response formatting, bridge typing, and replay/E2E coverage.
+- In scope: borrowing OpenClaw questionnaire parsing/state ideas where they map directly to Codex structured requests.
+- Out of scope: `item/permissions/requestApproval`; its response contract is different and should stay excluded from approval cards until it gets a dedicated implementation.
+- Out of scope: chat-platform callback tokens, compact text parsing for legacy chat prompts, or OpenClaw message queue behavior.
+- Out of scope: adding new Plan-mode behavior to the model or Codex CLI.
+
+## Context & Research
+
+### PwrAgnt Surfaces
+
+- `packages/shared/src/contracts/app-server.ts` currently has a broad `AppServerPendingRequestNotification` type and a notification union that is approval-oriented in its named variants.
+- `packages/shared/src/contracts/agent.ts` already lets `SubmitServerRequestRequest.response` be any `Record<string, unknown>`, which is broad enough for questionnaire answers.
+- `apps/desktop/src/main/codex-app-server/client.ts` already normalizes inbound JSON-RPC requests into pending request notifications and uses the JSON-RPC id as a fallback `requestId`.
+- `apps/desktop/src/main/app-server/backend-registry.ts` already stores pending server requests and resolves them through `submitServerRequest`.
+- `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts` currently promotes only supported command/file approval request methods into `pendingRequest`.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` currently builds approval-shaped responses and clears approval state after submit.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` currently renders pending approvals in the transcript.
+- `apps/desktop/e2e/approval-pending.spec.ts` and `apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json` provide the closest replay-backed E2E pattern.
+
+### OpenClaw Prior Art
+
+- `/Users/huntharo/pwrdrvr/openclaw-codex-app-server/src/types.ts` defines `PendingQuestionnaireQuestion`, `PendingQuestionnaireOption`, `PendingQuestionnaireAnswer`, and `PendingQuestionnaireState`.
+- `/Users/huntharo/pwrdrvr/openclaw-codex-app-server/src/pending-input.ts` has `extractQuestionnaireFromStructuredRequest`, `formatPendingQuestionnairePrompt`, `buildPendingQuestionnaireResponse`, `questionnaireIsComplete`, and `questionnaireCurrentQuestionHasAnswer`.
+- `/Users/huntharo/pwrdrvr/openclaw-codex-app-server/src/client.ts` keeps approval response mapping separate from non-approval pending input responses.
+- `/Users/huntharo/pwrdrvr/openclaw-codex-app-server/src/controller.test.ts` includes coverage that a visible questionnaire suppresses plan keepalive chatter.
+
+OpenClaw's useful ideas are the normalized questionnaire model, completion helpers, and response formatter. Its callback queue, compact text parser, and chat message formatting should remain OpenClaw-specific.
+
+### Codex Protocol Source
+
+Local Codex protocol definitions show the exact request and response contract:
+
+- `/Users/huntharo/github/codex/codex-rs/app-server-protocol/src/protocol/common.rs` maps tool user input to `item/tool/requestUserInput`.
+- `/Users/huntharo/github/codex/codex-rs/app-server-protocol/src/protocol/v2.rs` defines `ToolRequestUserInputParams`, `ToolRequestUserInputQuestion`, `ToolRequestUserInputOption`, `ToolRequestUserInputAnswer`, and `ToolRequestUserInputResponse`.
+- `/Users/huntharo/github/codex/codex-rs/app-server-protocol/schema/typescript/v2/ToolRequestUserInputResponse.ts` confirms the response shape is `{ answers: { [key in string]?: { answers: string[] } } }`.
+
+### Institutional Learnings
+
+No `docs/solutions/` artifacts were present for this topic. Existing plans for protocol parity and the replay harness are the relevant local guidance.
+
+### External References
+
+None. The authoritative references are the local Codex protocol definitions, OpenClaw prior art, and PwrAgnt's existing desktop replay harness.
+
+## Key Technical Decisions
+
+- **Use separate state for questionnaire requests.** Do not widen `pendingRequest` approvals to include user-input prompts. Add a distinct pending questionnaire/user-input state so approval response helpers cannot accidentally submit `{ decision: ... }`.
+- **Keep the response formatter protocol-shaped.** The renderer should emit `ToolRequestUserInputResponse` directly: one answer map entry per question id, each containing a string array.
+- **Borrow the model, not the transport.** Adapt OpenClaw's questionnaire state, completion helpers, and formatter; do not bring over callback ids, chat prompt rendering, or compact text parsing.
+- **Render the question card in the thread detail surface.** The questionnaire is part of the active turn, so it should appear where approval cards appear today, with composer affordances disabled while the request is pending.
+- **Store navigation locally and deterministically.** `currentIndex` and `answers` belong in renderer state keyed by request id. Server state only needs the final response.
+- **Treat replay as the E2E source.** Use a small replay fixture for `item/tool/requestUserInput` rather than relying on a live Plan-mode run for CI.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should Plan-mode questionnaires be approval cards? No. They have a different method and response contract.
+- Can `SubmitServerRequestRequest.response` carry the response? Yes, it is already `Record<string, unknown>`.
+- Do we need to support legacy compact text questionnaires first? No. Structured `questions` are the Codex app-server contract to target.
+- Should permissions approval be fixed as part of this? No. It remains a separate response contract.
+
+### Deferred to Implementation
+
+- Whether the UI should call the component "Pending input", "Plan question", or another short label after a screenshot pass.
+- Whether free-form answers should be represented as an always-visible "Other" text field or a selected Other option that reveals a field.
+- Whether `isSecret` needs masked input immediately; the protocol supports it, but current Plan-mode choices are usually non-secret.
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+    participant Codex as Codex app-server
+    participant Main as CodexAppServerClient
+    participant Registry as DesktopBackendRegistry
+    participant Session as useThreadSessionState
+    participant UI as ThreadView questionnaire card
+
+    Codex->>Main: item/tool/requestUserInput(params, rpc id)
+    Main->>Registry: pending request notification
+    Registry->>Session: AgentEvent
+    Session->>Session: build pending questionnaire state
+    Session->>UI: pendingUserInput
+    UI->>UI: answer question, Back, Next
+    UI->>Registry: submitServerRequest({ answers })
+    Registry->>Codex: JSON-RPC response
+    Registry->>Session: serverRequest/resolved
+    Session->>UI: clear pendingUserInput
+```
+
+State shape should stay close to the protocol:
+
+```ts
+type PendingQuestionnaireState = {
+  method: "item/tool/requestUserInput";
+  requestId: string;
+  threadId: string;
+  runId?: string;
+  itemId?: string;
+  questions: PendingQuestionnaireQuestion[];
+  currentIndex: number;
+  answers: Array<PendingQuestionnaireAnswer | null>;
+};
+```
+
+Question and answer helpers should be pure functions so unit tests can lock down completion, navigation, and response formatting without rendering React.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Shared protocol types and request classification"] --> U2["Unit 2: Questionnaire model and formatter"]
+    U2 --> U3["Unit 3: Session state lifecycle"]
+    U3 --> U4["Unit 4: Thread UI and navigation"]
+    U4 --> U5["Unit 5: Submit integration and error handling"]
+    U5 --> U6["Unit 6: Replay fixture and E2E coverage"]
+```
+
+- [x] **Unit 1: Add shared protocol types and request classification**
+
+**Goal:** Represent `item/tool/requestUserInput` distinctly from approval requests across shared contracts and renderer state.
+
+**Requirements:** RQ1, RQ2, RQ6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts` if normalization needs typed method metadata
+- Test: `apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
+- Test: `apps/desktop/src/main/__tests__/replay-runtime.test.ts`
+
+**Approach:**
+- Add narrow shared types for `AppServerToolRequestUserInputNotification`, question options, questions, and response answer maps.
+- Keep `AppServerPendingRequestNotification` generic enough for existing registry behavior, but add discriminated helpers so renderer code does not branch on loose strings everywhere.
+- Add or update tests proving an inbound `item/tool/requestUserInput` request keeps `threadId`, `turnId`/`runId`, `itemId`, `requestId`, and `questions`.
+
+**Test scenarios:**
+- Happy path: a structured `item/tool/requestUserInput` request is emitted through registry events with all question data intact.
+- Edge case: when params omit `requestId`, the JSON-RPC id is used as the fallback request id.
+- Regression: command/file approval methods still classify as approval requests and permissions approval still does not.
+
+**Verification:**
+- Type-level and main-process tests can distinguish approval requests from Plan questionnaire requests.
+
+- [x] **Unit 2: Add pure questionnaire model, navigation, and response helpers**
+
+**Goal:** Create a renderer-side pure utility module for deriving questionnaire state, moving through questions, validating answers, and formatting Codex responses.
+
+**Requirements:** RQ2, RQ3, RQ4, RQ5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.ts`
+
+**Approach:**
+- Adapt OpenClaw's structured extractor, completion helper, and response formatter to PwrAgnt's shared protocol types.
+- Keep one question id per answer map entry and render selected option labels or free-form text into `answers: string[]`.
+- Provide pure functions such as `createQuestionnaireState`, `answerCurrentQuestion`, `goToNextQuestion`, `goToPreviousQuestion`, `canAdvanceQuestionnaire`, `canSubmitQuestionnaire`, and `buildQuestionnaireResponse`.
+- Normalize recommended options by detecting `(Recommended)` in the label while preserving the original user-facing label.
+
+**Test scenarios:**
+- Happy path: a one-question request formats `{ answers: { questionId: { answers: ["Selected label"] } } }`.
+- Happy path: a multi-question request preserves answers while navigating Back and Next.
+- Happy path: recommended labels and option descriptions are preserved for rendering.
+- Edge case: Next is unavailable until the current question has an answer.
+- Edge case: Submit is unavailable until every question has an answer.
+- Edge case: free-form Other text must be non-empty before it counts as answered.
+- Edge case: malformed requests with no valid questions are rejected and do not create pending questionnaire state.
+
+**Verification:**
+- Questionnaire behavior is fully testable without React or Electron.
+
+- [x] **Unit 3: Wire questionnaire lifecycle into thread session state**
+
+**Goal:** Store pending Plan questionnaires alongside thread session state without mixing them with approval cards.
+
+**Requirements:** RQ1, RQ4, RQ5, RQ6
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Approach:**
+- Add `pendingUserInput?: PendingQuestionnaireState` or a similarly named field to `ThreadSessionEntry`.
+- Add `isRequestUserInputNotification` beside `isApprovalRequestNotification`.
+- On `item/tool/requestUserInput`, build questionnaire state and set `pendingStatusText` to a waiting-for-input status.
+- Clear the pending questionnaire when the matching `serverRequest/resolved` arrives, when the user submits successfully, or when the active turn fails/cancels/completes.
+- Ensure `hasHydratedTranscriptContent` and `hasThinkingState` treat pending questionnaires as live thread content.
+
+**Test scenarios:**
+- Happy path: `item/tool/requestUserInput` creates `pendingUserInput` and does not create `pendingRequest`.
+- Regression: permissions approval remains ignored by the approval UI.
+- Regression: command approval still creates `pendingRequest`.
+- Edge case: events for another backend or thread do not affect the selected session.
+- Edge case: `serverRequest/resolved` for the matching request id clears only the matching pending questionnaire.
+- Edge case: assistant output or turn terminal notifications clear stale pending input consistently with stale approvals.
+
+**Verification:**
+- Hook tests prove the renderer can hold Plan questions independently of approvals and lifecycle cleanup works.
+
+- [x] **Unit 4: Add the thread questionnaire UI with Back and Next navigation**
+
+**Goal:** Render Plan questions in the transcript area with compact controls and stable navigation.
+
+**Requirements:** RQ3, RQ4, RQ5
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` if pending request rendering stays centralized there
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Render a card with an accessible group label such as `Pending input`.
+- Show the current question header, prompt, progress text, option buttons/radios, option descriptions, and a free-form field when needed.
+- Add Back, Next, and Submit controls. Back is disabled on the first question; Next is disabled until the current answer is valid; Submit replaces Next on the last question and is disabled until all answers are valid.
+- Preserve layout stability by keeping the action row and progress treatment fixed across navigation.
+- Follow `docs/design/desktop-style-guide.md`: compact, tool-like, no nested cards, radius no larger than 8px, and no explanatory scaffold copy.
+
+**Test scenarios:**
+- Happy path: a one-question questionnaire shows Submit, not Approve/Decline.
+- Happy path: a multi-question questionnaire shows Back/Next and progress text.
+- Happy path: selecting an option, moving forward, moving back, and returning preserves the selected answer.
+- Edge case: long option labels wrap without changing control alignment unexpectedly.
+- Edge case: Other/free-form input is preserved across navigation.
+- Accessibility: controls have role/name coverage suitable for Playwright and Testing Library.
+
+**Verification:**
+- Renderer tests show Plan questions with navigation and no approval buttons.
+
+- [x] **Unit 5: Submit questionnaire responses through the desktop bridge**
+
+**Goal:** Send the final questionnaire response through `submitServerRequest` and clear UI state only after the bridge accepts it.
+
+**Requirements:** RQ2, RQ5, RQ6
+
+**Dependencies:** Units 3 and 4
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts` only if stronger exported typing is needed
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+
+**Approach:**
+- Add a submit handler separate from `respondToPendingRequest` so questionnaire submission cannot call `buildPendingRequestResponse`.
+- Submit `backend`, `threadId`, optional `runId`, `requestId`, and the questionnaire answer map.
+- Keep answers and show an inline error if `submitServerRequest` rejects.
+- Clear pending questionnaire state and move status back to Thinking only after successful submit or matching server resolution.
+
+**Test scenarios:**
+- Happy path: Submit calls `submitServerRequest` with `response: { answers: { ... } }`.
+- Regression: approval buttons still submit approval decisions unchanged.
+- Edge case: bridge failure leaves the questionnaire visible with answers preserved.
+- Edge case: the submit button is disabled while a submit is in flight.
+
+**Verification:**
+- ThreadView tests prove questionnaire and approval submit paths are separate and protocol-shaped.
+
+- [x] **Unit 6: Add replay-backed E2E coverage**
+
+**Goal:** Lock the full Electron path with a deterministic `request_user_input` replay fixture.
+
+**Requirements:** RQ1, RQ3, RQ4, RQ5, RQ6, RQ7
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `apps/desktop/e2e/fixtures/request-user-input/replay.fixture.json`
+- Create: `apps/desktop/e2e/request-user-input.spec.ts`
+- Modify: `apps/desktop/e2e/fixtures/README.md` if fixture conventions need a new note
+- Test: `apps/desktop/src/main/__tests__/fixture-derivation.test.ts` only if derivation tooling needs to understand the new request shape
+
+**Approach:**
+- Create a small replay fixture with a user prompt, turn start, and an inbound `item/tool/requestUserInput` request containing two or three questions.
+- E2E should open the fixture, start the turn, advance to the request, answer the first question, navigate Next, answer the second, go Back, verify the first answer is still selected, return forward, and Submit.
+- Assert that Approve, Decline, and Cancel turn approval controls are not present for the questionnaire card.
+- Assert the replay pending request clears after submit and the thread returns to Thinking or the next scripted turn state.
+
+**Test scenarios:**
+- Full path: Plan questionnaire appears, navigation works, Submit resolves the pending request.
+- Regression: no approval UI appears for `item/tool/requestUserInput`.
+- Edge case: Back/Next preservation is verified in the real Electron app, not only unit tests.
+
+**Verification:**
+- `apps/desktop` Playwright E2E can run the new request-user-input spec against the built Electron app.
+
+## System Impact
+
+- Shared contracts gain explicit user-input request typing but the bridge stays compatible with existing generic server requests.
+- Main-process request routing remains generic; the main change is preserving and typing the new request method.
+- Renderer session state gains a second pending server-request surface for user input.
+- Thread detail rendering gains one new interaction card.
+- Replay fixtures gain coverage for inbound JSON-RPC requests that are not approvals.
+
+## Risks And Mitigations
+
+- **Risk: response shape drift.** Mitigate by grounding helpers in the local Codex generated TypeScript/Rust protocol definitions and testing exact payloads.
+- **Risk: approval and questionnaire state interact badly.** Mitigate with separate state fields, separate type guards, separate submit helpers, and regression tests for approval behavior.
+- **Risk: answer state is lost during re-renders.** Mitigate by keying questionnaire state by backend/thread/request id in `useThreadSessionState`, not local component-only state.
+- **Risk: UI overfits to one-question prompts.** Mitigate with unit and E2E coverage for multi-question Back/Next flows.
+- **Risk: OpenClaw code is copied too broadly.** Mitigate by borrowing only pure model/formatter ideas and leaving chat callback handling behind.
+
+## Verification Plan
+
+Targeted commands for the implementation pass:
+
+```bash
+pnpm --filter @pwragnt/desktop test -- useThreadSessionState
+pnpm --filter @pwragnt/desktop test -- questionnaire
+pnpm --filter @pwragnt/desktop test -- thread-view
+pnpm --filter @pwragnt/desktop test -- transcript-list
+pnpm --filter @pwragnt/desktop test:e2e -- request-user-input
+pnpm --filter @pwragnt/desktop typecheck
+```
+
+Acceptance criteria:
+
+- `item/tool/requestUserInput` never renders approval controls.
+- A multi-question Plan questionnaire supports Back and Next with answer preservation.
+- Submit sends `{ answers: { [questionId]: { answers: [...] } } }`.
+- Pending state clears after successful submit or matching resolution.
+- Existing command/file approval tests continue to pass.
+- A replay-backed Electron E2E test covers the real UI path.

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -34,6 +34,7 @@ export type StartTurnRequest = {
   threadId: ThreadIdentifier;
   input: AppServerTurnInputItem[];
   model?: string;
+  collaborationMode?: AppServerCollaborationModeRequest;
 };
 
 export type StartTurnResponse = {
@@ -132,6 +133,7 @@ export type ResetDirectoryLaunchpadResponse = {
 export type MaterializeDirectoryLaunchpadRequest = {
   directoryKey: string;
   input?: AppServerTurnInputItem[];
+  collaborationMode?: AppServerCollaborationModeRequest;
 };
 
 export type MaterializeDirectoryLaunchpadResponse = {
@@ -145,4 +147,13 @@ export type MaterializeDirectoryLaunchpadResponse = {
 export type AgentEvent = {
   backend: AppServerBackendKind;
   notification: AppServerNotification;
+};
+
+export type AppServerCollaborationModeRequest = {
+  mode: "default" | "plan";
+  settings?: {
+    model?: string;
+    reasoningEffort?: string;
+    developerInstructions?: string | null;
+  };
 };

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -136,6 +136,7 @@ export type AppServerThreadPlanEntry = {
   id: string;
   createdAt?: number;
   explanation?: string;
+  markdown?: string;
   steps: AppServerThreadPlanStep[];
 };
 

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -210,6 +210,37 @@ export type AppServerPendingRequestNotification = {
   };
 };
 
+export type AppServerToolRequestUserInputOption = {
+  label: string;
+  description: string;
+};
+
+export type AppServerToolRequestUserInputQuestion = {
+  id: string;
+  header: string;
+  question: string;
+  isOther: boolean;
+  isSecret: boolean;
+  options: AppServerToolRequestUserInputOption[] | null;
+};
+
+export type AppServerToolRequestUserInputAnswer = {
+  answers: string[];
+};
+
+export type AppServerToolRequestUserInputResponse = {
+  answers: Record<string, AppServerToolRequestUserInputAnswer | undefined>;
+};
+
+export type AppServerToolRequestUserInputNotification = {
+  method: "item/tool/requestUserInput";
+  params: AppServerPendingRequestNotification["params"] & {
+    turnId?: string;
+    itemId?: string;
+    questions: AppServerToolRequestUserInputQuestion[];
+  };
+};
+
 export type AppServerNotification =
   | {
       method: "turn/started";
@@ -323,6 +354,7 @@ export type AppServerNotification =
       method: "turn/requestApproval" | "review/requestApproval";
       params: AppServerPendingRequestNotification["params"];
     }
+  | AppServerToolRequestUserInputNotification
   | {
       method: "thread/status/changed";
       params: {


### PR DESCRIPTION
## Summary

Desktop threads now surface the Codex app-server interactions that can pause a turn: command/file approval requests and Plan-mode `request_user_input` questionnaires.

The approval work keeps command execution requests out of the indefinite Thinking state, trims shell launcher noise from displayed commands, and renders commands as readable code blocks. The Plan questionnaire work adds a separate pending-input path so `item/tool/requestUserInput` never falls through to Approve/Decline and instead submits the Codex response shape: `{ answers: { [questionId]: { answers: [...] } } }`.

## What Changed

- Recognize command/file approval requests without treating permissions approvals as approval cards.
- Render pending approval commands as code blocks with shell launcher wrappers trimmed from display.
- Add shared request_user_input protocol types for structured questions and answer maps.
- Add pure questionnaire helpers for state creation, Back/Next navigation, answer validation, and response formatting.
- Track pending Plan questionnaires separately from approval requests in thread session state.
- Add a compact pending input card with option selection, recommended labels, Back/Next navigation, and Submit.
- Submit questionnaire answers through the existing `submitServerRequest` bridge and preserve answers on rerender.
- Add a replay fixture and Electron E2E coverage for the full request_user_input flow.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry-replay.test.ts apps/desktop/src/main/__tests__/replay-runtime.test.ts`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm test -- --project desktop-renderer --project desktop-main`
- `pnpm typecheck`
- `pnpm --filter @pwragnt/desktop test:e2e -- request-user-input approval-pending`

## Screenshots

- Captured locally: `/tmp/pwragnt-request-user-input.png`

## Post-Deploy Monitoring & Validation

No additional external production monitoring is required because this is local desktop UI/protocol handling with replay-backed regression coverage.

Validation window: first desktop build after merge.
Owner: desktop maintainer.
Healthy signals: approval-pending and request-user-input Playwright specs pass in CI; manual Plan-mode `request_user_input` prompts render as pending input with Back/Next controls; command approval prompts show the trimmed command block.
Failure signals: a turn remains stuck on Thinking after Codex emits `item/tool/requestUserInput` or `item/commandExecution/requestApproval`; Plan questions render Approve/Decline controls; `submitServerRequest` sends `{ decision: ... }` for request_user_input.
Mitigation trigger: if any failure signal appears, revert this PR or disable the request_user_input renderer branch while keeping command approval coverage intact.
Log/search terms: search desktop logs or replay captures for `item/tool/requestUserInput`, `item/commandExecution/requestApproval`, `serverRequest/resolved`, and `No pending server request found`.