### PR TITLE
feat(desktop): add tangerine terminal visual system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - Product requirements live in `docs/brainstorms/`
 - Implementation plans live in `docs/plans/`
+- UI theme tokens and visual language live in [docs/UI-THEME.md](docs/UI-THEME.md)
 - Desktop UI direction lives in [docs/design/desktop-style-guide.md](docs/design/desktop-style-guide.md)
 
 ## Workflow
@@ -23,13 +24,14 @@
 ## Frontend and Desktop UI
 
 - For renderer UI work, follow the desktop style guide before inventing local styling.
+- For colors, tokens, and visual theme decisions, follow the UI theme guide before adding local CSS.
 - Favor thread-first information hierarchy over generic dashboard layout.
 - Do not ship scaffold narration or placeholder implementation copy in user-facing UI.
 
 ## Current Product Direction
 
 - Threads are first-class and may exist without a directory.
-- Inbox sits above Recents and Directories.
+- Inbox, Recents, and Directories share the thread lens switch, with Inbox leftmost.
 - Recents is the default browsing lens.
 - A thread may be associated with multiple linked Git directories.
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -2,13 +2,22 @@
 
 ## Style Guide
 
-Use [../../docs/design/desktop-style-guide.md](../../docs/design/desktop-style-guide.md) as the visual source of truth for renderer UI work.
+Use [../../docs/UI-THEME.md](../../docs/UI-THEME.md) as the visual theme source of truth for renderer UI work.
 
-That guide defines:
+Use [../../docs/design/desktop-style-guide.md](../../docs/design/desktop-style-guide.md) for broader desktop layout, product tone, component behavior, and copy guidance.
+
+The theme guide defines:
+
+- theme thesis
+- palette and token usage
+- component theme rules
+- interaction constraints
+- visual anti-patterns
+
+The desktop style guide defines:
 
 - product tone
 - typography
-- color system
 - shell composition
 - sidebar and thread-row rules
 - component constraints
@@ -17,7 +26,8 @@ That guide defines:
 
 ## Non-Negotiables
 
-- Inbox belongs above Recents and Directories.
+- Inbox, Recents, and Directories live in one thread lens switch, with Inbox leftmost.
+- Unread state uses the orange cookie marker, not punctuation badges.
 - The sidebar is an information surface, not a stack of generic cards.
 - Do not use browser-default controls in shipped UI.
 - Do not ship implementation-status narration in user-facing copy.
@@ -26,7 +36,7 @@ That guide defines:
 
 ## Implementation Notes
 
-- Centralize visual tokens before expanding renderer surfaces.
+- Centralize visual tokens in `styles/app.css` before expanding renderer surfaces.
 - Reuse shell primitives instead of adding one-off page styling.
 - When in doubt, make the interface calmer, denser, and more editorial.
 - Use the project-local [desktop E2E fixture seeding skill](../../.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when capturing or refreshing replay-backed desktop E2E fixtures.

--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -138,3 +138,10 @@ desktop replay scenarios do not exercise Codex sidebar directory identity.
   viewport and avoids an extra replay `thread/read`
 - `focused-diff-zoom/`: eligible transcript diffs that condense locally and can
   hide low-signal hunks via the focused diff path
+
+## Visual System Guard
+
+The `tangerine-terminal-theme.spec.ts` Playwright spec reuses existing replay
+fixtures to check the desktop visual system at the composed-app level. It is not
+a pixel-perfect design-regression suite. Prefer computed style, contrast,
+focus/state, and screenshot-review checks over brittle full-page snapshots.

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -50,6 +50,20 @@ async function computedStyle(locator: Locator, property: string): Promise<string
   property);
 }
 
+async function computedPseudoStyle(
+  locator: Locator,
+  pseudoElement: string,
+  property: string
+): Promise<string> {
+  return await locator.evaluate(
+    (element, params) =>
+      getComputedStyle(element, params.pseudoElement)
+        .getPropertyValue(params.property)
+        .trim(),
+    { property, pseudoElement }
+  );
+}
+
 async function assertReadableText(params: {
   background: Locator;
   foreground: Locator;
@@ -120,6 +134,10 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     await expect(primaryButton).toHaveCSS("background-color", "rgb(18, 8, 0)");
     await expect(primaryButton).toHaveCSS("color", "rgb(255, 179, 92)");
     await expect(selectedRow).toHaveCSS("border-left-color", "rgba(255, 138, 31, 0.42)");
+    expect(await computedPseudoStyle(selectedRow, "::before", "background-color")).toBe(
+      "rgb(255, 138, 31)"
+    );
+    expect(await computedPseudoStyle(selectedRow, "::before", "width")).toBe("3px");
 
     await assertReadableText({
       background: sidebar,

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -1,0 +1,217 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const themeSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+type Rgb = {
+  blue: number;
+  green: number;
+  red: number;
+};
+
+function parseRgb(value: string): Rgb {
+  const match = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Expected CSS rgb() color, got: ${value}`);
+  }
+
+  return {
+    red: Number.parseInt(match[1], 10),
+    green: Number.parseInt(match[2], 10),
+    blue: Number.parseInt(match[3], 10),
+  };
+}
+
+function relativeLuminance(color: Rgb): number {
+  const [red, green, blue] = [color.red, color.green, color.blue].map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: Rgb, background: Rgb): number {
+  const [lighter, darker] = [
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  ].sort((left, right) => right - left);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+async function computedStyle(locator: Locator, property: string): Promise<string> {
+  return await locator.evaluate((element, styleProperty) =>
+    getComputedStyle(element).getPropertyValue(styleProperty).trim(),
+  property);
+}
+
+async function assertReadableText(params: {
+  background: Locator;
+  foreground: Locator;
+  label: string;
+  minimum?: number;
+}) {
+  const foregroundColor = parseRgb(await computedStyle(params.foreground, "color"));
+  const backgroundColor = parseRgb(
+    await computedStyle(params.background, "background-color")
+  );
+
+  expect(
+    contrastRatio(foregroundColor, backgroundColor),
+    params.label
+  ).toBeGreaterThanOrEqual(params.minimum ?? 4.5);
+}
+
+async function assertTangerineFocusRing(locator: Locator) {
+  await locator.focus();
+  await expect(locator).toHaveCSS("outline-color", "rgb(255, 138, 31)");
+  await expect(locator).toHaveCSS("outline-style", "solid");
+}
+
+async function openTodoThread(page: Page) {
+  await page
+    .getByRole("button", { name: /Add AGENTS docs for media VCL/i })
+    .first()
+    .click();
+  await expect(
+    page.getByRole("heading", {
+      level: 2,
+      name: "Add AGENTS docs for media VCL",
+    })
+  ).toBeVisible();
+}
+
+test("renders the desktop shell with the black-first Tangerine Terminal theme", async ({}, testInfo) => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      themeSpecDir,
+      "fixtures/codex-todo-list/replay.fixture.json"
+    ),
+    windowSize: {
+      height: 920,
+      width: 1440,
+    },
+  });
+
+  try {
+    await openTodoThread(app.window);
+
+    const shell = app.window.locator(".app-shell");
+    const sidebar = app.window.locator(".sidebar");
+    const transcriptPanel = app.window.locator(".transcript-panel");
+    const composer = app.window.locator(".composer");
+    const activeLens = app.window.locator(".lens-switch__button.is-active");
+    const selectedRow = app.window.locator(".thread-row.is-selected").first();
+    const primaryButton = app.window.locator(".button--primary").first();
+    const composerInput = app.window.getByLabel("Reply");
+    const sendButton = app.window.getByRole("button", { name: "Send" });
+
+    await expect(shell).toHaveCSS("background-color", "rgb(0, 0, 0)");
+    await expect(sidebar).toHaveCSS("background-color", "rgb(5, 5, 5)");
+    await expect(transcriptPanel).toHaveCSS("background-color", "rgb(10, 10, 10)");
+    await expect(composer).toHaveCSS("background-color", "rgb(10, 10, 10)");
+    await expect(activeLens).toHaveCSS("background-color", "rgb(18, 8, 0)");
+    await expect(activeLens).toHaveCSS("color", "rgb(255, 179, 92)");
+    await expect(primaryButton).toHaveCSS("background-color", "rgb(18, 8, 0)");
+    await expect(primaryButton).toHaveCSS("color", "rgb(255, 179, 92)");
+    await expect(selectedRow).toHaveCSS("border-left-color", "rgba(255, 138, 31, 0.42)");
+
+    await assertReadableText({
+      background: sidebar,
+      foreground: app.window.locator(".thread-row__title").first(),
+      label: "thread row title on sidebar",
+    });
+    await assertReadableText({
+      background: transcriptPanel,
+      foreground: app.window.locator(".transcript-message__text").first(),
+      label: "transcript body on transcript panel",
+    });
+    await assertReadableText({
+      background: composer,
+      foreground: app.window.locator(".composer__label").first(),
+      label: "composer label on composer panel",
+    });
+    await app.window.screenshot({
+      path: testInfo.outputPath("tangerine-terminal-wide.png"),
+    });
+
+    await assertTangerineFocusRing(activeLens);
+    await assertTangerineFocusRing(composerInput);
+    await composerInput.fill("Focus ring check");
+    await expect(sendButton).toBeEnabled();
+    await assertTangerineFocusRing(sendButton);
+  } finally {
+    await app.close();
+  }
+});
+
+test("keeps workflow states and narrow desktop layout readable", async ({}, testInfo) => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      themeSpecDir,
+      "fixtures/approval-pending/replay.fixture.json"
+    ),
+    windowSize: {
+      height: 760,
+      width: 980,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Approval pending replay/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Approval pending replay",
+      })
+    ).toBeVisible();
+
+    await app.window
+      .getByLabel("Reply")
+      .fill("Read /etc/hosts and tell me the first three lines.");
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "request-approval-1" });
+
+    const transcriptPanel = app.window.locator(".transcript-panel");
+    const contextRail = app.window.locator(".context-rail");
+    const composer = app.window.locator(".composer");
+    const approval = app.window.getByRole("group", { name: "Pending approval" });
+
+    await expect(transcriptPanel).toBeVisible();
+    await expect(contextRail).toBeVisible();
+    await expect(composer).toBeVisible();
+    await expect(approval).toContainText("Approval needed");
+    await expect(approval).toContainText(
+      "Read /etc/hosts and tell me the first three lines."
+    );
+    await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
+    await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();
+
+    await assertReadableText({
+      background: transcriptPanel,
+      foreground: approval.locator(".transcript-request__prompt"),
+      label: "approval prompt on transcript panel",
+    });
+
+    const transcriptBox = await transcriptPanel.boundingBox();
+    const composerBox = await composer.boundingBox();
+    expect(transcriptBox?.width ?? 0, "narrow transcript width").toBeGreaterThan(320);
+    expect(composerBox?.width ?? 0, "narrow composer width").toBeGreaterThan(320);
+
+    await app.window.screenshot({
+      path: testInfo.outputPath("tangerine-terminal-narrow-approval.png"),
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -218,8 +218,10 @@ test("keeps workflow states and narrow desktop layout readable", async ({}, test
     await expect(composer).toBeVisible();
     await expect(approval).toContainText("Approval needed");
     await expect(approval).toContainText(
-      "Read /etc/hosts and tell me the first three lines."
+      "Do you want to allow network access so I can query npm metadata for the dive package?"
     );
+    await expect(approval.getByText("Command:")).toBeVisible();
+    await expect(approval.locator("pre code")).toHaveText("npm view dive");
     await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
     await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();
 

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -115,6 +115,14 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
   try {
     await openTodoThread(app.window);
 
+    await expect(
+      app.window.getByRole("heading", { name: "Browse" })
+    ).toHaveCount(0);
+    await expect(
+      app.window.getByRole("heading", { name: "Transcript" })
+    ).toHaveCount(0);
+    await expect(app.window.getByText(/^\d+ messages?$/)).toHaveCount(0);
+
     const shell = app.window.locator(".app-shell");
     const sidebar = app.window.locator(".sidebar");
     const transcriptPanel = app.window.locator(".transcript-panel");

--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -239,6 +239,7 @@ test("shows initiated background turns as thinking, then unread once they finish
 
     await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toHaveCount(0);
     await expect(initiatedRow.locator('[data-thread-status="unread"]')).toBeVisible();
+    await expect(initiatedRow.locator(".thread-row__status-cookie")).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -6,6 +6,7 @@ const registerAppServerIpcHandlersMock = vi.fn();
 const disposeAppServerIpcHandlersMock = vi.fn();
 const registerAgentIpcHandlersMock = vi.fn();
 const disposeAgentIpcHandlersMock = vi.fn();
+const registerRendererErrorIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
 const setApplicationMenuMock = vi.fn();
 const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
@@ -55,6 +56,10 @@ vi.mock("../ipc/agent-ipc", () => ({
   disposeAgentIpcHandlers: disposeAgentIpcHandlersMock,
 }));
 
+vi.mock("../ipc/renderer-error", () => ({
+  registerRendererErrorIpcHandlers: registerRendererErrorIpcHandlersMock,
+}));
+
 vi.mock("../log", () => ({
   initializeMainLogger: initializeMainLoggerMock,
 }));
@@ -77,6 +82,7 @@ describe("bootstrapApp", () => {
     disposeAppServerIpcHandlersMock.mockReset();
     registerAgentIpcHandlersMock.mockReset();
     disposeAgentIpcHandlersMock.mockReset();
+    registerRendererErrorIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
     setApplicationMenuMock.mockReset();
     buildFromTemplateMock.mockClear();
@@ -119,6 +125,7 @@ describe("bootstrapApp", () => {
     });
     expect(registerAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerAgentIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(registerRendererErrorIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RendererErrorReport } from "../../shared/renderer-error";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const errorLog = {
+  error: vi.fn(),
+};
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => errorLog),
+}));
+
+describe("renderer error ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    errorLog.error.mockClear();
+  });
+
+  it("logs structured renderer error reports in the main process", async () => {
+    const {
+      registerRendererErrorIpcHandlers,
+      disposeRendererErrorIpcHandlers,
+    } = await import("../ipc/renderer-error");
+    const { RENDERER_ERROR_REPORT_CHANNEL } = await import("../../shared/ipc");
+    const report: RendererErrorReport = {
+      componentStack: "at App",
+      href: "http://localhost:5173/",
+      message: "Should have a queue",
+      name: "Error",
+      source: "error-boundary",
+      stack: "Error: Should have a queue",
+      timestamp: "2026-04-20T12:28:04.188Z",
+      userAgent: "Vitest",
+    };
+
+    registerRendererErrorIpcHandlers();
+
+    await expect(handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, report)).resolves.toEqual({
+      ok: true,
+    });
+    expect(errorLog.error).toHaveBeenCalledWith("report", report);
+
+    disposeRendererErrorIpcHandlers();
+    expect(handlers.has(RENDERER_ERROR_REPORT_CHANNEL)).toBe(false);
+  });
+});
+

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, shell } from "electron";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import { disposeAppServerIpcHandlers, registerAppServerIpcHandlers } from "./ipc/app-server";
+import { registerRendererErrorIpcHandlers } from "./ipc/renderer-error";
 import { initializeMainLogger } from "./log";
 import { StartupCpuProfiler } from "./diagnostics/startup-cpu-profiler";
 import { createMainWindow } from "./window";
@@ -41,6 +42,7 @@ export function bootstrapApp(): void {
     installApplicationMenu();
     registerAppServerIpcHandlers();
     registerAgentIpcHandlers();
+    registerRendererErrorIpcHandlers();
     createMainWindow({
       startupCpuProfiler,
     });

--- a/apps/desktop/src/main/ipc/renderer-error.ts
+++ b/apps/desktop/src/main/ipc/renderer-error.ts
@@ -1,0 +1,22 @@
+import { ipcMain } from "electron";
+import type { RendererErrorReport } from "../../shared/renderer-error";
+import { RENDERER_ERROR_REPORT_CHANNEL } from "../../shared/ipc";
+import { getMainLogger } from "../log";
+
+const rendererErrorLog = getMainLogger("pwragnt:renderer:error");
+
+export function registerRendererErrorIpcHandlers(): void {
+  ipcMain.removeHandler(RENDERER_ERROR_REPORT_CHANNEL);
+  ipcMain.handle(
+    RENDERER_ERROR_REPORT_CHANNEL,
+    async (_event, report: RendererErrorReport): Promise<{ ok: true }> => {
+      rendererErrorLog.error("report", report);
+      return { ok: true };
+    },
+  );
+}
+
+export function disposeRendererErrorIpcHandlers(): void {
+  ipcMain.removeHandler(RENDERER_ERROR_REPORT_CHANNEL);
+}
+

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -34,6 +34,7 @@ import type {
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
+import type { RendererErrorReport } from "../shared/renderer-error";
 import {
   AGENT_EVENT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
@@ -52,6 +53,7 @@ import {
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  RENDERER_ERROR_REPORT_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
 } from "../shared/ipc";
 
@@ -130,6 +132,9 @@ const desktopApi = Object.freeze({
     request: ResetDirectoryLaunchpadRequest,
   ): Promise<ResetDirectoryLaunchpadResponse> =>
     await ipcRenderer.invoke(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  reportRendererError: async (report: RendererErrorReport): Promise<void> => {
+    await ipcRenderer.invoke(RENDERER_ERROR_REPORT_CHANNEL, report);
+  },
   onWindowFocus: (callback: () => void): (() => void) => {
     const listener = () => callback();
     ipcRenderer.on(WINDOW_FOCUS_SYNC_CHANNEL, listener);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -29,7 +29,6 @@ export function App() {
         creatingThread={navigation.creatingThread}
         directories={navigation.directories}
         error={navigation.error}
-        fetchedAt={navigation.snapshot?.fetchedAt}
         inboxThreads={navigation.inboxThreads}
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
@@ -58,7 +57,6 @@ export function App() {
             )
           }
           desktopApi={desktopApi}
-          fetchedAt={session.response?.fetchedAt}
           launchpadError={navigation.launchpadError}
           loading={session.loading}
           loadingMore={session.loadingMore}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -271,9 +271,7 @@ describe("App", () => {
 
     expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 1, name: "Threads" })).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 2, name: "Inbox" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "inbox" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "recents" })
     ).toBeInTheDocument();
@@ -284,10 +282,6 @@ describe("App", () => {
         name: "Build Codex client"
       })
     ).toBeInTheDocument();
-    const inboxHeading = screen.getByRole("heading", { level: 2, name: "Inbox" });
-    const inboxSection = inboxHeading.closest("section");
-    expect(inboxSection).not.toBeNull();
-    expect(within(inboxSection as HTMLElement).getByText("1")).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
     expect(screen.getAllByText("codex/build-codex-client").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { level: 3, name: "Transcript" })).toBeInTheDocument();
@@ -1606,7 +1600,7 @@ describe("App", () => {
       threadId: "thread-2",
     });
 
-    fireEvent.click(screen.getAllByRole("button", { name: /First cached thread/i })[1]!);
+    fireEvent.click(screen.getByRole("button", { name: /First cached thread/i }));
 
     await screen.findByRole("heading", {
       level: 2,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -284,7 +284,7 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
     expect(screen.getAllByText("codex/build-codex-client").length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { level: 3, name: "Transcript" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 3, name: "Transcript" })).not.toBeInTheDocument();
     const transcript = screen.getByRole("region", { name: "Transcript" });
     await waitFor(() => {
       expect(transcript).toHaveTextContent("Open the desktop plan and build the Codex client.");
@@ -351,7 +351,7 @@ describe("App", () => {
         selector: ".composer__meta"
       })
     ).not.toBeInTheDocument();
-    expect(screen.getByText("3 messages")).toBeInTheDocument();
+    expect(screen.queryByText("3 messages")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Stop" }));
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -269,9 +269,8 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(
-      screen.getByRole("heading", { level: 1, name: "Threads" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 1, name: "Threads" })).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: "Inbox" })
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/diagnostics/RendererErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/src/features/diagnostics/RendererErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import type { RendererErrorReport } from "../../../../shared/renderer-error";
+import {
+  createRendererErrorReport,
+  reportRendererError,
+} from "../../lib/renderer-error-reporting";
+
+type RendererErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type RendererErrorBoundaryState = {
+  report?: RendererErrorReport;
+};
+
+export class RendererErrorBoundary extends Component<
+  RendererErrorBoundaryProps,
+  RendererErrorBoundaryState
+> {
+  override state: RendererErrorBoundaryState = {};
+
+  static getDerivedStateFromError(error: unknown): RendererErrorBoundaryState {
+    return {
+      report: createRendererErrorReport("error-boundary", error),
+    };
+  }
+
+  override componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    const report = createRendererErrorReport("error-boundary", error, {
+      componentStack: errorInfo.componentStack,
+    });
+    this.setState({ report });
+    reportRendererError(report);
+  }
+
+  override render() {
+    if (this.state.report) {
+      return (
+        <main className="renderer-error-boundary" role="alert">
+          <p className="eyebrow">PwrAgnt</p>
+          <h1>Renderer error</h1>
+          <p>
+            The desktop renderer hit an unrecoverable UI error. Details were logged for
+            diagnosis.
+          </p>
+          <pre>{this.state.report.message}</pre>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/apps/desktop/src/renderer/src/features/diagnostics/__tests__/RendererErrorBoundary.test.tsx
+++ b/apps/desktop/src/renderer/src/features/diagnostics/__tests__/RendererErrorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RendererErrorBoundary } from "../RendererErrorBoundary";
+
+function ThrowingChild() {
+  throw new Error("Should have a queue");
+  return null;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  delete (window as Window & { pwragnt?: unknown }).pwragnt;
+});
+
+describe("RendererErrorBoundary", () => {
+  it("renders a fallback and reports component stack diagnostics", async () => {
+    const reportRendererError = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        reportRendererError,
+      },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <RendererErrorBoundary>
+        <ThrowingChild />
+      </RendererErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Renderer error");
+    expect(screen.getByText("Should have a queue")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(reportRendererError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          componentStack: expect.stringContaining("ThrowingChild"),
+          message: "Should have a queue",
+          name: "Error",
+          source: "error-boundary",
+        }),
+      );
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
@@ -1,9 +1,11 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
-import { formatBackendLabel } from "../../lib/backend-label";
+import { ThreadMetaChips } from "./ThreadMetaChips";
+import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
 type InboxListProps = {
   selectedThreadKey?: string;
+  thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -12,33 +14,36 @@ export function InboxList(props: InboxListProps) {
   if (props.threads.length === 0) {
     return (
       <p className="sidebar-empty">
-        Nothing is waiting on you.
+        No unread threads.
       </p>
     );
   }
 
   return (
-    <div className="sidebar-list" role="list">
-      {props.threads.slice(0, 4).map((thread) => {
+    <div className="sidebar-list sidebar-list--dense" role="list">
+      {props.threads.map((thread) => {
         const selected =
           buildThreadIdentityKey(thread.source, thread.id) === props.selectedThreadKey;
+        const status = getThreadRowStatus(thread, props.thinkingThreadKeys);
         return (
           <button
             key={buildThreadIdentityKey(thread.source, thread.id)}
             aria-pressed={selected}
-            className={`thread-row thread-row--compact${selected ? " is-selected" : ""}`}
+            className={`thread-row${selected ? " is-selected" : ""}`}
             type="button"
             onClick={() => props.onSelectThread(thread)}
           >
             <span className="thread-row__header">
-              <span className="thread-row__title">{thread.title}</span>
-              <span className="thread-row__chip thread-row__chip--backend">
-                {formatBackendLabel(thread.source)}
+              <span className="thread-row__heading">
+                <ThreadRowStatus status={status} />
+                <span className="thread-row__title">{thread.title}</span>
+              </span>
+              <span className="thread-row__time">
+                {formatRelativeTime(thread.updatedAt)}
               </span>
             </span>
-            <span className="thread-row__time">
-              {formatRelativeTime(thread.updatedAt)}
-            </span>
+
+            <ThreadMetaChips includeLinkedDirectories thread={thread} />
           </button>
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -19,7 +19,6 @@ type SidebarProps = {
   createThreadError?: string;
   directories: NavigationDirectorySummary[];
   error?: string;
-  fetchedAt?: number;
   inboxThreads: NavigationThreadSummary[];
   loading: boolean;
   creatingThread?: {
@@ -125,30 +124,14 @@ export function Sidebar(props: SidebarProps) {
         <p className="sidebar-error sidebar-error--masthead">{props.launchpadError}</p>
       ) : null}
 
-      <section className="sidebar__section">
-        <div className="sidebar__section-header">
-          <h2>Inbox</h2>
-          <span className="count-pill">{props.inboxThreads.length}</span>
-        </div>
-        <InboxList
-          selectedThreadKey={props.selectedItemKey}
-          threads={props.inboxThreads}
-          onSelectThread={props.onSelectThread}
-        />
-      </section>
-
       <section className="sidebar__section sidebar__section--fill">
         <div className="sidebar__section-header sidebar__section-header--browse">
           <div className="sidebar__section-title">
             <h2>Browse</h2>
-            <p className="sidebar__supporting-text">
-              {props.threads.length} threads
-              {props.fetchedAt ? ` • ${formatTimestamp(props.fetchedAt)}` : ""}
-            </p>
           </div>
 
           <div className="lens-switch" role="tablist" aria-label="Thread lenses">
-            {(["recents", "directories"] as const).map((mode) => (
+            {(["inbox", "recents", "directories"] as const).map((mode) => (
               <button
                 key={mode}
                 aria-pressed={props.browseMode === mode}
@@ -169,8 +152,13 @@ export function Sidebar(props: SidebarProps) {
             <p className="sidebar-empty">Loading threads…</p>
           ) : props.error ? (
             <p className="sidebar-error">{props.error}</p>
-          ) : props.threads.length === 0 ? (
-            <p className="sidebar-empty">No threads yet.</p>
+          ) : props.browseMode === "inbox" ? (
+            <InboxList
+              selectedThreadKey={props.selectedItemKey}
+              thinkingThreadKeys={props.thinkingThreadKeys}
+              threads={props.inboxThreads}
+              onSelectThread={props.onSelectThread}
+            />
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
               directories={props.directories}
@@ -181,24 +169,19 @@ export function Sidebar(props: SidebarProps) {
               onSelectThread={props.onSelectThread}
             />
           ) : (
-            <RecentsList
-              selectedThreadKey={props.selectedItemKey}
-              thinkingThreadKeys={props.thinkingThreadKeys}
-              threads={props.threads}
-              onSelectThread={props.onSelectThread}
-            />
+            props.threads.length === 0 ? (
+              <p className="sidebar-empty">No threads yet.</p>
+            ) : (
+              <RecentsList
+                selectedThreadKey={props.selectedItemKey}
+                thinkingThreadKeys={props.thinkingThreadKeys}
+                threads={props.threads}
+                onSelectThread={props.onSelectThread}
+              />
+            )
           )}
         </div>
       </section>
     </aside>
   );
-}
-
-function formatTimestamp(timestamp: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(timestamp);
 }

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -69,12 +69,9 @@ export function Sidebar(props: SidebarProps) {
   const hasCreateThreadOptions = createThreadOptions.some((option) => option.enabled);
 
   return (
-    <aside className="sidebar">
+    <aside className="sidebar" aria-label="Threads">
       <header className="sidebar__masthead">
-        <div>
-          <p className="eyebrow">PwrAgnt</p>
-          <h1 className="sidebar__title">Threads</h1>
-        </div>
+        <p className="eyebrow sidebar__brand">PwrAgnt</p>
 
         <div className="sidebar__masthead-actions">
           <div className="sidebar__new-thread">
@@ -141,8 +138,8 @@ export function Sidebar(props: SidebarProps) {
       </section>
 
       <section className="sidebar__section sidebar__section--fill">
-        <div className="sidebar__section-header">
-          <div>
+        <div className="sidebar__section-header sidebar__section-header--browse">
+          <div className="sidebar__section-title">
             <h2>Browse</h2>
             <p className="sidebar__supporting-text">
               {props.threads.length} threads

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -124,27 +124,21 @@ export function Sidebar(props: SidebarProps) {
         <p className="sidebar-error sidebar-error--masthead">{props.launchpadError}</p>
       ) : null}
 
-      <section className="sidebar__section sidebar__section--fill">
-        <div className="sidebar__section-header sidebar__section-header--browse">
-          <div className="sidebar__section-title">
-            <h2>Browse</h2>
-          </div>
-
-          <div className="lens-switch" role="tablist" aria-label="Thread lenses">
-            {(["inbox", "recents", "directories"] as const).map((mode) => (
-              <button
-                key={mode}
-                aria-pressed={props.browseMode === mode}
-                className={`lens-switch__button${
-                  props.browseMode === mode ? " is-active" : ""
-                }`}
-                type="button"
-                onClick={() => props.onBrowseModeChange(mode)}
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
+      <section className="sidebar__section sidebar__section--fill" aria-label="Thread browser">
+        <div className="lens-switch" role="tablist" aria-label="Thread lenses">
+          {(["inbox", "recents", "directories"] as const).map((mode) => (
+            <button
+              key={mode}
+              aria-pressed={props.browseMode === mode}
+              className={`lens-switch__button${
+                props.browseMode === mode ? " is-active" : ""
+              }`}
+              type="button"
+              onClick={() => props.onBrowseModeChange(mode)}
+            >
+              {mode}
+            </button>
+          ))}
         </div>
 
         <div className="sidebar__scroll-region">

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -49,9 +49,7 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
       data-thread-status="unread"
       title="Unread update"
     >
-      <span aria-hidden="true" className="thread-row__status-dot">
-        !
-      </span>
+      <span aria-hidden="true" className="thread-row__status-cookie" />
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -2,7 +2,7 @@ import type { NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
-export type ThreadRowStatusKind = "thinking" | "unread";
+export type ThreadRowStatusKind = "thinking";
 
 export function getThreadRowStatus(
   thread: NavigationThreadSummary,
@@ -11,10 +11,6 @@ export function getThreadRowStatus(
   const threadKey = buildThreadIdentityKey(thread.source, thread.id);
   if (thinkingThreadKeys?.[threadKey]) {
     return "thinking";
-  }
-
-  if (thread.inbox.inInbox) {
-    return "unread";
   }
 
   return undefined;
@@ -41,17 +37,5 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
       </span>
     );
   }
-
-  return (
-    <span
-      aria-label="Needs attention"
-      className="thread-row__status-indicator thread-row__status-indicator--unread"
-      data-thread-status="unread"
-      title="Needs attention"
-    >
-      <span aria-hidden="true" className="thread-row__status-dot">
-        !
-      </span>
-    </span>
-  );
+  return null;
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -32,9 +32,10 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
   if (props.status === "thinking") {
     return (
       <span
-        aria-hidden="true"
+        aria-label="Thinking"
         className="thread-row__status-indicator thread-row__status-indicator--thinking"
         data-thread-status="thinking"
+        title="Thinking"
       >
         <ThinkingScanner compact />
       </span>
@@ -43,11 +44,14 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
 
   return (
     <span
-      aria-hidden="true"
+      aria-label="Needs attention"
       className="thread-row__status-indicator thread-row__status-indicator--unread"
       data-thread-status="unread"
+      title="Needs attention"
     >
-      <span className="thread-row__status-dot" />
+      <span aria-hidden="true" className="thread-row__status-dot">
+        !
+      </span>
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -2,7 +2,7 @@ import type { NavigationThreadSummary } from "@pwragnt/shared";
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
-export type ThreadRowStatusKind = "thinking";
+export type ThreadRowStatusKind = "thinking" | "unread";
 
 export function getThreadRowStatus(
   thread: NavigationThreadSummary,
@@ -11,6 +11,10 @@ export function getThreadRowStatus(
   const threadKey = buildThreadIdentityKey(thread.source, thread.id);
   if (thinkingThreadKeys?.[threadKey]) {
     return "thinking";
+  }
+
+  if (thread.inbox.reason === "updated-since-seen") {
+    return "unread";
   }
 
   return undefined;
@@ -37,5 +41,17 @@ export function ThreadRowStatus(props: ThreadRowStatusProps) {
       </span>
     );
   }
-  return null;
+
+  return (
+    <span
+      aria-label="Unread update"
+      className="thread-row__status-indicator thread-row__status-indicator--unread"
+      data-thread-status="unread"
+      title="Unread update"
+    >
+      <span aria-hidden="true" className="thread-row__status-dot">
+        !
+      </span>
+    </span>
+  );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -126,14 +126,13 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
-  it("keeps Inbox first and renders compact directory rows from directory summaries", () => {
+  it("renders Inbox as the first thread lens and keeps directory rows available", () => {
     render(
       <Sidebar
         backends={backends}
         browseMode="directories"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -148,7 +147,15 @@ describe("Sidebar", () => {
     );
 
     const headings = screen.getAllByRole("heading", { level: 2 });
-    expect(headings.map((heading) => heading.textContent)).toEqual(["Inbox", "Browse"]);
+    expect(headings.map((heading) => heading.textContent)).toEqual(["Browse"]);
+    const lensButtons = within(
+      screen.getByRole("tablist", { name: "Thread lenses" })
+    ).getAllByRole("button");
+    expect(lensButtons.map((button) => button.textContent)).toEqual([
+      "inbox",
+      "recents",
+      "directories",
+    ]);
     expect(screen.getByRole("button", { name: "directories" })).toHaveAttribute(
       "aria-pressed",
       "true"
@@ -167,7 +174,6 @@ describe("Sidebar", () => {
         browseMode="directories"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -197,7 +203,6 @@ describe("Sidebar", () => {
         browseMode="directories"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -232,7 +237,6 @@ describe("Sidebar", () => {
         browseMode="recents"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -263,7 +267,6 @@ describe("Sidebar", () => {
         browseMode="recents"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[updatedSinceSeenThread]}
         launchpadError={undefined}
         loading={false}
@@ -294,6 +297,41 @@ describe("Sidebar", () => {
     expect(unreadIndicator).not.toHaveTextContent("!");
   });
 
+  it("renders unread inbox rows with the same dense treatment as recents", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[updatedSinceSeenThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread, updatedSinceSeenThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
+    expect(browseSection).not.toBeNull();
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Updated thread/i,
+    });
+
+    expect(screen.getByRole("button", { name: "inbox" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(threadButton.querySelector('[data-thread-status="unread"]')).not.toBeNull();
+    expect(within(threadButton).getByText("PwrAgnt")).toBeInTheDocument();
+    expect(screen.queryByText("Cross-project cleanup")).not.toBeInTheDocument();
+  });
+
   it("renders directory rows without the raw chevron glyph affordance", () => {
     render(
       <Sidebar
@@ -301,7 +339,6 @@ describe("Sidebar", () => {
         browseMode="directories"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -333,7 +370,6 @@ describe("Sidebar", () => {
         browseMode="recents"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}
@@ -364,7 +400,6 @@ describe("Sidebar", () => {
         browseMode="recents"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[
           {
             ...sharedThread,
@@ -400,7 +435,6 @@ describe("Sidebar", () => {
         browseMode="recents"
         createThreadError={undefined}
         directories={directories}
-        fetchedAt={Date.now()}
         inboxThreads={[sharedThread]}
         launchpadError={undefined}
         loading={false}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -146,8 +146,8 @@ describe("Sidebar", () => {
       />
     );
 
-    const headings = screen.getAllByRole("heading", { level: 2 });
-    expect(headings.map((heading) => heading.textContent)).toEqual(["Browse"]);
+    expect(screen.queryByRole("heading", { level: 2, name: "Browse" })).not.toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Thread browser" })).toBeInTheDocument();
     const lensButtons = within(
       screen.getByRole("tablist", { name: "Thread lenses" })
     ).getAllByRole("button");
@@ -217,8 +217,7 @@ describe("Sidebar", () => {
       />
     );
 
-    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
-    expect(browseSection).not.toBeNull();
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
     const threadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: /Cross-project cleanup/i,
     });
@@ -250,8 +249,7 @@ describe("Sidebar", () => {
       />
     );
 
-    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
-    expect(browseSection).not.toBeNull();
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
     const threadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: /Cross-project cleanup/i,
     });
@@ -280,8 +278,7 @@ describe("Sidebar", () => {
       />
     );
 
-    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
-    expect(browseSection).not.toBeNull();
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
     const threadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: /Updated thread/i,
     });
@@ -317,8 +314,7 @@ describe("Sidebar", () => {
       />
     );
 
-    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
-    expect(browseSection).not.toBeNull();
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
     const threadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: /Updated thread/i,
     });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -92,6 +92,17 @@ const sharedThread = {
   ],
 };
 
+const updatedSinceSeenThread = {
+  ...sharedThread,
+  id: "thread-updated",
+  title: "Updated thread",
+  inbox: {
+    inInbox: true,
+    reason: "updated-since-seen" as const,
+    lastSeenUpdatedAt: sharedThread.updatedAt - 1,
+  },
+};
+
 const directories: NavigationDirectorySummary[] = [
   {
     key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
@@ -214,7 +225,7 @@ describe("Sidebar", () => {
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
-  it("does not duplicate inbox membership as an attention marker in recents", () => {
+  it("does not duplicate new-thread inbox membership as an attention marker in recents", () => {
     render(
       <Sidebar
         backends={backends}
@@ -244,6 +255,41 @@ describe("Sidebar", () => {
     expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
     expect(threadButton).not.toHaveTextContent("!");
+  });
+
+  it("shows an unread marker in recents for threads updated since they were seen", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        fetchedAt={Date.now()}
+        inboxThreads={[updatedSinceSeenThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[updatedSinceSeenThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("heading", { level: 2, name: "Browse" }).closest("section");
+    expect(browseSection).not.toBeNull();
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Updated thread/i,
+    });
+
+    expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
+    const unreadIndicator = threadButton.querySelector('[data-thread-status="unread"]');
+    expect(unreadIndicator).not.toBeNull();
+    expect(unreadIndicator).toHaveAttribute("aria-label", "Unread update");
+    expect(unreadIndicator).toHaveAttribute("title", "Unread update");
+    expect(unreadIndicator).toHaveTextContent("!");
   });
 
   it("renders directory rows without the raw chevron glyph affordance", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -254,7 +254,6 @@ describe("Sidebar", () => {
 
     expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
-    expect(threadButton).not.toHaveTextContent("!");
   });
 
   it("shows an unread marker in recents for threads updated since they were seen", () => {
@@ -289,7 +288,10 @@ describe("Sidebar", () => {
     expect(unreadIndicator).not.toBeNull();
     expect(unreadIndicator).toHaveAttribute("aria-label", "Unread update");
     expect(unreadIndicator).toHaveAttribute("title", "Unread update");
-    expect(unreadIndicator).toHaveTextContent("!");
+    expect(
+      threadButton.querySelector('[data-thread-status="unread"] .thread-row__status-cookie')
+    ).not.toBeNull();
+    expect(unreadIndicator).not.toHaveTextContent("!");
   });
 
   it("renders directory rows without the raw chevron glyph affordance", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -207,7 +207,10 @@ describe("Sidebar", () => {
       name: /Cross-project cleanup/i,
     });
 
-    expect(threadButton.querySelector('[data-thread-status="thinking"]')).not.toBeNull();
+    const thinkingIndicator = threadButton.querySelector('[data-thread-status="thinking"]');
+    expect(thinkingIndicator).not.toBeNull();
+    expect(thinkingIndicator).toHaveAttribute("aria-label", "Thinking");
+    expect(thinkingIndicator).toHaveAttribute("title", "Thinking");
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
@@ -239,7 +242,11 @@ describe("Sidebar", () => {
     });
 
     expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
-    expect(threadButton.querySelector('[data-thread-status="unread"]')).not.toBeNull();
+    const unreadIndicator = threadButton.querySelector('[data-thread-status="unread"]');
+    expect(unreadIndicator).not.toBeNull();
+    expect(unreadIndicator).toHaveAttribute("aria-label", "Needs attention");
+    expect(unreadIndicator).toHaveAttribute("title", "Needs attention");
+    expect(unreadIndicator).toHaveTextContent("!");
   });
 
   it("renders directory rows without the raw chevron glyph affordance", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -214,7 +214,7 @@ describe("Sidebar", () => {
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
-  it("falls back to the unread indicator in recents once the turn is done", () => {
+  it("does not duplicate inbox membership as an attention marker in recents", () => {
     render(
       <Sidebar
         backends={backends}
@@ -242,11 +242,8 @@ describe("Sidebar", () => {
     });
 
     expect(threadButton.querySelector('[data-thread-status="thinking"]')).toBeNull();
-    const unreadIndicator = threadButton.querySelector('[data-thread-status="unread"]');
-    expect(unreadIndicator).not.toBeNull();
-    expect(unreadIndicator).toHaveAttribute("aria-label", "Needs attention");
-    expect(unreadIndicator).toHaveAttribute("title", "Needs attention");
-    expect(unreadIndicator).toHaveTextContent("!");
+    expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
+    expect(threadButton).not.toHaveTextContent("!");
   });
 
   it("renders directory rows without the raw chevron glyph affordance", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -3,8 +3,6 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 
 type ThreadHeaderProps = {
-  fetchedAt?: number;
-  messageCount: number;
   thread: NavigationThreadSummary;
 };
 
@@ -24,26 +22,6 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           </span>
         </div>
       </div>
-
-      <div className="thread-header__stats">
-        <div>
-          <span className="thread-header__stat-label">Messages</span>
-          <strong>{props.messageCount}</strong>
-        </div>
-        <div>
-          <span className="thread-header__stat-label">Synced</span>
-          <strong>{props.fetchedAt ? formatTimestamp(props.fetchedAt) : "Waiting"}</strong>
-        </div>
-      </div>
     </header>
   );
-}
-
-function formatTimestamp(timestamp: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit"
-  }).format(timestamp);
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -13,7 +13,9 @@ export function ThreadHeader(props: ThreadHeaderProps) {
     <header className="thread-header">
       <div>
         <div className="thread-header__eyebrow-row">
-          <p className="eyebrow">Thread detail</p>
+          <h2 className="thread-header__compact-title" title={props.thread.title}>
+            {props.thread.title}
+          </h2>
           <span className="thread-row__chip thread-row__chip--backend">
             {formatBackendLabel(props.thread.source)}
           </span>
@@ -21,7 +23,6 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             {formatExecutionModeLabel(props.thread.executionMode)}
           </span>
         </div>
-        <h2 className="thread-header__title">{props.thread.title}</h2>
       </div>
 
       <div className="thread-header__stats">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -298,7 +298,6 @@ type ThreadViewProps = {
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   composerDisabled: boolean;
   desktopApi?: DesktopApi;
-  fetchedAt?: number;
   launchpadError?: string;
   loading: boolean;
   loadingMore: boolean;
@@ -710,11 +709,7 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section className="thread-view">
-      <ThreadHeader
-        fetchedAt={props.fetchedAt}
-        messageCount={props.messageCount}
-        thread={selectedThread!}
-      />
+      <ThreadHeader thread={selectedThread!} />
 
       <div className="thread-view__layout">
         <section className="transcript-panel" aria-label="Transcript">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -713,15 +713,6 @@ export function ThreadView(props: ThreadViewProps) {
 
       <div className="thread-view__layout">
         <section className="transcript-panel" aria-label="Transcript">
-          <div className="transcript-panel__header">
-            <div>
-              <h3>Transcript</h3>
-              <p>
-                {props.messageCount} message{props.messageCount === 1 ? "" : "s"}
-              </p>
-            </div>
-          </div>
-
           <TranscriptList
             entries={props.transcriptEntries}
             error={props.transcriptError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -100,7 +100,6 @@ describe("ThreadView", () => {
             runId: "turn-1",
           }),
         }}
-        fetchedAt={Date.now()}
         loading={false}
         loadingMore={false}
         messageCount={2}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -168,6 +168,10 @@ describe("ThreadView", () => {
     expect(
       screen.getByRole("heading", { level: 2, name: "Plan the app-server protocol" })
     ).toBeInTheDocument();
+    expect(document.querySelector(".thread-header__compact-title")).toHaveTextContent(
+      "Plan the app-server protocol"
+    );
+    expect(document.querySelector(".thread-header__title")).toBeNull();
     expect(document.querySelector(".thread-header__summary")).toBeNull();
     expect(screen.getByText("Codex")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open context rail" }));

--- a/apps/desktop/src/renderer/src/lib/__tests__/renderer-error-reporting.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/renderer-error-reporting.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installGlobalRendererErrorHandlers } from "../renderer-error-reporting";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as Window & { pwragnt?: unknown }).pwragnt;
+});
+
+describe("renderer error reporting", () => {
+  it("forwards uncaught window errors to the desktop bridge", async () => {
+    const reportRendererError = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        reportRendererError,
+      },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const uninstall = installGlobalRendererErrorHandlers();
+    window.dispatchEvent(
+      new ErrorEvent("error", {
+        colno: 7,
+        error: new Error("global render failure"),
+        filename: "renderer.js",
+        lineno: 42,
+      }),
+    );
+    uninstall();
+
+    await expect(reportRendererError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        colno: 7,
+        filename: "renderer.js",
+        lineno: 42,
+        message: "global render failure",
+        source: "window-error",
+      }),
+    );
+  });
+});
+

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -89,6 +89,91 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps a selected unread thread in Inbox until another item is selected", async () => {
+    const markThreadSeen = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-unread",
+      seenAt: Date.now(),
+      seenUpdatedAt: 2_000,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-unread"],
+      threads: [
+        {
+          id: "thread-unread",
+          title: "Unread thread",
+          titleSource: "explicit" as const,
+          summary: "Unread thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "updated-since-seen" as const,
+            lastSeenUpdatedAt: 1_000,
+          },
+          updatedAt: 2_000,
+        },
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_500,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
+        "thread-unread",
+      ]);
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-unread",
+        seenUpdatedAt: 2_000,
+      });
+    });
+    expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
+      "thread-unread",
+    ]);
+
+    act(() => {
+      result.current.selectThread(result.current.threads[1]!);
+    });
+
+    await waitFor(() => {
+      expect(result.current.inboxThreads).toHaveLength(0);
+    });
+  });
+
   it("coalesces repeated turn lifecycle notifications into one navigation refresh", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { RendererErrorReport } from "../../../shared/renderer-error";
 import type {
   AgentEvent,
   AppServerListSkillsRequest,
@@ -79,6 +80,7 @@ export type DesktopApi = {
   resetDirectoryLaunchpad?: (
     request: ResetDirectoryLaunchpadRequest
   ) => Promise<ResetDirectoryLaunchpadResponse>;
+  reportRendererError?: (report: RendererErrorReport) => Promise<void>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;

--- a/apps/desktop/src/renderer/src/lib/renderer-error-reporting.ts
+++ b/apps/desktop/src/renderer/src/lib/renderer-error-reporting.ts
@@ -1,0 +1,84 @@
+import type {
+  RendererErrorReport,
+  RendererErrorSource,
+} from "../../../shared/renderer-error";
+import { getDesktopApi } from "./desktop-api";
+
+function getErrorShape(error: unknown): {
+  message: string;
+  name?: string;
+  stack?: string;
+} {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: typeof error === "string" ? error : String(error),
+  };
+}
+
+export function createRendererErrorReport(
+  source: RendererErrorSource,
+  error: unknown,
+  details?: {
+    colno?: number;
+    componentStack?: string | null;
+    filename?: string;
+    lineno?: number;
+  },
+): RendererErrorReport {
+  const errorShape = getErrorShape(error);
+
+  return {
+    ...errorShape,
+    colno: details?.colno,
+    componentStack: details?.componentStack ?? undefined,
+    filename: details?.filename,
+    href: window.location.href,
+    lineno: details?.lineno,
+    source,
+    timestamp: new Date().toISOString(),
+    userAgent: navigator.userAgent,
+  };
+}
+
+export function reportRendererError(report: RendererErrorReport): void {
+  console.error("[pwragnt:renderer:error]", report);
+  void getDesktopApi()
+    ?.reportRendererError?.(report)
+    .catch((error: unknown) => {
+      console.error("[pwragnt:renderer:error] failed to report", error);
+    });
+}
+
+export function installGlobalRendererErrorHandlers(): () => void {
+  const handleError = (event: ErrorEvent): void => {
+    reportRendererError(
+      createRendererErrorReport("window-error", event.error ?? event.message, {
+        colno: event.colno,
+        filename: event.filename,
+        lineno: event.lineno,
+      }),
+    );
+  };
+
+  const handleUnhandledRejection = (event: PromiseRejectionEvent): void => {
+    reportRendererError(
+      createRendererErrorReport("unhandled-rejection", event.reason),
+    );
+  };
+
+  window.addEventListener("error", handleError);
+  window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+  return () => {
+    window.removeEventListener("error", handleError);
+    window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+  };
+}
+

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -12,7 +12,7 @@ import type {
 import { buildThreadIdentityKey } from "@pwragnt/shared";
 import type { DesktopApi } from "./desktop-api";
 
-export type BrowseMode = "recents" | "directories";
+export type BrowseMode = "inbox" | "recents" | "directories";
 
 type NavigationState = {
   loading: boolean;
@@ -403,6 +403,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
+  const [retainedUnreadThread, setRetainedUnreadThread] =
+    useState<NavigationThreadSummary>();
   const [optimisticThread, setOptimisticThread] = useState<NavigationThreadSummary>();
   const [creatingThread, setCreatingThread] = useState<{
     backend: AppServerBackendKind;
@@ -420,6 +422,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   });
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
+  const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const refreshInFlightRef = useRef(false);
   const queuedRefreshRef = useRef<
     | {
@@ -433,6 +436,32 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   );
 
   optimisticThreadRef.current = optimisticThread;
+  retainedUnreadThreadRef.current = retainedUnreadThread;
+
+  const releaseRetainedUnreadThread = useCallback((nextSelectionKey?: string): void => {
+    const retainedThread = retainedUnreadThreadRef.current;
+    if (!retainedThread) {
+      return;
+    }
+
+    const retainedThreadKey = buildThreadIdentityKey(
+      retainedThread.source,
+      retainedThread.id
+    );
+    if (nextSelectionKey === retainedThreadKey) {
+      return;
+    }
+
+    setState((current) => ({
+      ...current,
+      response: markThreadSeenInSnapshot(current.response, {
+        backend: retainedThread.source,
+        threadId: retainedThread.id,
+        seenUpdatedAt: retainedThread.updatedAt,
+      }),
+    }));
+    setRetainedUnreadThread(undefined);
+  }, []);
 
   const performRefresh = useCallback(
     async (
@@ -661,12 +690,27 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const directories = state.response?.directories ?? [];
 
   const inboxThreads = useMemo(() => {
-    const inboxThreadKeys = new Set(state.response?.inboxThreadKeys ?? []);
-    return threads.filter((thread) =>
-      inboxThreadKeys.has(buildThreadIdentityKey(thread.source, thread.id)) ||
-      thread.inbox.inInbox
+    const unreadThreads = threads.filter(
+      (thread) => thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen"
     );
-  }, [state.response?.inboxThreadKeys, threads]);
+    if (!retainedUnreadThread) {
+      return unreadThreads;
+    }
+
+    const retainedThreadKey = buildThreadIdentityKey(
+      retainedUnreadThread.source,
+      retainedUnreadThread.id
+    );
+    if (
+      unreadThreads.some(
+        (thread) => buildThreadIdentityKey(thread.source, thread.id) === retainedThreadKey
+      )
+    ) {
+      return unreadThreads;
+    }
+
+    return [retainedUnreadThread, ...unreadThreads];
+  }, [retainedUnreadThread, threads]);
 
   const selectedThreadKey = useMemo(() => {
     if (selectedItemKey && !getDirectoryKeyFromLaunchpadSelection(selectedItemKey)) {
@@ -699,6 +743,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const selectedLaunchpad = selectedDirectory?.launchpad;
 
   useEffect(() => {
+    releaseRetainedUnreadThread(selectedItemKey);
+  }, [releaseRetainedUnreadThread, retainedUnreadThread, selectedItemKey]);
+
+  useEffect(() => {
     const submitMarkThreadSeen = markThreadSeen;
 
     if (
@@ -723,14 +771,24 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           seenUpdatedAt: threadToMarkSeen.updatedAt,
         });
         if (!cancelled) {
-          setState((current) => ({
-            ...current,
-            response: markThreadSeenInSnapshot(current.response, {
-              backend: threadToMarkSeen.source,
-              threadId: threadToMarkSeen.id,
-              seenUpdatedAt: threadToMarkSeen.updatedAt,
-            }),
-          }));
+          const threadKey = buildThreadIdentityKey(
+            threadToMarkSeen.source,
+            threadToMarkSeen.id
+          );
+          if (
+            !retainedUnreadThread ||
+            buildThreadIdentityKey(retainedUnreadThread.source, retainedUnreadThread.id) !==
+              threadKey
+          ) {
+            setState((current) => ({
+              ...current,
+              response: markThreadSeenInSnapshot(current.response, {
+                backend: threadToMarkSeen.source,
+                threadId: threadToMarkSeen.id,
+                seenUpdatedAt: threadToMarkSeen.updatedAt,
+              }),
+            }));
+          }
         }
       } finally {
         if (!cancelled) {
@@ -744,16 +802,20 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return () => {
       cancelled = true;
     };
-  }, [markThreadSeen, pendingSeenThreadKey, selectedThread]);
+  }, [markThreadSeen, pendingSeenThreadKey, retainedUnreadThread, selectedThread]);
 
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    releaseRetainedUnreadThread(threadKey);
     setCreateThreadError(undefined);
     setLaunchpadError(undefined);
     setSetThreadExecutionModeError(undefined);
     setSelectedItemKey(threadKey);
     setPendingSeenThreadKey(threadKey);
-  }, []);
+    if (thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen") {
+      setRetainedUnreadThread(thread);
+    }
+  }, [releaseRetainedUnreadThread]);
 
   const createThread = useCallback(
     async (

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
+import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
 import "./styles/app.css";
+
+installGlobalRendererErrorHandlers();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <RendererErrorBoundary>
+      <App />
+    </RendererErrorBoundary>
   </React.StrictMode>
 );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cssPath = path.resolve(testDir, "../app.css");
+const css = readFileSync(cssPath, "utf8");
+
+function extractRootTokens(source: string): Record<string, string> {
+  const rootMatch = source.match(/:root\s*\{(?<body>[\s\S]*?)\n\}/);
+  if (!rootMatch?.groups?.body) {
+    throw new Error("Expected app.css to define a :root token block");
+  }
+
+  return Object.fromEntries(
+    [...rootMatch.groups.body.matchAll(/--([a-z0-9-]+):\s*([^;]+);/g)].map(
+      ([, name, value]) => [name, value.trim()]
+    )
+  );
+}
+
+function expandHex(hex: string): string {
+  const normalized = hex.replace("#", "");
+  if (normalized.length === 3) {
+    return [...normalized].map((char) => `${char}${char}`).join("");
+  }
+  return normalized;
+}
+
+function relativeLuminance(hex: string): number {
+  const normalized = expandHex(hex);
+  const [red, green, blue] = [0, 2, 4].map((start) => {
+    const channel = Number.parseInt(normalized.slice(start, start + 2), 16) / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const [lighter, darker] = [
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  ].sort((left, right) => right - left);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe("Tangerine Terminal theme contract", () => {
+  const tokens = extractRootTokens(css);
+
+  it("defines the semantic tokens used by the renderer theme", () => {
+    expect(tokens).toMatchObject({
+      "accent": "#ff8a1f",
+      "accent-border": "rgba(255, 138, 31, 0.42)",
+      "accent-bright": "#ffb35c",
+      "accent-soft": "rgba(255, 138, 31, 0.12)",
+      "bg-app": "#000000",
+      "bg-input": "#080808",
+      "bg-panel": "#0a0a0a",
+      "bg-panel-elevated": "#101010",
+      "bg-panel-hover": "#14110d",
+      "bg-row-active": "#120800",
+      "bg-sidebar": "#050505",
+      "border-strong": "rgba(247, 243, 235, 0.2)",
+      "border-subtle": "rgba(247, 243, 235, 0.1)",
+      "danger-soft": "rgba(185, 66, 50, 0.24)",
+      "danger-text": "#ffb0a1",
+      "focus-ring": "var(--accent)",
+      "info-text": "#9fc8ff",
+      "success-soft": "rgba(74, 148, 92, 0.18)",
+      "success-text": "#9ce5b3",
+      "text-muted": "#8c857a",
+      "text-primary": "#f7f3eb",
+      "text-secondary": "#b8b0a5",
+    });
+  });
+
+  it("keeps core text and accent pairings above contrast thresholds", () => {
+    const pairs: Array<[string, string, number]> = [
+      ["text-primary", "bg-app", 4.5],
+      ["text-primary", "bg-panel", 4.5],
+      ["text-secondary", "bg-app", 4.5],
+      ["text-secondary", "bg-panel-elevated", 4.5],
+      ["text-muted", "bg-app", 4.5],
+      ["text-muted", "bg-panel-elevated", 4.5],
+      ["accent", "bg-app", 4.5],
+      ["accent", "bg-panel-elevated", 4.5],
+      ["button-text", "accent", 4.5],
+    ];
+
+    for (const [foreground, background, threshold] of pairs) {
+      expect(
+        contrastRatio(tokens[foreground], tokens[background]),
+        `${foreground} on ${background}`
+      ).toBeGreaterThanOrEqual(threshold);
+    }
+  });
+
+  it("does not leave unresolved theme token references in app.css", () => {
+    const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
+      ([, token]) => token
+    );
+    const missingTokens = tokenReferences.filter((token) => !tokens[token]);
+
+    expect([...new Set(missingTokens)]).toEqual([]);
+  });
+
+  it("removes the previous chartreuse accent literals from app.css", () => {
+    expect(css).not.toContain("#b8ff4d");
+    expect(css).not.toContain("184, 255, 77");
+    expect(css).not.toContain("168, 255, 63");
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -443,19 +443,18 @@ textarea {
   flex: 0 0 16px;
 }
 
-.thread-row__status-dot {
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  background: var(--accent);
-  box-shadow: 0 0 10px var(--accent-shadow);
-  color: var(--button-text);
-  font-size: 9px;
-  font-weight: 700;
-  line-height: 1;
+.thread-row__status-cookie {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 35% 35%, var(--accent-bright) 0 2px, transparent 2.5px),
+    var(--accent);
+  box-shadow:
+    inset 0 0 0 2px rgba(18, 8, 0, 0.24),
+    0 0 8px var(--accent-shadow);
 }
 
 .thread-row__summary {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1252,7 +1252,7 @@ textarea {
   padding: 14px 16px;
   border: 1px solid var(--accent-border);
   border-radius: 8px;
-  background: rgba(184, 255, 77, 0.08);
+  background: var(--bg-row-active);
 }
 
 .transcript-image-lightbox {
@@ -1361,7 +1361,7 @@ textarea {
 .transcript-questionnaire__option:focus-visible,
 .transcript-questionnaire__option.is-selected {
   border-color: var(--accent-border);
-  background: rgba(184, 255, 77, 0.12);
+  background: var(--accent-soft);
   outline: none;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2239,6 +2239,47 @@ textarea {
   max-width: 520px;
 }
 
+.renderer-error-boundary {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  padding: 40px;
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.renderer-error-boundary h1,
+.renderer-error-boundary p {
+  max-width: 680px;
+  margin: 0;
+}
+
+.renderer-error-boundary h1 {
+  font-size: 32px;
+  line-height: 1.1;
+}
+
+.renderer-error-boundary p {
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.renderer-error-boundary pre {
+  max-width: 760px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--danger-soft);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--danger-text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  white-space: pre-wrap;
+}
+
 @media (max-width: 1100px) {
   .app-shell {
     grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -82,7 +82,8 @@ textarea {
 }
 
 .sidebar__masthead {
-  padding-bottom: 16px;
+  align-items: center;
+  padding-bottom: 14px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -153,16 +154,14 @@ textarea {
   text-transform: uppercase;
 }
 
-.sidebar__title,
+.sidebar__brand {
+  margin: 0;
+}
+
 .thread-header__title,
 .thread-empty-state h2 {
   margin: 0;
   line-height: 1.05;
-}
-
-.sidebar__title {
-  font-size: 40px;
-  font-weight: 700;
 }
 
 .sidebar__section {
@@ -194,6 +193,15 @@ textarea {
   font-weight: 600;
 }
 
+.sidebar__section-header--browse {
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.sidebar__section-title {
+  min-width: 0;
+}
+
 .sidebar__supporting-text,
 .transcript-panel__header p,
 .thread-header__summary,
@@ -219,7 +227,10 @@ textarea {
 }
 
 .lens-switch {
-  display: inline-flex;
+  display: inline-grid;
+  width: min(100%, 216px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-left: auto;
   padding: 3px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -238,7 +249,7 @@ textarea {
 }
 
 .lens-switch__button {
-  min-width: 96px;
+  min-width: 0;
   height: 32px;
   padding: 0 12px;
   background: transparent;
@@ -313,6 +324,7 @@ textarea {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+  padding-left: 4px;
   padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
@@ -323,6 +335,7 @@ textarea {
   min-height: 0;
   overflow-y: auto;
   padding-top: 0;
+  padding-left: 4px;
   padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
@@ -2309,7 +2322,6 @@ textarea {
     padding: 20px 16px 24px;
   }
 
-  .sidebar__title,
   .thread-header__title {
     font-size: 32px;
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -358,11 +358,12 @@ textarea {
 }
 
 .thread-row {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 100%;
-  padding: 12px;
+  padding: 12px 12px 12px 14px;
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
@@ -380,7 +381,18 @@ textarea {
 .thread-row.is-selected {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
-  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.thread-row.is-selected::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 5px;
+  width: 3px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: "";
+  pointer-events: none;
 }
 
 .thread-row__header {
@@ -777,6 +789,19 @@ textarea {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.thread-header__compact-title {
+  max-width: min(58vw, 520px);
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .thread-header__stats {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -228,8 +228,8 @@ textarea {
 
 .lens-switch {
   display: inline-grid;
-  width: min(100%, 216px);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: min(100%, 324px);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-left: auto;
   padding: 3px;
   border: 1px solid var(--border-subtle);
@@ -2044,7 +2044,7 @@ textarea {
 
 .composer__input {
   width: 100%;
-  min-height: 112px;
+  min-height: 144px;
   resize: vertical;
   padding: 12px;
   border: 1px solid var(--border-subtle);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -72,8 +72,6 @@ textarea {
 }
 
 .sidebar__masthead,
-.sidebar__section-header,
-.transcript-panel__header,
 .thread-header {
   display: flex;
   align-items: flex-start;
@@ -185,25 +183,13 @@ textarea {
   overflow: hidden;
 }
 
-.sidebar__section h2,
-.transcript-panel h3,
 .context-panel h3 {
   margin: 0;
   font-size: 14px;
   font-weight: 600;
 }
 
-.sidebar__section-header--browse {
-  align-items: flex-end;
-  flex-wrap: wrap;
-}
-
-.sidebar__section-title {
-  min-width: 0;
-}
-
 .sidebar__supporting-text,
-.transcript-panel__header p,
 .thread-header__summary,
 .thread-empty-state p {
   margin: 4px 0 0;
@@ -228,9 +214,8 @@ textarea {
 
 .lens-switch {
   display: inline-grid;
-  width: min(100%, 324px);
+  width: 100%;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-left: auto;
   padding: 3px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -897,11 +882,6 @@ textarea {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-}
-
-.transcript-panel__header {
-  padding: 16px 16px 12px;
-  border-bottom: 1px solid var(--border-subtle);
 }
 
 .transcript-list {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -255,6 +255,7 @@ textarea {
   background: transparent;
   color: var(--text-secondary);
   text-transform: capitalize;
+  transition: none;
 }
 
 .lens-switch__button.is-active {
@@ -269,19 +270,22 @@ textarea {
 }
 
 .button:focus,
-.lens-switch__button:focus,
 .thread-row:focus,
 .transcript-activity__toggle:focus,
 .composer__input:focus,
 .composer__attachment-remove:focus,
 .button:focus-visible,
-.lens-switch__button:focus-visible,
 .thread-row:focus-visible,
 .transcript-activity__toggle:focus-visible,
 .composer__input:focus-visible,
 .composer__attachment-remove:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+.lens-switch__button:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .button--ghost {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2,22 +2,32 @@
   color-scheme: dark;
   font-family: "Geist", "IBM Plex Sans", "SF Pro Text", "Inter", system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, monospace;
-  --bg-app: #0b0d12;
-  --bg-sidebar: #11151c;
-  --bg-panel: #151a22;
-  --bg-panel-hover: #1a202a;
-  --bg-row-active: #1b2230;
-  --border-subtle: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 255, 255, 0.14);
-  --text-primary: #f3f5f7;
-  --text-secondary: #a8b0bb;
-  --text-muted: #7e8794;
-  --accent: #b8ff4d;
-  --accent-soft: rgba(184, 255, 77, 0.14);
-  --accent-border: rgba(184, 255, 77, 0.36);
+  --bg-app: #000000;
+  --bg-sidebar: #050505;
+  --bg-panel: #0a0a0a;
+  --bg-panel-elevated: #101010;
+  --bg-panel-hover: #14110d;
+  --bg-row-active: #120800;
+  --bg-input: #080808;
+  --border-subtle: rgba(247, 243, 235, 0.1);
+  --border-strong: rgba(247, 243, 235, 0.2);
+  --text-primary: #f7f3eb;
+  --text-secondary: #b8b0a5;
+  --text-muted: #8c857a;
+  --accent: #ff8a1f;
+  --accent-strong: #ffa33d;
+  --accent-bright: #ffb35c;
+  --accent-soft: rgba(255, 138, 31, 0.12);
+  --accent-border: rgba(255, 138, 31, 0.42);
+  --accent-shadow: rgba(255, 138, 31, 0.34);
+  --focus-ring: var(--accent);
   --danger-soft: rgba(185, 66, 50, 0.24);
   --danger-text: #ffb0a1;
-  --button-text: #0f1300;
+  --success-soft: rgba(74, 148, 92, 0.18);
+  --success-text: #9ce5b3;
+  --info-soft: rgba(86, 137, 196, 0.16);
+  --info-text: #9fc8ff;
+  --button-text: #120800;
 }
 
 * {
@@ -98,7 +108,7 @@ textarea {
   padding: 8px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: rgba(16, 20, 28, 0.98);
+  background: rgba(10, 10, 10, 0.98);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.32);
 }
 
@@ -213,7 +223,7 @@ textarea {
   padding: 3px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-panel);
 }
 
 .lens-switch__button,
@@ -237,8 +247,9 @@ textarea {
 }
 
 .lens-switch__button.is-active {
-  background: var(--accent);
-  color: var(--button-text);
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
 }
 
 .button {
@@ -246,13 +257,19 @@ textarea {
   padding: 0 12px;
 }
 
+.button:focus,
+.lens-switch__button:focus,
+.thread-row:focus,
+.transcript-activity__toggle:focus,
+.composer__input:focus,
+.composer__attachment-remove:focus,
 .button:focus-visible,
 .lens-switch__button:focus-visible,
 .thread-row:focus-visible,
 .transcript-activity__toggle:focus-visible,
 .composer__input:focus-visible,
 .composer__attachment-remove:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -270,6 +287,11 @@ textarea {
 
 .button--primary {
   border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+}
+
+.button--primary:hover:not([disabled]) {
   background: var(--accent);
   color: var(--button-text);
 }
@@ -293,7 +315,7 @@ textarea {
   min-height: 0;
   padding-right: 4px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(168, 176, 187, 0.4) rgba(255, 255, 255, 0.04);
+  scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
 }
 
 .directory-groups {
@@ -303,7 +325,7 @@ textarea {
   padding-top: 0;
   padding-right: 4px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(168, 176, 187, 0.4) rgba(255, 255, 255, 0.04);
+  scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
 }
 
 .sidebar-list--dense::-webkit-scrollbar,
@@ -313,7 +335,7 @@ textarea {
 
 .sidebar-list--dense::-webkit-scrollbar-track,
 .directory-groups::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(247, 243, 235, 0.05);
   border-radius: 999px;
 }
 
@@ -321,13 +343,13 @@ textarea {
 .directory-groups::-webkit-scrollbar-thumb {
   border: 2px solid transparent;
   border-radius: 999px;
-  background: rgba(168, 176, 187, 0.4);
+  background: rgba(140, 133, 122, 0.46);
   background-clip: padding-box;
 }
 
 .sidebar-list--dense::-webkit-scrollbar-thumb:hover,
 .directory-groups::-webkit-scrollbar-thumb:hover {
-  background: rgba(168, 176, 187, 0.58);
+  background: rgba(184, 176, 165, 0.58);
   background-clip: padding-box;
 }
 
@@ -358,6 +380,7 @@ textarea {
 .thread-row.is-selected {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .thread-row__header {
@@ -401,19 +424,26 @@ textarea {
 
 .thread-row__status-indicator {
   display: inline-flex;
-  width: 14px;
-  min-width: 14px;
+  width: 16px;
+  min-width: 16px;
   align-items: center;
   justify-content: center;
-  flex: 0 0 14px;
+  flex: 0 0 16px;
 }
 
 .thread-row__status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
   background: var(--accent);
-  box-shadow: 0 0 10px rgba(184, 255, 77, 0.42);
+  box-shadow: 0 0 10px var(--accent-shadow);
+  color: var(--button-text);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .thread-row__summary {
@@ -448,14 +478,14 @@ textarea {
 
 .thread-row__chip--backend {
   border: 1px solid var(--border-subtle);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-panel-elevated);
   color: var(--text-secondary);
   font-weight: 600;
 }
 
 .thread-row__chip--mode {
   border: 1px solid var(--accent-border);
-  background: rgba(184, 255, 77, 0.08);
+  background: var(--accent-soft);
   color: var(--text-primary);
   font-weight: 600;
 }
@@ -487,7 +517,7 @@ textarea {
   padding: 8px 10px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: rgba(16, 20, 28, 0.96);
+  background: rgba(10, 10, 10, 0.96);
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
   color: var(--text-primary);
   font-size: 12px;
@@ -531,7 +561,7 @@ textarea {
 }
 
 .thread-row__chip--muted {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-panel-elevated);
   color: var(--text-secondary);
 }
 
@@ -631,7 +661,7 @@ textarea {
 
 .directory-row__launchpad-button.has-draft {
   border-color: var(--accent-border);
-  background: rgba(184, 255, 77, 0.08);
+  background: var(--bg-row-active);
   color: var(--accent);
 }
 
@@ -871,12 +901,10 @@ textarea {
   align-items: center;
   justify-content: center;
   padding: 0;
-  border-color: var(--border-strong);
-  background: rgba(11, 13, 18, 0.92);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
   transform: translateX(-50%);
   border-color: var(--accent-border);
-  background: rgba(17, 21, 28, 0.96);
+  background: rgba(10, 10, 10, 0.96);
 }
 
 .transcript-list__scroll-bottom-icon {
@@ -895,7 +923,7 @@ textarea {
   padding: 14px 16px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-panel-elevated);
 }
 
 .transcript-message--user {
@@ -905,7 +933,7 @@ textarea {
 
 .transcript-message--assistant {
   border-color: var(--accent-border);
-  background: var(--accent-soft);
+  background: var(--bg-panel);
 }
 
 .transcript-message__header {
@@ -999,9 +1027,9 @@ textarea {
 .transcript-message__code {
   display: inline-block;
   padding: 1px 6px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-panel-elevated);
   font-size: 12px;
   font-family: var(--font-mono);
 }
@@ -1009,9 +1037,9 @@ textarea {
 .transcript-message__pre {
   overflow-x: auto;
   padding: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.22);
+  background: var(--bg-app);
 }
 
 .transcript-message__pre code {
@@ -1028,7 +1056,7 @@ textarea {
 .transcript-message__link {
   color: var(--accent-bright);
   text-decoration: underline;
-  text-decoration-color: rgba(168, 255, 63, 0.45);
+  text-decoration-color: rgba(255, 138, 31, 0.55);
   text-underline-offset: 2px;
   word-break: break-word;
 }
@@ -1043,13 +1071,13 @@ textarea {
   padding: 0;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-panel-elevated);
   overflow: hidden;
   cursor: pointer;
 }
 
 .transcript-message__image-button:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
@@ -1080,7 +1108,7 @@ textarea {
   padding: 14px 16px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-panel-elevated);
 }
 
 .transcript-plan__header {
@@ -1145,11 +1173,11 @@ textarea {
 }
 
 .transcript-plan__step-status--completed {
-  background: var(--accent);
+  background: var(--success-text);
 }
 
 .transcript-plan__step-status--in_progress {
-  background: #6fb7ff;
+  background: var(--info-text);
 }
 
 .transcript-plan__step-index,
@@ -1192,7 +1220,7 @@ textarea {
   padding: 14px 16px;
   border: 1px solid var(--accent-border);
   border-radius: 8px;
-  background: rgba(184, 255, 77, 0.08);
+  background: var(--bg-row-active);
 }
 
 .transcript-questionnaire {
@@ -1214,7 +1242,7 @@ textarea {
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(11, 13, 18, 0.88);
+  background: rgba(0, 0, 0, 0.88);
 }
 
 .transcript-image-lightbox__content {
@@ -1235,7 +1263,7 @@ textarea {
   max-height: min(100vh - 120px, 800px);
   border-radius: 8px;
   border: 1px solid var(--border-strong);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-panel);
 }
 
 .transcript-request__header,
@@ -1400,8 +1428,8 @@ textarea {
   flex: 0 0 auto;
   overflow: hidden;
   border-radius: 999px;
-  background: rgba(95, 14, 14, 0.56);
-  box-shadow: inset 0 0 0 1px rgba(255, 106, 94, 0.14);
+  background: rgba(255, 138, 31, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 138, 31, 0.18);
 }
 
 .thinking-scanner--mini {
@@ -1418,13 +1446,13 @@ textarea {
   border-radius: 999px;
   background: linear-gradient(
     90deg,
-    rgba(255, 88, 72, 0.2) 0%,
-    rgba(255, 122, 112, 0.95) 48%,
-    rgba(255, 88, 72, 0.2) 100%
+    rgba(255, 138, 31, 0.18) 0%,
+    rgba(255, 179, 92, 0.95) 48%,
+    rgba(255, 138, 31, 0.18) 100%
   );
   box-shadow:
-    0 0 10px rgba(255, 106, 94, 0.55),
-    0 0 18px rgba(255, 78, 68, 0.28);
+    0 0 10px rgba(255, 138, 31, 0.42),
+    0 0 18px rgba(255, 138, 31, 0.22);
   animation:
     pwragnt-kitt-scan 1.35s cubic-bezier(0.4, 0, 0.2, 1) infinite,
     pwragnt-kitt-glow 0.7s ease-in-out infinite;
@@ -1433,8 +1461,8 @@ textarea {
 .thinking-scanner--mini .thinking-scanner__beam {
   width: 8px;
   box-shadow:
-    0 0 8px rgba(255, 106, 94, 0.55),
-    0 0 14px rgba(255, 78, 68, 0.24);
+    0 0 8px rgba(255, 138, 31, 0.42),
+    0 0 14px rgba(255, 138, 31, 0.22);
 }
 
 .transcript-activity__header {
@@ -1520,7 +1548,7 @@ textarea {
   overflow: hidden;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-panel-elevated);
 }
 
 .transcript-diff__path,
@@ -1573,13 +1601,13 @@ textarea {
 }
 
 .transcript-diff__stat--added {
-  background: rgba(49, 138, 83, 0.18);
-  color: #9ce5b3;
+  background: var(--success-soft);
+  color: var(--success-text);
 }
 
 .transcript-diff__stat--removed {
-  background: rgba(171, 73, 73, 0.18);
-  color: #ffb0a1;
+  background: var(--danger-soft);
+  color: var(--danger-text);
 }
 
 .transcript-diff__toggle {
@@ -1616,15 +1644,15 @@ textarea {
 }
 
 .transcript-diff__row--added {
-  background: rgba(49, 138, 83, 0.12);
+  background: var(--success-soft);
 }
 
 .transcript-diff__row--removed {
-  background: rgba(171, 73, 73, 0.12);
+  background: var(--danger-soft);
 }
 
 .transcript-diff__row--context {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-panel);
 }
 
 .transcript-diff__line-number {
@@ -1650,12 +1678,12 @@ textarea {
 
 .transcript-diff__row--added .transcript-diff__symbol,
 .transcript-diff__row--added .transcript-diff__text {
-  color: #9ce5b3;
+  color: var(--success-text);
 }
 
 .transcript-diff__row--removed .transcript-diff__symbol,
 .transcript-diff__row--removed .transcript-diff__text {
-  color: #ffb0a1;
+  color: var(--danger-text);
 }
 
 .transcript-diff__hunk,
@@ -1666,17 +1694,17 @@ textarea {
 }
 
 .transcript-diff__hunk {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-panel-hover);
 }
 
 .transcript-diff__separator {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-panel);
 }
 
 .skill-chip {
   max-width: 100%;
   vertical-align: middle;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-subtle);
 }
 
 .context-rail {
@@ -1705,7 +1733,7 @@ textarea {
 .context-rail:hover,
 .context-rail:focus-within,
 .context-rail.is-open {
-  border-color: rgba(168, 255, 63, 0.24);
+  border-color: var(--accent-border);
 }
 
 .context-rail__spine {
@@ -1717,7 +1745,7 @@ textarea {
   justify-content: flex-start;
   padding: 8px 0;
   border-right: 1px solid var(--border-subtle);
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-panel-elevated);
 }
 
 .context-rail__menu-button {
@@ -1944,7 +1972,7 @@ textarea {
   height: 8px;
   flex: 0 0 auto;
   border-radius: 999px;
-  background: var(--accent);
+  background: var(--success-text);
 }
 
 .backend-status-list__dot.is-unavailable {
@@ -1980,7 +2008,7 @@ textarea {
   padding: 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-input);
   color: var(--text-primary);
 }
 
@@ -2009,7 +2037,7 @@ textarea {
   padding: 8px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-panel-elevated);
 }
 
 .composer__attachment-preview {
@@ -2017,7 +2045,7 @@ textarea {
   aspect-ratio: 1;
   border-radius: 6px;
   object-fit: cover;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-panel-hover);
 }
 
 .composer__attachment-copy {
@@ -2087,7 +2115,7 @@ textarea {
   padding: 0 10px;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-input);
   color: var(--text-primary);
 }
 
@@ -2123,7 +2151,7 @@ textarea {
   padding: 8px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: rgba(16, 20, 28, 0.98);
+  background: rgba(10, 10, 10, 0.98);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
 }
 

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -19,4 +19,5 @@ export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:update-directory-launchpad";
 export const NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:reset-directory-launchpad";
+export const RENDERER_ERROR_REPORT_CHANNEL = "renderer:error-report";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";

--- a/apps/desktop/src/shared/renderer-error.ts
+++ b/apps/desktop/src/shared/renderer-error.ts
@@ -1,0 +1,19 @@
+export type RendererErrorSource =
+  | "error-boundary"
+  | "window-error"
+  | "unhandled-rejection";
+
+export type RendererErrorReport = {
+  colno?: number;
+  componentStack?: string;
+  filename?: string;
+  href: string;
+  lineno?: number;
+  message: string;
+  name?: string;
+  source: RendererErrorSource;
+  stack?: string;
+  timestamp: string;
+  userAgent: string;
+};
+

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -115,7 +115,7 @@ The thread lens switch is:
 
 `Inbox` is the leftmost lens and shows unread chats. It should use the same visual row language as Recents, not a separate mini-app above the browser.
 
-Do not show a generic Browse thread count or timestamp above the lens switch. Let the rows carry the useful context.
+Do not show a generic Browse header, thread count, or timestamp above the lens switch. Let the rows carry the useful context.
 
 ### Thread Rows
 
@@ -147,6 +147,8 @@ Avoid oversized "widget" header areas. Do not show message count or synced-at me
 ### Transcript
 
 Transcript surfaces should stay black-first. Message cards can have subtle near-black backgrounds and tangerine borders when they need focus, but large orange fills should be avoided.
+
+Do not show redundant transcript headers or message-count sublabels above the message list. The panel can keep an accessible label, but the visible surface should start with the transcript content.
 
 Do not put cards inside cards. Do not make the transcript feel like an embedded preview.
 
@@ -199,4 +201,3 @@ Before shipping a visual change:
 - check selected, hover, focus, disabled, empty, and unread states
 - inspect screenshots at desktop and narrow widths when layout changes
 - keep E2E or theme-contract coverage current for shared shell behavior
-

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -1,0 +1,202 @@
+# PwrAgnt UI Theme
+
+This document is the durable source of truth for PwrAgnt's visual theme. It pairs with [docs/design/desktop-style-guide.md](design/desktop-style-guide.md): the style guide covers desktop product layout and component behavior, while this document covers the theme thesis, palette, token usage, and visual anti-patterns.
+
+## Theme Thesis
+
+PwrAgnt uses a **Tangerine Terminal** theme:
+
+- absolute black app canvas
+- near-black structural surfaces
+- warm white primary text
+- neutral gray secondary text
+- sparse tangerine signal
+- dense, editorial, operator-tool composition
+- restrained motion and minimal elevation
+
+The desired impression is a serious black-first workstation that feels cool enough to work in all day. It should pop through contrast, typography, and precise orange signal, not through decoration.
+
+Avoid gray text on darker gray, generic blue-black Electron dashboard styling, and orange novelty-terminal cosplay.
+
+## Token Contract
+
+The desktop renderer centralizes theme values in [apps/desktop/src/renderer/src/styles/app.css](../apps/desktop/src/renderer/src/styles/app.css). Keep new UI on these semantic tokens instead of adding one-off colors.
+
+```css
+--bg-app: #000000;
+--bg-sidebar: #050505;
+--bg-panel: #0a0a0a;
+--bg-panel-elevated: #101010;
+--bg-panel-hover: #14110d;
+--bg-row-active: #120800;
+--bg-input: #080808;
+
+--border-subtle: rgba(247, 243, 235, 0.1);
+--border-strong: rgba(247, 243, 235, 0.2);
+
+--text-primary: #f7f3eb;
+--text-secondary: #b8b0a5;
+--text-muted: #8c857a;
+
+--accent: #ff8a1f;
+--accent-strong: #ffa33d;
+--accent-bright: #ffb35c;
+--accent-soft: rgba(255, 138, 31, 0.12);
+--accent-border: rgba(255, 138, 31, 0.42);
+--accent-shadow: rgba(255, 138, 31, 0.34);
+--focus-ring: var(--accent);
+```
+
+Status colors may exist, but they should remain low-volume and functional:
+
+- danger: red-orange text or soft fill for destructive and failed states
+- success: muted green for completed or healthy states
+- info: desaturated blue for non-primary informational state
+
+Status colors should not compete with tangerine as the main action and focus signal.
+
+## Color Rules
+
+Use absolute black as the app foundation. Panels, sidebars, inputs, and message surfaces should be near-black, not gray slabs.
+
+Use warm white for primary labels and content. Use neutral gray for timestamps, helper text, secondary labels, and less important metadata. Do not make the main reading experience gray-on-gray.
+
+Use tangerine for:
+
+- primary action states
+- selected and focused controls
+- active lens state
+- selected thread row cues
+- unread cookies
+- important command labels and links
+
+Do not use tangerine for:
+
+- body copy
+- large background panels
+- decorative gradients
+- every badge in a row
+- generic metadata
+
+The accent should feel like a trading-terminal signal: exact, limited, and useful.
+
+## Typography
+
+Use a restrained desktop typography system:
+
+- primary sans: `Geist`, `IBM Plex Sans`, `SF Pro Text`, `Inter`, `system-ui`, `sans-serif`
+- utility mono: `IBM Plex Mono`, `SFMono-Regular`, `SF Mono`, `Consolas`, `monospace`
+
+Rules:
+
+- no viewport-scaled font sizes
+- no negative letter spacing
+- no oversized utility headings
+- use mono for branch names, paths, worktree labels, command-ish labels, and machine state
+- keep text dense, scannable, and stable as state changes
+
+## Component Theme Rules
+
+### Shell
+
+The shell is a workstation, not a landing page. Use a fixed left operating rail and a primary work surface. Avoid stacked floating cards on a dark background.
+
+The main app canvas should stay black. Structural separation should come from spacing, typography, subtle borders, and selected-state treatment before shadows or filled panels.
+
+### Sidebar
+
+The sidebar is an information surface. It should read like an active operating queue.
+
+The thread lens switch is:
+
+1. `Inbox`
+2. `Recents`
+3. `Directories`
+
+`Inbox` is the leftmost lens and shows unread chats. It should use the same visual row language as Recents, not a separate mini-app above the browser.
+
+Do not show a generic Browse thread count or timestamp above the lens switch. Let the rows carry the useful context.
+
+### Thread Rows
+
+Thread rows are one of the main theme carriers. They should be compact, warm, and readable.
+
+Selected rows should use:
+
+- warm active background
+- tangerine border or left bar
+- stable geometry with no layout shift
+- metadata that remains readable without overpowering the title
+
+Unread state uses an orange cookie marker. Do not use a punctuation badge such as `!` for unread.
+
+The secondary "just clicked" or focus highlight must never clip on the left edge, resize the row, or obscure the selected state.
+
+### Lens Switches
+
+Segmented controls should feel crisp and physical. The active segment uses tangerine text or outline. Inactive segments use muted text and near-black surfaces.
+
+State transitions must not ghost the orange outline under another segment. Prefer a direct state update over crossfading borders, backgrounds, or outlines when animation makes the control look wrong.
+
+### Header
+
+Thread detail headers should be compact. Use the thread title as the primary label, then align mode and access pills with it.
+
+Avoid oversized "widget" header areas. Do not show message count or synced-at metadata in the top-right header unless it becomes actionable product context.
+
+### Transcript
+
+Transcript surfaces should stay black-first. Message cards can have subtle near-black backgrounds and tangerine borders when they need focus, but large orange fills should be avoided.
+
+Do not put cards inside cards. Do not make the transcript feel like an embedded preview.
+
+### Composer
+
+The reply box is a primary work surface. It can be taller than a standard form input and should feel intentional, with low-contrast chrome until focused.
+
+Controls below the composer should be compact and quiet unless active. The send action may use tangerine, but it should not dominate the screen when disabled or idle.
+
+## Interaction Rules
+
+Motion should help orientation only:
+
+- short hover transitions
+- stable selected-state updates
+- subtle panel or row changes
+- no theatrical page entrances
+
+Hover, focus, selected, loading, and disabled states must not cause layout shift. Fixed-format UI elements need stable dimensions.
+
+Focus states should be visible and tangerine-led, but contained so they do not create clipped halos or stray outlines.
+
+## Accessibility
+
+Maintain strong contrast between text and surfaces. Critical states should not rely on color alone: pair color with text, shape, placement, iconography, or row treatment.
+
+Long titles, paths, and branch names must truncate or wrap predictably without colliding with timestamps, pills, or controls.
+
+## Anti-Patterns
+
+Avoid:
+
+- gray text on darker gray
+- saturated slate, navy, or purple-blue dashboard palettes
+- purple accents, gradient orbs, and decorative glows
+- orange-dominant panels or orange body copy
+- browser-default controls
+- oversized headings for utility surfaces
+- punctuation unread badges such as `!`
+- animated tab states that leave a ghost outline
+- cards inside cards
+- generic implementation narration in UI copy
+
+## Implementation Checklist
+
+Before shipping a visual change:
+
+- update centralized tokens before adding local color values
+- verify the change against this document and the desktop style guide
+- check selected, hover, focus, disabled, empty, and unread states
+- inspect screenshots at desktop and narrow widths when layout changes
+- keep E2E or theme-contract coverage current for shared shell behavior
+

--- a/docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md
+++ b/docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md
@@ -1,0 +1,94 @@
+---
+date: 2026-04-20
+topic: desktop-tangerine-terminal-visual-system
+---
+
+# Desktop Tangerine Terminal Visual System
+
+## Problem Frame
+
+The desktop app currently has the right product ambition, but the active palette reads too much like gray text on darker gray surfaces with a loud chartreuse accent. The next visual pass should make PwrAgnt feel more distinctive, sharper, and more durable for all-day work: absolute black foundation, crisp white text, neutral gray metadata, and sparse tangerine signal.
+
+The goal is not a flashy theme or a literal Bloomberg clone. The goal is a serious terminal-like workstation with enough visual point of view that a screenshot immediately feels like a product.
+
+## Design System Context
+
+The desktop renderer currently uses hand-authored React/Electron CSS with centralized CSS custom properties. No shadcn, Tailwind, or Radix component system is installed in the desktop package today.
+
+Current industry systems point in the same general direction even when the libraries differ: semantic tokens for surfaces, foregrounds, borders, focus, accents, and component states. PwrAgnt should keep the lightweight CSS-variable approach for now and strengthen the token model before considering a component-system migration.
+
+## Requirements
+
+**Visual Direction**
+- R1. The app must adopt a "Tangerine Terminal" direction: absolute black app canvas, near-black structural surfaces, warm white primary text, neutral gray secondary text, and sparse tangerine accent.
+- R2. Tangerine must act as a precision signal, not the main reading color. It should be reserved for active/focus state, primary actions, important command labels, selected-state cues, thin structural emphasis, and live/running indicators.
+- R3. Core reading surfaces must be primarily white and gray on black so long transcripts, thread lists, and composer text remain comfortable for extended use.
+- R4. The interface must still feel restrained and operator-grade: no large orange panels, decorative gradients, novelty terminal effects, or rainbow status systems.
+
+**System Coverage**
+- R5. The visual pass must cover the full desktop shell, not only color tokens: sidebar hierarchy, thread rows, directory rows, header metadata, transcript cards/messages, composer, buttons, chips, badges, focus rings, hover states, selected states, loading/running states, and empty/error states.
+- R6. The desktop style guide must be updated so future renderer work follows the Tangerine Terminal direction instead of the current chartreuse control-room palette.
+- R7. The visual system must preserve existing product hierarchy: Inbox above Recents and Directories, thread-first navigation, compact desktop density, and one primary accent color.
+
+**Contrast and Readability**
+- R8. The redesign must eliminate low-contrast gray-on-gray presentation in primary workflows. Primary text, row titles, message text, labels, and button text must remain clearly legible on their surfaces.
+- R9. Muted metadata may be lower contrast than primary text, but must remain readable in dense lists and transcript headers.
+- R10. Focus and active states must be immediately visible without relying only on subtle background shifts.
+- R11. Critical workflow states must not rely on color alone. When a status changes what the user should do next, the UI should pair color with text, iconography, placement, or another non-color cue.
+
+**Theme Architecture**
+- R12. The implementation should continue to use centralized semantic tokens as the foundation. A shadcn, Tailwind, or Radix migration is not required to deliver this visual direction.
+- R13. Token names should make component intent clear enough that future UI work does not hard-code one-off black, gray, white, or tangerine values across renderer files.
+
+## Success Criteria
+
+- A full-app screenshot reads as black-first, crisp, and distinctive rather than charcoal-on-charcoal.
+- The UI has enough visual identity to feel compelling in an interview/demo context without becoming flashy or fatiguing.
+- Tangerine appears as a controlled signal; the app does not become orange-dominant.
+- Thread rows, transcript content, and the composer remain comfortable to scan during long sessions.
+- The style guide and renderer tokens tell the same visual story.
+
+## Scope Boundaries
+
+- Do not migrate to shadcn, Tailwind, Radix Themes, or another component library as part of this requirement unless planning finds a concrete implementation reason.
+- Do not introduce multiple brand accents. Green may remain only as a functional success color if needed.
+- Do not redesign the core information architecture in this pass.
+- Do not add marketing-style ornamentation, decorative glow effects, or heavy gradients.
+- Do not relax existing desktop constraints: compact density, radius of 8px or less, and thread-first hierarchy still apply.
+
+## Key Decisions
+
+- Tangerine Terminal: Chosen over the current chartreuse palette because it better matches the desired Bloomberg-esque, black-first workstation feel.
+- Full visual system pass: Chosen over a token-only swap because changing only global colors risks preserving the same gray-on-gray hierarchy problems.
+- Orange sparks: Chosen over high-orange terminal styling so the app can pop while staying usable all day.
+- Keep CSS-variable theming: Chosen because the app already has centralized custom properties and external systems validate token-based theming as the durable pattern.
+
+## Dependencies / Assumptions
+
+- The desktop style guide remains the source of truth for renderer UI direction.
+- The current renderer CSS token layer is the right starting point for this pass.
+- Exact color values should be chosen during planning/implementation with contrast checks, not finalized in this brainstorm.
+
+## Alternatives Considered
+
+| Option | Outcome |
+| --- | --- |
+| High-orange terminal | Rejected because it would create stronger demo impact but higher eye-fatigue risk. |
+| Color-token pass only | Rejected because it would be faster but likely preserve weak component hierarchy. |
+| shadcn-style neutral system | Rejected as the primary direction because it would be less distinctive and does not address the desired product personality by itself. |
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+None.
+
+### Deferred to Planning
+
+- [Affects R1-R4][Technical] What exact black, near-black, white, gray, and tangerine token values best balance contrast, warmth, and long-session comfort?
+- [Affects R5][Technical] Which renderer components can be updated through tokens alone, and which need targeted component styling changes?
+- [Affects R8-R11][Technical] Which contrast thresholds and screenshot checks should be part of verification?
+
+## Next Steps
+
+→ /prompts:ce-plan for structured implementation planning

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -2,6 +2,8 @@
 
 This guide defines the visual language for the PwrAgnt desktop app. It exists to keep the product from drifting into generic Electron-dark-dashboard styling as more UI gets built.
 
+For exact theme tokens, palette usage, and Tangerine Terminal visual rules, use [docs/UI-THEME.md](../UI-THEME.md).
+
 ## Product Tone
 
 PwrAgnt should feel like a serious operator tool:
@@ -173,14 +175,13 @@ The main shell should not look like stacked floating cards on a dark background.
 The sidebar is a structured queue. It should contain:
 
 1. top-level global actions
-2. Inbox
-3. Recents / Directories lens switch
-4. thread or project lists
-5. utility footer items
+2. Inbox / Recents / Directories thread lens switch
+3. thread or project lists
+4. utility footer items
 
 Rules:
 
-- Inbox belongs at the top of the navigation stack
+- Inbox is the leftmost thread lens and should show unread work
 - section headers should be quiet, compact, and utility-first
 - rows should carry metadata inline
 - active row state should be obvious without being loud

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -36,16 +36,19 @@ The visual direction is:
 
 ## Visual Thesis
 
-Use a **dark editorial control-room** aesthetic:
+Use a **Tangerine Terminal** aesthetic:
 
-- deep neutral backgrounds
-- soft but readable contrast
+- absolute black foundation
+- near-black structural surfaces
+- crisp warm-white primary text
+- neutral gray metadata
+- sparse tangerine signal
 - crisp typography
 - subtle separators
 - minimal elevation
 - state communicated by emphasis, badges, and row treatment rather than giant colored panels
 
-Avoid the default “blue-black Electron app with random rounded panels” look.
+Avoid the default “blue-black Electron app with random rounded panels” look, and avoid turning the product into an orange novelty terminal. The goal is a serious black-first workstation with a small amount of high-confidence signal.
 
 ## Typography
 
@@ -90,34 +93,35 @@ Rules:
 
 ### Neutral Base
 
-Start from neutral charcoal and slate, not saturated navy.
+Start from absolute black and near-black neutrals, not saturated navy, slate, or charcoal-heavy gray-on-gray.
 
 Suggested palette:
 
-- `--bg-app: #0b0d12`
-- `--bg-sidebar: #11151c`
-- `--bg-panel: #151a22`
-- `--bg-panel-hover: #1a202a`
-- `--bg-row-active: #1b2230`
-- `--border-subtle: rgba(255, 255, 255, 0.08)`
-- `--border-strong: rgba(255, 255, 255, 0.14)`
-- `--text-primary: #f3f5f7`
-- `--text-secondary: #a8b0bb`
-- `--text-muted: #7e8794`
+- `--bg-app: #000000`
+- `--bg-sidebar: #050505`
+- `--bg-panel: #0a0a0a`
+- `--bg-panel-hover: #101010`
+- `--bg-row-active: #120800`
+- `--border-subtle: rgba(247, 243, 235, 0.1)`
+- `--border-strong: rgba(247, 243, 235, 0.2)`
+- `--text-primary: #f7f3eb`
+- `--text-secondary: #b8b0a5`
+- `--text-muted: #8c857a`
 
 ### Accent
 
 Use one accent only. Recommended direction:
 
-- **acid green** or **electric chartreuse** for active state, confirmations, and live emphasis
+- **tangerine** for action, focus, selected state, important command labels, and live emphasis
 
 Suggested accent tokens:
 
-- `--accent: #b8ff4d`
-- `--accent-soft: rgba(184, 255, 77, 0.14)`
-- `--accent-border: rgba(184, 255, 77, 0.36)`
+- `--accent: #ff8a1f`
+- `--accent-strong: #ffa33d`
+- `--accent-soft: rgba(255, 138, 31, 0.12)`
+- `--accent-border: rgba(255, 138, 31, 0.42)`
 
-This gives the product a recognizable signature without turning the whole UI neon.
+Tangerine is a precision signal, not the main reading color. Use it for focus rings, primary action states, selected-row cues, important labels, and small live indicators. Do not use large orange panels, orange page backgrounds, or orange as the default body text color.
 
 ### Status Colors
 
@@ -126,9 +130,11 @@ Keep status colors muted and functional:
 - info: desaturated blue
 - warning: amber
 - danger: red-orange
-- success: accent green
+- success: muted green
 
 Status colors should appear mostly in badges, dots, and subtle row indicators, not full-panel fills.
+
+Critical workflow states should not rely on color alone. Pair status color with text, iconography, placement, shape, or another non-color cue when the state changes what the user should do next.
 
 ## Spacing and Rhythm
 
@@ -333,6 +339,7 @@ Avoid all of the following:
 - giant empty dark surfaces
 - every section boxed in the same bordered card
 - saturated blue-on-black default Electron look
+- orange-dominant terminal cosplay
 - heavy gradients
 - purple accents
 - oversized radii

--- a/docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md
+++ b/docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add Tangerine Terminal Visual System"
 type: feat
-status: active
+status: completed
 date: 2026-04-20
 origin: docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md
 ---
@@ -100,7 +100,7 @@ The app currently has centralized styling, but the active palette reads too much
 
 ## Implementation Units
 
-- [ ] **Unit 1: Update Desktop Style Guide**
+- [x] **Unit 1: Update Desktop Style Guide**
 
 **Goal:** Replace the existing chartreuse control-room direction with the Tangerine Terminal design direction so future renderer work has the right source of truth.
 
@@ -129,7 +129,7 @@ The app currently has centralized styling, but the active palette reads too much
 - The style guide no longer recommends chartreuse as the primary accent.
 - The style guide clearly describes the new palette, accent discipline, state guidance, and unchanged desktop constraints.
 
-- [ ] **Unit 2: Establish Tangerine Theme Tokens**
+- [x] **Unit 2: Establish Tangerine Theme Tokens**
 
 **Goal:** Convert `app.css` from the current chartreuse token set into a stronger semantic token layer for black-first Tangerine Terminal styling.
 
@@ -162,7 +162,7 @@ The app currently has centralized styling, but the active palette reads too much
 - Renderer CSS has one coherent token foundation.
 - Theme contract tests prove the token set is complete enough to support component work.
 
-- [ ] **Unit 3: Restyle Shell and Navigation States**
+- [x] **Unit 3: Restyle Shell and Navigation States**
 
 **Goal:** Make the sidebar, thread rows, directory rows, lens switch, chips, status markers, and context rail read as black-first, crisp, and stateful without depending on orange-heavy fills.
 
@@ -201,7 +201,7 @@ The app currently has centralized styling, but the active palette reads too much
 - Sidebar and context rail visually match the black/tangerine system.
 - Navigation state remains accessible and behaviorally unchanged.
 
-- [ ] **Unit 4: Restyle Transcript, Composer, and Work Surfaces**
+- [x] **Unit 4: Restyle Transcript, Composer, and Work Surfaces**
 
 **Goal:** Apply the visual system to the primary work area so transcript reading, pending approvals, plan progress, diff surfaces, composer controls, autocomplete, attachments, and empty/error states feel unified and readable.
 
@@ -242,7 +242,7 @@ The app currently has centralized styling, but the active palette reads too much
 - Primary work surfaces are readable on black and no longer rely on chartreuse panels for assistant/status emphasis.
 - Existing transcript and composer behavior remains unchanged.
 
-- [ ] **Unit 5: Add Visual and Contrast Verification**
+- [x] **Unit 5: Add Visual and Contrast Verification**
 
 **Goal:** Add targeted verification so the new theme is guarded by tests and screenshot review instead of relying only on manual taste.
 

--- a/docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md
+++ b/docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md
@@ -1,0 +1,321 @@
+---
+title: "feat: Add Tangerine Terminal Visual System"
+type: feat
+status: active
+date: 2026-04-20
+origin: docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md
+---
+
+# feat: Add Tangerine Terminal Visual System
+
+## Overview
+
+Update the desktop renderer from the current charcoal/chartreuse palette to a black-first Tangerine Terminal visual system. The work should preserve the existing React/Electron architecture and CSS-variable styling model while making the full shell, navigation, transcript, and composer read as crisp black, warm white, neutral gray, and sparse tangerine signal.
+
+## Problem Frame
+
+The app currently has centralized styling, but the active palette reads too much like gray text on darker gray surfaces and uses chartreuse as the main accent. The origin requirements ask for a more Bloomberg-esque workstation feel without becoming flashy: absolute black canvas, white and gray reading text, and tangerine used only as a precise signal (see origin: `docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md`).
+
+## Requirements Trace
+
+- R1. Adopt the Tangerine Terminal direction: black app canvas, near-black surfaces, warm white primary text, neutral gray secondary text, sparse tangerine accent.
+- R2. Use tangerine as a precision signal for active/focus state, primary actions, important command labels, selected-state cues, structural emphasis, and live/running indicators.
+- R3. Keep core reading surfaces white and gray on black for long-session comfort.
+- R4. Avoid large orange panels, decorative gradients, novelty terminal effects, and rainbow status systems.
+- R5. Cover the full shell: sidebar, thread rows, directory rows, header metadata, transcript cards/messages, composer, buttons, chips, badges, focus, hover, selected, loading/running, empty, and error states.
+- R6. Update the desktop style guide so future renderer work follows Tangerine Terminal.
+- R7. Preserve Inbox above Recents/Directories, thread-first hierarchy, compact density, and one primary accent color.
+- R8. Eliminate low-contrast gray-on-gray in primary workflows.
+- R9. Keep muted metadata readable in dense lists and transcript headers.
+- R10. Make focus and active states immediately visible without relying only on background shifts.
+- R11. Pair critical workflow state color with text, iconography, placement, or another non-color cue.
+- R12. Continue using centralized semantic CSS tokens; no shadcn/Tailwind/Radix migration is required.
+- R13. Token names should discourage one-off hard-coded black, gray, white, or tangerine values across renderer files.
+
+## Scope Boundaries
+
+- Do not migrate to shadcn, Tailwind, Radix Themes, or another component system.
+- Do not redesign the information architecture or change navigation behavior.
+- Do not add marketing-style ornamentation, decorative glow effects, large gradients, or multi-accent branding.
+- Do not relax existing desktop constraints: compact density, radius of 8px or less, and thread-first hierarchy.
+- Do not use green as a brand accent. Keep it only for functional success state if the final UI needs it.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/package.json` confirms the desktop app is React 19, Electron, Vite, Playwright, and Vitest with no Tailwind, shadcn, Radix, or component-library dependency.
+- `apps/desktop/src/renderer/src/styles/app.css` is the visual source for renderer tokens, typography, shell layout, rows, transcript surfaces, context rail, and composer styling.
+- `docs/design/desktop-style-guide.md` is the project source of truth for desktop UI direction and currently documents the chartreuse control-room palette that this plan replaces.
+- `apps/desktop/AGENTS.md` requires renderer UI work to follow the desktop style guide, preserve Inbox above Recents and Directories, avoid browser-default controls, keep radius at 8px or below, and favor one accent.
+- Navigation surfaces are split across `Sidebar.tsx`, `InboxList.tsx`, `RecentsList.tsx`, `DirectoriesList.tsx`, `ThreadMetaChips.tsx`, and `ThreadRowStatus.tsx`.
+- Thread detail surfaces are split across `ThreadView.tsx`, `ThreadHeader.tsx`, `ThreadContextPanel.tsx`, `TranscriptList.tsx`, `TranscriptMessage.tsx`, `TranscriptPlan.tsx`, `TranscriptActivity.tsx`, `TranscriptDiff.tsx`, and `ThinkingScanner.tsx`.
+- Composer surfaces live in `Composer.tsx` and `SkillChip.tsx`.
+- Existing tests cover behavior and rendering in `src/renderer/src/__tests__/app-shell.test.tsx`, navigation tests, composer tests, transcript tests, and desktop Playwright specs under `apps/desktop/e2e/`.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory or critical-patterns file is present in this checkout, so there are no project-local solution notes to apply.
+
+### External References
+
+- shadcn/ui theming uses semantic CSS variables for background, foreground, primary, borders, and component states: https://ui.shadcn.com/docs/theming
+- Tailwind CSS v4 exposes theme variables through CSS custom properties: https://tailwindcss.com/docs/theme
+- Radix Themes and Radix Colors model color systems as scale-based tokens that can be consumed from CSS variables: https://www.radix-ui.com/themes/docs/theme/color and https://www.radix-ui.com/colors/docs/overview/usage
+- WCAG contrast guidance: normal text should meet at least 4.5:1, large text 3:1, and non-text UI indicators generally 3:1 where applicable: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum and https://www.w3.org/WAI/WCAG21/understanding/non-text-contrast.html
+- WCAG use-of-color guidance supports R11: color should not be the only visual means of conveying information or prompting a response: https://www.w3.org/WAI/WCAG22/Understanding/use-of-color
+
+## Key Technical Decisions
+
+- Keep the current CSS-variable architecture: The repo already has centralized custom properties in `app.css`, and external design systems support the same tokenized direction without requiring a dependency migration.
+- Expand tokens before polishing components: `app.css` currently mixes semantic variables with hard-coded chartreuse, green, red, and white alpha values, and references `--accent-bright` without defining it. The foundation should be tightened first so component work does not multiply one-off colors.
+- Use a black-first baseline palette: Start from `#000000` app canvas, near-black structural surfaces `#050505`, `#0a0a0a`, and `#101010`, warm primary text `#f7f3eb`, secondary text `#b8b0a5`, muted text `#8c857a`, and tangerine `#ff8a1f`. These values clear AA contrast in the important text pairings checked during planning; implementation may tune within the same direction if screenshot and contrast checks reveal issues.
+- Treat tangerine as a sparse semantic accent: Primary actions, selected outlines, focus rings, active lens state, important labels, and live/running cues may use tangerine. Default panel backgrounds, long-form message bodies, and most metadata should stay neutral.
+- Preserve functional status colors as status-only tokens: Added/removed diff rows, danger/error, and optional success states should remain distinguishable, but they should not become brand accents or compete with tangerine.
+- Add lightweight theme contract coverage instead of visual snapshot sprawl: Unit-level token/contrast assertions and a small E2E computed-style/screenshot check should guard the theme better than brittle full-page snapshots alone.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Exact palette baseline: Use the black-first/tangerine token baseline listed in Key Technical Decisions, with implementation allowed to tune values only to satisfy contrast and screenshot quality.
+- Token-vs-component split: Begin with token expansion and hard-coded color cleanup, then target component classes where surface hierarchy or non-color state cues need explicit changes.
+- Verification thresholds: Target at least 4.5:1 for normal text, 3:1 for non-text active/focus indicators, visible focus on interactive controls, and no critical state conveyed by color alone.
+
+### Deferred to Implementation
+
+- Final micro-adjustments to individual alpha values after seeing the app in Playwright screenshots. This depends on rendered density, not just static token math.
+- Whether any current hard-coded status color should be promoted to a semantic token or left local to a single component. The implementer should decide based on actual reuse while avoiding broad token bloat.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+| Layer | Purpose | Examples |
+| --- | --- | --- |
+| Foundation tokens | Own raw palette and contrast-safe text/surface relationships | app canvas, surface levels, primary/secondary/muted text, tangerine accent, danger/success status |
+| Semantic tokens | Express UI intent without hard-coding colors in component rules | selected background, hover background, focus ring, accent soft fill, accent border, command label |
+| Component rules | Apply semantic tokens to real surfaces and states | rows, buttons, chips, transcript messages, plan/status cards, composer, context rail |
+| Verification | Keep the theme stable as later UI work lands | token contrast tests, non-color state tests, E2E computed style checks, screenshot review |
+
+## Implementation Units
+
+- [ ] **Unit 1: Update Desktop Style Guide**
+
+**Goal:** Replace the existing chartreuse control-room direction with the Tangerine Terminal design direction so future renderer work has the right source of truth.
+
+**Requirements:** R1, R2, R3, R4, R6, R7, R11
+
+**Dependencies:** Origin requirements document.
+
+**Files:**
+- Modify: `docs/design/desktop-style-guide.md`
+- Reference: `docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md`
+
+**Approach:**
+- Rewrite the Color System section around black canvas, near-black structural surfaces, warm white/neutral gray text, and sparse tangerine.
+- Preserve existing non-negotiables: thread-first hierarchy, compact desktop density, no card-heavy dashboard look, radius at 8px or less, one accent color.
+- Add explicit guidance that tangerine should be used as a precise signal, not as large fills or the default text color.
+- Add accessibility guidance from the origin doc: critical workflow states need a non-color cue.
+
+**Patterns to follow:**
+- Existing structure and tone in `docs/design/desktop-style-guide.md`.
+- `apps/desktop/AGENTS.md` as the renderer UI constraint source.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only change. Verification is review against the origin requirements.
+
+**Verification:**
+- The style guide no longer recommends chartreuse as the primary accent.
+- The style guide clearly describes the new palette, accent discipline, state guidance, and unchanged desktop constraints.
+
+- [ ] **Unit 2: Establish Tangerine Theme Tokens**
+
+**Goal:** Convert `app.css` from the current chartreuse token set into a stronger semantic token layer for black-first Tangerine Terminal styling.
+
+**Requirements:** R1, R2, R3, R4, R8, R9, R10, R12, R13
+
+**Dependencies:** Unit 1 for documented design direction.
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Create: `apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.ts`
+
+**Approach:**
+- Replace the root token set with a semantic palette that separates raw surface/text/accent/status roles from component usage.
+- Define missing link/focus/accent variants such as the current undefined `--accent-bright` equivalent.
+- Replace reusable hard-coded chartreuse values and white/black alpha values with semantic tokens where the value expresses shared intent.
+- Keep status-specific values for danger, success, diff added/removed, and warning distinct from the tangerine brand accent.
+- Avoid making every color a token. Promote only values that are reused or carry semantic meaning.
+
+**Patterns to follow:**
+- Existing `:root` CSS-variable pattern in `app.css`.
+- Existing Vitest renderer test setup under `apps/desktop/src/renderer/src/**/__tests__`.
+
+**Test scenarios:**
+- Happy path: Parse the renderer CSS token block and assert required semantic tokens exist for app background, surface levels, text levels, accent, accent soft fill, accent border, focus, danger, success, and links.
+- Happy path: Compute contrast for planned primary, secondary, muted, accent, and primary button text pairings and assert they meet the agreed thresholds.
+- Edge case: Assert no unresolved `var(--...)` references exist for new theme-critical tokens such as link/accent variants.
+- Regression: Assert the old chartreuse literal values are not present in the reusable theme-token area.
+
+**Verification:**
+- Renderer CSS has one coherent token foundation.
+- Theme contract tests prove the token set is complete enough to support component work.
+
+- [ ] **Unit 3: Restyle Shell and Navigation States**
+
+**Goal:** Make the sidebar, thread rows, directory rows, lens switch, chips, status markers, and context rail read as black-first, crisp, and stateful without depending on orange-heavy fills.
+
+**Requirements:** R2, R3, R5, R7, R8, R9, R10, R11, R13
+
+**Dependencies:** Unit 2 token foundation.
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/navigation/InboxList.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+
+**Approach:**
+- Apply the new tokens to sidebar canvas, selected rows, hover states, lens switch active state, count pills, chips, directory launchpad button, and context rail.
+- Change selected/active row treatment to combine near-black background, tangerine border/rail/outline, and clear typography rather than a large colored fill.
+- Ensure unread/thinking/running cues have shape, text, accessible names, or placement beyond color. The existing thinking scanner already has motion/shape; unread or needs-attention indicators should not be a silent color-only dot when they affect user action.
+- Keep the existing Inbox, Recents, and Directories hierarchy intact.
+
+**Patterns to follow:**
+- Existing navigation component structure and `thread-row` class naming.
+- Existing tests that query status markers via `data-thread-status`.
+
+**Test scenarios:**
+- Happy path: Rendering a thinking thread still exposes a non-color status marker and does not expose the unread marker.
+- Happy path: Rendering an unread/inbox thread exposes a visible or accessible non-color cue in addition to any color treatment.
+- Integration: Sidebar still renders Inbox above Browse, and Recents/Directories switching continues to work with the same accessible controls.
+- Regression: Selected thread rows still expose `aria-pressed` and keep row title/time/chip content visible.
+
+**Verification:**
+- Sidebar and context rail visually match the black/tangerine system.
+- Navigation state remains accessible and behaviorally unchanged.
+
+- [ ] **Unit 4: Restyle Transcript, Composer, and Work Surfaces**
+
+**Goal:** Apply the visual system to the primary work area so transcript reading, pending approvals, plan progress, diff surfaces, composer controls, autocomplete, attachments, and empty/error states feel unified and readable.
+
+**Requirements:** R2, R3, R4, R5, R8, R9, R10, R11, R13
+
+**Dependencies:** Units 2 and 3.
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Modify as needed: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx`
+- Modify as needed: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Restyle transcript message surfaces so assistant/user differentiation is clear but not orange-dominant. Use border, alignment, role labels, and subtle surface levels before color fill.
+- Restyle pending approval as an important workflow state with text, placement, button hierarchy, and tangerine emphasis, not just an orange/green panel.
+- Keep plan step status labels visible; color dots can remain secondary because the label text already carries the status.
+- Update the thinking scanner to fit the new tangerine direction without becoming a decorative glow effect.
+- Restyle composer inputs, controls, autocomplete, attachments, and buttons around the token system.
+- Preserve all existing composer behavior, image attachment behavior, skill mention behavior, and transcript scroll behavior.
+
+**Patterns to follow:**
+- Existing split between `TranscriptList`, `TranscriptMessage`, `TranscriptPlan`, and `TranscriptActivity`.
+- Existing composer test coverage for send, interrupt, skills, image paste, and launchpad controls.
+
+**Test scenarios:**
+- Happy path: Transcript list renders assistant, user, plan, activity, and pending status entries with their existing accessible roles/content intact.
+- Happy path: Pending approval still exposes Approve, Decline, and Cancel turn actions and conveys that approval is needed through text.
+- Integration: Composer still supports thread mode and launchpad mode after style changes.
+- Regression: Skill autocomplete and pasted image attachment controls remain reachable by role/name and keep focus-visible styling.
+- Regression: Plan steps still display both text and status labels for pending, in-progress, and completed states.
+
+**Verification:**
+- Primary work surfaces are readable on black and no longer rely on chartreuse panels for assistant/status emphasis.
+- Existing transcript and composer behavior remains unchanged.
+
+- [ ] **Unit 5: Add Visual and Contrast Verification**
+
+**Goal:** Add targeted verification so the new theme is guarded by tests and screenshot review instead of relying only on manual taste.
+
+**Requirements:** R1, R2, R3, R5, R8, R9, R10, R11, R12, R13
+
+**Dependencies:** Units 2 through 4.
+
+**Files:**
+- Create: `apps/desktop/e2e/tangerine-terminal-theme.spec.ts`
+- Modify as needed: `apps/desktop/e2e/fixtures/README.md`
+- Reuse fixtures under: `apps/desktop/e2e/fixtures/`
+- Reuse helper: `apps/desktop/e2e/fixtures/electron-app.ts`
+- Test: `apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.ts`
+
+**Approach:**
+- Add a Playwright E2E spec that launches the desktop app with focused existing replay fixtures rather than requiring one mega-fixture. Use fixtures such as `approval-pending`, `codex-todo-list` / `grok-todo-list`, `edited-changes-order`, and directory/navigation fixtures to cover approval, plan, activity, transcript, composer, and sidebar states.
+- Assert computed styles for key surfaces use black/near-black backgrounds, warm light foregrounds, and tangerine only for intended accent states.
+- Include screenshot capture or screenshot-on-failure guidance for desktop review, while avoiding brittle pixel-perfect snapshots as the primary assertion.
+- Add checks for focus visibility on representative controls: new thread, lens switch, selected row, context rail button, composer input, primary send/approval button where available.
+- Exercise both the wide desktop layout and the narrower layout covered by the existing `max-width: 1100px` media query so the theme does not only work in one shell geometry.
+- Document how the visual verification spec should be used during future UI passes.
+
+**Patterns to follow:**
+- Existing Playwright specs in `apps/desktop/e2e/`.
+- Existing fixture launch helper in `apps/desktop/e2e/fixtures/electron-app.ts`.
+
+**Test scenarios:**
+- Happy path: With a replay fixture loaded, the app shell exposes black/near-black computed backgrounds for app, sidebar, transcript panel, and composer.
+- Happy path: Primary text and metadata computed colors satisfy the contrast thresholds against their actual rendered backgrounds.
+- Happy path: Selected row, active lens, focus ring, and primary button use the tangerine accent token or its intended semantic variant.
+- Edge case: The narrow desktop layout keeps transcript, context rail, and composer surfaces readable and non-overlapping after the palette change.
+- Edge case: A workflow status such as pending approval or unread/thinking state exposes text, label, role, icon shape, or another non-color cue.
+- Regression: No major shell surface computes to the old chartreuse accent as a background or dominant text color.
+
+**Verification:**
+- Unit and E2E checks cover token completeness, contrast, key computed styles, focus visibility, and non-color status cues.
+- A reviewer can open the E2E screenshot artifacts and validate that the visual result matches Tangerine Terminal rather than chartreuse control-room.
+
+## System-Wide Impact
+
+- **Interaction graph:** This plan touches renderer styling and optional presentational/accessibility details only. It does not change app-server contracts, thread navigation state, transcript loading, composer submission, or directory launchpad behavior.
+- **Error propagation:** Existing error rendering remains in place; only the visual treatment and token mapping should change.
+- **State lifecycle risks:** Low functional risk, but visual state risk is meaningful: selected, active, running, approval-needed, error, and disabled states must remain distinguishable after the palette change.
+- **API surface parity:** No backend or shared contract changes are expected. If any component prop changes become necessary for non-color status cues, keep them renderer-local unless a shared type already carries the needed status.
+- **Integration coverage:** E2E verification should cover shell + sidebar + transcript + composer together because visual hierarchy problems appear at the composed-app level.
+- **Unchanged invariants:** Inbox remains above Recents/Directories; Recents remains the default browsing lens; thread rows continue to carry metadata; composer controls continue to map to the same backend/execution options.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Orange becomes too dominant and fatiguing | Keep tangerine to semantic accent roles and verify with composed screenshots, not isolated token checks. |
+| Token cleanup turns into a broad CSS refactor | Promote only reused semantic values. Leave local one-off values alone unless they conflict with the new theme or old chartreuse palette. |
+| Visual-only tests become brittle | Prefer contrast, computed-style, role/name, and focused screenshots over pixel-perfect snapshots. |
+| Critical state loses clarity when chartreuse is removed | Add non-color cues and tests for unread/thinking/approval-needed states. |
+| Existing dark surfaces collapse into one black sheet | Use a small set of near-black surface levels and separators to preserve structure without returning to gray-on-gray. |
+
+## Documentation / Operational Notes
+
+- Update the desktop style guide in the same change set as the renderer visual pass so future work does not reintroduce chartreuse.
+- Note in the E2E fixture docs that the theme spec is a visual-system guard, not a full design-regression suite.
+- No runtime config, migration, release flag, or backend rollout is needed.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md](../brainstorms/2026-04-20-desktop-tangerine-terminal-visual-system-requirements.md)
+- **Desktop app guidance:** [apps/desktop/AGENTS.md](../../apps/desktop/AGENTS.md)
+- **Desktop style guide:** [docs/design/desktop-style-guide.md](../design/desktop-style-guide.md)
+- **Renderer CSS:** [apps/desktop/src/renderer/src/styles/app.css](../../apps/desktop/src/renderer/src/styles/app.css)
+- **shadcn/ui theming:** https://ui.shadcn.com/docs/theming
+- **Tailwind CSS theme variables:** https://tailwindcss.com/docs/theme
+- **Radix Themes color:** https://www.radix-ui.com/themes/docs/theme/color
+- **Radix Colors usage:** https://www.radix-ui.com/colors/docs/overview/usage
+- **WCAG contrast minimum:** https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum
+- **WCAG non-text contrast:** https://www.w3.org/WAI/WCAG21/understanding/non-text-contrast.html
+- **WCAG use of color:** https://www.w3.org/WAI/WCAG22/Understanding/use-of-color


### PR DESCRIPTION
## Summary

Adds the Tangerine Terminal visual system for the desktop renderer: a black-first shell with warm white reading text, neutral gray metadata, and tangerine used as a sparse signal for active, focus, selected, and workflow states.

## What Changed

- Replaced the desktop style guide's chartreuse control-room direction with the Tangerine Terminal palette and accent discipline.
- Updated renderer CSS tokens and major shell surfaces across sidebar, thread rows, transcript panels, composer controls, chips, buttons, focus rings, and workflow states.
- Added non-color cues for thread row thinking and needs-attention states so status does not rely only on accent color.
- Added a theme contract test for semantic tokens, contrast thresholds, unresolved CSS variables, and old chartreuse literal leakage.
- Added an Electron replay-backed visual guard that checks computed colors, contrast, focus rings, narrow layout readability, approval state cues, and screenshot artifacts.

## Verification

- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/tangerine-terminal-theme.spec.ts`
- `git diff --check`

The visual E2E guard writes local screenshot artifacts for the wide shell and narrow approval state when run.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a renderer styling, documentation, and test-coverage change with no backend contracts, persistence changes, runtime config, or production service behavior changes.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (Codex context, medium reasoning) via [Codex](https://openai.com/codex)