### PR TITLE
ci(desktop): try e2e without Playwright install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
   desktop-e2e:
     name: Desktop E2E
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
-      options: --user 1001
     needs: install-deps
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
   desktop-e2e:
     name: Desktop E2E
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --user 1001
     needs: install-deps
     timeout-minutes: 20
     steps:
@@ -84,9 +87,6 @@ jobs:
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
-
-      - name: Install Playwright Linux dependencies
-        run: pnpm --filter @pwragnt/desktop exec playwright install --with-deps
 
       - name: Run desktop replay-backed Electron tests
         run: xvfb-run --auto-servernum pnpm run test:desktop-e2e


### PR DESCRIPTION
Tests whether the desktop E2E job can run on the normal `ubuntu-latest` runner without the expensive `playwright install --with-deps` step.

The previous Playwright-container experiment passed but did not improve wall-clock time after Docker image setup and the slower/broken `node_modules` cache restore path. This revision keeps the hosted runner and removes only the Playwright browser/system dependency install step, since the suite launches Electron via Playwright rather than Playwright-managed Chromium, Firefox, or WebKit projects.

What this PR should tell us:

| Outcome | Meaning |
|---|---|
| Desktop E2E passes and job time drops | The install step was unnecessary for Electron on `ubuntu-latest`; this is the keeper. |
| Desktop E2E fails with missing shared libraries | Next experiment should be `playwright install-deps` or `playwright install-deps chromium` to install OS deps without downloading browsers. |
| Job time is unchanged | The Playwright install step was not the current bottleneck after cache behavior changed. |

Validation so far: `git diff --check` passed and `.github/workflows/ci.yml` parses as YAML locally. The real validation is this PR's GitHub Actions run.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)