### PR TITLE
fix(desktop): show Grok turn status updates

### DIFF
--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -14,6 +14,12 @@ import { GrokAppServerClient } from "../grok-app-server/client";
 import { ProtocolCaptureStore } from "../testing/capture-store";
 import { createProtocolCaptureObserver } from "../testing/protocol-capture";
 
+async function flushAsync(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("GrokAppServerClient", () => {
   it("lists threads, reads replay, and forwards turn notifications", async () => {
     const provider = new FakeProvider();
@@ -152,6 +158,42 @@ describe("GrokAppServerClient", () => {
       },
     });
     expect(notifications).toContain("turn/completed");
+    expect(notifications).toContain("turn/started");
+
+    unsubscribe();
+    await client.close();
+  });
+
+  it("fails a Grok turn that resolves without assistant text", async () => {
+    const provider = new FakeProvider();
+    const server = new CodexAppServer({
+      provider,
+      threadIdGenerator: () => "thread-1",
+      runIdGenerator: () => "turn-1",
+    });
+    const client = new GrokAppServerClient({ server });
+    const notifications: string[] = [];
+    const unsubscribe = client.onNotification((notification) => {
+      notifications.push(notification.method);
+    });
+
+    await client.startThread({ cwd: "/repo/workspace", model: "grok-4.20-reasoning" });
+    const startedTurn = await client.startTurn({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Return a visible answer" }],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "",
+      providerResponseId: "resp_empty",
+    });
+    await flushAsync();
+
+    expect(startedTurn).toEqual({ threadId: "thread-1", runId: "turn-1" });
+    expect(notifications).toEqual(["turn/started", "turn/failed"]);
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      lastUserMessage: "Return a visible answer",
+      lastAssistantMessage: undefined,
+    });
 
     unsubscribe();
     await client.close();

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -30,10 +30,91 @@ import {
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   BACKEND_LIST_CHANNEL,
 } from "../../shared/ipc";
+import { getMainLogger } from "../log";
 
 let unsubscribeRegistryEvents: (() => void) | undefined;
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+const appServerLog = getMainLogger("pwragnt:app-server");
+
+function logDebug(event: string, payload: Record<string, unknown>): void {
+  if (!isDevelopment) {
+    return;
+  }
+
+  appServerLog.info(event, payload);
+}
+
+function summarizeTurnInput(input: StartTurnRequest["input"]): Record<string, unknown> {
+  const textChars = input
+    .filter((item): item is Extract<StartTurnRequest["input"][number], { type: "text" }> =>
+      item.type === "text"
+    )
+    .reduce((count, item) => count + item.text.length, 0);
+  const imageCount = input.filter((item) => item.type !== "text").length;
+
+  return {
+    inputCount: input.length,
+    textChars,
+    imageCount,
+  };
+}
+
+function summarizeAgentEvent(event: AgentEvent): Record<string, unknown> | undefined {
+  const params = event.notification.params;
+  const turn =
+    "turn" in params && typeof params.turn === "object" && params.turn !== null
+      ? (params.turn as Record<string, unknown>)
+      : undefined;
+  const threadId =
+    "threadId" in params && typeof params.threadId === "string"
+      ? params.threadId
+      : undefined;
+  const runId =
+    "runId" in params && typeof params.runId === "string"
+      ? params.runId
+      : undefined;
+
+  if (!event.notification.method.startsWith("turn/")) {
+    return undefined;
+  }
+
+  const summary: Record<string, unknown> = {
+    backend: event.backend,
+    method: event.notification.method,
+    threadId: threadId ?? null,
+    runId: runId ?? null,
+  };
+
+  if (event.notification.method === "turn/completed") {
+    const output = Array.isArray(turn?.output) ? turn.output : [];
+    summary.outputTextChars = output.reduce((count, item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return count;
+      }
+
+      const text = (item as Record<string, unknown>).text;
+      return typeof text === "string" ? count + text.length : count;
+    }, 0);
+  }
+
+  if (event.notification.method === "turn/failed") {
+    const error =
+      turn?.error && typeof turn.error === "object" && !Array.isArray(turn.error)
+        ? (turn.error as Record<string, unknown>)
+        : undefined;
+    summary.error = typeof error?.message === "string" ? error.message : null;
+  }
+
+  return summary;
+}
+
 function broadcastAgentEvent(event: AgentEvent): void {
+  const eventSummary = summarizeAgentEvent(event);
+  if (eventSummary) {
+    logDebug("agentEvent", eventSummary);
+  }
+
   for (const window of BrowserWindow.getAllWindows()) {
     if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
       continue;
@@ -84,7 +165,32 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: StartTurnRequest
     ): Promise<StartTurnResponse> => {
-      return await registry.startTurn(request);
+      logDebug("startTurn", {
+        backend: request.backend,
+        threadId: request.threadId,
+        model: request.model ?? null,
+        reasoningEffort: request.reasoningEffort ?? null,
+        serviceTier: request.serviceTier ?? null,
+        fastMode: request.fastMode ?? null,
+        ...summarizeTurnInput(request.input),
+      });
+
+      try {
+        const response = await registry.startTurn(request);
+        logDebug("startTurnResult", {
+          backend: response.backend,
+          threadId: response.threadId,
+          runId: response.runId,
+        });
+        return response;
+      } catch (error) {
+        appServerLog.error("startTurn failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
     },
   );
 
@@ -95,7 +201,23 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: InterruptTurnRequest
     ): Promise<InterruptTurnResponse> => {
-      return await registry.interruptTurn(request);
+      logDebug("interruptTurn", {
+        backend: request.backend,
+        threadId: request.threadId,
+        runId: request.runId,
+      });
+
+      try {
+        return await registry.interruptTurn(request);
+      } catch (error) {
+        appServerLog.error("interruptTurn failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          runId: request.runId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
     },
   );
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -900,6 +900,92 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeRunId).toBeUndefined();
   });
 
+  it("surfaces failed turn errors in the transcript state", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              runId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "in_progress",
+              },
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.activeRunId).toBe("turn-1");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/failed",
+            params: {
+              threadId: "thread-1",
+              runId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "failed",
+                error: {
+                  message: "Provider completed the turn without assistant text.",
+                },
+              },
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.activeRunId).toBeUndefined();
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.error).toBe("Provider completed the turn without assistant text.");
+  });
+
   it("surfaces command execution approval requests from app-server events", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -660,10 +660,29 @@ export function useThreadSessionState(params: {
           };
         }
 
-        if (
-          event.notification.method === "turn/failed" ||
-          event.notification.method === "turn/cancelled"
-        ) {
+        if (event.notification.method === "turn/failed") {
+          const errorMessage =
+            typeof event.notification.params.turn.error?.message === "string" &&
+            event.notification.params.turn.error.message.trim()
+              ? event.notification.params.turn.error.message
+              : "Turn failed.";
+
+          return {
+            ...current,
+            activeRunId: undefined,
+            completionHydrationRetries: 0,
+            error: errorMessage,
+            expectOwnUpdate: false,
+            lastTouchedAt: nextLastTouchedAt,
+            needsHydrationAfterCompletion: false,
+            pendingAssistantMessage: undefined,
+            pendingRequest: undefined,
+            pendingUserInput: undefined,
+            pendingStatusText: undefined,
+          };
+        }
+
+        if (event.notification.method === "turn/cancelled") {
           return {
             ...current,
             activeRunId: undefined,

--- a/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
@@ -28,6 +28,17 @@ describe("Codex turn lifecycle", () => {
     ]);
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "turn/completed",
         params: {
           threadId: "thread-1",
@@ -135,6 +146,17 @@ describe("Codex turn lifecycle", () => {
     expect(provider.runs[0]?.interrupted).toBe(true);
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "turn/cancelled",
         params: {
           threadId: "thread-1",
@@ -162,6 +184,17 @@ describe("Codex turn lifecycle", () => {
 
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "turn/failed",
         params: {
           threadId: "thread-1",
@@ -171,6 +204,50 @@ describe("Codex turn lifecycle", () => {
             status: "failed",
             error: {
               message: "Unauthorized",
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("fails the turn when the provider resolves without assistant text", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Return something visible" }],
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "",
+      providerResponseId: "resp_empty",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notifications).toEqual([
+      {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error: {
+              message: "Provider completed the turn without assistant text.",
             },
           },
         },

--- a/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
@@ -54,6 +54,17 @@ describe("Codex turn progress", () => {
 
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "item/started",
         params: {
           threadId: "thread-1",
@@ -63,6 +74,11 @@ describe("Codex turn progress", () => {
             type: "plan",
             text: undefined,
             review: undefined,
+            command: undefined,
+            commandAction: undefined,
+            toolName: undefined,
+            success: undefined,
+            arguments: undefined,
           },
         },
       },
@@ -102,6 +118,11 @@ describe("Codex turn progress", () => {
             type: "plan",
             text: "- inspect the code",
             review: undefined,
+            command: undefined,
+            commandAction: undefined,
+            toolName: undefined,
+            success: undefined,
+            arguments: undefined,
           },
         },
       },

--- a/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
+++ b/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
@@ -137,6 +137,17 @@ describe("OpenClaw compatibility sequences", () => {
     expect(startedTurn).toEqual({ threadId: "thread-1", runId: "turn-1" });
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "item/started",
         params: {
           threadId: "thread-1",
@@ -147,6 +158,10 @@ describe("OpenClaw compatibility sequences", () => {
             text: "search_code",
             toolName: "search_code",
             arguments: { query: "tool usage" },
+            review: undefined,
+            command: undefined,
+            commandAction: undefined,
+            success: undefined,
           },
         },
       },
@@ -162,6 +177,8 @@ describe("OpenClaw compatibility sequences", () => {
             toolName: "search_code",
             success: true,
             arguments: { query: "tool usage" },
+            review: undefined,
+            command: undefined,
             commandAction: "search",
           },
         },
@@ -341,6 +358,17 @@ describe("OpenClaw compatibility sequences", () => {
       lastAssistantMessage: "Shipped.",
     });
     expect(notifications).toEqual([
+      {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
       {
         method: "turn/completed",
         params: {

--- a/packages/agent-core/src/__tests__/pending-input.test.ts
+++ b/packages/agent-core/src/__tests__/pending-input.test.ts
@@ -54,6 +54,17 @@ describe("Codex pending input", () => {
       expect(provider.runs[0]?.eventResponses).toEqual([{ decision: "approve" }]);
       expect(notifications).toEqual([
         {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            runId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "in_progress",
+            },
+          },
+        },
+        {
           method: "serverRequest/resolved",
           params: {
             threadId: "thread-1",
@@ -182,6 +193,17 @@ describe("Codex pending input", () => {
     expect(provider.runs[0]?.eventResponses).toEqual([{ decision: "cancel" }]);
     expect(notifications).toEqual([
       {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
+      {
         method: "serverRequest/resolved",
         params: {
           threadId: "thread-1",
@@ -252,6 +274,17 @@ describe("Codex pending input", () => {
       { decision: "cancel" },
     ]);
     expect(notifications).toEqual([
+      {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          runId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "in_progress",
+          },
+        },
+      },
       {
         method: "serverRequest/resolved",
         params: {

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -309,15 +309,26 @@ export class CodexAppServer {
           }) ?? thread
         : thread;
     const normalizedInput = normalizeTurnInput(params.input);
+    const runId = this.createRunId();
     const handle = await this.provider.startTurn({
       thread: effectiveThread,
       input: normalizedInput,
       previousResponseId: this.state.getPreviousResponseId(threadId),
       tools: this.toolExecutor,
     });
-    const runId = this.createRunId();
     this.state.appendInput(threadId, normalizedInput);
     this.state.createRun({ runId, threadId, handle });
+    await this.emit({
+      method: "turn/started",
+      params: {
+        threadId,
+        runId,
+        turn: {
+          id: runId,
+          status: "in_progress",
+        },
+      },
+    });
     this.turnRunner.attach({ threadId, runId, handle });
     return { threadId, runId };
   }

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -175,6 +175,17 @@ export type AppServerTurnResult = {
 
 export type AppServerNotification =
   | {
+      method: "turn/started";
+      params: {
+        threadId: string;
+        runId?: string;
+        turn: {
+          id: string;
+          status?: string;
+        };
+      };
+    }
+  | {
       method: "turn/completed";
       params: {
         threadId: string;

--- a/packages/agent-core/src/app-server/turn-runner.ts
+++ b/packages/agent-core/src/app-server/turn-runner.ts
@@ -203,8 +203,18 @@ export class TurnRunner {
     runId: string,
     result: ProviderTurnResult,
   ): Promise<void> {
+    const assistantText = result.assistantText?.trim() ?? "";
+    if (!assistantText) {
+      await this.failDefaultTurn(
+        threadId,
+        runId,
+        new Error("Provider completed the turn without assistant text."),
+      );
+      return;
+    }
+
     this.state.completeRun(runId);
-    this.state.appendAssistant(threadId, result.assistantText ?? "");
+    this.state.appendAssistant(threadId, assistantText);
     this.state.setPreviousResponseId(threadId, result.providerResponseId);
     await this.emit({
       method: "turn/completed",
@@ -217,7 +227,7 @@ export class TurnRunner {
           output: [
             {
               type: "text",
-              text: result.assistantText ?? "",
+              text: assistantText,
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Emit `turn/started` for in-process Grok app-server turns so the renderer receives the active run id immediately.
- Treat empty assistant completions as `turn/failed` instead of silently completing with no response.
- Surface failed-turn messages in transcript state and add development logs for turn start/result/interrupt and lifecycle events.
- Add focused coverage for Grok start notifications, empty-response failures, renderer failed-turn state, and updated app-server lifecycle ordering.

## Why
Grok turns could appear as unread user-only threads without Thinking indicators or a Stop button because the renderer was not consistently getting a started event/run id. Empty provider completions also looked successful, leaving no assistant response and no visible error.

## Verification
- `pnpm typecheck`
- `pnpm test`
