### PR TITLE
refactor(agent-core): stream Grok tool process output

### DIFF
--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -336,6 +336,85 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves Grok messages when replay items only contain tool activity", async () => {
+    const server = {
+      request: async (method: string): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            serverInfo: { name: "@pwragnt/grok-app-server", version: "1.0.0" },
+            methods: ["thread/read"],
+          };
+        }
+        if (method === "thread/read") {
+          return {
+            messages: [
+              { role: "user", text: "Find the code" },
+              { role: "assistant", text: "Found it." },
+            ],
+            items: [
+              {
+                id: "search-1",
+                type: "dynamicToolCall",
+                status: "completed",
+                toolName: "search_code",
+                commandAction: "search",
+                arguments: { path: "src" },
+                success: true,
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+      notify: async () => undefined,
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [
+        {
+          type: "message",
+          role: "user",
+          text: "Find the code",
+        },
+        {
+          type: "activity",
+          summary: "Explored 1 item",
+          details: [
+            {
+              kind: "read",
+              label: "Searched src",
+              path: "src",
+              status: "completed",
+            },
+          ],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          text: "Found it.",
+        },
+      ],
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          text: "Find the code",
+        },
+        {
+          id: "message-2",
+          role: "assistant",
+          text: "Found it.",
+        },
+      ],
+      lastUserMessage: "Find the code",
+      lastAssistantMessage: "Found it.",
+    });
+
+    await client.close();
+  });
+
   it("preserves the full Grok message sequence when last-message summaries are also present", async () => {
     const provider = new FakeProvider();
     const server = new CodexAppServer({

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -182,6 +182,27 @@ describe("GrokAppServerClient", () => {
       threadId: "thread-1",
       input: [{ type: "text", text: "Return a visible answer" }],
     });
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        toolName: "search_code",
+        arguments: { query: "needle" },
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_completed",
+      item: {
+        id: "tool-1",
+        type: "dynamicToolCall",
+        text: "No matches.",
+        toolName: "search_code",
+        success: true,
+        arguments: { query: "needle" },
+        commandAction: "search",
+      },
+    });
     provider.runs[0]?.deferred.resolve({
       assistantText: "",
       providerResponseId: "resp_empty",
@@ -189,13 +210,129 @@ describe("GrokAppServerClient", () => {
     await flushAsync();
 
     expect(startedTurn).toEqual({ threadId: "thread-1", runId: "turn-1" });
-    expect(notifications).toEqual(["turn/started", "turn/failed"]);
+    expect(notifications).toEqual([
+      "turn/started",
+      "item/started",
+      "item/completed",
+      "turn/failed",
+    ]);
     await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [
+        {
+          type: "message",
+          role: "user",
+          text: "Return a visible answer",
+        },
+        {
+          type: "activity",
+          summary: "Explored 1 item",
+          details: [
+            {
+              kind: "read",
+              label: "Searched code",
+            },
+          ],
+        },
+      ],
       lastUserMessage: "Return a visible answer",
       lastAssistantMessage: undefined,
     });
 
     unsubscribe();
+    await client.close();
+  });
+
+  it("hydrates Grok tool replay items as transcript activity", async () => {
+    const server = {
+      request: async (method: string): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            serverInfo: { name: "@pwragnt/grok-app-server", version: "1.0.0" },
+            methods: ["thread/read"],
+          };
+        }
+        if (method === "thread/read") {
+          return {
+            messages: [
+              { role: "user", text: "Find the code" },
+              { role: "assistant", text: "Found it." },
+            ],
+            items: [
+              {
+                id: "user-1",
+                type: "userMessage",
+                role: "user",
+                text: "Find the code",
+              },
+              {
+                id: "search-1",
+                type: "dynamicToolCall",
+                status: "completed",
+                toolName: "search_code",
+                commandAction: "search",
+                arguments: { path: "src" },
+                success: true,
+              },
+              {
+                id: "shell-1",
+                type: "commandExecution",
+                status: "failed",
+                toolName: "shell_command",
+                command: "rg needle .",
+                commandAction: "search",
+                success: false,
+              },
+              {
+                id: "assistant-1",
+                type: "agentMessage",
+                role: "assistant",
+                text: "Found it.",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+      notify: async () => undefined,
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [
+        {
+          type: "message",
+          role: "user",
+          text: "Find the code",
+        },
+        {
+          type: "activity",
+          summary: "Explored 1 item, Ran 1 command",
+          status: "failed",
+          details: [
+            {
+              kind: "read",
+              label: "Searched src",
+              path: "src",
+              status: "completed",
+            },
+            {
+              kind: "command",
+              label: "rg needle .",
+              status: "failed",
+            },
+          ],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          text: "Found it.",
+        },
+      ],
+      lastUserMessage: "Find the code",
+      lastAssistantMessage: "Found it.",
+    });
+
     await client.close();
   });
 

--- a/apps/desktop/src/main/app-server/thread-activity.ts
+++ b/apps/desktop/src/main/app-server/thread-activity.ts
@@ -1,0 +1,184 @@
+import path from "node:path";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadActivityStatus,
+} from "@pwragnt/shared";
+
+export function summarizeToolActivityItems(
+  items: Record<string, unknown>[],
+  createdAt?: number,
+): AppServerThreadActivityEntry | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  const details: AppServerThreadActivityDetail[] = [];
+  let inspected = 0;
+  let commands = 0;
+  let writes = 0;
+  let status: AppServerThreadActivityStatus | undefined;
+
+  for (const item of items) {
+    const itemId = pickString(item, ["id", "itemId", "item_id"]) ?? `activity-${details.length + 1}`;
+    const itemStatus = normalizeActivityStatus(item);
+    if (itemStatus === "failed") {
+      status = "failed";
+    } else if (!status) {
+      status = itemStatus;
+    }
+
+    const itemType = pickString(item, ["type"]);
+    const toolName = pickString(item, ["toolName", "tool_name", "name"]);
+    const commandAction = pickString(item, ["commandAction", "command_action"]);
+    const command = pickString(item, ["command"]);
+
+    if (itemType === "commandExecution") {
+      commands += 1;
+      details.push({
+        id: itemId,
+        kind: "command",
+        label: formatCommandLabel(command),
+        status: itemStatus,
+      });
+      continue;
+    }
+
+    if (toolName === "read_file" || commandAction === "read") {
+      inspected += 1;
+      const filePath = extractPath(item);
+      details.push({
+        id: itemId,
+        kind: "read",
+        label: `Read ${formatPathName(filePath)}`,
+        path: filePath,
+        status: itemStatus,
+      });
+      continue;
+    }
+
+    if (toolName === "search_code" || commandAction === "search") {
+      inspected += 1;
+      const filePath = extractPath(item);
+      details.push({
+        id: itemId,
+        kind: "read",
+        label: filePath ? `Searched ${formatPathName(filePath)}` : "Searched code",
+        path: filePath,
+        status: itemStatus,
+      });
+      continue;
+    }
+
+    if (toolName === "list_files" || commandAction === "listFiles") {
+      inspected += 1;
+      const filePath = extractPath(item);
+      details.push({
+        id: itemId,
+        kind: "read",
+        label: filePath ? `Listed ${formatPathName(filePath)}` : "Listed files",
+        path: filePath,
+        status: itemStatus,
+      });
+      continue;
+    }
+
+    if (toolName === "write_file" || toolName === "edit_file") {
+      writes += 1;
+      const filePath = extractPath(item);
+      details.push({
+        id: itemId,
+        kind: "write",
+        label: `${toolName === "edit_file" ? "Edited" : "Wrote"} ${formatPathName(filePath)}`,
+        path: filePath,
+        status: itemStatus,
+      });
+      continue;
+    }
+  }
+
+  if (details.length === 0) {
+    return undefined;
+  }
+
+  const summaryParts: string[] = [];
+  if (inspected > 0) {
+    summaryParts.push(`Explored ${inspected} item${inspected === 1 ? "" : "s"}`);
+  }
+  if (commands > 0) {
+    summaryParts.push(`Ran ${commands} command${commands === 1 ? "" : "s"}`);
+  }
+  if (writes > 0) {
+    summaryParts.push(`Edited ${writes} file${writes === 1 ? "" : "s"}`);
+  }
+
+  return {
+    type: "activity",
+    id: `activity-${pickString(items[0] ?? {}, ["id", "itemId", "item_id"]) ?? "1"}`,
+    summary: summaryParts.length > 0
+      ? summaryParts.join(", ")
+      : `Recorded ${details.length} activity item${details.length === 1 ? "" : "s"}`,
+    createdAt,
+    status,
+    details,
+  };
+}
+
+function normalizeActivityStatus(
+  item: Record<string, unknown>,
+): AppServerThreadActivityStatus | undefined {
+  const status = pickString(item, ["status"]);
+  if (status === "failed" || item.success === false) {
+    return "failed";
+  }
+  if (status === "completed" || item.success === true) {
+    return "completed";
+  }
+  if (status === "in_progress") {
+    return "in_progress";
+  }
+  return undefined;
+}
+
+function extractPath(item: Record<string, unknown>): string | undefined {
+  const directPath = pickString(item, ["path"]);
+  if (directPath) {
+    return directPath;
+  }
+  const args = asRecord(item.arguments);
+  return pickString(args ?? {}, ["path"]);
+}
+
+function formatPathName(filePath: string | undefined): string {
+  if (!filePath) {
+    return "file";
+  }
+  return path.basename(filePath) || filePath;
+}
+
+function formatCommandLabel(command: string | undefined): string {
+  const collapsed = command?.replace(/\s+/g, " ").trim();
+  if (!collapsed) {
+    return "Ran command";
+  }
+  return collapsed.length > 72 ? `${collapsed.slice(0, 69)}...` : collapsed;
+}
+
+function pickString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -23,6 +23,7 @@ import type {
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
 import type { JsonRpcObserver } from "../codex-app-server/json-rpc";
+import { summarizeToolActivityItems } from "../app-server/thread-activity";
 
 const DEFAULT_PROTOCOL_VERSION = "1.0";
 
@@ -206,9 +207,24 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     lastUserMessage?: unknown;
     lastAssistantMessage?: unknown;
     messages?: Array<{ role?: unknown; text?: unknown }>;
+    items?: unknown[];
   };
 
   const rawMessages = Array.isArray(record.messages) ? record.messages : [];
+  const rawItems = Array.isArray(record.items)
+    ? record.items
+        .map((item) =>
+          item && typeof item === "object" && !Array.isArray(item)
+            ? (item as Record<string, unknown>)
+            : undefined
+        )
+        .filter((item): item is Record<string, unknown> => item !== undefined)
+    : [];
+  const replayFromItems = extractReplayFromItems(rawItems, pagination);
+  if (replayFromItems) {
+    return replayFromItems;
+  }
+
   if (rawMessages.length === 0) {
     const fallbackMessages = [
       typeof record.lastUserMessage === "string"
@@ -306,6 +322,101 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     lastAssistantMessage,
     pagination,
   };
+}
+
+function extractReplayFromItems(
+  items: Record<string, unknown>[],
+  pagination: AppServerThreadReplay["pagination"],
+): AppServerThreadReplay | undefined {
+  if (!items.some(isActivityReplayItem)) {
+    return undefined;
+  }
+
+  const entries: AppServerThreadEntry[] = [];
+  const messages: Array<{ id: string; role: "user" | "assistant"; text: string }> = [];
+  let pendingActivity: Record<string, unknown>[] = [];
+  let messageIndex = 0;
+
+  const flushActivity = () => {
+    const activity = summarizeToolActivityItems(pendingActivity);
+    pendingActivity = [];
+    if (activity) {
+      entries.push(activity);
+    }
+  };
+
+  for (const item of items) {
+    const message = itemToMessage(item, ++messageIndex);
+    if (message) {
+      flushActivity();
+      entries.push({
+        type: "message",
+        ...message,
+      });
+      messages.push(message);
+      continue;
+    }
+    messageIndex -= 1;
+    if (isActivityReplayItem(item)) {
+      pendingActivity.push(item);
+    }
+  }
+  flushActivity();
+
+  let lastUserMessage: string | undefined;
+  let lastAssistantMessage: string | undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!lastUserMessage && message?.role === "user") {
+      lastUserMessage = message.text;
+    }
+    if (!lastAssistantMessage && message?.role === "assistant") {
+      lastAssistantMessage = message.text;
+    }
+    if (lastUserMessage && lastAssistantMessage) {
+      break;
+    }
+  }
+
+  return {
+    entries,
+    messages,
+    lastUserMessage,
+    lastAssistantMessage,
+    pagination,
+  };
+}
+
+function itemToMessage(
+  item: Record<string, unknown>,
+  index: number,
+): { id: string; role: "user" | "assistant"; text: string } | undefined {
+  const type = typeof item.type === "string" ? item.type : undefined;
+  const role =
+    item.role === "user" || type === "userMessage"
+      ? "user"
+      : item.role === "assistant" || type === "agentMessage"
+        ? "assistant"
+        : undefined;
+  const text = typeof item.text === "string" ? item.text : undefined;
+  if (!role || !text) {
+    return undefined;
+  }
+  return {
+    id: `message-${index}`,
+    role,
+    text,
+  };
+}
+
+function isActivityReplayItem(item: Record<string, unknown>): boolean {
+  const type = typeof item.type === "string" ? item.type : undefined;
+  const toolName = typeof item.toolName === "string" ? item.toolName : undefined;
+  return (
+    type === "dynamicToolCall" ||
+    type === "commandExecution" ||
+    Boolean(toolName)
+  );
 }
 
 function extractThreadId(value: unknown): string | undefined {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -82,6 +82,12 @@ type SkillCatalogEntry = {
   skills: AppServerSkillSummary[];
 };
 
+type ReplayMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
 function normalizeThreadSummary(thread: RawThreadSummary): RawThreadSummary {
   const normalizedTitleSource = normalizeTitleSource(thread.titleSource);
   const normalizedRawTitle = thread.title?.trim();
@@ -211,6 +217,7 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
   };
 
   const rawMessages = Array.isArray(record.messages) ? record.messages : [];
+  const messages = normalizeRawMessages(rawMessages);
   const rawItems = Array.isArray(record.items)
     ? record.items
         .map((item) =>
@@ -222,53 +229,57 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     : [];
   const replayFromItems = extractReplayFromItems(rawItems, pagination);
   if (replayFromItems) {
-    return replayFromItems;
+    if (replayFromItems.messages.length > 0 || messages.length === 0) {
+      return replayFromItems;
+    }
+    return buildReplayFromMessages(messages, pagination, activityEntries(replayFromItems));
+  }
+
+  if (messages.length > 0) {
+    return buildReplayFromMessages(messages, pagination);
   }
 
   if (rawMessages.length === 0) {
-    const fallbackMessages = [
-      typeof record.lastUserMessage === "string"
-        ? {
-            id: "message-1",
-            role: "user" as const,
-            text: record.lastUserMessage,
-          }
-        : undefined,
-      typeof record.lastAssistantMessage === "string"
-        ? {
-            id:
-              typeof record.lastUserMessage === "string"
-                ? "message-2"
-                : "message-1",
-            role: "assistant" as const,
-            text: record.lastAssistantMessage,
-          }
-        : undefined,
-    ].filter((message): message is { id: string; role: "user" | "assistant"; text: string } =>
-      Boolean(message)
-    );
-
+    const fallbackMessages = fallbackLastMessages(record);
     if (fallbackMessages.length > 0) {
-      return {
-        entries: fallbackMessages.map((message) => ({
-          type: "message" as const,
-          ...message,
-        })),
-        messages: fallbackMessages,
-        lastUserMessage:
-          typeof record.lastUserMessage === "string"
-            ? record.lastUserMessage
-            : undefined,
-        lastAssistantMessage:
-          typeof record.lastAssistantMessage === "string"
-            ? record.lastAssistantMessage
-            : undefined,
-        pagination,
-      };
+      return buildReplayFromMessages(fallbackMessages, pagination);
     }
   }
 
-  const messages = rawMessages.flatMap((message, index) => {
+  return buildReplayFromMessages([], pagination);
+}
+
+function fallbackLastMessages(record: {
+  lastUserMessage?: unknown;
+  lastAssistantMessage?: unknown;
+}): ReplayMessage[] {
+  return [
+    typeof record.lastUserMessage === "string"
+      ? {
+          id: "message-1",
+          role: "user" as const,
+          text: record.lastUserMessage,
+        }
+      : undefined,
+    typeof record.lastAssistantMessage === "string"
+      ? {
+          id:
+            typeof record.lastUserMessage === "string"
+              ? "message-2"
+              : "message-1",
+          role: "assistant" as const,
+          text: record.lastAssistantMessage,
+        }
+      : undefined,
+  ].filter((message): message is ReplayMessage =>
+    Boolean(message)
+  );
+}
+
+function normalizeRawMessages(
+  rawMessages: Array<{ role?: unknown; text?: unknown }>,
+): ReplayMessage[] {
+  return rawMessages.flatMap((message, index) => {
     if (!message || typeof message !== "object") {
       return [];
     }
@@ -290,24 +301,41 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
       },
     ];
   });
-  const entries: AppServerThreadEntry[] = messages.map((message) => ({
-    type: "message",
-    ...message,
-  }));
+}
+
+function buildReplayFromMessages(
+  messages: ReplayMessage[],
+  pagination: AppServerThreadReplay["pagination"],
+  activityEntries: AppServerThreadEntry[] = [],
+): AppServerThreadReplay {
+  const entries: AppServerThreadEntry[] = [];
+  const lastUserIndex = messages.findLastIndex((message) => message.role === "user");
+  let insertedActivity = false;
+
+  for (const [index, message] of messages.entries()) {
+    entries.push({
+      type: "message",
+      ...message,
+    });
+    if (index === lastUserIndex) {
+      entries.push(...activityEntries);
+      insertedActivity = true;
+    }
+  }
+
+  if (!insertedActivity) {
+    entries.push(...activityEntries);
+  }
 
   let lastUserMessage: string | undefined;
   let lastAssistantMessage: string | undefined;
 
-  for (let index = rawMessages.length - 1; index >= 0; index -= 1) {
-    const message = rawMessages[index];
-    if (!lastUserMessage && message?.role === "user" && typeof message.text === "string") {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!lastUserMessage && message?.role === "user") {
       lastUserMessage = message.text;
     }
-    if (
-      !lastAssistantMessage &&
-      message?.role === "assistant" &&
-      typeof message.text === "string"
-    ) {
+    if (!lastAssistantMessage && message?.role === "assistant") {
       lastAssistantMessage = message.text;
     }
     if (lastUserMessage && lastAssistantMessage) {
@@ -322,6 +350,10 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
     lastAssistantMessage,
     pagination,
   };
+}
+
+function activityEntries(replay: AppServerThreadReplay): AppServerThreadEntry[] {
+  return replay.entries.filter((entry) => entry.type === "activity");
 }
 
 function extractReplayFromItems(

--- a/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
+++ b/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
@@ -1,0 +1,464 @@
+---
+title: "refactor: Codex-style exec and search runtime"
+type: refactor
+status: active
+date: 2026-04-20
+---
+
+# refactor: Codex-style exec and search runtime
+
+## Overview
+
+Replace the current buffered Grok tool execution paths with a shared process runtime that behaves like Codex: spawn commands, continuously drain stdout/stderr, stream bounded output events, retain only capped diagnostic output, and let search/list tools stop once their requested limits are satisfied. This plan builds on the existing Grok tool loop, but hardens the exec/search primitives so broad `rg`, `rg --files`, and shell commands do not fail merely because stdout crosses a Node `maxBuffer`.
+
+## Problem Frame
+
+Grok mode now has model-visible tools and app-server turn lifecycle events, but the execution layer still mixes Codex-like semantics with Node buffered process APIs. That mismatch caused the observed failure mode: a broad `search_code` call could produce enough ripgrep output to hit `stdout maxBuffer length exceeded`, then the model repeatedly retried until the Grok tool loop hit its max round limit. The same class of bug still exists in other tool paths.
+
+Current state:
+
+- A prior local investigation demonstrated a spawn-based `search_code` fix that stopped once the requested match limit was reached; implementation should recreate that behavior in the active checkout.
+- `packages/agent-core/src/tools/list-files-tool.ts` still uses `execFile("rg", ["--files", "."])` with `maxBuffer: 1024 * 1024`.
+- `packages/agent-core/src/tools/shell-command-tool.ts` still uses `exec(...)` with `maxBuffer: 10 * 1024 * 1024`.
+- `packages/agent-core/src/providers/responses-tool-loop.ts` emits tool start/completion events, but it does not expose command output deltas from running tools.
+- `packages/shared/src/contracts/app-server.ts` already defines `item/commandExecution/outputDelta`, and the desktop hook has tests proving unrelated output deltas must not disturb thinking state, but Grok does not emit those deltas.
+- `apps/desktop/src/main/grok-app-server/client.ts` converts Grok `thread/read` mostly from `messages`, so persisted Grok `items` are not yet surfaced as desktop activity entries.
+
+The target is not to copy Codex wholesale. The target is to take Codex's process-output invariants and apply them to the smaller PwrAgnt/Grok tool surface.
+
+## Requirements Trace
+
+- R1. No first-party Grok process-backed tool should fail solely because stdout/stderr exceeded a Node `exec` or `execFile` buffer.
+- R2. Foreground shell execution must continuously drain stdout and stderr until process exit, timeout, cancellation, or an intentional tool limit.
+- R3. `search_code` and `list_files` must be ripgrep-first, bounded, and able to return early without reading all output into memory.
+- R4. Shell command results must retain a capped final output summary while optionally streaming live deltas for UI/debugging.
+- R5. Output caps must be explicit and testable. The default retained-output cap should mirror Codex's 1 MiB default unless a tool has a tighter semantic limit.
+- R6. Existing approval behavior and command classification must remain intact: read-only searches/listing can auto-run under guarded settings, while unsafe or mutating commands still require approval.
+- R7. Grok rollout files must remain useful for debugging. Persisted items should record command/tool status, summary output, command action, and truncation/cap metadata without writing unbounded logs.
+- R8. Desktop should be able to render Grok tool/search activity from `thread/read` similarly to Codex activity entries.
+
+## Scope Boundaries
+
+- In scope: `packages/agent-core` tool process execution, search/list tools, shell command tool, app-server notifications, and Grok rollout item persistence.
+- In scope: desktop Grok `thread/read` conversion so persisted tool items become activity entries.
+- In scope: deterministic unit tests that reproduce broad-output failures before fixing them.
+- In scope: preserving the current Grok xAI Responses tool loop and max-round guard.
+- Out of scope: replacing the xAI Responses request model with true streaming model responses.
+- Out of scope: adding background process tools in this pass. Grok CLI has a useful background-process design, but the immediate bug is foreground output handling.
+- Out of scope: implementing Codex `command/exec` as a public standalone JSON-RPC API. PwrAgnt can add that later if desktop needs direct command execution outside turns.
+- Out of scope: changing `/Users/huntharo/github/codex` or `/Users/huntharo/github/grok-cli`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/agent-core/src/providers/responses-tool-loop.ts` already runs the xAI tool loop, emits provider item events, handles approval requests, and enforces `DEFAULT_MAX_TOOL_ROUNDS = 12`.
+- `packages/agent-core/src/tools/tool-contract.ts` and `packages/agent-core/src/tools/tool-execution.ts` centralize local tool execution and normalized tool result metadata.
+- `packages/agent-core/src/tools/shell-safety.ts` already classifies `rg`, read-only `git`, `cat`, `head`, `tail`, `ls`, and `find` as safe read-only commands, with unsafe ripgrep flags requiring approval.
+- `packages/agent-core/src/app-server/turn-runner.ts` already maps provider item events into app-server notifications and persisted replay items.
+- `packages/agent-core/src/persistence/grok-rollout-store.ts` already stores durable `item` records in `rollout.jsonl`.
+- `packages/shared/src/contracts/app-server.ts` already has `item/commandExecution/outputDelta`, which should be reused rather than inventing a Grok-only notification.
+- `apps/desktop/src/main/codex-app-server/client.ts` contains the mature desktop-side activity summarization logic for Codex command and file-change items.
+- `apps/desktop/src/main/grok-app-server/client.ts` is the narrower conversion path that needs to start using Grok `items`, not just `messages`.
+
+### Codex Reference
+
+Relevant files in `/Users/huntharo/github/codex`:
+
+- `codex-rs/core/src/tools/runtimes/shell.rs`
+- `codex-rs/core/src/exec.rs`
+- `codex-rs/core/src/unified_exec/process.rs`
+- `codex-rs/core/src/unified_exec/head_tail_buffer.rs`
+- `codex-rs/app-server/src/command_exec.rs`
+
+Codex behavior to mirror:
+
+- Commands are spawned and drained incrementally, not executed through a buffered Node-style `maxBuffer`.
+- Shell output is read in chunks and output delta events are emitted while a capped final output is retained.
+- The retained cap is 1 MiB by default.
+- Long-running or high-output commands continue to drain pipes to avoid child-process back-pressure.
+- The retained output is an explicit diagnostic snapshot, not the mechanism that decides whether process execution succeeds.
+- App-server streaming has a final response separate from `outputDelta` notifications; streamed bytes are not duplicated into every final response.
+
+### Grok CLI Reference
+
+Relevant files in `/Users/huntharo/github/grok-cli`:
+
+- `src/tools/bash.ts`
+- `src/tools/file.ts`
+- `src/grok/tools.ts`
+- `src/agent/agent.ts`
+- `src/storage/transcript.ts`
+- `src/utils/file-index.ts`
+
+Useful ideas:
+
+- `BashTool` separates foreground commands from background processes and stores background output in log files with tail reads.
+- The bash tool description explicitly tells the model to prefer dedicated file tools for durable edits.
+- Tool results can carry structured metadata such as diffs, background process info, diagnostics, and media rather than only text.
+- The streaming agent path yields `tool_calls`, `tool_result`, and approval chunks as first-class turn events.
+- Transcript persistence stores tool calls and tool results separately enough to reconstruct activity.
+
+Limits of the Grok CLI reference:
+
+- Foreground `BashTool.execute` still uses `exec(...)` with `maxBuffer: 10 * 1024 * 1024`, so it should not be copied for the foreground process-output fix.
+- `src/utils/file-index.ts` uses `execSync(..., maxBuffer: 10 * 1024 * 1024)` for file indexing. That is useful as a scoring/index idea, not as a robust process-output pattern for this bug class.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist in this repository yet.
+
+### External References
+
+- External research skipped. The relevant behavior is local and repo-specific, and the strongest references are the local Codex and Grok CLI source trees.
+
+## Key Technical Decisions
+
+- Add one shared process-output primitive in `packages/agent-core`, then migrate tools onto it. Keeping caps, cancellation, timeout, stdout/stderr collection, and delta emission in one place avoids fixing `search_code` while leaving `list_files` and `shell_command` exposed to the same failure class.
+- Prefer `spawn` over `exec`/`execFile` for tool execution. The implementation should pass argv arrays for known tools (`rg`, `git`, etc.) and use a shell only for the intentionally arbitrary `shell_command` tool.
+- Retain bounded output; do not treat the cap as an error. Matching Codex, cap/truncation should affect retained diagnostic text and metadata, not process success.
+- Keep semantic limits separate from retained-output caps. `search_code.limit` and `list_files.limit` are result limits and may terminate `rg` early. The 1 MiB retained cap is for process output safety.
+- Emit output deltas only for command-style executions initially. Dedicated `search_code` and `list_files` should return concise structured results; arbitrary shell commands benefit most from live output.
+- Reuse `item/commandExecution/outputDelta` from the shared app-server contract. If additional metadata is needed, extend the existing event shape with optional stream/cap fields in a backward-compatible way.
+- Store only summarized output and cap metadata in `rollout.jsonl`. Do not persist unbounded command logs.
+- Surface Grok persisted tool items through the desktop read path. Otherwise the server may have correct rollout/debug data while the desktop transcript still looks empty after a tool-heavy turn.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should Codex-style behavior mean adding a public `command/exec` API now? No. The current failure is inside model tool execution, so the first pass should fix tool execution and notifications. Public command execution can be planned separately.
+- Should Grok CLI's foreground bash implementation be copied? No. It uses the same buffered `exec` shape that this plan is trying to remove.
+- Should `search_code` return raw ripgrep output? No. It should return structured path/line/text matches and stop at the requested result limit.
+- Should broad output be considered a failed tool call? No. Broad output should be truncated/capped and reported as such, not failed due to buffering.
+
+### Deferred to Implementation
+
+- The exact retained-output formatting for shell output: implementation should choose the smallest format that preserves stdout/stderr clarity and cap metadata without noisy UI.
+- Whether the shared process runner should preserve head+tail output immediately or start with first-N retained output and add head+tail after shell migration. The plan prefers head+tail because Codex does, but the final shape can depend on implementation complexity.
+- Whether `item/commandExecution/outputDelta` needs optional `stream` and `capReached` fields in this pass. If renderer and shared contracts can tolerate the existing delta-only form, richer metadata may be deferred.
+- Whether desktop should render live Grok command deltas immediately or only hydrate the final activity from `thread/read`. The server should emit the events either way.
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification.
+
+```mermaid
+flowchart TB
+    XAI["xAI Responses tool call"] --> LOOP["responses-tool-loop"]
+    LOOP --> EXECUTOR["LocalToolExecutor"]
+    EXECUTOR --> SEARCH["search_code"]
+    EXECUTOR --> LIST["list_files"]
+    EXECUTOR --> SHELL["shell_command"]
+    SEARCH --> RUNNER["ProcessRunner"]
+    LIST --> RUNNER
+    SHELL --> RUNNER
+    RUNNER --> BUFFER["Capped output buffer"]
+    RUNNER --> DELTA["Output delta callback"]
+    DELTA --> PROVIDER["Provider item output event"]
+    PROVIDER --> TURN["TurnRunner"]
+    TURN --> NOTIFY["item/commandExecution/outputDelta"]
+    TURN --> STATE["ThreadReplayItem in session state"]
+    STATE --> ROLLOUT["Grok rollout.jsonl"]
+    STATE --> READ["thread/read"]
+    READ --> DESKTOP["Desktop activity transcript"]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add a shared process runner**
+
+**Goal:** Create one internal process execution primitive for tool commands that continuously drains output, honors timeout/cancellation, and retains capped diagnostics without failing on output volume.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/agent-core/src/tools/process-runner.ts`
+- Test: `packages/agent-core/src/__tests__/process-runner.test.ts`
+- Modify: `packages/agent-core/src/tools/tool-contract.ts`
+
+**Approach:**
+- Use `spawn` and async stdout/stderr listeners instead of `exec`/`execFile`.
+- Support both argv execution for known tools and shell execution for `shell_command`.
+- Return exit code, signal, timeout/cancel status, retained stdout, retained stderr, aggregated output, and truncation/cap metadata.
+- Add an optional output-delta callback to the tool execution context so command tools can stream live output without coupling the runner to app-server classes.
+- Keep a default retained cap of 1 MiB, matching Codex's current default.
+- Prefer a head/tail retained buffer if implementation cost stays modest; otherwise start with capped-first-output and record truncation clearly.
+
+**Execution note:** Characterization-first. Start by writing failing tests that produce more output than old `exec`/`execFile` buffers allowed, then implement the runner.
+
+**Patterns to follow:**
+- Codex `codex-rs/core/src/exec.rs` incremental `read_output`
+- Codex `codex-rs/core/src/unified_exec/head_tail_buffer.rs`
+- Current `packages/agent-core/src/tools/tool-errors.ts`
+
+**Test scenarios:**
+- Happy path: a command that writes to stdout and stderr returns success with both streams represented in the final output.
+- Happy path: a command that emits more than 1 MiB still completes successfully and reports truncation metadata.
+- Edge case: output exactly at the retained cap is not marked truncated.
+- Edge case: output above the retained cap drains to process exit without growing retained memory beyond the cap.
+- Error path: nonzero exit returns failure metadata and retained output without throwing an unstructured process error.
+- Error path: timeout terminates the child, returns a timeout status, and does not leave listeners/timers active.
+- Error path: abort signal terminates the child and reports cancellation.
+- Integration: output-delta callback receives chunks while retained output remains capped.
+
+**Verification:**
+- Existing tools can consume the runner without duplicating process lifecycle code.
+- Tests prove high-output commands do not fail with `maxBuffer`-style errors.
+
+- [ ] **Unit 2: Move ripgrep search and file listing onto the runner**
+
+**Goal:** Make `search_code` and `list_files` robust for large repositories and broad patterns by using streaming `rg` output and semantic result limits.
+
+**Requirements:** R1, R3, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/agent-core/src/tools/search-code-tool.ts`
+- Modify: `packages/agent-core/src/tools/list-files-tool.ts`
+- Test: `packages/agent-core/src/__tests__/search-code-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/list-files-tool.test.ts`
+
+**Approach:**
+- Keep `search_code` ripgrep-first and preserve the current structured match output.
+- Keep the broad-search regression test that proves searches stop at the requested limit before stdout overflows.
+- Migrate `list_files` away from `execFileAsync("rg", ...)` to the shared runner or a runner-backed streaming adapter.
+- For `search_code`, stop the child process once the requested match count is reached.
+- For `list_files`, stop once the requested file count is reached.
+- Preserve deterministic fallback filesystem walks for environments where `rg` is missing.
+- Treat ripgrep exit code 1 as an empty search result where appropriate, not as an execution failure.
+
+**Execution note:** Test-first for `list_files`, because it still has the old `maxBuffer` shape.
+
+**Patterns to follow:**
+- Current path escape checks in `packages/agent-core/src/tools/workspace-paths.ts`
+- Current `search_code` structured output shape
+- Codex command action classification for `search` and `listFiles`
+
+**Test scenarios:**
+- Happy path: `search_code` returns path, line, and trimmed text for a fixed-string query.
+- Happy path: `list_files` returns repository-relative paths for a scoped directory.
+- Edge case: `search_code` with `limit: 5` against 30,000 matches returns five matches and `truncated: true`.
+- Edge case: `list_files` with `limit: 5` against more than 1 MiB of path output returns five files and `truncated: true`.
+- Edge case: scoped paths stay relative to the workspace root and cannot escape with `..`.
+- Error path: invalid regex returns stable invalid-argument output.
+- Error path: missing `rg` uses fallback search/list behavior.
+- Error path: `rg` failure other than no-match or intentional early stop is reported as a tool failure with retained stderr.
+
+**Verification:**
+- No `execFile` maxBuffer path remains in `search_code` or `list_files`.
+- Search/list outputs remain concise enough to feed back into the model loop.
+
+- [ ] **Unit 3: Replace shell_command with streamed process execution**
+
+**Goal:** Make arbitrary shell execution Codex-like: safe command classification remains, approvals remain, output is drained continuously, final output is capped, and command output deltas can reach the app-server layer.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/agent-core/src/tools/shell-command-tool.ts`
+- Modify: `packages/agent-core/src/tools/tool-contract.ts`
+- Test: `packages/agent-core/src/__tests__/shell-command-tool.test.ts`
+- Test: `packages/agent-core/src/__tests__/shell-safety.test.ts`
+
+**Approach:**
+- Replace Node `exec(...)` with the shared process runner in shell mode.
+- Preserve `classifyShellCommand` and approval request behavior before execution.
+- Preserve timeout and cancellation behavior, but make the runner own the child lifecycle and forced kill timer.
+- Return exit code and truncation metadata in `data`.
+- Use the output-delta callback for foreground shell output. Dedicated search/list tools should remain summarized unless future UI needs their raw deltas.
+- Keep command output formatting stable enough for existing tests while allowing clear truncation markers.
+
+**Patterns to follow:**
+- Existing `packages/agent-core/src/tools/shell-command-tool.ts` approval path
+- Existing `packages/agent-core/src/tools/shell-safety.ts` classification rules
+- Codex `ExecCapturePolicy::ShellTool` behavior
+
+**Test scenarios:**
+- Happy path: safe `rg -n NEEDLE .` runs without approval and produces command action `search`.
+- Happy path: approved unsafe command executes and records exit code 0.
+- Edge case: command emits more than the retained cap and completes without maxBuffer failure.
+- Edge case: command emits both stdout and stderr; final output distinguishes stderr without losing stdout.
+- Error path: declined approval does not run the side effect.
+- Error path: nonzero exit returns a failed tool result with retained output.
+- Error path: timeout and abort both terminate the process and return stable error codes.
+- Integration: output-delta callback receives shell output chunks before command completion.
+
+**Verification:**
+- `shell-command-tool.ts` no longer imports `exec`.
+- Shell command behavior remains approval-compatible and command-action-compatible.
+
+- [ ] **Unit 4: Wire command output deltas through provider and app-server events**
+
+**Goal:** Let command tools stream live output through the existing app-server notification contract while preserving final item completion and replay persistence.
+
+**Requirements:** R4, R7
+
+**Dependencies:** Unit 1, Unit 3
+
+**Files:**
+- Modify: `packages/agent-core/src/tools/tool-execution.ts`
+- Modify: `packages/agent-core/src/providers/provider-contract.ts`
+- Modify: `packages/agent-core/src/providers/responses-tool-loop.ts`
+- Modify: `packages/agent-core/src/app-server/protocol.ts`
+- Modify: `packages/agent-core/src/app-server/turn-runner.ts`
+- Modify: `packages/shared/src/contracts/app-server.ts`
+- Test: `packages/agent-core/src/__tests__/grok-provider-tools.test.ts`
+- Test: `packages/agent-core/src/__tests__/codex-turn-progress.test.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Approach:**
+- Add a provider event for command output deltas that carries item id, delta text, and optional stream/cap metadata.
+- In `responses-tool-loop`, pass an output-delta callback into tool execution for `shell_command` calls and emit provider delta events using the active function call id.
+- Carry bounded command metadata from `LocalToolExecutor` into completed provider/app-server items so exit code, cap status, and truncation state are available to replay and logs without reparsing output text.
+- In `TurnRunner`, translate provider deltas to `item/commandExecution/outputDelta`.
+- Append output deltas to the in-memory item only up to the retained cap or store them as separate transient UI events, depending on the runner metadata. The persisted rollout record should remain bounded.
+- Keep existing `item/started` and `item/completed` semantics unchanged so current desktop thinking/stop behavior remains stable.
+
+**Patterns to follow:**
+- Existing `item/plan/delta` handling in `packages/agent-core/src/app-server/turn-runner.ts`
+- Existing shared contract event `item/commandExecution/outputDelta`
+- Desktop test that ensures output deltas do not clear thinking state
+
+**Test scenarios:**
+- Happy path: a shell tool emits `item/started`, one or more `item/commandExecution/outputDelta`, and `item/completed` in order.
+- Happy path: completed shell tool items include bounded metadata for exit code, truncation, and retained-output cap.
+- Edge case: output delta from an unrelated backend/thread is ignored by the selected desktop session state.
+- Edge case: output delta does not clear `pendingStatusText` or `activeRunId`.
+- Error path: command failure still emits completion with `success: false` after any output deltas.
+- Error path: cancelled turn stops further output-delta emission.
+- Integration: `thread/read` after completion contains bounded command output metadata, not an unbounded stream transcript.
+
+**Verification:**
+- Grok command output can be observed live through app-server notifications.
+- Existing Codex desktop event handling is not regressed.
+
+- [ ] **Unit 5: Surface Grok tool items as desktop activity entries**
+
+**Goal:** Make Grok `thread/read` replay activity visible in the desktop transcript so tool-heavy turns do not look empty or unreadable after hydration.
+
+**Requirements:** R7, R8
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/thread-activity.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Test: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Extend `extractThreadReplay` to read `items` from Grok app-server `thread/read`.
+- Convert `dynamicToolCall` and `commandExecution` items into `AppServerThreadActivityEntry` values.
+- Extract shared activity summarization from the Codex client when it reduces duplication; otherwise keep Codex behavior unchanged and implement an equivalent Grok mapping behind the same helper contract.
+- Preserve the existing `messages` output and last user/assistant message behavior.
+- Do not require live output-delta rendering for this unit; final hydrated activity is the acceptance gate.
+
+**Patterns to follow:**
+- `summarizeActivityItems` in `apps/desktop/src/main/codex-app-server/client.ts`
+- `TranscriptActivity` rendering in `apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx`
+- Existing Grok client `extractThreadReplay`
+
+**Test scenarios:**
+- Happy path: Grok `thread/read` with a completed `search_code` item produces an activity entry labeled as search/read activity.
+- Happy path: Grok `thread/read` with a completed `shell_command` item produces a command activity detail.
+- Edge case: failed tool item produces an activity entry with failed status.
+- Edge case: malformed or unknown item shape is ignored without failing transcript hydration.
+- Integration: transcript list renders the activity entry alongside user and assistant messages.
+
+**Verification:**
+- A Grok turn that used tools has visible hydrated transcript activity after reload.
+
+- [ ] **Unit 6: Improve debug evidence for tool-loop failures**
+
+**Goal:** When a tool loop fails, make logs and rollout files explain which tool, command, cap, exit status, and round produced the failure.
+
+**Requirements:** R7
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `packages/agent-core/src/providers/responses-tool-loop.ts`
+- Modify: `packages/agent-core/src/app-server/turn-runner.ts`
+- Modify: `packages/agent-core/src/persistence/grok-rollout-store.ts`
+- Modify: `apps/desktop/src/main/grok-app-server/client.ts`
+- Test: `packages/agent-core/src/__tests__/grok-provider-tools.test.ts`
+- Test: `packages/agent-core/src/__tests__/grok-rollout-store.test.ts`
+
+**Approach:**
+- Include round index and max round count in the provider error path when the tool loop limit is exceeded.
+- Include tool name, call id, command action, exit code, and cap/truncation metadata in completed tool item data where available.
+- When a provider completes without assistant text after one or more tool calls, preserve the completed tool items and emit a failure message that distinguishes empty model output from tool execution failure.
+- Keep logs concise but structured; do not add a global "verbose mode" as part of this plan unless implementation discovers existing logging controls to hook into.
+- Ensure rollout JSONL remains parseable when optional metadata is present.
+
+**Patterns to follow:**
+- Existing `GrokRolloutStore` `item` persistence
+- Existing desktop app-server diagnostics logging in `apps/desktop/src/main/ipc/agent-ipc.ts`
+
+**Test scenarios:**
+- Happy path: completed command item round-trips through rollout persistence with exit code and truncation metadata.
+- Error path: max tool round failure names the configured max round count and leaves completed prior tool items readable.
+- Error path: empty assistant output after tool execution fails the turn with a stable diagnostic while keeping prior tool activity visible.
+- Error path: malformed rollout item metadata still produces a path-specific parse error rather than silent data loss.
+- Integration: desktop app-server logs include the backend, method, thread id, run id, and tool failure message for failed turns.
+
+**Verification:**
+- A future "tool loop exceeded" report has enough local evidence to identify whether the trigger was a command failure, empty output, repeated model behavior, or truncation.
+
+## System-Wide Impact
+
+- **Interaction graph:** xAI tool calls flow through `responses-tool-loop`, `LocalToolExecutor`, individual tools, the process runner, provider events, `TurnRunner`, app-server notifications, `GrokRolloutStore`, desktop Grok client hydration, and renderer transcript/activity state.
+- **Error propagation:** Process errors should become structured failed tool results when the model can recover, and turn failures only when the provider loop itself cannot continue.
+- **State lifecycle risks:** Output deltas are transient; replay items are durable. The implementation must avoid appending unbounded output to persisted rollout files.
+- **API surface parity:** `packages/agent-core/src/app-server/protocol.ts` and `packages/shared/src/contracts/app-server.ts` need to stay aligned for any output-delta shape changes.
+- **Integration coverage:** Unit tests need to cover runner behavior, tool behavior, provider-event sequencing, app-server event translation, rollout persistence, and desktop replay conversion.
+- **Unchanged invariants:** Existing `turn/started`, `turn/completed`, `turn/failed`, approval requests, and tool start/completion notifications should keep their current semantics.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Replacing `exec` changes shell quoting behavior | Keep `shell_command` as shell-mode execution through the user's shell or a conservative `/bin/sh -c` wrapper, and add tests for existing command strings. |
+| Live output deltas create UI churn or clear thinking state | Reuse the existing output-delta contract and keep renderer state tests focused on preserving active-run status. |
+| Persisting output deltas bloats rollout files | Persist only bounded final item metadata; treat deltas as notifications unless a capped item text summary is explicitly needed. |
+| Killing `rg` after hitting limits could be reported as failure | Runner/tool adapters should treat intentional early termination as successful truncation. |
+| Windows behavior diverges from Unix process semantics | Keep tests platform-neutral where possible and isolate shell-specific assumptions in the process runner. |
+| Shared contract and agent-core protocol drift | Update both protocol type surfaces in the same unit and add compile-time tests through existing typecheck. |
+
+## Documentation / Operational Notes
+
+- Update the existing tool-search plan status only if implementation decides to supersede or close it; this plan should stand as the hardening follow-up.
+- No user-facing documentation is required unless new desktop activity labels become visible enough to warrant release notes.
+- Rollout files remain under the Grok state root configured by `~/.config/grok-app-server/config.toml`; this plan improves their diagnostic content but does not change that storage location.
+- The adjacent protocol-parity requirements in `docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md` are context only. This plan does not attempt the broader Codex Desktop grouping/worktree parity scope.
+
+## Review Notes
+
+- Confidence check result: strengthened implementation-unit ownership for desktop activity reuse, metadata propagation, and empty-assistant-output diagnostics.
+- Document review result: coherence, feasibility, scope, and adversarial checks found no remaining P0/P1 blockers. The main residual risk is implementation discipline around bounded persistence, covered by Unit 4, Unit 6, and the risks table.
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md`
+- Adjacent protocol-parity requirements: `docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md`
+- PwrAgnt search tool: `packages/agent-core/src/tools/search-code-tool.ts`
+- PwrAgnt list tool: `packages/agent-core/src/tools/list-files-tool.ts`
+- PwrAgnt shell tool: `packages/agent-core/src/tools/shell-command-tool.ts`
+- PwrAgnt Grok tool loop: `packages/agent-core/src/providers/responses-tool-loop.ts`
+- PwrAgnt Grok desktop client: `apps/desktop/src/main/grok-app-server/client.ts`
+- Codex shell runtime: `/Users/huntharo/github/codex/codex-rs/core/src/tools/runtimes/shell.rs`
+- Codex exec reader: `/Users/huntharo/github/codex/codex-rs/core/src/exec.rs`
+- Codex unified exec process: `/Users/huntharo/github/codex/codex-rs/core/src/unified_exec/process.rs`
+- Codex output buffer: `/Users/huntharo/github/codex/codex-rs/core/src/unified_exec/head_tail_buffer.rs`
+- Codex command exec API: `/Users/huntharo/github/codex/codex-rs/app-server/src/command_exec.rs`
+- Grok CLI bash tool: `/Users/huntharo/github/grok-cli/src/tools/bash.ts`
+- Grok CLI tool registry: `/Users/huntharo/github/grok-cli/src/grok/tools.ts`
+- Grok CLI transcript persistence: `/Users/huntharo/github/grok-cli/src/storage/transcript.ts`

--- a/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
+++ b/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
@@ -52,7 +52,7 @@ The target is not to copy Codex wholesale. The target is to take Codex's process
 
 ### Relevant Code and Patterns
 
-- `packages/agent-core/src/providers/responses-tool-loop.ts` already runs the xAI tool loop, emits provider item events, handles approval requests, and enforces `DEFAULT_MAX_TOOL_ROUNDS = 12`.
+- `packages/agent-core/src/providers/responses-tool-loop.ts` already runs the xAI tool loop, emits provider item events, handles approval requests, and enforces `DEFAULT_MAX_TOOL_ROUNDS = 100`.
 - `packages/agent-core/src/tools/tool-contract.ts` and `packages/agent-core/src/tools/tool-execution.ts` centralize local tool execution and normalized tool result metadata.
 - `packages/agent-core/src/tools/shell-safety.ts` already classifies `rg`, read-only `git`, `cat`, `head`, `tail`, `ls`, and `find` as safe read-only commands, with unsafe ripgrep flags requiring approval.
 - `packages/agent-core/src/app-server/turn-runner.ts` already maps provider item events into app-server notifications and persisted replay items.

--- a/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
+++ b/docs/plans/2026-04-20-002-refactor-codex-style-exec-search-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Codex-style exec and search runtime"
 type: refactor
-status: active
+status: completed
 date: 2026-04-20
 ---
 
@@ -166,7 +166,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add a shared process runner**
+- [x] **Unit 1: Add a shared process runner**
 
 **Goal:** Create one internal process execution primitive for tool commands that continuously drains output, honors timeout/cancellation, and retains capped diagnostics without failing on output volume.
 
@@ -208,7 +208,7 @@ flowchart TB
 - Existing tools can consume the runner without duplicating process lifecycle code.
 - Tests prove high-output commands do not fail with `maxBuffer`-style errors.
 
-- [ ] **Unit 2: Move ripgrep search and file listing onto the runner**
+- [x] **Unit 2: Move ripgrep search and file listing onto the runner**
 
 **Goal:** Make `search_code` and `list_files` robust for large repositories and broad patterns by using streaming `rg` output and semantic result limits.
 
@@ -252,7 +252,7 @@ flowchart TB
 - No `execFile` maxBuffer path remains in `search_code` or `list_files`.
 - Search/list outputs remain concise enough to feed back into the model loop.
 
-- [ ] **Unit 3: Replace shell_command with streamed process execution**
+- [x] **Unit 3: Replace shell_command with streamed process execution**
 
 **Goal:** Make arbitrary shell execution Codex-like: safe command classification remains, approvals remain, output is drained continuously, final output is capped, and command output deltas can reach the app-server layer.
 
@@ -293,7 +293,7 @@ flowchart TB
 - `shell-command-tool.ts` no longer imports `exec`.
 - Shell command behavior remains approval-compatible and command-action-compatible.
 
-- [ ] **Unit 4: Wire command output deltas through provider and app-server events**
+- [x] **Unit 4: Wire command output deltas through provider and app-server events**
 
 **Goal:** Let command tools stream live output through the existing app-server notification contract while preserving final item completion and replay persistence.
 
@@ -338,7 +338,7 @@ flowchart TB
 - Grok command output can be observed live through app-server notifications.
 - Existing Codex desktop event handling is not regressed.
 
-- [ ] **Unit 5: Surface Grok tool items as desktop activity entries**
+- [x] **Unit 5: Surface Grok tool items as desktop activity entries**
 
 **Goal:** Make Grok `thread/read` replay activity visible in the desktop transcript so tool-heavy turns do not look empty or unreadable after hydration.
 
@@ -376,7 +376,7 @@ flowchart TB
 **Verification:**
 - A Grok turn that used tools has visible hydrated transcript activity after reload.
 
-- [ ] **Unit 6: Improve debug evidence for tool-loop failures**
+- [x] **Unit 6: Improve debug evidence for tool-loop failures**
 
 **Goal:** When a tool loop fails, make logs and rollout files explain which tool, command, cap, exit status, and round produced the failure.
 

--- a/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
@@ -79,6 +79,7 @@ describe("Codex turn progress", () => {
             toolName: undefined,
             success: undefined,
             arguments: undefined,
+            data: undefined,
           },
         },
       },
@@ -123,6 +124,7 @@ describe("Codex turn progress", () => {
             toolName: undefined,
             success: undefined,
             arguments: undefined,
+            data: undefined,
           },
         },
       },
@@ -139,5 +141,44 @@ describe("Codex turn progress", () => {
         },
       },
     ]);
+  });
+
+  it("emits command output deltas without completing the turn", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Run command" }],
+    });
+
+    await provider.runs[0]?.emit({
+      type: "item_started",
+      item: {
+        id: "command-1",
+        type: "commandExecution",
+        command: "echo hello",
+      },
+    });
+    await provider.runs[0]?.emit({
+      type: "item_command_output_delta",
+      itemId: "command-1",
+      delta: "hello\n",
+      stream: "stdout",
+      bytes: 6,
+    });
+
+    expect(notifications.at(-1)).toEqual({
+      method: "item/commandExecution/outputDelta",
+      params: {
+        threadId: "thread-1",
+        runId: "turn-1",
+        itemId: "command-1",
+        delta: "hello\n",
+        stream: "stdout",
+        bytes: 6,
+      },
+    });
   });
 });

--- a/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-progress.test.ts
@@ -1,5 +1,13 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
+import { AppServerSessionState } from "../app-server/session-state.js";
+import { GrokRolloutStore } from "../persistence/grok-rollout-store.js";
+import {
+  createTemporaryTestDirectory,
+  createTestHarness,
+  FakeProvider,
+} from "../testing/test-harness.js";
 
 async function flushNotifications(): Promise<void> {
   await Promise.resolve();
@@ -180,5 +188,53 @@ describe("Codex turn progress", () => {
         bytes: 6,
       },
     });
+  });
+
+  it("does not persist streamed command output deltas into rollout state", async () => {
+    const temp = await createTemporaryTestDirectory();
+
+    try {
+      const provider = new FakeProvider();
+      const sessionState = new AppServerSessionState({
+        store: new GrokRolloutStore(temp.path),
+      });
+      const { server } = createTestHarness({ provider, sessionState });
+      await server.request("thread/start", { cwd: "/repo/workspace" });
+
+      await server.request("turn/start", {
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Run noisy command" }],
+      });
+
+      await provider.runs[0]?.emit({
+        type: "item_started",
+        item: {
+          id: "command-1",
+          type: "commandExecution",
+          command: "yes",
+        },
+      });
+      await provider.runs[0]?.emit({
+        type: "item_command_output_delta",
+        itemId: "command-1",
+        delta: "NOISY_OUTPUT\n",
+        stream: "stdout",
+        bytes: 13,
+      });
+
+      expect(
+        sessionState.readThread("thread-1").items.find((item) => item.id === "command-1"),
+      ).toEqual({
+        id: "command-1",
+        type: "commandExecution",
+        status: "in_progress",
+        command: "yes",
+      });
+      await expect(
+        fs.readFile(path.join(temp.path, "threads/thread-1/rollout.jsonl"), "utf8"),
+      ).resolves.not.toContain("NOISY_OUTPUT");
+    } finally {
+      await temp.cleanup();
+    }
   });
 });

--- a/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
@@ -424,6 +424,120 @@ describe("GrokProvider tool loop", () => {
     ]);
   });
 
+  it("emits command output deltas from shell tool execution", async () => {
+    const fetchImpl = createFetchSequence([
+      makeXaiFunctionCallResponse({
+        id: "resp_shell_delta",
+        calls: [
+          {
+            callId: "call_shell_delta",
+            name: "shell_command",
+            argumentsText: JSON.stringify({ command: "echo live" }),
+          },
+        ],
+      }),
+      makeXaiResponse({ id: "resp_shell_delta_final", text: "Done." }),
+    ]);
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const tools: ToolDescriptor[] = [
+      {
+        name: "shell_command",
+        description: "Run a shell command.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            command: { type: "string" },
+          },
+          required: ["command"],
+          additionalProperties: false,
+        },
+        readOnly: false,
+      },
+    ];
+    const executor: ToolExecutor = {
+      listTools: () => tools,
+      getTool: (name) => tools.find((tool) => tool.name === name),
+      executeTool: async (invocation, context) => {
+        context.onOutputDelta?.({
+          stream: "stdout",
+          text: "live output",
+          bytes: 11,
+        });
+        return {
+          toolName: invocation.name,
+          arguments: invocation.arguments ?? {},
+          success: true,
+          output: "live output",
+          data: {
+            exitCode: 0,
+            stdoutTruncated: false,
+          },
+          commandAction: "unknown",
+          item: {
+            type: "commandExecution",
+            text: "live output",
+            toolName: invocation.name,
+            success: true,
+            arguments: invocation.arguments ?? {},
+            commandAction: "unknown",
+            command: "echo live",
+            data: {
+              exitCode: 0,
+              stdoutTruncated: false,
+            },
+          },
+        };
+      },
+    };
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Run shell." }],
+      tools: executor,
+    });
+    const { events } = collectSubscribedEvents(activeTurn.subscribe);
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Done.",
+      providerResponseId: "resp_shell_delta_final",
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "item_started",
+        item: expect.objectContaining({
+          id: "call_shell_delta",
+          type: "commandExecution",
+        }),
+      }),
+      {
+        type: "item_command_output_delta",
+        itemId: "call_shell_delta",
+        delta: "live output",
+        stream: "stdout",
+        bytes: 11,
+      },
+      expect.objectContaining({
+        type: "item_completed",
+        item: expect.objectContaining({
+          id: "call_shell_delta",
+          type: "commandExecution",
+          data: {
+            exitCode: 0,
+            stdoutTruncated: false,
+          },
+        }),
+      }),
+    ]);
+  });
+
   it("turns malformed tool arguments into a failed tool item instead of crashing", async () => {
     const fetchImpl = createFetchSequence([
       makeXaiFunctionCallResponse({
@@ -529,7 +643,7 @@ describe("GrokProvider tool loop", () => {
     });
 
     await expect(activeTurn.result).rejects.toThrow(
-      "Grok tool loop exceeded the maximum round limit (1)",
+      "Grok tool loop exceeded the maximum round limit (1) before round 2",
     );
   });
 });

--- a/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
+++ b/packages/agent-core/src/__tests__/grok-rollout-store.test.ts
@@ -25,6 +25,11 @@ describe("GrokRolloutStore", () => {
         status: "completed",
         command: "rg --files",
         commandAction: "search",
+        data: {
+          exitCode: 0,
+          stdoutTruncated: true,
+          outputLimitBytes: 1024,
+        },
       });
       state.setPreviousResponseId("thread-1", "resp_1");
 
@@ -64,6 +69,11 @@ describe("GrokRolloutStore", () => {
             status: "completed",
             command: "rg --files",
             commandAction: "search",
+            data: {
+              exitCode: 0,
+              stdoutTruncated: true,
+              outputLimitBytes: 1024,
+            },
           },
         ],
         lastUserMessage: "Ship Unit 3",
@@ -85,6 +95,7 @@ describe("GrokRolloutStore", () => {
       expect(rolloutJsonl).toContain('"type":"message"');
       expect(rolloutJsonl).toContain("Ship Unit 3");
       expect(rolloutJsonl).toContain('"command":"rg --files"');
+      expect(rolloutJsonl).toContain('"stdoutTruncated":true');
     } finally {
       await temp.cleanup();
     }

--- a/packages/agent-core/src/__tests__/list-files-tool.test.ts
+++ b/packages/agent-core/src/__tests__/list-files-tool.test.ts
@@ -35,4 +35,30 @@ describe("list_files tool", () => {
       commandAction: "listFiles",
     });
   });
+
+  it("stops broad file listings at the requested limit", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await Promise.all(
+      Array.from({ length: 100 }, async (_, index) => {
+        await fs.writeFile(
+          path.join(workspace.path, "src", `file-${String(index).padStart(3, "0")}.ts`),
+          "export {};\n",
+          "utf8",
+        );
+      }),
+    );
+    const tool = createListFilesTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({ path: "src", limit: 5 }),
+      { cwd: workspace.path },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.files).toHaveLength(5);
+    expect(result.data?.truncated).toBe(true);
+    expect(result.output.split("\n")).toHaveLength(5);
+  });
 });

--- a/packages/agent-core/src/__tests__/process-runner.test.ts
+++ b/packages/agent-core/src/__tests__/process-runner.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { runProcess } from "../tools/process-runner.js";
+
+describe("process runner", () => {
+  it("captures stdout and stderr while reporting a successful exit", async () => {
+    const result = await runProcess({
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdout.write('hello stdout'); process.stderr.write('hello stderr');",
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        cancelled: false,
+      }),
+    );
+    expect(result.stdout).toBe("hello stdout");
+    expect(result.stderr).toBe("hello stderr");
+    expect(result.stdoutTruncated).toBe(false);
+    expect(result.stderrTruncated).toBe(false);
+  });
+
+  it("drains output beyond the retained cap and reports truncation metadata", async () => {
+    const result = await runProcess({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('A'.repeat(1024));"],
+      outputLimitBytes: 64,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdoutBytes).toBe(1024);
+    expect(result.stdoutTruncated).toBe(true);
+    expect(result.stdout).toContain("output truncated");
+    expect(result.stdout.length).toBeLessThan(256);
+  });
+
+  it("emits output deltas while retaining capped output", async () => {
+    const deltas: string[] = [];
+
+    const result = await runProcess({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('first'); process.stdout.write('second');"],
+      outputLimitBytes: 8,
+      onOutputDelta: (delta) => {
+        deltas.push(`${delta.stream}:${delta.text}`);
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.stdoutTruncated).toBe(true);
+    expect(deltas.join("|")).toContain("first");
+    expect(deltas.join("|")).toContain("second");
+  });
+
+  it("terminates timed out processes and reports timeout status", async () => {
+    const result = await runProcess({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => process.stdout.write('tick\\n'), 10);"],
+      timeoutMs: 30,
+      killGraceMs: 10,
+    });
+
+    expect(result.status).toBe("timed_out");
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("terminates aborted processes and reports cancellation status", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 30);
+
+    const result = await runProcess({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => process.stdout.write('tick\\n'), 10);"],
+      signal: controller.signal,
+      killGraceMs: 10,
+    });
+
+    expect(result.status).toBe("cancelled");
+    expect(result.cancelled).toBe(true);
+    expect(result.exitCode).toBeNull();
+  });
+});

--- a/packages/agent-core/src/__tests__/search-code-tool.test.ts
+++ b/packages/agent-core/src/__tests__/search-code-tool.test.ts
@@ -74,4 +74,30 @@ describe("search_code tool", () => {
       commandAction: "search",
     });
   });
+
+  it("stops broad ripgrep searches at the requested match limit", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "many.txt"),
+      Array.from({ length: 30_000 }, (_, index) => `BROAD_MARKER_${index}`).join("\n"),
+      "utf8",
+    );
+    const tool = createSearchCodeTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({
+        query: "BROAD_MARKER",
+        fixedStrings: true,
+        limit: 5,
+      }),
+      { cwd: workspace.path },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.matches).toHaveLength(5);
+    expect(result.data?.truncated).toBe(true);
+    expect(result.output.split("\n")).toHaveLength(5);
+  });
 });

--- a/packages/agent-core/src/__tests__/search-code-tool.test.ts
+++ b/packages/agent-core/src/__tests__/search-code-tool.test.ts
@@ -51,6 +51,56 @@ describe("search_code tool", () => {
     });
   });
 
+  it("searches a single file when path points at a file", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    await fs.mkdir(path.join(workspace.path, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.path, "src", "app.ts"),
+      "const FILE_MARKER = true;\nexport { FILE_MARKER };\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(workspace.path, "src", "other.ts"),
+      "const FILE_MARKER = false;\n",
+      "utf8",
+    );
+    const tool = createSearchCodeTool();
+
+    const result = await tool.execute(
+      tool.parseArguments({
+        query: "FILE_MARKER",
+        path: "src/app.ts",
+        fixedStrings: true,
+      }),
+      { cwd: workspace.path },
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output:
+        "src/app.ts:1: const FILE_MARKER = true;\nsrc/app.ts:2: export { FILE_MARKER };",
+      data: {
+        query: "FILE_MARKER",
+        path: "src/app.ts",
+        matches: [
+          {
+            path: "src/app.ts",
+            line: 1,
+            text: "const FILE_MARKER = true;",
+          },
+          {
+            path: "src/app.ts",
+            line: 2,
+            text: "export { FILE_MARKER };",
+          },
+        ],
+        truncated: false,
+      },
+      commandAction: "search",
+    });
+  });
+
   it("returns a successful empty result when there are no matches", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);

--- a/packages/agent-core/src/__tests__/shell-command-tool.test.ts
+++ b/packages/agent-core/src/__tests__/shell-command-tool.test.ts
@@ -80,15 +80,65 @@ describe("shell_command tool", () => {
     );
 
     await expect(fs.stat(path.join(workspace.path, "created.txt"))).resolves.toBeTruthy();
-    expect(result).toEqual({
-      success: true,
-      output: "Command executed successfully (no output).",
-      data: {
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        output: "Command executed successfully (no output).",
+        data: expect.objectContaining({
+          exitCode: 0,
+          status: "completed",
+        }),
+        commandAction: "unknown",
+        itemType: "commandExecution",
+        command: "touch created.txt",
+      }),
+    );
+  });
+
+  it("completes high-output commands without maxBuffer failures", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createShellCommandTool();
+    const command = `${JSON.stringify(process.execPath)} -e "process.stdout.write('A'.repeat(11 * 1024 * 1024))"`;
+
+    const result = await tool.execute(
+      tool.parseArguments({ command }),
+      { cwd: workspace.path, approvalPolicy: "never" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("output truncated");
+    expect(result.data).toEqual(
+      expect.objectContaining({
         exitCode: 0,
+        status: "completed",
+        stdoutTruncated: true,
+      }),
+    );
+  });
+
+  it("emits shell output deltas before command completion", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const tool = createShellCommandTool();
+    const deltas: string[] = [];
+    const command = `${JSON.stringify(process.execPath)} -e "process.stdout.write('first'); process.stderr.write('second')"`;
+
+    const result = await tool.execute(
+      tool.parseArguments({ command }),
+      {
+        cwd: workspace.path,
+        approvalPolicy: "never",
+        onOutputDelta: (delta) => {
+          deltas.push(`${delta.stream}:${delta.text}`);
+        },
       },
-      commandAction: "unknown",
-      itemType: "commandExecution",
-      command: "touch created.txt",
-    });
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("first");
+    expect(result.output).toContain("STDERR: second");
+    expect(deltas.join("|")).toContain("stdout:first");
+    expect(deltas.join("|")).toContain("stderr:second");
   });
 });

--- a/packages/agent-core/src/app-server/protocol.ts
+++ b/packages/agent-core/src/app-server/protocol.ts
@@ -96,6 +96,7 @@ export type ThreadReplayItem = {
   toolName?: string;
   success?: boolean;
   arguments?: Record<string, unknown>;
+  data?: Record<string, unknown>;
 };
 
 export type ModelSummary = {
@@ -240,7 +241,19 @@ export type AppServerNotification =
           toolName?: string;
           success?: boolean;
           arguments?: Record<string, unknown>;
+          data?: Record<string, unknown>;
         };
+      };
+    }
+  | {
+      method: "item/commandExecution/outputDelta";
+      params: {
+        threadId: string;
+        runId?: string;
+        itemId: string;
+        delta: string;
+        stream?: "stdout" | "stderr";
+        bytes?: number;
       };
     }
   | {

--- a/packages/agent-core/src/app-server/turn-runner.ts
+++ b/packages/agent-core/src/app-server/turn-runner.ts
@@ -116,12 +116,6 @@ export class TurnRunner {
         });
         return;
       case "item_command_output_delta":
-        this.state.appendItemTextDelta(
-          execution.threadId,
-          event.itemId,
-          event.delta,
-          "commandExecution",
-        );
         await this.emit({
           method: "item/commandExecution/outputDelta",
           params: {

--- a/packages/agent-core/src/app-server/turn-runner.ts
+++ b/packages/agent-core/src/app-server/turn-runner.ts
@@ -93,6 +93,7 @@ export class TurnRunner {
           toolName: event.item.toolName,
           success: event.item.success,
           arguments: event.item.arguments,
+          data: event.item.data,
         });
         await this.emit({
           method: event.type === "item_started" ? "item/started" : "item/completed",
@@ -109,7 +110,27 @@ export class TurnRunner {
               toolName: event.item.toolName,
               success: event.item.success,
               arguments: event.item.arguments,
+              data: event.item.data,
             },
+          },
+        });
+        return;
+      case "item_command_output_delta":
+        this.state.appendItemTextDelta(
+          execution.threadId,
+          event.itemId,
+          event.delta,
+          "commandExecution",
+        );
+        await this.emit({
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: execution.threadId,
+            runId: execution.runId,
+            itemId: event.itemId,
+            delta: event.delta,
+            stream: event.stream,
+            bytes: event.bytes,
           },
         });
         return;

--- a/packages/agent-core/src/providers/provider-contract.ts
+++ b/packages/agent-core/src/providers/provider-contract.ts
@@ -41,7 +41,15 @@ export type ProviderTurnEvent =
         toolName?: string;
         success?: boolean;
         arguments?: Record<string, unknown>;
+        data?: Record<string, unknown>;
       };
+    }
+  | {
+      type: "item_command_output_delta";
+      itemId: string;
+      delta: string;
+      stream?: "stdout" | "stderr";
+      bytes?: number;
     }
   | {
       type: "item_plan_delta";

--- a/packages/agent-core/src/providers/responses-tool-loop.ts
+++ b/packages/agent-core/src/providers/responses-tool-loop.ts
@@ -25,7 +25,7 @@ import type {
 } from "../tools/tool-contract.js";
 import { ToolError } from "../tools/tool-errors.js";
 
-const DEFAULT_MAX_TOOL_ROUNDS = 12;
+const DEFAULT_MAX_TOOL_ROUNDS = 100;
 
 type StartResponsesToolLoopOptions = {
   client: XaiResponsesClient;

--- a/packages/agent-core/src/providers/responses-tool-loop.ts
+++ b/packages/agent-core/src/providers/responses-tool-loop.ts
@@ -104,7 +104,7 @@ async function runResponsesToolLoop(params: {
     }
     if (round >= params.maxToolRounds) {
       throw new Error(
-        `Grok tool loop exceeded the maximum round limit (${params.maxToolRounds})`,
+        `Grok tool loop exceeded the maximum round limit (${params.maxToolRounds}) before round ${round + 1}`,
       );
     }
     if (!normalized.providerResponseId) {
@@ -139,6 +139,7 @@ async function runResponsesToolLoop(params: {
           toolName: execution.toolName,
           success: execution.success,
           arguments: execution.arguments,
+          data: execution.item.type === "commandExecution" ? execution.data : undefined,
         },
       });
 
@@ -225,6 +226,15 @@ async function executeFunctionCall(params: {
     approvalPolicy: params.thread.approvalPolicy,
     sandbox: params.thread.sandbox,
     signal: params.signal,
+    onOutputDelta: (delta) => {
+      void params.emit({
+        type: "item_command_output_delta",
+        itemId: params.functionCall.callId,
+        delta: delta.text,
+        stream: delta.stream,
+        bytes: delta.bytes,
+      });
+    },
     requestApproval: async (request) =>
       await requestToolApprovalFromProvider({
         request,

--- a/packages/agent-core/src/tools/list-files-tool.ts
+++ b/packages/agent-core/src/tools/list-files-tool.ts
@@ -1,16 +1,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
 import {
   asObjectArguments,
   readOptionalPositiveInteger,
   readOptionalString,
 } from "./tool-contract.js";
+import { runProcess, type ProcessRunResult } from "./process-runner.js";
 import { ToolExecutionFailure } from "./tool-errors.js";
+import { resolveWorkspaceScopePath, toPosix } from "./workspace-paths.js";
 
-const execFileAsync = promisify(execFile);
 const TOOL_NAME = "list_files";
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 1000;
@@ -48,16 +47,21 @@ export function createListFilesTool(): ToolDefinition<ListFilesArguments> {
       };
     },
     async execute(arguments_, context) {
-      const root = resolveWorkspacePath(context, arguments_.path);
+      const root = resolveWorkspaceScopePath(context, TOOL_NAME, arguments_.path);
       const limit = Math.min(arguments_.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
-      const files = await listWorkspaceFiles(root.workspacePath, root.scopePath, limit);
-      if (files.length === 0) {
+      const listResult = await listWorkspaceFiles(
+        root.workspacePath,
+        root.scopePath,
+        limit,
+        context,
+      );
+      if (listResult.files.length === 0) {
         return {
           success: true,
           output: `No files found in ${root.displayPath}.`,
           data: {
             path: root.scopeLabel,
-            files: [],
+            files: listResult.files,
             truncated: false,
           },
           commandAction: "listFiles",
@@ -65,11 +69,11 @@ export function createListFilesTool(): ToolDefinition<ListFilesArguments> {
       }
       return {
         success: true,
-        output: files.join("\n"),
+        output: listResult.files.join("\n"),
         data: {
           path: root.scopeLabel,
-          files,
-          truncated: files.length >= limit,
+          files: listResult.files,
+          truncated: listResult.truncated,
         },
         commandAction: "listFiles",
       };
@@ -81,32 +85,16 @@ async function listWorkspaceFiles(
   workspacePath: string,
   scopePath: string,
   limit: number,
-): Promise<string[]> {
-  try {
-    const { stdout } = await execFileAsync(
-      "rg",
-      ["--files", "."],
-      {
-        cwd: scopePath,
-        maxBuffer: 1024 * 1024,
-      },
-    );
-    const prefix = path.relative(workspacePath, scopePath);
-    return stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => (prefix ? path.posix.join(toPosix(prefix), toPosix(line)) : toPosix(line)))
-      .sort((left, right) => left.localeCompare(right))
-      .slice(0, limit);
-  } catch (error) {
-    if (!isCommandMissing(error)) {
-      throw new ToolExecutionFailure(
-        TOOL_NAME,
-        `ripgrep listing failed: ${error instanceof Error ? error.message : String(error)}`,
-        "list_files_failed",
-      );
-    }
+  context: ToolExecutionContext,
+): Promise<{ files: string[]; truncated: boolean }> {
+  const ripgrepResult = await listWorkspaceFilesWithRipgrep(
+    workspacePath,
+    scopePath,
+    limit,
+    context,
+  );
+  if (ripgrepResult !== "missing") {
+    return ripgrepResult;
   }
 
   const results: string[] = [];
@@ -115,7 +103,91 @@ async function listWorkspaceFiles(
     results.push(relative);
     return results.length < limit;
   });
-  return results;
+  return {
+    files: results,
+    truncated: results.length >= limit,
+  };
+}
+
+async function listWorkspaceFilesWithRipgrep(
+  workspacePath: string,
+  scopePath: string,
+  limit: number,
+  context: ToolExecutionContext,
+): Promise<{ files: string[]; truncated: boolean } | "missing"> {
+  const prefix = path.relative(workspacePath, scopePath);
+  const files: string[] = [];
+  let pending = "";
+  const result = await runProcess({
+    command: "rg",
+    args: ["--files", "."],
+    cwd: scopePath,
+    signal: context.signal,
+    onStdoutChunk: (chunk, control) => {
+      pending = collectFileLines({
+        prefix,
+        input: pending + chunk.toString("utf8"),
+        files,
+        limit,
+        final: false,
+      });
+      if (files.length >= limit) {
+        control.stop();
+      }
+    },
+  });
+  if (pending && files.length < limit) {
+    collectFileLines({
+      prefix,
+      input: pending,
+      files,
+      limit,
+      final: true,
+    });
+  }
+  if (result.status === "failed_to_start" && isCommandMissing(result)) {
+    return "missing";
+  }
+  if (result.status !== "completed" && result.status !== "stopped") {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      processFailureMessage("ripgrep listing failed", result),
+      "list_files_failed",
+    );
+  }
+  if (result.exitCode && result.exitCode !== 0) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      processFailureMessage("ripgrep listing failed", result),
+      "list_files_failed",
+    );
+  }
+  return {
+    files: files.sort((left, right) => left.localeCompare(right)),
+    truncated: result.status === "stopped" || files.length >= limit,
+  };
+}
+
+function collectFileLines(params: {
+  prefix: string;
+  input: string;
+  files: string[];
+  limit: number;
+  final: boolean;
+}): string {
+  const lines = params.input.split(/\r?\n/);
+  const completeLines = params.final ? lines : lines.slice(0, -1);
+  for (const line of completeLines) {
+    if (params.files.length >= params.limit || !line.trim()) {
+      continue;
+    }
+    params.files.push(
+      params.prefix
+        ? path.posix.join(toPosix(params.prefix), toPosix(line.trim()))
+        : toPosix(line.trim()),
+    );
+  }
+  return params.final ? "" : (lines.at(-1) ?? "");
 }
 
 async function walk(
@@ -147,41 +219,22 @@ async function walk(
   return true;
 }
 
-function resolveWorkspacePath(context: ToolExecutionContext, scope: string | undefined) {
-  const workspacePath = context.cwd?.trim();
-  if (!workspacePath) {
-    throw new ToolExecutionFailure(
-      TOOL_NAME,
-      "thread cwd is required for repository tools",
-      "missing_cwd",
-    );
-  }
-  const scopePath = path.resolve(workspacePath, scope ?? ".");
-  const relative = path.relative(workspacePath, scopePath);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new ToolExecutionFailure(
-      TOOL_NAME,
-      `path escapes workspace: ${scope ?? "."}`,
-      "path_outside_workspace",
-    );
-  }
-  return {
-    workspacePath,
-    scopePath,
-    scopeLabel: relative ? toPosix(relative) : ".",
-    displayPath: relative ? toPosix(relative) : "workspace",
-  };
-}
-
-function isCommandMissing(error: unknown): boolean {
+function isCommandMissing(result: ProcessRunResult): boolean {
+  const error = result.error;
   return Boolean(
     error &&
-      typeof error === "object" &&
       "code" in error &&
       (error as { code?: string }).code === "ENOENT",
   );
 }
 
-function toPosix(value: string): string {
-  return value.split(path.sep).join(path.posix.sep);
+function processFailureMessage(prefix: string, result: ProcessRunResult): string {
+  return [
+    prefix,
+    result.output || result.error?.message,
+    `status=${result.status}`,
+    `exitCode=${result.exitCode ?? "null"}`,
+  ]
+    .filter(Boolean)
+    .join(": ");
 }

--- a/packages/agent-core/src/tools/process-runner.ts
+++ b/packages/agent-core/src/tools/process-runner.ts
@@ -1,0 +1,316 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+export const DEFAULT_PROCESS_OUTPUT_LIMIT_BYTES = 1024 * 1024;
+
+export type ProcessOutputStream = "stdout" | "stderr";
+
+export type ProcessOutputDelta = {
+  stream: ProcessOutputStream;
+  text: string;
+  bytes: number;
+};
+
+export type ProcessRunStatus =
+  | "completed"
+  | "failed_to_start"
+  | "timed_out"
+  | "cancelled"
+  | "stopped";
+
+export type ProcessRunOptions = {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  shell?: boolean;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  killGraceMs?: number;
+  signal?: AbortSignal;
+  outputLimitBytes?: number;
+  onOutputDelta?: (delta: ProcessOutputDelta) => void;
+  onStdoutChunk?: (chunk: Buffer, control: ProcessRunControl) => void;
+  onStderrChunk?: (chunk: Buffer, control: ProcessRunControl) => void;
+};
+
+export type ProcessRunControl = {
+  stop: () => void;
+};
+
+export type ProcessRunResult = {
+  status: ProcessRunStatus;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  cancelled: boolean;
+  stopped: boolean;
+  stdout: string;
+  stderr: string;
+  output: string;
+  stdoutBytes: number;
+  stderrBytes: number;
+  outputLimitBytes: number;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+  error?: Error;
+};
+
+const DEFAULT_KILL_GRACE_MS = 1_000;
+
+export async function runProcess(options: ProcessRunOptions): Promise<ProcessRunResult> {
+  const outputLimitBytes =
+    options.outputLimitBytes ?? DEFAULT_PROCESS_OUTPUT_LIMIT_BYTES;
+  const stdout = new CappedOutputBuffer(outputLimitBytes);
+  const stderr = new CappedOutputBuffer(outputLimitBytes);
+  let child: ChildProcessWithoutNullStreams | undefined;
+  let timedOut = false;
+  let cancelled = false;
+  let stopped = false;
+  let settled = false;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const control: ProcessRunControl = {
+    stop: () => {
+      stopped = true;
+      terminateChild("SIGTERM");
+    },
+  };
+
+  const cleanup = () => {
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = undefined;
+    }
+    if (forceKillTimer) {
+      clearTimeout(forceKillTimer);
+      forceKillTimer = undefined;
+    }
+    options.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const terminateChild = (signal: NodeJS.Signals) => {
+    if (settled) {
+      return;
+    }
+    if (!child) {
+      return;
+    }
+    try {
+      child.kill(signal);
+    } catch {
+      return;
+    }
+    if (signal === "SIGTERM" && !forceKillTimer) {
+      forceKillTimer = setTimeout(() => {
+        terminateChild("SIGKILL");
+      }, options.killGraceMs ?? DEFAULT_KILL_GRACE_MS);
+    }
+  };
+
+  const onAbort = () => {
+    cancelled = true;
+    terminateChild("SIGTERM");
+  };
+
+  try {
+    child = spawn(options.command, options.args ?? [], {
+      cwd: options.cwd,
+      shell: options.shell ?? false,
+      env: { ...process.env, ...(options.env ?? {}), FORCE_COLOR: "0" },
+    });
+  } catch (error) {
+    return buildResult({
+      status: "failed_to_start",
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      cancelled: false,
+      stopped: false,
+      stdout,
+      stderr,
+      error: error instanceof Error ? error : new Error(String(error)),
+    });
+  }
+
+  const runningChild = child;
+
+  return await new Promise<ProcessRunResult>((resolve) => {
+    runningChild.stdout.on("data", (chunk: Buffer) => {
+      stdout.append(chunk);
+      emitDelta("stdout", chunk);
+      options.onStdoutChunk?.(chunk, control);
+    });
+    runningChild.stderr.on("data", (chunk: Buffer) => {
+      stderr.append(chunk);
+      emitDelta("stderr", chunk);
+      options.onStderrChunk?.(chunk, control);
+    });
+    runningChild.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(
+        buildResult({
+          status: "failed_to_start",
+          exitCode: null,
+          signal: null,
+          timedOut,
+          cancelled,
+          stopped,
+          stdout,
+          stderr,
+          error,
+        }),
+      );
+    });
+    runningChild.on("close", (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(
+        buildResult({
+          status: cancelled
+            ? "cancelled"
+            : timedOut
+              ? "timed_out"
+              : stopped
+                ? "stopped"
+                : "completed",
+          exitCode,
+          signal,
+          timedOut,
+          cancelled,
+          stopped,
+          stdout,
+          stderr,
+        }),
+      );
+    });
+
+    if (options.timeoutMs && options.timeoutMs > 0) {
+      timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        terminateChild("SIGTERM");
+      }, options.timeoutMs);
+    }
+
+    if (options.signal?.aborted) {
+      onAbort();
+    } else {
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+    }
+
+    function emitDelta(stream: ProcessOutputStream, chunk: Buffer) {
+      options.onOutputDelta?.({
+        stream,
+        text: chunk.toString("utf8"),
+        bytes: chunk.length,
+      });
+    }
+  });
+}
+
+function buildResult(params: {
+  status: ProcessRunStatus;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  cancelled: boolean;
+  stopped: boolean;
+  stdout: CappedOutputBuffer;
+  stderr: CappedOutputBuffer;
+  error?: Error;
+}): ProcessRunResult {
+  const stdout = params.stdout.toString();
+  const stderr = params.stderr.toString();
+  return {
+    status: params.status,
+    exitCode: params.exitCode,
+    signal: params.signal,
+    timedOut: params.timedOut,
+    cancelled: params.cancelled,
+    stopped: params.stopped,
+    stdout,
+    stderr,
+    output: formatCombinedOutput(stdout, stderr),
+    stdoutBytes: params.stdout.totalBytes,
+    stderrBytes: params.stderr.totalBytes,
+    outputLimitBytes: params.stdout.limitBytes,
+    stdoutTruncated: params.stdout.truncated,
+    stderrTruncated: params.stderr.truncated,
+    ...(params.error ? { error: params.error } : {}),
+  };
+}
+
+function formatCombinedOutput(stdout: string, stderr: string): string {
+  const trimmedStdout = stdout.trim();
+  const trimmedStderr = stderr.trim();
+  return [trimmedStdout, trimmedStderr ? `STDERR: ${trimmedStderr}` : ""]
+    .filter(Boolean)
+    .join("\n");
+}
+
+class CappedOutputBuffer {
+  readonly limitBytes: number;
+  totalBytes = 0;
+  truncated = false;
+  private chunks: Buffer[] = [];
+  private head: Buffer | undefined;
+  private tail: Buffer | undefined;
+
+  constructor(limitBytes: number) {
+    this.limitBytes = Math.max(0, limitBytes);
+  }
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0 || this.limitBytes === 0) {
+      this.totalBytes += chunk.length;
+      this.truncated ||= chunk.length > 0;
+      return;
+    }
+    this.totalBytes += chunk.length;
+    if (!this.truncated) {
+      const current = Buffer.concat([...this.chunks, chunk]);
+      if (current.length <= this.limitBytes) {
+        this.chunks = [current];
+        return;
+      }
+      this.truncated = true;
+      this.setHeadTail(current);
+      this.chunks = [];
+      return;
+    }
+    const tailSource = Buffer.concat([this.tail ?? Buffer.alloc(0), chunk]);
+    this.tail = tailSource.subarray(
+      Math.max(0, tailSource.length - this.tailLimit),
+    );
+  }
+
+  toString(): string {
+    if (!this.truncated) {
+      return Buffer.concat(this.chunks).toString("utf8");
+    }
+    return [
+      (this.head ?? Buffer.alloc(0)).toString("utf8"),
+      `\n... output truncated to ${this.limitBytes} retained bytes ...\n`,
+      (this.tail ?? Buffer.alloc(0)).toString("utf8"),
+    ].join("");
+  }
+
+  private setHeadTail(buffer: Buffer): void {
+    this.head = buffer.subarray(0, this.headLimit);
+    this.tail = buffer.subarray(Math.max(0, buffer.length - this.tailLimit));
+  }
+
+  private get headLimit(): number {
+    return Math.ceil(this.limitBytes / 2);
+  }
+
+  private get tailLimit(): number {
+    return Math.floor(this.limitBytes / 2);
+  }
+}

--- a/packages/agent-core/src/tools/search-code-tool.ts
+++ b/packages/agent-core/src/tools/search-code-tool.ts
@@ -46,7 +46,8 @@ export function createSearchCodeTool(): ToolDefinition<SearchCodeArguments> {
         },
         path: {
           type: "string",
-          description: "Optional directory path inside the workspace to scope the search.",
+          description:
+            "Optional file or directory path inside the workspace to scope the search.",
         },
         limit: {
           type: "integer",
@@ -120,45 +121,80 @@ async function searchWorkspace(
   limit: number,
   context: ToolExecutionContext,
 ): Promise<SearchMatch[]> {
+  const scope = await describeSearchScope(workspacePath, scopePath);
   const result = await searchWithRipgrep(
-    workspacePath,
-    scopePath,
+    scope,
     arguments_,
     limit,
     context,
   );
   if (result === "missing") {
-    return await searchWithFallback(workspacePath, scopePath, arguments_, limit);
+    return await searchWithFallback(workspacePath, scope, arguments_, limit);
   }
   return result;
 }
 
-async function searchWithRipgrep(
+type SearchScope = {
+  scopePath: string;
+  cwd: string;
+  target: string;
+  prefix: string;
+  isFile: boolean;
+};
+
+async function describeSearchScope(
   workspacePath: string,
   scopePath: string,
+): Promise<SearchScope> {
+  const stats = await fs.stat(scopePath);
+  if (stats.isFile()) {
+    return {
+      scopePath,
+      cwd: workspacePath,
+      target: toPosix(path.relative(workspacePath, scopePath)),
+      prefix: "",
+      isFile: true,
+    };
+  }
+  return {
+    scopePath,
+    cwd: scopePath,
+    target: ".",
+    prefix: path.relative(workspacePath, scopePath),
+    isFile: false,
+  };
+}
+
+async function searchWithRipgrep(
+  scope: SearchScope,
   arguments_: SearchCodeArguments,
   limit: number,
   context: ToolExecutionContext,
 ): Promise<SearchMatch[] | "missing"> {
-  const args = ["--line-number", "--no-heading", "--color", "never"];
+  const args = [
+    "--line-number",
+    "--no-heading",
+    "--with-filename",
+    "--color",
+    "never",
+  ];
   if (arguments_.fixedStrings) {
     args.push("--fixed-strings");
   }
   if (!arguments_.caseSensitive) {
     args.push("--ignore-case");
   }
-  args.push(arguments_.query, ".");
-  const prefix = path.relative(workspacePath, scopePath);
+  args.push(arguments_.query, scope.target);
   const matches: SearchMatch[] = [];
   let pending = "";
   const result = await runProcess({
     command: "rg",
     args,
-    cwd: scopePath,
+    cwd: scope.cwd,
     signal: context.signal,
     onStdoutChunk: (chunk, control) => {
       pending = collectRipgrepMatches({
-        prefix,
+        prefix: scope.prefix,
         input: pending + chunk.toString("utf8"),
         matches,
         limit,
@@ -171,7 +207,7 @@ async function searchWithRipgrep(
   });
   if (pending && matches.length < limit) {
     collectRipgrepMatches({
-      prefix,
+      prefix: scope.prefix,
       input: pending,
       matches,
       limit,
@@ -236,11 +272,13 @@ function parseRipgrepLine(prefix: string, line: string): SearchMatch {
 
 async function searchWithFallback(
   workspacePath: string,
-  scopePath: string,
+  scope: SearchScope,
   arguments_: SearchCodeArguments,
   limit: number,
 ): Promise<SearchMatch[]> {
-  const files = await collectFiles(scopePath, workspacePath, limit * 10);
+  const files = scope.isFile
+    ? [path.relative(workspacePath, scope.scopePath)]
+    : await collectFiles(scope.scopePath, workspacePath, limit * 10);
   const matcher = buildMatcher(arguments_);
   const matches: SearchMatch[] = [];
   for (const file of files) {

--- a/packages/agent-core/src/tools/search-code-tool.ts
+++ b/packages/agent-core/src/tools/search-code-tool.ts
@@ -1,7 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
 import {
   asObjectArguments,
@@ -10,9 +8,10 @@ import {
   readOptionalString,
   readRequiredString,
 } from "./tool-contract.js";
+import { runProcess, type ProcessRunResult } from "./process-runner.js";
 import { InvalidToolArgumentsError, ToolExecutionFailure } from "./tool-errors.js";
+import { resolveWorkspaceScopePath, toPosix } from "./workspace-paths.js";
 
-const execFileAsync = promisify(execFile);
 const TOOL_NAME = "search_code";
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -76,9 +75,15 @@ export function createSearchCodeTool(): ToolDefinition<SearchCodeArguments> {
       };
     },
     async execute(arguments_, context) {
-      const root = resolveWorkspacePath(context, arguments_.path);
+      const root = resolveWorkspaceScopePath(context, TOOL_NAME, arguments_.path);
       const limit = Math.min(arguments_.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
-      const matches = await searchWorkspace(root.workspacePath, root.scopePath, arguments_, limit);
+      const matches = await searchWorkspace(
+        root.workspacePath,
+        root.scopePath,
+        arguments_,
+        limit,
+        context,
+      );
       if (matches.length === 0) {
         return {
           success: true,
@@ -113,22 +118,19 @@ async function searchWorkspace(
   scopePath: string,
   arguments_: SearchCodeArguments,
   limit: number,
+  context: ToolExecutionContext,
 ): Promise<SearchMatch[]> {
-  try {
-    return await searchWithRipgrep(workspacePath, scopePath, arguments_, limit);
-  } catch (error) {
-    if (!isCommandMissing(error)) {
-      if (isNoMatchesError(error)) {
-        return [];
-      }
-      throw new ToolExecutionFailure(
-        TOOL_NAME,
-        `ripgrep search failed: ${error instanceof Error ? error.message : String(error)}`,
-        "search_failed",
-      );
-    }
+  const result = await searchWithRipgrep(
+    workspacePath,
+    scopePath,
+    arguments_,
+    limit,
+    context,
+  );
+  if (result === "missing") {
+    return await searchWithFallback(workspacePath, scopePath, arguments_, limit);
   }
-  return await searchWithFallback(workspacePath, scopePath, arguments_, limit);
+  return result;
 }
 
 async function searchWithRipgrep(
@@ -136,7 +138,8 @@ async function searchWithRipgrep(
   scopePath: string,
   arguments_: SearchCodeArguments,
   limit: number,
-): Promise<SearchMatch[]> {
+  context: ToolExecutionContext,
+): Promise<SearchMatch[] | "missing"> {
   const args = ["--line-number", "--no-heading", "--color", "never"];
   if (arguments_.fixedStrings) {
     args.push("--fixed-strings");
@@ -145,17 +148,75 @@ async function searchWithRipgrep(
     args.push("--ignore-case");
   }
   args.push(arguments_.query, ".");
-  const { stdout } = await execFileAsync("rg", args, {
-    cwd: scopePath,
-    maxBuffer: 1024 * 1024,
-  });
   const prefix = path.relative(workspacePath, scopePath);
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => parseRipgrepLine(prefix, line))
-    .slice(0, limit);
+  const matches: SearchMatch[] = [];
+  let pending = "";
+  const result = await runProcess({
+    command: "rg",
+    args,
+    cwd: scopePath,
+    signal: context.signal,
+    onStdoutChunk: (chunk, control) => {
+      pending = collectRipgrepMatches({
+        prefix,
+        input: pending + chunk.toString("utf8"),
+        matches,
+        limit,
+        final: false,
+      });
+      if (matches.length >= limit) {
+        control.stop();
+      }
+    },
+  });
+  if (pending && matches.length < limit) {
+    collectRipgrepMatches({
+      prefix,
+      input: pending,
+      matches,
+      limit,
+      final: true,
+    });
+  }
+  if (result.status === "failed_to_start" && isCommandMissing(result)) {
+    return "missing";
+  }
+  if (result.exitCode === 1) {
+    return matches;
+  }
+  if (result.status !== "completed" && result.status !== "stopped") {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      processFailureMessage("ripgrep search failed", result),
+      "search_failed",
+    );
+  }
+  if (result.exitCode && result.exitCode !== 0) {
+    throw new ToolExecutionFailure(
+      TOOL_NAME,
+      processFailureMessage("ripgrep search failed", result),
+      "search_failed",
+    );
+  }
+  return matches;
+}
+
+function collectRipgrepMatches(params: {
+  prefix: string;
+  input: string;
+  matches: SearchMatch[];
+  limit: number;
+  final: boolean;
+}): string {
+  const lines = params.input.split(/\r?\n/);
+  const completeLines = params.final ? lines : lines.slice(0, -1);
+  for (const line of completeLines) {
+    if (params.matches.length >= params.limit || !line.trim()) {
+      continue;
+    }
+    params.matches.push(parseRipgrepLine(params.prefix, line.trim()));
+  }
+  return params.final ? "" : (lines.at(-1) ?? "");
 }
 
 function parseRipgrepLine(prefix: string, line: string): SearchMatch {
@@ -272,52 +333,24 @@ async function walk(
   return true;
 }
 
-function resolveWorkspacePath(context: ToolExecutionContext, scope: string | undefined) {
-  const workspacePath = context.cwd?.trim();
-  if (!workspacePath) {
-    throw new ToolExecutionFailure(
-      TOOL_NAME,
-      "thread cwd is required for repository tools",
-      "missing_cwd",
-    );
-  }
-  const scopePath = path.resolve(workspacePath, scope ?? ".");
-  const relative = path.relative(workspacePath, scopePath);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new ToolExecutionFailure(
-      TOOL_NAME,
-      `path escapes workspace: ${scope ?? "."}`,
-      "path_outside_workspace",
-    );
-  }
-  return {
-    workspacePath,
-    scopePath,
-    scopeLabel: relative ? toPosix(relative) : ".",
-    displayPath: relative ? toPosix(relative) : "workspace",
-  };
-}
-
-function isCommandMissing(error: unknown): boolean {
+function isCommandMissing(result: ProcessRunResult): boolean {
+  const error = result.error;
   return Boolean(
     error &&
-      typeof error === "object" &&
       "code" in error &&
       (error as { code?: string }).code === "ENOENT",
   );
 }
 
-function isNoMatchesError(error: unknown): boolean {
-  return Boolean(
-    error &&
-      typeof error === "object" &&
-      "code" in error &&
-      (error as { code?: number }).code === 1,
-  );
-}
-
-function toPosix(value: string): string {
-  return value.split(path.sep).join(path.posix.sep);
+function processFailureMessage(prefix: string, result: ProcessRunResult): string {
+  return [
+    prefix,
+    result.output || result.error?.message,
+    `status=${result.status}`,
+    `exitCode=${result.exitCode ?? "null"}`,
+  ]
+    .filter(Boolean)
+    .join(": ");
 }
 
 function normalizeRelativePath(value: string): string {

--- a/packages/agent-core/src/tools/shell-command-tool.ts
+++ b/packages/agent-core/src/tools/shell-command-tool.ts
@@ -1,4 +1,3 @@
-import { exec } from "node:child_process";
 import type { ToolDefinition, ToolExecutionContext } from "./tool-contract.js";
 import {
   asObjectArguments,
@@ -6,7 +5,7 @@ import {
   readRequiredString,
   requestToolApproval,
 } from "./tool-contract.js";
-import { ToolExecutionFailure } from "./tool-errors.js";
+import { runProcess, type ProcessRunResult } from "./process-runner.js";
 import { classifyShellCommand } from "./shell-safety.js";
 import { requireWorkspacePath } from "./workspace-paths.js";
 
@@ -70,29 +69,12 @@ export function createShellCommandTool(): ToolDefinition<ShellCommandArguments> 
           };
         }
       }
-      let result;
-      try {
-        result = await runShellCommand(
-          arguments_.command,
-          cwd,
-          arguments_.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          context,
-        );
-      } catch (error) {
-        if (error instanceof ToolExecutionFailure) {
-          return {
-            success: false,
-            output: error.message,
-            data: {
-              exitCode: null,
-            },
-            commandAction: classification.commandAction,
-            itemType: "commandExecution",
-            command: arguments_.command,
-          };
-        }
-        throw error;
-      }
+      const result = await runShellCommand(
+        arguments_.command,
+        cwd,
+        arguments_.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        context,
+      );
       return {
         ...result,
         commandAction: classification.commandAction,
@@ -109,77 +91,44 @@ async function runShellCommand(
   timeoutMs: number,
   context: ToolExecutionContext,
 ) {
-  return await new Promise<{
-    success: boolean;
-    output: string;
-    data: Record<string, unknown>;
-  }>((resolve, reject) => {
-    let settled = false;
-    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
-    const child = exec(
-      command,
-      {
-        cwd,
-        timeout: timeoutMs,
-        maxBuffer: 10 * 1024 * 1024,
-        env: { ...process.env, FORCE_COLOR: "0" },
-      },
-      (error, stdout, stderr) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        if (forceKillTimer) {
-          clearTimeout(forceKillTimer);
-        }
-        context.signal?.removeEventListener("abort", onAbort);
-        const combined = [stdout.trim(), stderr.trim() ? `STDERR: ${stderr.trim()}` : ""]
-          .filter(Boolean)
-          .join("\n");
-        if (error) {
-          reject(
-            new ToolExecutionFailure(
-              TOOL_NAME,
-              combined || error.message,
-              context.signal?.aborted ? "command_cancelled" : "command_failed",
-            ),
-          );
-          return;
-        }
-        resolve({
-          success: true,
-          output: combined || "Command executed successfully (no output).",
-          data: {
-            exitCode: 0,
-          },
-        });
-      },
-    );
-
-    const onAbort = () => {
-      if (settled) {
-        return;
-      }
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        settled = true;
-        reject(new ToolExecutionFailure(TOOL_NAME, "command was cancelled", "command_cancelled"));
-        return;
-      }
-      forceKillTimer = setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          /* already exited */
-        }
-      }, 1_000);
-    };
-
-    if (context.signal?.aborted) {
-      onAbort();
-      return;
-    }
-    context.signal?.addEventListener("abort", onAbort, { once: true });
+  const result = await runProcess({
+    command,
+    cwd,
+    shell: true,
+    timeoutMs,
+    signal: context.signal,
+    onOutputDelta: context.onOutputDelta,
   });
+  const output = result.output || fallbackOutput(result);
+  return {
+    success: result.status === "completed" && result.exitCode === 0,
+    output,
+    data: processResultData(result),
+  };
+}
+
+function fallbackOutput(result: ProcessRunResult): string {
+  if (result.status === "completed" && result.exitCode === 0) {
+    return "Command executed successfully (no output).";
+  }
+  if (result.status === "timed_out") {
+    return "Command timed out.";
+  }
+  if (result.status === "cancelled") {
+    return "Command was cancelled.";
+  }
+  return result.error?.message || "Command failed.";
+}
+
+function processResultData(result: ProcessRunResult): Record<string, unknown> {
+  return {
+    exitCode: result.exitCode,
+    signal: result.signal,
+    status: result.status,
+    stdoutBytes: result.stdoutBytes,
+    stderrBytes: result.stderrBytes,
+    outputLimitBytes: result.outputLimitBytes,
+    stdoutTruncated: result.stdoutTruncated,
+    stderrTruncated: result.stderrTruncated,
+  };
 }

--- a/packages/agent-core/src/tools/tool-contract.ts
+++ b/packages/agent-core/src/tools/tool-contract.ts
@@ -1,4 +1,5 @@
 import type { AppServerCommandAction } from "../app-server/protocol.js";
+import type { ProcessOutputDelta } from "./process-runner.js";
 import { InvalidToolArgumentsError } from "./tool-errors.js";
 
 export type ToolInputSchemaProperty = {
@@ -19,6 +20,7 @@ export type ToolExecutionContext = {
   approvalPolicy?: string;
   sandbox?: string;
   signal?: AbortSignal;
+  onOutputDelta?: (delta: ProcessOutputDelta) => void;
   requestApproval?: (
     request: ToolApprovalRequest,
   ) => Promise<unknown> | unknown;
@@ -76,6 +78,7 @@ export interface ToolExecutor {
       arguments: Record<string, unknown>;
       commandAction?: AppServerCommandAction;
       command?: string;
+      data?: Record<string, unknown>;
     };
   }>;
 }

--- a/packages/agent-core/src/tools/tool-execution.ts
+++ b/packages/agent-core/src/tools/tool-execution.ts
@@ -29,10 +29,11 @@ export class LocalToolExecutor implements ToolExecutor {
 
     try {
       const parsedArguments = tool.parseArguments(invocation.arguments ?? {});
+      const normalizedArguments = stripUndefined(parsedArguments);
       const execution = await tool.execute(parsedArguments, context);
       return {
         toolName: tool.name,
-        arguments: parsedArguments,
+        arguments: normalizedArguments,
         success: execution.success,
         output: execution.output,
         data: execution.data,
@@ -42,15 +43,24 @@ export class LocalToolExecutor implements ToolExecutor {
           text: execution.output,
           toolName: tool.name,
           success: execution.success,
-          arguments: parsedArguments,
+          arguments: normalizedArguments,
           commandAction: execution.commandAction,
-          command: execution.command,
+          ...(execution.command ? { command: execution.command } : {}),
+          ...(execution.itemType === "commandExecution" && execution.data
+            ? { data: execution.data }
+            : {}),
         },
       };
     } catch (error) {
       return failureResult(tool.name, invocation.arguments, error);
     }
   }
+}
+
+function stripUndefined<T extends Record<string, unknown>>(value: T): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  );
 }
 
 function failureResult(

--- a/packages/shared/src/contracts/app-server.ts
+++ b/packages/shared/src/contracts/app-server.ts
@@ -263,8 +263,11 @@ export type AppServerNotification =
       params: {
         threadId: string;
         turnId?: string;
+        runId?: string;
         itemId: string;
         delta: string;
+        stream?: "stdout" | "stderr";
+        bytes?: number;
       };
     }
   | {


### PR DESCRIPTION
## Summary

Implements the Codex-style Grok exec/search runtime plan. Grok process-backed tools now spawn and drain commands instead of relying on Node `exec`/`execFile` buffers, retain bounded diagnostics, and can emit command output deltas while preserving existing approval behavior. The Grok tool loop also now allows up to 100 rounds by default while the runtime matures, so normal multi-step code work no longer trips the old 12-round ceiling.

## What Changed

- Added a shared `agent-core` process runner with capped stdout/stderr retention, timeout/cancel handling, early-stop support, and output delta callbacks.
- Migrated `search_code`, `list_files`, and `shell_command` off buffered process APIs.
- Wired shell command output deltas through provider events and app-server notifications.
- Persisted bounded command metadata such as exit code, signal, truncation flags, and retained-output cap in command replay items.
- Raised Grok's default tool-loop round limit from 12 to 100.
- Hydrated Grok persisted tool items into desktop transcript activity entries so failed or tool-heavy turns no longer look empty after reload.
- Marked the implementation plan completed.

## Validation

- `pnpm --filter @pwragnt/agent-core test -- process-runner.test.ts search-code-tool.test.ts list-files-tool.test.ts shell-command-tool.test.ts grok-provider-tools.test.ts codex-turn-progress.test.ts tool-registry.test.ts`
- `pnpm --filter @pwragnt/agent-core test -- grok-provider-tools.test.ts grok-rollout-store.test.ts codex-turn-progress.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
- `pnpm typecheck`
- `pnpm test`

## Post-Deploy Monitoring & Validation

Watch Grok app-server logs for these terms over the first few real Grok tool turns after deployment:

- `Grok tool loop exceeded the maximum round limit`
- `stdout maxBuffer length exceeded`
- `stderr maxBuffer length exceeded`
- `item/commandExecution/outputDelta`
- `turn/failed` with backend `grok`

Healthy signals:

- Broad `search_code`, `list_files`, and safe `shell_command` calls complete without `maxBuffer` errors.
- Tool-heavy Grok turns continue past the old 12-round ceiling when they are making progress.
- Tool-heavy Grok turns show command/search activity in `thread/read` after reload.
- Failed Grok turns retain prior tool activity and command metadata in rollout JSONL.

Failure signals and mitigation:

- Any new `maxBuffer` failure means a remaining tool path still uses buffered process APIs; inspect the logged tool name and migrate that path to the shared runner.
- A max-round failure should now indicate a likely runaway loop or repeated failed tool-call pattern, not ordinary multi-step code work.
- Repeated `turn/failed` after output deltas should be checked against rollout item metadata for command exit status, truncation flags, and max-round diagnostics.
- If desktop transcript hydration regresses, temporarily fall back to message-only rendering while keeping server-side bounded item persistence.

Validation window: first development session using Grok tools after merge. Owner: developer running the Grok desktop session.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 via [Codex](https://openai.com/codex)