### PR TITLE
feat(review): add desktop /review command parity

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -21,6 +21,9 @@ type LaunchResult = {
   getLastStartTurn: (params?: {
     executionMode?: ThreadExecutionMode;
   }) => Promise<unknown>;
+  getLastStartReview: (params?: {
+    executionMode?: ThreadExecutionMode;
+  }) => Promise<unknown>;
   respondToPendingRequest: (params: {
     executionMode?: ThreadExecutionMode;
     requestId: string;
@@ -117,6 +120,12 @@ export async function launchElectronApp(params: {
       await electronApp.evaluate(
         (_electron, value) =>
           globalThis.__PWRAGNT_REPLAY_DRIVER__?.getLastStartTurn(value),
+        requestParams
+      ),
+    getLastStartReview: async (requestParams) =>
+      await electronApp.evaluate(
+        (_electron, value) =>
+          globalThis.__PWRAGNT_REPLAY_DRIVER__?.getLastStartReview(value),
         requestParams
       ),
     respondToPendingRequest: async (requestParams) => {

--- a/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-command-flow/replay.fixture.json
@@ -1,0 +1,211 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "review-command-flow",
+    "sourceCaptureId": "synthetic-review-command-flow",
+    "threadId": "thread-review-command"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start",
+          "review/start"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-review-command",
+          "title": "Review command flow",
+          "titleSource": "explicit",
+          "summary": "Replay seeded review command transcript",
+          "source": "codex",
+          "executionMode": "default",
+          "gitBranch": "codex/review-command-flow",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000003000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Prepare this thread for review command coverage."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for review command coverage."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Prepare this thread for review command coverage."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for review command coverage."
+          }
+        ],
+        "lastUserMessage": "Prepare this thread for review command coverage.",
+        "lastAssistantMessage": "Ready for review command coverage.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "review-start-1",
+      "kind": "response",
+      "method": "review/start",
+      "result": {
+        "threadId": "thread-review-command",
+        "reviewThreadId": "thread-review-command",
+        "turnId": "turn-review-1"
+      }
+    },
+    {
+      "id": "status-active-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-review-command",
+          "status": {
+            "type": "active",
+            "activeFlags": []
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-review-command",
+          "turnId": "turn-review-1",
+          "turn": {
+            "id": "turn-review-1",
+            "status": "inProgress"
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-completed-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-review-command",
+          "turnId": "turn-review-1",
+          "turn": {
+            "id": "turn-review-1",
+            "status": "completed"
+          }
+        }
+      }
+    },
+    {
+      "id": "thread-read-2",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Prepare this thread for review command coverage."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for review command coverage."
+          },
+          {
+            "type": "review",
+            "id": "review-entered-1",
+            "displayText": "Review changes against main",
+            "review": ""
+          },
+          {
+            "type": "review",
+            "id": "review-exited-1",
+            "displayText": "Code review",
+            "review": "No findings. The branch comparison is ready to merge.",
+            "output": {
+              "findings": [],
+              "overall_correctness": "patch is correct",
+              "overall_explanation": "No findings. The branch comparison is ready to merge.",
+              "overall_confidence_score": 0.91
+            }
+          },
+          {
+            "type": "message",
+            "id": "message-3",
+            "role": "assistant",
+            "text": "No findings. The branch comparison is ready to merge."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Prepare this thread for review command coverage."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready for review command coverage."
+          },
+          {
+            "id": "message-3",
+            "role": "assistant",
+            "text": "No findings. The branch comparison is ready to merge."
+          }
+        ],
+        "lastUserMessage": "Prepare this thread for review command coverage.",
+        "lastAssistantMessage": "No findings. The branch comparison is ready to merge.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const reviewCommandSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("review command asks for target and preserves transcript order", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      reviewCommandSpecDir,
+      "fixtures/review-command-flow/replay.fixture.json"
+    )
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Review command flow/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Review command flow"
+      })
+    ).toBeVisible();
+
+    await app.window.getByLabel("Reply").fill("/review");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    const reviewTarget = app.window.getByRole("group", { name: "Review target" });
+    await expect(reviewTarget).toBeVisible();
+    await expect
+      .poll(async () => await app.getLastStartReview())
+      .toBeUndefined();
+
+    await reviewTarget.getByRole("button", { name: /Base branch/ }).click();
+    await reviewTarget.getByLabel("Base branch").fill("main");
+    await reviewTarget.getByRole("button", { name: "Start review" }).click();
+
+    await expect
+      .poll(async () => await app.getLastStartReview())
+      .toMatchObject({
+        threadId: "thread-review-command",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    await expect(transcript.getByText("Review changes against main")).toBeVisible();
+
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect(transcript.getByText("Code review")).toBeVisible();
+    await expect(
+      transcript.getByText("No findings. The branch comparison is ready to merge.")
+        .first()
+    ).toBeVisible();
+    await expect(
+      transcript.getByText(
+        "Review the current code changes (staged, unstaged, and untracked files) and provide prioritized findings."
+      )
+    ).toHaveCount(0);
+
+    const transcriptText = await transcript.innerText();
+    expect(transcriptText.indexOf("Ready for review command coverage.")).toBeGreaterThan(-1);
+    expect(transcriptText.indexOf("Review changes against main")).toBeGreaterThan(
+      transcriptText.indexOf("Ready for review command coverage.")
+    );
+    expect(transcriptText.indexOf("Code review")).toBeGreaterThan(
+      transcriptText.indexOf("Review changes against main")
+    );
+    expect(
+      transcriptText.indexOf("No findings. The branch comparison is ready to merge.")
+    ).toBeGreaterThan(transcriptText.indexOf("Code review"));
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -4,6 +4,7 @@ import type {
   InterruptTurnRequest,
   ListBackendsRequest,
   MaterializeDirectoryLaunchpadRequest,
+  StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
 } from "@pwragnt/shared";
@@ -31,6 +32,12 @@ const registry = {
     backend: request.backend,
     threadId: request.threadId,
     turnId: "turn-1",
+  })),
+  startReview: vi.fn(async (request: StartReviewRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    reviewThreadId: request.threadId,
+    turnId: "turn-review-1",
   })),
   interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
     backend: request.backend,
@@ -79,6 +86,7 @@ describe("agent ipc", () => {
     registry.onEvent.mockClear();
     registry.startThread.mockClear();
     registry.startTurn.mockClear();
+    registry.startReview.mockClear();
     registry.interruptTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
     registryListener = undefined;
@@ -94,6 +102,7 @@ describe("agent ipc", () => {
       AGENT_INTERRUPT_TURN_CHANNEL,
       AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
       AGENT_START_THREAD_CHANNEL,
+      AGENT_START_REVIEW_CHANNEL,
       AGENT_START_TURN_CHANNEL,
       BACKEND_LIST_CHANNEL,
     } = await import("../../shared/ipc");
@@ -120,6 +129,18 @@ describe("agent ipc", () => {
       backend: "grok",
       threadId: "thread-1",
       turnId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
+        backend: "grok",
+        threadId: "thread-1",
+        target: { type: "uncommittedChanges" },
+      }),
+    ).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+      reviewThreadId: "thread-1",
+      turnId: "turn-review-1",
     });
     expect(
       await handlers.get(AGENT_INTERRUPT_TURN_CHANNEL)?.({}, {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5,6 +5,7 @@ import type {
   AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadSummary,
+  AppServerReviewTarget,
   AppServerTurnInputItem,
   ThreadOverlayState,
 } from "@pwragnt/shared";
@@ -100,6 +101,11 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+  };
+  lastStartReviewParams?: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: "inline" | "detached";
   };
   lastArchiveThreadParams?: {
     threadId: string;
@@ -245,6 +251,19 @@ class MockBackendClient {
   }): Promise<{ threadId: string; turnId: string }> {
     this.lastStartTurnParams = params;
     return { threadId: params.threadId, turnId: "turn-1" };
+  }
+
+  async startReview(params: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: "inline" | "detached";
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    this.lastStartReviewParams = params;
+    return {
+      threadId: params.threadId,
+      reviewThreadId: params.threadId,
+      turnId: "turn-review-1",
+    };
   }
 
   async setThreadPermissions(params: {
@@ -548,6 +567,43 @@ describe("DesktopBackendRegistry", () => {
       serviceTier: undefined,
       reasoningEffort: "medium",
       fastMode: undefined,
+    });
+
+    await registry.close();
+  });
+
+  it("routes review start to the selected backend client", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["review/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeError: new Error("codex unavailable"),
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeError: new Error("codex unavailable"),
+      }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const response = await registry.startReview({
+      backend: "grok",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(response).toEqual({
+      backend: "grok",
+      threadId: "thread-1",
+      reviewThreadId: "thread-1",
+      turnId: "turn-review-1",
+    });
+    expect(grokClient.lastStartReviewParams).toEqual({
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1679,6 +1679,129 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("extracts rollout-style review events and suppresses hidden review prompts", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const reviewOutput = {
+      findings: [],
+      overall_correctness: "patch is correct",
+      overall_explanation:
+        "There are no staged, unstaged, or untracked code changes in the working tree to review.",
+      overall_confidence_score: 0.98,
+    };
+    MockTransport.readThreadResultByThreadId.set("thread-rollout-review", {
+      thread: {
+        turns: [
+          {
+            id: "turn-review",
+            status: "completed",
+            startedAt: 1_763_509_850,
+            items: [
+              {
+                type: "event_msg",
+                id: "entered-review",
+                payload: {
+                  type: "entered_review_mode",
+                  target: { type: "uncommittedChanges" },
+                  user_facing_hint: "current changes",
+                },
+              },
+              {
+                type: "event_msg",
+                id: "hidden-review-prompt",
+                payload: {
+                  type: "user_message",
+                  message:
+                    "Review the current code changes (staged, unstaged, and untracked files) and provide prioritized findings.",
+                  images: [],
+                  local_images: [],
+                  text_elements: [],
+                },
+              },
+              {
+                type: "response_item",
+                id: "review-action",
+                payload: {
+                  type: "message",
+                  role: "user",
+                  content: [
+                    {
+                      type: "input_text",
+                      text: "<user_action>\n<action>review</action>\n</user_action>",
+                    },
+                  ],
+                },
+              },
+              {
+                type: "event_msg",
+                id: "exited-review",
+                payload: {
+                  type: "exited_review_mode",
+                  review_output: reviewOutput,
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "review-answer",
+                text: reviewOutput.overall_explanation,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-rollout-review",
+    });
+    const turn = {
+      id: "turn-review",
+      status: "completed",
+      startedAt: 1_763_509_850_000,
+    };
+
+    expect(replay.entries).toEqual([
+      {
+        type: "review",
+        id: "entered-review",
+        review: "",
+        displayText: "Review current changes",
+        createdAt: 1_763_509_850_000,
+        turn,
+      },
+      {
+        type: "review",
+        id: "exited-review",
+        review: reviewOutput.overall_explanation,
+        createdAt: 1_763_509_850_000,
+        output: reviewOutput,
+        turn,
+      },
+      {
+        type: "message",
+        id: "review-answer",
+        role: "assistant",
+        text: reviewOutput.overall_explanation,
+        createdAt: 1_763_509_850_000,
+        turn,
+      },
+    ]);
+    expect(replay.messages).toEqual([
+      {
+        id: "review-answer",
+        role: "assistant",
+        text: reviewOutput.overall_explanation,
+        createdAt: undefined,
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("normalizes generated in-progress activity statuses from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-in-progress-tools", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -36,6 +36,13 @@ class MockTransport implements JsonRpcTransport {
       id: "turn-1"
     }
   };
+  static reviewStartResult: unknown = {
+    reviewThreadId: "thread-2",
+    turn: {
+      id: "turn-review-1",
+      status: "inProgress"
+    }
+  };
   static threadArchiveResult: unknown = {
     thread: {
       id: "thread-2"
@@ -617,6 +624,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "review/start") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.reviewStartResult
+        })
+      );
+      return;
+    }
+
     if (payload.method === "turn/interrupt") {
       if (MockTransport.turnInterruptResponseMode === "timeout") {
         return;
@@ -708,6 +726,13 @@ describe("CodexAppServerClient", () => {
       },
       turn: {
         id: "turn-1"
+      }
+    };
+    MockTransport.reviewStartResult = {
+      reviewThreadId: "thread-2",
+      turn: {
+        id: "turn-review-1",
+        status: "inProgress"
       }
     };
     MockTransport.turnInterruptResult = {
@@ -2342,6 +2367,46 @@ describe("CodexAppServerClient", () => {
     const startIndex = rpcMethods.indexOf("turn/start");
     expect(resumeIndex).toBeGreaterThan(-1);
     expect(startIndex).toBeGreaterThan(resumeIndex);
+
+    await client.close();
+  });
+
+  it("best-effort resumes an existing thread before starting a review", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const result = await client.startReview({
+      threadId: "thread-2",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(result).toEqual({
+      threadId: "thread-2",
+      reviewThreadId: "thread-2",
+      turnId: "turn-review-1",
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const requests = transport!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown }
+    );
+    expect(requests.map((request) => request.method)).toContain("thread/resume");
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "review/start",
+        params: {
+          threadId: "thread-2",
+          target: { type: "baseBranch", branch: "main" },
+          delivery: "inline",
+        },
+      })
+    );
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -164,6 +164,66 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("starts review runs and normalizes review replay items", async () => {
+    const provider = new FakeProvider();
+    const server = new CodexAppServer({
+      provider,
+      threadIdGenerator: () => "thread-1",
+      turnIdGenerator: () => "turn-review-1",
+    });
+    const client = new GrokAppServerClient({ server });
+
+    await client.startThread({ cwd: "/repo/workspace" });
+    const startedReview = await client.startReview({
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(startedReview).toEqual({
+      threadId: "thread-1",
+      reviewThreadId: "thread-1",
+      turnId: "turn-review-1",
+    });
+    expect(provider.runs[0]?.input[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("Review the code changes against the base branch 'main'"),
+    });
+
+    provider.runs[0]?.deferred.resolve({
+      assistantText: JSON.stringify({
+        findings: [],
+        overall_correctness: "patch is correct",
+        overall_explanation: "No issues found.",
+        overall_confidence_score: 0.7,
+      }),
+      providerResponseId: "resp_review",
+    });
+    await flushAsync();
+
+    await expect(client.readThread({ threadId: "thread-1" })).resolves.toMatchObject({
+      entries: [
+        {
+          type: "review",
+          displayText: "Review changes against main",
+        },
+        {
+          type: "review",
+          review: expect.stringContaining("No issues found."),
+          output: {
+            findings: [],
+            overall_correctness: "patch is correct",
+            overall_explanation: "No issues found.",
+            overall_confidence_score: 0.7,
+          },
+        },
+      ],
+      messages: [],
+    });
+
+    await client.close();
+  });
+
   it("fails a Grok turn that resolves without assistant text", async () => {
     const provider = new FakeProvider();
     const server = new CodexAppServer({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -39,6 +39,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  StartReviewRequest,
+  StartReviewResponse,
   StartThreadResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
@@ -112,6 +114,11 @@ type BackendClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
   }): Promise<{ threadId: string; turnId: string }>;
+  startReview?(params: {
+    threadId: string;
+    target: StartReviewRequest["target"];
+    delivery?: StartReviewRequest["delivery"];
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
   listModels?(): Promise<BackendModelOption[]>;
   interruptTurn(params: {
     threadId: string;
@@ -253,6 +260,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     renameThread: supported.has("thread/name/set") || assumeCodexAppServerSurface,
     readThread: supported.has("thread/read") || assumeCodexAppServerSurface,
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
+    startReview: supported.has("review/start") || assumeCodexAppServerSurface,
     interruptTurn: supported.has("turn/interrupt"),
     steerTurn: supported.has("turn/steer"),
     transcriptPagination: false,
@@ -878,6 +886,33 @@ export class DesktopBackendRegistry {
     };
   }
 
+  async startReview(params: StartReviewRequest): Promise<StartReviewResponse> {
+    const startWithClient = async (
+      client: BackendClient,
+    ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
+      if (!client.startReview) {
+        throw new Error("Selected backend does not support review/start");
+      }
+      return await client.startReview({
+        threadId: params.threadId,
+        target: params.target,
+        delivery: params.delivery ?? "inline",
+      });
+    };
+
+    const result =
+      params.backend === "codex"
+        ? await this.withCodexThreadClient(params.threadId, startWithClient)
+        : await startWithClient(this.grokClient);
+
+    return {
+      backend: params.backend,
+      threadId: result.threadId,
+      reviewThreadId: result.reviewThreadId,
+      turnId: result.turnId,
+    };
+  }
+
   async interruptTurn(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -1096,7 +1131,15 @@ export class DesktopBackendRegistry {
         ? [{ type: "text", text: launchpad.prompt } as const]
         : []);
     let turnId: string | undefined;
-    if (input.length > 0) {
+    if (request.reviewTarget) {
+      const reviewResponse = await this.startReview({
+        backend: launchpad.backend,
+        threadId: startThreadResponse.threadId,
+        target: request.reviewTarget,
+        delivery: "inline",
+      });
+      turnId = reviewResponse.turnId;
+    } else if (input.length > 0) {
       const turnResponse = await this.startTurn({
         backend: launchpad.backend,
         threadId: startThreadResponse.threadId,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -548,6 +548,28 @@ function collectLegacyMessageText(record: Record<string, unknown>): string {
   );
 }
 
+function isReviewActionText(text: string): boolean {
+  return text.includes("<user_action>") && text.includes("<action>review</action>");
+}
+
+function isCodexInternalReviewPrompt(
+  record: Record<string, unknown>,
+  text: string
+): boolean {
+  const normalizedType = normalizeItemType(pickString(record, ["type"]));
+  return (
+    normalizedType === "usermessage" &&
+    ("images" in record || "local_images" in record || "text_elements" in record) &&
+    text.startsWith("Review ") &&
+    text.includes("provide prioritized findings")
+  );
+}
+
+function shouldSuppressConversationMessage(record: Record<string, unknown>): boolean {
+  const text = collectLegacyMessageText(record);
+  return isReviewActionText(text) || isCodexInternalReviewPrompt(record, text);
+}
+
 function normalizeRenderableImageUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -679,7 +701,11 @@ function extractConversationMessages(
       pickString(record, ["role", "author", "speaker", "source", "type"])
     );
     const content = buildMessageContent(record);
-    if (role && (content.text || content.parts?.length)) {
+    if (
+      role &&
+      (content.text || content.parts?.length) &&
+      !shouldSuppressConversationMessage(record)
+    ) {
       output.push({
         id:
           pickString(record, ["id", "messageId", "message_id", "itemId", "item_id"]) ??
@@ -1016,48 +1042,131 @@ function extractReviewEntryFromItem(
   createdAt?: number,
   turn?: AppServerThreadTurnMetadata,
 ): AppServerThreadReviewEntry | undefined {
-  const normalizedItemType = normalizeItemType(pickString(item, ["type"]));
+  const reviewEvent = normalizeReviewEventItem(item);
+  if (!reviewEvent) {
+    return undefined;
+  }
+
+  const { event, item: reviewItem, parent } = reviewEvent;
+  const reviewOutput = normalizeReviewOutput(reviewItem);
+  const review =
+    pickRawString(reviewItem, ["review", "text"]) ??
+    (event === "exitedreviewmode" ? reviewOutput?.overall_explanation : undefined) ??
+    "";
+
+  return {
+    type: "review",
+    id:
+      pickString(parent, ["id", "itemId", "item_id"]) ??
+      pickString(reviewItem, ["id", "itemId", "item_id"]) ??
+      `review-${event}`,
+    review,
+    displayText:
+      event === "enteredreviewmode"
+        ? reviewDisplayText(reviewItem) || "Code review started"
+        : undefined,
+    ...(createdAt ? { createdAt } : {}),
+    ...(turn ? { turn } : {}),
+    ...(reviewOutput ? { output: reviewOutput } : {}),
+  };
+}
+
+function normalizeReviewEventItem(
+  item: Record<string, unknown>
+): {
+  event: "enteredreviewmode" | "exitedreviewmode";
+  item: Record<string, unknown>;
+  parent: Record<string, unknown>;
+} | undefined {
   if (
-    normalizedItemType !== "enteredreviewmode" &&
-    normalizedItemType !== "exitedreviewmode"
+    normalizeItemType(pickString(item, ["type"])) === "enteredreviewmode" ||
+    normalizeItemType(pickString(item, ["type"])) === "exitedreviewmode"
+  ) {
+    return {
+      event: normalizeItemType(pickString(item, ["type"])) as
+        | "enteredreviewmode"
+        | "exitedreviewmode",
+      item,
+      parent: item,
+    };
+  }
+
+  for (const key of ["payload", "item", "responseItem", "response_item", "data"]) {
+    const nested = asRecord(item[key]);
+    const nestedType = normalizeItemType(pickString(nested ?? {}, ["type"]));
+    if (nested && (nestedType === "enteredreviewmode" || nestedType === "exitedreviewmode")) {
+      return {
+        event: nestedType,
+        item: nested,
+        parent: item,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeReviewOutput(
+  item: Record<string, unknown>
+): AppServerThreadReviewEntry["output"] | undefined {
+  const data = asRecord(item.data);
+  const reviewOutput =
+    asRecord(data?.reviewOutput) ??
+    asRecord(data?.review_output) ??
+    asRecord(item.reviewOutput) ??
+    asRecord(item.review_output);
+  const findings = Array.isArray(reviewOutput?.findings)
+    ? reviewOutput.findings
+    : undefined;
+
+  if (
+    !reviewOutput ||
+    !findings ||
+    (reviewOutput.overall_correctness !== "patch is correct" &&
+      reviewOutput.overall_correctness !== "patch is incorrect") ||
+    typeof reviewOutput.overall_explanation !== "string" ||
+    typeof reviewOutput.overall_confidence_score !== "number"
   ) {
     return undefined;
   }
 
-  const review = pickRawString(item, ["review", "text"]) ?? "";
-  const data = asRecord(item.data);
-  const reviewOutput = asRecord(data?.reviewOutput);
-  const findings = Array.isArray(reviewOutput?.findings)
-    ? reviewOutput.findings
-    : undefined;
   return {
-    type: "review",
-    id:
-      pickString(item, ["id", "itemId", "item_id"]) ??
-      `review-${normalizedItemType}`,
-    review,
-    displayText:
-      normalizedItemType === "enteredreviewmode"
-        ? review || "Code review started"
-        : undefined,
-    ...(createdAt ? { createdAt } : {}),
-    ...(turn ? { turn } : {}),
-    ...(reviewOutput &&
-    findings &&
-    (reviewOutput.overall_correctness === "patch is correct" ||
-      reviewOutput.overall_correctness === "patch is incorrect") &&
-    typeof reviewOutput.overall_explanation === "string" &&
-    typeof reviewOutput.overall_confidence_score === "number"
-      ? {
-          output: {
-            findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
-            overall_correctness: reviewOutput.overall_correctness,
-            overall_explanation: reviewOutput.overall_explanation,
-            overall_confidence_score: reviewOutput.overall_confidence_score,
-          },
-        }
-      : {}),
+    findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
+    overall_correctness: reviewOutput.overall_correctness,
+    overall_explanation: reviewOutput.overall_explanation,
+    overall_confidence_score: reviewOutput.overall_confidence_score,
   };
+}
+
+function reviewDisplayText(item: Record<string, unknown>): string | undefined {
+  const direct = pickRawString(item, ["review", "text"]);
+  if (direct) {
+    return direct;
+  }
+
+  const hint = pickString(item, ["user_facing_hint", "userFacingHint"]);
+  if (hint === "current changes") {
+    return "Review current changes";
+  }
+  if (hint) {
+    return `Review ${hint}`;
+  }
+
+  const target = asRecord(item.target);
+  const targetType = pickString(target ?? {}, ["type"]);
+  if (targetType === "uncommittedChanges" || targetType === "uncommitted_changes") {
+    return "Review current changes";
+  }
+  if (targetType === "baseBranch" || targetType === "base_branch") {
+    const branch = pickString(target ?? {}, ["branch", "baseBranch", "base_branch"]);
+    return branch ? `Review changes against ${branch}` : "Review changes";
+  }
+  if (targetType === "commit") {
+    const sha = pickString(target ?? {}, ["sha", "commit"]);
+    return sha ? `Review commit ${sha}` : "Review commit";
+  }
+
+  return undefined;
 }
 
 function pushActivityDetail(
@@ -1412,6 +1521,9 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       const role = normalizeConversationRole(itemType);
       if (role) {
         flushActivityItems();
+        if (shouldSuppressConversationMessage(item)) {
+          continue;
+        }
         const content = buildMessageContent(item);
         if (!content.text && !content.parts?.length) {
           continue;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -15,6 +15,7 @@ import type {
   AppServerThreadMessagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
+  AppServerThreadReviewEntry,
   AppServerThreadPlanStep,
   AppServerThreadPlanStepStatus,
   AppServerThreadTurnMetadata,
@@ -26,6 +27,8 @@ import type {
   AppServerThreadSummary,
   AppServerTurnInputItem,
   AppServerCollaborationModeRequest,
+  AppServerReviewDelivery,
+  AppServerReviewTarget,
   BackendModelOption,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
@@ -42,6 +45,7 @@ import type {
   AskForApproval as CodexAskForApproval,
   ModelListParams as CodexModelListParams,
   SandboxMode as CodexSandboxMode,
+  ReviewStartParams as CodexReviewStartParams,
   SkillsListParams as CodexSkillsListParams,
   ThreadListParams as CodexThreadListParams,
   ThreadReadParams as CodexThreadReadParams,
@@ -1007,6 +1011,55 @@ function extractPlanEntryFromItem(
   };
 }
 
+function extractReviewEntryFromItem(
+  item: Record<string, unknown>,
+  createdAt?: number,
+  turn?: AppServerThreadTurnMetadata,
+): AppServerThreadReviewEntry | undefined {
+  const normalizedItemType = normalizeItemType(pickString(item, ["type"]));
+  if (
+    normalizedItemType !== "enteredreviewmode" &&
+    normalizedItemType !== "exitedreviewmode"
+  ) {
+    return undefined;
+  }
+
+  const review = pickRawString(item, ["review", "text"]) ?? "";
+  const data = asRecord(item.data);
+  const reviewOutput = asRecord(data?.reviewOutput);
+  const findings = Array.isArray(reviewOutput?.findings)
+    ? reviewOutput.findings
+    : undefined;
+  return {
+    type: "review",
+    id:
+      pickString(item, ["id", "itemId", "item_id"]) ??
+      `review-${normalizedItemType}`,
+    review,
+    displayText:
+      normalizedItemType === "enteredreviewmode"
+        ? review || "Code review started"
+        : undefined,
+    ...(createdAt ? { createdAt } : {}),
+    ...(turn ? { turn } : {}),
+    ...(reviewOutput &&
+    findings &&
+    (reviewOutput.overall_correctness === "patch is correct" ||
+      reviewOutput.overall_correctness === "patch is incorrect") &&
+    typeof reviewOutput.overall_explanation === "string" &&
+    typeof reviewOutput.overall_confidence_score === "number"
+      ? {
+          output: {
+            findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
+            overall_correctness: reviewOutput.overall_correctness,
+            overall_explanation: reviewOutput.overall_explanation,
+            overall_confidence_score: reviewOutput.overall_confidence_score,
+          },
+        }
+      : {}),
+  };
+}
+
 function pushActivityDetail(
   details: AppServerThreadActivityDetail[],
   detail: AppServerThreadActivityDetail
@@ -1383,6 +1436,13 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       if (planEntry) {
         flushActivityItems();
         entries.push(planEntry);
+        continue;
+      }
+
+      const reviewEntry = extractReviewEntryFromItem(item, createdAt, turnMetadata);
+      if (reviewEntry) {
+        flushActivityItems();
+        entries.push(reviewEntry);
         continue;
       }
 
@@ -2261,6 +2321,18 @@ function buildTurnStartPayload(params: {
   return base;
 }
 
+function buildReviewStartPayload(params: {
+  threadId: string;
+  target: AppServerReviewTarget;
+  delivery?: AppServerReviewDelivery;
+}): CodexReviewStartParams {
+  return {
+    threadId: params.threadId,
+    target: params.target,
+    delivery: params.delivery ?? "inline",
+  };
+}
+
 type CodexThreadReadPayload = CodexThreadReadParams & {
   before?: string;
   limit?: number;
@@ -2683,6 +2755,44 @@ export class CodexAppServerClient {
     const turnId = extractTurnIdFromValue(result) ?? `pending:${threadId}`;
 
     return { threadId, turnId };
+  }
+
+  async startReview(params: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: AppServerReviewDelivery;
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    await this.ensureInitialized();
+
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/resume"],
+      payloads: buildThreadResumePayloads({
+        threadId: params.threadId,
+      }),
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    }).catch(() => undefined);
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["review/start"],
+      payloads: [buildReviewStartPayload(params)],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+    const record = asRecord(result);
+    const reviewThreadId =
+      pickString(record ?? {}, ["reviewThreadId", "review_thread_id"]) ?? params.threadId;
+    const turnRecord = asRecord(record?.turn);
+    const turnId =
+      extractTurnIdFromValue(result) ??
+      pickString(turnRecord ?? {}, ["id", "turnId", "turn_id"]) ??
+      `pending:${reviewThreadId}`;
+
+    return {
+      threadId: params.threadId,
+      reviewThreadId,
+      turnId,
+    };
   }
 
   async setThreadPermissions(params: {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -16,11 +16,14 @@ import type {
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
+  AppServerThreadReviewEntry,
   AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadTitleSource,
   AppServerThreadSummary,
   AppServerTurnInputItem,
+  AppServerReviewDelivery,
+  AppServerReviewTarget,
   BackendModelOption,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
@@ -427,7 +430,7 @@ function extractReplayFromItems(
   items: Record<string, unknown>[],
   pagination: AppServerThreadReplay["pagination"],
 ): AppServerThreadReplay | undefined {
-  if (!items.some(isActivityReplayItem)) {
+  if (!items.some((item) => isActivityReplayItem(item) || isReviewReplayItem(item))) {
     return undefined;
   }
 
@@ -458,6 +461,12 @@ function extractReplayFromItems(
     messageIndex -= 1;
     if (isActivityReplayItem(item)) {
       pendingActivity.push(item);
+      continue;
+    }
+    const reviewEntry = itemToReviewEntry(item);
+    if (reviewEntry) {
+      flushActivity();
+      entries.push(reviewEntry);
     }
   }
   flushActivity();
@@ -483,6 +492,42 @@ function extractReplayFromItems(
     lastUserMessage,
     lastAssistantMessage,
     pagination,
+  };
+}
+
+function itemToReviewEntry(item: Record<string, unknown>): AppServerThreadReviewEntry | undefined {
+  const type = typeof item.type === "string" ? item.type : undefined;
+  if (type !== "enteredReviewMode" && type !== "exitedReviewMode") {
+    return undefined;
+  }
+  const review = typeof item.review === "string"
+    ? item.review
+    : typeof item.text === "string"
+      ? item.text
+      : "";
+  const data = asRecord(item.data);
+  const output = asRecord(data?.reviewOutput);
+  const findings = Array.isArray(output?.findings) ? output.findings : undefined;
+  return {
+    type: "review",
+    id: typeof item.id === "string" ? item.id : `review-${type}`,
+    review,
+    displayText: type === "enteredReviewMode" ? review || "Code review started" : undefined,
+    ...(output &&
+    findings &&
+    (output.overall_correctness === "patch is correct" ||
+      output.overall_correctness === "patch is incorrect") &&
+    typeof output.overall_explanation === "string" &&
+    typeof output.overall_confidence_score === "number"
+      ? {
+          output: {
+            findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
+            overall_correctness: output.overall_correctness,
+            overall_explanation: output.overall_explanation,
+            overall_confidence_score: output.overall_confidence_score,
+          },
+        }
+      : {}),
   };
 }
 
@@ -515,6 +560,10 @@ function isActivityReplayItem(item: Record<string, unknown>): boolean {
     type === "commandExecution" ||
     Boolean(toolName)
   );
+}
+
+function isReviewReplayItem(item: Record<string, unknown>): boolean {
+  return item.type === "enteredReviewMode" || item.type === "exitedReviewMode";
 }
 
 function extractThreadId(value: unknown): string | undefined {
@@ -806,6 +855,38 @@ export class GrokAppServerClient {
     }
 
     return { threadId, turnId };
+  }
+
+  async startReview(params: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: AppServerReviewDelivery;
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    await this.ensureInitialized();
+
+    await this.request("thread/resume", {
+      threadId: params.threadId,
+    });
+
+    const result = await this.request("review/start", {
+      threadId: params.threadId,
+      target: params.target,
+      delivery: params.delivery ?? "inline",
+    });
+    const record = asRecord(result);
+    const threadId = extractThreadId(result) ?? params.threadId;
+    const reviewThreadId =
+      typeof record?.reviewThreadId === "string"
+        ? record.reviewThreadId
+        : typeof record?.review_thread_id === "string"
+          ? record.review_thread_id
+          : threadId;
+    const turnId = extractTurnId(result);
+    if (!turnId) {
+      throw new Error("grok app server review/start did not return turnId");
+    }
+
+    return { threadId, reviewThreadId, turnId };
   }
 
   async interruptTurn(params: {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -11,6 +11,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  StartReviewRequest,
+  StartReviewResponse,
   StartThreadRequest,
   StartThreadResponse,
   StartTurnRequest,
@@ -26,6 +28,7 @@ import {
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
+  AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   BACKEND_LIST_CHANNEL,
@@ -221,6 +224,40 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
+  ipcMain.handle(
+    AGENT_START_REVIEW_CHANNEL,
+    async (
+      _event,
+      request: StartReviewRequest
+    ): Promise<StartReviewResponse> => {
+      logDebug("startReview", {
+        backend: request.backend,
+        threadId: request.threadId,
+        targetType: request.target.type,
+        delivery: request.delivery ?? "inline",
+      });
+
+      try {
+        const response = await registry.startReview(request);
+        logDebug("startReviewResult", {
+          backend: response.backend,
+          threadId: response.threadId,
+          reviewThreadId: response.reviewThreadId,
+          turnId: response.turnId,
+        });
+        return response;
+      } catch (error) {
+        appServerLog.error("startReview failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  );
+
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_INTERRUPT_TURN_CHANNEL,
@@ -298,6 +335,7 @@ export function disposeAgentIpcHandlers(): void {
   unsubscribeRegistryEvents = undefined;
   ipcMain.removeHandler(BACKEND_LIST_CHANNEL);
   ipcMain.removeHandler(AGENT_START_THREAD_CHANNEL);
+  ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -3,6 +3,8 @@ import type {
   AppServerListSkillsResponse,
   AppServerNotification,
   AppServerPendingRequestNotification,
+  AppServerReviewDelivery,
+  AppServerReviewTarget,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   AppServerTurnInputItem,
@@ -44,6 +46,11 @@ export class ReplayClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+  };
+  private lastStartReviewParams?: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: AppServerReviewDelivery;
   };
 
   constructor(private readonly controller: ReplayController) {}
@@ -140,6 +147,20 @@ export class ReplayClient {
     };
   }
 
+  async startReview(params: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: AppServerReviewDelivery;
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    await this.ensureInitialized();
+    this.lastStartReviewParams = params;
+    return this.controller.consumeResponse("review/start").result as {
+      threadId: string;
+      reviewThreadId: string;
+      turnId: string;
+    };
+  }
+
   async interruptTurn(_params?: {
     threadId: string;
     turnId: string;
@@ -187,6 +208,16 @@ export class ReplayClient {
       }
     | undefined {
     return this.lastStartTurnParams;
+  }
+
+  getLastStartReviewParams():
+    | {
+        threadId: string;
+        target: AppServerReviewTarget;
+        delivery?: AppServerReviewDelivery;
+      }
+    | undefined {
+    return this.lastStartReviewParams;
   }
 
   async respondToPendingRequest(requestId: string): Promise<void> {

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -5,6 +5,8 @@ import type {
   AppServerListSkillsResponse,
   AppServerNotification,
   AppServerPendingRequestNotification,
+  AppServerReviewDelivery,
+  AppServerReviewTarget,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   AppServerTurnInputItem,
@@ -37,6 +39,16 @@ type ReplayDriver = {
         fastMode?: boolean;
       }
     | undefined;
+  getLastStartReview(params?: {
+    backend?: AppServerBackendKind;
+    executionMode?: ThreadExecutionMode;
+  }):
+    | {
+        threadId: string;
+        target: AppServerReviewTarget;
+        delivery?: AppServerReviewDelivery;
+      }
+    | undefined;
   getPendingRequest(params?: {
     backend?: AppServerBackendKind;
     executionMode?: ThreadExecutionMode;
@@ -64,6 +76,13 @@ type ReplayRuntimeClient = {
         serviceTier?: string;
         reasoningEffort?: string;
         fastMode?: boolean;
+      }
+    | undefined;
+  getLastStartReviewParams?():
+    | {
+        threadId: string;
+        target: AppServerReviewTarget;
+        delivery?: AppServerReviewDelivery;
       }
     | undefined;
   getInitializeResult(): Promise<{
@@ -112,6 +131,11 @@ type ReplayRuntimeClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
   }): Promise<{ threadId: string; turnId: string }>;
+  startReview(params: {
+    threadId: string;
+    target: AppServerReviewTarget;
+    delivery?: AppServerReviewDelivery;
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
   interruptTurn(params: {
     threadId: string;
     turnId: string;
@@ -164,6 +188,13 @@ export function createReplayClientsFromEnv():
         executionMode: params?.executionMode,
       });
       return client.getLastStartTurnParams?.();
+    },
+    getLastStartReview: (params) => {
+      const client = getReplayClient(clients, {
+        backend: params?.backend,
+        executionMode: params?.executionMode,
+      });
+      return client.getLastStartReviewParams?.();
     },
     respondToPendingRequest: async (params) => {
       const client = getReplayClient(clients, {
@@ -244,6 +275,7 @@ function createUnavailableReplayClient(
     close: async () => undefined,
     getPendingRequest: () => undefined,
     getLastStartTurnParams: () => undefined,
+    getLastStartReviewParams: () => undefined,
     getInitializeResult: async () => {
       throw new Error(message);
     },
@@ -262,6 +294,9 @@ function createUnavailableReplayClient(
       throw new Error(message);
     },
     startTurn: async () => {
+      throw new Error(message);
+    },
+    startReview: async () => {
       throw new Error(message);
     },
     interruptTurn: async () => {

--- a/apps/desktop/src/main/vite-env.d.ts
+++ b/apps/desktop/src/main/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+  const value: string;
+  export default value;
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -37,6 +37,8 @@ import type {
   RestoreWorktreeResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
+  StartReviewRequest,
+  StartReviewResponse,
   StartThreadRequest,
   StartThreadResponse,
   StartTurnRequest,
@@ -59,6 +61,7 @@ import {
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
+  AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   APP_SERVER_LIST_SKILLS_CHANNEL,
@@ -150,6 +153,10 @@ const desktopApi = Object.freeze({
     request: StartThreadRequest
   ): Promise<StartThreadResponse> =>
     await ipcRenderer.invoke(AGENT_START_THREAD_CHANNEL, request),
+  startReview: async (
+    request: StartReviewRequest
+  ): Promise<StartReviewResponse> =>
+    await ipcRenderer.invoke(AGENT_START_REVIEW_CHANNEL, request),
   startTurn: async (
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -49,6 +49,7 @@ export function App() {
         <ThreadView
           activeTurnId={session.activeTurnId}
           activeTurnStartedAt={session.activeTurnStartedAt}
+          addOptimisticReviewEntry={session.addOptimisticReviewEntry}
           addOptimisticUserMessage={session.addOptimisticUserMessage}
           backendError={backendSummaries.error}
           backends={backendSummaries.backends}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -107,6 +107,14 @@ type SlashCommandSuggestion = {
 };
 
 type AutocompleteKind = "skills" | "slash";
+type ReviewTargetChoice = AppServerReviewTarget["type"];
+
+type ReviewConfigState = {
+  branch: string;
+  commit: string;
+  customInstructions: string;
+  target?: ReviewTargetChoice;
+};
 
 const DEFAULT_REASONING_EFFORT = "medium";
 
@@ -116,6 +124,33 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
     label: "/review",
     insertText: "/review",
     description: "Review current staged, unstaged, and untracked changes",
+  },
+];
+
+const REVIEW_TARGET_OPTIONS: Array<{
+  description: string;
+  label: string;
+  target: ReviewTargetChoice;
+}> = [
+  {
+    target: "baseBranch",
+    label: "Base branch",
+    description: "Compare this branch with a base branch",
+  },
+  {
+    target: "uncommittedChanges",
+    label: "Current changes",
+    description: "Review staged, unstaged, and untracked files",
+  },
+  {
+    target: "commit",
+    label: "Commit",
+    description: "Review one commit by SHA",
+  },
+  {
+    target: "custom",
+    label: "Custom",
+    description: "Review using custom instructions",
   },
 ];
 
@@ -143,6 +178,82 @@ function getReasoningEffortValue(
   return reasoningEfforts.includes(currentValue ?? "")
     ? currentValue
     : getDefaultReasoningEffort(backend);
+}
+
+function buildReviewBranchOptions(params: {
+  directory?: NavigationDirectorySummary;
+  thread?: NavigationThreadSummary;
+}): string[] {
+  const candidates = [
+    "main",
+    params.thread?.gitBranch,
+    params.thread?.observedGitBranch,
+    params.directory?.gitStatus?.currentBranch,
+    params.directory?.gitStatus?.upstreamBranch?.replace(/^origin\//, ""),
+    ...(params.directory?.gitStatus?.branches ?? []),
+  ];
+  const options = new Set<string>();
+  for (const candidate of candidates) {
+    const value = candidate?.trim();
+    if (value) {
+      options.add(value);
+    }
+  }
+  return [...options];
+}
+
+function createReviewConfig(params: {
+  directory?: NavigationDirectorySummary;
+  thread?: NavigationThreadSummary;
+}): ReviewConfigState {
+  return {
+    branch: buildReviewBranchOptions(params)[0] ?? "main",
+    commit: "",
+    customInstructions: "",
+  };
+}
+
+function buildConfiguredReviewCommand(
+  config: ReviewConfigState | undefined
+): { displayText: string; target: AppServerReviewTarget } | undefined {
+  if (!config?.target) {
+    return undefined;
+  }
+
+  if (config.target === "uncommittedChanges") {
+    return {
+      target: { type: "uncommittedChanges" },
+      displayText: "Review current changes",
+    };
+  }
+
+  if (config.target === "baseBranch") {
+    const branch = config.branch.trim();
+    return branch
+      ? {
+          target: { type: "baseBranch", branch },
+          displayText: `Review changes against ${branch}`,
+        }
+      : undefined;
+  }
+
+  if (config.target === "commit") {
+    const sha = config.commit.trim();
+    return sha
+      ? {
+          target: { type: "commit", sha, title: null },
+          displayText: `Review commit ${sha}`,
+        }
+      : undefined;
+  }
+
+  const instructions = config.customInstructions.trim();
+  return instructions
+    ? {
+        target: { type: "custom", instructions },
+        displayText: "Review custom instructions",
+      }
+    : undefined;
 }
 
 function findSlashCommandTrigger(text: string, caret: number): {
@@ -198,6 +309,7 @@ export function Composer(props: ComposerProps) {
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
+  const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
   const launchpad = props.launchpad;
   const backend = useMemo(
@@ -269,6 +381,14 @@ export function Composer(props: ComposerProps) {
     () => listMentionedSkills(draft, props.skills),
     [draft, props.skills]
   );
+  const reviewBranchOptions = useMemo(
+    () => buildReviewBranchOptions({
+      directory: props.directory,
+      thread: props.thread,
+    }),
+    [props.directory, props.thread]
+  );
+  const isBareReviewCommand = draft.trim() === "/review";
 
   useEffect(() => {
     setActiveSkillIndex(0);
@@ -307,6 +427,7 @@ export function Composer(props: ComposerProps) {
     setInterrupting(false);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
+    setReviewConfig(undefined);
   }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.updatedAt]);
 
   useEffect(() => {
@@ -319,6 +440,7 @@ export function Composer(props: ComposerProps) {
     setInterrupting(false);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
+    setReviewConfig(undefined);
     setImageAttachments([]);
   }, [props.thread?.id, props.thread?.source]);
 
@@ -435,71 +557,97 @@ export function Composer(props: ComposerProps) {
     };
   }, [draft, launchpad, props.onUpdateLaunchpad]);
 
+  const submitReviewCommand = async (reviewCommand: {
+    displayText: string;
+    target: AppServerReviewTarget;
+  }): Promise<void> => {
+    if (props.disabled) {
+      return;
+    }
+    if (imageAttachments.length > 0) {
+      setSendError("/review does not accept image attachments.");
+      return;
+    }
+
+    setSendError(undefined);
+    setSending(true);
+    props.onPendingStatusChange?.("Reviewing");
+
+    if (props.launchpad && props.onMaterializeLaunchpad) {
+      try {
+        await props.onMaterializeLaunchpad(
+          props.launchpad.directoryKey,
+          undefined,
+          undefined,
+          reviewCommand.target
+        );
+        setDraft("");
+        setReviewConfig(undefined);
+        setImageAttachments([]);
+      } catch (error) {
+        props.onPendingStatusChange?.(undefined);
+        setSendError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setSending(false);
+      }
+      return;
+    }
+
+    if (!props.thread || !props.desktopApi?.startReview) {
+      props.onPendingStatusChange?.(undefined);
+      setSending(false);
+      return;
+    }
+
+    const optimisticReviewId = props.addOptimisticReviewEntry?.(
+      reviewCommand.displayText
+    );
+    setActiveOptimisticMessageId(optimisticReviewId);
+    try {
+      const response = await props.desktopApi.startReview({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        target: reviewCommand.target,
+        delivery: "inline",
+      });
+      updateActiveTurnId(response.turnId);
+      props.onActiveTurnIdChange?.(response.turnId);
+      setDraft("");
+      setReviewConfig(undefined);
+    } catch (error) {
+      if (optimisticReviewId) {
+        props.removeOptimisticMessage?.(optimisticReviewId);
+      }
+      props.onPendingStatusChange?.(undefined);
+      setSending(false);
+      setInterrupting(false);
+      updateActiveTurnId(undefined);
+      props.onActiveTurnIdChange?.(undefined);
+      setSendError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
   const submitTurn = async (): Promise<void> => {
     const reviewCommand = parseReviewCommand(draft);
     if (reviewCommand) {
-      if (props.disabled) {
-        return;
-      }
-      if (imageAttachments.length > 0) {
-        setSendError("/review does not accept image attachments.");
-        return;
-      }
-
-      setSendError(undefined);
-      setSending(true);
-      props.onPendingStatusChange?.("Reviewing");
-
-      if (props.launchpad && props.onMaterializeLaunchpad) {
-        try {
-          await props.onMaterializeLaunchpad(
-            props.launchpad.directoryKey,
-            undefined,
-            undefined,
-            reviewCommand.target
-          );
-          setDraft("");
-          setImageAttachments([]);
-        } catch (error) {
-          props.onPendingStatusChange?.(undefined);
-          setSendError(error instanceof Error ? error.message : String(error));
-        } finally {
-          setSending(false);
+      if (isBareReviewCommand) {
+        const nextReviewConfig =
+          reviewConfig ??
+          createReviewConfig({
+            directory: props.directory,
+            thread: props.thread,
+          });
+        const configuredReviewCommand = buildConfiguredReviewCommand(nextReviewConfig);
+        if (!configuredReviewCommand) {
+          setReviewConfig(nextReviewConfig);
+          setSendError(undefined);
+          return;
         }
+        await submitReviewCommand(configuredReviewCommand);
         return;
       }
 
-      if (!props.thread || !props.desktopApi?.startReview) {
-        props.onPendingStatusChange?.(undefined);
-        setSending(false);
-        return;
-      }
-
-      const optimisticReviewId = props.addOptimisticReviewEntry?.(
-        reviewCommand.displayText
-      );
-      setActiveOptimisticMessageId(optimisticReviewId);
-      try {
-        const response = await props.desktopApi.startReview({
-          backend: props.thread.source,
-          threadId: props.thread.id,
-          target: reviewCommand.target,
-          delivery: "inline",
-        });
-        updateActiveTurnId(response.turnId);
-        props.onActiveTurnIdChange?.(response.turnId);
-        setDraft("");
-      } catch (error) {
-        if (optimisticReviewId) {
-          props.removeOptimisticMessage?.(optimisticReviewId);
-        }
-        props.onPendingStatusChange?.(undefined);
-        setSending(false);
-        setInterrupting(false);
-        updateActiveTurnId(undefined);
-        props.onActiveTurnIdChange?.(undefined);
-        setSendError(error instanceof Error ? error.message : String(error));
-      }
+      await submitReviewCommand(reviewCommand);
       return;
     }
 
@@ -860,7 +1008,11 @@ export function Composer(props: ComposerProps) {
           }
           value={draft}
           onChange={(event) => {
-            setDraft(event.target.value);
+            const nextDraft = event.target.value;
+            setDraft(nextDraft);
+            if (nextDraft.trim() !== "/review") {
+              setReviewConfig(undefined);
+            }
             setSendError(undefined);
           }}
           onPaste={handlePaste}
@@ -989,6 +1141,138 @@ export function Composer(props: ComposerProps) {
           </div>
         ) : null}
       </div>
+
+      {reviewConfig && isBareReviewCommand ? (
+        <fieldset className="composer__review-config" aria-label="Review target">
+          <legend>Review target</legend>
+          <div className="composer__review-options">
+            {REVIEW_TARGET_OPTIONS.map((option) => (
+              <button
+                key={option.target}
+                type="button"
+                aria-pressed={reviewConfig.target === option.target}
+                className={`composer__review-option${reviewConfig.target === option.target ? " is-active" : ""}`}
+                onClick={() => {
+                  setReviewConfig((current) => ({
+                    ...(current ??
+                      createReviewConfig({
+                        directory: props.directory,
+                        thread: props.thread,
+                      })),
+                    target: option.target,
+                  }));
+                  setSendError(undefined);
+                }}
+              >
+                <span>{option.label}</span>
+                <small>{option.description}</small>
+              </button>
+            ))}
+          </div>
+
+          {reviewConfig.target === "baseBranch" ? (
+            <label className="composer__review-field">
+              <span>Base branch</span>
+              <input
+                className="composer__review-input"
+                list="composer-review-branches"
+                value={reviewConfig.branch}
+                onChange={(event) => {
+                  setReviewConfig((current) => ({
+                    ...(current ??
+                      createReviewConfig({
+                        directory: props.directory,
+                        thread: props.thread,
+                      })),
+                    branch: event.target.value,
+                    target: "baseBranch",
+                  }));
+                  setSendError(undefined);
+                }}
+              />
+              {reviewBranchOptions.length > 0 ? (
+                <datalist id="composer-review-branches">
+                  {reviewBranchOptions.map((branch) => (
+                    <option key={branch} value={branch} />
+                  ))}
+                </datalist>
+              ) : null}
+            </label>
+          ) : null}
+
+          {reviewConfig.target === "commit" ? (
+            <label className="composer__review-field">
+              <span>Commit SHA</span>
+              <input
+                className="composer__review-input"
+                value={reviewConfig.commit}
+                onChange={(event) => {
+                  setReviewConfig((current) => ({
+                    ...(current ??
+                      createReviewConfig({
+                        directory: props.directory,
+                        thread: props.thread,
+                      })),
+                    commit: event.target.value,
+                    target: "commit",
+                  }));
+                  setSendError(undefined);
+                }}
+              />
+            </label>
+          ) : null}
+
+          {reviewConfig.target === "custom" ? (
+            <label className="composer__review-field">
+              <span>Instructions</span>
+              <textarea
+                className="composer__review-input composer__review-input--textarea"
+                value={reviewConfig.customInstructions}
+                onChange={(event) => {
+                  setReviewConfig((current) => ({
+                    ...(current ??
+                      createReviewConfig({
+                        directory: props.directory,
+                        thread: props.thread,
+                      })),
+                    customInstructions: event.target.value,
+                    target: "custom",
+                  }));
+                  setSendError(undefined);
+                }}
+              />
+            </label>
+          ) : null}
+
+          <div className="composer__review-actions">
+            <button
+              type="button"
+              className="composer__secondary-action"
+              onClick={() => {
+                setReviewConfig(undefined);
+                setSendError(undefined);
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="composer__primary-action"
+              disabled={!buildConfiguredReviewCommand(reviewConfig)}
+              onClick={() => {
+                const configuredReviewCommand =
+                  buildConfiguredReviewCommand(reviewConfig);
+                if (!configuredReviewCommand) {
+                  return;
+                }
+                void submitReviewCommand(configuredReviewCommand);
+              }}
+            >
+              Start review
+            </button>
+          </div>
+        </fieldset>
+      ) : null}
 
       {imageAttachments.length > 0 ? (
         <div className="composer__attachments" aria-label="Pasted images">

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,6 +1,7 @@
 import { type ClipboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerCollaborationModeRequest,
+  AppServerReviewTarget,
   AppServerSkillSummary,
   AppServerThreadImagePart,
   AppServerTurnInputItem,
@@ -21,6 +22,7 @@ import {
   insertSkillLabel,
   listMentionedSkills,
 } from "../../lib/skill-mentions";
+import { parseReviewCommand } from "../../../../shared/review-command";
 import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
@@ -42,7 +44,8 @@ type ComposerProps = {
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: AppServerTurnInputItem[],
-    collaborationMode?: AppServerCollaborationModeRequest
+    collaborationMode?: AppServerCollaborationModeRequest,
+    reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onUpdateLaunchpad?: (
@@ -331,6 +334,66 @@ export function Composer(props: ComposerProps) {
   }, [draft, launchpad, props.onUpdateLaunchpad]);
 
   const submitTurn = async (): Promise<void> => {
+    const reviewCommand = parseReviewCommand(draft);
+    if (reviewCommand) {
+      if (props.disabled) {
+        return;
+      }
+      if (imageAttachments.length > 0) {
+        setSendError("/review does not accept image attachments.");
+        return;
+      }
+
+      setSendError(undefined);
+      setSending(true);
+      props.onPendingStatusChange?.("Reviewing");
+
+      if (props.launchpad && props.onMaterializeLaunchpad) {
+        try {
+          await props.onMaterializeLaunchpad(
+            props.launchpad.directoryKey,
+            undefined,
+            undefined,
+            reviewCommand.target
+          );
+          setDraft("");
+          setImageAttachments([]);
+        } catch (error) {
+          props.onPendingStatusChange?.(undefined);
+          setSendError(error instanceof Error ? error.message : String(error));
+        } finally {
+          setSending(false);
+        }
+        return;
+      }
+
+      if (!props.thread || !props.desktopApi?.startReview) {
+        props.onPendingStatusChange?.(undefined);
+        setSending(false);
+        return;
+      }
+
+      try {
+        const response = await props.desktopApi.startReview({
+          backend: props.thread.source,
+          threadId: props.thread.id,
+          target: reviewCommand.target,
+          delivery: "inline",
+        });
+        updateActiveTurnId(response.turnId);
+        props.onActiveTurnIdChange?.(response.turnId);
+        setDraft("");
+      } catch (error) {
+        props.onPendingStatusChange?.(undefined);
+        setSending(false);
+        setInterrupting(false);
+        updateActiveTurnId(undefined);
+        props.onActiveTurnIdChange?.(undefined);
+        setSendError(error instanceof Error ? error.message : String(error));
+      }
+      return;
+    }
+
     const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
     const imageParts = imageAttachments.map((attachment, index) => ({
       type: "image" as const,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -27,6 +27,7 @@ import { SkillChip } from "./SkillChip";
 
 type ComposerProps = {
   activeTurnId?: string;
+  addOptimisticReviewEntry?: (displayText: string) => string;
   addOptimisticUserMessage?: (
     text: string,
     imageParts?: AppServerThreadImagePart[]
@@ -98,7 +99,25 @@ type ModelOption = NonNullable<
   NonNullable<BackendSummary["launchpadOptions"]>["models"]
 >[number];
 
+type SlashCommandSuggestion = {
+  description: string;
+  id: string;
+  insertText: string;
+  label: string;
+};
+
+type AutocompleteKind = "skills" | "slash";
+
 const DEFAULT_REASONING_EFFORT = "medium";
+
+const SLASH_COMMANDS: SlashCommandSuggestion[] = [
+  {
+    id: "review-current",
+    label: "/review",
+    insertText: "/review",
+    description: "Review current staged, unstaged, and untracked changes",
+  },
+];
 
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
@@ -126,9 +145,49 @@ function getReasoningEffortValue(
     : getDefaultReasoningEffort(backend);
 }
 
+function findSlashCommandTrigger(text: string, caret: number): {
+  end: number;
+  query: string;
+  start: number;
+} | undefined {
+  const prefix = text.slice(0, caret);
+  if (/\s$/.test(prefix)) {
+    return undefined;
+  }
+  const match = /^\/([^\r\n]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    start: 0,
+    end: caret,
+    query: match[1] ?? "",
+  };
+}
+
+function HighlightedAutocompleteLabel(props: {
+  label: string;
+  query: string;
+}) {
+  if (!props.query || !props.label.toLowerCase().startsWith(props.query.toLowerCase())) {
+    return <span>{props.label}</span>;
+  }
+
+  return (
+    <span>
+      <span className="composer__autocomplete-match">
+        {props.label.slice(0, props.query.length)}
+      </span>
+      {props.label.slice(props.query.length)}
+    </span>
+  );
+}
+
 export function Composer(props: ComposerProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
+  const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
@@ -137,6 +196,7 @@ export function Composer(props: ComposerProps) {
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
+  const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
   const launchpad = props.launchpad;
@@ -154,6 +214,7 @@ export function Composer(props: ComposerProps) {
     setActiveTurnId(nextTurnId);
   };
   const trigger = findSkillTrigger(draft, selectionStart);
+  const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
   const filteredSkills = useMemo(() => {
     if (!trigger) {
       return [];
@@ -176,7 +237,34 @@ export function Composer(props: ComposerProps) {
       );
     });
   }, [props.skills, trigger]);
-  const hasAutocomplete = Boolean(trigger && filteredSkills.length > 0);
+  const filteredSlashCommands = useMemo(() => {
+    if (!slashTrigger) {
+      return [];
+    }
+
+    const typed = draft.slice(slashTrigger.start, slashTrigger.end).trim().toLowerCase();
+    return SLASH_COMMANDS.filter(
+      (command) =>
+        command.label.toLowerCase().startsWith(typed) ||
+        command.description.toLowerCase().includes(typed.slice(1))
+    );
+  }, [draft, slashTrigger]);
+  const displayedAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
+    ? "skills"
+    : slashTrigger && filteredSlashCommands.length > 0
+      ? "slash"
+      : undefined;
+  const autocompleteKind: AutocompleteKind | undefined =
+    displayedAutocompleteKind === "slash" &&
+    parseReviewCommand(draft) &&
+    draft.trim() === "/review"
+      ? undefined
+      : displayedAutocompleteKind;
+  const hasAutocomplete = Boolean(autocompleteKind);
+  const activeAutocompleteIndex =
+    displayedAutocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
+  const autocompleteLength =
+    displayedAutocompleteKind === "skills" ? filteredSkills.length : filteredSlashCommands.length;
   const mentionedSkills = useMemo(
     () => listMentionedSkills(draft, props.skills),
     [draft, props.skills]
@@ -185,6 +273,20 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     setActiveSkillIndex(0);
   }, [trigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  useEffect(() => {
+    setActiveSlashIndex(0);
+  }, [slashTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  useEffect(() => {
+    if (!displayedAutocompleteKind) {
+      return;
+    }
+
+    autocompleteOptionRefs.current[activeAutocompleteIndex]?.scrollIntoView?.({
+      block: "nearest",
+    });
+  }, [activeAutocompleteIndex, displayedAutocompleteKind]);
 
   useEffect(() => {
     if (!trigger) {
@@ -373,6 +475,10 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
+      const optimisticReviewId = props.addOptimisticReviewEntry?.(
+        reviewCommand.displayText
+      );
+      setActiveOptimisticMessageId(optimisticReviewId);
       try {
         const response = await props.desktopApi.startReview({
           backend: props.thread.source,
@@ -384,6 +490,9 @@ export function Composer(props: ComposerProps) {
         props.onActiveTurnIdChange?.(response.turnId);
         setDraft("");
       } catch (error) {
+        if (optimisticReviewId) {
+          props.removeOptimisticMessage?.(optimisticReviewId);
+        }
         props.onPendingStatusChange?.(undefined);
         setSending(false);
         setInterrupting(false);
@@ -537,6 +646,32 @@ export function Composer(props: ComposerProps) {
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(inserted.nextSelection, inserted.nextSelection);
+    });
+  };
+
+  const applySlashCommand = (command: SlashCommandSuggestion): void => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const selectionStart = inputRef.current.selectionStart ?? draft.length;
+    const selectionEnd = inputRef.current.selectionEnd ?? selectionStart;
+    const trigger = findSlashCommandTrigger(draft, selectionStart);
+    if (!trigger) {
+      return;
+    }
+
+    const before = draft.slice(0, trigger.start);
+    const after = draft.slice(Math.max(trigger.end, selectionEnd));
+    const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
+    const nextDraft = `${before}${command.insertText}${needsTrailingSpace ? " " : ""}${after}`;
+    const nextSelection = before.length + command.insertText.length + (needsTrailingSpace ? 1 : 0);
+
+    setDraft(nextDraft);
+    setActiveSlashIndex(0);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
     });
   };
 
@@ -731,6 +866,7 @@ export function Composer(props: ComposerProps) {
           onPaste={handlePaste}
           onClick={() => {
             setActiveSkillIndex(0);
+            setActiveSlashIndex(0);
           }}
           onKeyDown={(event) => {
             if (!hasAutocomplete) {
@@ -743,38 +879,58 @@ export function Composer(props: ComposerProps) {
 
             if (event.key === "ArrowDown") {
               event.preventDefault();
-              setActiveSkillIndex((current) =>
-                Math.min(current + 1, filteredSkills.length - 1)
-              );
+              if (autocompleteKind === "skills") {
+                setActiveSkillIndex((current) =>
+                  Math.min(current + 1, autocompleteLength - 1)
+                );
+              } else {
+                setActiveSlashIndex((current) =>
+                  Math.min(current + 1, autocompleteLength - 1)
+                );
+              }
               return;
             }
 
             if (event.key === "ArrowUp") {
               event.preventDefault();
-              setActiveSkillIndex((current) => Math.max(current - 1, 0));
+              if (autocompleteKind === "skills") {
+                setActiveSkillIndex((current) => Math.max(current - 1, 0));
+              } else {
+                setActiveSlashIndex((current) => Math.max(current - 1, 0));
+              }
               return;
             }
 
             if (event.key === "Escape") {
               event.preventDefault();
               setActiveSkillIndex(0);
+              setActiveSlashIndex(0);
               return;
             }
 
             if (event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
-              applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
+              if (autocompleteKind === "skills") {
+                applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
+              } else {
+                applySlashCommand(
+                  filteredSlashCommands[activeSlashIndex] ?? filteredSlashCommands[0]!
+                );
+              }
             }
           }}
         />
 
-        {hasAutocomplete ? (
+        {displayedAutocompleteKind === "skills" ? (
           <div className="composer__autocomplete" role="listbox" aria-label="Skills">
             {filteredSkills.map((skill, index) => (
               <button
                 key={skill.path ?? skill.name}
+                ref={(node) => {
+                  autocompleteOptionRefs.current[index] = node;
+                }}
                 aria-selected={index === activeSkillIndex}
-                className={`composer__skill-option${index === activeSkillIndex ? " is-active" : ""}`}
+                className={`composer__autocomplete-option${index === activeSkillIndex ? " is-active" : ""}`}
                 type="button"
                 onMouseDown={(event) => {
                   event.preventDefault();
@@ -784,12 +940,49 @@ export function Composer(props: ComposerProps) {
                   applySkill(skill);
                 }}
               >
-                <span className="composer__skill-option-title">
+                <span className="composer__autocomplete-title">
                   <span aria-hidden="true">🧰</span>
-                  <span>{`$${skill.name}`}</span>
+                  <HighlightedAutocompleteLabel
+                    label={`$${skill.name}`}
+                    query={trigger?.query ? `$${trigger.query}` : "$"}
+                  />
                 </span>
-                <span className="composer__skill-option-meta">
+                <span className="composer__autocomplete-meta">
                   {skill.shortDescription || skill.description || skill.path}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : displayedAutocompleteKind === "slash" ? (
+          <div className="composer__autocomplete" role="listbox" aria-label="Commands">
+            {filteredSlashCommands.map((command, index) => (
+              <button
+                key={command.id}
+                ref={(node) => {
+                  autocompleteOptionRefs.current[index] = node;
+                }}
+                aria-selected={index === activeSlashIndex}
+                className={`composer__autocomplete-option${index === activeSlashIndex ? " is-active" : ""}`}
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  applySlashCommand(command);
+                }}
+                onClick={() => {
+                  applySlashCommand(command);
+                }}
+              >
+                <span className="composer__autocomplete-title">
+                  <span className="composer__autocomplete-token" aria-hidden="true">/</span>
+                  <HighlightedAutocompleteLabel
+                    label={command.label}
+                    query={slashTrigger
+                      ? draft.slice(slashTrigger.start, slashTrigger.end).trim()
+                      : "/"}
+                  />
+                </span>
+                <span className="composer__autocomplete-meta">
+                  {command.description}
                 </span>
               </button>
             ))}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -273,6 +273,7 @@ describe("Composer", () => {
 
   it("routes slash review to startReview instead of startTurn", async () => {
     const startTurn = vi.fn();
+    const addOptimisticReviewEntry = vi.fn(() => "review-optimistic-1");
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -282,6 +283,7 @@ describe("Composer", () => {
 
     render(
       <Composer
+        addOptimisticReviewEntry={addOptimisticReviewEntry}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,
@@ -314,7 +316,122 @@ describe("Composer", () => {
         delivery: "inline",
       });
     });
+    expect(addOptimisticReviewEntry).toHaveBeenCalledWith("Review changes against main");
     expect(startTurn).not.toHaveBeenCalled();
+  });
+
+  it("submits exact slash review commands from the keyboard", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/review" } });
+
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "uncommittedChanges" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("inserts slash review commands from autocomplete", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/r" } });
+
+    expect(screen.getByRole("listbox", { name: "Commands" })).toHaveClass(
+      "composer__autocomplete"
+    );
+    fireEvent.click(screen.getByRole("button", { name: /\/review/i }));
+
+    expect(textarea).toHaveValue("/review ");
+  });
+
+  it("applies the focused slash command option from the keyboard", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/r" } });
+
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(textarea).toHaveValue("/review ");
   });
 
   it("shows thread access in the composer and updates it from the select", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -320,7 +320,61 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
-  it("submits exact slash review commands from the keyboard", async () => {
+  it("asks for a review target before submitting bare slash review commands", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "codex/feature",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/review" } });
+
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(startReview).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
+    fireEvent.change(screen.getByLabelText("Base branch"), {
+      target: { value: "release" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "release" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("submits current changes when selected from the bare review target prompt", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -348,11 +402,12 @@ describe("Composer", () => {
       />
     );
 
-    const textarea = screen.getByLabelText("Reply");
-    fireEvent.change(textarea, { target: { value: "/review" } });
-
-    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
-    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.click(screen.getByRole("button", { name: /Current changes/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
 
     await waitFor(() => {
       expect(startReview).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import type {
   BackendSummary,
   NavigationLaunchpadDraft,
+  StartReviewRequest,
   StartTurnRequest,
 } from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -268,6 +269,52 @@ describe("Composer", () => {
         fastMode: undefined,
       });
     });
+  });
+
+  it("routes slash review to startReview instead of startTurn", async () => {
+    const startTurn = vi.fn();
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+    expect(startTurn).not.toHaveBeenCalled();
   });
 
   it("shows thread access in the composer and updates it from the select", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -771,6 +771,7 @@ function activityContainsDiff(
 type ThreadViewProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
+  addOptimisticReviewEntry?: (displayText: string) => string;
   addOptimisticUserMessage: (text: string) => string;
   backendError?: string;
   backends: BackendSummary[];
@@ -1439,6 +1440,7 @@ export function ThreadView(props: ThreadViewProps) {
 
       <Composer
         activeTurnId={props.activeTurnId}
+        addOptimisticReviewEntry={props.addOptimisticReviewEntry}
         addOptimisticUserMessage={props.addOptimisticUserMessage}
         backends={props.backends}
         desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
+  AppServerReviewTarget,
   AppServerSource,
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
@@ -804,7 +805,8 @@ type ThreadViewProps = {
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: AppServerTurnInputItem[],
-    collaborationMode?: AppServerCollaborationModeRequest
+    collaborationMode?: AppServerCollaborationModeRequest,
+    reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
   onPendingStatusChange?: (status?: string) => void;
   onUpdatePendingUserInput?: (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1444,6 +1444,7 @@ export function ThreadView(props: ThreadViewProps) {
         addOptimisticUserMessage={props.addOptimisticUserMessage}
         backends={props.backends}
         desktopApi={props.desktopApi}
+        directory={props.selectedDirectory}
         disabled={props.composerDisabled}
         onActiveTurnIdChange={props.onActiveTurnIdChange}
         onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -15,6 +15,7 @@ import { TranscriptActivity } from "./TranscriptActivity";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
+import { TranscriptReview } from "./TranscriptReview";
 import { TranscriptWorkPhaseGroup } from "./TranscriptWorkPhaseGroup";
 import type { PendingQuestionnaireState } from "./questionnaire";
 import { buildTranscriptRenderItems } from "./transcript-render-items";
@@ -508,6 +509,8 @@ export function TranscriptList(props: TranscriptListProps) {
             <TranscriptActivity key={entry.id} entry={entry} />
           ) : entry.type === "plan" ? (
             <TranscriptPlan key={entry.id} entry={entry} />
+          ) : entry.type === "review" ? (
+            <TranscriptReview key={entry.id} entry={entry} />
           ) : (
             <TranscriptMessage
               key={entry.id}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -12,6 +12,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
     (findingCount === undefined
       ? "Code review"
       : `${findingCount} review ${findingCount === 1 ? "finding" : "findings"}`);
+  const body = props.entry.review.trim() === summary.trim() ? "" : props.entry.review;
 
   return (
     <aside className="transcript-review" role="group" aria-label="Code review">
@@ -35,7 +36,9 @@ export function TranscriptReview(props: TranscriptReviewProps) {
           </time>
         ) : null}
       </header>
-      <ThreadMarkdown className="transcript-plan__markdown" text={props.entry.review} />
+      {body ? (
+        <ThreadMarkdown className="transcript-plan__markdown" text={body} />
+      ) : null}
     </aside>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -5,24 +5,52 @@ type TranscriptReviewProps = {
   entry: AppServerThreadReviewEntry;
 };
 
+function formatConfidence(value: number | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return `${Math.round(value * 100)}% confidence`;
+}
+
+function formatPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.slice(-3).join("/") || path;
+}
+
+function priorityLabel(priority: number | undefined): string {
+  return typeof priority === "number" ? `P${priority}` : "P?";
+}
+
 export function TranscriptReview(props: TranscriptReviewProps) {
-  const findingCount = props.entry.output?.findings.length;
+  const output = props.entry.output;
+  const findings = output?.findings ?? [];
+  const findingCount = output?.findings.length;
   const summary =
     props.entry.displayText ??
     (findingCount === undefined
       ? "Code review"
       : `${findingCount} review ${findingCount === 1 ? "finding" : "findings"}`);
-  const body = props.entry.review.trim() === summary.trim() ? "" : props.entry.review;
+  const body =
+    output?.overall_explanation ??
+    (props.entry.review.trim() === summary.trim() ? "" : props.entry.review);
+  const confidence = formatConfidence(output?.overall_confidence_score);
+  const correctness =
+    output?.overall_correctness === "patch is correct"
+      ? "Patch correct"
+      : output?.overall_correctness === "patch is incorrect"
+        ? "Patch needs work"
+        : undefined;
 
   return (
     <aside className="transcript-review" role="group" aria-label="Code review">
-      <header className="transcript-plan__header">
-        <div className="transcript-plan__copy">
-          <p className="transcript-plan__summary">{summary}</p>
-          {props.entry.output?.overall_correctness ? (
-            <p className="transcript-plan__explanation">
-              {props.entry.output.overall_correctness}
-            </p>
+      <header className="transcript-review__header">
+        <div className="transcript-review__copy">
+          <p className="transcript-review__eyebrow">Review</p>
+          <p className="transcript-review__summary">{summary}</p>
+          {body ? (
+            <ThreadMarkdown className="transcript-review__body" text={body} />
           ) : null}
         </div>
         {props.entry.createdAt ? (
@@ -36,8 +64,62 @@ export function TranscriptReview(props: TranscriptReviewProps) {
           </time>
         ) : null}
       </header>
-      {body ? (
-        <ThreadMarkdown className="transcript-plan__markdown" text={body} />
+
+      {output ? (
+        <div className="transcript-review__meta" aria-label="Review summary">
+          {correctness ? (
+            <span
+              className={`transcript-review__badge transcript-review__badge--${
+                output.overall_correctness === "patch is correct" ? "success" : "danger"
+              }`}
+            >
+              {correctness}
+            </span>
+          ) : null}
+          <span className="transcript-review__badge">
+            {findingCount} {findingCount === 1 ? "finding" : "findings"}
+          </span>
+          {confidence ? (
+            <span className="transcript-review__badge">{confidence}</span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {findings.length > 0 ? (
+        <ol className="transcript-review__findings">
+          {findings.map((finding, index) => {
+            const range = finding.code_location.line_range;
+            return (
+              <li
+                className="transcript-review__finding"
+                key={`${finding.code_location.absolute_file_path}:${range.start}:${index}`}
+              >
+                <div className="transcript-review__finding-head">
+                  <span className="transcript-review__priority">
+                    {priorityLabel(finding.priority)}
+                  </span>
+                  <span className="transcript-review__finding-title">
+                    {finding.title}
+                  </span>
+                </div>
+                <ThreadMarkdown
+                  className="transcript-review__finding-body"
+                  text={finding.body}
+                />
+                <div className="transcript-review__location">
+                  <span>{formatPath(finding.code_location.absolute_file_path)}</span>
+                  <span>
+                    {range.start === range.end
+                      ? `Line ${range.start}`
+                      : `Lines ${range.start}-${range.end}`}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      ) : output ? (
+        <p className="transcript-review__empty">No findings.</p>
       ) : null}
     </aside>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -1,0 +1,41 @@
+import type { AppServerThreadReviewEntry } from "@pwragnt/shared";
+import { ThreadMarkdown } from "./ThreadMarkdown";
+
+type TranscriptReviewProps = {
+  entry: AppServerThreadReviewEntry;
+};
+
+export function TranscriptReview(props: TranscriptReviewProps) {
+  const findingCount = props.entry.output?.findings.length;
+  const summary =
+    props.entry.displayText ??
+    (findingCount === undefined
+      ? "Code review"
+      : `${findingCount} review ${findingCount === 1 ? "finding" : "findings"}`);
+
+  return (
+    <aside className="transcript-review" role="group" aria-label="Code review">
+      <header className="transcript-plan__header">
+        <div className="transcript-plan__copy">
+          <p className="transcript-plan__summary">{summary}</p>
+          {props.entry.output?.overall_correctness ? (
+            <p className="transcript-plan__explanation">
+              {props.entry.output.overall_correctness}
+            </p>
+          ) : null}
+        </div>
+        {props.entry.createdAt ? (
+          <time className="transcript-message__time">
+            {new Intl.DateTimeFormat(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+            }).format(props.entry.createdAt)}
+          </time>
+        ) : null}
+      </header>
+      <ThreadMarkdown className="transcript-plan__markdown" text={props.entry.review} />
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -7,6 +7,7 @@ import type {
 import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
+import { TranscriptReview } from "./TranscriptReview";
 
 type TranscriptWorkPhaseGroupProps = {
   collapsible: boolean;
@@ -66,6 +67,8 @@ function renderEntry(
     <TranscriptActivity key={entry.id} entry={entry} />
   ) : entry.type === "plan" ? (
     <TranscriptPlan key={entry.id} entry={entry} />
+  ) : entry.type === "review" ? (
+    <TranscriptReview key={entry.id} entry={entry} />
   ) : (
     <TranscriptMessage
       key={entry.id}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -1,0 +1,54 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TranscriptReview } from "../TranscriptReview";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TranscriptReview", () => {
+  it("renders review summary metadata and prioritized findings", () => {
+    render(
+      <TranscriptReview
+        entry={{
+          type: "review",
+          id: "review-1",
+          review: "The patch has one review issue.",
+          displayText: "Review changes against main",
+          output: {
+            findings: [
+              {
+                title: "Hydrate review transcript items",
+                body: "The live transcript should show review cards instead of assistant text.",
+                confidence_score: 0.91,
+                priority: 1,
+                code_location: {
+                  absolute_file_path:
+                    "/repo/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+                  line_range: {
+                    start: 845,
+                    end: 848,
+                  },
+                },
+              },
+            ],
+            overall_correctness: "patch is incorrect",
+            overall_explanation: "The live review result is currently rendered as plain text.",
+            overall_confidence_score: 0.87,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("Review changes against main")).toBeInTheDocument();
+    expect(screen.getByText("Patch needs work")).toBeInTheDocument();
+    expect(screen.getByText("1 finding")).toBeInTheDocument();
+    expect(screen.getByText("87% confidence")).toBeInTheDocument();
+    expect(screen.getByText("P1")).toBeInTheDocument();
+    expect(screen.getByText("Hydrate review transcript items")).toBeInTheDocument();
+    expect(screen.getByText("src/lib/useThreadSessionState.ts")).toBeInTheDocument();
+    expect(screen.getByText("Lines 845-848")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1755,4 +1755,140 @@ describe("useThreadSessionState", () => {
       text: "The new thread is live and the reply has been hydrated.",
     });
   });
+
+  it("renders live review items without synthesizing an assistant completion message", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.addOptimisticReviewEntry("Review changes against main");
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-review-1",
+              item: {
+                id: "turn-review-1-item-entered",
+                type: "enteredReviewMode",
+                review: "Review changes against main",
+              },
+            },
+          },
+        });
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-review-1",
+              item: {
+                id: "turn-review-1-item",
+                type: "exitedReviewMode",
+                review: "No findings. Ready to merge.",
+                data: {
+                  reviewOutput: {
+                    findings: [],
+                    overall_correctness: "patch is correct",
+                    overall_explanation: "No findings. Ready to merge.",
+                    overall_confidence_score: 0.92,
+                  },
+                },
+              },
+            },
+          },
+        });
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-review-1",
+              turn: {
+                id: "turn-review-1",
+                status: "completed",
+                output: [{ type: "text", text: "No findings. Ready to merge." }],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : `${entry.type}:${entry.id}`
+        )
+      ).toEqual([
+        "assistant:Loaded thread-1",
+        "review:turn-review-1-item-entered",
+        "review:turn-review-1-item",
+      ]);
+    });
+    expect(result.current.response?.replay.messages).toHaveLength(1);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -44,6 +44,8 @@ import type {
   SetThreadModelSettingsResponse,
   StartThreadRequest,
   StartThreadResponse,
+  StartReviewRequest,
+  StartReviewResponse,
   StartTurnRequest,
   StartTurnResponse,
   SubmitServerRequestRequest,
@@ -80,6 +82,7 @@ export type DesktopApi = {
     request: RenameThreadRequest
   ) => Promise<RenameThreadResponse>;
   startThread?: (request: StartThreadRequest) => Promise<StartThreadResponse>;
+  startReview?: (request: StartReviewRequest) => Promise<StartReviewResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
   interruptTurn?: (
     request: InterruptTurnRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
   AppServerCollaborationModeRequest,
+  AppServerReviewTarget,
   AppServerThreadImagePart,
   AppServerTurnInputItem,
   LinkedDirectorySummary,
@@ -610,7 +611,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   materializeDirectoryLaunchpad: (
     directoryKey: string,
     input?: AppServerTurnInputItem[],
-    collaborationMode?: AppServerCollaborationModeRequest
+    collaborationMode?: AppServerCollaborationModeRequest,
+    reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
   openDirectoryLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -1328,7 +1330,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     async (
       directoryKey: string,
       input?: AppServerTurnInputItem[],
-      collaborationMode?: AppServerCollaborationModeRequest
+      collaborationMode?: AppServerCollaborationModeRequest,
+      reviewTarget?: AppServerReviewTarget
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -1349,6 +1352,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           directoryKey,
           input,
           collaborationMode,
+          reviewTarget,
         });
         const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
           directory,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -130,6 +130,14 @@ function pruneOptimisticEntries(
   });
 }
 
+function optimisticMessageEntries(
+  optimisticEntries: AppServerThreadEntry[]
+): AppServerThreadMessageEntry[] {
+  return optimisticEntries.filter(
+    (entry): entry is AppServerThreadMessageEntry => entry.type === "message"
+  );
+}
+
 function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
   return Boolean(
     session.response?.replay.entries.length ||
@@ -603,7 +611,9 @@ export function useThreadSessionState(params: {
         const persistedMessageExists = current.response?.replay.messages.some((message) =>
           messageMatchesOptimisticEntry(message, optimisticEntry)
         );
-        const optimisticMessageExists = current.optimisticEntries.some((entry) =>
+        const optimisticMessageExists = optimisticMessageEntries(
+          current.optimisticEntries
+        ).some((entry) =>
           messageMatchesOptimisticEntry(
             {
               id: entry.id,
@@ -756,7 +766,7 @@ export function useThreadSessionState(params: {
                   backend: event.backend,
                   threadId: notificationThreadId,
                 },
-                current.optimisticEntries,
+                optimisticMessageEntries(current.optimisticEntries),
                 current.pendingAssistantMessage
               );
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerPendingRequestNotification,
   AppServerReadThreadResponse,
+  AppServerReviewOutput,
   AppServerToolRequestUserInputNotification,
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  AppServerThreadReviewEntry,
   AppServerThreadTurnMetadata,
   AppServerThreadImagePart,
   NavigationThreadSummary,
@@ -326,6 +328,25 @@ function appendMessageEntries(
   };
 }
 
+function appendThreadEntries(
+  response: AppServerReadThreadResponse | undefined,
+  params: {
+    backend: NavigationThreadSummary["source"];
+    threadId: NavigationThreadSummary["id"];
+  },
+  entries: AppServerThreadEntry[]
+): AppServerReadThreadResponse {
+  const baseResponse = response ?? buildEmptyResponse(params);
+  return {
+    ...baseResponse,
+    fetchedAt: Date.now(),
+    replay: {
+      ...baseResponse.replay,
+      entries: mergeItems(baseResponse.replay.entries, entries),
+    },
+  };
+}
+
 function appendPendingAssistantMessage(
   response: AppServerReadThreadResponse | undefined,
   params: {
@@ -343,6 +364,96 @@ function appendPendingAssistantMessage(
     ...optimisticEntries,
     pendingAssistantMessage,
   ]);
+}
+
+function normalizeReviewOutput(value: unknown): AppServerReviewOutput | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const findings = Array.isArray(record.findings) ? record.findings : undefined;
+  if (
+    !findings ||
+    (record.overall_correctness !== "patch is correct" &&
+      record.overall_correctness !== "patch is incorrect") ||
+    typeof record.overall_explanation !== "string" ||
+    typeof record.overall_confidence_score !== "number"
+  ) {
+    return undefined;
+  }
+
+  return {
+    findings: findings as AppServerReviewOutput["findings"],
+    overall_correctness: record.overall_correctness,
+    overall_explanation: record.overall_explanation,
+    overall_confidence_score: record.overall_confidence_score,
+  };
+}
+
+function reviewEntryFromCompletedItem(params: {
+  turnId?: string;
+  item?: {
+    id: string;
+    type: string;
+    review?: string;
+    text?: string;
+    data?: Record<string, unknown>;
+  };
+}): AppServerThreadReviewEntry | undefined {
+  const item = params.item;
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+
+  const record = item as {
+    id?: unknown;
+    type?: unknown;
+    review?: unknown;
+    text?: unknown;
+    data?: Record<string, unknown>;
+  };
+  if (record.type !== "enteredReviewMode" && record.type !== "exitedReviewMode") {
+    return undefined;
+  }
+
+  const review =
+    typeof record.review === "string"
+      ? record.review
+      : typeof record.text === "string"
+        ? record.text
+        : "";
+  const output = normalizeReviewOutput(record.data?.reviewOutput);
+  const turn = buildTurnMetadata({
+    fallbackId: typeof params.turnId === "string" ? params.turnId : undefined,
+    fallbackStatus:
+      record.type === "enteredReviewMode" ? "in_progress" : "completed",
+  });
+
+  return {
+    type: "review",
+    id: typeof record.id === "string" ? record.id : `review-${record.type}`,
+    review,
+    ...(record.type === "enteredReviewMode"
+      ? { displayText: review || "Code review started" }
+      : {}),
+    ...(output ? { output } : {}),
+    ...(turn ? { turn } : {}),
+    createdAt: Date.now(),
+  };
+}
+
+function hasReviewEntryForTurn(
+  response: AppServerReadThreadResponse | undefined,
+  turnId: string | undefined
+): boolean {
+  if (!response || !turnId) {
+    return false;
+  }
+
+  return response.replay.entries.some(
+    (entry) => entry.type === "review" && entry.turn?.id === turnId
+  );
 }
 
 function retainSessionCache(
@@ -838,6 +949,33 @@ export function useThreadSessionState(params: {
           };
         }
 
+        if (event.notification.method === "item/completed") {
+          const reviewEntry = reviewEntryFromCompletedItem(event.notification.params);
+          if (reviewEntry) {
+            const nextResponse = appendThreadEntries(
+              current.response,
+              {
+                backend: event.backend,
+                threadId: notificationThreadId,
+              },
+              [reviewEntry]
+            );
+
+            return {
+              ...current,
+              expectOwnUpdate: true,
+              interacted: true,
+              lastTouchedAt: nextLastTouchedAt,
+              optimisticEntries: current.optimisticEntries.filter(
+                (entry) =>
+                  entry.type !== "review" ||
+                  entry.displayText !== reviewEntry.displayText
+              ),
+              response: nextResponse,
+            };
+          }
+        }
+
         if (event.notification.method === "turn/completed") {
           const completedTurn = buildTurnMetadata({
             fallbackId: event.notification.params.turnId ?? current.activeTurnId,
@@ -845,9 +983,15 @@ export function useThreadSessionState(params: {
             fallbackStatus: "completed",
             turn: event.notification.params.turn,
           });
+          const completedTurnHasReview = hasReviewEntryForTurn(
+            current.response,
+            completedTurn?.id
+          );
           const completedTurnText = readCompletedTurnText(event.notification.params);
           const completedText =
-            completedTurnText ?? current.pendingAssistantMessage?.text;
+            completedTurnHasReview
+              ? undefined
+              : completedTurnText ?? current.pendingAssistantMessage?.text;
           const shouldAppendFinalMessage = Boolean(
             completedText &&
               current.pendingAssistantMessage?.text !== completedText

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -43,7 +43,7 @@ type ThreadSessionEntry = {
   loading: boolean;
   loadingMore: boolean;
   needsHydrationAfterCompletion: boolean;
-  optimisticEntries: AppServerThreadMessageEntry[];
+  optimisticEntries: AppServerThreadEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
@@ -103,19 +103,31 @@ function getThreadHydrationVersion(
 }
 
 function pruneOptimisticEntries(
-  optimisticEntries: AppServerThreadMessageEntry[],
+  optimisticEntries: AppServerThreadEntry[],
   response: AppServerReadThreadResponse | undefined
-): AppServerThreadMessageEntry[] {
+): AppServerThreadEntry[] {
   if (!response) {
     return optimisticEntries;
   }
 
-  return optimisticEntries.filter(
-    (entry) =>
-      !response.replay.messages.some(
-        (message) => messageMatchesOptimisticEntry(message, entry)
-      )
-  );
+  return optimisticEntries.filter((entry) => {
+    if (entry.type === "message") {
+      return !response.replay.messages.some((message) =>
+        messageMatchesOptimisticEntry(message, entry)
+      );
+    }
+
+    if (entry.type === "review") {
+      return !response.replay.entries.some(
+        (candidate) =>
+          candidate.type === "review" &&
+          (candidate.review === entry.review ||
+            candidate.displayText === entry.displayText)
+      );
+    }
+
+    return !response.replay.entries.some((candidate) => candidate.id === entry.id);
+  });
 }
 
 function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
@@ -416,6 +428,7 @@ export function useThreadSessionState(params: {
     text: string,
     imageParts?: AppServerThreadImagePart[]
   ) => string;
+  addOptimisticReviewEntry: (displayText: string) => string;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   entries: AppServerThreadEntry[];
   error?: string;
@@ -838,11 +851,13 @@ export function useThreadSessionState(params: {
                 current.pendingAssistantMessage.phase === undefined
             );
           const nextEntries = [
-            ...current.optimisticEntries.map((entry) =>
-              entry.turn?.id === completedTurn?.id
-                ? withTurnMetadata(entry, completedTurn)
-                : entry
-            ),
+            ...current.optimisticEntries
+              .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
+              .map((entry) =>
+                entry.turn?.id === completedTurn?.id
+                  ? { ...entry, turn: completedTurn }
+                  : entry
+              ),
             ...(current.pendingAssistantMessage
               ? [
                   withTurnMetadataAndPhase(
@@ -1114,6 +1129,34 @@ export function useThreadSessionState(params: {
     [threadKey, updateSession]
   );
 
+  const addOptimisticReviewEntry = useCallback(
+    (displayText: string): string => {
+      if (!thread || !threadKey) {
+        return `optimistic-review-${Date.now()}`;
+      }
+
+      const id = `optimistic-review-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      updateSession(threadKey, (current) => ({
+        ...current,
+        expectOwnUpdate: true,
+        interacted: true,
+        lastTouchedAt: Date.now(),
+        optimisticEntries: [
+          ...current.optimisticEntries,
+          {
+            type: "review",
+            id,
+            review: displayText,
+            displayText,
+            createdAt: Date.now(),
+          },
+        ],
+      }));
+      return id;
+    },
+    [thread, threadKey, updateSession]
+  );
+
   const setPendingStatusText = useCallback(
     (status?: string): void => {
       if (!threadKey) {
@@ -1246,7 +1289,9 @@ export function useThreadSessionState(params: {
     () =>
       mergeItems(
         selectedSession?.response?.replay.messages ?? [],
-        visibleOptimisticEntries.map(({ type: _type, ...message }) => message)
+        visibleOptimisticEntries
+          .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
+          .map(({ type: _type, ...message }) => message)
       ),
     [selectedSession?.response?.replay.messages, visibleOptimisticEntries]
   );
@@ -1268,6 +1313,7 @@ export function useThreadSessionState(params: {
     activeTurnId: selectedSession?.activeTurnId,
     activeTurnStartedAt: selectedSession?.activeTurnStartedAt,
     addOptimisticUserMessage,
+    addOptimisticReviewEntry,
     clearPendingRequest,
     entries,
     error: selectedSession?.error,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2458,17 +2458,23 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  max-height: clamp(180px, 34vh, 320px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 8px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: rgba(10, 10, 10, 0.98);
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
+  scrollbar-color: var(--border-strong) transparent;
+  scrollbar-width: thin;
 }
 
-.composer__skill-option {
+.composer__autocomplete-option {
   display: flex;
   width: 100%;
   min-width: 0;
+  flex: 0 0 auto;
   flex-direction: column;
   gap: 4px;
   padding: 10px 12px;
@@ -2476,15 +2482,16 @@ textarea {
   border-radius: 8px;
   background: transparent;
   color: var(--text-primary);
+  cursor: pointer;
   text-align: left;
 }
 
-.composer__skill-option:hover,
-.composer__skill-option.is-active {
+.composer__autocomplete-option:hover,
+.composer__autocomplete-option.is-active {
   background: var(--bg-row-active);
 }
 
-.composer__skill-option-title {
+.composer__autocomplete-title {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -2492,7 +2499,25 @@ textarea {
   font-weight: 600;
 }
 
-.composer__skill-option-meta {
+.composer__autocomplete-match {
+  color: var(--accent-bright);
+}
+
+.composer__autocomplete-token {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent-border);
+  border-radius: 5px;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.composer__autocomplete-meta {
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.45;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1455,6 +1455,171 @@ textarea {
   overflow-wrap: anywhere;
 }
 
+.transcript-review {
+  gap: 12px;
+  border-color: rgba(255, 138, 31, 0.24);
+  background:
+    linear-gradient(180deg, rgba(255, 138, 31, 0.08), rgba(255, 138, 31, 0.02)),
+    var(--bg-panel-elevated);
+}
+
+.transcript-review__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.transcript-review__copy {
+  min-width: 0;
+}
+
+.transcript-review__eyebrow,
+.transcript-review__summary,
+.transcript-review__body,
+.transcript-review__empty {
+  margin: 0;
+}
+
+.transcript-review__eyebrow {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.transcript-review__summary {
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.transcript-review__body {
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.transcript-review__body > * {
+  margin: 0;
+}
+
+.transcript-review__body > * + * {
+  margin-top: 8px;
+}
+
+.transcript-review__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.transcript-review__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: rgba(247, 243, 235, 0.04);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.transcript-review__badge--success {
+  border-color: rgba(156, 229, 179, 0.34);
+  background: var(--success-soft);
+  color: var(--success-text);
+}
+
+.transcript-review__badge--danger {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
+.transcript-review__findings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.transcript-review__finding {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.transcript-review__finding-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+}
+
+.transcript-review__priority {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.transcript-review__finding-title {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.transcript-review__finding-body {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.transcript-review__finding-body > * {
+  margin: 0;
+}
+
+.transcript-review__finding-body > * + * {
+  margin-top: 8px;
+}
+
+.transcript-review__location {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.transcript-review__empty {
+  padding-top: 2px;
+  color: var(--success-text);
+  font-size: 14px;
+  font-weight: 600;
+}
+
 .transcript-list__items > .transcript-activity:first-child {
   padding-top: 0;
   border-top: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -263,12 +263,16 @@ textarea {
 .transcript-activity__toggle:focus,
 .composer__input:focus,
 .composer__select:focus,
+.composer__review-input:focus,
+.composer__review-option:focus,
 .composer__attachment-remove:focus,
 .button:focus-visible,
 .thread-row:focus-visible,
 .transcript-activity__toggle:focus-visible,
 .composer__input:focus-visible,
 .composer__select:focus-visible,
+.composer__review-input:focus-visible,
+.composer__review-option:focus-visible,
 .composer__checkbox input:focus-visible,
 .composer__attachment-remove:focus-visible {
   outline: 2px solid var(--focus-ring);
@@ -2523,6 +2527,133 @@ textarea {
   line-height: 1.45;
 }
 
+.composer__review-config {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.composer__review-config legend {
+  padding: 0 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.composer__review-options {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.composer__review-option {
+  display: flex;
+  min-width: 0;
+  min-height: 58px;
+  flex-direction: column;
+  gap: 3px;
+  justify-content: center;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.composer__review-option:hover,
+.composer__review-option.is-active {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.composer__review-option span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.composer__review-option small {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.composer__review-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.composer__review-input {
+  width: 100%;
+  min-height: 34px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.composer__review-input--textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.composer__review-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.composer__secondary-action,
+.composer__primary-action {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.composer__secondary-action {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.composer__secondary-action:hover {
+  background: var(--bg-panel-hover);
+}
+
+.composer__primary-action {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+}
+
+.composer__primary-action:hover:not([disabled]) {
+  background: var(--accent);
+  color: var(--button-text);
+}
+
+.composer__primary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .composer__meta {
   margin: 0;
   color: var(--text-secondary);
@@ -2663,5 +2794,9 @@ textarea {
 
   .thread-header__title {
     font-size: 32px;
+  }
+
+  .composer__review-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1354,7 +1354,8 @@ textarea {
   color: var(--accent-bright);
 }
 
-.transcript-plan {
+.transcript-plan,
+.transcript-review {
   width: min(100%, 760px);
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/shared/__tests__/diff-focus.test.ts
+++ b/apps/desktop/src/shared/__tests__/diff-focus.test.ts
@@ -76,7 +76,9 @@ describe("diff-focus", () => {
       reason: "eligible"
     });
     expect(buildDiffView(parsed, { mode: "condensed" }).hiddenContextLineCount).toBeGreaterThan(0);
-    expect(summarizeHunksForFocus(parsed)).toMatchObject([
+    const summaries = summarizeHunksForFocus(parsed);
+    expect(summaries).toHaveLength(4);
+    expect(summaries.slice(0, 2)).toMatchObject([
       expect.objectContaining({
         index: 0,
         changedLineCount: 2

--- a/apps/desktop/src/shared/__tests__/review-command.test.ts
+++ b/apps/desktop/src/shared/__tests__/review-command.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseReviewCommand } from "../review-command";
+
+describe("parseReviewCommand", () => {
+  it("parses bare review as uncommitted changes", () => {
+    expect(parseReviewCommand(" /review ")).toEqual({
+      target: { type: "uncommittedChanges" },
+      displayText: "Review current changes",
+    });
+  });
+
+  it("parses a branch argument as a base branch review", () => {
+    expect(parseReviewCommand("/review main")).toEqual({
+      target: { type: "baseBranch", branch: "main" },
+      displayText: "Review changes against main",
+    });
+  });
+
+  it("parses explicit custom review instructions", () => {
+    expect(parseReviewCommand("/review --custom focus on API compatibility")).toEqual({
+      target: { type: "custom", instructions: "focus on API compatibility" },
+      displayText: "Review custom instructions",
+    });
+  });
+
+  it("parses explicit commit review", () => {
+    expect(parseReviewCommand("/review --commit abc123 Fix title")).toEqual({
+      target: { type: "commit", sha: "abc123", title: "Fix title" },
+      displayText: "Review commit abc123",
+    });
+  });
+
+  it("does not parse similar slash commands", () => {
+    expect(parseReviewCommand("/reviewer main")).toBeUndefined();
+    expect(parseReviewCommand("please /review main")).toBeUndefined();
+    expect(parseReviewCommand("/review --custom")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -10,6 +10,7 @@ export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
+export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
 export const AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL = "agent:set-thread-model-settings";

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -1,0 +1,61 @@
+import type { AppServerReviewTarget } from "@pwragnt/shared";
+
+export type ParsedReviewCommand = {
+  target: AppServerReviewTarget;
+  displayText: string;
+};
+
+export function parseReviewCommand(input: string): ParsedReviewCommand | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const match = /^\/review(?:\s+([\s\S]*))?$/.exec(trimmed);
+  if (!match) {
+    return undefined;
+  }
+
+  const argument = match[1]?.trim() ?? "";
+  if (!argument) {
+    return {
+      target: { type: "uncommittedChanges" },
+      displayText: "Review current changes",
+    };
+  }
+
+  const customPrefix = "--custom";
+  if (argument === customPrefix || argument.startsWith(`${customPrefix} `)) {
+    const instructions = argument.slice(customPrefix.length).trim();
+    if (!instructions) {
+      return undefined;
+    }
+    return {
+      target: { type: "custom", instructions },
+      displayText: "Review custom instructions",
+    };
+  }
+
+  const commitPrefix = "--commit";
+  if (argument === commitPrefix || argument.startsWith(`${commitPrefix} `)) {
+    const rest = argument.slice(commitPrefix.length).trim();
+    const [sha, ...titleParts] = rest.split(/\s+/);
+    if (!sha) {
+      return undefined;
+    }
+    const title = titleParts.join(" ").trim();
+    return {
+      target: {
+        type: "commit",
+        sha,
+        title: title || null,
+      },
+      displayText: `Review commit ${sha}`,
+    };
+  }
+
+  return {
+    target: { type: "baseBranch", branch: argument },
+    displayText: `Review changes against ${argument}`,
+  };
+}

--- a/docs/plans/2026-04-22-002-feat-review-command-parity-plan.md
+++ b/docs/plans/2026-04-22-002-feat-review-command-parity-plan.md
@@ -1,0 +1,255 @@
+---
+title: "feat: /review command parity for Codex and Grok"
+type: feat
+status: completed
+date: 2026-04-22
+origin: user-directive
+deepened: 2026-04-22
+---
+
+# feat: /review command parity for Codex and Grok
+
+## Context
+
+Codex Desktop can display review sessions, but PwrAgnt currently lacks an end-to-end `/review` path. The desktop composer only submits normal turns, the backend registry has no `startReview` abstraction, and the Grok-compatible app server implements only a minimal `review/start` runner with a generic prompt.
+
+The target behavior is Codex-compatible:
+
+- `/review` in the desktop composer starts a review, not a normal turn.
+- Codex-backed threads call the Codex app-server `review/start` method.
+- Grok-backed threads support the same app-server method through `packages/agent-core`.
+- Grok review uses a dedicated markdown review prompt similar to Codex's built-in `review_prompt.md`.
+- The Grok prompt specifies the same review output schema as Codex: `findings`, `overall_correctness`, `overall_explanation`, and `overall_confidence_score`, with each finding carrying `title`, `body`, `confidence_score`, optional `priority`, and `code_location.absolute_file_path` plus `line_range.start/end`.
+
+Related local references:
+
+- `docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`
+- `docs/plans/2026-04-16-003-feat-grok-tool-usage-code-search-plan.md`
+- `docs/plans/2026-04-16-004-feat-grok-thread-storage-plan.md`
+- Codex reference checkout: `/Users/huntharo/github/codex/codex-rs/core/review_prompt.md`
+- Codex protocol reference: `/Users/huntharo/github/codex/codex-rs/app-server-protocol/src/protocol/v2.rs`
+- Codex review output reference: `/Users/huntharo/github/codex/codex-rs/protocol/src/protocol.rs`
+
+## Requirements
+
+1. `/review` must be parsed as a command only when it is the first token in the composer text, with optional arguments after it.
+2. `/review` must start a review through the active backend, not by sending the full review prompt as a visible user message.
+3. Codex-backed threads must call app-server `review/start` with a Codex-compatible `ReviewTarget` and default inline delivery.
+4. Grok-backed threads must accept the same `review/start` request shape used by Codex App Server.
+5. Grok review must use a committed markdown prompt file that is similar in intent and rubric to Codex's prompt and explicitly includes the Codex review JSON schema.
+6. Grok review must support `uncommitted_changes`, `base_branch`, `commit`, and `custom` targets at the protocol boundary, even if the desktop command initially exposes only the common cases.
+7. Grok review must parse model output into structured review data when valid JSON is returned and retain a readable fallback when parsing fails.
+8. Desktop transcript state must reflect entered/exited review mode and review results without showing the hidden rubric as the user's prompt.
+9. Tests must cover Codex routing, Grok routing, command parsing, target mapping, schema prompt inclusion, and review notification lifecycle.
+
+## Non-Goals
+
+- Publishing GitHub PR review comments.
+- Detached review threads beyond accepting the protocol field for future compatibility.
+- Auto-applying review findings.
+- Building a general slash-command framework beyond the `/review` path needed here.
+- Replacing the existing normal `turn/start` flow.
+
+## Design
+
+```mermaid
+flowchart LR
+  Composer["Desktop composer /review"] --> IPC["desktopApi.startReview"]
+  IPC --> Registry["BackendRegistry.startReview"]
+  Registry --> CodexClient["Codex client review/start"]
+  Registry --> GrokClient["Grok client review/start"]
+  GrokClient --> AgentCore["agent-core CodexAppServer.review/start"]
+  AgentCore --> Runner["ReviewRunner + review-prompt.md"]
+  CodexClient --> Notifications["app-server notifications"]
+  Runner --> Notifications
+  Notifications --> Transcript["Thread transcript review items"]
+```
+
+The desktop should treat `/review` as a command wrapper around the app-server review API. The visible text in the transcript should be the user-facing target description, such as "Review changes against main", while the full markdown rubric stays inside the backend/model request.
+
+Grok cannot rely on Codex core's Rust `base_instructions` mechanism, so `ReviewRunner` should compose the markdown review prompt and the target-specific review request into a single provider input with clear delimiters. The markdown file is still the source of truth for the review rubric and output schema.
+
+## Implementation Units
+
+### 1. Shared review contract
+
+Files:
+
+- `packages/shared/src/contracts/app-server.ts`
+- `apps/desktop/src/shared/ipc.ts`
+- `packages/shared/src/contracts/__tests__/app-server-review.test.ts`
+- `apps/desktop/src/shared/__tests__/review-command.test.ts`
+
+Work:
+
+- Add shared `ReviewTarget`, `ReviewDelivery`, `StartReviewRequest`, and `StartReviewResponse` types that match Codex App Server naming and payload shape where practical.
+- Add an IPC channel for starting review from the renderer.
+- Add a small parser for composer text that recognizes `/review`, `/review <branch>`, and `/review --custom <instructions>` without changing normal message submission.
+- Map bare `/review` to `uncommitted_changes`.
+- Map `/review main` to `base_branch` with branch `main`.
+- Preserve custom instructions only for explicit custom syntax.
+
+Acceptance checks:
+
+- Normal messages beginning with similar text such as `/reviewer` still submit as normal turns.
+- Empty `/review` becomes an uncommitted-changes review target.
+- Branch and custom forms produce stable structured targets.
+
+### 2. Desktop routing for Codex and Grok backends
+
+Files:
+
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- `apps/desktop/src/preload/index.ts`
+- `apps/desktop/src/main/ipc/agent-ipc.ts`
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `apps/desktop/src/main/grok-app-server/client.ts`
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+
+Work:
+
+- Add `desktopApi.startReview(...)` from renderer to main.
+- Extend `BackendClient` with `startReview`.
+- Route Codex threads to `review/start` on the Codex app-server client.
+- Route Grok threads to `review/start` on the Grok app-server client.
+- For launchpad/directory flows, materialize the thread the same way normal turns do, then start review against that thread and selected workspace.
+- Keep active-run bookkeeping consistent with `startTurn`, including cancellation and notification handling.
+
+Acceptance checks:
+
+- `/review` does not call `turn/start`.
+- Codex client sends `review/start` with `threadId`, `target`, and inline delivery.
+- Grok client sends the same request shape to agent-core.
+- The composer clears or preserves draft text consistently with normal successful submissions.
+
+### 3. Grok review prompt asset and schema source
+
+Files:
+
+- `packages/agent-core/src/app-server/review-prompt.md`
+- `packages/agent-core/src/app-server/review-prompt.ts`
+- `packages/agent-core/src/__tests__/review-start.test.ts`
+
+Work:
+
+- Add `review-prompt.md` as the committed Grok review rubric.
+- Base its structure on Codex's review guidelines: findings only for actionable bugs, tight line ranges, priority guidance, confidence scoring, and no markdown fences around JSON.
+- Include the Codex-compatible JSON schema in the markdown prompt, with the same top-level and nested field names.
+- Add a loader/export helper so `ReviewRunner` can read the prompt reliably in source and packaged builds.
+- Add a test that fails if the prompt no longer mentions the required schema fields.
+
+Acceptance checks:
+
+- `review-prompt.md` exists and is used by the runner.
+- The prompt contains every required Codex review schema field.
+- Tests do not depend on the exact wording of the whole prompt, only on required compatibility anchors.
+
+### 4. Grok `review/start` protocol parity
+
+Files:
+
+- `packages/agent-core/src/app-server/codex-app-server.ts`
+- `packages/agent-core/src/app-server/review-runner.ts`
+- `packages/agent-core/src/app-server/protocol.ts`
+- `packages/agent-core/src/__tests__/review-start.test.ts`
+- `packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts`
+
+Work:
+
+- Replace the current generic review prompt builder with target-specific prompt composition.
+- Add target mapping equivalent to Codex:
+  - `uncommitted_changes`: review staged, unstaged, and untracked changes.
+  - `base_branch`: compute merge base when a workspace is available and ask the model to inspect `git diff <merge-base>`.
+  - `commit`: review the named commit.
+  - `custom`: review using caller-supplied instructions.
+- Emit `enteredReviewMode` before review work starts when compatible with existing transcript persistence.
+- Emit `exitedReviewMode` with the structured review result or fallback explanation when work finishes.
+- Parse final provider text as Codex review JSON. Validate required top-level fields and finding locations before storing structured review data.
+- Preserve existing interactive provider request handling during review.
+- Keep `review/start` failure behavior aligned with `turn/start`: notify failure and avoid leaving active runs stuck.
+
+Acceptance checks:
+
+- Existing `review-start` tests still pass after being updated to expect Codex-compatible prompt content.
+- A mocked valid JSON provider response produces structured review output.
+- A mocked invalid JSON provider response still yields a readable completion item and does not crash the run.
+- Base branch target includes merge-base context when available and falls back to a clear branch diff request when unavailable.
+
+### 5. Transcript normalization and rendering
+
+Files:
+
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `apps/desktop/src/main/grok-app-server/client.ts`
+- Existing renderer transcript item components under `apps/desktop/src/renderer/src/features/thread-detail/`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+
+Work:
+
+- Normalize Codex and Grok `enteredReviewMode` / `exitedReviewMode` items into the same local transcript shape.
+- Render review output as review output, not as an assistant chat message containing raw JSON.
+- Show fallback explanation text when structured findings are unavailable.
+- Ensure review request approval notifications still surface in the same UI path as existing server requests.
+
+Acceptance checks:
+
+- A Codex review session and a Grok review session produce visually consistent transcript items.
+- Raw review prompt text is never shown as the composer-submitted user message.
+- Raw JSON is not the primary rendered review UI when structured fields are present.
+
+### 6. Verification and regression coverage
+
+Files:
+
+- `packages/agent-core/src/__tests__/review-start.test.ts`
+- `apps/desktop/src/shared/__tests__/review-command.test.ts`
+- `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Optional replay-backed E2E fixture/spec if the command affects captured app-server flows
+
+Work:
+
+- Add unit tests for command parsing.
+- Add main-process tests for backend routing.
+- Add client tests for Codex and Grok `review/start` payloads.
+- Add agent-core tests for prompt composition, JSON parsing, notification order, and failure cleanup.
+- Run the package-level test suites that cover desktop IPC/backend clients and `packages/agent-core`.
+
+Acceptance checks:
+
+- Review command tests prove `/review` uses `review/start`.
+- Existing normal turn tests prove non-review composer submissions still use `turn/start`.
+- Agent-core tests prove Grok review emits Codex-compatible lifecycle notifications.
+
+## Open Decisions
+
+1. Slash syntax for custom review instructions: default to `/review --custom <instructions>` to avoid mistaking branch names for prose.
+2. Detached delivery: accept the field for protocol compatibility, but implement inline behavior first unless a current Codex Desktop UI path needs detached reviews immediately.
+3. Structured rendering depth: initial UI can show a compact review summary plus findings; richer grouping by priority can be a follow-up if existing transcript components do not already support it.
+
+## Risks
+
+- Codex protocol names may drift. Mitigation: keep mappings close to the local Codex checkout references and assert payload shapes in client tests.
+- Grok provider may return non-JSON despite the prompt. Mitigation: strict parse when possible, readable fallback when not, and tests for both paths.
+- Base-branch reviews need workspace context. Mitigation: use the thread's linked directory when present and make the no-workspace fallback explicit.
+- Showing the prompt as transcript text would leak implementation detail and confuse users. Mitigation: separate display text from provider prompt throughout the review path.
+
+## Done When
+
+- `/review` in Desktop starts review sessions for Codex and Grok-backed threads.
+- Grok review uses `packages/agent-core/src/app-server/review-prompt.md`.
+- The Grok prompt includes the Codex-compatible review output schema.
+- Codex and Grok clients both call `review/start`.
+- Review lifecycle notifications and transcript rendering are consistent across both backends.
+- Focused tests cover parsing, routing, prompt/schema inclusion, JSON review parsing, and failure cleanup.

--- a/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
+++ b/packages/agent-core/src/__tests__/openclaw-compat-sequences.test.ts
@@ -427,8 +427,13 @@ describe("OpenClaw compatibility sequences", () => {
     await flushAsync();
 
     expect(reviewResult).toEqual({
+      threadId: "thread-1",
       reviewThreadId: "thread-1",
       turnId: "turn-2",
+      turn: {
+        id: "turn-2",
+        status: "inProgress",
+      },
     });
     expect(compactionResult).toEqual({
       threadId: "thread-1",
@@ -444,9 +449,22 @@ describe("OpenClaw compatibility sequences", () => {
           threadId: "thread-1",
           turnId: "turn-2",
           item: {
+            id: "turn-2-item-entered",
+            type: "enteredReviewMode",
+            review: "Review current changes",
+          },
+        },
+      },
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          item: {
             id: "turn-2-item",
             type: "exitedReviewMode",
             review: "Review looks good.",
+            data: undefined,
           },
         },
       },

--- a/packages/agent-core/src/__tests__/review-start.test.ts
+++ b/packages/agent-core/src/__tests__/review-start.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readReviewPrompt } from "../app-server/review-prompt.js";
 import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
 
 async function flushAsync(): Promise<void> {
@@ -8,8 +9,47 @@ async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+const reviewOutput = {
+  findings: [
+    {
+      title: "Wrong branch comparison",
+      body: "The review checks the wrong base branch when main is requested.",
+      confidence_score: 0.9,
+      priority: 2,
+      code_location: {
+        absolute_file_path: "/repo/workspace/src/review.ts",
+        line_range: {
+          start: 12,
+          end: 12,
+        },
+      },
+    },
+  ],
+  overall_correctness: "patch is incorrect",
+  overall_explanation: "The patch has one review issue.",
+  overall_confidence_score: 0.88,
+} as const;
+
 describe("Codex review start", () => {
-  it("starts an inline review run and emits the review completion notifications", async () => {
+  it("keeps the committed review prompt aligned with the Codex review schema", () => {
+    const prompt = readReviewPrompt();
+
+    expect(prompt).toContain("findings");
+    expect(prompt).toContain("title");
+    expect(prompt).toContain("body");
+    expect(prompt).toContain("confidence_score");
+    expect(prompt).toContain("priority");
+    expect(prompt).toContain("code_location");
+    expect(prompt).toContain("absolute_file_path");
+    expect(prompt).toContain("line_range");
+    expect(prompt).toContain("start");
+    expect(prompt).toContain("end");
+    expect(prompt).toContain("overall_correctness");
+    expect(prompt).toContain("overall_explanation");
+    expect(prompt).toContain("overall_confidence_score");
+  });
+
+  it("starts an inline review run and emits structured review completion notifications", async () => {
     const provider = new FakeProvider();
     const { server, notifications } = createTestHarness({ provider });
     await server.request("thread/start", {
@@ -38,21 +78,30 @@ describe("Codex review start", () => {
     });
 
     expect(started).toEqual({
+      threadId: "thread-1",
       reviewThreadId: "thread-1",
       turnId: "turn-2",
+      turn: {
+        id: "turn-2",
+        status: "inProgress",
+      },
     });
     expect(provider.runs[1]?.previousResponseId).toBe("resp_turn_1");
     expect(provider.runs[1]?.input).toEqual([
       {
         type: "text",
         text: expect.stringContaining(
-          "Review the requested target and respond with inline review feedback.",
+          "You are acting as a reviewer for a proposed code change",
         ),
       },
     ]);
     expect(provider.runs[1]?.input[0]).toEqual({
       type: "text",
-      text: expect.stringContaining('"type": "uncommittedChanges"'),
+      text: expect.stringContaining("Review the current code changes"),
+    });
+    expect(provider.runs[1]?.input[0]).toEqual({
+      type: "text",
+      text: expect.stringContaining("overall_confidence_score"),
     });
     expect(provider.runs[1]?.input[0]).toEqual({
       type: "text",
@@ -64,7 +113,7 @@ describe("Codex review start", () => {
     });
 
     provider.runs[1]?.deferred.resolve({
-      assistantText: "Looks good overall.",
+      assistantText: JSON.stringify(reviewOutput),
       providerResponseId: "resp_review_1",
     });
     await flushAsync();
@@ -81,9 +130,22 @@ describe("Codex review start", () => {
           threadId: "thread-1",
           turnId: "turn-2",
           item: {
+            id: "turn-2-item-entered",
+            type: "enteredReviewMode",
+            review: "Review current changes",
+          },
+        },
+      },
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          item: {
             id: "turn-2-item",
             type: "exitedReviewMode",
-            review: "Looks good overall.",
+            review: expect.stringContaining("The patch has one review issue."),
+            data: { reviewOutput },
           },
         },
       },
@@ -95,7 +157,12 @@ describe("Codex review start", () => {
           turn: {
             id: "turn-2",
             status: "completed",
-            output: [{ type: "text", text: "Looks good overall." }],
+            output: [
+              {
+                type: "text",
+                text: expect.stringContaining("The patch has one review issue."),
+              },
+            ],
           },
         },
       },
@@ -109,7 +176,6 @@ describe("Codex review start", () => {
       messages: [
         { role: "user", text: "Please review the current diff." },
         { role: "assistant", text: "Ready to review." },
-        { role: "assistant", text: "Looks good overall." },
       ],
       items: [
         {
@@ -127,21 +193,21 @@ describe("Codex review start", () => {
           text: "Ready to review.",
         },
         {
+          id: "turn-2-item-entered",
+          type: "enteredReviewMode",
+          status: "completed",
+          review: "Review current changes",
+        },
+        {
           id: "turn-2-item",
           type: "exitedReviewMode",
           status: "completed",
-          review: "Looks good overall.",
-        },
-        {
-          id: expect.any(String),
-          type: "agentMessage",
-          status: "completed",
-          role: "assistant",
-          text: "Looks good overall.",
+          review: expect.stringContaining("The patch has one review issue."),
+          data: { reviewOutput },
         },
       ],
       lastUserMessage: "Please review the current diff.",
-      lastAssistantMessage: "Looks good overall.",
+      lastAssistantMessage: "Ready to review.",
     });
   });
 
@@ -178,6 +244,18 @@ describe("Codex review start", () => {
 
     expect(provider.runs[0]?.eventResponses).toEqual([{ decision: "approve" }]);
     expect(notifications).toEqual([
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "turn-1-item-entered",
+            type: "enteredReviewMode",
+            review: "Review current changes",
+          },
+        },
+      },
       {
         method: "serverRequest/resolved",
         params: {
@@ -288,10 +366,49 @@ describe("Codex review start", () => {
             success: true,
             commandAction: "search",
           }),
+          expect.objectContaining({
+            id: "turn-2-item-entered",
+            type: "enteredReviewMode",
+            review: "Review current changes",
+          }),
         ]),
         lastAssistantMessage: "I found the tool usage plan.",
       }),
     );
+  });
+
+  it("normalizes snake_case base branch targets at the protocol boundary", async () => {
+    const provider = new FakeProvider();
+    const { server, notifications } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    await server.request("review/start", {
+      threadId: "thread-1",
+      target: {
+        type: "base_branch",
+        base_branch: "develop",
+      },
+      delivery: "inline",
+    });
+
+    expect(provider.runs[0]?.input).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("base branch 'develop'"),
+      },
+    ]);
+    expect(notifications[0]).toEqual({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "turn-1-item-entered",
+          type: "enteredReviewMode",
+          review: "Review changes against develop",
+        },
+      },
+    });
   });
 
   it("emits a failed turn when the provider review run rejects", async () => {
@@ -314,6 +431,18 @@ describe("Codex review start", () => {
 
     expect(notifications).toEqual([
       {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "turn-1-item-entered",
+            type: "enteredReviewMode",
+            review: "Review current changes",
+          },
+        },
+      },
+      {
         method: "turn/failed",
         params: {
           threadId: "thread-1",
@@ -335,7 +464,14 @@ describe("Codex review start", () => {
         cwd: "/repo/workspace",
       }),
       messages: [],
-      items: [],
+      items: [
+        {
+          id: "turn-1-item-entered",
+          type: "enteredReviewMode",
+          status: "completed",
+          review: "Review current changes",
+        },
+      ],
       lastUserMessage: undefined,
       lastAssistantMessage: undefined,
     });

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -314,7 +314,12 @@ export class CodexAppServer {
 
   private async startReview(
     params: Record<string, unknown>,
-  ): Promise<{ reviewThreadId: string; turnId: string }> {
+  ): Promise<{
+    threadId: string;
+    reviewThreadId: string;
+    turnId: string;
+    turn: { id: string; status: "inProgress" };
+  }> {
     const threadId = asRequiredString(params.threadId, "review/start requires threadId");
     const thread = this.state.getThread(threadId);
     if (!thread) {
@@ -322,12 +327,21 @@ export class CodexAppServer {
     }
     const turnId = this.createTurnId();
     const itemId = `${turnId}-item`;
-    return await this.reviewRunner.start({
+    const result = await this.reviewRunner.start({
       thread,
       turnId,
       itemId,
       target: params.target,
     });
+    return {
+      threadId,
+      reviewThreadId: result.reviewThreadId,
+      turnId: result.turnId,
+      turn: {
+        id: result.turnId,
+        status: "inProgress",
+      },
+    };
   }
 
   private async startTurn(params: AppServerTurnInput): Promise<AppServerTurnResult> {

--- a/packages/agent-core/src/app-server/review-prompt.md
+++ b/packages/agent-core/src/app-server/review-prompt.md
@@ -1,0 +1,41 @@
+# Code review guidelines
+
+You are acting as a reviewer for a proposed code change made by another engineer.
+
+Findings should identify bugs that the original author would likely fix. Focus on correctness, regressions, data loss, security, race conditions, broken user flows, and contract violations. Avoid style preferences, broad praise, or speculative issues that cannot be tied to the reviewed change.
+
+Use tight line ranges. Prefer the smallest range that identifies the problem. Do not cite more lines than needed.
+
+Prioritize findings:
+
+- `0`: Critical. Must block release.
+- `1`: High. Should be fixed before release.
+- `2`: Medium. Should be fixed eventually.
+- `3`: Low. Nice to fix.
+
+Return only valid JSON. Do not wrap the JSON in markdown fences. Use this exact top-level schema:
+
+```json
+{
+  "findings": [
+    {
+      "title": "<short bug title>",
+      "body": "<one paragraph explaining why this is a bug and when it happens>",
+      "confidence_score": 0.0,
+      "priority": 2,
+      "code_location": {
+        "absolute_file_path": "/absolute/path/to/file",
+        "line_range": {
+          "start": 1,
+          "end": 1
+        }
+      }
+    }
+  ],
+  "overall_correctness": "patch is correct",
+  "overall_explanation": "<brief summary of whether the patch is safe>",
+  "overall_confidence_score": 0.0
+}
+```
+
+If there are no findings, return an empty `findings` array. `overall_correctness` must be either `patch is correct` or `patch is incorrect`.

--- a/packages/agent-core/src/app-server/review-prompt.ts
+++ b/packages/agent-core/src/app-server/review-prompt.ts
@@ -1,8 +1,5 @@
-import fs from "node:fs";
-import { fileURLToPath } from "node:url";
-
-const REVIEW_PROMPT_URL = new URL("./review-prompt.md", import.meta.url);
+import reviewPrompt from "./review-prompt.md?raw";
 
 export function readReviewPrompt(): string {
-  return fs.readFileSync(fileURLToPath(REVIEW_PROMPT_URL), "utf8");
+  return reviewPrompt;
 }

--- a/packages/agent-core/src/app-server/review-prompt.ts
+++ b/packages/agent-core/src/app-server/review-prompt.ts
@@ -1,0 +1,8 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const REVIEW_PROMPT_URL = new URL("./review-prompt.md", import.meta.url);
+
+export function readReviewPrompt(): string {
+  return fs.readFileSync(fileURLToPath(REVIEW_PROMPT_URL), "utf8");
+}

--- a/packages/agent-core/src/app-server/review-runner.ts
+++ b/packages/agent-core/src/app-server/review-runner.ts
@@ -1,8 +1,14 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { AppServerReviewOutput, AppServerReviewTarget } from "@pwragnt/shared";
 import type { AppServerNotification, ThreadState } from "./internal-contract.js";
 import { AppServerSessionState } from "./session-state.js";
 import { TurnRunner } from "./turn-runner.js";
+import { readReviewPrompt } from "./review-prompt.js";
 import type { AppServerProvider } from "../providers/provider-contract.js";
 import type { ToolExecutor } from "../tools/tool-contract.js";
+
+const execFileAsync = promisify(execFile);
 
 type ReviewRunnerOptions = {
   provider: AppServerProvider;
@@ -10,6 +16,11 @@ type ReviewRunnerOptions = {
   emit: (notification: AppServerNotification) => Promise<void>;
   turnRunner: TurnRunner;
   tools: ToolExecutor;
+};
+
+type ReviewPromptContext = {
+  displayText: string;
+  prompt: string;
 };
 
 export class ReviewRunner {
@@ -33,15 +44,38 @@ export class ReviewRunner {
     itemId: string;
     target: unknown;
   }): Promise<{ reviewThreadId: string; turnId: string }> {
+    const context = await buildReviewPromptContext({
+      replay: this.state.readThread(params.thread.threadId),
+      target: normalizeReviewTarget(params.target),
+      thread: params.thread,
+    });
+
+    const enteredItemId = `${params.itemId}-entered`;
+    this.state.upsertItem(params.thread.threadId, {
+      id: enteredItemId,
+      type: "enteredReviewMode",
+      status: "completed",
+      review: context.displayText,
+    });
+    await this.emit({
+      method: "item/completed",
+      params: {
+        threadId: params.thread.threadId,
+        turnId: params.turnId,
+        item: {
+          id: enteredItemId,
+          type: "enteredReviewMode",
+          review: context.displayText,
+        },
+      },
+    });
+
     const handle = await this.provider.startTurn({
       thread: params.thread,
       input: [
         {
           type: "text",
-          text: buildReviewPrompt(
-            this.state.readThread(params.thread.threadId),
-            params.target,
-          ),
+          text: context.prompt,
         },
       ],
       previousResponseId: this.state.getPreviousResponseId(params.thread.threadId),
@@ -57,14 +91,19 @@ export class ReviewRunner {
       turnId: params.turnId,
       handle,
       onSuccess: async (result) => {
+        const parsed = parseReviewOutput(result.assistantText);
+        const reviewText = parsed
+          ? formatReviewOutput(parsed)
+          : result.assistantText?.trim() || "Review completed without output.";
+
         this.state.completeRun(params.turnId);
         this.state.upsertItem(params.thread.threadId, {
           id: params.itemId,
           type: "exitedReviewMode",
           status: "completed",
-          review: result.assistantText,
+          review: reviewText,
+          data: parsed ? { reviewOutput: parsed } : undefined,
         });
-        this.state.appendAssistant(params.thread.threadId, result.assistantText ?? "");
         this.state.setPreviousResponseId(
           params.thread.threadId,
           result.providerResponseId,
@@ -77,7 +116,8 @@ export class ReviewRunner {
             item: {
               id: params.itemId,
               type: "exitedReviewMode",
-              review: result.assistantText,
+              review: reviewText,
+              data: parsed ? { reviewOutput: parsed } : undefined,
             },
           },
         });
@@ -92,9 +132,26 @@ export class ReviewRunner {
               output: [
                 {
                   type: "text",
-                  text: result.assistantText ?? "",
+                  text: reviewText,
                 },
               ],
+            },
+          },
+        });
+      },
+      onError: async (error) => {
+        this.state.failRun(params.turnId);
+        await this.emit({
+          method: "turn/failed",
+          params: {
+            threadId: params.thread.threadId,
+            turnId: params.turnId,
+            turn: {
+              id: params.turnId,
+              status: "failed",
+              error: {
+                message: error instanceof Error ? error.message : String(error),
+              },
             },
           },
         });
@@ -107,17 +164,229 @@ export class ReviewRunner {
   }
 }
 
-function buildReviewPrompt(
-  replay: ReturnType<AppServerSessionState["readThread"]>,
-  target: unknown,
-): string {
-  const transcript = replay.messages
+function normalizeReviewTarget(value: unknown): AppServerReviewTarget {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { type: "uncommittedChanges" };
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawType = typeof record.type === "string" ? record.type : "";
+  if (rawType === "uncommittedChanges" || rawType === "uncommitted_changes") {
+    return { type: "uncommittedChanges" };
+  }
+  if (rawType === "baseBranch" || rawType === "base_branch") {
+    const branch =
+      firstNonEmptyString(record.branch, record.baseBranch, record.base_branch) ??
+      "main";
+    return {
+      type: "baseBranch",
+      branch,
+    };
+  }
+  if (rawType === "commit") {
+    return {
+      type: "commit",
+      sha: firstNonEmptyString(record.sha, record.commit) ?? "HEAD",
+      title: typeof record.title === "string" ? record.title : null,
+    };
+  }
+  if (rawType === "custom") {
+    return {
+      type: "custom",
+      instructions:
+        firstNonEmptyString(record.instructions, record.prompt) ??
+        "Review the requested code changes.",
+    };
+  }
+  return { type: "uncommittedChanges" };
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+async function buildReviewPromptContext(params: {
+  replay: ReturnType<AppServerSessionState["readThread"]>;
+  target: AppServerReviewTarget;
+  thread: ThreadState;
+}): Promise<ReviewPromptContext> {
+  const targetPrompt = await buildTargetPrompt(params.thread, params.target);
+  const transcript = params.replay.messages
     .map((message) => `${message.role.toUpperCase()}: ${message.text}`)
     .join("\n\n");
-  const serializedTarget = JSON.stringify(target, null, 2);
-  return [
-    "Review the requested target and respond with inline review feedback.",
-    `Target:\n${serializedTarget}`,
-    transcript ? `Thread transcript:\n${transcript}` : "No prior transcript is available.",
+  const prompt = [
+    readReviewPrompt().trim(),
+    "## Review request",
+    targetPrompt.prompt,
+    "## Thread transcript",
+    transcript || "No prior transcript is available.",
   ].join("\n\n");
+
+  return {
+    displayText: targetPrompt.displayText,
+    prompt,
+  };
+}
+
+async function buildTargetPrompt(
+  thread: ThreadState,
+  target: AppServerReviewTarget,
+): Promise<ReviewPromptContext> {
+  if (target.type === "baseBranch") {
+    const mergeBase = await findMergeBase(thread.cwd, target.branch);
+    if (mergeBase) {
+      return {
+        displayText: `Review changes against ${target.branch}`,
+        prompt: `Review the code changes against the base branch '${target.branch}'. The merge base commit for this comparison is ${mergeBase}. Run git diff ${mergeBase} to inspect the patch.`,
+      };
+    }
+    return {
+      displayText: `Review changes against ${target.branch}`,
+      prompt: `Review the code changes against the base branch '${target.branch}'. If a merge base is needed, inspect the repository and compare the current checkout with that branch.`,
+    };
+  }
+
+  if (target.type === "commit") {
+    return {
+      displayText: `Review commit ${target.sha}`,
+      prompt: `Review commit ${target.sha}${target.title ? ` (${target.title})` : ""} and provide prioritized findings.`,
+    };
+  }
+
+  if (target.type === "custom") {
+    return {
+      displayText: "Review custom instructions",
+      prompt: target.instructions,
+    };
+  }
+
+  return {
+    displayText: "Review current changes",
+    prompt: "Review the current code changes (staged, unstaged, and untracked files) and provide prioritized findings.",
+  };
+}
+
+async function findMergeBase(
+  cwd: string | undefined,
+  branch: string,
+): Promise<string | undefined> {
+  if (!cwd?.trim() || !branch.trim()) {
+    return undefined;
+  }
+  try {
+    const { stdout } = await execFileAsync("git", ["merge-base", "HEAD", branch], {
+      cwd,
+      timeout: 10_000,
+    });
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseReviewOutput(text: string | undefined): AppServerReviewOutput | undefined {
+  if (!text?.trim()) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const record = parsed as Record<string, unknown>;
+  if (!Array.isArray(record.findings)) {
+    return undefined;
+  }
+  const overallCorrectness = record.overall_correctness;
+  const overallExplanation = record.overall_explanation;
+  const overallConfidence = record.overall_confidence_score;
+  if (
+    (overallCorrectness !== "patch is correct" &&
+      overallCorrectness !== "patch is incorrect") ||
+    typeof overallExplanation !== "string" ||
+    typeof overallConfidence !== "number"
+  ) {
+    return undefined;
+  }
+
+  const findings = record.findings.flatMap((finding): AppServerReviewOutput["findings"] => {
+    if (!finding || typeof finding !== "object" || Array.isArray(finding)) {
+      return [];
+    }
+    const item = finding as Record<string, unknown>;
+    const location =
+      item.code_location &&
+      typeof item.code_location === "object" &&
+      !Array.isArray(item.code_location)
+        ? item.code_location as Record<string, unknown>
+        : undefined;
+    const lineRange =
+      location?.line_range &&
+      typeof location.line_range === "object" &&
+      !Array.isArray(location.line_range)
+        ? location.line_range as Record<string, unknown>
+        : undefined;
+    if (
+      typeof item.title !== "string" ||
+      typeof item.body !== "string" ||
+      typeof item.confidence_score !== "number" ||
+      typeof location?.absolute_file_path !== "string" ||
+      typeof lineRange?.start !== "number" ||
+      typeof lineRange?.end !== "number"
+    ) {
+      return [];
+    }
+    return [
+      {
+        title: item.title,
+        body: item.body,
+        confidence_score: item.confidence_score,
+        priority: typeof item.priority === "number" ? item.priority : undefined,
+        code_location: {
+          absolute_file_path: location.absolute_file_path,
+          line_range: {
+            start: lineRange.start,
+            end: lineRange.end,
+          },
+        },
+      },
+    ];
+  });
+
+  return {
+    findings,
+    overall_correctness: overallCorrectness,
+    overall_explanation: overallExplanation,
+    overall_confidence_score: overallConfidence,
+  };
+}
+
+function formatReviewOutput(output: AppServerReviewOutput): string {
+  const lines = [
+    output.overall_explanation.trim() || output.overall_correctness,
+    "",
+  ];
+  if (output.findings.length === 0) {
+    lines.push("No findings.");
+    return lines.join("\n").trim();
+  }
+
+  for (const finding of output.findings) {
+    const range = finding.code_location.line_range;
+    const priority = finding.priority === undefined ? "P?" : `P${finding.priority}`;
+    lines.push(
+      `- [${priority}] ${finding.title} (${finding.code_location.absolute_file_path}:${range.start}-${range.end})`,
+      `  ${finding.body}`,
+    );
+  }
+  return lines.join("\n").trim();
 }

--- a/packages/agent-core/src/vite-env.d.ts
+++ b/packages/agent-core/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+  const value: string;
+  export default value;
+}

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -2,6 +2,8 @@ import type {
   AppServerBackendKind,
   AppServerNotification,
   ThreadExecutionMode,
+  AppServerReviewDelivery,
+  AppServerReviewTarget,
   AppServerTurnInputItem,
   ThreadIdentifier,
 } from "./normalized-app-server";
@@ -43,6 +45,20 @@ export type StartTurnRequest = {
 export type StartTurnResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  turnId: string;
+};
+
+export type StartReviewRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  target: AppServerReviewTarget;
+  delivery?: AppServerReviewDelivery;
+};
+
+export type StartReviewResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  reviewThreadId: ThreadIdentifier;
   turnId: string;
 };
 
@@ -149,6 +165,7 @@ export type MaterializeDirectoryLaunchpadRequest = {
   directoryKey: string;
   input?: AppServerTurnInputItem[];
   collaborationMode?: AppServerCollaborationModeRequest;
+  reviewTarget?: AppServerReviewTarget;
 };
 
 export type MaterializeDirectoryLaunchpadResponse = {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -11,6 +11,7 @@ export type BackendCapabilities = {
   renameThread: boolean;
   readThread: boolean;
   startTurn: boolean;
+  startReview?: boolean;
   interruptTurn: boolean;
   steerTurn: boolean;
   transcriptPagination: boolean;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -33,6 +33,47 @@ export type AppServerTurnInputItem =
   | AppServerImageInputItem
   | AppServerLocalImageInputItem;
 
+export type AppServerReviewTarget =
+  | {
+      type: "uncommittedChanges";
+    }
+  | {
+      type: "baseBranch";
+      branch: string;
+    }
+  | {
+      type: "commit";
+      sha: string;
+      title: string | null;
+    }
+  | {
+      type: "custom";
+      instructions: string;
+    };
+
+export type AppServerReviewDelivery = "inline" | "detached";
+
+export type AppServerReviewFinding = {
+  title: string;
+  body: string;
+  confidence_score: number;
+  priority?: number;
+  code_location: {
+    absolute_file_path: string;
+    line_range: {
+      start: number;
+      end: number;
+    };
+  };
+};
+
+export type AppServerReviewOutput = {
+  findings: AppServerReviewFinding[];
+  overall_correctness: "patch is correct" | "patch is incorrect";
+  overall_explanation: string;
+  overall_confidence_score: number;
+};
+
 export type LinkedDirectorySummary = {
   id: string;
   label: string;
@@ -203,10 +244,22 @@ export type AppServerThreadPlanEntry = {
   turn?: AppServerThreadTurnMetadata;
 };
 
+export type AppServerThreadReviewEntry = {
+  type: "review";
+  id: string;
+  createdAt?: number;
+  status?: AppServerThreadActivityStatus;
+  review: string;
+  displayText?: string;
+  output?: AppServerReviewOutput;
+  turn?: AppServerThreadTurnMetadata;
+};
+
 export type AppServerThreadEntry =
   | AppServerThreadMessageEntry
   | AppServerThreadActivityEntry
-  | AppServerThreadPlanEntry;
+  | AppServerThreadPlanEntry
+  | AppServerThreadReviewEntry;
 
 export type AppServerThreadReplayPagination = {
   supportsPagination: boolean;

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -16,7 +16,10 @@ export default defineConfig({
           name: "desktop-main",
           globals: true,
           environment: "node",
-          include: ["apps/desktop/src/main/__tests__/**/*.test.ts"]
+          include: [
+            "apps/desktop/src/main/__tests__/**/*.test.ts",
+            "apps/desktop/src/shared/__tests__/**/*.test.ts"
+          ]
         }
       },
       {


### PR DESCRIPTION
## Summary
Adds desktop `/review` support end to end for both Codex App Server and agent-core/Grok, then follows through on the renderer and replay work needed to make the command usable in the app.

This PR:
- adds `review/start` support across shared contracts, agent-core, desktop main/preload/IPC, and both backend clients
- adds the committed review prompt/schema and bundles it correctly in desktop builds
- adds `/review` parsing, slash autocomplete support, and a bare-command target picker so users can choose current changes, base branch, commit, or custom instructions before starting a review
- normalizes Codex rollout review events so the transcript shows review runs in the right order without leaking hidden internal prompt text
- adds replay support and E2E coverage for the review flow, including optimistic review cards and hydrated transcript ordering

## Notable details
- Bare `/review` no longer silently defaults to uncommitted changes; it opens a compact review target chooser.
- Explicit commands like `/review main`, `/review --commit <sha>`, and `/review --custom ...` still submit directly.
- Codex rollout files now hydrate entered/exited review mode into transcript review entries instead of leaving orphaned `tool` rows or duplicated user/assistant prompt text.

## Testing
- `pnpm --dir . exec tsc --noEmit -p apps/desktop/tsconfig.json`
- `pnpm --dir . exec tsc --noEmit -p packages/agent-core/tsconfig.json`
- `pnpm --dir . exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --dir . exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --dir . exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/replay-client.test.ts apps/desktop/src/main/__tests__/replay-runtime.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --dir apps/desktop build`
- `pnpm --dir apps/desktop exec playwright test e2e/review-command-flow.spec.ts`
