### PR TITLE
fix(desktop): show new directory threads immediately

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -317,6 +317,77 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("shows a newly materialized directory thread under its directory before the backend snapshot catches up", async () => {
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "directory:/Users/huntharo/github/PwrAgnt",
+          kind: "directory" as const,
+          label: "PwrAgnt",
+          path: "/Users/huntharo/github/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgnt",
+            directoryPath: "/Users/huntharo/github/PwrAgnt",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt: "",
+            workMode: "local" as const,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-new",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.directoryKey).toBe(
+        "directory:/Users/huntharo/github/PwrAgnt"
+      );
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(
+        "directory:/Users/huntharo/github/PwrAgnt"
+      );
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+      input: undefined,
+      collaborationMode: undefined,
+    });
+    expect(result.current.selectedThread?.id).toBe("thread-new");
+    expect(result.current.directories[0]?.threadKeys).toEqual(["codex:thread-new"]);
+    expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
+  });
+
   it("restores backend state and surfaces errors when rename fails", async () => {
     const renameThread = vi.fn(async () => {
       throw new Error("rename failed");

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -376,6 +376,66 @@ function applyLaunchpadReset(
   };
 }
 
+function projectOptimisticThreadIntoDirectories(
+  directories: NavigationSnapshot["directories"],
+  optimisticThread?: NavigationThreadSummary
+): NavigationSnapshot["directories"] {
+  if (!optimisticThread) {
+    return directories;
+  }
+
+  const threadKey = buildThreadIdentityKey(optimisticThread.source, optimisticThread.id);
+  let changed = false;
+  const nextDirectories = [...directories];
+
+  for (const linkedDirectory of optimisticThread.linkedDirectories) {
+    const directoryKey = linkedDirectory.id.startsWith("launchpad:")
+      ? linkedDirectory.id.slice("launchpad:".length)
+      : linkedDirectory.path
+        ? `directory:${linkedDirectory.path}`
+        : undefined;
+    if (!directoryKey) {
+      continue;
+    }
+
+    const existingIndex = nextDirectories.findIndex(
+      (directory) => directory.key === directoryKey
+    );
+    if (existingIndex >= 0) {
+      const existing = nextDirectories[existingIndex]!;
+      if (existing.threadKeys.includes(threadKey)) {
+        continue;
+      }
+
+      nextDirectories[existingIndex] = {
+        ...existing,
+        threadKeys: [threadKey, ...existing.threadKeys],
+        needsAttentionCount:
+          existing.needsAttentionCount + (optimisticThread.inbox.inInbox ? 1 : 0),
+        latestUpdatedAt: Math.max(
+          existing.latestUpdatedAt ?? 0,
+          optimisticThread.updatedAt ?? 0
+        ),
+      };
+      changed = true;
+      continue;
+    }
+
+    nextDirectories.push({
+      key: directoryKey,
+      kind: "directory",
+      label: linkedDirectory.label,
+      path: linkedDirectory.path,
+      threadKeys: [threadKey],
+      needsAttentionCount: optimisticThread.inbox.inInbox ? 1 : 0,
+      latestUpdatedAt: optimisticThread.updatedAt,
+    });
+    changed = true;
+  }
+
+  return changed ? nextDirectories : directories;
+}
+
 function hasSelectionKey(
   response: NavigationSnapshot,
   selectionKey: string,
@@ -855,7 +915,14 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     return [optimisticThread, ...currentThreads];
   }, [optimisticThread, state.response?.threads]);
 
-  const directories = state.response?.directories ?? [];
+  const directories = useMemo(
+    () =>
+      projectOptimisticThreadIntoDirectories(
+        state.response?.directories ?? [],
+        optimisticThread
+      ),
+    [optimisticThread, state.response?.directories]
+  );
 
   const inboxThreads = useMemo(() => {
     const unreadThreads = threads.filter(


### PR DESCRIPTION
## Summary

I fixed a desktop navigation bug where a newly created thread from a directory launchpad could appear in Recents immediately but not show up under that directory in the Directories tab until a later refresh.

The root cause was that the renderer only injected the optimistic newly created thread into the thread list used by Recents. The Directories view still relied on the last backend snapshot, so the directory row had no `threadKeys` entry for the just-created thread.

I fixed this by projecting the optimistic thread into the matching directory row in `useThreadNavigation` until the backend snapshot catches up. I also added a regression test that reproduces the stale-snapshot case and verifies the new thread appears under the directory immediately.

## Testing

I verified this works in the app: newly created threads in a directory now show up in the Directories tab immediately.

I also ran:

- `pnpm --dir . exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
