### PR TITLE
fix(desktop): dedupe pasted images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - Keep changes aligned with the current active plan unless the user explicitly changes scope.
 - Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
+- For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragnt/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.
 
 ## Runtime Config
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "dev": "electron-vite dev",
     "derive:replay-fixture": "tsx ./scripts/derive-replay-fixture.ts",
     "export:session-capture": "tsx ./scripts/export-session-capture.ts",
+    "pretest:e2e": "pnpm build",
     "preview": "electron-vite preview",
     "test:e2e": "playwright test -c playwright.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1098,6 +1098,7 @@ export function Composer(props: ComposerProps) {
 function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
   const files: PastedImageFile[] = [];
   const seenFiles = new Set<string>();
+  let foundImageItem = false;
 
   for (const item of Array.from(clipboardData.items)) {
     if (item.kind !== "file" || !item.type.startsWith("image/")) {
@@ -1109,11 +1110,16 @@ function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
       continue;
     }
 
+    foundImageItem = true;
     const key = buildFileKey(file);
     if (!seenFiles.has(key)) {
       files.push({ file, type: item.type });
       seenFiles.add(key);
     }
+  }
+
+  if (foundImageItem) {
+    return files;
   }
 
   for (const file of Array.from(clipboardData.files)) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -623,6 +623,73 @@ describe("Composer", () => {
     });
   });
 
+  it("does not duplicate a pasted image when clipboard items and files both expose it", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const itemImageFile = new File([new Uint8Array([1, 2, 3])], "clipboard-item.png", {
+      type: "image/png",
+      lastModified: 111,
+    });
+    const filesImageFile = new File([new Uint8Array([1, 2, 3])], "clipboard-files.png", {
+      type: "image/png",
+      lastModified: 222,
+    });
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [filesImageFile],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => itemImageFile,
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("img")).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "image",
+            url: expect.stringMatching(/^data:image\/png;base64,/),
+          },
+        ],
+      });
+    });
+  });
+
   it("keeps Shift+Enter available for a newline", () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,


### PR DESCRIPTION
## Summary

I fixed the desktop composer so a pasted image is only attached once when Electron exposes the same clipboard image through both `clipboardData.items` and `clipboardData.files`.

I also made the desktop package E2E entrypoint build `apps/desktop/out/` before Playwright launches Electron, and I documented the reliable desktop E2E commands in the root `AGENTS.md`.

## Verification

I verified the image paste flow manually in the desktop app and confirmed the first paste now attaches a single image.

I also ran:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop test:e2e -- composer-image-normalization.spec.ts`
- `pnpm --filter desktop typecheck`
