### PR TITLE
fix(desktop): create detached launchpad worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -122,6 +122,7 @@ class MockBackendClient {
     fastMode?: boolean;
   };
   listThreadsCallCount = 0;
+  listModelsCallCount = 0;
   lastListThreadsParams?: {
     filter?: string;
   };
@@ -139,6 +140,13 @@ class MockBackendClient {
       threads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
       skills?: Array<{ cwd?: string; skills: AppServerSkillSummary[] }>;
+      models?: Array<{
+        id: string;
+        label?: string;
+        current?: boolean;
+        supportsReasoning?: boolean;
+        supportsFast?: boolean;
+      }>;
       setThreadPermissionsError?: Error;
     }
   ) {}
@@ -181,6 +189,11 @@ class MockBackendClient {
 
   async listSkills(): Promise<Array<{ cwd?: string; skills: AppServerSkillSummary[] }>> {
     return this.options.skills ?? [];
+  }
+
+  async listModels() {
+    this.listModelsCallCount += 1;
+    return this.options.models ?? [];
   }
 
   onNotification(
@@ -264,19 +277,21 @@ class MockBackendClient {
 
 describe("DesktopBackendRegistry", () => {
   it("reports backend availability and capabilities", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+    });
     const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({
-        initializeResult: {
-          serverInfo: { name: "Codex App Server", version: "1.0.0" },
-          methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
-        },
-      }),
-      codexFullAccessClient: new MockBackendClient({
-        initializeResult: {
-          serverInfo: { name: "Codex App Server", version: "1.0.0" },
-          methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
-        },
-      }),
+      codexClient,
+      codexFullAccessClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
@@ -284,6 +299,9 @@ describe("DesktopBackendRegistry", () => {
     });
 
     const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(codexClient.listModelsCallCount).toBe(1);
+    expect(codexFullAccessClient.listModelsCallCount).toBe(0);
 
     expect(response.backends).toMatchObject([
       {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1224,7 +1224,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("exposes the locally observed branch when directory enrichment finds drift", async () => {
+  it("surfaces the locally observed branch when protocol metadata omits the branch name", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -1250,8 +1250,41 @@ describe("CodexAppServerClient", () => {
 
     expect(thread).toMatchObject({
       id: "thread-2",
-      gitBranch: undefined,
+      gitBranch: "main",
       observedGitBranch: "main",
+    });
+
+    await client.close();
+  });
+
+  it("keeps the protocol branch when the observed branch drifts after branch creation", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher: async (projectKey) => ({
+        linkedDirectories: projectKey
+          ? [
+              {
+                id: "/Users/huntharo/GIPHY/search-product",
+                label: "search-product",
+                path: "/Users/huntharo/GIPHY/search-product",
+                worktreePath: projectKey,
+                kind: "worktree",
+              },
+            ]
+          : [],
+        observedGitBranch: "fix/desktop-codex-live-tool-labels",
+      }),
+    });
+
+    const threads = await client.listThreads({ filter: "search-product-parity" });
+    const thread = threads.find((entry) => entry.id === "thread-projmgr");
+
+    expect(thread).toMatchObject({
+      id: "thread-projmgr",
+      gitBranch: "main",
+      observedGitBranch: "fix/desktop-codex-live-tool-labels",
     });
 
     await client.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1257,6 +1257,41 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("shows HEAD for detached worktrees even when session metadata still names a source branch", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher: async (projectKey) => ({
+        linkedDirectories: projectKey
+          ? [
+              {
+                id: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                label: "PwrAgnt",
+                path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                worktreePath: projectKey,
+                kind: "worktree",
+              },
+            ]
+          : [],
+        observedGitBranch: "HEAD",
+      }),
+    });
+
+    const threads = await client.listThreads({ filter: "search-product-parity" });
+    const thread = threads.find(
+      (entry) => entry.id === "019d88a2-0e0b-77f0-bfce-130ae8e37d8f"
+    );
+
+    expect(thread).toMatchObject({
+      id: "019d88a2-0e0b-77f0-bfce-130ae8e37d8f",
+      gitBranch: "HEAD",
+      observedGitBranch: "HEAD",
+    });
+
+    await client.close();
+  });
+
   it("extracts transcript messages and pagination metadata from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1,0 +1,80 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { GitDirectoryService } from "../app-server/git-directory-service";
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+}
+
+async function createFixtureRepo(): Promise<string> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-git-directory-service-"));
+  execFileSync("git", ["init", rootDir], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "checkout", "-B", "main"], { stdio: "ignore" });
+  execFileSync("git", ["-C", rootDir, "config", "user.name", "PwrAgnt Tests"], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", rootDir, "config", "user.email", "pwragnt-tests@example.invalid"], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", rootDir, "commit", "--allow-empty", "-m", "Seed fixture repo"], {
+    stdio: "ignore",
+  });
+  execFileSync("git", ["-C", rootDir, "branch", "release"], { stdio: "ignore" });
+  return rootDir;
+}
+
+describe("GitDirectoryService", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanupPaths.splice(0).map((target) => rm(target, { recursive: true, force: true })));
+  });
+
+  it("returns the original directory for local launchpads", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService();
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        workMode: "local",
+      }),
+    ).resolves.toEqual({
+      cwd: repoDir,
+      workMode: "local",
+    });
+  });
+
+  it("creates a detached worktree from the selected base branch without creating a new branch", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService();
+    const branchesBefore = runGit(repoDir, ["branch", "--format=%(refname:short)"])
+      .split("\n")
+      .filter(Boolean);
+    const releaseRevision = runGit(repoDir, ["rev-parse", "release"]);
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "release",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    expect(workspace.cwd).toContain(`${path.sep}.worktrees${path.sep}launchpad-fixturerepo-release-`);
+    expect(runGit(workspace.cwd!, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+    expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("");
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(releaseRevision);
+
+    const branchesAfter = runGit(repoDir, ["branch", "--format=%(refname:short)"])
+      .split("\n")
+      .filter(Boolean);
+    expect(branchesAfter).toEqual(branchesBefore);
+  });
+});

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { compareCodexCliVersions } from "../codex-app-server/stdio-transport";
+
+describe("stdio transport Codex CLI resolution", () => {
+  it("orders stable Codex CLI releases ahead of prereleases with the same version", () => {
+    expect(compareCodexCliVersions("0.125.0", "0.125.0-alpha.3")).toBeGreaterThan(0);
+    expect(compareCodexCliVersions("0.125.0-alpha.4", "0.125.0-alpha.3")).toBeGreaterThan(0);
+  });
+
+  it("orders newer Codex.app prereleases ahead of older stable PATH releases", () => {
+    expect(compareCodexCliVersions("0.126.0-alpha.1", "0.125.0")).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1078,12 +1078,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
   ): Promise<BackendLaunchpadOptions | undefined> {
     if (backend === "codex") {
-      const models = (
-        await Promise.allSettled([
-          readClientModels(this.codexDefaultClient),
-          readClientModels(this.codexFullAccessClient),
-        ])
-      ).flatMap((result) => (result.status === "fulfilled" ? result.value : []));
+      const models = await readClientModels(this.codexDefaultClient).catch(() => []);
       return buildLaunchpadOptions(backend, models);
     }
 
@@ -1147,18 +1142,17 @@ export class DesktopBackendRegistry {
   }
 
   private async describeCodexBackend(): Promise<BackendSummary> {
-    const [defaultResult, fullAccessResult, defaultModelsResult, fullAccessModelsResult] = await Promise.allSettled([
+    const [defaultResult, fullAccessResult, defaultModelsResult] = await Promise.allSettled([
       this.codexDefaultClient.getInitializeResult(),
       this.codexFullAccessClient.getInitializeResult(),
       readClientModels(this.codexDefaultClient),
-      readClientModels(this.codexFullAccessClient),
     ]);
     const successful = [defaultResult, fullAccessResult].flatMap((result) =>
       result.status === "fulfilled" ? [result.value] : [],
     );
     const methods = mergeMethods(successful);
     const available = successful.length > 0;
-    const discoveredModels = [defaultModelsResult, fullAccessModelsResult].flatMap((result) =>
+    const discoveredModels = [defaultModelsResult].flatMap((result) =>
       result.status === "fulfilled" ? result.value : [],
     );
     const unavailableReason = [defaultResult, fullAccessResult]

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -29,7 +29,7 @@ function sanitizeBranchName(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function buildWorktreeBranchName(params: {
+function buildWorktreeDirectoryName(params: {
   baseBranch: string;
   directoryLabel: string;
   timestamp?: number;
@@ -37,11 +37,11 @@ function buildWorktreeBranchName(params: {
   const base = sanitizeBranchName(params.baseBranch) || "main";
   const label = sanitizeBranchName(params.directoryLabel.toLowerCase()) || "launchpad";
   const suffix = (params.timestamp ?? Date.now()).toString(36);
-  return `pwragnt/${label}-${base.replace(/\//g, "-")}-${suffix}`;
+  return `launchpad-${label}-${base.replace(/\//g, "-")}-${suffix}`;
 }
 
-function buildWorktreePath(repoRoot: string, branchName: string): string {
-  return path.join(repoRoot, ".worktrees", branchName.replace(/[\\/]/g, "-"));
+function buildWorktreePath(repoRoot: string, worktreeName: string): string {
+  return path.join(repoRoot, ".worktrees", worktreeName.replace(/[\\/]/g, "-"));
 }
 
 type WorktreeEntry = {
@@ -242,13 +242,13 @@ export class GitDirectoryService {
       sanitizeBranchName(launchpad.branchName ?? "") ||
       sanitizeBranchName(await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"])) ||
       "main";
-    const worktreeBranch = buildWorktreeBranchName({
+    const worktreeName = buildWorktreeDirectoryName({
       baseBranch,
       directoryLabel: launchpad.directoryLabel,
     });
-    const worktreePath = buildWorktreePath(repoRoot, worktreeBranch);
+    const worktreePath = buildWorktreePath(repoRoot, worktreeName);
     await mkdir(path.dirname(worktreePath), { recursive: true });
-    await runGit(repoRoot, ["worktree", "add", "-b", worktreeBranch, worktreePath, baseBranch]);
+    await runGit(repoRoot, ["worktree", "add", "--detach", worktreePath, baseBranch]);
 
     return {
       cwd: worktreePath,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1523,6 +1523,35 @@ function extractModelOptions(value: unknown): BackendModelOption[] {
   return sortCodexModels(models);
 }
 
+function summarizeRawModelList(value: unknown): Array<Record<string, unknown>> {
+  const record = asRecord(value);
+  const data = Array.isArray(record?.data)
+    ? record.data
+    : Array.isArray(value)
+      ? value
+      : [];
+
+  return data.flatMap((entry) => {
+    const modelRecord = asRecord(entry);
+    if (!modelRecord) {
+      return [];
+    }
+
+    return [
+      {
+        id: pickString(modelRecord, ["id", "name", "model"]) ?? null,
+        displayName:
+          pickString(modelRecord, ["displayName", "display_name", "label"]) ?? null,
+        current: pickBoolean(modelRecord, ["current", "default"]) ?? null,
+        hidden: pickBoolean(modelRecord, ["hidden"]) ?? null,
+        supportsReasoning:
+          pickBoolean(modelRecord, ["supportsReasoning", "supports_reasoning"]) ?? null,
+        supportsFast: pickBoolean(modelRecord, ["supportsFast", "supports_fast"]) ?? null,
+      },
+    ];
+  });
+}
+
 function shouldHideCodexModel(
   id: string,
   modelRecord: Record<string, unknown>,
@@ -2428,7 +2457,13 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     });
 
-    return extractModelOptions(result);
+    const models = extractModelOptions(result);
+    codexClientLog.info("model/list", {
+      rawModels: summarizeRawModelList(result),
+      normalizedModelIds: models.map((model) => model.id),
+    });
+
+    return models;
   }
 
   async readThread(params: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1852,7 +1852,7 @@ function resolveDisplayGitBranch(params: {
     return "HEAD";
   }
 
-  return params.gitBranch;
+  return params.gitBranch ?? params.observedGitBranch;
 }
 
 function hydrateMissingLinkedDirectoriesFromSiblingRepos(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1844,6 +1844,17 @@ type EnrichedCodexThread = AppServerThreadSummary & {
   gitOriginUrl?: string;
 };
 
+function resolveDisplayGitBranch(params: {
+  gitBranch?: string;
+  observedGitBranch?: string;
+}): string | undefined {
+  if (params.observedGitBranch === "HEAD") {
+    return "HEAD";
+  }
+
+  return params.gitBranch;
+}
+
 function hydrateMissingLinkedDirectoriesFromSiblingRepos(
   threads: EnrichedCodexThread[]
 ): EnrichedCodexThread[] {
@@ -2368,6 +2379,10 @@ export class CodexAppServerClient {
         return {
           ...thread,
           projectKey,
+          gitBranch: resolveDisplayGitBranch({
+            gitBranch: thread.gitBranch,
+            observedGitBranch: enrichment.observedGitBranch,
+          }),
           linkedDirectories: enrichment.linkedDirectories,
           observedGitBranch: enrichment.observedGitBranch,
           source: "codex" as const

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -1,12 +1,227 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  execFile as execFileCallback,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { access } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import readline from "node:readline";
+import { promisify } from "node:util";
 import type { JsonRpcTransport } from "./json-rpc";
+import { getMainLogger } from "../log";
+
+const execFile = promisify(execFileCallback);
+const codexTransportLog = getMainLogger("pwragnt:codex-transport");
+const CODEX_COMMAND_OVERRIDE_ENV = "PWRAGNT_CODEX_COMMAND";
 
 export type StdioJsonRpcTransportOptions = {
   command: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
 };
+
+type CodexCommandCandidate = {
+  command: string;
+  source: "override" | "path" | "codex-app" | "explicit";
+  version?: string;
+};
+
+async function pathIsExecutable(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate, 0o111);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolvePathCommand(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  if (command.includes(path.sep)) {
+    return (await pathIsExecutable(command)) ? command : undefined;
+  }
+
+  try {
+    const result = await execFile("/usr/bin/which", [command], {
+      env,
+      timeout: 2_000,
+    });
+    return result.stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readCodexVersion(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  try {
+    const result = await execFile(command, ["--version"], {
+      env,
+      timeout: 2_000,
+    });
+    const match = result.stdout.trim().match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function parseVersion(value?: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+} | undefined {
+  const match = value?.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) {
+    return 0;
+  }
+  if (left.length === 0) {
+    return 1;
+  }
+  if (right.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const leftNumber = /^\d+$/.test(leftPart) ? Number(leftPart) : undefined;
+    const rightNumber = /^\d+$/.test(rightPart) ? Number(rightPart) : undefined;
+    if (leftNumber !== undefined && rightNumber !== undefined) {
+      if (leftNumber !== rightNumber) {
+        return Math.sign(leftNumber - rightNumber);
+      }
+      continue;
+    }
+    if (leftNumber !== undefined) {
+      return -1;
+    }
+    if (rightNumber !== undefined) {
+      return 1;
+    }
+    if (leftPart !== rightPart) {
+      return leftPart.localeCompare(rightPart);
+    }
+  }
+
+  return 0;
+}
+
+export function compareCodexCliVersions(left?: string, right?: string): number {
+  const leftVersion = parseVersion(left);
+  const rightVersion = parseVersion(right);
+  if (!leftVersion && !rightVersion) {
+    return 0;
+  }
+  if (!leftVersion) {
+    return -1;
+  }
+  if (!rightVersion) {
+    return 1;
+  }
+
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (leftVersion[key] !== rightVersion[key]) {
+      return Math.sign(leftVersion[key] - rightVersion[key]);
+    }
+  }
+
+  return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
+}
+
+function getCodexAppCandidatePaths(): string[] {
+  return [
+    "/Applications/Codex.app/Contents/Resources/codex",
+    path.join(os.homedir(), "Applications/Codex.app/Contents/Resources/codex"),
+  ];
+}
+
+async function buildCandidate(
+  command: string | undefined,
+  source: CodexCommandCandidate["source"],
+  env: NodeJS.ProcessEnv,
+): Promise<CodexCommandCandidate | undefined> {
+  if (!command?.trim()) {
+    return undefined;
+  }
+
+  const resolvedCommand =
+    source === "path" ? await resolvePathCommand(command.trim(), env) : command.trim();
+  if (!resolvedCommand || !(await pathIsExecutable(resolvedCommand))) {
+    return undefined;
+  }
+
+  return {
+    command: resolvedCommand,
+    source,
+    version: await readCodexVersion(resolvedCommand, env),
+  };
+}
+
+async function resolveCodexCommand(params: {
+  command: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<CodexCommandCandidate> {
+  const override = params.env[CODEX_COMMAND_OVERRIDE_ENV]?.trim();
+  if (override) {
+    const candidate = await buildCandidate(override, "override", params.env);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  const command = params.command.trim() || "codex";
+  if (command !== "codex") {
+    return (
+      (await buildCandidate(command, "explicit", params.env)) ?? {
+        command,
+        source: "explicit",
+      }
+    );
+  }
+
+  const candidates = (
+    await Promise.all([
+      buildCandidate(command, "path", params.env),
+      ...getCodexAppCandidatePaths().map((candidatePath) =>
+        buildCandidate(candidatePath, "codex-app", params.env),
+      ),
+    ])
+  ).filter((candidate): candidate is CodexCommandCandidate => Boolean(candidate));
+
+  return (
+    candidates.sort(
+      (left, right) => compareCodexCliVersions(right.version, left.version),
+    )[0] ?? { command, source: "path" }
+  );
+}
 
 export class StdioJsonRpcTransport implements JsonRpcTransport {
   private childProcess: ChildProcessWithoutNullStreams | null = null;
@@ -28,9 +243,20 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       return;
     }
 
-    const child = spawn(this.options.command, ["app-server", ...(this.options.args ?? [])], {
+    const env = this.options.env ?? process.env;
+    const command = await resolveCodexCommand({
+      command: this.options.command,
+      env,
+    });
+    codexTransportLog.info("launch app-server", {
+      command: command.command,
+      source: command.source,
+      version: command.version ?? null,
+    });
+
+    const child = spawn(command.command, ["app-server", ...(this.options.args ?? [])], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: this.options.env ?? process.env
+      env,
     });
 
     if (!child.stdin || !child.stdout || !child.stderr) {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -579,6 +579,17 @@ describe("App", () => {
         }
       })
     );
+    let launchpadState = {
+      directoryKey: "unlinked:new-thread",
+      directoryKind: "unlinked" as const,
+      directoryLabel: "New thread",
+      backend: "grok" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      workMode: "local" as const,
+      createdAt: 1,
+      updatedAt: 1,
+    };
     let navigationCallCount = 0;
 
     Object.defineProperty(window, "pwragnt", {
@@ -805,17 +816,7 @@ describe("App", () => {
           };
         },
         ensureDirectoryLaunchpad: async () => ({
-          launchpad: {
-            directoryKey: "unlinked:new-thread",
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
-            backend: "grok" as const,
-            executionMode: "default" as const,
-            prompt: "",
-            workMode: "local" as const,
-            createdAt: 1,
-            updatedAt: 1,
-          },
+          launchpad: launchpadState,
           defaults: {
             backend: "grok" as const,
             executionMode: "default" as const,
@@ -827,23 +828,22 @@ describe("App", () => {
         }: {
           directoryKey: string;
           patch: Record<string, unknown>;
-        }) => ({
-          launchpad: {
+        }) => {
+          launchpadState = {
+            ...launchpadState,
+            ...patch,
             directoryKey,
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
-            backend: "grok" as const,
-            executionMode: "default" as const,
-            prompt: typeof patch.prompt === "string" ? patch.prompt : "",
-            workMode: "local" as const,
-            createdAt: 1,
-            updatedAt: 2,
-          },
-          defaults: {
-            backend: "grok" as const,
-            executionMode: "default" as const,
-          },
-        }),
+            updatedAt: launchpadState.updatedAt + 1,
+          };
+
+          return {
+            launchpad: launchpadState,
+            defaults: {
+              backend: "grok" as const,
+              executionMode: "default" as const,
+            },
+          };
+        },
         materializeDirectoryLaunchpad,
         startTurn,
         platform: "darwin",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -391,6 +391,81 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
   });
 
+  it("refreshes the selected thread when only the observed branch changes", async () => {
+    const listeners = new Set<(event: any) => void>();
+    let navigationCallCount = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      navigationCallCount += 1;
+      return {
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [
+          {
+            id: "thread-1",
+            title: "Detached branch naming",
+            titleSource: "explicit" as const,
+            summary: "Test branch chip refresh",
+            source: "codex" as const,
+            gitBranch: navigationCallCount === 1 ? undefined : "fix/branch-pill",
+            observedGitBranch:
+              navigationCallCount === 1 ? undefined : "fix/branch-pill",
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+            updatedAt: 1_000,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+    expect(result.current.selectedThread?.gitBranch).toBeUndefined();
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.gitBranch).toBe("fix/branch-pill");
+      expect(result.current.selectedThread?.observedGitBranch).toBe(
+        "fix/branch-pill"
+      );
+    });
+  });
+
   it("restores backend state and surfaces errors when rename fails", async () => {
     const renameThread = vi.fn(async () => {
       throw new Error("rename failed");

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -317,7 +317,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("shows a newly materialized directory thread under its directory before the backend snapshot catches up", async () => {
+  it("shows a newly materialized detached worktree thread as HEAD before the backend snapshot catches up", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -340,7 +340,8 @@ describe("useThreadNavigation", () => {
             backend: "codex" as const,
             executionMode: "default" as const,
             prompt: "",
-            workMode: "local" as const,
+            workMode: "worktree" as const,
+            branchName: "main",
             createdAt: 1,
             updatedAt: 1,
           },
@@ -355,7 +356,7 @@ describe("useThreadNavigation", () => {
       backend: "codex" as const,
       threadId: "thread-new",
       executionMode: "default" as const,
-      workMode: "local" as const,
+      workMode: "worktree" as const,
     }));
 
     const desktopApi: DesktopApi = {
@@ -384,6 +385,8 @@ describe("useThreadNavigation", () => {
       collaborationMode: undefined,
     });
     expect(result.current.selectedThread?.id).toBe("thread-new");
+    expect(result.current.selectedThread?.gitBranch).toBe("HEAD");
+    expect(result.current.selectedThread?.observedGitBranch).toBe("HEAD");
     expect(result.current.directories[0]?.threadKeys).toEqual(["codex:thread-new"]);
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -82,6 +82,7 @@ function threadSummariesEqual(
     left.createdAt === right.createdAt &&
     left.updatedAt === right.updatedAt &&
     left.gitBranch === right.gitBranch &&
+    left.observedGitBranch === right.observedGitBranch &&
     left.executionMode === right.executionMode &&
     left.model === right.model &&
     left.reasoningEffort === right.reasoningEffort &&

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -506,8 +506,9 @@ function buildOptimisticThreadFromLaunchpad(params: {
       : [],
     gitBranch:
       params.workMode === "worktree"
-        ? params.launchpad.branchName
+        ? "HEAD"
         : params.directory?.gitStatus?.currentBranch ?? params.launchpad.branchName,
+    observedGitBranch: params.workMode === "worktree" ? "HEAD" : undefined,
     updatedAt: Date.now(),
     inbox: {
       inInbox: true,

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -106,6 +106,31 @@ describe("refresh reconciliation", () => {
     expect(snapshot.unchanged).toBe(false);
   });
 
+  it("treats observed branch changes as material snapshot changes", async () => {
+    const store = await createStore();
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread({ gitBranch: "HEAD", observedGitBranch: "HEAD" })],
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [
+        buildThread({
+          gitBranch: "fix/testing-detached-head",
+          observedGitBranch: "fix/testing-detached-head",
+        }),
+      ],
+    });
+
+    expect(snapshot.unchanged).toBe(false);
+    expect(snapshot.threads[0]?.gitBranch).toBe("fix/testing-detached-head");
+    expect(snapshot.threads[0]?.observedGitBranch).toBe("fix/testing-detached-head");
+  });
+
   it("tracks mixed-backend threads with duplicate ids independently in aggregate snapshots", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -119,6 +119,7 @@ export function buildNavigationSnapshotHash(params: {
       projectKey: thread.projectKey ?? null,
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,
+      observedGitBranch: thread.observedGitBranch ?? null,
       executionMode: thread.executionMode ?? "default",
       model: thread.model ?? null,
       reasoningEffort: thread.reasoningEffort ?? null,


### PR DESCRIPTION
## Summary

I changed directory launchpad worktree creation to start from a detached `HEAD` instead of creating a new branch up front.

I also added a git-backed test that verifies the new worktree is detached, comes from the selected base branch, and does not create an extra local branch.

## Testing

I verified `pnpm vitest run apps/desktop/src/main/__tests__/git-directory-service.test.ts`.

I also attempted `pnpm vitest run apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`, but that suite is currently blocked in this workspace because `@testing-library/jest-dom/vitest` is not installed.
