### PR TITLE
fix(desktop): live transcript ordering during streamed replies

### DIFF
--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -57,12 +57,23 @@ test("preserves live assistant commentary messages, tool usage, and final answer
     await app.advance({ stepId: "assistant-message-1a" });
     await app.advance({ stepId: "assistant-message-1b" });
     await expect(transcript).toContainText("Using ce:brainstorm for this.");
+    await expect(transcript).toContainText("What would it take to add Telegram support?");
 
     await app.advance({ stepId: "tool-search-completed-1" });
     await app.advance({ stepId: "tool-command-started-1" });
     await app.advance({ stepId: "assistant-message-2" });
     await expect(transcript).toContainText("Using ce:brainstorm for this.");
     await expect(transcript).toContainText("The broad search was too noisy");
+    let transcriptText = await transcript.innerText();
+    expect(transcriptText.indexOf("What would it take to add Telegram support?")).toBeGreaterThan(
+      transcriptText.indexOf("Ready to brainstorm Telegram support.")
+    );
+    expect(transcriptText.indexOf("Using ce:brainstorm for this.")).toBeGreaterThan(
+      transcriptText.indexOf("What would it take to add Telegram support?")
+    );
+    expect(transcriptText.indexOf("The broad search was too noisy")).toBeGreaterThan(
+      transcriptText.indexOf("Using ce:brainstorm for this.")
+    );
 
     await app.advance({ stepId: "tool-command-completed-1" });
     await app.advance({ stepId: "assistant-message-3" });
@@ -105,6 +116,10 @@ test("preserves live assistant commentary messages, tool usage, and final answer
     );
     await expect(transcript).toContainText(
       "Remote control: Telegram lets you start, steer, approve, and monitor agent threads from mobile."
+    );
+    transcriptText = await transcript.innerText();
+    expect(transcriptText.indexOf("What would it take to add Telegram support?")).toBeGreaterThan(
+      transcriptText.indexOf("Ready to brainstorm Telegram support.")
     );
 
     await workedForToggle.click();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -356,6 +356,118 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage).toBeUndefined();
   });
 
+  it("keeps streamed assistant commentary below the optimistic user prompt", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "history-1",
+              role: "assistant" as const,
+              text: "Earlier thread context.",
+            },
+          ],
+          messages: [
+            {
+              id: "history-1",
+              role: "assistant" as const,
+              text: "Earlier thread context.",
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.addOptimisticUserMessage("Please keep the reply under this prompt.");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-1",
+            delta: "First commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-2",
+            delta: "Second commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+      )
+    ).toEqual([
+      "assistant:Earlier thread context.",
+      "user:Please keep the reply under this prompt.",
+      "assistant:First commentary.",
+    ]);
+    expect(result.current.pendingAssistantMessage?.text).toBe("Second commentary.");
+  });
+
   it("hydrates unphased streamed assistant text after completion", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -312,13 +312,17 @@ function appendPendingAssistantMessage(
     backend: NavigationThreadSummary["source"];
     threadId: NavigationThreadSummary["id"];
   },
+  optimisticEntries: AppServerThreadMessageEntry[],
   pendingAssistantMessage: AppServerThreadMessageEntry | undefined
 ): AppServerReadThreadResponse | undefined {
   if (!pendingAssistantMessage) {
     return response;
   }
 
-  return appendMessageEntries(response, params, [pendingAssistantMessage]);
+  return appendMessageEntries(response, params, [
+    ...optimisticEntries,
+    pendingAssistantMessage,
+  ]);
 }
 
 function retainSessionCache(
@@ -687,12 +691,13 @@ export function useThreadSessionState(params: {
           const pendingText = current.pendingAssistantMessage?.text ?? "";
           const flushedResponse = isSamePendingMessage
             ? current.response
-            : appendPendingAssistantMessage(
+              : appendPendingAssistantMessage(
                 current.response,
                 {
                   backend: event.backend,
                   threadId: notificationThreadId,
                 },
+                current.optimisticEntries,
                 current.pendingAssistantMessage
               );
 


### PR DESCRIPTION
## Summary

I fixed the live transcript ordering regression that could place streamed assistant commentary above the user prompt until the turn completed.

I added regression coverage at both the session-state layer and the replay-backed desktop E2E layer so the in-flight ordering is checked before and after completion.

## Verification

I verified it works end to end with:

`pnpm exec vitest run apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx --config vitest.workspace.ts`

`pnpm test:desktop-e2e -- apps/desktop/e2e/live-agent-messages.spec.ts`
