### PR TITLE
fix(desktop): preserve codex live tool labels

### DIFF
--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -85,7 +85,9 @@ test("preserves live assistant commentary messages, tool usage, and final answer
     await expect(toolSummary).toBeVisible();
     await toolSummary.click();
     await expect(transcript).toContainText("Searched Web (8.4s)");
-    await expect(transcript).toContainText("Ran command (1.1s)");
+    await expect(transcript).toContainText(
+      'rg -n "Telegram|telegram|webhook" docs apps packages (1.1s)'
+    );
 
     await app.advance({ stepId: "turn-completed-1" });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1801,6 +1801,67 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves tool metadata on live item notifications", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        item: {
+          id: "item-tool-1",
+          type: "commandExecution",
+          status: "inProgress",
+          name: "write_stdin",
+          arguments: "{\"session_id\":40500,\"chars\":\"\",\"yield_time_ms\":1000}",
+        }
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(notifications).toEqual([
+      {
+        method: "item/started",
+        params: expect.objectContaining({
+          threadId: "thread-2",
+          turnId: "turn-2",
+          item: expect.objectContaining({
+            id: "item-tool-1",
+            type: "commandExecution",
+            toolName: "write_stdin",
+            arguments: {
+              session_id: 40500,
+              chars: "",
+              yield_time_ms: 1000
+            }
+          })
+        })
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("extracts update_plan function calls from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-plan-call", {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -340,16 +340,41 @@ function normalizeServerNotification(
 ): AppServerNotification {
   const record = asRecord(params) ?? {};
   const metadata = extractRequestMetadata(params);
+  const itemRecord = asRecord(record.item);
+  const normalizedItem =
+    itemRecord && (method === "item/started" || method === "item/completed")
+      ? normalizeLiveNotificationItem(itemRecord)
+      : undefined;
 
   return {
     method: method as AppServerNotification["method"],
     params: {
       ...record,
+      ...(normalizedItem ? { item: normalizedItem } : {}),
       ...(metadata.threadId ? { threadId: metadata.threadId } : {}),
       ...(metadata.turnId ? { turnId: metadata.turnId } : {}),
       ...(metadata.requestId ? { requestId: metadata.requestId } : {}),
     } as AppServerNotification["params"],
   } as AppServerNotification;
+}
+
+function normalizeLiveNotificationItem(
+  item: Record<string, unknown>
+): Record<string, unknown> {
+  const normalized = { ...item };
+  const functionName =
+    pickString(item, ["toolName", "tool_name", "name"]) ??
+    undefined;
+  if (functionName && typeof normalized.toolName !== "string") {
+    normalized.toolName = functionName;
+  }
+
+  const parsedArguments = parseStructuredValue(item.arguments);
+  if (parsedArguments && typeof parsedArguments === "object" && !Array.isArray(parsedArguments)) {
+    normalized.arguments = parsedArguments;
+  }
+
+  return normalized;
 }
 
 function normalizeEpochTimestamp(value: number | undefined): number | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -191,6 +191,70 @@ function formatElapsedMs(elapsedMs: number): string {
   return seconds >= 10 ? `${seconds.toFixed(0)}s` : `${seconds.toFixed(1)}s`;
 }
 
+function formatCommandLabel(command: string | undefined): string {
+  if (!command) {
+    return "Ran command";
+  }
+
+  const stripped = command
+    .replace(/^\/bin\/[a-z]+ -lc /, "")
+    .replace(/^['"]|['"]$/g, "");
+  const collapsed = stripped.replace(/\s+/g, " ").trim();
+  if (!collapsed) {
+    return "Ran command";
+  }
+
+  return collapsed.length > 72 ? `${collapsed.slice(0, 69)}...` : collapsed;
+}
+
+function readCommandActionLabel(item: Record<string, unknown>): string | undefined {
+  const actions = Array.isArray(item.commandActions) ? item.commandActions : [];
+  for (const action of actions) {
+    if (typeof action !== "object" || action === null || Array.isArray(action)) {
+      continue;
+    }
+    const record = action as Record<string, unknown>;
+    const actionType = readString(record, "type");
+    const actionPath = readString(record, "path");
+    const fallbackName = readString(record, "name");
+    if (actionType === "read" && actionPath) {
+      return `Read ${actionPath.split("/").filter(Boolean).pop() ?? actionPath}`;
+    }
+    if (actionType === "search" && actionPath) {
+      return `Searched ${actionPath.split("/").filter(Boolean).pop() ?? actionPath}`;
+    }
+    if (actionType === "listFiles") {
+      return "Listed files";
+    }
+    if (actionType === "search") {
+      return "Ran search";
+    }
+    if (fallbackName) {
+      return fallbackName;
+    }
+  }
+
+  return undefined;
+}
+
+function readCommandActivityKind(
+  item: Record<string, unknown>,
+): AppServerThreadActivityDetail["kind"] {
+  const actions = Array.isArray(item.commandActions) ? item.commandActions : [];
+  for (const action of actions) {
+    if (typeof action !== "object" || action === null || Array.isArray(action)) {
+      continue;
+    }
+    const record = action as Record<string, unknown>;
+    const actionType = readString(record, "type");
+    if (actionType === "read" || actionType === "search") {
+      return "read";
+    }
+  }
+
+  return "command";
+}
+
 function readItemSources(item: Record<string, unknown>): AppServerSource[] {
   const data =
     typeof item.data === "object" && item.data !== null && !Array.isArray(item.data)
@@ -252,6 +316,24 @@ function formatLiveToolName(
   return toolName.replace(/_/g, " ");
 }
 
+function buildLiveToolLabel(
+  item: Record<string, unknown>,
+  itemType: string,
+  status: AppServerThreadActivityDetail["status"],
+  toolName: string,
+): string {
+  if (itemType === "commandexecution") {
+    const command = readString(item, "command");
+    return (
+      readCommandActionLabel(item) ??
+      (command ? formatCommandLabel(command) : undefined) ??
+      formatLiveToolName(toolName, status)
+    );
+  }
+
+  return formatLiveToolName(toolName, status);
+}
+
 function buildLiveToolDetails(
   item: Record<string, unknown>,
 ): AppServerThreadActivityDetail[] {
@@ -273,9 +355,14 @@ function buildLiveToolDetails(
   const details: AppServerThreadActivityDetail[] = [
     {
       id: itemId,
-      kind: toolName.startsWith("search_") ? "read" : "command",
+      kind:
+        itemType === "commandexecution"
+          ? readCommandActivityKind(item)
+          : toolName.startsWith("search_")
+            ? "read"
+            : "command",
       label: [
-        formatLiveToolName(toolName, status),
+        buildLiveToolLabel(item, itemType, status, toolName),
         elapsedMs ? ` (${formatElapsedMs(elapsedMs)})` : "",
         query ? `: ${query}` : "",
         preview ? ` - ${preview}` : "",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1257,6 +1257,244 @@ describe("ThreadView", () => {
     );
   });
 
+  it("renders live Codex command execution activity without falling back to tool", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Response Ordering Bug",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Investigate the tool labels."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            item: {
+              id: "cmd-1",
+              type: "commandExecution",
+              status: "in_progress",
+              command: "/bin/zsh -lc 'git status --short'",
+            },
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByText("git status --short")).toBeInTheDocument();
+    expect(screen.queryByText(/^tool$/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            item: {
+              id: "cmd-1",
+              type: "commandExecution",
+              status: "completed",
+              command: "/bin/zsh -lc 'git status --short'",
+              commandActions: [
+                {
+                  type: "read",
+                  path: "/Users/huntharo/github/PwrAgnt/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx",
+                },
+              ],
+            },
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByText("Read ThreadView.tsx")).toBeInTheDocument();
+  });
+
+  it("renders live Codex tool names when command execution items lack a command string", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Response Ordering Bug",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Investigate the tool labels."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            item: {
+              id: "cmd-2",
+              type: "commandExecution",
+              status: "in_progress",
+              toolName: "write_stdin",
+            },
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByText("write stdin")).toBeInTheDocument();
+  });
+
   it("renders live diff activity from turn/diff/updated and clears it once replay catches up", async () => {
     const selectedThread = {
       id: "thread-2",


### PR DESCRIPTION
## Summary

I fixed the live Codex tool activity regression that collapsed transcript rows to a generic `tool` label.

I preserved Codex tool metadata in the app-server adapter so live `item/started` and `item/completed` notifications keep the original tool name and parsed arguments instead of dropping them during normalization.

I updated the desktop transcript renderer to label live `commandExecution` rows from the best available source in priority order: command actions, command text, then recovered tool name. This keeps rows like `exec_command`, `write_stdin`, and `apply_patch` informative even when the command payload is sparse.

I added regression coverage in both the Codex client adapter tests and the thread view tests so we keep the metadata preservation and renderer labeling paths pinned.

## Testing

I verified this with:

- `pnpm exec vitest run apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx --config vitest.workspace.ts`
