### PR TITLE
fix(desktop): persist launchpad image attachments

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7,6 +7,7 @@ import type {
   BackendSummary,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
+  NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
@@ -60,6 +61,7 @@ type ComposerProps = {
         | "branchName"
         | "directoryLabel"
         | "directoryPath"
+        | "imageAttachments"
       >
     >
   ) => Promise<void>;
@@ -82,15 +84,7 @@ type ComposerProps = {
   threadModelSettingsError?: string;
 };
 
-type ComposerImageAttachment = {
-  id: string;
-  height?: number;
-  name: string;
-  size: number;
-  type: string;
-  url: string;
-  width?: number;
-};
+type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
 type PastedImageFile = {
   file: File;
@@ -203,15 +197,12 @@ export function Composer(props: ComposerProps) {
     }
 
     setDraft(props.launchpad?.prompt ?? "");
+    setImageAttachments(props.launchpad?.imageAttachments ?? []);
     setSending(false);
     setInterrupting(false);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
   }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.updatedAt]);
-
-  useEffect(() => {
-    setImageAttachments([]);
-  }, [props.launchpad?.directoryKey]);
 
   useEffect(() => {
     if (!props.thread) {
@@ -487,9 +478,23 @@ export function Composer(props: ComposerProps) {
   };
 
   const removeImageAttachment = (id: string): void => {
-    setImageAttachments((current) =>
-      current.filter((attachment) => attachment.id !== id)
-    );
+    setImageAttachments((current) => {
+      const nextAttachments = current.filter((attachment) => attachment.id !== id);
+      persistLaunchpadImageAttachments(nextAttachments);
+      return nextAttachments;
+    });
+  };
+
+  const persistLaunchpadImageAttachments = (
+    attachments: ComposerImageAttachment[],
+  ): void => {
+    if (!props.launchpad || !props.onUpdateLaunchpad) {
+      return;
+    }
+
+    void props.onUpdateLaunchpad(props.launchpad.directoryKey, {
+      imageAttachments: attachments.length > 0 ? attachments : undefined,
+    });
   };
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>): void => {
@@ -541,7 +546,11 @@ export function Composer(props: ComposerProps) {
         })
       );
 
-      setImageAttachments((current) => [...current, ...nextAttachments]);
+      setImageAttachments((current) => {
+        const mergedAttachments = [...current, ...nextAttachments];
+        persistLaunchpadImageAttachments(mergedAttachments);
+        return mergedAttachments;
+      });
     } catch (error) {
       setSendError(
         error instanceof Error ? error.message : "The pasted image could not be read."

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,6 +1,10 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import type { BackendSummary, StartTurnRequest } from "@pwragnt/shared";
+import type {
+  BackendSummary,
+  NavigationLaunchpadDraft,
+  StartTurnRequest,
+} from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Composer } from "../Composer";
 
@@ -430,6 +434,138 @@ describe("Composer", () => {
         { workMode: "worktree" }
       );
     });
+  });
+
+  it("restores pasted launchpad images after switching away and back before starting the thread", async () => {
+    const launchpads = new Map<string, NavigationLaunchpadDraft>([
+      [
+        "directory:/repo-a",
+        {
+          directoryKey: "directory:/repo-a",
+          directoryKind: "directory" as const,
+          directoryLabel: "Repo A",
+          directoryPath: "/repo-a",
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      [
+        "directory:/repo-b",
+        {
+          directoryKey: "directory:/repo-b",
+          directoryKind: "directory" as const,
+          directoryLabel: "Repo B",
+          directoryPath: "/repo-b",
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    ]);
+    const onUpdateLaunchpad = vi.fn(async (directoryKey, patch) => {
+      const current = launchpads.get(directoryKey);
+      if (!current) {
+        throw new Error(`Unknown launchpad ${directoryKey}`);
+      }
+      launchpads.set(directoryKey, {
+        ...current,
+        ...patch,
+        updatedAt: current.updatedAt + 1,
+      });
+    });
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "mockup.png", {
+      type: "image/png",
+    });
+
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-a",
+          kind: "directory",
+          label: "Repo A",
+          path: "/repo-a",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-a")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Review the pasted mockup" },
+    });
+    fireEvent.paste(screen.getByLabelText("New thread"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("mockup.png")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(launchpads.get("directory:/repo-a")?.prompt).toBe(
+        "Review the pasted mockup"
+      );
+    });
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-b",
+          kind: "directory",
+          label: "Repo B",
+          path: "/repo-b",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-b")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+    expect(screen.queryByAltText("mockup.png")).not.toBeInTheDocument();
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-a",
+          kind: "directory",
+          label: "Repo A",
+          path: "/repo-a",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-a")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("New thread")).toHaveValue(
+      "Review the pasted mockup"
+    );
+    expect(screen.getByAltText("mockup.png")).toBeInTheDocument();
   });
 
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -84,6 +84,42 @@ function normalizeExecutionMode(value: unknown): ThreadExecutionMode {
   return value === "full-access" ? "full-access" : "default";
 }
 
+function migrateLaunchpadImageAttachments(
+  value: unknown,
+): DirectoryLaunchpadOverlayState["imageAttachments"] {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const attachments = value.flatMap((item) => {
+    const record = asRecord(item);
+    if (
+      !record ||
+      typeof record.id !== "string" ||
+      typeof record.name !== "string" ||
+      typeof record.size !== "number" ||
+      typeof record.type !== "string" ||
+      typeof record.url !== "string"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        id: record.id,
+        height: typeof record.height === "number" ? record.height : undefined,
+        name: record.name,
+        size: record.size,
+        type: record.type,
+        url: record.url,
+        width: typeof record.width === "number" ? record.width : undefined,
+      },
+    ];
+  });
+
+  return attachments.length > 0 ? attachments : undefined;
+}
+
 export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
   const record = asRecord(raw);
   if (!record) {
@@ -156,6 +192,9 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
             executionMode: normalizeExecutionMode(launchpadRecord.executionMode),
             prompt:
               typeof launchpadRecord.prompt === "string" ? launchpadRecord.prompt : "",
+            imageAttachments: migrateLaunchpadImageAttachments(
+              launchpadRecord.imageAttachments,
+            ),
             workMode:
               launchpadRecord.workMode === "worktree" ? "worktree" : "local",
             branchName:

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -115,6 +115,7 @@ export type UpdateDirectoryLaunchpadRequest = {
   patch: Partial<
     Pick<
       NavigationLaunchpadDraft,
+      | "imageAttachments"
       | "prompt"
       | "backend"
       | "executionMode"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -37,11 +37,22 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   directoryKind: DirectorySummaryKind;
   directoryLabel: string;
   directoryPath?: string;
+  imageAttachments?: NavigationLaunchpadImageAttachment[];
   prompt: string;
   workMode: LaunchpadWorkMode;
   branchName?: string;
   createdAt: number;
   updatedAt: number;
+};
+
+export type NavigationLaunchpadImageAttachment = {
+  id: string;
+  height?: number;
+  name: string;
+  size: number;
+  type: string;
+  url: string;
+  width?: number;
 };
 
 export type NavigationDirectoryGitStatus = {


### PR DESCRIPTION
## Summary

I fixed the Directories launchpad composer so pasted image attachments persist with the unsent launchpad draft, matching the existing behavior for typed text.

## What changed

- I added pending image attachments to the launchpad draft contract and overlay-store migration path.
- I updated the composer to hydrate launchpad attachments when returning to a directory draft.
- I persist pasted launchpad images when they are added, and clear the saved attachment list when images are removed.
- I added a regression test for switching away from a directory launchpad and returning before starting the thread.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "restores pasted launchpad images"`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm typecheck`
