### PR TITLE
fix(desktop): index app-created Codex threads

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2182,6 +2182,7 @@ describe("CodexAppServerClient", () => {
       expect(indexLines).toEqual([
         {
           id: "019dd225-74fb-7a83-b4e4-5970680d9382",
+          source: "pwragnt",
           thread_name: "Untitled thread",
           updated_at: "2026-04-28T03:32:43.000Z",
         },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
@@ -2137,6 +2140,55 @@ describe("CodexAppServerClient", () => {
     });
 
     await client.close();
+  });
+
+  it("adds materialized app-created Codex threads to the Codex session index", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragnt-session-index-"));
+    const sessionIndexPath = path.join(tempDir, "session_index.jsonl");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "019dd225-74fb-7a83-b4e4-5970680d9382",
+        path: path.join(
+          tempDir,
+          "sessions/2026/04/27/rollout-2026-04-27T23-32-43-019dd225-74fb-7a83-b4e4-5970680d9382.jsonl"
+        ),
+        cwd: "/Users/huntharo/github/PwrAgnt/.worktrees/launchpad-pwragnt-main-moi2lzw4",
+        preview: "",
+        name: null,
+        updatedAt: 1_777_347_163,
+      },
+      model: "gpt-5.5",
+    };
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+        sessionIndexPath,
+      });
+
+      await client.startThread({
+        cwd: "/Users/huntharo/github/PwrAgnt/.worktrees/launchpad-pwragnt-main-moi2lzw4",
+      });
+      await client.close();
+
+      const indexLines = (await fs.readFile(sessionIndexPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(indexLines).toEqual([
+        {
+          id: "019dd225-74fb-7a83-b4e4-5970680d9382",
+          thread_name: "Untitled thread",
+          updated_at: "2026-04-28T03:32:43.000Z",
+        },
+      ]);
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
   });
 
   it("archives threads through the Codex app server", async () => {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -113,6 +113,7 @@ type SkillCatalogEntry = {
 
 type CodexSessionIndexEntry = {
   id: string;
+  source: "pwragnt";
   thread_name: string;
   updated_at: string;
 };
@@ -1486,6 +1487,7 @@ function extractThreadIndexEntryFromValue(
 
   return {
     id: threadId,
+    source: "pwragnt",
     thread_name: rawName?.trim() || "Untitled thread",
     updated_at: new Date(updatedAt).toISOString(),
   };

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,3 +1,5 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   shortenDerivedThreadTitle,
@@ -85,6 +87,7 @@ type CodexClientOptions = {
   ) => Promise<ThreadDirectoryEnrichment>;
   connectionObserver?: JsonRpcObserver;
   requestTimeoutMs?: number;
+  sessionIndexPath?: string;
 };
 
 type InitializeResult = {
@@ -108,11 +111,18 @@ type SkillCatalogEntry = {
   skills: AppServerSkillSummary[];
 };
 
+type CodexSessionIndexEntry = {
+  id: string;
+  thread_name: string;
+  updated_at: string;
+};
+
 type CodexClientRequestMethod = CodexClientRequest["method"];
 type CodexServerNotificationMethod = CodexServerNotification["method"];
 type CodexServerRequestMethod = CodexServerRequest["method"];
 
 const KNOWN_NOTIFICATION_METHODS = new Set<string>([
+  "thread/started",
   "turn/started",
   "turn/completed",
   "turn/failed",
@@ -136,6 +146,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "mcpServer/startupStatus/updated",
 ]);
 const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<CodexServerNotificationMethod>([
+  "thread/started",
   "turn/started",
   "turn/completed",
   "item/agentMessage/delta",
@@ -1434,6 +1445,60 @@ function extractThreadIdFromValue(value: unknown): string | undefined {
   );
 }
 
+function extractThreadIndexEntryFromValue(
+  value: unknown,
+): CodexSessionIndexEntry | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const threadRecord = asRecord(record.thread) ?? asRecord(record.session);
+  const threadPath =
+    pickString(record, ["path"]) ?? pickString(threadRecord ?? {}, ["path"]);
+  const threadId = extractThreadIdFromValue(value);
+  if (!threadId || !threadPath) {
+    return undefined;
+  }
+
+  const preview =
+    pickString(record, ["preview", "snippet", "firstUserMessage", "first_user_message"]) ??
+    pickString(threadRecord ?? {}, [
+      "preview",
+      "snippet",
+      "firstUserMessage",
+      "first_user_message",
+    ]);
+  const rawName =
+    pickString(record, ["threadName", "thread_name", "name", "title"]) ??
+    pickString(threadRecord ?? {}, ["threadName", "thread_name", "name", "title"]) ??
+    (preview ? shortenDerivedThreadTitle(preview) ?? preview : undefined);
+  const updatedAt =
+    normalizeEpochTimestamp(
+      pickNumber(record, ["updatedAt", "updated_at", "lastActivityAt", "createdAt"]) ??
+        pickNumber(threadRecord ?? {}, [
+          "updatedAt",
+          "updated_at",
+          "lastActivityAt",
+          "createdAt",
+        ])
+    ) ?? Date.now();
+
+  return {
+    id: threadId,
+    thread_name: rawName?.trim() || "Untitled thread",
+    updated_at: new Date(updatedAt).toISOString(),
+  };
+}
+
+async function appendCodexSessionIndexEntry(
+  sessionIndexPath: string,
+  entry: CodexSessionIndexEntry,
+): Promise<void> {
+  await mkdir(path.dirname(sessionIndexPath), { recursive: true });
+  await appendFile(sessionIndexPath, `${JSON.stringify(entry)}\n`, "utf8");
+}
+
 function extractSkillSummary(value: unknown): AppServerSkillSummary | undefined {
   const record = asRecord(value);
   if (!record) {
@@ -2240,6 +2305,7 @@ export class CodexAppServerClient {
   private readonly notificationListeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
   >();
+  private readonly indexedThreadIds = new Set<string>();
   private readonly requestListeners = new Set<
     (
       request: AppServerPendingRequestNotification
@@ -2272,6 +2338,10 @@ export class CodexAppServerClient {
           method,
           payload: params,
         });
+      }
+
+      if (method === "thread/started") {
+        await this.recordThreadInSessionIndex(params);
       }
 
       for (const listener of this.notificationListeners) {
@@ -2359,6 +2429,30 @@ export class CodexAppServerClient {
   async getInitializeResult(): Promise<InitializeResult> {
     await this.ensureInitialized();
     return this.initializeResult ?? {};
+  }
+
+  private getSessionIndexPath(): string {
+    return (
+      this.options.sessionIndexPath?.trim() ||
+      path.join(os.homedir(), ".codex", "session_index.jsonl")
+    );
+  }
+
+  private async recordThreadInSessionIndex(value: unknown): Promise<void> {
+    const entry = extractThreadIndexEntryFromValue(value);
+    if (!entry || this.indexedThreadIds.has(entry.id)) {
+      return;
+    }
+
+    try {
+      await appendCodexSessionIndexEntry(this.getSessionIndexPath(), entry);
+      this.indexedThreadIds.add(entry.id);
+    } catch (error) {
+      codexClientLog.warn("failed to append codex session index", {
+        threadId: entry.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async listThreads(params?: {
@@ -2522,6 +2616,8 @@ export class CodexAppServerClient {
     if (!threadId) {
       throw new Error("codex app server thread/start did not return threadId");
     }
+
+    await this.recordThreadInSessionIndex(result);
 
     return { threadId };
   }


### PR DESCRIPTION
## Summary

I fixed app-created Codex threads so they are registered in Codex's `session_index.jsonl` after `thread/start` materializes a session file. Without that index row, Codex Desktop can miss the thread after restart even though the session JSONL exists on disk.

## What changed

- I append materialized app-created Codex threads to the Codex session index from `thread/start` results and `thread/started` notifications.
- I mark those index rows with `source: "pwragnt"`, which I verified locally still keeps the thread visible in Codex Desktop.
- I added a regression test that creates a Codex thread through the client and verifies the index row is written.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts -t "adds materialized app-created Codex threads"`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
