### PR TITLE
fix(desktop): keep launchpad prompt visible

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
@@ -281,10 +281,16 @@ test("directory launchpad rereads the created thread after completion when the f
       app.window.getByRole("heading", { level: 2, name: "hello from launchpad" }),
     ).toBeVisible();
     await expect(
-      app.window.getByRole("region", { name: "Transcript" }).getByText("No thread history yet."),
+      app.window.getByRole("region", { name: "Transcript" }).getByText("hello from launchpad"),
     ).toBeVisible();
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("No thread history yet."),
+    ).toBeHidden();
 
     await app.advance({ stepId: "turn-started-1" });
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("hello from launchpad"),
+    ).toBeVisible();
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect(

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -272,10 +272,20 @@ test("top-level new thread rereads the created thread until the assistant reply 
     await app.window.getByRole("button", { name: "Start thread" }).click();
 
     await expect(
-      app.window.getByRole("region", { name: "Transcript" }).getByText("No thread history yet."),
+      app.window
+        .getByRole("region", { name: "Transcript" })
+        .getByText("Let's test creating a new thread again"),
     ).toBeVisible();
+    await expect(
+      app.window.getByRole("region", { name: "Transcript" }).getByText("No thread history yet."),
+    ).toBeHidden();
 
     await app.advance({ stepId: "turn-started-1" });
+    await expect(
+      app.window
+        .getByRole("region", { name: "Transcript" })
+        .getByText("Let's test creating a new thread again"),
+    ).toBeVisible();
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
   AppServerCollaborationModeRequest,
+  AppServerThreadImagePart,
   AppServerTurnInputItem,
   NavigationDirectorySummary,
   NavigationLaunchpadDefaults,
@@ -482,6 +483,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   threadId: string;
   executionMode: ThreadExecutionMode;
   workMode: NavigationLaunchpadDraft["workMode"];
+  optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
 }): NavigationThreadSummary {
   return {
     id: params.threadId,
@@ -495,6 +497,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     reasoningEffort: params.launchpad.reasoningEffort,
     serviceTier: params.launchpad.serviceTier,
     fastMode: params.launchpad.fastMode,
+    optimisticUserMessage: params.optimisticUserMessage,
     linkedDirectories: params.launchpad.directoryPath
       ? [
           {
@@ -515,6 +518,40 @@ function buildOptimisticThreadFromLaunchpad(params: {
       inInbox: true,
       reason: "new-thread",
     },
+  };
+}
+
+function buildOptimisticUserMessage(
+  input: AppServerTurnInputItem[] | undefined
+): NavigationThreadSummary["optimisticUserMessage"] {
+  if (!input?.length) {
+    return undefined;
+  }
+
+  const text = input
+    .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> =>
+      item.type === "text" && typeof item.text === "string"
+    )
+    .map((item) => item.text.trim())
+    .filter(Boolean)
+    .join("\n\n");
+  const imageParts: AppServerThreadImagePart[] = input
+    .filter((item): item is Extract<AppServerTurnInputItem, { type: "image" }> =>
+      item.type === "image" && typeof item.url === "string"
+    )
+    .map((item) => ({
+      type: "image",
+      url: item.url,
+    }));
+
+  if (!text && imageParts.length === 0) {
+    return undefined;
+  }
+
+  return {
+    text,
+    ...(imageParts.length > 0 ? { imageParts } : {}),
+    createdAt: Date.now(),
   };
 }
 
@@ -705,7 +742,9 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
             (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
           )
         ) {
-          setOptimisticThread(undefined);
+          setOptimisticThread((current) =>
+            current?.optimisticUserMessage ? current : undefined
+          );
         }
 
         setSelectedItemKey((current) => {
@@ -906,12 +945,23 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       optimisticThread.id
     );
 
-    if (
-      currentThreads.some(
-        (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
-      )
-    ) {
-      return currentThreads;
+    const hasHydratedThread = currentThreads.some(
+      (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+    );
+    if (hasHydratedThread) {
+      if (!optimisticThread.optimisticUserMessage) {
+        return currentThreads;
+      }
+
+      return currentThreads.map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+          ? {
+              ...thread,
+              optimisticUserMessage:
+                thread.optimisticUserMessage ?? optimisticThread.optimisticUserMessage,
+            }
+          : thread
+      );
     }
 
     return [optimisticThread, ...currentThreads];
@@ -1258,6 +1308,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           threadId: response.threadId,
           executionMode: response.executionMode,
           workMode: response.workMode,
+          optimisticUserMessage: buildOptimisticUserMessage(input),
         });
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         setOptimisticThread(optimisticMaterializedThread);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -570,6 +570,56 @@ export function useThreadSessionState(params: {
       return;
     }
 
+    const optimisticUserMessage = thread.optimisticUserMessage;
+    if (optimisticUserMessage) {
+      const optimisticEntry: AppServerThreadMessageEntry = {
+        type: "message",
+        id: `optimistic-launchpad-${threadKey}`,
+        role: "user",
+        text: optimisticUserMessage.text,
+        parts: [
+          ...(optimisticUserMessage.text
+            ? [{ type: "text" as const, text: optimisticUserMessage.text }]
+            : []),
+          ...(optimisticUserMessage.imageParts ?? []),
+        ],
+        createdAt: optimisticUserMessage.createdAt ?? Date.now(),
+      };
+
+      updateSession(threadKey, (current) => {
+        const persistedMessageExists = current.response?.replay.messages.some((message) =>
+          messageMatchesOptimisticEntry(message, optimisticEntry)
+        );
+        const optimisticMessageExists = current.optimisticEntries.some((entry) =>
+          messageMatchesOptimisticEntry(
+            {
+              id: entry.id,
+              role: entry.role,
+              text: entry.text,
+              parts: entry.parts,
+              createdAt: entry.createdAt,
+            },
+            optimisticEntry
+          )
+        );
+
+        if (persistedMessageExists || optimisticMessageExists) {
+          return current;
+        }
+
+        return {
+          ...current,
+          expectOwnUpdate: true,
+          interacted: true,
+          lastTouchedAt: Date.now(),
+          optimisticEntries: [
+            ...current.optimisticEntries,
+            optimisticEntry,
+          ],
+        };
+      });
+    }
+
     const session = sessions[threadKey];
     const hydrationVersion = getThreadHydrationVersion(thread);
     if (!session?.response) {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerBackendScope,
   AppServerBackendKind,
+  AppServerThreadImagePart,
   AppServerThreadSummary,
   LinkedDirectorySummary,
   ThreadExecutionMode,
@@ -18,6 +19,11 @@ export type ThreadInboxState = {
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
+  optimisticUserMessage?: {
+    text: string;
+    imageParts?: AppServerThreadImagePart[];
+    createdAt?: number;
+  };
 };
 
 export type DirectorySummaryKind = "directory" | "workspace" | "unlinked";


### PR DESCRIPTION
## Summary

I fixed the Directories launchpad thread creation path so the submitted prompt stays visible on the new chat screen while the first turn is still running.

The bug was that regular replies seeded an optimistic user message before starting a turn, but directory launchpad creation selected the newly materialized thread and immediately hydrated from `thread/read`. When that first replay read was empty, the transcript showed no user prompt until the backend later persisted the final transcript.

I now carry the launchpad submission as an optimistic user message on the materialized thread summary and let the session state display it until the real replay message arrives. I also tightened the existing replay E2E so it fails if the prompt disappears during the empty initial read or after `turn/started`.

## Testing

I verified this with:

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop test:e2e -- directory-launchpad-transcript-sync.spec.ts`
