### PR TITLE
fix(desktop): handle Codex protocol notices / reload remotely modified threads

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1372,7 +1372,7 @@ describe("CodexAppServerClient", () => {
         {
           type: "activity",
           id: "activity-item-3",
-          summary: "Explored 1 file, Ran 1 command, Edited 1 file",
+          summary: "Explored 1 file, Ran 1 command, Edited 1 file, +2, -1",
           createdAt: 1_763_500_100_000,
           status: "completed",
           turn,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -35,7 +35,6 @@ import type {
   CollaborationMode as CodexCollaborationMode,
   InitializeParams as CodexInitializeParams,
   ReasoningEffort as CodexReasoningEffort,
-  ServerNotification as CodexServerNotification,
   ServerRequest as CodexServerRequest,
   ServiceTier as CodexServiceTier,
 } from "@pwragnt/shared/codex-app-server-protocol";
@@ -119,7 +118,6 @@ type CodexSessionIndexEntry = {
 };
 
 type CodexClientRequestMethod = CodexClientRequest["method"];
-type CodexServerNotificationMethod = CodexServerNotification["method"];
 type CodexServerRequestMethod = CodexServerRequest["method"];
 
 const KNOWN_NOTIFICATION_METHODS = new Set<string>([
@@ -135,18 +133,23 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "turn/plan/updated",
   "turn/diff/updated",
   "serverRequest/resolved",
+  "warning",
   "thread/compacted",
   "thread/archived",
   "thread/unarchived",
+  "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",
   "turn/requestApproval",
   "review/requestApproval",
   "account/rateLimits/updated",
   "item/commandExecution/outputDelta",
+  "item/commandExecution/terminalInteraction",
+  "item/fileChange/outputDelta",
   "mcpServer/startupStatus/updated",
 ]);
-const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<CodexServerNotificationMethod>([
+const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
+  "warning",
   "thread/started",
   "turn/started",
   "turn/completed",
@@ -158,10 +161,13 @@ const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<CodexServerNotificationMeth
   "turn/diff/updated",
   "serverRequest/resolved",
   "thread/compacted",
+  "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",
   "account/rateLimits/updated",
   "item/commandExecution/outputDelta",
+  "item/commandExecution/terminalInteraction",
+  "item/fileChange/outputDelta",
   "mcpServer/startupStatus/updated",
 ]);
 const GENERATED_CODEX_SERVER_REQUEST_METHODS = new Set<CodexServerRequestMethod>([
@@ -187,10 +193,8 @@ function isHandledServerRequestMethod(method: string): boolean {
 
 function isKnownCodexNotificationMethod(
   method: string
-): method is CodexServerNotificationMethod {
-  return GENERATED_CODEX_NOTIFICATION_METHODS.has(
-    method as CodexServerNotificationMethod
-  );
+): boolean {
+  return GENERATED_CODEX_NOTIFICATION_METHODS.has(method);
 }
 
 function isKnownCodexServerRequestMethod(
@@ -1119,6 +1123,8 @@ function summarizeActivityItems(
   let inspectedFiles = 0;
   let commandsRun = 0;
   let changedFiles = 0;
+  let changedFileAdditions = 0;
+  let changedFileRemovals = 0;
   let toolCalls = 0;
   let status: AppServerThreadActivityStatus | undefined;
 
@@ -1217,6 +1223,8 @@ function summarizeActivityItems(
         const diff = extractDiffText(change);
         const diffSummary = diff ? summarizeDiff(diff) : undefined;
         changedFiles += 1;
+        changedFileAdditions += diffSummary?.additions ?? 0;
+        changedFileRemovals += diffSummary?.removals ?? 0;
         pushActivityDetail(details, {
           id: `${itemId}-${index + 1}`,
           kind: "write",
@@ -1271,7 +1279,14 @@ function summarizeActivityItems(
     summaryParts.push(`Ran ${commandsRun} command${commandsRun === 1 ? "" : "s"}`);
   }
   if (changedFiles > 0) {
-    summaryParts.push(`Edited ${changedFiles} file${changedFiles === 1 ? "" : "s"}`);
+    summaryParts.push(
+      [
+        `Edited ${changedFiles} file${changedFiles === 1 ? "" : "s"}`,
+        changedFileAdditions > 0 || changedFileRemovals > 0
+          ? `+${changedFileAdditions.toLocaleString()}, -${changedFileRemovals.toLocaleString()}`
+          : "",
+      ].filter(Boolean).join(", ")
+    );
   }
   if (toolCalls > 0) {
     summaryParts.push(`Used ${toolCalls} tool${toolCalls === 1 ? "" : "s"}`);
@@ -2347,16 +2362,10 @@ export class CodexAppServerClient {
       }
 
       for (const listener of this.notificationListeners) {
-        const wireNotification = isKnownCodexMethod
-          ? ({
-              method,
-              params: params ?? {},
-            } as CodexServerNotification)
-          : undefined;
         await listener(
           normalizeServerNotification(
-            wireNotification?.method ?? method,
-            wireNotification?.params ?? params,
+            method,
+            params,
           )
         );
       }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1773,7 +1773,9 @@ describe("App", () => {
       name: "First cached thread",
     });
 
-    expect(readThread).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
     expect(readThread).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       threadId: "thread-1",
@@ -1786,7 +1788,9 @@ describe("App", () => {
       name: "Second cached thread",
     });
 
-    expect(readThread).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
     expect(readThread).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       threadId: "thread-2",

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -502,6 +502,23 @@ function buildDiffLabel(kind: "add" | "delete" | "update", path?: string): strin
   return `${verb} ${path ? getBasename(path) : "file"}`;
 }
 
+function formatChangedFileSummary(params: {
+  count: number;
+  prefix: "Changed" | "Edited";
+  additions: number;
+  removals: number;
+}): string {
+  const parts = [
+    `${params.prefix} ${params.count} file${params.count === 1 ? "" : "s"}`,
+  ];
+  if (params.additions > 0 || params.removals > 0) {
+    parts.push(
+      `+${params.additions.toLocaleString()}, -${params.removals.toLocaleString()}`
+    );
+  }
+  return parts.join(", ");
+}
+
 function extractDiffDetails(
   diff: string,
   entryId: string
@@ -572,14 +589,110 @@ function buildPendingDiffEntry(params: {
   if (details.length === 0) {
     return undefined;
   }
+  const additions = details.reduce(
+    (total, detail) => total + (detail.fileDiff?.additions ?? 0),
+    0
+  );
+  const removals = details.reduce(
+    (total, detail) => total + (detail.fileDiff?.removals ?? 0),
+    0
+  );
 
   return {
     type: "activity",
     id: params.id,
     createdAt: Date.now(),
-    summary: `Edited ${details.length} file${details.length === 1 ? "" : "s"}`,
+    summary: formatChangedFileSummary({
+      count: details.length,
+      prefix: "Edited",
+      additions,
+      removals,
+    }),
     details,
     ...(params.turn ? { turn: params.turn } : {}),
+  };
+}
+
+function parseFileChangeOutput(delta: string, entryId: string): AppServerThreadActivityDetail[] {
+  const changes = new Map<string, Set<"add" | "delete" | "update">>();
+
+  for (const line of delta.replace(/\r\n?/g, "\n").split("\n")) {
+    const match = line.trim().match(/^([ADM])\s+(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const kind =
+      match[1] === "A" ? "add" : match[1] === "D" ? "delete" : "update";
+    const path = match[2].trim();
+    if (!path) {
+      continue;
+    }
+
+    const existing = changes.get(path) ?? new Set<"add" | "delete" | "update">();
+    existing.add(kind);
+    changes.set(path, existing);
+  }
+
+  return [...changes.entries()].map(([path, kinds], index) => {
+    const labelKind =
+      kinds.has("add") && kinds.has("delete")
+        ? "Recreated"
+        : kinds.has("add")
+          ? "Added"
+          : kinds.has("delete")
+            ? "Deleted"
+            : "Modified";
+    return {
+      id: `${entryId}-${index + 1}`,
+      kind: "write",
+      label: `${labelKind} ${getBasename(path)}`,
+      path,
+    };
+  });
+}
+
+function buildFileChangeOutputEntry(params: {
+  delta: string;
+  id: string;
+  turn?: AppServerThreadTurnMetadata;
+}): AppServerThreadActivityEntry | undefined {
+  const details = parseFileChangeOutput(params.delta, params.id);
+  if (details.length === 0) {
+    return undefined;
+  }
+
+  return {
+    type: "activity",
+    id: params.id,
+    createdAt: Date.now(),
+    summary: formatChangedFileSummary({
+      count: details.length,
+      prefix: "Changed",
+      additions: 0,
+      removals: 0,
+    }),
+    details,
+    ...(params.turn ? { turn: params.turn } : {}),
+  };
+}
+
+function buildWarningActivityEntry(params: {
+  id: string;
+  message: string;
+}): AppServerThreadActivityEntry | undefined {
+  const message = params.message.replace(/^warning:\s*/i, "").trim();
+  if (!message) {
+    return undefined;
+  }
+
+  return {
+    type: "activity",
+    id: params.id,
+    createdAt: Date.now(),
+    tone: "warning",
+    summary: `Warning: ${message}`,
+    details: [],
   };
 }
 
@@ -741,6 +854,8 @@ export function ThreadView(props: ThreadViewProps) {
     useState<AppServerThreadActivityEntry>();
   const [pendingToolActivityEntry, setPendingToolActivityEntry] =
     useState<AppServerThreadActivityEntry>();
+  const [pendingProtocolActivityEntry, setPendingProtocolActivityEntry] =
+    useState<AppServerThreadActivityEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
@@ -750,6 +865,7 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     setPendingActivityEntry(undefined);
     setPendingToolActivityEntry(undefined);
+    setPendingProtocolActivityEntry(undefined);
     setPendingPlanEntry(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
@@ -833,6 +949,7 @@ export function ThreadView(props: ThreadViewProps) {
       ) {
         setPendingActivityEntry(undefined);
         setPendingToolActivityEntry(undefined);
+        setPendingProtocolActivityEntry(undefined);
         return;
       }
 
@@ -856,8 +973,23 @@ export function ThreadView(props: ThreadViewProps) {
           ): T | undefined => (entry ? { ...entry, turn } : undefined);
           setPendingActivityEntry((current) => completeEntryTurn(current));
           setPendingToolActivityEntry((current) => completeEntryTurn(current));
+          setPendingProtocolActivityEntry((current) => completeEntryTurn(current));
           setPendingPlanEntry((current) => completeEntryTurn(current));
         }
+        return;
+      }
+
+      if (event.notification.method === "warning") {
+        const message =
+          typeof event.notification.params.message === "string"
+            ? event.notification.params.message
+            : "";
+        setPendingProtocolActivityEntry(
+          buildWarningActivityEntry({
+            id: `live-warning-${selectedThread.id}`,
+            message,
+          })
+        );
         return;
       }
 
@@ -881,6 +1013,28 @@ export function ThreadView(props: ThreadViewProps) {
                 typeof event.notification.params.turnId === "string"
                   ? event.notification.params.turnId
                   : props.activeTurnId,
+              activeTurnStartedAt: props.activeTurnStartedAt,
+            }),
+          })
+        );
+        return;
+      }
+
+      if (event.notification.method === "item/fileChange/outputDelta") {
+        if (typeof event.notification.params.delta !== "string") {
+          return;
+        }
+
+        const turnId =
+          typeof event.notification.params.turnId === "string"
+            ? event.notification.params.turnId
+            : props.activeTurnId ?? selectedThread.id;
+        setPendingProtocolActivityEntry(
+          buildFileChangeOutputEntry({
+            delta: event.notification.params.delta,
+            id: `live-file-change-${event.notification.params.itemId || turnId}`,
+            turn: buildLiveTurnMetadata({
+              turnId,
               activeTurnStartedAt: props.activeTurnStartedAt,
             }),
           })
@@ -1235,6 +1389,7 @@ export function ThreadView(props: ThreadViewProps) {
             pendingStatusText={props.pendingStatusText}
             restoredViewport={props.transcriptViewport}
             skills={props.skills}
+            pendingProtocolActivityEntry={pendingProtocolActivityEntry}
             threadId={`${selectedThread!.source}:${selectedThread!.id}`}
             onLoadOlder={props.onLoadOlder}
             onOpenImage={setExpandedImage}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -10,9 +10,13 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
   const detailsId = useId();
   const [isExpanded, setIsExpanded] = useState(false);
   const hasDetails = props.entry.details.length > 0;
+  const className =
+    props.entry.tone === "warning"
+      ? "transcript-activity transcript-activity--warning"
+      : "transcript-activity";
 
   return (
-    <aside className="transcript-activity">
+    <aside className={className}>
       <header className="transcript-activity__header">
         {hasDetails ? (
           <button
@@ -72,6 +76,16 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
               ) : (
                 <span className="transcript-activity__detail-label">{detail.label}</span>
               )}
+              {detail.fileDiff ? (
+                <span className="transcript-activity__detail-stats" aria-label="File diff summary">
+                  <span className="transcript-activity__detail-stat transcript-activity__detail-stat--removed">
+                    -{detail.fileDiff.removals.toLocaleString()}
+                  </span>
+                  <span className="transcript-activity__detail-stat transcript-activity__detail-stat--added">
+                    +{detail.fileDiff.additions.toLocaleString()}
+                  </span>
+                </span>
+              ) : null}
               {detail.fileDiff ? <TranscriptDiff detail={detail} /> : null}
             </li>
           ))}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -27,6 +27,7 @@ type TranscriptListProps = {
   loading: boolean;
   loadingMore: boolean;
   pendingActivityEntry?: AppServerThreadActivityEntry;
+  pendingProtocolActivityEntry?: AppServerThreadActivityEntry;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -178,6 +179,7 @@ export function TranscriptList(props: TranscriptListProps) {
   );
   const hasPendingContent = Boolean(
     props.pendingActivityEntry ||
+      props.pendingProtocolActivityEntry ||
       props.pendingAssistantMessage ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
@@ -192,6 +194,9 @@ export function TranscriptList(props: TranscriptListProps) {
     if (props.pendingActivityEntry) {
       entries.push(props.pendingActivityEntry);
     }
+    if (props.pendingProtocolActivityEntry) {
+      entries.push(props.pendingProtocolActivityEntry);
+    }
     if (props.pendingAssistantMessage) {
       entries.push(props.pendingAssistantMessage);
     }
@@ -199,6 +204,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [
     props.entries,
     props.pendingActivityEntry,
+    props.pendingProtocolActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
   ]);
@@ -260,6 +266,7 @@ export function TranscriptList(props: TranscriptListProps) {
     const itemCount =
       props.entries.length +
       (props.pendingActivityEntry ? 1 : 0) +
+      (props.pendingProtocolActivityEntry ? 1 : 0) +
       (props.pendingAssistantMessage ? 1 : 0) +
       (props.pendingPlanEntry ? 1 : 0) +
       (props.pendingStatusText ? 1 : 0) +
@@ -284,6 +291,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [
     props.entries,
     props.pendingActivityEntry,
+    props.pendingProtocolActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
@@ -369,6 +377,7 @@ export function TranscriptList(props: TranscriptListProps) {
       previousSnapshot.itemCount <
             props.entries.length +
               (props.pendingActivityEntry ? 1 : 0) +
+              (props.pendingProtocolActivityEntry ? 1 : 0) +
               (props.pendingAssistantMessage ? 1 : 0) +
               (props.pendingPlanEntry ? 1 : 0) +
               (props.pendingStatusText ? 1 : 0) +
@@ -416,6 +425,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [
     props.entries,
     props.pendingActivityEntry,
+    props.pendingProtocolActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1612,7 +1612,7 @@ describe("ThreadView", () => {
       });
     });
 
-    const toggle = screen.getByRole("button", { name: /Edited 1 file/i });
+    const toggle = screen.getByRole("button", { name: /Edited 1 file, \+1, -2/i });
     expect(toggle).toBeInTheDocument();
 
     fireEvent.click(toggle);
@@ -1705,6 +1705,318 @@ describe("ThreadView", () => {
     );
 
     expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(1);
+  });
+
+  it("renders Codex warning notifications inline", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Too many skills",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Start with many skills."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "warning",
+          params: {
+            threadId: "thread-2",
+            message:
+              "Warning: Exceeded skills context budget of 2%. Loaded skill descriptions were truncated."
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(
+      screen.getByText(
+        "Warning: Exceeded skills context budget of 2%. Loaded skill descriptions were truncated."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders Codex file change output as live file activity", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Update PR description",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Create the PR description."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/fileChange/outputDelta",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            itemId: "call-file-change",
+            delta:
+              "Success. Updated the following files:\nA /Users/huntharo/github/PwrAgnt/.local/PR.md\nD /Users/huntharo/github/PwrAgnt/.local/PR.md\n"
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByText("Changed 1 file")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Changed 1 file/ }));
+    expect(screen.getByText("Recreated PR.md")).toBeInTheDocument();
+  });
+
+  it("renders modified files from Codex file change output", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Update transcript list",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Update the transcript list."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/fileChange/outputDelta",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            itemId: "call-file-change",
+            delta:
+              "Success. Updated the following files:\nM apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx\n"
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(screen.getByText("Changed 1 file")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Changed 1 file/ }));
+    expect(screen.getByText("Modified TranscriptList.tsx")).toBeInTheDocument();
   });
 
   it("maps command approval actions to native decision values and dismisses the approval card", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -486,7 +486,7 @@ describe("TranscriptList", () => {
         pendingActivityEntry={{
           type: "activity",
           id: "pending-activity-1",
-          summary: "Edited 1 file",
+          summary: "Edited 1 file, +1, -2",
           details: [
             {
               id: "pending-detail-1",
@@ -514,12 +514,14 @@ describe("TranscriptList", () => {
       />
     );
 
-    const toggle = screen.getByRole("button", { name: /Edited 1 file/i });
+    const toggle = screen.getByRole("button", { name: /Edited 1 file, \+1, -2/i });
     expect(toggle).toBeInTheDocument();
 
     fireEvent.click(toggle);
 
     expect(screen.getByText("Update useThreadSessionState.ts")).toBeInTheDocument();
+    expect(screen.getAllByText("-2")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("+1")[0]).toBeInTheDocument();
     expect(screen.getByText("function messageMatchesOptimisticEntry(")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -687,7 +687,7 @@ describe("useThreadSessionState", () => {
     });
   });
 
-  it("does not reread an interacted thread when only updatedAt changed on reselect", async () => {
+  it("rereads an interacted thread when updatedAt changed on reselect", async () => {
     const readThread = vi.fn(
       async ({
         backend,
@@ -774,10 +774,13 @@ describe("useThreadSessionState", () => {
     rerender({ thread: thread1Updated });
 
     await waitFor(() => {
-      expect(result.current.entries[0]?.id).toBe("thread-1-message-1");
+      expect(readThread).toHaveBeenCalledTimes(3);
     });
 
-    expect(readThread).toHaveBeenCalledTimes(2);
+    expect(readThread).toHaveBeenNthCalledWith(3, {
+      backend: "codex",
+      threadId: "thread-1",
+    });
   });
 
   it("rereads an interacted thread when the cached transcript is still empty", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -924,6 +924,11 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         return;
       }
 
+      if (method === "thread/started") {
+        scheduleRefresh();
+        return;
+      }
+
       if (
         method === "turn/completed" ||
         method === "turn/failed" ||

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -646,7 +646,7 @@ export function useThreadSessionState(params: {
     }
 
     if (session.expectOwnUpdate) {
-      if (!hasHydratedTranscriptContent(session)) {
+      if (!hasThinkingState(session) || !hasHydratedTranscriptContent(session)) {
         void loadLatest(thread);
         return;
       }
@@ -666,11 +666,7 @@ export function useThreadSessionState(params: {
         return;
       }
 
-      updateSession(threadKey, (current) => ({
-        ...current,
-        hydratedUpdatedAt: thread.updatedAt,
-        lastTouchedAt: Date.now(),
-      }));
+      void loadLatest(thread);
       return;
     }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1339,6 +1339,17 @@ textarea {
   border-top: 1px solid var(--border-subtle);
 }
 
+.transcript-activity--warning {
+  padding: 10px 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-soft);
+}
+
+.transcript-activity--warning .transcript-activity__label {
+  color: var(--accent-bright);
+}
+
 .transcript-plan {
   width: min(100%, 760px);
   display: flex;
@@ -1778,6 +1789,22 @@ textarea {
 
 .transcript-activity__detail-label {
   color: var(--text-primary);
+}
+
+.transcript-activity__detail-stats {
+  display: inline-flex;
+  gap: 8px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.transcript-activity__detail-stat--added {
+  color: var(--success-text);
+}
+
+.transcript-activity__detail-stat--removed {
+  color: var(--danger-text);
 }
 
 .transcript-diff {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -152,6 +152,7 @@ export type AppServerThreadActivityEntry = {
   id: string;
   summary: string;
   createdAt?: number;
+  tone?: "warning";
   status?: AppServerThreadActivityStatus;
   details: AppServerThreadActivityDetail[];
   turn?: AppServerThreadTurnMetadata;
@@ -509,6 +510,39 @@ export type AppServerNotification =
         turnId?: string;
         itemId: string;
         delta: string;
+      };
+    }
+  | {
+      method: "item/commandExecution/terminalInteraction";
+      params: {
+        threadId: string;
+        turnId?: string;
+        itemId: string;
+        processId?: string;
+        stdin?: string;
+      };
+    }
+  | {
+      method: "item/fileChange/outputDelta";
+      params: {
+        threadId: string;
+        turnId?: string;
+        itemId: string;
+        delta: string;
+      };
+    }
+  | {
+      method: "thread/started";
+      params: {
+        threadId?: string;
+        thread?: Record<string, unknown>;
+      };
+    }
+  | {
+      method: "warning";
+      params: {
+        threadId?: string;
+        message: string;
       };
     }
   | {


### PR DESCRIPTION
## Summary

I handled the Codex protocol notifications that were previously logged as unknown while a turn was running.

This PR makes the desktop app:

- render `warning` notifications inline in the transcript, including the skills context budget warning
- recognize `thread/started` and refresh the thread list when a Codex thread is created
- render `item/fileChange/outputDelta` as live file activity, including modified files and add/delete pairs on the same path
- summarize file-change activity with aggregate file and line counts, for example `Edited 45 files, +3,244, -1,032`
- show per-file `+/-` counts in the expandable file-change section before the full diff
- reload cached transcript state when a selected thread's navigation `updatedAt` shows external drift
- treat `item/commandExecution/terminalInteraction` as a known notification without adding noisy UI for empty terminal interactions

## Verification

I verified this with:

- `pnpm test -- apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test -- apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm test -- apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm test -- apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm test -- apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test`
- `pnpm --filter @pwragnt/desktop typecheck`
