### PR TITLE
fix(desktop): Add transcript scroll follow tests and fixes

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -168,6 +168,7 @@ export function TranscriptList(props: TranscriptListProps) {
     new Map<string, { distanceFromBottom: number; scrollTop: number }>()
   );
   const shouldScrollToBottomRef = useRef(true);
+  const isFollowingBottomRef = useRef(true);
   const [hasContentBelow, setHasContentBelow] = useState(false);
   const [expandedCommentaryGroupIds, setExpandedCommentaryGroupIds] = useState(
     () => new Set<string>()
@@ -295,6 +296,9 @@ export function TranscriptList(props: TranscriptListProps) {
   const syncScrollState = useCallback(() => {
     const snapshot = captureSnapshot();
     snapshotRef.current = snapshot;
+    isFollowingBottomRef.current = Boolean(
+      snapshot && snapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX
+    );
     setHasContentBelow(Boolean(snapshot && snapshot.distanceFromBottom > BOTTOM_THRESHOLD_PX));
     if (snapshot?.threadId) {
       savedViewportsRef.current.set(snapshot.threadId, {
@@ -319,6 +323,7 @@ export function TranscriptList(props: TranscriptListProps) {
       container.scrollTop = container.scrollHeight;
     }
 
+    isFollowingBottomRef.current = true;
     syncScrollState();
   }, [syncScrollState]);
 
@@ -344,6 +349,7 @@ export function TranscriptList(props: TranscriptListProps) {
     const container = scrollContainerRef.current;
     if (!container || props.entries.length === 0) {
       snapshotRef.current = undefined;
+      isFollowingBottomRef.current = true;
       setHasContentBelow(false);
       return;
     }
@@ -375,6 +381,14 @@ export function TranscriptList(props: TranscriptListProps) {
               (props.pendingRequest ? 1 : 0) +
               (props.pendingUserInput ? 1 : 0))
     );
+    const hasGrownWhileFollowingBottom = Boolean(
+      previousSnapshot &&
+        previousSnapshot.threadId === props.threadId &&
+        previousSnapshot.firstMessageId === firstMessageId &&
+        !hasPrependedMessages &&
+        isFollowingBottomRef.current &&
+        container.scrollHeight > previousSnapshot.scrollHeight
+    );
 
     if (hasPrependedMessages && previousSnapshot) {
       const heightDelta = container.scrollHeight - previousSnapshot.scrollHeight;
@@ -405,8 +419,8 @@ export function TranscriptList(props: TranscriptListProps) {
       shouldScrollToBottomRef.current = false;
       return;
     } else if (
-      hasAppendedMessages &&
-      previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX
+      (hasAppendedMessages && previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX) ||
+      hasGrownWhileFollowingBottom
     ) {
       scrollToBottom("instant");
       return;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1009,6 +1009,422 @@ describe("TranscriptList", () => {
     expect(scrollToMock).not.toHaveBeenCalled();
   });
 
+  it("keeps following the bottom while a streamed turn grows in place", () => {
+    const longEntries = Array.from({ length: 24 }, (_, index) => ({
+      type: "message" as const,
+      id: `history-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `History message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={longEntries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+
+    scrollHeight = 840;
+    const entriesWithUserPrompt = [
+      ...longEntries,
+      {
+        type: "message" as const,
+        id: "user-prompt-1",
+        role: "user" as const,
+        text: "Please continue from here."
+      }
+    ];
+    rerender(
+      <TranscriptList
+        entries={entriesWithUserPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+    expect(list.scrollTop).toBe(840);
+
+    list.scrollTop = 600;
+    fireEvent.scroll(list);
+    scrollHeight = 980;
+    rerender(
+      <TranscriptList
+        entries={entriesWithUserPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "tool-usage-1",
+          summary: "Searched 12 files",
+          details: [
+            {
+              id: "tool-detail-1",
+              kind: "command",
+              label: "rg -n scroll apps/desktop/src"
+            }
+          ]
+        }}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "I found the transcript scroll handling."
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+    expect(list.scrollTop).toBe(980);
+
+    list.scrollTop = 740;
+    fireEvent.scroll(list);
+    scrollHeight = 1120;
+    rerender(
+      <TranscriptList
+        entries={entriesWithUserPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "tool-usage-1",
+          summary: "Searched 12 files and read 3 files",
+          details: [
+            {
+              id: "tool-detail-1",
+              kind: "command",
+              label: "rg -n scroll apps/desktop/src"
+            },
+            {
+              id: "tool-detail-2",
+              kind: "read",
+              label: "Read TranscriptList.tsx"
+            }
+          ]
+        }}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-1",
+          role: "assistant",
+          phase: "commentary",
+          text: [
+            "I found the transcript scroll handling.",
+            "The pending assistant message is still streaming, so the same message id grows taller.",
+            "When the viewport was already pinned to the bottom, that growth should keep moving the viewport."
+          ].join(" ")
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(1120);
+  });
+
+  it("keeps following after a new prompt is appended to a long bottom-pinned chat", () => {
+    const entries = Array.from({ length: 32 }, (_, index) => ({
+      type: "message" as const,
+      id: `long-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Long transcript message ${index + 1}`
+    }));
+    scrollHeight = 960;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 720;
+    fireEvent.scroll(list);
+
+    const entriesWithNextPrompt = [
+      ...entries,
+      {
+        type: "message" as const,
+        id: "user-prompt-2",
+        role: "user" as const,
+        text: "Add one more answer at the bottom."
+      }
+    ];
+    scrollHeight = 1080;
+    rerender(
+      <TranscriptList
+        entries={entriesWithNextPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+    expect(list.scrollTop).toBe(1080);
+
+    list.scrollTop = 840;
+    fireEvent.scroll(list);
+    scrollHeight = 1200;
+    rerender(
+      <TranscriptList
+        entries={entriesWithNextPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-2",
+          role: "assistant",
+          phase: "final",
+          text: "Here is the beginning of the answer."
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+    expect(list.scrollTop).toBe(1200);
+
+    list.scrollTop = 960;
+    fireEvent.scroll(list);
+    scrollHeight = 1340;
+    rerender(
+      <TranscriptList
+        entries={entriesWithNextPrompt}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-2",
+          role: "assistant",
+          phase: "final",
+          text: [
+            "Here is the beginning of the answer.",
+            "More streamed content arrived after the prompt, and following mode should keep the latest line visible."
+          ].join(" ")
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(1340);
+  });
+
+  it("does not move the reader when new messages arrive below an older viewport", () => {
+    const entries = Array.from({ length: 16 }, (_, index) => ({
+      type: "message" as const,
+      id: `message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 96;
+    fireEvent.scroll(list);
+
+    scrollHeight = 920;
+    rerender(
+      <TranscriptList
+        entries={[
+          ...entries,
+          {
+            type: "message",
+            id: "new-message-1",
+            role: "assistant",
+            text: "This arrived out of view."
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "new-message-2",
+          role: "assistant",
+          phase: "commentary",
+          text: "This is still below the reader."
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(96);
+  });
+
+  it("re-enters bottom-following mode after the jump-to-latest button is clicked", () => {
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "First message"
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-3",
+          role: "assistant",
+          phase: "commentary",
+          text: "Streaming starts."
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 80;
+    fireEvent.scroll(list);
+    fireEvent.click(screen.getByRole("button", { name: "Jump to latest message" }));
+    expect(scrollToMock).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      top: 720
+    });
+
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+    scrollHeight = 860;
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "First message"
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-3",
+          role: "assistant",
+          phase: "commentary",
+          text: "Streaming starts. More content arrives after the jump button re-entered following mode."
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(860);
+  });
+
+  it("re-enters bottom-following mode after manually scrolling to the bottom", () => {
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "First message"
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-4",
+          role: "assistant",
+          phase: "commentary",
+          text: "Streaming starts."
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 80;
+    fireEvent.scroll(list);
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+
+    scrollHeight = 860;
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "First message"
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-4",
+          role: "assistant",
+          phase: "commentary",
+          text: "Streaming starts. Manual scrolling reached the bottom, so the next streamed chunk should stay visible."
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(860);
+  });
+
   it("shows command approval reason and command when no prompt is provided", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -113,4 +113,16 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toContain("184, 255, 77");
     expect(css).not.toContain("168, 255, 63");
   });
+
+  it("keeps transcript bottom reserve close to the thinking indicator height", () => {
+    expect(css).toMatch(
+      /\.transcript-list__items\s*\{[\s\S]*?padding-bottom:\s*24px;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.transcript-list__items:has\(\.transcript-list__pending:last-child\)\s*\{[\s\S]*?padding-bottom:\s*4px;[\s\S]*?\}/
+    );
+    expect(css).not.toMatch(
+      /\.transcript-list__items\s*\{[\s\S]*?padding-bottom:\s*(?:[4-9]\d|\d{3,})px;[\s\S]*?\}/
+    );
+  });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1077,7 +1077,11 @@ textarea {
   min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
-  padding-bottom: 72px;
+  padding-bottom: 24px;
+}
+
+.transcript-list__items:has(.transcript-list__pending:last-child) {
+  padding-bottom: 4px;
 }
 
 .transcript-list__scroll-bottom {


### PR DESCRIPTION
## Summary

I added regression coverage for transcript scroll-follow behavior while live turns stream into a long chat, fixed the follow-bottom state, and tightened the reserved bottom space in the transcript viewport.

The scroll-follow tests cover:

- staying pinned to the bottom while a user prompt, thinking state, tool usage, and streamed assistant messages are appended
- staying pinned after another user prompt is added to a long bottom-pinned chat and subsequent assistant content streams in
- preserving the reader's older viewport when new bottom content arrives out of view
- re-entering bottom-following mode after clicking the jump-to-latest button
- re-entering bottom-following mode after manually scrolling to the bottom

The implementation now tracks explicit bottom-following state from scroll events and jump-to-latest actions, then uses that state to keep following when streamed content grows in place without new item ids.

The layout update reduces the idle transcript bottom reserve from 72px to 24px and collapses it to 4px when the live Thinking row is present, so the indicator sits near the bottom instead of floating above a large empty band.

## Verification

I ran:

```sh
pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
```

Result: 25 passed.

```sh
pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer
```

Result: 18 files passed, 151 tests passed.
