### PR TITLE
fix(desktop): preserve composer images and launchpad mode

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7,6 +7,8 @@ import type {
   AppServerThreadSummary,
   AppServerReviewTarget,
   AppServerTurnInputItem,
+  NavigationLaunchpadDefaults,
+  NavigationLaunchpadDraft,
   ThreadOverlayState,
 } from "@pwragnt/shared";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
@@ -27,6 +29,12 @@ function createOverlayStoreMock(params?: {
   const overlays = new Map<string, ThreadOverlayState>(
     Object.entries(params?.overlays ?? {})
   );
+  let launchpadDefaults: NavigationLaunchpadDefaults = {
+    backend: "codex",
+    executionMode: "default",
+    workMode: "local",
+  };
+  const launchpads = new Map<string, NavigationLaunchpadDraft>();
   if (initialOverlay) {
     overlays.set("codex:thread-1", initialOverlay);
   }
@@ -71,6 +79,27 @@ function createOverlayStoreMock(params?: {
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
+    },
+    getLaunchpadDefaults: async () => launchpadDefaults,
+    setLaunchpadDefaults: async (patch: Partial<NavigationLaunchpadDefaults>) => {
+      launchpadDefaults = {
+        ...launchpadDefaults,
+        ...patch,
+      };
+      return launchpadDefaults;
+    },
+    getDirectoryLaunchpad: async ({ directoryKey }: { directoryKey: string }) =>
+      launchpads.get(directoryKey),
+    upsertDirectoryLaunchpad: async (launchpad: NavigationLaunchpadDraft) => {
+      const nextLaunchpad = {
+        ...launchpads.get(launchpad.directoryKey),
+        ...launchpad,
+      };
+      launchpads.set(launchpad.directoryKey, nextLaunchpad);
+      return nextLaunchpad;
+    },
+    resetDirectoryLaunchpad: async ({ directoryKey }: { directoryKey: string }) => {
+      launchpads.delete(directoryKey);
     },
   } as unknown as InstanceType<typeof import("@pwragnt/agent-core").OverlayStore>;
 }
@@ -457,6 +486,43 @@ describe("DesktopBackendRegistry", () => {
         startTurn: true,
       },
     });
+
+    await registry.close();
+  });
+
+  it("remembers launchpad work mode for future directory drafts", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { workMode: "worktree" },
+    });
+    const next = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-b",
+      directoryKind: "directory",
+      directoryLabel: "Repo B",
+      directoryPath: "/repo-b",
+    });
+
+    expect(updated.defaults.workMode).toBe("worktree");
+    expect(next.launchpad.workMode).toBe("worktree");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1028,7 +1028,7 @@ export class DesktopBackendRegistry {
       serviceTier: defaults.serviceTier,
       fastMode: defaults.fastMode,
       prompt: "",
-      workMode: "local",
+      workMode: defaults.workMode ?? "local",
       branchName: request.currentBranch,
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -1079,6 +1079,9 @@ export class DesktopBackendRegistry {
     }
     if ("fastMode" in request.patch) {
       stickyPatch.fastMode = request.patch.fastMode;
+    }
+    if (request.patch.workMode) {
+      stickyPatch.workMode = request.patch.workMode;
     }
 
     const defaults =

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -299,6 +299,7 @@ export function Composer(props: ComposerProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
@@ -418,9 +419,15 @@ export function Composer(props: ComposerProps) {
 
   useEffect(() => {
     if (!isLaunchpad) {
+      hydratedLaunchpadKeyRef.current = undefined;
       return;
     }
 
+    if (hydratedLaunchpadKeyRef.current === props.launchpad?.directoryKey) {
+      return;
+    }
+
+    hydratedLaunchpadKeyRef.current = props.launchpad?.directoryKey;
     setDraft(props.launchpad?.prompt ?? "");
     setImageAttachments(props.launchpad?.imageAttachments ?? []);
     setSending(false);
@@ -428,7 +435,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-  }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.updatedAt]);
+  }, [isLaunchpad, props.launchpad?.directoryKey]);
 
   useEffect(() => {
     if (!props.thread) {
@@ -548,6 +555,7 @@ export function Composer(props: ComposerProps) {
 
     const timeout = window.setTimeout(() => {
       void props.onUpdateLaunchpad?.(launchpad.directoryKey, {
+        imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
         prompt: draft,
       });
     }, 250);
@@ -555,7 +563,7 @@ export function Composer(props: ComposerProps) {
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [draft, launchpad, props.onUpdateLaunchpad]);
+  }, [draft, imageAttachments, launchpad, props.onUpdateLaunchpad]);
 
   const submitReviewCommand = async (reviewCommand: {
     displayText: string;
@@ -840,6 +848,7 @@ export function Composer(props: ComposerProps) {
 
     void props.onUpdateLaunchpad(props.launchpad.directoryKey, {
       imageAttachments: attachments.length > 0 ? attachments : undefined,
+      prompt: draft,
     });
   };
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -741,6 +741,18 @@ describe("Composer", () => {
     expect(await screen.findByAltText("mockup.png")).toBeInTheDocument();
 
     await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo-a",
+        expect.objectContaining({
+          imageAttachments: expect.arrayContaining([
+            expect.objectContaining({ name: "mockup.png" }),
+          ]),
+          prompt: "Review the pasted mockup",
+        })
+      );
+    });
+
+    await waitFor(() => {
       expect(launchpads.get("directory:/repo-a")?.prompt).toBe(
         "Review the pasted mockup"
       );
@@ -785,6 +797,64 @@ describe("Composer", () => {
       "Review the pasted mockup"
     );
     expect(screen.getByAltText("mockup.png")).toBeInTheDocument();
+  });
+
+  it("keeps active launchpad edits stable when an autosave rerenders the same draft", () => {
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "Line one\nLine two",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+    const textarea = screen.getByLabelText("New thread") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "Line one edited\nLine two" } });
+    textarea.setSelectionRange(8, 8);
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          ...launchpad,
+          updatedAt: 2,
+        }}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    expect(textarea).toHaveValue("Line one edited\nLine two");
+    expect(textarea.selectionStart).toBe(8);
   });
 
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
@@ -41,6 +41,7 @@ type SidebarProps = {
 };
 
 export function Sidebar(props: SidebarProps) {
+  const renameInputRef = useRef<HTMLInputElement>(null);
   const [contextMenu, setContextMenu] = useState<
     | {
         position: { x: number; y: number };
@@ -99,6 +100,16 @@ export function Sidebar(props: SidebarProps) {
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [contextMenu]);
+
+  useLayoutEffect(() => {
+    if (!renameThread) {
+      return;
+    }
+
+    const input = renameInputRef.current;
+    input?.focus();
+    input?.select();
+  }, [renameThread]);
 
   const openThreadContextMenu = (
     thread: NavigationThreadSummary,
@@ -275,6 +286,7 @@ export function Sidebar(props: SidebarProps) {
               <span>Name</span>
               <input
                 autoFocus
+                ref={renameInputRef}
                 value={renameDraft}
                 onChange={(event) => {
                   setRenameDraft(event.currentTarget.value);
@@ -286,6 +298,19 @@ export function Sidebar(props: SidebarProps) {
                   } else if (event.key === "Enter") {
                     event.preventDefault();
                     submitRename();
+                  } else if (
+                    (event.key === "ArrowLeft" || event.key === "ArrowRight") &&
+                    !event.altKey &&
+                    !event.ctrlKey &&
+                    !event.metaKey &&
+                    !event.shiftKey &&
+                    event.currentTarget.selectionStart === 0 &&
+                    event.currentTarget.selectionEnd === event.currentTarget.value.length
+                  ) {
+                    event.preventDefault();
+                    const nextPosition =
+                      event.key === "ArrowLeft" ? 0 : event.currentTarget.value.length;
+                    event.currentTarget.setSelectionRange(nextPosition, nextPosition);
                   }
                 }}
               />

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -440,6 +440,77 @@ describe("Sidebar", () => {
     expect(onRenameThread).toHaveBeenCalledWith(sharedThread, "Renamed cleanup");
   });
 
+  it("focuses and selects the current name when opening the rename dialog", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onRenameThread={async () => undefined}
+      />
+    );
+
+    const threadButton = screen.getByText("Cross-project cleanup").closest("button");
+    expect(threadButton).not.toBeNull();
+    fireEvent.contextMenu(threadButton as HTMLElement, { clientX: 12, clientY: 34 });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Thread" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Rename Thread" });
+    const input = within(dialog).getByLabelText("Name") as HTMLInputElement;
+
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe("Cross-project cleanup".length);
+  });
+
+  it("collapses a fully selected rename field to either end with arrow keys", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onRenameThread={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Thread" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Rename Thread" });
+    const input = within(dialog).getByLabelText("Name") as HTMLInputElement;
+
+    fireEvent.keyDown(input, { key: "ArrowLeft" });
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+
+    input.select();
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+    expect(input.selectionStart).toBe("Cross-project cleanup".length);
+    expect(input.selectionEnd).toBe("Cross-project cleanup".length);
+  });
+
   it("keeps the rename dialog open for blank names", () => {
     const onRenameThread = vi.fn(async () => undefined);
 

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -217,6 +217,7 @@ describe("OverlayStore", () => {
     expect(await store.getLaunchpadDefaults()).toEqual({
       backend: "grok",
       executionMode: "full-access",
+      workMode: "local",
       reasoningEffort: "high",
       fastMode: true,
     });
@@ -272,6 +273,7 @@ describe("OverlayStore", () => {
     await expect(reloaded.getLaunchpadDefaults()).resolves.toEqual({
       backend: "grok",
       executionMode: "default",
+      workMode: "local",
       model: "grok-4",
       reasoningEffort: "medium",
       fastMode: true,

--- a/packages/agent-core/src/app-server/internal-contract.ts
+++ b/packages/agent-core/src/app-server/internal-contract.ts
@@ -257,6 +257,15 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "item/fileChange/outputDelta";
+      params: {
+        threadId: string;
+        turnId?: string;
+        itemId: string;
+        delta: string;
+      };
+    }
+  | {
       method: "thread/archived";
       params: {
         threadId: string;

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -67,6 +67,7 @@ const EMPTY_OVERLAY_STORE_DATA: OverlayStoreData = {
   launchpadDefaults: {
     backend: "codex",
     executionMode: "default",
+    workMode: "local",
   },
   directoryLaunchpads: {},
   threads: {},
@@ -147,6 +148,7 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
           ? (launchpadDefaultsRecord.backend as AppServerBackendKind)
           : "codex",
       executionMode: normalizeExecutionMode(launchpadDefaultsRecord.executionMode),
+      workMode: launchpadDefaultsRecord.workMode === "worktree" ? "worktree" : "local",
       model:
         typeof launchpadDefaultsRecord.model === "string"
           ? launchpadDefaultsRecord.model

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -33,6 +33,7 @@ export type LaunchpadWorkMode = "local" | "worktree";
 export type NavigationLaunchpadDefaults = {
   backend: AppServerBackendKind;
   executionMode: ThreadExecutionMode;
+  workMode?: LaunchpadWorkMode;
   model?: string;
   reasoningEffort?: string;
   serviceTier?: string;


### PR DESCRIPTION
## Summary

I fixed two launchpad composer state races, made the launchpad workspace mode sticky, and tightened the rename-thread dialog interaction.

- Preserve pasted image attachments when prompt autosave and image attachment saves land out of order.
- Keep the active launchpad composer from rehydrating on same-draft autosave updates, which prevents the text caret from jumping back to the bottom while editing.
- Persist the Local / New worktree selection as a launchpad default and seed future directory drafts from that default.
- Focus and fully select the current thread name when the rename dialog opens, with left/right arrows collapsing the selection to the beginning/end before typing.
- Add `item/fileChange/outputDelta` to the typed app-server notification contract so live file-change output is represented in the shared event surface.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/overlay-store.test.ts`
- `pnpm typecheck`
