### PR TITLE
fix(desktop): pad tool activity focus ring

### DIFF
--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -108,11 +108,11 @@ test("preserves live assistant commentary messages, tool usage, and final answer
       name: /Worked for 8m/
     });
     await expect(workedForToggle).toBeVisible();
-    await expect(workedForToggle).toHaveAttribute("aria-expanded", "false");
-    await expect(transcript.getByText("Using ce:brainstorm for this.")).toBeHidden();
-    await expect(transcript.getByText("The broad search was too noisy")).toBeHidden();
-    await expect(transcript.getByText("The existing product direction is thread-first")).toBeHidden();
-    await expect(transcript.getByRole("button", { name: /Used 2 tools/i })).toBeHidden();
+    await expect(workedForToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(transcript.getByText("Using ce:brainstorm for this.")).toBeVisible();
+    await expect(transcript.getByText("The broad search was too noisy")).toBeVisible();
+    await expect(transcript.getByText("The existing product direction is thread-first")).toBeVisible();
+    await expect(transcript.getByRole("button", { name: /Used 2 tools/i })).toBeVisible();
     await expect(transcript).toContainText(
       "From the repo scan: Telegram support is probably not another model provider."
     );
@@ -125,14 +125,11 @@ test("preserves live assistant commentary messages, tool usage, and final answer
     );
 
     await workedForToggle.click();
-    await expect(workedForToggle).toHaveAttribute("aria-expanded", "true");
-    await expect(transcript.getByText("Using ce:brainstorm for this.")).toBeVisible();
-    await expect(transcript.getByText("The broad search was too noisy")).toBeVisible();
-    await expect(transcript.getByText("The existing product direction is thread-first")).toBeVisible();
-    await expect(transcript.getByText("From the repo scan, Telegram should probably")).toBeVisible();
-    await expect(transcript.getByText("The v1 shape should probably focus")).toBeVisible();
-    await expect(transcript.getByText("I’m ready to turn that into requirements")).toBeVisible();
-    await expect(transcript.getByRole("button", { name: /Used 2 tools/i })).toBeVisible();
+    await expect(workedForToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(transcript.getByText("Using ce:brainstorm for this.")).toBeHidden();
+    await expect(transcript.getByText("The broad search was too noisy")).toBeHidden();
+    await expect(transcript.getByText("The existing product direction is thread-first")).toBeHidden();
+    await expect(transcript.getByRole("button", { name: /Used 2 tools/i })).toBeHidden();
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1880,6 +1880,133 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("hydrates persisted OpenAI function calls as transcript activity", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-openai-function-calls", {
+      thread: {
+        turns: [
+          {
+            id: "turn-tools",
+            status: "completed",
+            startedAt: 1_763_500_220,
+            completedAt: 1_763_500_250,
+            items: [
+              {
+                type: "assistantMessage",
+                id: "message-1",
+                phase: "commentary",
+                content: [{ type: "text", text: "I am checking CI." }]
+              },
+              {
+                type: "response_item",
+                id: "call-1",
+                payload: {
+                  type: "function_call",
+                  name: "exec_command",
+                  arguments: JSON.stringify({
+                    cmd: "gh pr checks 62 --watch --interval 10"
+                  })
+                }
+              },
+              {
+                type: "response_item",
+                id: "call-1-output",
+                payload: {
+                  type: "function_call_output",
+                  call_id: "call-1",
+                  output: "Build pass"
+                }
+              },
+              {
+                type: "response_item",
+                id: "call-2",
+                payload: {
+                  type: "function_call",
+                  name: "exec_command",
+                  arguments: JSON.stringify({
+                    cmd: "git status --short --branch"
+                  })
+                }
+              },
+              {
+                type: "assistantMessage",
+                id: "message-2",
+                content: [{ type: "text", text: "CI is green." }]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-openai-function-calls"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "message-1",
+        role: "assistant",
+        text: "I am checking CI.",
+        createdAt: 1_763_500_220_000,
+        parts: [{ type: "text", text: "I am checking CI." }],
+        phase: "commentary",
+        turn: {
+          id: "turn-tools",
+          status: "completed",
+          startedAt: 1_763_500_220_000,
+          completedAt: 1_763_500_250_000
+        }
+      },
+      {
+        type: "activity",
+        id: "activity-call-1",
+        summary: "Used 2 tools",
+        createdAt: 1_763_500_220_000,
+        details: [
+          {
+            id: "call-1",
+            kind: "command",
+            label: "gh pr checks 62 --watch --interval 10"
+          },
+          {
+            id: "call-2",
+            kind: "command",
+            label: "git status --short --branch"
+          }
+        ],
+        turn: {
+          id: "turn-tools",
+          status: "completed",
+          startedAt: 1_763_500_220_000,
+          completedAt: 1_763_500_250_000
+        }
+      },
+      {
+        type: "message",
+        id: "message-2",
+        role: "assistant",
+        text: "CI is green.",
+        createdAt: 1_763_500_220_000,
+        parts: [{ type: "text", text: "CI is green." }],
+        turn: {
+          id: "turn-tools",
+          status: "completed",
+          startedAt: 1_763_500_220_000,
+          completedAt: 1_763_500_250_000
+        }
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("normalizes request_user_input requests from rpc envelope ids", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1264,11 +1264,46 @@ function isActivityItemType(itemType: string | undefined): boolean {
   return (
     normalized === "commandexecution" ||
     normalized === "filechange" ||
+    normalized === "functioncall" ||
     normalized === "mcptoolcall" ||
     normalized === "dynamictoolcall" ||
     normalized === "websearch" ||
     normalized === "imageview" ||
     normalized === "imagegeneration"
+  );
+}
+
+function extractActivityItemFromReplayItem(
+  item: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (isActivityItemType(pickString(item, ["type"]))) {
+    return item;
+  }
+
+  for (const key of ["payload", "item", "responseItem", "response_item"]) {
+    const nestedItem = asRecord(item[key]);
+    if (!nestedItem || !isActivityItemType(pickString(nestedItem, ["type"]))) {
+      continue;
+    }
+
+    return {
+      ...nestedItem,
+      id:
+        pickString(item, ["id", "itemId", "item_id"]) ??
+        pickString(nestedItem, ["id", "itemId", "item_id", "call_id"])
+    };
+  }
+
+  return undefined;
+}
+
+function parseToolArguments(item: Record<string, unknown>): Record<string, unknown> | undefined {
+  return (
+    asRecord(parseStructuredValue(item.arguments)) ??
+    asRecord(parseStructuredValue(item.input)) ??
+    asRecord(item.arguments) ??
+    asRecord(item.input) ??
+    undefined
   );
 }
 
@@ -1407,6 +1442,21 @@ function summarizeActivityItems(
             : {})
         });
       }
+      continue;
+    }
+
+    if (normalizedItemType === "functioncall") {
+      toolCalls += 1;
+      const functionName =
+        pickString(item, ["name", "toolName", "tool_name", "tool", "text"]) ?? "Used tool";
+      const args = parseToolArguments(item);
+      const command = args ? pickString(args, ["cmd", "command", "displayCommand"]) : undefined;
+      pushActivityDetail(details, {
+        id: itemId,
+        kind: "command",
+        label: functionName === "exec_command" ? formatCommandLabel(command) : functionName,
+        status: itemStatus
+      });
       continue;
     }
 
@@ -1558,8 +1608,9 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
         continue;
       }
 
-      if (isActivityItemType(itemType)) {
-        pendingActivityItems.push(item);
+      const activityItem = extractActivityItemFromReplayItem(item);
+      if (activityItem) {
+        pendingActivityItems.push(activityItem);
       }
     }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -227,10 +227,58 @@ export function TranscriptList(props: TranscriptListProps) {
       transcriptEntries,
     ]
   );
+  const livePendingWorkEntryIds = useMemo(
+    () =>
+      new Set(
+        [
+          props.pendingActivityEntry?.id,
+          props.pendingProtocolActivityEntry?.id,
+          props.pendingPlanEntry?.id,
+        ].filter((id): id is string => typeof id === "string")
+      ),
+    [
+      props.pendingActivityEntry?.id,
+      props.pendingPlanEntry?.id,
+      props.pendingProtocolActivityEntry?.id,
+    ]
+  );
 
   useEffect(() => {
     setExpandedCommentaryGroupIds(new Set());
   }, [props.threadId]);
+
+  useEffect(() => {
+    if (livePendingWorkEntryIds.size === 0) {
+      return;
+    }
+
+    const liveWorkGroupIds = transcriptRenderItems.flatMap((item) => {
+      if (
+        item.type !== "workPhaseGroup" ||
+        !item.collapsible ||
+        !item.entries.some((entry) => livePendingWorkEntryIds.has(entry.id))
+      ) {
+        return [];
+      }
+
+      return [item.id];
+    });
+    if (liveWorkGroupIds.length === 0) {
+      return;
+    }
+
+    setExpandedCommentaryGroupIds((current) => {
+      const next = new Set(current);
+      let changed = false;
+      for (const groupId of liveWorkGroupIds) {
+        if (!next.has(groupId)) {
+          next.add(groupId);
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [livePendingWorkEntryIds, transcriptRenderItems]);
 
   useEffect(() => {
     if (!props.activeTurnId) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptList } from "../TranscriptList";
 
@@ -523,6 +523,62 @@ describe("TranscriptList", () => {
     expect(screen.getAllByText("-2")[0]).toBeInTheDocument();
     expect(screen.getAllByText("+1")[0]).toBeInTheDocument();
     expect(screen.getByText("function messageMatchesOptimisticEntry(")).toBeInTheDocument();
+  });
+
+  it("keeps just-finished live tool activity visible when the final message arrives", async () => {
+    const completedTurn = {
+      id: "turn-1",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 72_000,
+      durationMs: 71_000,
+    };
+
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Fix the transcript activity."
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Fixed.",
+            turn: completedTurn,
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "tool-usage-1",
+          summary: "Used 2 tools",
+          details: [
+            {
+              id: "tool-detail-1",
+              kind: "command",
+              label: "rg -n transcript activity"
+            },
+            {
+              id: "tool-detail-2",
+              kind: "read",
+              label: "Read TranscriptList.tsx"
+            }
+          ],
+          turn: completedTurn,
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Used 2 tools/i })).toBeVisible();
+    });
   });
 
   it("anchors a freshly loaded transcript to the newest entry", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1902,12 +1902,18 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 0;
+  padding: 4px 12px;
   border: 0;
+  border-radius: 4px;
   background: transparent;
   color: inherit;
   text-align: left;
   cursor: pointer;
+}
+
+.transcript-activity__toggle:focus,
+.transcript-activity__toggle:focus-visible {
+  outline-offset: -2px;
 }
 
 .transcript-activity__label {


### PR DESCRIPTION
## Summary

I fixed the transcript tool-usage toggle styling, the completed-turn transition, and restart hydration so tool usage remains visible both live and after loading a completed OpenAI/Codex rollout from disk.

## Changes

- Added horizontal padding to the transcript activity toggle hit area.
- Added a small radius and inward focus outline offset so the focus ring stays inside the row.
- Auto-expanded the just-finished live work group when it contains pending tool activity, preserving visibility as the turn completes.
- Hydrated persisted OpenAI `function_call` replay items, including wrapped `response_item.payload.function_call` records, as transcript activity after app restart.
- Added regression coverage for final-message arrival while live tool activity is still pending.
- Added regression coverage for persisted OpenAI function calls restoring as `Used N tools` activity.

## Verification

- I ran `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`.
- I ran `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`.
- I ran `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts`.
- I ran `pnpm typecheck`.
