### PR TITLE
fix(desktop): archive linked worktrees with threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10,9 +10,10 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   ThreadOverlayState,
+  WorktreeSnapshotSummary,
 } from "@pwragnt/shared";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
-import type { GitDirectoryService } from "../app-server/git-directory-service";
+import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
 function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
@@ -100,6 +101,34 @@ function createOverlayStoreMock(params?: {
     },
     resetDirectoryLaunchpad: async ({ directoryKey }: { directoryKey: string }) => {
       launchpads.delete(directoryKey);
+    },
+    upsertWorktreeSnapshot: async ({
+      backend,
+      threadId,
+      snapshot,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      snapshot: WorktreeSnapshotSummary;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        worktreeSnapshots: [
+          ...(current.worktreeSnapshots ?? []).filter(
+            (candidate) => candidate.id !== snapshot.id
+          ),
+          snapshot,
+        ],
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
     },
   } as unknown as InstanceType<typeof import("@pwragnt/agent-core").OverlayStore>;
 }
@@ -861,7 +890,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("archives a thread without cleaning up linked worktrees", async () => {
+  it("snapshots and removes linked worktrees when archiving a thread", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",
       title: "Archive me",
@@ -883,14 +912,21 @@ describe("DesktopBackendRegistry", () => {
       initializeResult: { methods: ["thread/list", "thread/archive"] },
       threads: [thread],
     });
-    const cleanupThreadWorktrees = vi.fn(async () => [
-      {
-        worktreePath: "/repo/.worktrees/archive-me",
-        branch: "codex/archive-me",
-        removedWorktree: true,
-        deletedBranch: true,
-      },
-    ]);
+    const archiveWorktree = vi.fn(async () => ({
+      id: "snapshot-1",
+      backend: "codex" as const,
+      threadId: "thread-1",
+      worktreePath: "/repo/.worktrees/archive-me",
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/archive-me",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived" as const,
+      ignoredFilesExcluded: true,
+    }));
     const registry = new DesktopBackendRegistry({
       codexClient,
       codexFullAccessClient: new MockBackendClient({
@@ -901,10 +937,9 @@ describe("DesktopBackendRegistry", () => {
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore: createOverlayStoreMock(),
-      gitDirectoryService: {
-        cleanupThreadWorktrees,
-        readDirectoryStatuses: async () => ({}),
-      } as unknown as GitDirectoryService,
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
     });
 
     const response = await registry.archiveThread({
@@ -913,12 +948,24 @@ describe("DesktopBackendRegistry", () => {
     });
 
     expect(codexClient.lastArchiveThreadParams).toEqual({ threadId: "thread-1" });
-    expect(cleanupThreadWorktrees).not.toHaveBeenCalled();
+    expect(archiveWorktree).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/repo/.worktrees/archive-me",
+      repositoryPath: "/repo/app",
+    });
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
       archivedAt: expect.any(Number),
-      cleanup: [],
+      cleanup: [
+        {
+          worktreePath: "/repo/.worktrees/archive-me",
+          branch: "codex/archive-me",
+          removedWorktree: true,
+          deletedBranch: false,
+        },
+      ],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5,6 +5,7 @@ import type {
   ArchiveWorktreeRequest,
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
+  ArchiveThreadCleanupResult,
   ArchiveThreadResponse,
   AppServerListSkillsResponse,
   AppServerNotification,
@@ -139,6 +140,11 @@ type BackendClient = {
 type PendingServerRequest = {
   resolve: (response: SubmitServerRequestRequest["response"]) => void;
   reject: (error: Error) => void;
+};
+
+type WorktreeArchiveCandidate = {
+  repositoryPath: string;
+  worktreePath: string;
 };
 
 const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
@@ -625,18 +631,28 @@ export class DesktopBackendRegistry {
     request: ArchiveThreadRequest,
   ): Promise<ArchiveThreadResponse> {
     const backend = request.backend ?? "codex";
+    const thread = await this.findThreadForArchiveCleanup({
+      backend,
+      threadId: request.threadId,
+    });
     const result =
       backend === "codex"
         ? await this.withCodexThreadClient(request.threadId, async (client) =>
             await this.archiveWithClient(client, request.threadId),
           )
         : await this.archiveWithClient(this.grokClient, request.threadId);
+    const cleanup = thread
+      ? await this.archiveThreadWorktrees({
+          backend,
+          thread,
+        })
+      : [];
 
     return {
       backend,
       threadId: result.threadId,
       archivedAt: Date.now(),
-      cleanup: [],
+      cleanup,
     };
   }
 
@@ -1410,6 +1426,88 @@ export class DesktopBackendRegistry {
     }
 
     return await client.archiveThread({ threadId });
+  }
+
+  private async findThreadForArchiveCleanup(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadSummary | undefined> {
+    const activeThreads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+    }).catch(() => []);
+    const archivedThreads = activeThreads.some((thread) => thread.id === params.threadId)
+      ? []
+      : await this.listThreads({
+          backend: params.backend,
+          archived: true,
+        }).catch(() => []);
+
+    return [...activeThreads, ...archivedThreads].find(
+      (thread) => thread.id === params.threadId,
+    );
+  }
+
+  private async archiveThreadWorktrees(params: {
+    backend: AppServerBackendKind;
+    thread: AppServerThreadSummary;
+  }): Promise<ArchiveThreadCleanupResult[]> {
+    const candidates: WorktreeArchiveCandidate[] =
+      params.thread.linkedDirectories.flatMap((directory) => {
+        const worktreePath =
+          directory.worktreePath ?? (directory.kind === "worktree" ? directory.path : undefined);
+        if (!worktreePath?.trim()) {
+          return [];
+        }
+
+        return [
+          {
+            repositoryPath: directory.path,
+            worktreePath,
+          },
+        ];
+      });
+    const uniqueCandidates: WorktreeArchiveCandidate[] = [
+      ...new Map(
+        candidates.map((candidate) => [
+          `${candidate.repositoryPath}:${candidate.worktreePath}`,
+          candidate,
+        ]),
+      ).values(),
+    ];
+
+    return await Promise.all(
+      uniqueCandidates.map(async (candidate): Promise<ArchiveThreadCleanupResult> => {
+        try {
+          const snapshot = await this.worktreeArchiveService.archive({
+            backend: params.backend,
+            threadId: params.thread.id,
+            worktreePath: candidate.worktreePath,
+            repositoryPath: candidate.repositoryPath,
+          });
+          await this.overlayStore.upsertWorktreeSnapshot({
+            backend: params.backend,
+            threadId: params.thread.id,
+            snapshot,
+          });
+
+          return {
+            worktreePath: snapshot.worktreePath,
+            branch: snapshot.sourceBranch,
+            removedWorktree: true,
+            deletedBranch: false,
+          };
+        } catch (error) {
+          return {
+            worktreePath: candidate.worktreePath,
+            branch: params.thread.observedGitBranch ?? params.thread.gitBranch,
+            removedWorktree: false,
+            deletedBranch: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }),
+    );
   }
 
   private async restoreWithClient(


### PR DESCRIPTION
## Summary

I fixed thread archiving so linked worktrees are actually snapshotted and removed instead of always returning an empty cleanup result.

## Root Cause

The snapshot/restore worktree service existed, but `DesktopBackendRegistry.archiveThread()` still returned `cleanup: []` and never called it. The backend test also encoded that missed behavior.

## Changes

- Look up the thread summary before archiving so linked worktree paths are still available.
- Archive each linked worktree through `WorktreeArchiveService`, which creates the snapshot ref and removes the worktree.
- Persist the snapshot metadata in the overlay store for later restore.
- Return per-worktree cleanup results from the archive response.
- Update the backend registry test to assert snapshot/removal behavior.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
