### PR TITLE
fix(desktop): Keep thread selection stable across refreshes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -248,6 +248,98 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("does not move selection to another thread when refresh temporarily drops the selected thread", async () => {
+    const listeners = new Set<(event: any) => void>();
+    let includeSelectedThread = true;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_000,
+        },
+        ...(includeSelectedThread
+          ? [
+              {
+                id: "thread-2",
+                title: "Clicked thread",
+                titleSource: "explicit" as const,
+                summary: "Clicked thread summary",
+                source: "codex" as const,
+                linkedDirectories: [],
+                inbox: {
+                  inInbox: false,
+                },
+                updatedAt: 2_000,
+              },
+            ]
+          : []),
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[1]!);
+    });
+
+    expect(result.current.selectedThread?.id).toBe("thread-2");
+
+    includeSelectedThread = false;
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.selectedItemKey).toBe("codex:thread-2");
+    expect(result.current.selectedThread?.id).not.toBe("thread-1");
+  });
+
   it("renames a thread and refreshes navigation with the explicit title", async () => {
     let threadTitle = "First thread";
     const renameThread = vi.fn(async ({ name }: { name: string }) => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -799,6 +799,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
             return candidate;
           }
 
+          if (candidate) {
+            return candidate;
+          }
+
           return getFallbackSelectionKey(response, optimisticThreadKey);
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

This fixes a renderer navigation race where a background refresh could move the selected thread to the first thread in the refreshed snapshot even though the user had clicked a different thread.

The bug happened when the clicked thread was temporarily missing from a navigation snapshot. The hook treated that as an invalid selection and fell back to the first available thread, which left browser/DOM focus on the clicked row while the selected highlight moved elsewhere.

## Changes

- Preserve an existing or preferred thread selection key across navigation refreshes, even if the refreshed snapshot temporarily does not contain that thread.
- Keep initial fallback behavior for the no-selection case, so first load still selects the first available item.
- Add a regression test that selects a second thread, refreshes with that selected thread omitted, and asserts selection does not jump to the first thread.

## Verification

I verified this locally with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer`
- `pnpm --filter @pwragnt/desktop typecheck`
