### PR TITLE
fix(desktop): refresh empty launchpad defaults

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -14,7 +14,9 @@ async function createDirectoryLaunchpadFixture(): Promise<{
 }> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-e2e-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
+  const otherRepoDir = path.join(rootDir, "OtherRepo");
   await mkdir(repoDir, { recursive: true });
+  await mkdir(otherRepoDir, { recursive: true });
 
   execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
   execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
@@ -33,6 +35,22 @@ async function createDirectoryLaunchpadFixture(): Promise<{
     { cwd: repoDir, stdio: "ignore" },
   );
   execFileSync("git", ["branch", "release"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["init"], { cwd: otherRepoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: otherRepoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed other fixture repo",
+    ],
+    { cwd: otherRepoDir, stdio: "ignore" },
+  );
 
   const fixturePath = path.join(rootDir, "directory-launchpad-workspace.fixture.json");
   await writeFile(
@@ -80,6 +98,24 @@ async function createDirectoryLaunchpadFixture(): Promise<{
                 ],
                 updatedAt: 1760000000000,
               },
+              {
+                id: "thread-other-directory",
+                title: "Other directory replay",
+                titleSource: "explicit",
+                summary: "Open a new thread from another directory",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "main",
+                linkedDirectories: [
+                  {
+                    id: "other-repo",
+                    label: "OtherRepo",
+                    path: otherRepoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1759999999000,
+              },
             ],
           },
           {
@@ -103,6 +139,111 @@ async function createDirectoryLaunchpadFixture(): Promise<{
                 },
               ],
               lastUserMessage: "Seed the directory launchpad.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-start-1",
+            kind: "response",
+            method: "thread/start",
+            result: {
+              threadId: "thread-new-worktree",
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-new-worktree",
+              turnId: "turn-new-worktree-1",
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-new-worktree",
+                title: "Use a sticky worktree default",
+                titleSource: "derived",
+                summary: "Started from the sticky worktree launchpad.",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "HEAD",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "worktree",
+                  },
+                ],
+                updatedAt: 1760000001000,
+              },
+              {
+                id: "thread-directory-launchpad",
+                title: "Directory launchpad replay",
+                titleSource: "explicit",
+                summary: "Open a new thread from a directory",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "main",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1760000000000,
+              },
+              {
+                id: "thread-other-directory",
+                title: "Other directory replay",
+                titleSource: "explicit",
+                summary: "Open a new thread from another directory",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "main",
+                linkedDirectories: [
+                  {
+                    id: "other-repo",
+                    label: "OtherRepo",
+                    path: otherRepoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1759999999000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-new-1",
+                  role: "user",
+                  text: "Use a sticky worktree default",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-new-1",
+                  role: "user",
+                  text: "Use a sticky worktree default",
+                },
+              ],
+              lastUserMessage: "Use a sticky worktree default",
               pagination: {
                 supportsPagination: false,
                 hasPreviousPage: false,
@@ -151,6 +292,92 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
     await workspaceMode.selectOption("worktree");
 
     await expect(workspaceMode).toHaveValue("worktree");
+    await expect(settings.getByLabel("Base branch")).toHaveValue("main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad keeps new worktree as the sticky default after starting a thread", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const workspaceMode = settings.getByLabel("Workspace mode");
+
+    await workspaceMode.selectOption("worktree");
+    await expect(workspaceMode).toHaveValue("worktree");
+
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("Use a sticky worktree default");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Use a sticky worktree default",
+      }),
+    ).toBeVisible();
+
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+
+    await expect(settings.getByLabel("Workspace mode")).toHaveValue("worktree");
+    await expect(settings.getByLabel("Base branch")).toHaveValue("main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad applies new worktree sticky defaults to stale empty drafts", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+    const settings = app.window.getByLabel("New thread settings");
+    await expect(settings.getByLabel("Workspace mode")).toHaveValue("local");
+
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for OtherRepo" })
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "OtherRepo" }),
+    ).toBeVisible();
+    const otherWorkspaceMode = settings.getByLabel("Workspace mode");
+    await expect(otherWorkspaceMode.getByRole("option", { name: "New worktree" })).toHaveCount(1);
+    await otherWorkspaceMode.selectOption("worktree");
+    await expect(otherWorkspaceMode).toHaveValue("worktree");
+
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+
+    await expect(settings.getByLabel("Workspace mode")).toHaveValue("worktree");
     await expect(settings.getByLabel("Base branch")).toHaveValue("main");
   } finally {
     await app.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -527,6 +527,47 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("refreshes empty saved directory drafts from current launchpad work mode defaults", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      currentBranch: "main",
+    });
+    await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-b",
+      patch: { workMode: "worktree" },
+    });
+
+    const reopened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      currentBranch: "main",
+    });
+
+    expect(reopened.defaults.workMode).toBe("worktree");
+    expect(reopened.launchpad.workMode).toBe("worktree");
+    expect(reopened.launchpad.branchName).toBe("main");
+
+    await registry.close();
+  });
+
   it("creates a scratch workspace for Codex thread creation when cwd is omitted", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -409,6 +409,13 @@ type ModelSettings = {
   fastMode?: boolean;
 };
 
+function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): boolean {
+  return (
+    launchpad.prompt.trim().length === 0 &&
+    (launchpad.imageAttachments?.length ?? 0) === 0
+  );
+}
+
 function getDefaultModelOption(
   backend: AppServerBackendKind,
   options?: BackendLaunchpadOptions,
@@ -1010,6 +1017,26 @@ export class DesktopBackendRegistry {
     });
     const defaults = await this.overlayStore.getLaunchpadDefaults();
     if (existing) {
+      if (isEmptyDirectoryLaunchpadDraft(existing)) {
+        const refreshed: NavigationLaunchpadDraft = {
+          ...existing,
+          backend: request.preferredBackend ?? defaults.backend,
+          executionMode: defaults.executionMode,
+          model: defaults.model,
+          reasoningEffort: defaults.reasoningEffort,
+          serviceTier: defaults.serviceTier,
+          fastMode: defaults.fastMode,
+          workMode: defaults.workMode ?? "local",
+          branchName: existing.branchName ?? request.currentBranch,
+          updatedAt: Date.now(),
+        };
+        const persisted = await this.overlayStore.upsertDirectoryLaunchpad(refreshed);
+        return {
+          launchpad: persisted,
+          defaults,
+        };
+      }
+
       return {
         launchpad: existing,
         defaults,


### PR DESCRIPTION
## Summary

This fixes the directory launchpad path where an empty saved draft could keep an old `Local` workspace mode even after I selected `New worktree` as the sticky default elsewhere.

The registry now refreshes empty saved launchpad drafts from the current sticky defaults when they are reopened. Drafts with typed prompt text or image attachments are still preserved so in-progress user input is not overwritten.

## Testing

- `pnpm vitest run apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop test:e2e directory-launchpad-workspace.spec.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
