### PR TITLE
fix(desktop): make context rail overlay and resizable

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, type CSSProperties, type PointerEvent } from "react";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { ThreadView } from "./features/thread-detail/ThreadView";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
@@ -7,6 +8,7 @@ import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
 
 export function App() {
+  const [sidebarWidth, setSidebarWidth] = useState(408);
   const desktopApi = useDesktopApi();
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
@@ -20,8 +22,34 @@ export function App() {
     thread: navigation.selectedThread,
   });
 
+  const resizeSidebar = (nextWidth: number): void => {
+    setSidebarWidth(Math.min(560, Math.max(280, nextWidth)));
+  };
+
+  const startSidebarResize = (event: PointerEvent<HTMLElement>): void => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = sidebarWidth;
+
+    const move = (moveEvent: globalThis.PointerEvent): void => {
+      resizeSidebar(startWidth + moveEvent.clientX - startX);
+    };
+    const stop = (): void => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+    };
+
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
+  };
+
   return (
-    <div className="app-shell">
+    <div
+      className="app-shell"
+      style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+    >
       <Sidebar
         backends={backendSummaries.backends}
         browseMode={navigation.browseMode}
@@ -43,6 +71,8 @@ export function App() {
         onSelectThread={navigation.selectThread}
         onArchiveThread={navigation.archiveThread}
         onRenameThread={navigation.renameThread}
+        onResizeStart={startSidebarResize}
+        onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
       />
 
       <main className="app-main">

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -300,7 +300,7 @@ describe("App", () => {
     const openContextButton = screen.getByRole("button", { name: "Open context rail" });
     openContextButton.click();
     expect(
-      await screen.findByRole("heading", { level: 3, name: "Thread details" })
+      await screen.findByRole("heading", { level: 3, name: "Linked directories" })
     ).toBeInTheDocument();
     const context = screen.getByLabelText("Thread context");
     fireEvent.click(

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
@@ -38,6 +39,8 @@ type SidebarProps = {
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRenameThread?: (thread: NavigationThreadSummary, name: string) => Promise<void>;
+  onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
+  onResizeByKeyboard?: (delta: number) => void;
 };
 
 export function Sidebar(props: SidebarProps) {
@@ -157,6 +160,23 @@ export function Sidebar(props: SidebarProps) {
 
   return (
     <aside className="sidebar" aria-label="Threads">
+      <div
+        aria-label="Resize thread sidebar"
+        aria-orientation="vertical"
+        className="sidebar__resize-handle"
+        role="separator"
+        tabIndex={0}
+        onKeyDown={(event: ReactKeyboardEvent<HTMLElement>) => {
+          if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            props.onResizeByKeyboard?.(-16);
+          } else if (event.key === "ArrowRight") {
+            event.preventDefault();
+            props.onResizeByKeyboard?.(16);
+          }
+        }}
+        onPointerDown={props.onResizeStart}
+      />
       <header className="sidebar__masthead">
         <p className="eyebrow sidebar__brand">PwrAgnt</p>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -189,7 +189,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <div className="context-panel__rail-header">
             <div>
               <p className="eyebrow">Context</p>
-              <h3 className="context-panel__title">Thread details</h3>
             </div>
 
             <div className="context-panel__rail-actions">
@@ -227,23 +226,19 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
                   return (
                     <li key={directory.id} className="context-list__item">
-                      <button
-                        aria-label={`Copy path for ${directory.label}`}
-                        className="context-list__label path-copy-target"
-                        type="button"
-                        onBlur={hideRailTooltip}
-                        onClick={(event) => {
-                          void handleCopyPath(event, directory.path);
-                        }}
-                        onFocus={(event) => showRailTooltip(event, directory.path)}
-                        onMouseEnter={(event) => showRailTooltip(event, directory.path)}
-                        onMouseLeave={hideRailTooltip}
-                      >
+                      <div className="context-list__label">
+                        <CopyValueButton
+                          label={`Copy path for ${directory.label}`}
+                          value={directory.path}
+                          onBlur={hideRailTooltip}
+                          onCopy={handleCopyPath}
+                          onShowTooltip={showRailTooltip}
+                        />
                         <span aria-hidden="true" className="context-list__icon">
                           {directory.kind === "worktree" ? "🔀" : "📁"}
                         </span>
                         {directory.label}
-                      </button>
+                      </div>
                       <div className="context-list__actions">
                         {canRestore && snapshot ? (
                           <button
@@ -260,20 +255,16 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                             Restore
                           </button>
                         ) : null}
-                        <button
-                          aria-label={`Copy path for ${directory.kind} ${directory.label}`}
-                          className="context-list__meta path-copy-target"
-                          type="button"
-                          onBlur={hideRailTooltip}
-                          onClick={(event) => {
-                            void handleCopyPath(event, worktreePath);
-                          }}
-                          onFocus={(event) => showRailTooltip(event, worktreePath)}
-                          onMouseEnter={(event) => showRailTooltip(event, worktreePath)}
-                          onMouseLeave={hideRailTooltip}
-                        >
+                        <span className="context-list__meta">
+                          <CopyValueButton
+                            label={`Copy path for ${directory.kind} ${directory.label}`}
+                            value={worktreePath}
+                            onBlur={hideRailTooltip}
+                            onCopy={handleCopyPath}
+                            onShowTooltip={showRailTooltip}
+                          />
                           {snapshot?.state === "archived" ? "archived" : directory.kind}
-                        </button>
+                        </span>
                       </div>
                     </li>
                   );
@@ -283,37 +274,29 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               <>
                 <ul className="context-list">
                   <li className="context-list__item">
-                    <button
-                      aria-label="Copy recorded working directory"
-                      className="context-list__label path-copy-target"
-                      type="button"
-                      onBlur={hideRailTooltip}
-                      onClick={(event) => {
-                        void handleCopyPath(event, props.thread.projectKey!);
-                      }}
-                      onFocus={(event) => showRailTooltip(event, props.thread.projectKey!)}
-                      onMouseEnter={(event) => showRailTooltip(event, props.thread.projectKey!)}
-                      onMouseLeave={hideRailTooltip}
-                    >
+                    <div className="context-list__label">
+                      <CopyValueButton
+                        label="Copy recorded working directory"
+                        value={props.thread.projectKey!}
+                        onBlur={hideRailTooltip}
+                        onCopy={handleCopyPath}
+                        onShowTooltip={showRailTooltip}
+                      />
                       <span aria-hidden="true" className="context-list__icon">
                         📁
                       </span>
                       {pathBaseName(props.thread.projectKey)}
-                    </button>
-                    <button
-                      aria-label="Copy missing working directory path"
-                      className="context-list__meta path-copy-target"
-                      type="button"
-                      onBlur={hideRailTooltip}
-                      onClick={(event) => {
-                        void handleCopyPath(event, props.thread.projectKey!);
-                      }}
-                      onFocus={(event) => showRailTooltip(event, props.thread.projectKey!)}
-                      onMouseEnter={(event) => showRailTooltip(event, props.thread.projectKey!)}
-                      onMouseLeave={hideRailTooltip}
-                    >
+                    </div>
+                    <span className="context-list__meta">
+                      <CopyValueButton
+                        label="Copy missing working directory path"
+                        value={props.thread.projectKey!}
+                        onBlur={hideRailTooltip}
+                        onCopy={handleCopyPath}
+                        onShowTooltip={showRailTooltip}
+                      />
                       missing
-                    </button>
+                    </span>
                   </li>
                 </ul>
                 <p className="context-empty">Recorded working directory is no longer available.</p>
@@ -390,21 +373,19 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               </div>
               <div>
                 <dt>Thread ID</dt>
-                <dd>
-                  <button
+                <dd className="context-value-row">
+                  <CopyValueButton
                     aria-label="Copy thread id"
-                    className="context-grid__copy context-grid__mono path-copy-target"
-                    type="button"
+                    label="Copy thread id"
+                    maxTooltipLength={48}
+                    value={props.thread.id}
                     onBlur={hideRailTooltip}
-                    onClick={(event) => {
-                      void handleCopyPath(event, props.thread.id);
-                    }}
-                    onFocus={(event) => showRailTooltip(event, props.thread.id, 48)}
-                    onMouseEnter={(event) => showRailTooltip(event, props.thread.id, 48)}
-                    onMouseLeave={hideRailTooltip}
-                  >
+                    onCopy={handleCopyPath}
+                    onShowTooltip={showRailTooltip}
+                  />
+                  <span className="context-grid__mono">
                     {props.thread.id}
-                  </button>
+                  </span>
                 </dd>
               </div>
               <div>
@@ -413,8 +394,19 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               </div>
               <div>
                 <dt>Branch</dt>
-                <dd className="context-grid__mono">
-                  {props.thread.gitBranch ?? "Not attached"}
+                <dd className="context-value-row">
+                  {props.thread.gitBranch ? (
+                    <CopyValueButton
+                      label="Copy branch name"
+                      value={props.thread.gitBranch}
+                      onBlur={hideRailTooltip}
+                      onCopy={handleCopyPath}
+                      onShowTooltip={showRailTooltip}
+                    />
+                  ) : null}
+                  <span className="context-grid__mono">
+                    {props.thread.gitBranch ?? "Not attached"}
+                  </span>
                 </dd>
               </div>
               <div>
@@ -495,6 +487,44 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   function hideRailTooltip(): void {
     setTooltip(undefined);
   }
+}
+
+function CopyValueButton(props: {
+  label?: string;
+  "aria-label"?: string;
+  maxTooltipLength?: number;
+  onBlur: () => void;
+  onCopy: (
+    event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+    value: string
+  ) => Promise<void>;
+  onShowTooltip: (
+    event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
+    value: string,
+    maxLength?: number
+  ) => void;
+  value: string;
+}) {
+  const label = props["aria-label"] ?? props.label ?? "Copy to clipboard";
+
+  return (
+    <button
+      aria-label={label}
+      className="context-copy-button path-copy-target"
+      type="button"
+      onBlur={props.onBlur}
+      onClick={(event) => {
+        void props.onCopy(event, props.value);
+      }}
+      onFocus={(event) => props.onShowTooltip(event, props.value, props.maxTooltipLength)}
+      onMouseEnter={(event) =>
+        props.onShowTooltip(event, props.value, props.maxTooltipLength)
+      }
+      onMouseLeave={props.onBlur}
+    >
+      <span aria-hidden="true">📋</span>
+    </button>
+  );
 }
 
 async function handleCopyPath(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,6 +1,9 @@
 import {
+  useLayoutEffect,
+  useRef,
   useState,
   type CSSProperties,
+  type FocusEvent,
   type KeyboardEvent,
   type MouseEvent,
   type PointerEvent,
@@ -30,11 +33,48 @@ type ThreadContextPanelProps = {
 };
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
+  const tooltipRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState(false);
   const [revealed, setRevealed] = useState(false);
   const [railWidth, setRailWidth] = useState(380);
   const [resizing, setResizing] = useState(false);
+  const [tooltip, setTooltip] = useState<{
+    left?: number;
+    text: string;
+    targetBottom: number;
+    targetCenter: number;
+    targetTop: number;
+    top?: number;
+  }>();
   const open = pinned || revealed;
+
+  useLayoutEffect(() => {
+    if (!tooltip || tooltip.left !== undefined) {
+      return;
+    }
+
+    const tooltipElement = tooltipRef.current;
+    if (!tooltipElement) {
+      return;
+    }
+
+    const tooltipRect = tooltipElement.getBoundingClientRect();
+    const viewportPadding = 12;
+    const left = Math.min(
+      window.innerWidth - tooltipRect.width - viewportPadding,
+      Math.max(viewportPadding, tooltip.targetCenter - tooltipRect.width / 2)
+    );
+    const top =
+      tooltip.targetTop - tooltipRect.height - 10 >= viewportPadding
+        ? tooltip.targetTop - 10
+        : tooltip.targetBottom + tooltipRect.height + 10;
+
+    setTooltip({
+      ...tooltip,
+      left,
+      top,
+    });
+  }, [tooltip]);
 
   const updatePinned = (nextPinned: boolean): void => {
     setPinned(nextPinned);
@@ -189,12 +229,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                     <li key={directory.id} className="context-list__item">
                       <button
                         aria-label={`Copy path for ${directory.label}`}
-                        className="context-list__label path-copy-target tooltip-target"
-                        data-tooltip={formatCopyTooltip(directory.path)}
+                        className="context-list__label path-copy-target"
                         type="button"
+                        onBlur={hideRailTooltip}
                         onClick={(event) => {
                           void handleCopyPath(event, directory.path);
                         }}
+                        onFocus={(event) => showRailTooltip(event, directory.path)}
+                        onMouseEnter={(event) => showRailTooltip(event, directory.path)}
+                        onMouseLeave={hideRailTooltip}
                       >
                         <span aria-hidden="true" className="context-list__icon">
                           {directory.kind === "worktree" ? "🔀" : "📁"}
@@ -219,12 +262,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         ) : null}
                         <button
                           aria-label={`Copy path for ${directory.kind} ${directory.label}`}
-                          className="context-list__meta path-copy-target tooltip-target"
-                          data-tooltip={formatCopyTooltip(worktreePath)}
+                          className="context-list__meta path-copy-target"
                           type="button"
+                          onBlur={hideRailTooltip}
                           onClick={(event) => {
                             void handleCopyPath(event, worktreePath);
                           }}
+                          onFocus={(event) => showRailTooltip(event, worktreePath)}
+                          onMouseEnter={(event) => showRailTooltip(event, worktreePath)}
+                          onMouseLeave={hideRailTooltip}
                         >
                           {snapshot?.state === "archived" ? "archived" : directory.kind}
                         </button>
@@ -239,12 +285,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                   <li className="context-list__item">
                     <button
                       aria-label="Copy recorded working directory"
-                      className="context-list__label path-copy-target tooltip-target"
-                      data-tooltip={formatCopyTooltip(props.thread.projectKey)}
+                      className="context-list__label path-copy-target"
                       type="button"
+                      onBlur={hideRailTooltip}
                       onClick={(event) => {
                         void handleCopyPath(event, props.thread.projectKey!);
                       }}
+                      onFocus={(event) => showRailTooltip(event, props.thread.projectKey!)}
+                      onMouseEnter={(event) => showRailTooltip(event, props.thread.projectKey!)}
+                      onMouseLeave={hideRailTooltip}
                     >
                       <span aria-hidden="true" className="context-list__icon">
                         📁
@@ -253,12 +302,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                     </button>
                     <button
                       aria-label="Copy missing working directory path"
-                      className="context-list__meta path-copy-target tooltip-target"
-                      data-tooltip={formatCopyTooltip(props.thread.projectKey)}
+                      className="context-list__meta path-copy-target"
                       type="button"
+                      onBlur={hideRailTooltip}
                       onClick={(event) => {
                         void handleCopyPath(event, props.thread.projectKey!);
                       }}
+                      onFocus={(event) => showRailTooltip(event, props.thread.projectKey!)}
+                      onMouseEnter={(event) => showRailTooltip(event, props.thread.projectKey!)}
+                      onMouseLeave={hideRailTooltip}
                     >
                       missing
                     </button>
@@ -288,12 +340,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                     <li key={snapshot.id} className="context-list__item">
                       <button
                         aria-label={`Copy snapshot ref ${snapshot.snapshotRef}`}
-                        className="context-list__label path-copy-target tooltip-target"
-                        data-tooltip={formatCopyTooltip(snapshot.snapshotRef)}
+                        className="context-list__label path-copy-target"
                         type="button"
+                        onBlur={hideRailTooltip}
                         onClick={(event) => {
                           void handleCopyPath(event, snapshot.snapshotRef);
                         }}
+                        onFocus={(event) => showRailTooltip(event, snapshot.snapshotRef)}
+                        onMouseEnter={(event) => showRailTooltip(event, snapshot.snapshotRef)}
+                        onMouseLeave={hideRailTooltip}
                       >
                         <span aria-hidden="true" className="context-list__icon">
                           🔀
@@ -338,12 +393,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                 <dd>
                   <button
                     aria-label="Copy thread id"
-                    className="context-grid__copy context-grid__mono path-copy-target tooltip-target"
-                    data-tooltip={formatCopyTooltip(props.thread.id, 48)}
+                    className="context-grid__copy context-grid__mono path-copy-target"
                     type="button"
+                    onBlur={hideRailTooltip}
                     onClick={(event) => {
                       void handleCopyPath(event, props.thread.id);
                     }}
+                    onFocus={(event) => showRailTooltip(event, props.thread.id, 48)}
+                    onMouseEnter={(event) => showRailTooltip(event, props.thread.id, 48)}
+                    onMouseLeave={hideRailTooltip}
                   >
                     {props.thread.id}
                   </button>
@@ -402,8 +460,41 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           </section>
         </div>
       ) : null}
+
+      {tooltip ? (
+        <div
+          ref={tooltipRef}
+          className="context-rail__tooltip"
+          role="tooltip"
+          style={{
+            left: tooltip.left,
+            top: tooltip.top,
+            visibility: tooltip.left === undefined ? "hidden" : undefined,
+          }}
+        >
+          {tooltip.text}
+        </div>
+      ) : null}
     </aside>
   );
+
+  function showRailTooltip(
+    event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
+    path: string,
+    maxLength?: number
+  ): void {
+    const rect = event.currentTarget.getBoundingClientRect();
+    setTooltip({
+      text: formatCopyTooltip(path, maxLength),
+      targetBottom: rect.bottom,
+      targetCenter: rect.left + rect.width / 2,
+      targetTop: rect.top,
+    });
+  }
+
+  function hideRailTooltip(): void {
+    setTooltip(undefined);
+  }
 }
 
 async function handleCopyPath(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -22,6 +22,7 @@ type ThreadContextPanelProps = {
   onPinnedChange?: (pinned: boolean) => void;
   onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
+  pinned: boolean;
   platform?: string;
   thread: NavigationThreadSummary;
   worktreeArchiveError?: string;
@@ -34,7 +35,6 @@ type ThreadContextPanelProps = {
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const tooltipRef = useRef<HTMLDivElement>(null);
-  const [pinned, setPinned] = useState(false);
   const [revealed, setRevealed] = useState(false);
   const [railWidth, setRailWidth] = useState(380);
   const [resizing, setResizing] = useState(false);
@@ -46,6 +46,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     targetTop: number;
     top?: number;
   }>();
+  const pinned = props.pinned;
   const open = pinned || revealed;
 
   useLayoutEffect(() => {
@@ -77,7 +78,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   }, [tooltip]);
 
   const updatePinned = (nextPinned: boolean): void => {
-    setPinned(nextPinned);
     props.onPinnedChange?.(nextPinned);
   };
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import type {
   BackendSummary,
-  LinkedDirectorySummary,
   NavigationThreadSummary,
   WorktreeSnapshotSummary,
 } from "@pwragnt/shared";
@@ -18,14 +17,11 @@ type ThreadContextPanelProps = {
   backendError?: string;
   backends: BackendSummary[];
   onPinnedChange?: (pinned: boolean) => void;
+  onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
   platform?: string;
   thread: NavigationThreadSummary;
   worktreeArchiveError?: string;
-  onArchiveWorktree?: (
-    thread: NavigationThreadSummary,
-    directory: LinkedDirectorySummary
-  ) => Promise<void>;
   onRestoreWorktree?: (
     thread: NavigationThreadSummary,
     snapshotRef: string,
@@ -37,6 +33,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const [pinned, setPinned] = useState(false);
   const [revealed, setRevealed] = useState(false);
   const [railWidth, setRailWidth] = useState(380);
+  const [resizing, setResizing] = useState(false);
   const open = pinned || revealed;
 
   const updatePinned = (nextPinned: boolean): void => {
@@ -56,6 +53,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
     event.preventDefault();
     event.stopPropagation();
+    setResizing(true);
+    props.onResizingChange?.(true);
     const startX = event.clientX;
     const startWidth = railWidth;
 
@@ -66,6 +65,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       window.removeEventListener("pointermove", move);
       window.removeEventListener("pointerup", stop);
       window.removeEventListener("pointercancel", stop);
+      setResizing(false);
+      props.onResizingChange?.(false);
     };
 
     window.addEventListener("pointermove", move);
@@ -78,7 +79,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       aria-label="Thread context"
       className={`context-rail${open ? " is-open" : " is-collapsed"}${
         pinned ? " is-pinned" : ""
-      }`}
+      }${resizing ? " is-resizing" : ""}`}
       style={{ "--context-rail-width": `${railWidth}px` } as CSSProperties}
       onMouseEnter={() => {
         if (!pinned) {
@@ -179,10 +180,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                     props.thread.worktreeSnapshots,
                     worktreePath
                   );
-                  const canArchive =
-                    directory.kind === "worktree" &&
-                    snapshot?.state !== "archived" &&
-                    Boolean(props.onArchiveWorktree);
                   const canRestore =
                     directory.kind === "worktree" &&
                     snapshot?.state === "archived" &&
@@ -205,17 +202,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         {directory.label}
                       </button>
                       <div className="context-list__actions">
-                        {canArchive ? (
-                          <button
-                            className="context-list__action"
-                            type="button"
-                            onClick={() => {
-                              void props.onArchiveWorktree?.(props.thread, directory);
-                            }}
-                          >
-                            Archive
-                          </button>
-                        ) : canRestore && snapshot ? (
+                        {canRestore && snapshot ? (
                           <button
                             className="context-list__action"
                             type="button"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -17,6 +17,8 @@ import { formatExecutionModeLabel } from "../../lib/execution-mode";
 type ThreadContextPanelProps = {
   backendError?: string;
   backends: BackendSummary[];
+  onPinnedChange?: (pinned: boolean) => void;
+  onWidthChange?: (width: number) => void;
   platform?: string;
   thread: NavigationThreadSummary;
   worktreeArchiveError?: string;
@@ -36,8 +38,16 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const [revealed, setRevealed] = useState(false);
   const [railWidth, setRailWidth] = useState(380);
   const open = pinned || revealed;
+
+  const updatePinned = (nextPinned: boolean): void => {
+    setPinned(nextPinned);
+    props.onPinnedChange?.(nextPinned);
+  };
+
   const resizeRail = (nextWidth: number): void => {
-    setRailWidth(Math.min(560, Math.max(300, nextWidth)));
+    const clampedWidth = Math.min(560, Math.max(300, nextWidth));
+    setRailWidth(clampedWidth);
+    props.onWidthChange?.(clampedWidth);
   };
   const startRailResize = (event: PointerEvent<HTMLElement>): void => {
     if (!pinned) {
@@ -117,7 +127,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           type="button"
           onClick={() => {
             if (pinned) {
-              setPinned(false);
+              updatePinned(false);
               setRevealed(false);
               return;
             }
@@ -150,7 +160,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                 className="button button--ghost context-panel__pin-button"
                 type="button"
                 onClick={() => {
-                  setPinned((current) => !current);
+                  updatePinned(!pinned);
                   setRevealed(true);
                 }}
               >

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,4 +1,10 @@
-import { useState, type KeyboardEvent, type MouseEvent } from "react";
+import {
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+} from "react";
 import type {
   BackendSummary,
   LinkedDirectorySummary,
@@ -28,7 +34,34 @@ type ThreadContextPanelProps = {
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const [pinned, setPinned] = useState(false);
   const [revealed, setRevealed] = useState(false);
+  const [railWidth, setRailWidth] = useState(380);
   const open = pinned || revealed;
+  const resizeRail = (nextWidth: number): void => {
+    setRailWidth(Math.min(560, Math.max(300, nextWidth)));
+  };
+  const startRailResize = (event: PointerEvent<HTMLElement>): void => {
+    if (!pinned) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startWidth = railWidth;
+
+    const move = (moveEvent: globalThis.PointerEvent): void => {
+      resizeRail(startWidth + startX - moveEvent.clientX);
+    };
+    const stop = (): void => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", stop);
+      window.removeEventListener("pointercancel", stop);
+    };
+
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", stop);
+    window.addEventListener("pointercancel", stop);
+  };
 
   return (
     <aside
@@ -36,6 +69,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       className={`context-rail${open ? " is-open" : " is-collapsed"}${
         pinned ? " is-pinned" : ""
       }`}
+      style={{ "--context-rail-width": `${railWidth}px` } as CSSProperties}
       onMouseEnter={() => {
         if (!pinned) {
           setRevealed(true);
@@ -57,6 +91,25 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         }
       }}
     >
+      {pinned ? (
+        <div
+          aria-label="Resize context rail"
+          aria-orientation="vertical"
+          className="context-rail__resize-handle"
+          role="separator"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowLeft") {
+              event.preventDefault();
+              resizeRail(railWidth + 16);
+            } else if (event.key === "ArrowRight") {
+              event.preventDefault();
+              resizeRail(railWidth - 16);
+            }
+          }}
+          onPointerDown={startRailResize}
+        />
+      ) : null}
       <div className="context-rail__spine">
         <button
           aria-label={pinned ? "Unpin context rail" : "Open context rail"}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1384,39 +1384,66 @@ export function ThreadView(props: ThreadViewProps) {
       <ThreadHeader thread={selectedThread!} />
 
       <div className="thread-view__layout">
-        <section className="transcript-panel" aria-label="Transcript">
-          <TranscriptList
-            entries={props.transcriptEntries}
+        <div className="thread-view__primary">
+          <section className="transcript-panel" aria-label="Transcript">
+            <TranscriptList
+              entries={props.transcriptEntries}
+              activeTurnId={props.activeTurnId}
+              activeTurnStartedAt={props.activeTurnStartedAt}
+              error={props.transcriptError}
+              loading={props.loading}
+              loadingMore={props.loadingMore}
+              pagination={props.transcriptPagination}
+              pendingActivityEntry={pendingToolActivityEntry ?? pendingActivityEntry}
+              pendingAssistantMessage={props.pendingAssistantMessage}
+              pendingPlanEntry={pendingPlanEntry}
+              pendingRequest={props.pendingRequest}
+              pendingRequestBusy={pendingRequestBusy}
+              pendingUserInput={props.pendingUserInput}
+              pendingStatusText={props.pendingStatusText}
+              restoredViewport={props.transcriptViewport}
+              skills={props.skills}
+              pendingProtocolActivityEntry={pendingProtocolActivityEntry}
+              threadId={`${selectedThread!.source}:${selectedThread!.id}`}
+              onLoadOlder={props.onLoadOlder}
+              onOpenImage={setExpandedImage}
+              onRespondToPendingRequest={respondToPendingRequest}
+              onPendingUserInputChange={(state) => {
+                props.onUpdatePendingUserInput?.(state.requestId, () => state);
+              }}
+              onSubmitPendingUserInput={submitPendingUserInput}
+              onViewportChange={props.onTranscriptViewportChange}
+            />
+            {pendingRequestError ? (
+              <p className="transcript-error">{pendingRequestError}</p>
+            ) : null}
+          </section>
+
+          <Composer
             activeTurnId={props.activeTurnId}
-            activeTurnStartedAt={props.activeTurnStartedAt}
-            error={props.transcriptError}
-            loading={props.loading}
-            loadingMore={props.loadingMore}
-            pagination={props.transcriptPagination}
-            pendingActivityEntry={pendingToolActivityEntry ?? pendingActivityEntry}
-            pendingAssistantMessage={props.pendingAssistantMessage}
-            pendingPlanEntry={pendingPlanEntry}
-            pendingRequest={props.pendingRequest}
-            pendingRequestBusy={pendingRequestBusy}
-            pendingUserInput={props.pendingUserInput}
-            pendingStatusText={props.pendingStatusText}
-            restoredViewport={props.transcriptViewport}
+            addOptimisticReviewEntry={props.addOptimisticReviewEntry}
+            addOptimisticUserMessage={props.addOptimisticUserMessage}
+            backends={props.backends}
+            desktopApi={props.desktopApi}
+            directory={props.selectedDirectory}
+            disabled={props.composerDisabled}
+            onActiveTurnIdChange={props.onActiveTurnIdChange}
+            onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+            onPendingStatusChange={props.onPendingStatusChange}
+            onSetExecutionMode={props.onSetExecutionMode}
+            onSetThreadModelSettings={props.onSetThreadModelSettings}
+            pendingRequestActive={Boolean(props.pendingRequest)}
+            pendingUserInputActive={Boolean(props.pendingUserInput)}
+            removeOptimisticMessage={props.removeOptimisticMessage}
+            setExecutionModeError={props.setExecutionModeError}
+            threadModelSettingsError={props.setThreadModelSettingsError}
+            skillError={props.skillError}
+            skillLoading={props.skillLoading}
             skills={props.skills}
-            pendingProtocolActivityEntry={pendingProtocolActivityEntry}
-            threadId={`${selectedThread!.source}:${selectedThread!.id}`}
-            onLoadOlder={props.onLoadOlder}
-            onOpenImage={setExpandedImage}
-            onRespondToPendingRequest={respondToPendingRequest}
-            onPendingUserInputChange={(state) => {
-              props.onUpdatePendingUserInput?.(state.requestId, () => state);
-            }}
-            onSubmitPendingUserInput={submitPendingUserInput}
-            onViewportChange={props.onTranscriptViewportChange}
+            thread={selectedThread!}
+            updatingExecutionMode={props.updatingExecutionMode}
           />
-          {pendingRequestError ? (
-            <p className="transcript-error">{pendingRequestError}</p>
-          ) : null}
-        </section>
+        </div>
 
         <ThreadContextPanel
           backendError={props.backendError}
@@ -1438,30 +1465,6 @@ export function ThreadView(props: ThreadViewProps) {
         />
       ) : null}
 
-      <Composer
-        activeTurnId={props.activeTurnId}
-        addOptimisticReviewEntry={props.addOptimisticReviewEntry}
-        addOptimisticUserMessage={props.addOptimisticUserMessage}
-        backends={props.backends}
-        desktopApi={props.desktopApi}
-        directory={props.selectedDirectory}
-        disabled={props.composerDisabled}
-        onActiveTurnIdChange={props.onActiveTurnIdChange}
-        onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
-        onPendingStatusChange={props.onPendingStatusChange}
-        onSetExecutionMode={props.onSetExecutionMode}
-        onSetThreadModelSettings={props.onSetThreadModelSettings}
-        pendingRequestActive={Boolean(props.pendingRequest)}
-        pendingUserInputActive={Boolean(props.pendingUserInput)}
-        removeOptimisticMessage={props.removeOptimisticMessage}
-        setExecutionModeError={props.setExecutionModeError}
-        threadModelSettingsError={props.setThreadModelSettingsError}
-        skillError={props.skillError}
-        skillLoading={props.skillLoading}
-        skills={props.skills}
-        thread={selectedThread!}
-        updatingExecutionMode={props.updatingExecutionMode}
-      />
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -885,6 +885,8 @@ export function ThreadView(props: ThreadViewProps) {
     setPendingPlanEntry(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
+    setContextRailPinned(false);
+    setContextRailResizing(false);
     setExpandedImage(undefined);
   }, [
     props.selectedLaunchpad?.directoryKey,
@@ -1463,6 +1465,7 @@ export function ThreadView(props: ThreadViewProps) {
           onPinnedChange={setContextRailPinned}
           onResizingChange={setContextRailResizing}
           onWidthChange={setContextRailWidth}
+          pinned={contextRailPinned}
           platform={props.platform}
           thread={selectedThread!}
           worktreeArchiveError={props.worktreeArchiveError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -875,6 +875,7 @@ export function ThreadView(props: ThreadViewProps) {
   const [pendingRequestError, setPendingRequestError] = useState<string>();
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
   const [contextRailPinned, setContextRailPinned] = useState(false);
+  const [contextRailResizing, setContextRailResizing] = useState(false);
   const [contextRailWidth, setContextRailWidth] = useState(380);
 
   useEffect(() => {
@@ -1388,7 +1389,7 @@ export function ThreadView(props: ThreadViewProps) {
       <div
         className={`thread-view__layout${
           contextRailPinned ? " has-pinned-context-rail" : ""
-        }`}
+        }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
         style={
           {
             "--context-rail-width": `${contextRailWidth}px`,
@@ -1460,11 +1461,11 @@ export function ThreadView(props: ThreadViewProps) {
           backendError={props.backendError}
           backends={props.backends}
           onPinnedChange={setContextRailPinned}
+          onResizingChange={setContextRailResizing}
           onWidthChange={setContextRailWidth}
           platform={props.platform}
           thread={selectedThread!}
           worktreeArchiveError={props.worktreeArchiveError}
-          onArchiveWorktree={props.onArchiveWorktree}
           onRestoreWorktree={props.onRestoreWorktree}
         />
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
@@ -874,6 +874,8 @@ export function ThreadView(props: ThreadViewProps) {
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
   const [pendingRequestError, setPendingRequestError] = useState<string>();
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
+  const [contextRailPinned, setContextRailPinned] = useState(false);
+  const [contextRailWidth, setContextRailWidth] = useState(380);
 
   useEffect(() => {
     setPendingActivityEntry(undefined);
@@ -1383,7 +1385,16 @@ export function ThreadView(props: ThreadViewProps) {
     <section className="thread-view">
       <ThreadHeader thread={selectedThread!} />
 
-      <div className="thread-view__layout">
+      <div
+        className={`thread-view__layout${
+          contextRailPinned ? " has-pinned-context-rail" : ""
+        }`}
+        style={
+          {
+            "--context-rail-width": `${contextRailWidth}px`,
+          } as CSSProperties
+        }
+      >
         <div className="thread-view__primary">
           <section className="transcript-panel" aria-label="Transcript">
             <TranscriptList
@@ -1448,6 +1459,8 @@ export function ThreadView(props: ThreadViewProps) {
         <ThreadContextPanel
           backendError={props.backendError}
           backends={props.backends}
+          onPinnedChange={setContextRailPinned}
+          onWidthChange={setContextRailWidth}
           platform={props.platform}
           thread={selectedThread!}
           worktreeArchiveError={props.worktreeArchiveError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -185,7 +185,7 @@ describe("ThreadView", () => {
     expect(screen.queryByRole("link", { name: "desktop docs" })).not.toBeInTheDocument();
     expect(screen.getByText("Explored 2 files")).toBeInTheDocument();
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 3, name: "Thread details" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Execution context" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pin context rail" })).toBeInTheDocument();
     expect(screen.getByText("Codex app server")).toBeInTheDocument();
     expect(screen.getByText("Grok app server")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1060,6 +1060,10 @@ textarea {
   padding-right: min(var(--context-rail-width, 380px), 42vw);
 }
 
+.thread-view__layout.is-resizing-context-rail {
+  transition: none;
+}
+
 .thread-view__primary {
   display: flex;
   flex: 1;
@@ -2259,8 +2263,7 @@ textarea {
 .context-rail.is-open {
   width: min(var(--context-rail-width, 380px), calc(100% - 32px));
   z-index: 30;
-  overflow-x: visible;
-  overflow-y: auto;
+  overflow: visible;
   box-shadow: var(--shadow-popover);
 }
 
@@ -2274,6 +2277,10 @@ textarea {
   width: min(var(--context-rail-width, 380px), 42vw);
   overflow-y: auto;
   box-shadow: none;
+}
+
+.context-rail.is-resizing {
+  transition: none;
 }
 
 .context-rail:hover,
@@ -2295,15 +2302,7 @@ textarea {
 }
 
 .context-rail.is-open .context-rail__spine {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  z-index: 2;
-  width: 36px;
-  flex-basis: 36px;
-  padding: 0;
-  border-right: 0;
-  background: transparent;
+  display: none;
 }
 
 .context-rail__resize-handle {
@@ -2381,7 +2380,7 @@ textarea {
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px 16px 16px 64px;
+  padding: 16px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -3055,6 +3054,7 @@ textarea {
   }
 
   .context-rail.is-open .context-rail__spine {
+    display: flex;
     position: static;
     width: 100%;
     flex-basis: auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2275,7 +2275,7 @@ textarea {
   z-index: 10;
   flex: 0 0 min(var(--context-rail-width, 380px), 42vw);
   width: min(var(--context-rail-width, 380px), 42vw);
-  overflow-y: auto;
+  overflow: hidden;
   box-shadow: none;
 }
 
@@ -2376,7 +2376,8 @@ textarea {
   flex: 1;
   min-width: 0;
   min-height: 0;
-  overflow: visible;
+  overflow-y: auto;
+  overflow-x: visible;
   overscroll-behavior: contain;
   border: 0;
   border-radius: 0;
@@ -2397,17 +2398,11 @@ textarea {
 
 .context-panel__rail-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 16px;
   border-bottom: 1px solid var(--border-subtle);
-}
-
-.context-panel__title {
-  margin: 2px 0 0;
-  font-size: 14px;
-  font-weight: 600;
 }
 
 .context-panel__rail-actions {
@@ -2443,6 +2438,7 @@ textarea {
 
 .context-panel__section--status {
   margin-top: auto;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .context-list {
@@ -2464,6 +2460,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .context-list__actions {
@@ -2489,6 +2486,9 @@ textarea {
 
 .context-list__label,
 .context-list__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -2520,12 +2520,40 @@ textarea {
   font-size: 14px;
 }
 
-.context-grid__copy {
+.context-value-row {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.context-value-row .context-grid__mono {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.context-copy-button {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  align-items: center;
+  justify-content: center;
   padding: 0;
-  border: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
   background: transparent;
-  color: inherit;
-  text-align: left;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.context-copy-button:hover,
+.context-copy-button:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+  outline: none;
 }
 
 .context-mode-switch {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -58,7 +58,7 @@ textarea {
 
 .app-shell {
   display: grid;
-  grid-template-columns: minmax(320px, 408px) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width, 408px) minmax(0, 1fr);
   height: 100vh;
   overflow: hidden;
   background: var(--bg-app);
@@ -67,12 +67,56 @@ textarea {
 
 .sidebar {
   display: flex;
+  position: relative;
   flex-direction: column;
   min-height: 0;
   padding: 16px;
   overflow: hidden;
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border-subtle);
+}
+
+.sidebar__resize-handle,
+.context-rail__resize-handle {
+  position: absolute;
+  z-index: 12;
+  width: 11px;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.sidebar__resize-handle {
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.sidebar__resize-handle::after,
+.context-rail__resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  left: 5px;
+  width: 1px;
+  border-radius: 999px;
+  background: transparent;
+  transition:
+    background 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.sidebar__resize-handle:hover::after,
+.sidebar__resize-handle:focus-visible::after,
+.context-rail__resize-handle:hover::after,
+.context-rail__resize-handle:focus-visible::after {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px rgba(255, 138, 31, 0.16);
+}
+
+.sidebar__resize-handle:focus-visible,
+.context-rail__resize-handle:focus-visible {
+  outline: none;
 }
 
 .sidebar__masthead,
@@ -949,7 +993,7 @@ textarea {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 24px;
+  gap: 18px;
   min-height: 0;
   overflow: hidden;
 }
@@ -992,9 +1036,20 @@ textarea {
 
 .thread-view__layout {
   display: flex;
+  position: relative;
   flex: 1;
-  gap: 24px;
   align-items: stretch;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.thread-view__primary {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
   min-height: 0;
 }
 
@@ -2164,8 +2219,12 @@ textarea {
 
 .context-rail {
   display: flex;
-  align-self: stretch;
-  flex: 0 0 48px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  flex: 0 0 auto;
   width: 48px;
   min-width: 48px;
   min-height: 0;
@@ -2181,8 +2240,20 @@ textarea {
 }
 
 .context-rail.is-open {
-  flex-basis: min(380px, 34vw);
-  width: min(380px, 34vw);
+  width: min(var(--context-rail-width, 380px), calc(100% - 32px));
+  box-shadow: var(--shadow-popover);
+}
+
+.context-rail.is-pinned {
+  position: relative;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  z-index: 1;
+  flex: 0 0 min(var(--context-rail-width, 380px), 42vw);
+  width: min(var(--context-rail-width, 380px), 42vw);
+  margin-left: 24px;
+  box-shadow: none;
 }
 
 .context-rail:hover,
@@ -2201,6 +2272,12 @@ textarea {
   padding: 8px 0;
   border-right: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
+}
+
+.context-rail__resize-handle {
+  top: 0;
+  bottom: 0;
+  left: 0;
 }
 
 .context-rail__menu-button {
@@ -2248,7 +2325,8 @@ textarea {
   flex: 1;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -2907,7 +2985,7 @@ textarea {
 
 @media (max-width: 1100px) {
   .app-shell {
-    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+    grid-template-columns: minmax(280px, min(var(--sidebar-width, 360px), 360px)) minmax(0, 1fr);
   }
 
   .thread-view__layout {
@@ -2929,6 +3007,8 @@ textarea {
     width: 100%;
     min-width: 0;
     flex-basis: auto;
+    margin-left: 0;
+    box-shadow: none;
   }
 
   .context-rail__spine {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2350,6 +2350,26 @@ textarea {
   background: currentColor;
 }
 
+.context-rail__tooltip {
+  position: fixed;
+  z-index: 90;
+  width: max-content;
+  max-width: min(420px, calc(100vw - 32px));
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: rgba(10, 10, 10, 0.98);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+  pointer-events: none;
+  text-align: left;
+  transform: translateY(-100%);
+  white-space: pre-wrap;
+}
+
 .context-panel {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -671,6 +671,16 @@ textarea {
   transform: translateY(0);
 }
 
+.context-panel .context-list__label.tooltip-target[data-tooltip]::after {
+  left: 0;
+  transform: translateY(4px);
+}
+
+.context-panel .context-list__label.tooltip-target[data-tooltip]:hover::after,
+.context-panel .context-list__label.tooltip-target[data-tooltip]:focus-visible::after {
+  transform: translateY(0);
+}
+
 .tooltip-target:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -985,7 +995,7 @@ textarea {
   display: flex;
   min-height: 0;
   min-width: 0;
-  padding: 24px 28px;
+  padding: 24px 0 24px 28px;
   overflow: hidden;
 }
 
@@ -1042,6 +1052,12 @@ textarea {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+  padding-right: 48px;
+  transition: padding-right 160ms ease;
+}
+
+.thread-view__layout.has-pinned-context-rail {
+  padding-right: min(var(--context-rail-width, 380px), 42vw);
 }
 
 .thread-view__primary {
@@ -2219,7 +2235,7 @@ textarea {
 
 .context-rail {
   display: flex;
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
@@ -2229,8 +2245,9 @@ textarea {
   min-width: 48px;
   min-height: 0;
   overflow: hidden;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
+  border: 0;
+  border-left: 1px solid var(--border-subtle);
+  border-radius: 0;
   background: var(--bg-panel);
   transition:
     width 160ms ease,
@@ -2241,18 +2258,21 @@ textarea {
 
 .context-rail.is-open {
   width: min(var(--context-rail-width, 380px), calc(100% - 32px));
+  z-index: 30;
+  overflow-x: visible;
+  overflow-y: auto;
   box-shadow: var(--shadow-popover);
 }
 
 .context-rail.is-pinned {
-  position: relative;
-  top: auto;
-  right: auto;
-  bottom: auto;
-  z-index: 1;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
   flex: 0 0 min(var(--context-rail-width, 380px), 42vw);
   width: min(var(--context-rail-width, 380px), 42vw);
-  margin-left: 24px;
+  overflow-y: auto;
   box-shadow: none;
 }
 
@@ -2272,6 +2292,18 @@ textarea {
   padding: 8px 0;
   border-right: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
+}
+
+.context-rail.is-open .context-rail__spine {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  width: 36px;
+  flex-basis: 36px;
+  padding: 0;
+  border-right: 0;
+  background: transparent;
 }
 
 .context-rail__resize-handle {
@@ -2325,7 +2357,7 @@ textarea {
   flex: 1;
   min-width: 0;
   min-height: 0;
-  overflow-y: auto;
+  overflow: visible;
   overscroll-behavior: contain;
   border: 0;
   border-radius: 0;
@@ -2349,7 +2381,7 @@ textarea {
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px;
+  padding: 16px 16px 16px 64px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -2990,6 +3022,7 @@ textarea {
 
   .thread-view__layout {
     flex-direction: column;
+    padding-right: 0;
   }
 
   .transcript-list__scroll-bottom {
@@ -3018,6 +3051,14 @@ textarea {
     justify-content: flex-end;
     padding: 8px;
     border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .context-rail.is-open .context-rail__spine {
+    position: static;
+    width: 100%;
+    flex-basis: auto;
+    padding: 8px;
     border-bottom: 1px solid var(--border-subtle);
   }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1052,12 +1052,12 @@ textarea {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  padding-right: 48px;
+  padding-right: calc(48px + 24px);
   transition: padding-right 160ms ease;
 }
 
 .thread-view__layout.has-pinned-context-rail {
-  padding-right: min(var(--context-rail-width, 380px), 42vw);
+  padding-right: calc(min(var(--context-rail-width, 380px), 42vw) + 24px);
 }
 
 .thread-view__layout.is-resizing-context-rail {


### PR DESCRIPTION
## Summary

I fixed the desktop context rail so it behaves like a real right-edge inspector: collapsed it reserves the 48px rail plus the normal 24px content gutter, auto-hide expansion overlays the transcript and composer, and pinned mode reserves the full rail width plus that same gutter.

## Changes

- Anchored the context rail to the window's right, top, and bottom edges with no right-side margin or rounded floating-card treatment.
- Reserved collapsed rail width plus a 24px gutter so transcript content and the composer keep the same breathing room they have elsewhere.
- Kept auto-hide expansion elevated above the work area so hovering the rail opens it over the transcript and composer without reflow.
- Made `ThreadView` the source of truth for pinned reservation so the collapsed rail cannot keep stale pinned-width layout space after unpinning or switching threads.
- Removed the hamburger control while the rail is expanded or pinned, leaving it only as the collapsed rail affordance.
- Removed the context-rail Archive action from linked worktree rows.
- Removed the redundant `Thread details` heading so the rail starts with the `Context` label and the first real section.
- Added explicit clipboard buttons immediately beside the copyable values for linked directories, worktree paths, thread IDs, and branch names.
- Put the context panel itself on vertical overflow and added the missing separator above the App servers section.
- Replaced clipped pseudo-tooltips in the context rail with a measured fixed tooltip that centers on the hovered control and clamps to the viewport.
- Disabled layout/rail transitions while dragging the resize handle so resizing tracks the pointer instead of easing behind it.
- Added resize handles for both the pinned context rail and the left thread sidebar, including keyboard arrow support.

## Verification

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragnt/desktop build`
- Electron geometry checks for edge anchoring, reserved collapsed gutter, 24px content-to-rail gap in collapsed and pinned states, hover overlay, pinned reservation, pin/unpin collapse back to 48px, hidden expanded hamburger, removed Archive action, removed Thread details heading, App servers separator, visible clipboard buttons, tooltip viewport clamping, context-panel vertical overflow, disabled resize transitions, and resize behavior
- `pnpm --filter @pwragnt/desktop test:e2e smoke.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
