### PR TITLE
feat(desktop): add turn steering and queued prompts

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -7,6 +7,7 @@ import type {
   StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
+  SteerTurnRequest,
 } from "@pwragnt/shared";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
@@ -43,6 +44,11 @@ const registry = {
     backend: request.backend,
     threadId: request.threadId,
     turnId: request.turnId,
+  })),
+  steerTurn: vi.fn(async (request: SteerTurnRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    turnId: request.expectedTurnId,
   })),
   materializeDirectoryLaunchpad: vi.fn(
     async (request: MaterializeDirectoryLaunchpadRequest) => ({
@@ -88,6 +94,7 @@ describe("agent ipc", () => {
     registry.startTurn.mockClear();
     registry.startReview.mockClear();
     registry.interruptTurn.mockClear();
+    registry.steerTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
     registryListener = undefined;
   });
@@ -104,6 +111,7 @@ describe("agent ipc", () => {
       AGENT_START_THREAD_CHANNEL,
       AGENT_START_REVIEW_CHANNEL,
       AGENT_START_TURN_CHANNEL,
+      AGENT_STEER_TURN_CHANNEL,
       BACKEND_LIST_CHANNEL,
     } = await import("../../shared/ipc");
 
@@ -150,6 +158,18 @@ describe("agent ipc", () => {
       }),
     ).toEqual({
       backend: "grok",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_STEER_TURN_CHANNEL)?.({}, {
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "Course correct" }],
+      }),
+    ).toEqual({
+      backend: "codex",
       threadId: "thread-1",
       turnId: "turn-1",
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -409,7 +409,7 @@ describe("DesktopBackendRegistry", () => {
           readThread: true,
           startTurn: true,
           interruptTurn: false,
-          steerTurn: false,
+          steerTurn: true,
           transcriptPagination: false,
           toolUse: false,
           approvalRequests: true,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -41,6 +41,8 @@ import {
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
   type SetThreadModelSettingsResponse,
+  type SteerTurnRequest,
+  type SteerTurnResponse,
   type StartReviewRequest,
   type StartReviewResponse,
   type StartThreadResponse,
@@ -144,6 +146,11 @@ type BackendClient = {
     threadId: string;
     turnId: string;
   }): Promise<{ threadId: string; turnId: string }>;
+  steerTurn?(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    expectedTurnId: string;
+  }): Promise<{ threadId: string; turnId: string }>;
   setThreadPermissions?(params: {
     threadId: string;
     cwd?: string;
@@ -186,27 +193,32 @@ const OPENAI_FALLBACK_MODELS: BackendModelOption[] = [
     current: true,
     supportsReasoning: true,
     supportsFast: true,
+    supportsSteering: true,
   },
   {
     id: "gpt-5.4",
     label: "GPT-5.4",
     supportsReasoning: true,
     supportsFast: true,
+    supportsSteering: true,
   },
   {
     id: "gpt-5.4-mini",
     label: "GPT-5.4-Mini",
     supportsReasoning: true,
+    supportsSteering: true,
   },
   {
     id: "gpt-5.3-codex",
     label: "GPT-5.3-Codex",
     supportsReasoning: true,
+    supportsSteering: true,
   },
   {
     id: "gpt-5.2",
     label: "GPT-5.2",
     supportsReasoning: true,
+    supportsSteering: true,
   },
 ];
 
@@ -216,35 +228,41 @@ const GROK_FALLBACK_MODELS: BackendModelOption[] = [
     label: "Grok 4.20 Reasoning",
     current: true,
     supportsReasoning: false,
+    supportsSteering: false,
   },
   {
     id: "grok-4.20-non-reasoning",
     label: "Grok 4.20 Non-Reasoning",
     supportsReasoning: false,
+    supportsSteering: false,
   },
   {
     id: "grok-4-1-fast-reasoning",
     label: "Grok 4.1 Fast Reasoning",
     supportsReasoning: false,
     supportsFast: true,
+    supportsSteering: false,
   },
   {
     id: "grok-4-1-fast-non-reasoning",
     label: "Grok 4.1 Fast Non-Reasoning",
     supportsReasoning: false,
     supportsFast: true,
+    supportsSteering: false,
   },
   {
     id: "grok-4-fast-reasoning",
     label: "Grok 4 Fast Reasoning",
     supportsReasoning: false,
     supportsFast: true,
+    supportsSteering: false,
   },
   {
     id: "grok-4-fast-non-reasoning",
     label: "Grok 4 Fast Non-Reasoning",
     supportsReasoning: false,
     supportsFast: true,
+    supportsSteering: false,
   },
 ];
 
@@ -356,6 +374,17 @@ function inferSupportsFast(
   return backend === "codex" && (id === "gpt-5.5" || id === "gpt-5.4");
 }
 
+function inferSupportsSteering(
+  backend: AppServerBackendKind,
+  model: BackendModelOption,
+): boolean {
+  if (typeof model.supportsSteering === "boolean") {
+    return model.supportsSteering;
+  }
+
+  return backend === "codex";
+}
+
 function getBackendFallbackModels(backend: AppServerBackendKind): BackendModelOption[] {
   return backend === "codex" ? OPENAI_FALLBACK_MODELS : GROK_FALLBACK_MODELS;
 }
@@ -378,6 +407,7 @@ function dedupeModelOptions(
       ...model,
       supportsReasoning: inferSupportsReasoning(backend, model),
       supportsFast: inferSupportsFast(backend, model),
+      supportsSteering: inferSupportsSteering(backend, model),
     };
     const current = byId.get(model.id);
     byId.set(model.id, {
@@ -386,6 +416,7 @@ function dedupeModelOptions(
       current: current?.current || normalizedModel.current,
       supportsReasoning: current?.supportsReasoning || normalizedModel.supportsReasoning,
       supportsFast: current?.supportsFast || normalizedModel.supportsFast,
+      supportsSteering: current?.supportsSteering || normalizedModel.supportsSteering,
     });
   }
 
@@ -1115,6 +1146,32 @@ export class DesktopBackendRegistry {
             await client.interruptTurn(params),
           )
         : await this.grokClient.interruptTurn(params);
+
+    return {
+      backend: params.backend,
+      threadId: result.threadId,
+      turnId: result.turnId,
+    };
+  }
+
+  async steerTurn(params: SteerTurnRequest): Promise<SteerTurnResponse> {
+    const steerWithClient = async (
+      client: BackendClient,
+    ): Promise<{ threadId: string; turnId: string }> => {
+      if (!client.steerTurn) {
+        throw new Error("Selected backend does not support turn/steer");
+      }
+      return await client.steerTurn({
+        threadId: params.threadId,
+        input: params.input,
+        expectedTurnId: params.expectedTurnId,
+      });
+    };
+
+    const result =
+      params.backend === "codex"
+        ? await this.withCodexThreadClient(params.threadId, steerWithClient)
+        : await steerWithClient(this.grokClient);
 
     return {
       backend: params.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -313,7 +313,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     startTurn: supported.has("turn/start") || assumeCodexAppServerSurface,
     startReview: supported.has("review/start") || assumeCodexAppServerSurface,
     interruptTurn: supported.has("turn/interrupt"),
-    steerTurn: supported.has("turn/steer"),
+    steerTurn: backend === "codex" || supported.has("turn/steer"),
     transcriptPagination: false,
     toolUse: false,
     approvalRequests: true,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -53,6 +53,7 @@ import type {
   ThreadStartParams as CodexThreadStartParams,
   TurnInterruptParams as CodexTurnInterruptParams,
   TurnStartParams as CodexTurnStartParams,
+  TurnSteerParams as CodexTurnSteerParams,
   UserInput as CodexUserInput,
 } from "@pwragnt/shared/codex-app-server-protocol/v2";
 import {
@@ -1956,6 +1957,10 @@ function extractModelOptions(value: unknown): BackendModelOption[] {
           "supports_reasoning",
         ]),
         supportsFast: pickBoolean(modelRecord, ["supportsFast", "supports_fast"]),
+        supportsSteering: pickBoolean(modelRecord, [
+          "supportsSteering",
+          "supports_steering",
+        ]),
       },
     ];
   });
@@ -3497,6 +3502,40 @@ export class CodexAppServerClient {
         turnId: params.turnId,
       };
     }
+  }
+
+  async steerTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    expectedTurnId: string;
+  }): Promise<{ threadId: string; turnId: string }> {
+    await this.ensureInitialized();
+
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/resume"],
+      payloads: buildThreadResumePayloads({
+        threadId: params.threadId,
+      }),
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    }).catch(() => undefined);
+
+    const payload: CodexTurnSteerParams = {
+      threadId: params.threadId,
+      input: params.input.map(toCodexUserInput),
+      expectedTurnId: params.expectedTurnId,
+    };
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["turn/steer"],
+      payloads: [payload],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    return {
+      threadId: params.threadId,
+      turnId: extractTurnIdFromValue(result) ?? params.expectedTurnId,
+    };
   }
 
   private async ensureInitialized(): Promise<void> {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -677,6 +677,8 @@ function extractModelOptions(value: unknown): BackendModelOption[] {
             : undefined,
         supportsFast:
           typeof record.supportsFast === "boolean" ? record.supportsFast : undefined,
+        supportsSteering:
+          typeof record.supportsSteering === "boolean" ? record.supportsSteering : false,
       },
     ];
   });

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -11,6 +11,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  SteerTurnRequest,
+  SteerTurnResponse,
   StartReviewRequest,
   StartReviewResponse,
   StartThreadRequest,
@@ -30,6 +32,7 @@ import {
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
+  AGENT_STEER_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   BACKEND_LIST_CHANNEL,
 } from "../../shared/ipc";
@@ -285,6 +288,34 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
+  ipcMain.handle(
+    AGENT_STEER_TURN_CHANNEL,
+    async (
+      _event,
+      request: SteerTurnRequest
+    ): Promise<SteerTurnResponse> => {
+      logDebug("steerTurn", {
+        backend: request.backend,
+        threadId: request.threadId,
+        expectedTurnId: request.expectedTurnId,
+        ...summarizeTurnInput(request.input),
+      });
+
+      try {
+        return await registry.steerTurn(request);
+      } catch (error) {
+        appServerLog.error("steerTurn failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          expectedTurnId: request.expectedTurnId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  );
+
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.handle(
     AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
@@ -338,6 +369,7 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
+  ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL);
   ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -17,6 +17,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  SteerTurnRequest,
+  SteerTurnResponse,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   FocusedDiffAnalysisRequest,
@@ -63,6 +65,7 @@ import {
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
+  AGENT_STEER_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
@@ -175,6 +178,10 @@ const desktopApi = Object.freeze({
     request: InterruptTurnRequest
   ): Promise<InterruptTurnResponse> =>
     await ipcRenderer.invoke(AGENT_INTERRUPT_TURN_CHANNEL, request),
+  steerTurn: async (
+    request: SteerTurnRequest
+  ): Promise<SteerTurnResponse> =>
+    await ipcRenderer.invoke(AGENT_STEER_TURN_CHANNEL, request),
   setThreadExecutionMode: async (
     request: SetThreadExecutionModeRequest
   ): Promise<SetThreadExecutionModeResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -95,6 +95,10 @@ type QueuedTurnDraft = {
   text: string;
 };
 
+type PendingSteerDraft = QueuedTurnDraft & {
+  status: "pending" | "steering";
+};
+
 type PastedImageFile = {
   file: File;
   type: string;
@@ -287,6 +291,53 @@ function findSlashCommandTrigger(text: string, caret: number): {
   };
 }
 
+function formatDraftPreview(draft: QueuedTurnDraft): string {
+  const text = draft.text.trim();
+  if (text) {
+    return text;
+  }
+
+  return `${draft.imageAttachments.length} image${
+    draft.imageAttachments.length === 1 ? "" : "s"
+  }`;
+}
+
+function collectTextFragments(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectTextFragments(entry));
+  }
+
+  const record = value as Record<string, unknown>;
+  const directText = ["text", "content", "message", "input"].flatMap((key) =>
+    typeof record[key] === "string" ? [record[key] as string] : []
+  );
+  const nestedText = ["content", "parts", "input", "item"].flatMap((key) =>
+    typeof record[key] === "string" ? [] : collectTextFragments(record[key])
+  );
+  return [...directText, ...nestedText];
+}
+
+function notificationIncludesDraftText(params: unknown, draft: QueuedTurnDraft): boolean {
+  const preview = draft.text.trim();
+  if (!preview) {
+    return false;
+  }
+
+  return collectTextFragments(params).some((fragment) =>
+    fragment.includes(preview)
+  );
+}
+
+function isSteerInjectionOpportunity(method: string): boolean {
+  return method === "item/completed" || method === "exec_command/ended";
+}
+
 function HighlightedAutocompleteLabel(props: {
   label: string;
   query: string;
@@ -323,6 +374,7 @@ export function Composer(props: ComposerProps) {
   const [interrupting, setInterrupting] = useState(false);
   const [steering, setSteering] = useState(false);
   const [queuedTurn, setQueuedTurn] = useState<QueuedTurnDraft>();
+  const [pendingSteer, setPendingSteer] = useState<PendingSteerDraft>();
   const [activeTurnId, setActiveTurnId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
@@ -463,6 +515,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
+    setPendingSteer(undefined);
   }, [composerScopeKey]);
 
   useEffect(() => {
@@ -511,6 +564,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
+    setPendingSteer(undefined);
   }, [isLaunchpad, props.launchpad?.directoryKey]);
 
   useEffect(() => {
@@ -562,6 +616,24 @@ export function Composer(props: ComposerProps) {
       }
 
       if (
+        pendingSteer &&
+        event.notification.method === "item/completed" &&
+        notificationIncludesDraftText(event.notification.params, pendingSteer)
+      ) {
+        setPendingSteer(undefined);
+        setSteering(false);
+        props.onPendingStatusChange?.("Thinking");
+      }
+
+      if (
+        pendingSteer?.status === "pending" &&
+        activeTurnIdRef.current &&
+        isSteerInjectionOpportunity(event.notification.method)
+      ) {
+        void submitPendingSteer(pendingSteer);
+      }
+
+      if (
         event.notification.method === "turn/started" &&
         typeof startedTurnRecord?.id === "string"
       ) {
@@ -585,6 +657,15 @@ export function Composer(props: ComposerProps) {
         setSending(false);
         setInterrupting(false);
         setSteering(false);
+        if (pendingSteer?.status === "pending") {
+          setQueuedTurn((queued) =>
+            queued ?? {
+              text: pendingSteer.text,
+              imageAttachments: pendingSteer.imageAttachments,
+            }
+          );
+        }
+        setPendingSteer(undefined);
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -603,6 +684,7 @@ export function Composer(props: ComposerProps) {
         setSending(false);
         setInterrupting(false);
         setSteering(false);
+        setPendingSteer(undefined);
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -615,6 +697,7 @@ export function Composer(props: ComposerProps) {
     props.onPendingStatusChange,
     props.removeOptimisticMessage,
     props.thread,
+    pendingSteer,
   ]);
 
   useEffect(() => {
@@ -832,9 +915,79 @@ export function Composer(props: ComposerProps) {
     setSendError(undefined);
   };
 
-  const steerCurrentDraft = async (): Promise<void> => {
+  const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
     const turnId = activeTurnIdRef.current;
     if (!props.thread || !turnId || !props.desktopApi?.steerTurn) {
+      setSendError("Steering is not available for this backend.");
+      return;
+    }
+    if (!supportsSteering) {
+      setSendError("Steering is not available for this model.");
+      return;
+    }
+
+    const payload = buildTurnPayload(pending.text, pending.imageAttachments);
+    if (payload.input.length === 0 || props.disabled || steering) {
+      return;
+    }
+
+    setSendError(undefined);
+    setSteering(true);
+    setPendingSteer((current) =>
+      current?.text === pending.text &&
+      current.imageAttachments === pending.imageAttachments
+        ? { ...current, status: "steering" }
+        : current
+    );
+    props.onPendingStatusChange?.("Steering");
+    try {
+      await props.desktopApi.steerTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        expectedTurnId: turnId,
+        input: payload.input,
+      });
+    } catch (error) {
+      setPendingSteer((current) =>
+        current?.text === pending.text &&
+        current.imageAttachments === pending.imageAttachments
+          ? { ...current, status: "pending" }
+          : current
+      );
+      props.onPendingStatusChange?.("Thinking");
+      setSendError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSteering(false);
+    }
+  };
+
+  const createPendingSteer = (pending: QueuedTurnDraft): boolean => {
+    const turnId = activeTurnIdRef.current;
+    if (!props.thread || !turnId || !props.desktopApi?.steerTurn || !supportsSteering) {
+      setSendError("Steering is not available for this model.");
+      return false;
+    }
+
+    const payload = buildTurnPayload(pending.text, pending.imageAttachments);
+    if (payload.input.length === 0 || props.disabled || pendingSteer) {
+      return false;
+    }
+
+    setSendError(undefined);
+    setPendingSteer({
+      text: pending.text,
+      imageAttachments: pending.imageAttachments,
+      status: "pending",
+    });
+    clearThreadComposerDraft(composerScopeKey);
+    setDraft("");
+    setImageAttachments([]);
+    setReviewConfig(undefined);
+    return true;
+  };
+
+  const steerCurrentDraft = (): void => {
+    if (!props.thread || !activeTurnIdRef.current || !props.desktopApi?.steerTurn) {
       queueCurrentDraft();
       setSendError("Steering is not available for this backend.");
       return;
@@ -845,55 +998,19 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const payload = buildTurnPayload(draft, imageAttachments);
-    if (payload.input.length === 0 || props.disabled || steering) {
-      return;
-    }
-
-    setSendError(undefined);
-    setSteering(true);
-    try {
-      await props.desktopApi.steerTurn({
-        backend: props.thread.source,
-        threadId: props.thread.id,
-        expectedTurnId: turnId,
-        input: payload.input,
-      });
-      setDraft("");
-      setImageAttachments([]);
-      setReviewConfig(undefined);
-    } catch (error) {
-      setSendError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setSteering(false);
-    }
+    createPendingSteer({
+      text: draft,
+      imageAttachments,
+    });
   };
 
-  const steerQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
-    const turnId = activeTurnIdRef.current;
-    if (!props.thread || !turnId || !props.desktopApi?.steerTurn || !supportsSteering) {
+  const steerQueuedTurn = (queued: QueuedTurnDraft): void => {
+    if (!createPendingSteer(queued)) {
       return;
     }
-
-    const payload = buildTurnPayload(queued.text, queued.imageAttachments);
-    if (payload.input.length === 0 || props.disabled || steering) {
-      return;
-    }
-
-    setSendError(undefined);
-    setSteering(true);
-    try {
-      await props.desktopApi.steerTurn({
-        backend: props.thread.source,
-        threadId: props.thread.id,
-        expectedTurnId: turnId,
-        input: payload.input,
-      });
-      setQueuedTurn(undefined);
-    } catch (error) {
-      setSendError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setSteering(false);
+    setQueuedTurn(undefined);
+    if (activeTurnIdRef.current) {
+      void submitPendingSteer(queued);
     }
   };
 
@@ -901,7 +1018,7 @@ export function Composer(props: ComposerProps) {
     const reviewCommand = parseReviewCommand(draft);
     if (activeTurnIdRef.current && !props.launchpad) {
       if (mode === "steer") {
-        await steerCurrentDraft();
+        steerCurrentDraft();
       } else {
         queueCurrentDraft();
       }
@@ -1266,15 +1383,55 @@ export function Composer(props: ComposerProps) {
         {isLaunchpad ? "New thread" : "Reply"}
       </label>
 
+      {pendingSteer ? (
+        <div
+          className="composer__queued composer__queued--steer"
+          aria-label="Pending steer message"
+        >
+          <div className="composer__queued-copy">
+            <span className="composer__queued-label">
+              {pendingSteer.status === "steering" ? "Steering now" : "Pending steer"}
+            </span>
+            <span className="composer__queued-text">
+              {formatDraftPreview(pendingSteer)}
+            </span>
+          </div>
+          <div className="composer__queued-actions">
+            {pendingSteer.status === "pending" ? (
+              <>
+                <button
+                  className="composer__secondary-action"
+                  type="button"
+                  onClick={() => {
+                    setDraft(pendingSteer.text);
+                    setImageAttachments(pendingSteer.imageAttachments);
+                    setPendingSteer(undefined);
+                    requestAnimationFrame(() => inputRef.current?.focus());
+                  }}
+                >
+                  Edit
+                </button>
+                <button
+                  className="composer__secondary-action"
+                  type="button"
+                  onClick={() => {
+                    setPendingSteer(undefined);
+                  }}
+                >
+                  Delete
+                </button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
       {queuedTurn ? (
         <div className="composer__queued" aria-label="Queued message">
           <div className="composer__queued-copy">
             <span className="composer__queued-label">Queued next</span>
             <span className="composer__queued-text">
-              {queuedTurn.text.trim() ||
-                `${queuedTurn.imageAttachments.length} image${
-                  queuedTurn.imageAttachments.length === 1 ? "" : "s"
-                }`}
+              {formatDraftPreview(queuedTurn)}
             </span>
           </div>
           <div className="composer__queued-actions">
@@ -1284,7 +1441,7 @@ export function Composer(props: ComposerProps) {
                 disabled={props.disabled || steering || !activeTurnId}
                 type="button"
                 onClick={() => {
-                  void steerQueuedTurn(queuedTurn);
+                  steerQueuedTurn(queuedTurn);
                 }}
               >
                 {steering ? "Steering..." : "Steer"}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -616,7 +616,7 @@ export function Composer(props: ComposerProps) {
       }
 
       if (
-        pendingSteer &&
+        pendingSteer?.status === "steering" &&
         event.notification.method === "item/completed" &&
         notificationIncludesDraftText(event.notification.params, pendingSteer)
       ) {
@@ -658,12 +658,15 @@ export function Composer(props: ComposerProps) {
         setInterrupting(false);
         setSteering(false);
         if (pendingSteer?.status === "pending") {
-          setQueuedTurn((queued) =>
-            queued ?? {
+          if (queuedTurn) {
+            setDraft(pendingSteer.text);
+            setImageAttachments(pendingSteer.imageAttachments);
+          } else {
+            setQueuedTurn({
               text: pendingSteer.text,
               imageAttachments: pendingSteer.imageAttachments,
-            }
-          );
+            });
+          }
         }
         setPendingSteer(undefined);
         updateActiveTurnId(undefined);
@@ -698,6 +701,7 @@ export function Composer(props: ComposerProps) {
     props.removeOptimisticMessage,
     props.thread,
     pendingSteer,
+    queuedTurn,
   ]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -90,6 +90,11 @@ type ComposerProps = {
 
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
+type QueuedTurnDraft = {
+  imageAttachments: ComposerImageAttachment[];
+  text: string;
+};
+
 type PastedImageFile = {
   file: File;
   type: string;
@@ -316,6 +321,8 @@ export function Composer(props: ComposerProps) {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
+  const [steering, setSteering] = useState(false);
+  const [queuedTurn, setQueuedTurn] = useState<QueuedTurnDraft>();
   const [activeTurnId, setActiveTurnId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
@@ -451,9 +458,11 @@ export function Composer(props: ComposerProps) {
     }
     setSending(false);
     setInterrupting(false);
+    setSteering(false);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
+    setQueuedTurn(undefined);
   }, [composerScopeKey]);
 
   useEffect(() => {
@@ -497,9 +506,11 @@ export function Composer(props: ComposerProps) {
     setImageAttachments(props.launchpad?.imageAttachments ?? []);
     setSending(false);
     setInterrupting(false);
+    setSteering(false);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
+    setQueuedTurn(undefined);
   }, [isLaunchpad, props.launchpad?.directoryKey]);
 
   useEffect(() => {
@@ -516,6 +527,7 @@ export function Composer(props: ComposerProps) {
     if (!props.activeTurnId) {
       setSending(false);
       setInterrupting(false);
+      setSteering(false);
     }
   }, [props.activeTurnId]);
 
@@ -572,6 +584,7 @@ export function Composer(props: ComposerProps) {
         props.onPendingStatusChange?.(undefined);
         setSending(false);
         setInterrupting(false);
+        setSteering(false);
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -589,6 +602,7 @@ export function Composer(props: ComposerProps) {
         props.onPendingStatusChange?.(undefined);
         setSending(false);
         setInterrupting(false);
+        setSteering(false);
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
         setActiveOptimisticMessageId(undefined);
@@ -695,8 +709,205 @@ export function Composer(props: ComposerProps) {
     }
   };
 
-  const submitTurn = async (): Promise<void> => {
+  const buildTurnPayload = (
+    textDraft: string,
+    attachments: ComposerImageAttachment[],
+  ): {
+    displayText: string;
+    imageParts: AppServerThreadImagePart[];
+    input: AppServerTurnInputItem[];
+  } => {
+    const turnSkills = listMentionedSkills(textDraft, props.skills);
+    const displayText = hydrateSkillLabelsWithMarkdown(textDraft.trim(), turnSkills);
+    const imageParts = attachments.map((attachment, index) => ({
+      type: "image" as const,
+      url: attachment.url,
+      alt: formatPastedImageAlt(attachment, index),
+    }));
+    const input: AppServerTurnInputItem[] = [
+      ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
+      ...imageParts.map(({ url }) => ({ type: "image" as const, url })),
+    ];
+
+    return { displayText, imageParts, input };
+  };
+
+  const sendThreadTurn = async (queued?: QueuedTurnDraft): Promise<void> => {
+    if (!props.thread || !props.desktopApi?.startTurn) {
+      return;
+    }
+
+    const payload = queued
+      ? buildTurnPayload(queued.text, queued.imageAttachments)
+      : buildTurnPayload(draft, imageAttachments);
+    if (payload.input.length === 0 || props.disabled) {
+      return;
+    }
+
+    const collaborationMode =
+      !queued && planModeEnabled && supportsPlanMode
+        ? ({
+            mode: "plan",
+            settings: {
+              developerInstructions: null,
+            },
+          } satisfies AppServerCollaborationModeRequest)
+        : undefined;
+
+    props.onPendingStatusChange?.(collaborationMode ? "Planning" : "Thinking");
+    const optimisticMessageId = props.addOptimisticUserMessage?.(
+      payload.displayText,
+      payload.imageParts
+    );
+    setActiveOptimisticMessageId(optimisticMessageId);
+
+    try {
+      const response = await props.desktopApi.startTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        input: payload.input,
+        collaborationMode,
+        model: selectedModelOption?.id,
+        reasoningEffort: supportsReasoning ? selectedReasoningEffort : undefined,
+        serviceTier: selectedServiceTier,
+        fastMode: props.thread.source === "codex" && supportsFast
+          ? Boolean(currentSettings?.fastMode)
+          : undefined,
+      });
+      updateActiveTurnId(response.turnId);
+      props.onActiveTurnIdChange?.(response.turnId);
+      if (queued) {
+        setQueuedTurn(undefined);
+      } else {
+        clearThreadComposerDraft(composerScopeKey);
+        setDraft("");
+        setImageAttachments([]);
+        if (collaborationMode) {
+          setPlanModeEnabled(false);
+        }
+      }
+    } catch (error) {
+      if (optimisticMessageId) {
+        props.removeOptimisticMessage?.(optimisticMessageId);
+      }
+      props.onPendingStatusChange?.(undefined);
+      setSending(false);
+      setInterrupting(false);
+      setSteering(false);
+      updateActiveTurnId(undefined);
+      props.onActiveTurnIdChange?.(undefined);
+      setActiveOptimisticMessageId(undefined);
+      setSendError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  useEffect(() => {
+    if (!queuedTurn || activeTurnId || sending || props.launchpad || props.disabled) {
+      return;
+    }
+
+    setSending(true);
+    void sendThreadTurn(queuedTurn).finally(() => {
+      setSending(false);
+    });
+  }, [activeTurnId, queuedTurn, sending, props.disabled, props.launchpad]);
+
+  const queueCurrentDraft = (): void => {
+    if (!draft.trim() && imageAttachments.length === 0) {
+      return;
+    }
+    if (queuedTurn) {
+      setSendError("A message is already queued.");
+      return;
+    }
+
+    setQueuedTurn({
+      text: draft,
+      imageAttachments,
+    });
+    clearThreadComposerDraft(composerScopeKey);
+    setDraft("");
+    setImageAttachments([]);
+    setReviewConfig(undefined);
+    setSendError(undefined);
+  };
+
+  const steerCurrentDraft = async (): Promise<void> => {
+    const turnId = activeTurnIdRef.current;
+    if (!props.thread || !turnId || !props.desktopApi?.steerTurn) {
+      queueCurrentDraft();
+      setSendError("Steering is not available for this backend.");
+      return;
+    }
+    if (!supportsSteering) {
+      queueCurrentDraft();
+      setSendError("Steering is not available for this model.");
+      return;
+    }
+
+    const payload = buildTurnPayload(draft, imageAttachments);
+    if (payload.input.length === 0 || props.disabled || steering) {
+      return;
+    }
+
+    setSendError(undefined);
+    setSteering(true);
+    try {
+      await props.desktopApi.steerTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        expectedTurnId: turnId,
+        input: payload.input,
+      });
+      setDraft("");
+      setImageAttachments([]);
+      setReviewConfig(undefined);
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSteering(false);
+    }
+  };
+
+  const steerQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
+    const turnId = activeTurnIdRef.current;
+    if (!props.thread || !turnId || !props.desktopApi?.steerTurn || !supportsSteering) {
+      return;
+    }
+
+    const payload = buildTurnPayload(queued.text, queued.imageAttachments);
+    if (payload.input.length === 0 || props.disabled || steering) {
+      return;
+    }
+
+    setSendError(undefined);
+    setSteering(true);
+    try {
+      await props.desktopApi.steerTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        expectedTurnId: turnId,
+        input: payload.input,
+      });
+      setQueuedTurn(undefined);
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSteering(false);
+    }
+  };
+
+  const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
     const reviewCommand = parseReviewCommand(draft);
+    if (activeTurnIdRef.current && !props.launchpad) {
+      if (mode === "steer") {
+        await steerCurrentDraft();
+      } else {
+        queueCurrentDraft();
+      }
+      return;
+    }
+
     if (reviewCommand) {
       if (isBareReviewCommand) {
         const nextReviewConfig =
@@ -719,16 +930,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const text = hydrateSkillLabelsWithMarkdown(draft.trim(), mentionedSkills);
-    const imageParts = imageAttachments.map((attachment, index) => ({
-      type: "image" as const,
-      url: attachment.url,
-      alt: formatPastedImageAlt(attachment, index),
-    }));
-    const input: AppServerTurnInputItem[] = [
-      ...(text ? [{ type: "text" as const, text }] : []),
-      ...imageParts.map(({ url }) => ({ type: "image" as const, url })),
-    ];
+    const payload = buildTurnPayload(draft, imageAttachments);
     const collaborationMode = planModeEnabled && supportsPlanMode
       ? ({
           mode: "plan",
@@ -738,7 +940,7 @@ export function Composer(props: ComposerProps) {
         } satisfies AppServerCollaborationModeRequest)
       : undefined;
 
-    if (input.length === 0 || props.disabled) {
+    if (payload.input.length === 0 || props.disabled) {
       return;
     }
 
@@ -749,7 +951,7 @@ export function Composer(props: ComposerProps) {
       try {
         await props.onMaterializeLaunchpad(
           props.launchpad.directoryKey,
-          input,
+          payload.input,
           collaborationMode
         );
         setDraft("");
@@ -770,43 +972,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    props.onPendingStatusChange?.(collaborationMode ? "Planning" : "Thinking");
-    const optimisticMessageId = props.addOptimisticUserMessage?.(text, imageParts);
-    setActiveOptimisticMessageId(optimisticMessageId);
-
-    try {
-      const response = await props.desktopApi.startTurn({
-        backend: props.thread.source,
-        threadId: props.thread.id,
-        input,
-        collaborationMode,
-        model: selectedModelOption?.id,
-        reasoningEffort: supportsReasoning ? selectedReasoningEffort : undefined,
-        serviceTier: selectedServiceTier,
-        fastMode: props.thread.source === "codex" && supportsFast
-          ? Boolean(currentSettings?.fastMode)
-          : undefined,
-      });
-      updateActiveTurnId(response.turnId);
-      props.onActiveTurnIdChange?.(response.turnId);
-      clearThreadComposerDraft(composerScopeKey);
-      setDraft("");
-      setImageAttachments([]);
-      if (collaborationMode) {
-        setPlanModeEnabled(false);
-      }
-    } catch (error) {
-      if (optimisticMessageId) {
-        props.removeOptimisticMessage?.(optimisticMessageId);
-      }
-      props.onPendingStatusChange?.(undefined);
-      setSending(false);
-      setInterrupting(false);
-      updateActiveTurnId(undefined);
-      props.onActiveTurnIdChange?.(undefined);
-      setActiveOptimisticMessageId(undefined);
-      setSendError(error instanceof Error ? error.message : String(error));
-    }
+    await sendThreadTurn();
   };
 
   const stopTurn = async (): Promise<void> => {
@@ -1080,6 +1246,10 @@ export function Composer(props: ComposerProps) {
   const workspaceLabel = formatThreadWorkspaceLabel(props.thread);
   const supportsPlanMode =
     (props.launchpad?.backend ?? props.thread?.source) === "codex";
+  const supportsSteering =
+    Boolean(backend?.capabilities.steerTurn) &&
+    selectedModelOption?.supportsSteering !== false &&
+    props.thread?.source !== "grok";
   const launchpadWorkspaceOptions = props.launchpad
     ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
     : [];
@@ -1096,6 +1266,55 @@ export function Composer(props: ComposerProps) {
         {isLaunchpad ? "New thread" : "Reply"}
       </label>
 
+      {queuedTurn ? (
+        <div className="composer__queued" aria-label="Queued message">
+          <div className="composer__queued-copy">
+            <span className="composer__queued-label">Queued next</span>
+            <span className="composer__queued-text">
+              {queuedTurn.text.trim() ||
+                `${queuedTurn.imageAttachments.length} image${
+                  queuedTurn.imageAttachments.length === 1 ? "" : "s"
+                }`}
+            </span>
+          </div>
+          <div className="composer__queued-actions">
+            {supportsSteering ? (
+              <button
+                className="composer__secondary-action"
+                disabled={props.disabled || steering || !activeTurnId}
+                type="button"
+                onClick={() => {
+                  void steerQueuedTurn(queuedTurn);
+                }}
+              >
+                {steering ? "Steering..." : "Steer"}
+              </button>
+            ) : null}
+            <button
+              className="composer__secondary-action"
+              type="button"
+              onClick={() => {
+                setDraft(queuedTurn.text);
+                setImageAttachments(queuedTurn.imageAttachments);
+                setQueuedTurn(undefined);
+                requestAnimationFrame(() => inputRef.current?.focus());
+              }}
+            >
+              Edit
+            </button>
+            <button
+              className="composer__secondary-action"
+              type="button"
+              onClick={() => {
+                setQueuedTurn(undefined);
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {mentionedSkills.length > 0 ? (
         <div className="composer__mentioned-skills" aria-label="Mentioned skills">
           {mentionedSkills.map((skill) => (
@@ -1109,7 +1328,7 @@ export function Composer(props: ComposerProps) {
           ref={inputRef}
           id="thread-composer"
           className="composer__input"
-          disabled={sending}
+          disabled={props.disabled && !draft}
           placeholder={
             isLaunchpad
               ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
@@ -1133,7 +1352,7 @@ export function Composer(props: ComposerProps) {
             if (!hasAutocomplete) {
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
-                void submitTurn();
+                void submitTurn(event.metaKey ? "steer" : "default");
               }
               return;
             }
@@ -1737,10 +1956,17 @@ export function Composer(props: ComposerProps) {
         ) : null}
         <button
           className="button button--primary"
-          disabled={props.disabled || sending || (!draft.trim() && imageAttachments.length === 0)}
-          type="submit"
-        >
-          {sending
+        disabled={
+          props.disabled ||
+          steering ||
+          (!activeTurnId && sending) ||
+          (!draft.trim() && imageAttachments.length === 0)
+        }
+        type="submit"
+      >
+          {activeTurnId
+            ? "Queue"
+            : sending
             ? props.launchpad
               ? "Starting…"
               : "Sending…"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5,6 +5,7 @@ import type {
   NavigationLaunchpadDraft,
   StartReviewRequest,
   StartTurnRequest,
+  StartTurnResponse,
 } from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeImageFile } from "../../../lib/image-normalization";
@@ -213,6 +214,52 @@ describe("Composer", () => {
         reasoningEffort: "medium",
       })
     );
+  });
+
+  it("keeps the reply input focusable while the send request is pending", async () => {
+    let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
+    const startTurn = vi.fn(
+      (request: StartTurnRequest) =>
+        new Promise<StartTurnResponse>((resolve) => {
+          resolveStartTurn = resolve;
+        })
+    );
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Slow send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Start a slow turn" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
+    expect(textarea).toBeEnabled();
+
+    await act(async () => {
+      resolveStartTurn?.({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    });
   });
 
   it("queues Enter during an active turn and sends it after the turn clears", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -215,6 +215,124 @@ describe("Composer", () => {
     );
   });
 
+  it("queues Enter during an active turn and sends it after the turn clears", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Active turn",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Follow up next" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+    expect(screen.getByText("Follow up next")).toBeInTheDocument();
+    expect(textarea).toHaveValue("");
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Follow up next" }],
+        })
+      );
+    });
+  });
+
+  it("steers Command Enter during an active turn when supported", async () => {
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const startTurn = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Steerable thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Change direction" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "Change direction" }],
+      });
+    });
+    expect(startTurn).not.toHaveBeenCalled();
+  });
+
   it("updates model settings without crashing when fast-mode support changes", async () => {
     const onSetThreadModelSettings = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -317,6 +317,15 @@ describe("Composer", () => {
   });
 
   it("steers Command Enter during an active turn when supported", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
@@ -347,7 +356,10 @@ describe("Composer", () => {
           },
         ]}
         desktopApi={{
-          onAgentEvent: () => () => undefined,
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
           startTurn,
           steerTurn,
         }}
@@ -369,6 +381,27 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Change direction" } });
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
+    expect(steerTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    expect(screen.getByText("Change direction")).toBeInTheDocument();
+    expect(textarea).toHaveValue("");
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "ready for another instruction",
+            },
+          },
+        },
+      });
+    });
+
     await waitFor(() => {
       expect(steerTurn).toHaveBeenCalledWith({
         backend: "codex",
@@ -377,7 +410,86 @@ describe("Composer", () => {
         input: [{ type: "text", text: "Change direction" }],
       });
     });
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
     expect(startTurn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "message",
+              role: "user",
+              text: "Change direction",
+            },
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByText("Steering now")).not.toBeInTheDocument();
+  });
+
+  it("lets pending steers be edited before they are injected", async () => {
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Editable steer",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Revise the plan" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(textarea).toHaveValue("Revise the plan");
+    expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
+    expect(steerTurn).not.toHaveBeenCalled();
   });
 
   it("updates model settings without crashing when fast-mode support changes", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -492,6 +492,203 @@ describe("Composer", () => {
     expect(steerTurn).not.toHaveBeenCalled();
   });
 
+  it("does not acknowledge matching steer text before the steer is sent", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerTurn = vi.fn(async () => {
+      throw new Error("steer failed");
+    });
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Steer race",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Change direction" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter", metaKey: true });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "tool output mentioning Change direction before injection",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    expect(screen.getByText("Change direction")).toBeInTheDocument();
+    expect(screen.getByText("steer failed")).toBeInTheDocument();
+  });
+
+  it("restores a pending steer to the draft when turn completion leaves an existing queue", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: "turn/completed";
+            params: {
+              threadId: string;
+              turnId: string;
+              turn: {
+                id: string;
+                status: "completed";
+              };
+            };
+          };
+        }) => void)
+      | undefined;
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn,
+          steerTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Queue and steer",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Pending steer draft" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+    expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Queued follow-up" }],
+        })
+      );
+    });
+    expect(textarea).toHaveValue("Pending steer draft");
+    expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
+  });
+
   it("updates model settings without crashing when fast-mode support changes", async () => {
     const onSetThreadModelSettings = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -42,6 +42,8 @@ import type {
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  SteerTurnRequest,
+  SteerTurnResponse,
   StartThreadRequest,
   StartThreadResponse,
   StartReviewRequest,
@@ -89,6 +91,7 @@ export type DesktopApi = {
   interruptTurn?: (
     request: InterruptTurnRequest
   ) => Promise<InterruptTurnResponse>;
+  steerTurn?: (request: SteerTurnRequest) => Promise<SteerTurnResponse>;
   setThreadExecutionMode?: (
     request: SetThreadExecutionModeRequest
   ) => Promise<SetThreadExecutionModeResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2741,6 +2741,47 @@ textarea {
   gap: 8px;
 }
 
+.composer__queued {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.composer__queued-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.composer__queued-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.composer__queued-text {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer__queued-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 .composer__attachments {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2752,6 +2752,11 @@ textarea {
   background: var(--bg-panel-elevated);
 }
 
+.composer__queued--steer {
+  border-color: var(--accent-border);
+  background: color-mix(in srgb, var(--accent-soft) 48%, var(--bg-panel-elevated));
+}
+
 .composer__queued-copy {
   display: flex;
   min-width: 0;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -12,6 +12,7 @@ export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
+export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
 export const AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL = "agent:set-thread-model-settings";
 export const AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -74,6 +74,19 @@ export type InterruptTurnResponse = {
   turnId: string;
 };
 
+export type SteerTurnRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  input: AppServerTurnInputItem[];
+  expectedTurnId: string;
+};
+
+export type SteerTurnResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId: string;
+};
+
 export type SetThreadExecutionModeRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -26,6 +26,7 @@ export type BackendModelOption = {
   current?: boolean;
   supportsReasoning?: boolean;
   supportsFast?: boolean;
+  supportsSteering?: boolean;
 };
 
 export type BackendLaunchpadOptions = {


### PR DESCRIPTION
## Summary

- I added a `turn/steer` path through the shared desktop contracts, preload API, IPC layer, backend registry, and Codex app-server client.
- I marked Grok model options as not supporting steering while preserving capability-driven steering for Codex models.
- I updated the composer so Enter queues a draft during an active turn, Command+Enter steers when supported, and queued drafts can be steered, edited, deleted, or auto-sent after the active turn clears.

## Verification

- I ran `pnpm install` to restore this worktree's dependencies.
- I ran `pnpm typecheck`.
- I ran `pnpm --filter @pwragnt/desktop build`.
- I ran the Vitest workspace; it passed with `85 passed | 1 skipped`, `484 passed | 3 skipped`.
