### PR TITLE
fix(desktop): clarify protocol captures

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -206,6 +206,29 @@ class MockTransport implements JsonRpcTransport {
         return;
       }
 
+      if (searchTerm === "placeholder-title") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data: params.params?.archived
+                ? []
+                : [
+                    {
+                      id: "thread-placeholder-title",
+                      name: "Untitled thread",
+                      preview: "Why do all the worktree-hashes start with `moi`?",
+                      updatedAt: 1_777_401_255,
+                      cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                    },
+                  ],
+            },
+          }),
+        );
+        return;
+      }
+
       if (searchTerm === "search-product-parity") {
         const matchesCodexWindow =
           params.params?.limit === 50 &&
@@ -839,6 +862,27 @@ describe("CodexAppServerClient", () => {
         })
       ])
     );
+
+    await client.close();
+  });
+
+  it("derives a title from preview when Codex returns the placeholder name", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const threads = await client.listThreads({ filter: "placeholder-title" });
+
+    expect(threads).toEqual([
+      expect.objectContaining({
+        id: "thread-placeholder-title",
+        title: "Why do all the worktree-hashes start with `moi`?",
+        titleSource: "derived",
+      }),
+    ]);
 
     await client.close();
   });
@@ -2461,6 +2505,52 @@ describe("CodexAppServerClient", () => {
           thread_name: "Untitled thread",
           updated_at: "2026-04-28T03:32:43.000Z",
         },
+      ]);
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("records a derived session-index name when Codex returns the placeholder name", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragnt-session-index-"));
+    const sessionIndexPath = path.join(tempDir, "session_index.jsonl");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-placeholder-title",
+        path: path.join(tempDir, "sessions/thread-placeholder-title.jsonl"),
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+        preview: "Why do all the worktree-hashes start with `moi`?",
+        name: "Untitled thread",
+        updatedAt: 1_777_401_255,
+      },
+      model: "gpt-5.5",
+    };
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+        sessionIndexPath,
+      });
+
+      await client.startThread({
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+      });
+      await client.close();
+
+      const indexLines = (await fs.readFile(sessionIndexPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(indexLines).toEqual([
+        expect.objectContaining({
+          id: "thread-placeholder-title",
+          source: "pwragnt",
+          thread_name: "Why do all the worktree-hashes start with `moi`?",
+        }),
       ]);
     } finally {
       await fs.rm(tempDir, { force: true, recursive: true });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -903,6 +903,65 @@ describe("GrokAppServerClient", () => {
     }
   });
 
+  it("fails missing API key before recording a synthetic outbound initialize", async () => {
+    const originalHome = process.env.HOME;
+    const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    const originalXaiApiKey = process.env.XAI_API_KEY;
+    const originalGrokModel = process.env.GROK_MODEL;
+    const originalXaiBaseUrl = process.env.XAI_BASE_URL;
+    delete process.env.XAI_API_KEY;
+    delete process.env.GROK_MODEL;
+    delete process.env.XAI_BASE_URL;
+    delete process.env.XDG_CONFIG_HOME;
+
+    const temp = await createTemporaryTestDirectory();
+    const observed: unknown[] = [];
+    process.env.HOME = temp.path;
+
+    try {
+      const client = new GrokAppServerClient({
+        connectionObserver: {
+          onMessage: (event) => {
+            observed.push(event);
+          },
+        },
+      });
+
+      await expect(client.getInitializeResult()).rejects.toThrow(
+        "grok app server unavailable: XAI_API_KEY is not set",
+      );
+      expect(observed).toEqual([]);
+      await client.close();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      if (originalXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+      }
+      if (originalXaiApiKey === undefined) {
+        delete process.env.XAI_API_KEY;
+      } else {
+        process.env.XAI_API_KEY = originalXaiApiKey;
+      }
+      if (originalGrokModel === undefined) {
+        delete process.env.GROK_MODEL;
+      } else {
+        process.env.GROK_MODEL = originalGrokModel;
+      }
+      if (originalXaiBaseUrl === undefined) {
+        delete process.env.XAI_BASE_URL;
+      } else {
+        process.env.XAI_BASE_URL = originalXaiBaseUrl;
+      }
+      await temp.cleanup();
+    }
+  });
+
   it("reloads persisted Grok thread metadata after client recreation", async () => {
     const temp = await createTemporaryTestDirectory();
     const stateRoot = path.join(temp.path, "state");

--- a/apps/desktop/src/main/__tests__/json-rpc.test.ts
+++ b/apps/desktop/src/main/__tests__/json-rpc.test.ts
@@ -47,11 +47,16 @@ describe("JsonRpcConnection", () => {
 
   it("continues outbound traffic when the observer throws", async () => {
     const transport = new MockTransport();
-    const connection = new JsonRpcConnection(transport, 1_000, {
-      onMessage: async () => {
-        throw new Error("disk full");
-      }
-    });
+    const connection = new JsonRpcConnection(
+      transport,
+      1_000,
+      {
+        onMessage: async () => {
+          throw new Error("disk full");
+        },
+      },
+      { logContext: { backend: "codex" } },
+    );
 
     await connection.connect();
 
@@ -72,7 +77,13 @@ describe("JsonRpcConnection", () => {
     );
 
     await expect(requestPromise).resolves.toEqual({ ok: true });
-    expect(jsonRpcLogError).toHaveBeenCalled();
+    expect(jsonRpcLogError).toHaveBeenCalledWith(
+      "observer failed",
+      expect.objectContaining({
+        backend: "codex",
+        error: "disk full",
+      }),
+    );
 
     await connection.close();
   });

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -103,6 +103,7 @@ describe("ProtocolCaptureStore", () => {
     expect(
       createProtocolCaptureFromEnv({
         backend: "codex",
+        backendInstance: "default",
         userDataPath: rootDir
       })
     ).toBeUndefined();
@@ -112,6 +113,7 @@ describe("ProtocolCaptureStore", () => {
 
     const capture = createProtocolCaptureFromEnv({
       backend: "codex",
+      backendInstance: "default",
       userDataPath: "/unused"
     });
 
@@ -129,9 +131,10 @@ describe("ProtocolCaptureStore", () => {
 
     const index = JSON.parse(
       await fs.readFile(path.join(rootDir, "index.json"), "utf8")
-    ) as Record<string, { backend: string }>;
+    ) as Record<string, { backend: string; backendInstance?: string }>;
     expect(Object.values(index)).toHaveLength(1);
     expect(Object.values(index)[0]?.backend).toBe("codex");
+    expect(Object.values(index)[0]?.backendInstance).toBe("default");
   });
 
   it("serializes index writes shared by concurrent backend captures", async () => {

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -134,6 +134,55 @@ describe("ProtocolCaptureStore", () => {
     expect(Object.values(index)[0]?.backend).toBe("codex");
   });
 
+  it("serializes index writes shared by concurrent backend captures", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    const codexStore = new ProtocolCaptureStore({
+      backend: "codex",
+      captureId: "codex-capture",
+      rootDir,
+    });
+    const grokStore = new ProtocolCaptureStore({
+      backend: "grok",
+      captureId: "grok-capture",
+      rootDir,
+    });
+
+    await Promise.all([
+      codexStore.append({
+        direction: "outbound",
+        raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"thread/read","params":{"threadId":"codex-thread"}}',
+        envelope: {
+          id: "rpc-1",
+          method: "thread/read",
+          params: { threadId: "codex-thread" },
+        },
+      }),
+      grokStore.append({
+        direction: "outbound",
+        raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"thread/read","params":{"threadId":"grok-thread"}}',
+        envelope: {
+          id: "rpc-1",
+          method: "thread/read",
+          params: { threadId: "grok-thread" },
+        },
+      }),
+    ]);
+    await Promise.all([codexStore.close(), grokStore.close()]);
+
+    const index = JSON.parse(
+      await fs.readFile(path.join(rootDir, "index.json"), "utf8"),
+    ) as Record<string, { backend: string; threadIds: string[] }>;
+    expect(index["codex-capture"]).toMatchObject({
+      backend: "codex",
+      threadIds: ["codex-thread"],
+    });
+    expect(index["grok-capture"]).toMatchObject({
+      backend: "grok",
+      threadIds: ["grok-thread"],
+    });
+  });
+
   it("reads capture files with parsed envelopes and optional redactions", async () => {
     const rootDir = await createTempDir();
     cleanupPaths.push(rootDir);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -498,18 +498,36 @@ export class DesktopBackendRegistry {
     createScratchProjectDirectory?: () => Promise<string>;
   }) {
     const replayClients = createReplayClientsFromEnv();
-    const codexCapture = options?.codexClient
+    const codexDefaultCapture = options?.codexClient
       || replayClients
       ? undefined
       : createProtocolCaptureFromEnv({
           backend: "codex",
+          backendInstance: "default",
           userDataPath: app.getPath("userData"),
         });
-    if (codexCapture) {
-      this.captureStores.push(codexCapture.store);
+    if (codexDefaultCapture) {
+      this.captureStores.push(codexDefaultCapture.store);
     }
-    const codexObserver = createCompositeJsonRpcObserver([
-      codexCapture?.observer,
+    const codexDefaultObserver = createCompositeJsonRpcObserver([
+      codexDefaultCapture?.observer,
+      createProtocolLogObserverFromEnv({
+        backend: "codex",
+      }),
+    ]);
+    const codexFullAccessCapture = options?.codexFullAccessClient
+      || replayClients
+      ? undefined
+      : createProtocolCaptureFromEnv({
+          backend: "codex",
+          backendInstance: "full-access",
+          userDataPath: app.getPath("userData"),
+        });
+    if (codexFullAccessCapture) {
+      this.captureStores.push(codexFullAccessCapture.store);
+    }
+    const codexFullAccessObserver = createCompositeJsonRpcObserver([
+      codexFullAccessCapture?.observer,
       createProtocolLogObserverFromEnv({
         backend: "codex",
       }),
@@ -519,6 +537,7 @@ export class DesktopBackendRegistry {
       ? undefined
       : createProtocolCaptureFromEnv({
           backend: "grok",
+          backendInstance: "default",
           userDataPath: app.getPath("userData"),
         });
     if (grokCapture) {
@@ -535,14 +554,14 @@ export class DesktopBackendRegistry {
       options?.codexClient ??
       replayClients?.codexDefaultClient ??
       new CodexAppServerClient({
-        connectionObserver: codexObserver,
+        connectionObserver: codexDefaultObserver,
       });
     this.codexFullAccessClient =
       options?.codexFullAccessClient ??
       replayClients?.codexFullAccessClient ??
       new CodexAppServerClient({
         args: buildCodexClientArgs("full-access"),
-        connectionObserver: codexObserver,
+        connectionObserver: codexFullAccessObserver,
       });
     this.grokClient =
       options?.grokClient ??

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2572,7 +2572,8 @@ export class CodexAppServerClient {
         env: options.env
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
-      options.connectionObserver
+      options.connectionObserver,
+      { logContext: { backend: "codex" } },
     );
     const directoryResolver = options.directoryResolver;
     this.threadDirectoryEnricher =

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -460,6 +460,10 @@ function normalizeThreadSummary(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+function isPlaceholderThreadTitle(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "untitled thread";
+}
+
 function getThreadTitleInfo(record: Record<string, unknown>): {
   title: string;
   titleSource: AppServerThreadTitleSource;
@@ -469,7 +473,7 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
     pickString(record, ["title", "name", "headline"]) ??
     pickString(sessionRecord ?? {}, ["title", "name", "headline"]);
 
-  if (explicitTitle) {
+  if (explicitTitle && !isPlaceholderThreadTitle(explicitTitle)) {
     return {
       title: explicitTitle,
       titleSource: "explicit",
@@ -1710,8 +1714,13 @@ function extractThreadIndexEntryFromValue(
     ]);
   const rawName =
     pickString(record, ["threadName", "thread_name", "name", "title"]) ??
-    pickString(threadRecord ?? {}, ["threadName", "thread_name", "name", "title"]) ??
-    (preview ? shortenDerivedThreadTitle(preview) ?? preview : undefined);
+    pickString(threadRecord ?? {}, ["threadName", "thread_name", "name", "title"]);
+  const indexName =
+    rawName && !isPlaceholderThreadTitle(rawName)
+      ? rawName
+      : preview
+        ? shortenDerivedThreadTitle(preview) ?? preview
+        : rawName;
   const updatedAt =
     normalizeEpochTimestamp(
       pickNumber(record, ["updatedAt", "updated_at", "lastActivityAt", "createdAt"]) ??
@@ -1726,7 +1735,7 @@ function extractThreadIndexEntryFromValue(
   return {
     id: threadId,
     source: "pwragnt",
-    thread_name: rawName?.trim() || "Untitled thread",
+    thread_name: indexName?.trim() || "Untitled thread",
     updated_at: new Date(updatedAt).toISOString(),
   };
 }

--- a/apps/desktop/src/main/codex-app-server/json-rpc.ts
+++ b/apps/desktop/src/main/codex-app-server/json-rpc.ts
@@ -52,6 +52,10 @@ export interface JsonRpcObserver {
   onMessage(event: JsonRpcObserverEvent): void | Promise<void>;
 }
 
+type JsonRpcConnectionOptions = {
+  logContext?: Record<string, string>;
+};
+
 function parseJsonRpcEnvelope(raw: string): JsonRpcEnvelope | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -74,7 +78,8 @@ export class JsonRpcConnection {
   constructor(
     private readonly transport: JsonRpcTransport,
     private readonly requestTimeoutMs: number,
-    private readonly observer?: JsonRpcObserver
+    private readonly observer?: JsonRpcObserver,
+    private readonly options: JsonRpcConnectionOptions = {},
   ) {
     this.transport.setMessageHandler((message) => {
       void this.handleMessage(message);
@@ -226,6 +231,7 @@ export class JsonRpcConnection {
       await this.observer.onMessage(event);
     } catch (error) {
       jsonRpcLog.error("observer failed", {
+        ...this.options.logContext,
         direction: event.direction,
         message: event.envelope.method ?? event.envelope.id ?? "message",
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1002,14 +1002,15 @@ export class GrokAppServerClient {
       ),
     });
 
-    this.server = new CodexAppServer({
+    const server = new CodexAppServer({
       provider,
       sessionState,
       threadIdGenerator: this.options.threadIdGenerator,
       turnIdGenerator: this.options.turnIdGenerator,
     });
-    this.subscribeToServerNotifications(this.server);
-    return this.server;
+    this.server = server;
+    this.subscribeToServerNotifications(server);
+    return server;
   }
 
   private subscribeToServerNotifications(server: GrokServerLike): void {
@@ -1086,6 +1087,8 @@ export class GrokAppServerClient {
 
   private async request(method: string, params?: unknown): Promise<unknown> {
     const id = `rpc-${++this.requestCounter}`;
+    const server = this.getServer();
+
     await this.observe({
       direction: "outbound",
       envelope: {
@@ -1097,7 +1100,7 @@ export class GrokAppServerClient {
     });
 
     try {
-      const result = await this.getServer().request(method, params);
+      const result = await server.request(method, params);
       await this.observe({
         direction: "inbound",
         envelope: {
@@ -1124,6 +1127,8 @@ export class GrokAppServerClient {
   }
 
   private async notify(method: string, params?: unknown): Promise<void> {
+    const server = this.getServer();
+
     await this.observe({
       direction: "outbound",
       envelope: {
@@ -1132,7 +1137,7 @@ export class GrokAppServerClient {
         params: params ?? {},
       },
     });
-    await this.getServer().notify?.(method, params);
+    await server.notify?.(method, params);
   }
 
   private async observe(params: {
@@ -1161,6 +1166,7 @@ export class GrokAppServerClient {
       });
     } catch (error) {
       grokClientLog.error("observer failed", {
+        backend: "grok",
         direction: params.direction,
         message: params.envelope.method ?? params.envelope.id ?? "message",
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/testing/capture-store.ts
+++ b/apps/desktop/src/main/testing/capture-store.ts
@@ -46,6 +46,8 @@ type CaptureIndexEntry = {
   updatedAt: number;
 };
 
+const indexWriteQueues = new Map<string, Promise<void>>();
+
 export async function readProtocolCaptureFile(
   filePath: string,
   redactions: ProtocolCaptureStringReplacement[] = [],
@@ -140,7 +142,7 @@ export class ProtocolCaptureStore {
     const nextWrite = this.writeQueue.then(async () => {
       await this.ensureInitialized();
       await fs.appendFile(this.captureFilePath, `${JSON.stringify(record)}\n`, "utf8");
-      await this.writeIndex();
+      await this.writeIndexQueued();
     });
     this.writeQueue = nextWrite;
     await nextWrite;
@@ -158,8 +160,24 @@ export class ProtocolCaptureStore {
     }
 
     await fs.mkdir(this.params.rootDir, { recursive: true });
-    await this.writeIndex();
+    await this.writeIndexQueued();
     this.initialized = true;
+  }
+
+  private async writeIndexQueued(): Promise<void> {
+    const previousWrite = indexWriteQueues.get(this.indexFilePath) ?? Promise.resolve();
+    const nextWrite = previousWrite
+      .catch(() => undefined)
+      .then(() => this.writeIndex());
+    indexWriteQueues.set(this.indexFilePath, nextWrite);
+
+    try {
+      await nextWrite;
+    } finally {
+      if (indexWriteQueues.get(this.indexFilePath) === nextWrite) {
+        indexWriteQueues.delete(this.indexFilePath);
+      }
+    }
   }
 
   private async writeIndex(): Promise<void> {

--- a/apps/desktop/src/main/testing/capture-store.ts
+++ b/apps/desktop/src/main/testing/capture-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 export type ProtocolCaptureEventRecord = {
   backend: "codex" | "grok";
+  backendInstance?: string;
   captureId: string;
   direction: "inbound" | "outbound";
   kind: "request" | "response" | "notification";
@@ -39,6 +40,7 @@ export type CapturedProtocolEnvelopeRecord = {
 
 type CaptureIndexEntry = {
   backend: "codex" | "grok";
+  backendInstance?: string;
   captureId: string;
   createdAt: number;
   path: string;
@@ -93,6 +95,7 @@ export class ProtocolCaptureStore {
   constructor(
     private readonly params: {
       backend: "codex" | "grok";
+      backendInstance?: string;
       captureId: string;
       rootDir: string;
     }
@@ -121,6 +124,7 @@ export class ProtocolCaptureStore {
   }): Promise<ProtocolCaptureEventRecord> {
     const record: ProtocolCaptureEventRecord = {
       backend: this.params.backend,
+      backendInstance: this.params.backendInstance,
       captureId: this.params.captureId,
       direction: params.direction,
       kind: getEnvelopeKind(params.envelope),
@@ -184,6 +188,7 @@ export class ProtocolCaptureStore {
     const current = await readIndex(this.indexFilePath);
     const nextEntry: CaptureIndexEntry = {
       backend: this.params.backend,
+      backendInstance: this.params.backendInstance,
       captureId: this.params.captureId,
       createdAt: this.createdAt,
       path: this.captureFilePath,

--- a/apps/desktop/src/main/testing/protocol-capture.ts
+++ b/apps/desktop/src/main/testing/protocol-capture.ts
@@ -24,6 +24,7 @@ export function createProtocolCaptureObserver(params: {
 
 export function createProtocolCaptureFromEnv(params: {
   backend: "codex" | "grok";
+  backendInstance: string;
   userDataPath: string;
 }): {
   store: ProtocolCaptureStore;
@@ -36,14 +37,16 @@ export function createProtocolCaptureFromEnv(params: {
   const rootDir =
     process.env[CAPTURE_ROOT_ENV]?.trim() ||
     path.join(params.userDataPath, "test-artifacts", "protocol-captures");
-  const captureId = buildCaptureId(params.backend);
+  const captureId = buildCaptureId(params.backend, params.backendInstance);
   const store = new ProtocolCaptureStore({
     backend: params.backend,
+    backendInstance: params.backendInstance,
     captureId,
     rootDir
   });
   protocolCaptureLog.info("capture enabled", {
     backend: params.backend,
+    backendInstance: params.backendInstance,
     captureId,
     path: store.captureFilePath,
     indexPath: store.indexFilePath,
@@ -58,9 +61,14 @@ export function createProtocolCaptureFromEnv(params: {
   };
 }
 
-function buildCaptureId(backend: "codex" | "grok"): string {
+function buildCaptureId(backend: "codex" | "grok", backendInstance: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  return `${timestamp}-${backend}`;
+  return `${timestamp}-${backend}-${sanitizeCapturePart(backendInstance)}`;
+}
+
+function sanitizeCapturePart(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  return normalized || "default";
 }
 
 function isCaptureEnabled(value: string | undefined): boolean {

--- a/apps/desktop/src/main/testing/protocol-capture.ts
+++ b/apps/desktop/src/main/testing/protocol-capture.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import type { JsonRpcObserver } from "../codex-app-server/json-rpc";
+import { getMainLogger } from "../log";
 import { ProtocolCaptureStore } from "./capture-store";
 
 const CAPTURE_ENABLED_ENV = "PWRAGNT_PROTOCOL_CAPTURE";
 const CAPTURE_ROOT_ENV = "PWRAGNT_PROTOCOL_CAPTURE_ROOT";
+const protocolCaptureLog = getMainLogger("pwragnt:protocol-capture");
 
 export function createProtocolCaptureObserver(params: {
   backend: "codex" | "grok";
@@ -39,6 +41,12 @@ export function createProtocolCaptureFromEnv(params: {
     backend: params.backend,
     captureId,
     rootDir
+  });
+  protocolCaptureLog.info("capture enabled", {
+    backend: params.backend,
+    captureId,
+    path: store.captureFilePath,
+    indexPath: store.indexFilePath,
   });
 
   return {


### PR DESCRIPTION
## Summary

This fixes protocol capture diagnostics so capture failures are easier to attribute and capture files are scoped to the backend instance that produced them.

I changed protocol capture to:

- serialize writes to the shared capture `index.json`
- log the capture file and index paths when capture is enabled
- include backend context in observer failure logs
- fail Grok initialization before recording a synthetic outbound request when `XAI_API_KEY` is missing
- split capture traffic into separate JSONL files for `codex-default`, `codex-full-access`, and `grok-default`

This also fixes Codex thread titles when the app-server returns the placeholder `name: "Untitled thread"` alongside a real `preview`. PwrAgnt now treats that placeholder as absent and derives the displayed/session-index title from the preview instead of preserving `Untitled thread`.

The shared `index.json` remains a lookup table for capture files and thread IDs. The raw protocol traffic is written to per-instance `.jsonl` files.

## Verification

I verified this with:

```sh
pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/json-rpc.test.ts apps/desktop/src/main/__tests__/protocol-capture.test.ts apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
pnpm --filter @pwragnt/desktop typecheck
```
