### PR TITLE
feat(desktop): add out-of-band thread naming

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -779,6 +779,58 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("applies generated titles when Codex exposes the prompt as an explicit title", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Jaguar tea button",
+      })),
+    };
+    const prompt =
+      "Let's make a button with an animated jaguar sipping tea. Just for grins.";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title: prompt,
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "text", text: prompt }],
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      userPrompt: prompt,
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-title",
+      name: "Jaguar tea button",
+    });
+
+    await registry.close();
+  });
+
   it("applies generated Grok thread titles after starting turns", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -831,6 +831,59 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("applies generated titles when Codex derives the current title from injected AGENTS context", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Jaguar tea button",
+      })),
+    };
+    const prompt =
+      "Let's make a button with an animated jaguar sipping tea. Just for grins.";
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title:
+            "# AGENTS.md instructions for /Users/huntharo/github/PwrAgnt/.worktrees/launchpad-pwragnt-main-moj56ty6",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "text", text: prompt }],
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      userPrompt: prompt,
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-title",
+      name: "Jaguar tea button",
+    });
+
+    await registry.close();
+  });
+
   it("applies generated Grok thread titles after starting turns", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15,6 +15,19 @@ import type {
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(predicate: () => boolean): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    if (predicate()) {
+      return;
+    }
+    await flushAsync();
+  }
+}
+
 function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
   overlays?: Record<string, ThreadOverlayState>;
@@ -704,6 +717,193 @@ describe("DesktopBackendRegistry", () => {
       reasoningEffort: "medium",
       fastMode: undefined,
     });
+
+    await registry.close();
+  });
+
+  it("applies generated Codex thread titles after starting turns", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Leopard tea button",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-title",
+        input: [{ type: "text", text: "Make button" }],
+      })
+    ).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-title",
+      turnId: "turn-1",
+    });
+
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      userPrompt: "Make button",
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-title",
+      name: "Leopard tea button",
+    });
+
+    await registry.close();
+  });
+
+  it("applies generated Grok thread titles after starting turns", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Issue 123 rename",
+      })),
+    };
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title: "Issue 123 rename",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "grok",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeError: new Error("codex unavailable"),
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeError: new Error("codex unavailable"),
+      }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "grok",
+      threadId: "thread-title",
+      input: [{ type: "text", text: "Issue 123 rename" }],
+    });
+    await waitForCondition(() => grokClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "grok",
+      userPrompt: "Issue 123 rename",
+    });
+    expect(grokClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-title",
+      name: "Issue 123 rename",
+    });
+
+    await registry.close();
+  });
+
+  it("skips generated titles when the thread already has an explicit name", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Generated title",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title: "User title",
+          titleSource: "explicit",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(titleService.generateTitle).not.toHaveBeenCalled();
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("does not schedule generated titles for image-only turns", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Generated title",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "image", url: "file:///tmp/image.png" }],
+    });
+    await flushAsync();
+
+    expect(titleService.generateTitle).not.toHaveBeenCalled();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -230,6 +230,30 @@ class MockTransport implements JsonRpcTransport {
         return;
       }
 
+      if (searchTerm === "prompt-placeholder-title") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data: params.params?.archived
+                ? []
+                : [
+                    {
+                      id: "thread-prompt-placeholder-title",
+                      name: "Let's make a button with an animated jaguar sipping tea. Just for grins.",
+                      preview:
+                        "Let's make a button with an animated jaguar sipping tea. Just for grins.",
+                      updatedAt: 1_777_401_256,
+                      cwd: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                    },
+                  ],
+            },
+          }),
+        );
+        return;
+      }
+
       if (searchTerm === "search-product-parity") {
         const matchesCodexWindow =
           params.params?.limit === 50 &&
@@ -900,6 +924,27 @@ describe("CodexAppServerClient", () => {
       expect.objectContaining({
         id: "thread-placeholder-title",
         title: "Why do all the worktree-hashes start with `moi`?",
+        titleSource: "derived",
+      }),
+    ]);
+
+    await client.close();
+  });
+
+  it("treats Codex prompt titles as derived placeholders", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const threads = await client.listThreads({ filter: "prompt-placeholder-title" });
+
+    expect(threads).toEqual([
+      expect.objectContaining({
+        id: "thread-prompt-placeholder-title",
+        title: "Make a button with an animated jaguar sipping tea. Just for grins",
         titleSource: "derived",
       }),
     ]);

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -28,6 +28,7 @@ class MockTransport implements JsonRpcTransport {
       id: "turn-1"
     }
   };
+  static turnStartPreResponseNotification: unknown | null = null;
   static turnInterruptResult: unknown = {
     thread: {
       id: "thread-2"
@@ -646,6 +647,9 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "turn/start") {
+      if (MockTransport.turnStartPreResponseNotification) {
+        this.messageHandler(JSON.stringify(MockTransport.turnStartPreResponseNotification));
+      }
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -760,6 +764,7 @@ describe("CodexAppServerClient", () => {
         id: "turn-1"
       }
     };
+    MockTransport.turnStartPreResponseNotification = null;
     MockTransport.reviewStartResult = {
       reviewThreadId: "thread-2",
       turn: {
@@ -2771,6 +2776,67 @@ describe("CodexAppServerClient", () => {
         }),
       })
     );
+
+    await client.close();
+  });
+
+  it("uses helper title notifications that arrive before the turn/start response", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+    };
+    MockTransport.turnStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+      turn: {
+        id: "turn-title-helper",
+      },
+    };
+    MockTransport.turnStartPreResponseNotification = {
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "thread-title-helper",
+        turnId: "turn-title-helper",
+        output: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              title: "Early helper title",
+            }),
+          },
+        ],
+      },
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: { type: "string" },
+          },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      })
+    ).resolves.toEqual({
+      status: "ok",
+      object: {
+        title: "Early helper title",
+      },
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -397,6 +397,15 @@ class MockTransport implements JsonRpcTransport {
                 session: {
                   cwd: "/Users/huntharo/pwrdrvr/PwrAgnt"
                 }
+              },
+              {
+                id: "thread-placeholder",
+                name: "Untitled thread",
+                preview: "Investigate why new Codex threads keep showing as untitled",
+                updatedAt: 1_763_500_050,
+                session: {
+                  cwd: "/Users/huntharo/pwrdrvr/PwrAgnt"
+                }
               }
             ]
           }
@@ -804,10 +813,11 @@ describe("CodexAppServerClient", () => {
     const threads = await client.listThreads();
     const primaryThread = threads.find((thread) => thread.id === "thread-2");
     const derivedThread = threads.find((thread) => thread.id === "thread-1");
+    const placeholderThread = threads.find((thread) => thread.id === "thread-placeholder");
     const renamedThread = threads.find((thread) => thread.id === "thread-renamed");
     const archivedThread = threads.find((thread) => thread.id === "thread-archive");
 
-    expect(threads).toHaveLength(3);
+    expect(threads).toHaveLength(4);
     expect(primaryThread).toMatchObject({
       id: "thread-2",
       title: "Ship desktop shell",
@@ -828,6 +838,11 @@ describe("CodexAppServerClient", () => {
     );
     expect(derivedThread?.titleSource).toBe("derived");
     expect(derivedThread?.summary).toBeUndefined();
+    expect(placeholderThread).toMatchObject({
+      id: "thread-placeholder",
+      title: "Investigate why new Codex threads keep showing as untitled",
+      titleSource: "derived",
+    });
     expect(renamedThread).toMatchObject({
       id: "thread-renamed",
       title: "Spud up the thread",
@@ -2461,7 +2476,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("adds materialized app-created Codex threads to the Codex session index", async () => {
+  it("updates placeholder session index names after the first turn starts", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragnt-session-index-"));
     const sessionIndexPath = path.join(tempDir, "session_index.jsonl");
     MockTransport.threadStartResult = {
@@ -2491,6 +2506,15 @@ describe("CodexAppServerClient", () => {
       await client.startThread({
         cwd: "/Users/huntharo/github/PwrAgnt/.worktrees/launchpad-pwragnt-main-moi2lzw4",
       });
+      await client.startTurn({
+        threadId: "019dd225-74fb-7a83-b4e4-5970680d9382",
+        input: [
+          {
+            type: "text",
+            text: "Figure out why new Codex threads keep showing as untitled in PwrAgnt",
+          },
+        ],
+      });
       await client.close();
 
       const indexLines = (await fs.readFile(sessionIndexPath, "utf8"))
@@ -2504,6 +2528,12 @@ describe("CodexAppServerClient", () => {
           source: "pwragnt",
           thread_name: "Untitled thread",
           updated_at: "2026-04-28T03:32:43.000Z",
+        },
+        {
+          id: "019dd225-74fb-7a83-b4e4-5970680d9382",
+          source: "pwragnt",
+          thread_name: "Figure out why new Codex threads keep showing as untitled in PwrAgnt",
+          updated_at: expect.any(String),
         },
       ]);
     } finally {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2674,6 +2674,107 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("generates thread titles through an ephemeral Codex helper turn", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+    };
+    MockTransport.turnStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+      turn: {
+        id: "turn-title-helper",
+      },
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+    const forwardedNotifications: string[] = [];
+    client.onNotification((notification) => {
+      forwardedNotifications.push(notification.method);
+    });
+
+    const titlePromise = client.generateTitle({
+      prompt: "Name the thread from this prompt",
+      promptVersion: "thread-title-v1",
+      schema: {
+        type: "object",
+        required: ["title"],
+        properties: {
+          title: { type: "string" },
+        },
+      },
+      schemaName: "thread_title",
+      timeoutMs: 5_000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "thread-title-helper",
+        turn: {
+          id: "turn-title-helper",
+          output: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                title: "Add animated leopard tea button",
+              }),
+            },
+          ],
+        },
+      },
+    });
+
+    await expect(titlePromise).resolves.toEqual({
+      status: "ok",
+      object: {
+        title: "Add animated leopard tea button",
+      },
+    });
+    expect(forwardedNotifications).toEqual([]);
+
+    const requests = transport!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: Record<string, unknown> }
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/start",
+        params: expect.objectContaining({
+          ephemeral: true,
+          model: "gpt-5.4-mini",
+          serviceTier: "fast",
+        }),
+      })
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "turn/start",
+        params: expect.objectContaining({
+          threadId: "thread-title-helper",
+          model: "gpt-5.4-mini",
+          serviceTier: "fast",
+          effort: "low",
+          outputSchema: expect.objectContaining({
+            type: "object",
+          }),
+        }),
+      })
+    );
+
+    await client.close();
+  });
+
   it("treats unmaterialized new threads as empty transcripts", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadErrorByThreadId.set("thread-empty", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2759,6 +2759,9 @@ describe("CodexAppServerClient", () => {
           ephemeral: true,
           model: "gpt-5.4-mini",
           serviceTier: "fast",
+          config: {
+            web_search: "disabled",
+          },
         }),
       })
     );

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2780,6 +2780,84 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("uses helper title item completions when turn completion omits items", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+    };
+    MockTransport.turnStartResult = {
+      thread: {
+        id: "thread-title-helper",
+      },
+      turn: {
+        id: "turn-title-helper",
+      },
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const titlePromise = client.generateTitle({
+      prompt: "Name the thread from this prompt",
+      promptVersion: "thread-title-v1",
+      schema: {
+        type: "object",
+        required: ["title"],
+        properties: {
+          title: { type: "string" },
+        },
+      },
+      schemaName: "thread_title",
+      timeoutMs: 5_000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "thread-title-helper",
+        turnId: "turn-title-helper",
+        item: {
+          type: "agentMessage",
+          id: "message-title-helper",
+          text: JSON.stringify({
+            title: "Animated jaguar tea button",
+          }),
+          phase: "final_answer",
+        },
+      },
+    });
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "thread-title-helper",
+        turn: {
+          id: "turn-title-helper",
+          items: [],
+          status: "completed",
+        },
+      },
+    });
+
+    await expect(titlePromise).resolves.toEqual({
+      status: "ok",
+      object: {
+        title: "Animated jaguar tea button",
+      },
+    });
+
+    await client.close();
+  });
+
   it("uses helper title notifications that arrive before the turn/start response", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.threadStartResult = {

--- a/apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts
+++ b/apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts
@@ -50,6 +50,7 @@ describe("XaiEphemeralObjectCaller", () => {
         apiKey: undefined,
         baseUrl: undefined,
         model: "grok-4.20-reasoning",
+        configPath: "/tmp/grok-config.toml",
         stateRoot: "/tmp/grok-state",
       }),
     });

--- a/apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts
+++ b/apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { XaiEphemeralObjectCaller } from "../app-server/ephemeral-object-call";
+
+function makeStructuredResult(object: unknown, cachedTokens?: number) {
+  return {
+    object,
+    cachedTokens,
+  };
+}
+
+describe("XaiEphemeralObjectCaller", () => {
+  it("returns parsed object output from an injected client", async () => {
+    const client = {
+      generateObject: vi.fn(async () => makeStructuredResult({ title: "PROJECT-123 crash" }, 42)),
+    };
+    const caller = new XaiEphemeralObjectCaller({ client, model: "grok-test-model" });
+
+    const result = await caller.generateObject({
+      promptCacheKey: "thread-title-v1",
+      headers: { "x-grok-conv-id": "thread-title-v1" },
+      schema: { type: "object" },
+      schemaName: "thread_title",
+      system: "Return a title.",
+      prompt: "PROJECT-123 investigate crash",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      response: {
+        object: { title: "PROJECT-123 crash" },
+        cachedTokens: 42,
+      },
+    });
+    expect(client.generateObject).toHaveBeenCalledWith({
+      model: "grok-test-model",
+      promptCacheKey: "thread-title-v1",
+      headers: { "x-grok-conv-id": "thread-title-v1" },
+      signal: expect.any(AbortSignal),
+      schema: { type: "object" },
+      schemaName: "thread_title",
+      system: "Return a title.",
+      prompt: "PROJECT-123 investigate crash",
+    });
+  });
+
+  it("returns unavailable when no xAI credentials are configured", async () => {
+    const caller = new XaiEphemeralObjectCaller({
+      resolveRuntimeConfig: () => ({
+        apiKey: undefined,
+        baseUrl: undefined,
+        model: "grok-4.20-reasoning",
+        stateRoot: "/tmp/grok-state",
+      }),
+    });
+
+    await expect(
+      caller.generateObject({
+        schema: { type: "object" },
+        system: "Return a title.",
+        prompt: "Name this thread.",
+      })
+    ).resolves.toEqual({
+      status: "unavailable",
+      reason: "xai_unavailable",
+    });
+  });
+
+  it("returns failed when the object call rejects", async () => {
+    const client = {
+      generateObject: vi.fn(async () => {
+        throw new Error("timeout");
+      }),
+    };
+    const caller = new XaiEphemeralObjectCaller({ client });
+
+    await expect(
+      caller.generateObject({
+        schema: { type: "object" },
+        system: "Return a title.",
+        prompt: "Name this thread.",
+      })
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "timeout",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -90,6 +90,24 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
+  it("rejects titles that preserve only one of multiple references", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "Issue 123 rename followup" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "In issue 123 and PR 456, why does rename fail?",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "ticket_reference_missing",
+    });
+  });
+
   it("cleans wrapper quotes and trailing punctuation", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -36,6 +36,27 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
+  it("allows 20 seconds for title generators by default", async () => {
+    const generateTitle = vi.fn(async () => ({
+      status: "ok",
+      object: { title: "Thread naming" },
+    } as const));
+    const service = new ThreadTitleGenerationService({
+      generators: { codex: { generateTitle } },
+    });
+
+    await service.generateTitle({
+      backend: "codex",
+      userPrompt: "Name this thread",
+    });
+
+    expect(generateTitle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 20_000,
+      })
+    );
+  });
+
   it("preserves recognized issue and PR references", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_GROK_THREAD_TITLE_MODEL,
+  GrokThreadTitleGenerator,
+  THREAD_TITLE_PROMPT_VERSION,
+  ThreadTitleGenerationService,
+  type ThreadTitleGenerator,
+} from "../app-server/thread-title-generation-service";
+
+function makeGenerator(object: unknown): ThreadTitleGenerator {
+  return {
+    generateTitle: vi.fn(async () => ({
+      status: "ok",
+      object,
+      cachedTokens: 12,
+    } as const)),
+  };
+}
+
+describe("ThreadTitleGenerationService", () => {
+  it("accepts a valid generated title", async () => {
+    const generator = makeGenerator({ title: "PROJECT-123 checkout crash" });
+    const service = new ThreadTitleGenerationService({
+      generators: { codex: generator },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "PROJECT-123 investigate checkout crash",
+      })
+    ).resolves.toEqual({
+      status: "generated",
+      title: "PROJECT-123 checkout crash",
+      cachedTokens: 12,
+    });
+  });
+
+  it("preserves recognized issue and PR references", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "PR 456 issue 123 followup" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "In issue 123 and PR 456, why does rename fail?",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "PR 456 issue 123 followup",
+    });
+  });
+
+  it("preserves bare numeric references", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "456 rename followup" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "Can we inspect 456 for rename behavior?",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "456 rename followup",
+    });
+  });
+
+  it("rejects titles that drop ticket references from the prompt", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "Checkout crash followup" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "PROJECT-123 investigate checkout crash",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "ticket_reference_missing",
+    });
+  });
+
+  it("cleans wrapper quotes and trailing punctuation", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: '"Rename thread #123."' }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "Can we inspect #123 rename behavior?",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "Rename thread #123",
+    });
+  });
+
+  it("rejects overlong and wordy generated titles", async () => {
+    const longTitleService = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({
+          title: "This title is intentionally much too long for the desktop thread title limit",
+        }),
+      },
+    });
+    const wordyTitleService = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "One two three four five six seven" }),
+      },
+    });
+
+    await expect(
+      longTitleService.generateTitle({
+        backend: "codex",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "title_too_long",
+    });
+    await expect(
+      wordyTitleService.generateTitle({
+        backend: "codex",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "title_too_many_words",
+    });
+  });
+
+  it("rejects malformed title objects", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: 123 }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "title_must_be_string",
+    });
+  });
+
+  it("returns unavailable when a backend generator is absent", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: { grok: undefined },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "grok",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "unavailable",
+      reason: "grok_title_generator_unavailable",
+    });
+  });
+});
+
+describe("GrokThreadTitleGenerator", () => {
+  it("calls xAI with the fast non-reasoning title model", async () => {
+    const client = {
+      generateObject: vi.fn(async () => ({
+        object: { title: "Thread naming" },
+        cachedTokens: 8,
+      })),
+    };
+    const generator = new GrokThreadTitleGenerator({ client });
+
+    await expect(
+      generator.generateTitle({
+        prompt: "Name this thread",
+        promptVersion: THREAD_TITLE_PROMPT_VERSION,
+        schema: { type: "object" },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      })
+    ).resolves.toEqual({
+      status: "ok",
+      object: { title: "Thread naming" },
+      cachedTokens: 8,
+    });
+
+    expect(client.generateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: DEFAULT_GROK_THREAD_TITLE_MODEL,
+        promptCacheKey: THREAD_TITLE_PROMPT_VERSION,
+        schemaName: "thread_title",
+        headers: {
+          "x-grok-conv-id": THREAD_TITLE_PROMPT_VERSION,
+        },
+      })
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildThreadTitlePrompt,
+  readThreadTitlePrompt,
+} from "../app-server/thread-title-prompt";
+
+describe("thread title prompt", () => {
+  it("captures desktop thread title constraints", () => {
+    const prompt = readThreadTitlePrompt();
+
+    expect(prompt).toContain("same language as the user's prompt");
+    expect(prompt).toContain("under 50 characters");
+    expect(prompt).toContain("6 words or fewer");
+    expect(prompt).toContain("PROJECT-123");
+    expect(prompt).toContain("#123");
+    expect(prompt).toContain("456");
+    expect(prompt).toContain("issue 123");
+    expect(prompt).toContain("PR 456");
+    expect(prompt).not.toMatch(/\bfix\b/i);
+    expect(prompt).not.toMatch(/\badd\b/i);
+    expect(prompt).not.toMatch(/\bimperative\b/i);
+    expect(prompt).not.toMatch(/\blocale\b/i);
+  });
+
+  it("builds a prompt from the user's first prompt", () => {
+    const prompt = buildThreadTitlePrompt("  Investigate PROJECT-123 in pr 456  ");
+
+    expect(prompt).toContain("Investigate PROJECT-123 in pr 456");
+    expect(prompt).not.toContain("{{USER_PROMPT}}");
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -470,6 +470,9 @@ function isEligibleForGeneratedTitle(
   if (!thread) {
     return true;
   }
+  if (isPromptPlaceholderTitle(thread.title, prompt)) {
+    return true;
+  }
   if (thread.titleSource === "explicit") {
     return false;
   }
@@ -483,6 +486,16 @@ function isEligibleForGeneratedTitle(
 
 function normalizeTitleForComparison(value: string): string {
   return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function isPromptPlaceholderTitle(title: string, prompt: string): boolean {
+  const normalizedTitle = normalizeTitleForComparison(title);
+  const normalizedPrompt = normalizeTitleForComparison(prompt);
+  const derivedTitle = shortenDerivedThreadTitle(prompt) ?? prompt;
+  return (
+    normalizedTitle === normalizedPrompt ||
+    normalizedTitle === normalizeTitleForComparison(derivedTitle)
+  );
 }
 
 function getDefaultModelOption(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -163,6 +163,12 @@ type PendingServerRequest = {
 
 type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle">;
 
+type ThreadTitleGenerationLogStatus =
+  | ThreadTitleGenerationResult["status"]
+  | "applied"
+  | "requesting"
+  | "skipped";
+
 type WorktreeArchiveCandidate = {
   repositoryPath: string;
   worktreePath: string;
@@ -1780,6 +1786,9 @@ export class DesktopBackendRegistry {
         return;
       }
 
+      this.logThreadTitleGeneration("requesting", params, undefined, {
+        promptTitle: truncateLogValue(shortenDerivedThreadTitle(params.prompt) ?? params.prompt),
+      });
       const result = await this.threadTitleGenerationService?.generateTitle({
         backend: params.backend,
         userPrompt: params.prompt,
@@ -1792,10 +1801,16 @@ export class DesktopBackendRegistry {
         );
         return;
       }
+      this.logThreadTitleGeneration("generated", params, undefined, {
+        generatedTitle: truncateLogValue(result.title),
+        cachedTokens: result.cachedTokens ?? null,
+      });
 
       const pending = this.pendingTitleGenerations.get(params.key);
       if (!pending || pending.token !== params.token) {
-        this.logThreadTitleGeneration("skipped", params, "stale_generation");
+        this.logThreadTitleGeneration("skipped", params, "stale_generation", {
+          generatedTitle: truncateLogValue(result.title),
+        });
         return;
       }
 
@@ -1820,7 +1835,9 @@ export class DesktopBackendRegistry {
       } else {
         await this.renameWithClient(this.grokClient, params.threadId, result.title);
       }
-      this.logThreadTitleGeneration("applied", params);
+      this.logThreadTitleGeneration("applied", params, undefined, {
+        generatedTitle: truncateLogValue(result.title),
+      });
     } catch (error) {
       this.logThreadTitleGeneration(
         "failed",
@@ -1847,7 +1864,7 @@ export class DesktopBackendRegistry {
   }
 
   private logThreadTitleGeneration(
-    status: ThreadTitleGenerationResult["status"] | "applied" | "skipped",
+    status: ThreadTitleGenerationLogStatus,
     params: {
       backend: AppServerBackendKind;
       threadId: string;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -476,6 +476,9 @@ function isEligibleForGeneratedTitle(
   if (thread.titleSource === "explicit") {
     return false;
   }
+  if (isInjectedContextPlaceholderTitle(thread.title)) {
+    return true;
+  }
   if (thread.titleSource === "fallback" || thread.title === "Untitled thread") {
     return true;
   }
@@ -496,6 +499,37 @@ function isPromptPlaceholderTitle(title: string, prompt: string): boolean {
     normalizedTitle === normalizedPrompt ||
     normalizedTitle === normalizeTitleForComparison(derivedTitle)
   );
+}
+
+function isInjectedContextPlaceholderTitle(title: string): boolean {
+  const normalizedTitle = normalizeTitleForComparison(title);
+  return (
+    normalizedTitle.startsWith("# agents.md instructions") ||
+    normalizedTitle.startsWith("agents.md instructions for")
+  );
+}
+
+function truncateLogValue(value: string | undefined): string | null {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function buildTitleEligibilityLogDetails(
+  thread: AppServerThreadSummary | undefined,
+  prompt: string,
+): Record<string, unknown> {
+  return {
+    currentTitle: truncateLogValue(thread?.title),
+    currentTitleSource: thread?.titleSource ?? null,
+    promptTitle: truncateLogValue(shortenDerivedThreadTitle(prompt) ?? prompt),
+    promptMatchesCurrentTitle: thread ? isPromptPlaceholderTitle(thread.title, prompt) : null,
+    injectedContextPlaceholderTitle: thread
+      ? isInjectedContextPlaceholderTitle(thread.title)
+      : null,
+  };
 }
 
 function getDefaultModelOption(
@@ -1737,7 +1771,12 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
       });
       if (!isEligibleForGeneratedTitle(currentThread, params.prompt)) {
-        this.logThreadTitleGeneration("skipped", params, "current_title_not_eligible");
+        this.logThreadTitleGeneration(
+          "skipped",
+          params,
+          "current_title_not_eligible",
+          buildTitleEligibilityLogDetails(currentThread, params.prompt)
+        );
         return;
       }
 
@@ -1765,7 +1804,12 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
       });
       if (!latestThread || !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
-        this.logThreadTitleGeneration("skipped", params, "latest_title_not_eligible");
+        this.logThreadTitleGeneration(
+          "skipped",
+          params,
+          "latest_title_not_eligible",
+          buildTitleEligibilityLogDetails(latestThread, params.prompt)
+        );
         return;
       }
 
@@ -1809,12 +1853,14 @@ export class DesktopBackendRegistry {
       threadId: string;
     },
     reason?: string,
+    details?: Record<string, unknown>,
   ): void {
     logDebug("threadTitleGeneration", {
       backend: params.backend,
       threadId: params.threadId,
       status,
       reason: reason ?? null,
+      ...details,
     });
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,55 +1,56 @@
 import { app } from "electron";
 import { OverlayStore } from "@pwragnt/agent-core";
-import type {
-  AgentEvent,
-  ArchiveWorktreeRequest,
-  ArchiveWorktreeResponse,
-  ArchiveThreadRequest,
-  ArchiveThreadCleanupResult,
-  ArchiveThreadResponse,
-  AppServerListSkillsResponse,
-  AppServerNotification,
-  AppServerPendingRequestNotification,
-  AppServerReadThreadRequest,
-  AppServerReadThreadResponse,
-  AppServerThreadSummary,
-  AppServerTurnInputItem,
-  AppServerBackendKind,
-  AppServerCollaborationModeRequest,
-  BackendCapabilities,
-  BackendLaunchpadOptions,
-  BackendModelOption,
-  BackendSummary,
-  ListBackendsRequest,
-  ListBackendsResponse,
-  MaterializeDirectoryLaunchpadRequest,
-  MaterializeDirectoryLaunchpadResponse,
-  NavigationDirectoryGitStatus,
-  NavigationDirectorySummary,
-  NavigationLaunchpadDraft,
-  NavigationLaunchpadDefaults,
-  ResetDirectoryLaunchpadRequest,
-  ResetDirectoryLaunchpadResponse,
-  RenameThreadRequest,
-  RenameThreadResponse,
-  RestoreWorktreeRequest,
-  RestoreWorktreeResponse,
-  RestoreThreadRequest,
-  RestoreThreadResponse,
-  SetThreadExecutionModeRequest,
-  SetThreadExecutionModeResponse,
-  SetThreadModelSettingsRequest,
-  SetThreadModelSettingsResponse,
-  StartReviewRequest,
-  StartReviewResponse,
-  StartThreadResponse,
-  SubmitServerRequestRequest,
-  SubmitServerRequestResponse,
-  ThreadExecutionMode,
-  UpdateDirectoryLaunchpadRequest,
-  UpdateDirectoryLaunchpadResponse,
-  EnsureDirectoryLaunchpadRequest,
-  EnsureDirectoryLaunchpadResponse,
+import {
+  shortenDerivedThreadTitle,
+  type AgentEvent,
+  type ArchiveWorktreeRequest,
+  type ArchiveWorktreeResponse,
+  type ArchiveThreadRequest,
+  type ArchiveThreadCleanupResult,
+  type ArchiveThreadResponse,
+  type AppServerListSkillsResponse,
+  type AppServerNotification,
+  type AppServerPendingRequestNotification,
+  type AppServerReadThreadRequest,
+  type AppServerReadThreadResponse,
+  type AppServerThreadSummary,
+  type AppServerTurnInputItem,
+  type AppServerBackendKind,
+  type AppServerCollaborationModeRequest,
+  type BackendCapabilities,
+  type BackendLaunchpadOptions,
+  type BackendModelOption,
+  type BackendSummary,
+  type ListBackendsRequest,
+  type ListBackendsResponse,
+  type MaterializeDirectoryLaunchpadRequest,
+  type MaterializeDirectoryLaunchpadResponse,
+  type NavigationDirectoryGitStatus,
+  type NavigationDirectorySummary,
+  type NavigationLaunchpadDraft,
+  type NavigationLaunchpadDefaults,
+  type ResetDirectoryLaunchpadRequest,
+  type ResetDirectoryLaunchpadResponse,
+  type RenameThreadRequest,
+  type RenameThreadResponse,
+  type RestoreWorktreeRequest,
+  type RestoreWorktreeResponse,
+  type RestoreThreadRequest,
+  type RestoreThreadResponse,
+  type SetThreadExecutionModeRequest,
+  type SetThreadExecutionModeResponse,
+  type SetThreadModelSettingsRequest,
+  type SetThreadModelSettingsResponse,
+  type StartReviewRequest,
+  type StartReviewResponse,
+  type StartThreadResponse,
+  type SubmitServerRequestRequest,
+  type SubmitServerRequestResponse,
+  type ThreadExecutionMode,
+  type UpdateDirectoryLaunchpadRequest,
+  type UpdateDirectoryLaunchpadResponse,
+  type EnsureDirectoryLaunchpadRequest,
+  type EnsureDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
@@ -64,6 +65,12 @@ import {
   createCompositeJsonRpcObserver,
   createProtocolLogObserverFromEnv,
 } from "./protocol-log-observer";
+import {
+  ThreadTitleGenerationService,
+  type ThreadTitleGenerator,
+  type ThreadTitleGenerationResult,
+} from "./thread-title-generation-service";
+import { getMainLogger } from "../log";
 
 type InitializeResult = {
   serverInfo?: {
@@ -73,6 +80,17 @@ type InitializeResult = {
   methods?: string[];
 };
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+const backendRegistryLog = getMainLogger("pwragnt:backend-registry");
+
+function logDebug(event: string, payload: Record<string, unknown>): void {
+  if (!isDevelopment) {
+    return;
+  }
+
+  backendRegistryLog.info(event, payload);
+}
+
 type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
@@ -80,6 +98,7 @@ type BackendClient = {
   archiveThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   restoreThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   renameThread?(params: { threadId: string; name: string }): Promise<{ threadId: string }>;
+  generateTitle?: ThreadTitleGenerator["generateTitle"];
   listSkills(params?: {
     cwd?: string;
     cwds?: string[];
@@ -141,6 +160,8 @@ type PendingServerRequest = {
   resolve: (response: SubmitServerRequestRequest["response"]) => void;
   reject: (error: Error) => void;
 };
+
+type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle">;
 
 type WorktreeArchiveCandidate = {
   repositoryPath: string;
@@ -422,6 +443,48 @@ function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): bo
   );
 }
 
+function extractFirstMeaningfulTextInput(input: AppServerTurnInputItem[]): string | undefined {
+  const text = input
+    .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
+    .map((item) => item.text.trim())
+    .filter(Boolean)
+    .join("\n");
+  return text || undefined;
+}
+
+function buildTitleGenerationKey(
+  backend: AppServerBackendKind,
+  threadId: string,
+): string {
+  return `${backend}:${threadId}`;
+}
+
+function buildPromptHash(prompt: string): string {
+  return prompt.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function isEligibleForGeneratedTitle(
+  thread: AppServerThreadSummary | undefined,
+  prompt: string,
+): boolean {
+  if (!thread) {
+    return true;
+  }
+  if (thread.titleSource === "explicit") {
+    return false;
+  }
+  if (thread.titleSource === "fallback" || thread.title === "Untitled thread") {
+    return true;
+  }
+
+  const derivedTitle = shortenDerivedThreadTitle(prompt) ?? prompt;
+  return normalizeTitleForComparison(thread.title) === normalizeTitleForComparison(derivedTitle);
+}
+
+function normalizeTitleForComparison(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
 function getDefaultModelOption(
   backend: AppServerBackendKind,
   options?: BackendLaunchpadOptions,
@@ -481,12 +544,21 @@ export class DesktopBackendRegistry {
   private readonly gitDirectoryService: GitDirectoryService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
+  private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
   >();
   private readonly unsubscribers: Array<() => void> = [];
   private readonly pendingServerRequests = new Map<string, PendingServerRequest>();
+  private readonly pendingTitleGenerations = new Map<
+    string,
+    {
+      promptHash: string;
+      token: number;
+    }
+  >();
+  private titleGenerationSequence = 0;
 
   constructor(options?: {
     codexClient?: BackendClient;
@@ -496,6 +568,7 @@ export class DesktopBackendRegistry {
     gitDirectoryService?: GitDirectoryService;
     worktreeArchiveService?: WorktreeArchiveService;
     createScratchProjectDirectory?: () => Promise<string>;
+    threadTitleGenerationService?: ThreadTitleService | null;
   }) {
     const replayClients = createReplayClientsFromEnv();
     const codexDefaultCapture = options?.codexClient
@@ -575,6 +648,22 @@ export class DesktopBackendRegistry {
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
     this.createScratchProjectDirectory =
       options?.createScratchProjectDirectory ?? createScratchProjectDirectory;
+    this.threadTitleGenerationService =
+      options?.threadTitleGenerationService === null
+        ? undefined
+        : options?.threadTitleGenerationService ??
+          (replayClients
+            ? undefined
+            : new ThreadTitleGenerationService({
+                generators: {
+                  codex: this.codexDefaultClient.generateTitle
+                    ? {
+                        generateTitle: (params) =>
+                          this.codexDefaultClient.generateTitle!(params),
+                      }
+                    : undefined,
+                },
+              }));
 
     this.subscribeClient("codex", this.codexDefaultClient);
     this.subscribeClient("codex", this.codexFullAccessClient);
@@ -921,11 +1010,18 @@ export class DesktopBackendRegistry {
       });
     }
 
-    return {
+    const response = {
       backend: params.backend,
       threadId: result.threadId,
       turnId: result.turnId,
     };
+    this.scheduleThreadTitleGeneration({
+      backend: params.backend,
+      threadId: result.threadId,
+      input: params.input,
+    });
+
+    return response;
   }
 
   async startReview(params: StartReviewRequest): Promise<StartReviewResponse> {
@@ -1577,6 +1673,136 @@ export class DesktopBackendRegistry {
     }
 
     return await client.renameThread({ threadId, name });
+  }
+
+  private scheduleThreadTitleGeneration(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+  }): void {
+    if (!this.threadTitleGenerationService) {
+      return;
+    }
+
+    const prompt = extractFirstMeaningfulTextInput(params.input);
+    if (!prompt) {
+      return;
+    }
+
+    const key = buildTitleGenerationKey(params.backend, params.threadId);
+    const promptHash = buildPromptHash(prompt);
+    const current = this.pendingTitleGenerations.get(key);
+    if (current?.promptHash === promptHash) {
+      return;
+    }
+
+    const token = ++this.titleGenerationSequence;
+    this.pendingTitleGenerations.set(key, {
+      promptHash,
+      token,
+    });
+
+    void this.generateAndApplyThreadTitle({
+      backend: params.backend,
+      threadId: params.threadId,
+      prompt,
+      key,
+      token,
+    });
+  }
+
+  private async generateAndApplyThreadTitle(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prompt: string;
+    key: string;
+    token: number;
+  }): Promise<void> {
+    try {
+      const currentThread = await this.findThreadForTitleGeneration({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      if (!isEligibleForGeneratedTitle(currentThread, params.prompt)) {
+        this.logThreadTitleGeneration("skipped", params, "current_title_not_eligible");
+        return;
+      }
+
+      const result = await this.threadTitleGenerationService?.generateTitle({
+        backend: params.backend,
+        userPrompt: params.prompt,
+      });
+      if (!result || result.status !== "generated") {
+        this.logThreadTitleGeneration(
+          result?.status ?? "unavailable",
+          params,
+          result?.reason ?? "title_generation_unavailable"
+        );
+        return;
+      }
+
+      const pending = this.pendingTitleGenerations.get(params.key);
+      if (!pending || pending.token !== params.token) {
+        this.logThreadTitleGeneration("skipped", params, "stale_generation");
+        return;
+      }
+
+      const latestThread = await this.findThreadForTitleGeneration({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      if (!latestThread || !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
+        this.logThreadTitleGeneration("skipped", params, "latest_title_not_eligible");
+        return;
+      }
+
+      if (params.backend === "codex") {
+        await this.withCodexThreadClient(params.threadId, async (client) =>
+          await this.renameWithClient(client, params.threadId, result.title)
+        );
+      } else {
+        await this.renameWithClient(this.grokClient, params.threadId, result.title);
+      }
+      this.logThreadTitleGeneration("applied", params);
+    } catch (error) {
+      this.logThreadTitleGeneration(
+        "failed",
+        params,
+        error instanceof Error ? error.message : String(error)
+      );
+    } finally {
+      const pending = this.pendingTitleGenerations.get(params.key);
+      if (pending?.token === params.token) {
+        this.pendingTitleGenerations.delete(params.key);
+      }
+    }
+  }
+
+  private async findThreadForTitleGeneration(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadSummary | undefined> {
+    const activeThreads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+    }).catch(() => []);
+    return activeThreads.find((thread) => thread.id === params.threadId);
+  }
+
+  private logThreadTitleGeneration(
+    status: ThreadTitleGenerationResult["status"] | "applied" | "skipped",
+    params: {
+      backend: AppServerBackendKind;
+      threadId: string;
+    },
+    reason?: string,
+  ): void {
+    logDebug("threadTitleGeneration", {
+      backend: params.backend,
+      threadId: params.threadId,
+      status,
+      reason: reason ?? null,
+    });
   }
 
   private async handleServerRequest(

--- a/apps/desktop/src/main/app-server/ephemeral-object-call.ts
+++ b/apps/desktop/src/main/app-server/ephemeral-object-call.ts
@@ -1,0 +1,139 @@
+import {
+  resolveGrokAppServerRuntimeConfig,
+  XaiAiSdkObjectClient,
+  type GrokAppServerRuntimeConfig,
+  type XaiAiSdkObjectResult,
+} from "@pwragnt/agent-core";
+
+export type XaiObjectClientLike = Pick<XaiAiSdkObjectClient, "generateObject">;
+
+export type XaiEphemeralObjectCallRequest = {
+  model?: string;
+  promptCacheKey?: string;
+  headers?: Record<string, string>;
+  schema: Record<string, unknown>;
+  schemaName?: string;
+  system: string;
+  prompt: string;
+  timeoutMs?: number;
+};
+
+export type XaiEphemeralObjectCallResult =
+  | {
+      status: "ok";
+      response: XaiAiSdkObjectResult;
+    }
+  | {
+      status: "unavailable";
+      reason: string;
+    }
+  | {
+      status: "failed";
+      reason: string;
+    };
+
+export type XaiEphemeralObjectCallerOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  client?: XaiObjectClientLike;
+  model?: string;
+  resolveRuntimeConfig?: () => GrokAppServerRuntimeConfig;
+};
+
+export class XaiEphemeralObjectCaller {
+  private readonly configuredApiKey?: string;
+  private readonly configuredBaseUrl?: string;
+  private readonly configuredClient?: XaiObjectClientLike;
+  private readonly configuredModel?: string;
+  private readonly resolveRuntimeConfig: () => GrokAppServerRuntimeConfig;
+  private envClient: XaiObjectClientLike | null | undefined;
+  private runtimeConfig: GrokAppServerRuntimeConfig | undefined;
+
+  constructor(options: XaiEphemeralObjectCallerOptions = {}) {
+    this.configuredApiKey = options.apiKey?.trim() || undefined;
+    this.configuredBaseUrl = options.baseUrl?.trim() || undefined;
+    this.configuredClient = options.client;
+    this.configuredModel = options.model?.trim() || undefined;
+    this.resolveRuntimeConfig = options.resolveRuntimeConfig ?? resolveGrokAppServerRuntimeConfig;
+  }
+
+  async generateObject(
+    request: XaiEphemeralObjectCallRequest
+  ): Promise<XaiEphemeralObjectCallResult> {
+    const client = this.getClient();
+    if (!client) {
+      return {
+        status: "unavailable",
+        reason: "xai_unavailable",
+      };
+    }
+
+    const controller = new AbortController();
+    const timeoutHandle =
+      request.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            controller.abort();
+          }, request.timeoutMs);
+
+    try {
+      const response = await client.generateObject({
+        model: request.model?.trim() || this.configuredModel,
+        promptCacheKey: request.promptCacheKey,
+        headers: request.headers,
+        signal: controller.signal,
+        schema: request.schema,
+        schemaName: request.schemaName,
+        system: request.system,
+        prompt: request.prompt,
+      });
+      return {
+        status: "ok",
+        response,
+      };
+    } catch (error) {
+      return {
+        status: "failed",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private getClient(): XaiObjectClientLike | null {
+    if (this.configuredClient) {
+      return this.configuredClient;
+    }
+
+    if (this.envClient !== undefined) {
+      return this.envClient;
+    }
+
+    const runtimeConfig = this.getRuntimeConfig();
+    const apiKey = this.configuredApiKey ?? runtimeConfig.apiKey;
+    if (!apiKey) {
+      this.envClient = null;
+      return this.envClient;
+    }
+
+    this.envClient = new XaiAiSdkObjectClient({
+      apiKey,
+      baseUrl: this.configuredBaseUrl ?? runtimeConfig.baseUrl,
+      model: this.configuredModel,
+    });
+
+    return this.envClient;
+  }
+
+  private getRuntimeConfig(): GrokAppServerRuntimeConfig {
+    if (this.runtimeConfig) {
+      return this.runtimeConfig;
+    }
+
+    this.runtimeConfig = this.resolveRuntimeConfig();
+    return this.runtimeConfig;
+  }
+}

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -1,0 +1,273 @@
+import type { AppServerBackendKind } from "@pwragnt/shared";
+import {
+  XaiEphemeralObjectCaller,
+  type XaiObjectClientLike,
+} from "./ephemeral-object-call";
+import { buildThreadTitlePrompt } from "./thread-title-prompt";
+
+export const THREAD_TITLE_PROMPT_VERSION = "thread-title-v1";
+export const DEFAULT_GROK_THREAD_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
+
+const THREAD_TITLE_TIMEOUT_MS = 5_000;
+const MAX_TITLE_CHARACTERS = 50;
+const MAX_TITLE_WORDS = 6;
+
+const THREAD_TITLE_RESPONSE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["title"],
+  properties: {
+    title: {
+      type: "string",
+      minLength: 1,
+      maxLength: 80,
+    },
+  },
+} as const;
+
+type ThreadTitleAdapterParams = {
+  prompt: string;
+  promptVersion: string;
+  schema: Record<string, unknown>;
+  schemaName: string;
+  timeoutMs: number;
+};
+
+type ThreadTitleAdapterResult =
+  | {
+      status: "ok";
+      object: unknown;
+      cachedTokens?: number;
+    }
+  | {
+      status: "unavailable" | "failed";
+      reason: string;
+    };
+
+export type ThreadTitleGenerator = {
+  generateTitle(params: ThreadTitleAdapterParams): Promise<ThreadTitleAdapterResult>;
+};
+
+export type ThreadTitleGenerationResult =
+  | {
+      status: "generated";
+      title: string;
+      cachedTokens?: number;
+    }
+  | {
+      status: "unavailable" | "invalid" | "failed";
+      reason: string;
+    };
+
+export type ThreadTitleGenerationServiceOptions = {
+  generators?: Partial<Record<AppServerBackendKind, ThreadTitleGenerator>>;
+  timeoutMs?: number;
+};
+
+export type GrokThreadTitleGeneratorOptions = {
+  apiKey?: string;
+  baseUrl?: string;
+  client?: XaiObjectClientLike;
+  model?: string;
+  timeoutMs?: number;
+};
+
+export class ThreadTitleGenerationService {
+  private readonly generators: Partial<Record<AppServerBackendKind, ThreadTitleGenerator>>;
+  private readonly timeoutMs: number;
+
+  constructor(options: ThreadTitleGenerationServiceOptions = {}) {
+    this.generators = {
+      grok: new GrokThreadTitleGenerator({ timeoutMs: options.timeoutMs }),
+      ...options.generators,
+    };
+    this.timeoutMs = options.timeoutMs ?? THREAD_TITLE_TIMEOUT_MS;
+  }
+
+  async generateTitle(params: {
+    backend: AppServerBackendKind;
+    userPrompt: string;
+  }): Promise<ThreadTitleGenerationResult> {
+    const userPrompt = params.userPrompt.trim();
+    if (!userPrompt) {
+      return {
+        status: "invalid",
+        reason: "empty_prompt",
+      };
+    }
+
+    const generator = this.generators[params.backend];
+    if (!generator) {
+      return {
+        status: "unavailable",
+        reason: `${params.backend}_title_generator_unavailable`,
+      };
+    }
+
+    const result = await generator.generateTitle({
+      prompt: buildThreadTitlePrompt(userPrompt),
+      promptVersion: THREAD_TITLE_PROMPT_VERSION,
+      schema: THREAD_TITLE_RESPONSE_SCHEMA,
+      schemaName: "thread_title",
+      timeoutMs: this.timeoutMs,
+    });
+    if (result.status !== "ok") {
+      return result;
+    }
+
+    const normalized = normalizeThreadTitleObject(result.object, userPrompt);
+    if (!normalized.title) {
+      return {
+        status: "invalid",
+        reason: normalized.reason,
+      };
+    }
+
+    return {
+      status: "generated",
+      title: normalized.title,
+      cachedTokens: result.cachedTokens,
+    };
+  }
+}
+
+export class GrokThreadTitleGenerator implements ThreadTitleGenerator {
+  private readonly caller: XaiEphemeralObjectCaller;
+  private readonly model: string;
+  private readonly timeoutMs?: number;
+
+  constructor(options: GrokThreadTitleGeneratorOptions = {}) {
+    this.model = options.model?.trim() || DEFAULT_GROK_THREAD_TITLE_MODEL;
+    this.timeoutMs = options.timeoutMs;
+    this.caller = new XaiEphemeralObjectCaller({
+      apiKey: options.apiKey,
+      baseUrl: options.baseUrl,
+      client: options.client,
+      model: this.model,
+    });
+  }
+
+  async generateTitle(
+    params: ThreadTitleAdapterParams
+  ): Promise<ThreadTitleAdapterResult> {
+    const result = await this.caller.generateObject({
+      model: this.model,
+      promptCacheKey: params.promptVersion,
+      headers: {
+        "x-grok-conv-id": params.promptVersion,
+      },
+      timeoutMs: this.timeoutMs ?? params.timeoutMs,
+      schema: params.schema,
+      schemaName: params.schemaName,
+      system: [
+        "Generate a concise desktop thread title.",
+        "Return JSON that matches the schema exactly.",
+      ].join("\n"),
+      prompt: params.prompt,
+    });
+
+    if (result.status !== "ok") {
+      return result;
+    }
+
+    return {
+      status: "ok",
+      object: result.response.object,
+      cachedTokens: result.response.cachedTokens,
+    };
+  }
+}
+
+function normalizeThreadTitleObject(
+  object: unknown,
+  userPrompt: string
+): { title?: string; reason: string } {
+  if (!object || typeof object !== "object" || Array.isArray(object)) {
+    return { reason: "title_payload_must_be_object" };
+  }
+
+  const title = (object as { title?: unknown }).title;
+  if (typeof title !== "string") {
+    return { reason: "title_must_be_string" };
+  }
+
+  const cleaned = cleanThreadTitle(title);
+  if (!cleaned) {
+    return { reason: "title_empty" };
+  }
+  if (cleaned.length > MAX_TITLE_CHARACTERS) {
+    return { reason: "title_too_long" };
+  }
+  if (countWords(cleaned) > MAX_TITLE_WORDS) {
+    return { reason: "title_too_many_words" };
+  }
+  if (!preservesTicketReferences(userPrompt, cleaned)) {
+    return { reason: "ticket_reference_missing" };
+  }
+
+  return {
+    title: cleaned,
+    reason: "ok",
+  };
+}
+
+function cleanThreadTitle(value: string): string {
+  let title = value.trim();
+  title = stripMatchingQuotes(title);
+  title = title.replace(/[.!?。！？]+$/u, "").trim();
+  return title;
+}
+
+function stripMatchingQuotes(value: string): string {
+  const pairs: Array<[string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["`", "`"],
+  ];
+
+  for (const [left, right] of pairs) {
+    if (value.startsWith(left) && value.endsWith(right) && value.length >= 2) {
+      return value.slice(1, -1).trim();
+    }
+  }
+
+  return value;
+}
+
+function countWords(value: string): number {
+  return value.split(/\s+/).filter(Boolean).length;
+}
+
+function preservesTicketReferences(userPrompt: string, title: string): boolean {
+  const promptRefs = extractTicketReferences(userPrompt);
+  if (promptRefs.length === 0) {
+    return true;
+  }
+
+  const normalizedTitle = normalizeReferenceText(title);
+  return promptRefs.some((reference) =>
+    normalizedTitle.includes(normalizeReferenceText(reference))
+  );
+}
+
+function extractTicketReferences(value: string): string[] {
+  const references: string[] = [];
+  const patterns = [
+    /\b[A-Z][A-Z0-9]+-\d+\b/g,
+    /#\d+\b/g,
+    /\b\d{2,}\b/g,
+    /\b(?:issue|pr|pull request)\s+#?\d+\b/gi,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of value.matchAll(pattern)) {
+      references.push(match[0]);
+    }
+  }
+
+  return references;
+}
+
+function normalizeReferenceText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -25,7 +25,7 @@ const THREAD_TITLE_RESPONSE_SCHEMA = {
   },
 } as const;
 
-type ThreadTitleAdapterParams = {
+export type ThreadTitleAdapterParams = {
   prompt: string;
   promptVersion: string;
   schema: Record<string, unknown>;
@@ -33,7 +33,7 @@ type ThreadTitleAdapterParams = {
   timeoutMs: number;
 };
 
-type ThreadTitleAdapterResult =
+export type ThreadTitleAdapterResult =
   | {
       status: "ok";
       object: unknown;

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -245,7 +245,7 @@ function preservesTicketReferences(userPrompt: string, title: string): boolean {
   }
 
   const normalizedTitle = normalizeReferenceText(title);
-  return promptRefs.some((reference) =>
+  return promptRefs.every((reference) =>
     normalizedTitle.includes(normalizeReferenceText(reference))
   );
 }

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -8,7 +8,7 @@ import { buildThreadTitlePrompt } from "./thread-title-prompt";
 export const THREAD_TITLE_PROMPT_VERSION = "thread-title-v1";
 export const DEFAULT_GROK_THREAD_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
 
-const THREAD_TITLE_TIMEOUT_MS = 5_000;
+const THREAD_TITLE_TIMEOUT_MS = 20_000;
 const MAX_TITLE_CHARACTERS = 50;
 const MAX_TITLE_WORDS = 6;
 

--- a/apps/desktop/src/main/app-server/thread-title-prompt.md
+++ b/apps/desktop/src/main/app-server/thread-title-prompt.md
@@ -1,0 +1,36 @@
+# Thread title guidelines
+
+You are writing a short title for a desktop app thread from the user's first prompt.
+
+Return only valid JSON. Do not wrap the JSON in markdown fences. Use this exact schema:
+
+```json
+{
+  "title": "<thread title>"
+}
+```
+
+Requirements:
+
+- Write the title in the same language as the user's prompt.
+- Keep the title under 50 characters when possible.
+- Keep the title to 6 words or fewer when possible.
+- Capture the main task, question, bug, artifact, or decision.
+- Prefer specific nouns from the prompt over generic wording.
+- Preserve code identifiers, filenames, product names, and proper nouns when they are central to the request.
+- Preserve ticket and work item references when present, including JIRA-style keys such as `PROJECT-123`, GitHub-style references such as `#123`, bare numeric issue or PR references such as `456`, and textual references such as `issue 123`, `Issue #123`, `PR 456`, or `pull request #456`.
+- If the user explicitly provides a title, use it unless it conflicts with the length limits.
+- Do not answer the prompt or explain the title.
+- Do not include markdown, quotes, labels, or trailing punctuation in the title.
+
+Examples:
+
+- User prompt: `Can we figure out why thread #456 does not update after rename?`
+  Output: `{ "title": "Thread #456 rename updates" }`
+- User prompt: `PROJ-123 investigate checkout crash`
+  Output: `{ "title": "PROJ-123 checkout crash" }`
+- User prompt: `In issue 789, where is foo_bar created?`
+  Output: `{ "title": "Issue 789 foo_bar origin" }`
+
+User prompt:
+{{USER_PROMPT}}

--- a/apps/desktop/src/main/app-server/thread-title-prompt.ts
+++ b/apps/desktop/src/main/app-server/thread-title-prompt.ts
@@ -1,0 +1,11 @@
+import threadTitlePrompt from "./thread-title-prompt.md?raw";
+
+const USER_PROMPT_PLACEHOLDER = "{{USER_PROMPT}}";
+
+export function readThreadTitlePrompt(): string {
+  return threadTitlePrompt;
+}
+
+export function buildThreadTitlePrompt(userPrompt: string): string {
+  return threadTitlePrompt.replace(USER_PROMPT_PLACEHOLDER, userPrompt.trim());
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -73,7 +73,10 @@ import type {
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
-const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 10_000;
+const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
+const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
+  web_search: "disabled",
+};
 const SUPPORTED_CODEX_MODEL_ORDER = [
   "gpt-5.5",
   "gpt-5.4",
@@ -2425,6 +2428,7 @@ function buildThreadStartPayload(params: {
   sandbox?: string;
   serviceTier?: string;
   ephemeral?: boolean;
+  config?: CodexThreadStartParams["config"];
 }): CodexThreadStartParams {
   const base: CodexThreadStartParams = {
     experimentalRawEvents: false,
@@ -2454,6 +2458,9 @@ function buildThreadStartPayload(params: {
   }
   if (params.ephemeral !== undefined) {
     base.ephemeral = params.ephemeral;
+  }
+  if (params.config) {
+    base.config = params.config;
   }
 
   return base;
@@ -3242,10 +3249,12 @@ export class CodexAppServerClient {
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             serviceTier: "fast",
             ephemeral: true,
+            config: CODEX_THREAD_TITLE_CONFIG,
           }),
           buildThreadStartPayload({
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             ephemeral: true,
+            config: CODEX_THREAD_TITLE_CONFIG,
           }),
         ],
         timeoutMs,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -552,6 +552,10 @@ function isPlaceholderThreadTitle(value: string | undefined): boolean {
   return value?.trim().toLowerCase() === "untitled thread";
 }
 
+function normalizeTitleForComparison(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
 function getThreadTitleInfo(record: Record<string, unknown>): {
   title: string;
   titleSource: AppServerThreadTitleSource;
@@ -561,14 +565,6 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
     pickString(record, ["title", "name", "headline"]) ??
       pickString(sessionRecord ?? {}, ["title", "name", "headline"])
   );
-
-  if (explicitTitle && !isPlaceholderThreadTitle(explicitTitle)) {
-    return {
-      title: explicitTitle,
-      titleSource: "explicit",
-    };
-  }
-
   const derivedTitle =
     pickString(record, ["preview", "snippet", "firstUserMessage", "first_user_message"]) ??
     pickString(sessionRecord ?? {}, [
@@ -577,10 +573,31 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
       "firstUserMessage",
       "first_user_message",
     ]);
+  const shortenedDerivedTitle = shortenDerivedThreadTitle(derivedTitle) ?? derivedTitle;
+
+  if (explicitTitle && !isPlaceholderThreadTitle(explicitTitle)) {
+    if (
+      derivedTitle &&
+      (normalizeTitleForComparison(explicitTitle) === normalizeTitleForComparison(derivedTitle) ||
+        (shortenedDerivedTitle &&
+          normalizeTitleForComparison(explicitTitle) ===
+            normalizeTitleForComparison(shortenedDerivedTitle)))
+    ) {
+      return {
+        title: shortenedDerivedTitle ?? explicitTitle,
+        titleSource: "derived",
+      };
+    }
+
+    return {
+      title: explicitTitle,
+      titleSource: "explicit",
+    };
+  }
 
   if (derivedTitle) {
     return {
-      title: shortenDerivedThreadTitle(derivedTitle) ?? derivedTitle,
+      title: shortenedDerivedTitle ?? derivedTitle,
       titleSource: "derived",
     };
   }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -279,6 +279,16 @@ function buildHelperTurnKey(threadId: string, turnId: string): string {
   return `${threadId}:${turnId}`;
 }
 
+function extractTurnIdFromNotificationParams(params: unknown): string | undefined {
+  const directTurnId = readStringFromRecord(params, "turnId");
+  if (directTurnId) {
+    return directTurnId;
+  }
+
+  const turn = asRecord(params)?.turn;
+  return readStringFromRecord(turn, "id");
+}
+
 function extractThreadIdFromNotification(
   notification: AppServerNotification,
   rawParams: unknown
@@ -2701,6 +2711,7 @@ export class CodexAppServerClient {
     }
   >();
   private readonly completedHelperTurnResults = new Map<string, HelperTurnResult>();
+  private readonly helperTurnTitleObjects = new Map<string, unknown>();
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -2796,6 +2807,7 @@ export class CodexAppServerClient {
     this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
     this.helperThreadIds.clear();
     this.completedHelperTurnResults.clear();
+    this.helperTurnTitleObjects.clear();
     await this.connection.close();
   }
 
@@ -2885,20 +2897,33 @@ export class CodexAppServerClient {
     method: string,
     notification: AppServerNotification
   ): void {
-    if (method !== "turn/completed" && method !== "turn/failed") {
+    if (
+      method !== "item/completed" &&
+      method !== "turn/completed" &&
+      method !== "turn/failed"
+    ) {
       return;
     }
 
     const threadId = readStringFromRecord(notification.params, "threadId");
-    const turnId = readStringFromRecord(notification.params, "turnId");
+    const turnId = extractTurnIdFromNotificationParams(notification.params);
     if (!threadId || !turnId) {
       return;
     }
 
     const key = buildHelperTurnKey(threadId, turnId);
+    if (method === "item/completed") {
+      const object = extractGeneratedTitleObject(notification.params);
+      if (object) {
+        this.helperTurnTitleObjects.set(key, object);
+      }
+      return;
+    }
+
     const waiter = this.helperTurnWaiters.get(key);
     if (method === "turn/failed") {
       const error = new Error("codex_title_turn_failed");
+      this.helperTurnTitleObjects.delete(key);
       if (!waiter) {
         this.completedHelperTurnResults.set(key, {
           status: "failed",
@@ -2912,7 +2937,10 @@ export class CodexAppServerClient {
       return;
     }
 
-    const object = extractGeneratedTitleObject(notification.params);
+    const object =
+      extractGeneratedTitleObject(notification.params) ??
+      this.helperTurnTitleObjects.get(key);
+    this.helperTurnTitleObjects.delete(key);
     if (!object) {
       const error = new Error("codex_title_turn_completed_without_title");
       if (!waiter) {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2664,6 +2664,16 @@ async function requestWithFallbacks(params: {
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+type HelperTurnResult =
+  | {
+      status: "ok";
+      object: unknown;
+    }
+  | {
+      status: "failed";
+      error: Error;
+    };
+
 export class CodexAppServerClient {
   private readonly connection: JsonRpcConnection;
   private readonly threadDirectoryEnricher: (
@@ -2690,6 +2700,7 @@ export class CodexAppServerClient {
       timer: ReturnType<typeof setTimeout>;
     }
   >();
+  private readonly completedHelperTurnResults = new Map<string, HelperTurnResult>();
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -2784,6 +2795,7 @@ export class CodexAppServerClient {
     this.initializeResult = null;
     this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
     this.helperThreadIds.clear();
+    this.completedHelperTurnResults.clear();
     await this.connection.close();
   }
 
@@ -2885,24 +2897,47 @@ export class CodexAppServerClient {
 
     const key = buildHelperTurnKey(threadId, turnId);
     const waiter = this.helperTurnWaiters.get(key);
-    if (!waiter) {
-      return;
-    }
-
-    clearTimeout(waiter.timer);
-    this.helperTurnWaiters.delete(key);
-
     if (method === "turn/failed") {
-      waiter.reject(new Error("codex_title_turn_failed"));
+      const error = new Error("codex_title_turn_failed");
+      if (!waiter) {
+        this.completedHelperTurnResults.set(key, {
+          status: "failed",
+          error,
+        });
+        return;
+      }
+      clearTimeout(waiter.timer);
+      this.helperTurnWaiters.delete(key);
+      waiter.reject(error);
       return;
     }
 
     const object = extractGeneratedTitleObject(notification.params);
     if (!object) {
-      waiter.reject(new Error("codex_title_turn_completed_without_title"));
+      const error = new Error("codex_title_turn_completed_without_title");
+      if (!waiter) {
+        this.completedHelperTurnResults.set(key, {
+          status: "failed",
+          error,
+        });
+        return;
+      }
+      clearTimeout(waiter.timer);
+      this.helperTurnWaiters.delete(key);
+      waiter.reject(error);
       return;
     }
 
+    if (!waiter) {
+      this.completedHelperTurnResults.set(key, {
+        status: "ok",
+        object,
+      });
+      return;
+    }
+
+    clearTimeout(waiter.timer);
+    this.helperTurnWaiters.delete(key);
     waiter.resolve(object);
   }
 
@@ -2912,6 +2947,15 @@ export class CodexAppServerClient {
     timeoutMs: number;
   }): Promise<unknown> {
     const key = buildHelperTurnKey(params.threadId, params.turnId);
+    const completed = this.completedHelperTurnResults.get(key);
+    if (completed) {
+      this.completedHelperTurnResults.delete(key);
+      if (completed.status === "failed") {
+        return Promise.reject(completed.error);
+      }
+      return Promise.resolve(completed.object);
+    }
+
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.helperTurnWaiters.delete(key);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -469,9 +469,10 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
   titleSource: AppServerThreadTitleSource;
 } {
   const sessionRecord = asRecord(record.session);
-  const explicitTitle =
+  const explicitTitle = normalizeExplicitThreadName(
     pickString(record, ["title", "name", "headline"]) ??
-    pickString(sessionRecord ?? {}, ["title", "name", "headline"]);
+      pickString(sessionRecord ?? {}, ["title", "name", "headline"])
+  );
 
   if (explicitTitle && !isPlaceholderThreadTitle(explicitTitle)) {
     return {
@@ -500,6 +501,28 @@ function getThreadTitleInfo(record: Record<string, unknown>): {
     title: "Untitled thread",
     titleSource: "fallback",
   };
+}
+
+function normalizeExplicitThreadName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || isPlaceholderThreadTitle(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function isPlaceholderThreadName(value: string | undefined): boolean {
+  return isPlaceholderThreadTitle(value);
+}
+
+function deriveThreadNameFromInput(input: AppServerTurnInputItem[]): string | undefined {
+  const text = input
+    .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
+    .map((item) => item.text.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  return (shortenDerivedThreadTitle(text) ?? text) || undefined;
 }
 
 async function resolveThreadProjectKey(
@@ -1713,14 +1736,12 @@ function extractThreadIndexEntryFromValue(
       "first_user_message",
     ]);
   const rawName =
-    pickString(record, ["threadName", "thread_name", "name", "title"]) ??
-    pickString(threadRecord ?? {}, ["threadName", "thread_name", "name", "title"]);
+    normalizeExplicitThreadName(
+      pickString(record, ["threadName", "thread_name", "name", "title"]) ??
+        pickString(threadRecord ?? {}, ["threadName", "thread_name", "name", "title"])
+    );
   const indexName =
-    rawName && !isPlaceholderThreadTitle(rawName)
-      ? rawName
-      : preview
-        ? shortenDerivedThreadTitle(preview) ?? preview
-        : rawName;
+    rawName ?? (preview ? shortenDerivedThreadTitle(preview) ?? preview : undefined);
   const updatedAt =
     normalizeEpochTimestamp(
       pickNumber(record, ["updatedAt", "updated_at", "lastActivityAt", "createdAt"]) ??
@@ -2566,7 +2587,7 @@ export class CodexAppServerClient {
   private readonly notificationListeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
   >();
-  private readonly indexedThreadIds = new Set<string>();
+  private readonly indexedThreads = new Map<string, CodexSessionIndexEntry>();
   private readonly requestListeners = new Set<
     (
       request: AppServerPendingRequestNotification
@@ -2696,15 +2717,48 @@ export class CodexAppServerClient {
 
   private async recordThreadInSessionIndex(value: unknown): Promise<void> {
     const entry = extractThreadIndexEntryFromValue(value);
-    if (!entry || this.indexedThreadIds.has(entry.id)) {
+    const previous = entry ? this.indexedThreads.get(entry.id) : undefined;
+    if (
+      !entry ||
+      (previous &&
+        (previous.thread_name === entry.thread_name ||
+          !isPlaceholderThreadName(previous.thread_name)))
+    ) {
       return;
     }
 
     try {
       await appendCodexSessionIndexEntry(this.getSessionIndexPath(), entry);
-      this.indexedThreadIds.add(entry.id);
+      this.indexedThreads.set(entry.id, entry);
     } catch (error) {
       codexClientLog.warn("failed to append codex session index", {
+        threadId: entry.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async recordDerivedThreadNameInSessionIndex(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+  }): Promise<void> {
+    const previous = this.indexedThreads.get(params.threadId);
+    const threadName = deriveThreadNameFromInput(params.input);
+    if (!previous || !threadName || !isPlaceholderThreadName(previous.thread_name)) {
+      return;
+    }
+
+    const entry: CodexSessionIndexEntry = {
+      ...previous,
+      thread_name: threadName,
+      updated_at: new Date().toISOString(),
+    };
+
+    try {
+      await appendCodexSessionIndexEntry(this.getSessionIndexPath(), entry);
+      this.indexedThreads.set(entry.id, entry);
+    } catch (error) {
+      codexClientLog.warn("failed to append derived codex session index title", {
         threadId: entry.id,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -2926,6 +2980,10 @@ export class CodexAppServerClient {
 
     const threadId = extractThreadIdFromValue(result) ?? params.threadId;
     const turnId = extractTurnIdFromValue(result) ?? `pending:${threadId}`;
+    await this.recordDerivedThreadNameInSessionIndex({
+      threadId: params.threadId,
+      input: params.input,
+    });
 
     return { threadId, turnId };
   }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -65,9 +65,15 @@ import {
   type ThreadDirectoryEnrichment,
 } from "./thread-directory-enricher";
 import { StdioJsonRpcTransport } from "./stdio-transport";
+import type {
+  ThreadTitleAdapterParams,
+  ThreadTitleAdapterResult,
+} from "../app-server/thread-title-generation-service";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
+const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
+const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 10_000;
 const SUPPORTED_CODEX_MODEL_ORDER = [
   "gpt-5.5",
   "gpt-5.4",
@@ -262,6 +268,75 @@ function pickString(
     }
   }
   return undefined;
+}
+
+function readStringFromRecord(value: unknown, key: string): string | undefined {
+  const record = asRecord(value);
+  return record ? pickString(record, [key]) : undefined;
+}
+
+function buildHelperTurnKey(threadId: string, turnId: string): string {
+  return `${threadId}:${turnId}`;
+}
+
+function extractThreadIdFromNotification(
+  notification: AppServerNotification,
+  rawParams: unknown
+): string | undefined {
+  return (
+    readStringFromRecord(notification.params, "threadId") ??
+    extractThreadIdFromValue(rawParams)
+  );
+}
+
+function extractGeneratedTitleObject(value: unknown): unknown | undefined {
+  if (typeof value === "string") {
+    const parsed = parseStructuredValue(value);
+    return isThreadTitleObject(parsed) ? parsed : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const object = extractGeneratedTitleObject(entry);
+      if (object) {
+        return object;
+      }
+    }
+    return undefined;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  if (isThreadTitleObject(record)) {
+    return { title: record.title };
+  }
+
+  for (const key of [
+    "output",
+    "content",
+    "message",
+    "text",
+    "item",
+    "items",
+    "turn",
+    "response",
+    "result",
+    "data",
+  ]) {
+    const object = extractGeneratedTitleObject(record[key]);
+    if (object) {
+      return object;
+    }
+  }
+
+  return undefined;
+}
+
+function isThreadTitleObject(value: unknown): value is { title: string } {
+  const record = asRecord(value);
+  return typeof record?.title === "string" && record.title.trim().length > 0;
 }
 
 function pickRawString(
@@ -2339,6 +2414,7 @@ function buildThreadStartPayload(params: {
   approvalPolicy?: string;
   sandbox?: string;
   serviceTier?: string;
+  ephemeral?: boolean;
 }): CodexThreadStartParams {
   const base: CodexThreadStartParams = {
     experimentalRawEvents: false,
@@ -2365,6 +2441,9 @@ function buildThreadStartPayload(params: {
   const serviceTier = normalizeCodexServiceTier(params.serviceTier);
   if (serviceTier) {
     base.serviceTier = serviceTier;
+  }
+  if (params.ephemeral !== undefined) {
+    base.ephemeral = params.ephemeral;
   }
 
   return base;
@@ -2483,6 +2562,8 @@ function buildTurnStartPayload(params: {
   input: AppServerTurnInputItem[];
   model?: string;
   reasoningEffort?: string;
+  serviceTier?: string;
+  outputSchema?: CodexTurnStartParams["outputSchema"];
   collaborationMode?: AppServerCollaborationModeRequest;
   collaborationFallbackModel?: string;
   collaborationFallbackReasoningEffort?: string;
@@ -2499,6 +2580,13 @@ function buildTurnStartPayload(params: {
   const reasoningEffort = normalizeCodexReasoningEffort(params.reasoningEffort);
   if (reasoningEffort) {
     base.effort = reasoningEffort;
+  }
+  const serviceTier = normalizeCodexServiceTier(params.serviceTier);
+  if (serviceTier) {
+    base.serviceTier = serviceTier;
+  }
+  if (params.outputSchema) {
+    base.outputSchema = params.outputSchema;
   }
 
   const collaborationMode = buildCollaborationModePayload({
@@ -2593,6 +2681,15 @@ export class CodexAppServerClient {
       request: AppServerPendingRequestNotification
     ) => Promise<unknown> | unknown
   >();
+  private readonly helperThreadIds = new Set<string>();
+  private readonly helperTurnWaiters = new Map<
+    string,
+    {
+      resolve: (object: unknown) => void;
+      reject: (error: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -2627,13 +2724,18 @@ export class CodexAppServerClient {
         await this.recordThreadInSessionIndex(params);
       }
 
+      const normalized = normalizeServerNotification(
+        method,
+        params,
+      );
+      const helperThreadId = extractThreadIdFromNotification(normalized, params);
+      if (helperThreadId && this.helperThreadIds.has(helperThreadId)) {
+        this.handleHelperThreadNotification(method, normalized);
+        return;
+      }
+
       for (const listener of this.notificationListeners) {
-        await listener(
-          normalizeServerNotification(
-            method,
-            params,
-          )
-        );
+        await listener(normalized);
       }
     });
     this.connection.setRequestHandler(async (method, params, rpcId) => {
@@ -2680,6 +2782,8 @@ export class CodexAppServerClient {
     this.initialized = false;
     this.initializationPromise = null;
     this.initializeResult = null;
+    this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
+    this.helperThreadIds.clear();
     await this.connection.close();
   }
 
@@ -2762,6 +2866,70 @@ export class CodexAppServerClient {
         threadId: entry.id,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  private handleHelperThreadNotification(
+    method: string,
+    notification: AppServerNotification
+  ): void {
+    if (method !== "turn/completed" && method !== "turn/failed") {
+      return;
+    }
+
+    const threadId = readStringFromRecord(notification.params, "threadId");
+    const turnId = readStringFromRecord(notification.params, "turnId");
+    if (!threadId || !turnId) {
+      return;
+    }
+
+    const key = buildHelperTurnKey(threadId, turnId);
+    const waiter = this.helperTurnWaiters.get(key);
+    if (!waiter) {
+      return;
+    }
+
+    clearTimeout(waiter.timer);
+    this.helperTurnWaiters.delete(key);
+
+    if (method === "turn/failed") {
+      waiter.reject(new Error("codex_title_turn_failed"));
+      return;
+    }
+
+    const object = extractGeneratedTitleObject(notification.params);
+    if (!object) {
+      waiter.reject(new Error("codex_title_turn_completed_without_title"));
+      return;
+    }
+
+    waiter.resolve(object);
+  }
+
+  private waitForHelperTurnTitle(params: {
+    threadId: string;
+    turnId: string;
+    timeoutMs: number;
+  }): Promise<unknown> {
+    const key = buildHelperTurnKey(params.threadId, params.turnId);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.helperTurnWaiters.delete(key);
+        reject(new Error("codex_title_turn_timeout"));
+      }, Math.max(100, params.timeoutMs));
+      this.helperTurnWaiters.set(key, {
+        resolve,
+        reject,
+        timer,
+      });
+    });
+  }
+
+  private rejectHelperTurnWaiters(error: Error): void {
+    for (const [key, waiter] of this.helperTurnWaiters) {
+      clearTimeout(waiter.timer);
+      this.helperTurnWaiters.delete(key);
+      waiter.reject(error);
     }
   }
 
@@ -2986,6 +3154,91 @@ export class CodexAppServerClient {
     });
 
     return { threadId, turnId };
+  }
+
+  async generateTitle(params: ThreadTitleAdapterParams): Promise<ThreadTitleAdapterResult> {
+    await this.ensureInitialized();
+
+    let helperThreadId: string | undefined;
+    const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
+    try {
+      const threadStartResult = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["thread/start"],
+        payloads: [
+          buildThreadStartPayload({
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            serviceTier: "fast",
+            ephemeral: true,
+          }),
+          buildThreadStartPayload({
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            ephemeral: true,
+          }),
+        ],
+        timeoutMs,
+      });
+      helperThreadId = extractThreadIdFromValue(threadStartResult);
+      if (!helperThreadId) {
+        return {
+          status: "failed",
+          reason: "codex_title_thread_start_missing_thread_id",
+        };
+      }
+      this.helperThreadIds.add(helperThreadId);
+
+      const turnStartResult = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["turn/start"],
+        payloads: [
+          buildTurnStartPayload({
+            threadId: helperThreadId,
+            input: [{ type: "text", text: params.prompt }],
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            serviceTier: "fast",
+            reasoningEffort: "low",
+            outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
+          }),
+          buildTurnStartPayload({
+            threadId: helperThreadId,
+            input: [{ type: "text", text: params.prompt }],
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            reasoningEffort: "low",
+            outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
+          }),
+        ],
+        timeoutMs,
+      });
+      const immediateObject = extractGeneratedTitleObject(turnStartResult);
+      if (immediateObject) {
+        return {
+          status: "ok",
+          object: immediateObject,
+        };
+      }
+
+      const turnId = extractTurnIdFromValue(turnStartResult);
+      if (!turnId) {
+        return {
+          status: "failed",
+          reason: "codex_title_turn_start_missing_turn_id",
+        };
+      }
+
+      return {
+        status: "ok",
+        object: await this.waitForHelperTurnTitle({
+          threadId: helperThreadId,
+          turnId,
+          timeoutMs,
+        }),
+      };
+    } catch (error) {
+      return {
+        status: "failed",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   async startReview(params: {

--- a/apps/desktop/src/main/diff-focus/focused-diff-service.ts
+++ b/apps/desktop/src/main/diff-focus/focused-diff-service.ts
@@ -1,9 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  resolveGrokAppServerRuntimeConfig,
-  XaiAiSdkObjectClient,
-  type XaiAiSdkObjectResult
-} from "@pwragnt/agent-core";
+import type { XaiAiSdkObjectResult } from "@pwragnt/agent-core";
 import type {
   FocusedDiffAnalysisRequest,
   FocusedDiffAnalysisResponse,
@@ -16,6 +12,10 @@ import {
   parseUnifiedDiff,
   summarizeHunksForFocus
 } from "../../shared/diff-focus";
+import {
+  XaiEphemeralObjectCaller,
+  type XaiObjectClientLike,
+} from "../app-server/ephemeral-object-call";
 
 const FOCUSED_DIFF_PROMPT_VERSION = "focused-diff-v1";
 const FOCUSED_DIFF_MODEL = "grok-4-1-fast-reasoning";
@@ -71,12 +71,10 @@ const FOCUSED_DIFF_SYSTEM_PROMPT = [
   "Return JSON that matches the schema exactly."
 ].join("\n");
 
-type XaiClientLike = Pick<XaiAiSdkObjectClient, "generateObject">;
-
 type FocusedDiffServiceOptions = {
   apiKey?: string;
   baseUrl?: string;
-  client?: XaiClientLike;
+  client?: XaiObjectClientLike;
   model?: string;
   promptVersion?: string;
   timeoutMs?: number;
@@ -84,24 +82,21 @@ type FocusedDiffServiceOptions = {
 
 export class FocusedDiffService {
   private readonly cache = new Map<string, FocusedDiffAnalysisResponse>();
-  private readonly configuredClient?: XaiClientLike;
-  private readonly configuredApiKey?: string;
-  private readonly configuredBaseUrl?: string;
+  private readonly objectCaller: XaiEphemeralObjectCaller;
   private readonly configuredModel?: string;
   private readonly promptVersion: string;
   private readonly timeoutMs: number;
-  private runtimeConfig:
-    | ReturnType<typeof resolveGrokAppServerRuntimeConfig>
-    | undefined;
-  private envClient: XaiClientLike | null | undefined;
 
   constructor(options: FocusedDiffServiceOptions = {}) {
-    this.configuredClient = options.client;
-    this.configuredApiKey = options.apiKey?.trim() || undefined;
-    this.configuredBaseUrl = options.baseUrl?.trim() || undefined;
     this.configuredModel = options.model?.trim() || undefined;
     this.promptVersion = options.promptVersion?.trim() || FOCUSED_DIFF_PROMPT_VERSION;
     this.timeoutMs = options.timeoutMs ?? FOCUSED_DIFF_TIMEOUT_MS;
+    this.objectCaller = new XaiEphemeralObjectCaller({
+      apiKey: options.apiKey,
+      baseUrl: options.baseUrl,
+      client: options.client,
+      model: this.getModel(),
+    });
   }
 
   async analyze(
@@ -146,13 +141,8 @@ export class FocusedDiffService {
       return testOverride;
     }
 
-    const client = this.getClient();
-    if (!client) {
-      return this.buildFallbackResponse(decisions, "grok_unavailable");
-    }
-
     try {
-      const response = await this.requestFocusedDiffDecision(client, request.filePath, hunks);
+      const response = await this.requestFocusedDiffDecision(request.filePath, hunks);
       const result = normalizeFocusedDiffResult(response, parsed.hunks.length);
       const analysis: FocusedDiffAnalysisResponse = {
         mode: result.hiddenHunkIndices.length > 0 ? "focused" : "fallback",
@@ -187,73 +177,35 @@ export class FocusedDiffService {
     };
   }
 
-  private getClient(): XaiClientLike | null {
-    if (this.configuredClient) {
-      return this.configuredClient;
-    }
-
-    if (this.envClient !== undefined) {
-      return this.envClient;
-    }
-
-    const runtimeConfig = this.getRuntimeConfig();
-    const apiKey = this.configuredApiKey ?? runtimeConfig.apiKey;
-    if (!apiKey) {
-      this.envClient = null;
-      return this.envClient;
-    }
-
-    this.envClient = new XaiAiSdkObjectClient({
-      apiKey,
-      baseUrl: this.configuredBaseUrl ?? runtimeConfig.baseUrl,
-      model: this.getModel()
-    });
-
-    return this.envClient;
-  }
-
-  private getRuntimeConfig(): ReturnType<typeof resolveGrokAppServerRuntimeConfig> {
-    if (this.runtimeConfig) {
-      return this.runtimeConfig;
-    }
-
-    this.runtimeConfig = resolveGrokAppServerRuntimeConfig();
-    return this.runtimeConfig;
-  }
-
   private getModel(): string {
     return this.configuredModel ?? FOCUSED_DIFF_MODEL;
   }
 
   private async requestFocusedDiffDecision(
-    client: XaiClientLike,
     filePath: string | undefined,
     hunks: FocusedDiffHunkSummary[]
   ): Promise<XaiAiSdkObjectResult> {
-    const controller = new AbortController();
-    const timeoutHandle = setTimeout(() => {
-      controller.abort();
-    }, this.timeoutMs);
+    const result = await this.objectCaller.generateObject({
+      model: this.getModel(),
+      promptCacheKey: this.promptVersion,
+      headers: {
+        "x-grok-conv-id": this.promptVersion
+      },
+      timeoutMs: this.timeoutMs,
+      schema: FOCUSED_DIFF_RESPONSE_SCHEMA,
+      schemaName: "focused_diff_hunk_decisions",
+      system: FOCUSED_DIFF_SYSTEM_PROMPT,
+      prompt: JSON.stringify({
+        filePath,
+        hunks
+      })
+    });
 
-    try {
-      return await client.generateObject({
-        model: this.getModel(),
-        promptCacheKey: this.promptVersion,
-        headers: {
-          "x-grok-conv-id": this.promptVersion
-        },
-        signal: controller.signal,
-        schema: FOCUSED_DIFF_RESPONSE_SCHEMA,
-        schemaName: "focused_diff_hunk_decisions",
-        system: FOCUSED_DIFF_SYSTEM_PROMPT,
-        prompt: JSON.stringify({
-          filePath,
-          hunks
-        })
-      });
-    } finally {
-      clearTimeout(timeoutHandle);
+    if (result.status === "ok") {
+      return result.response;
     }
+
+    throw new Error(result.status === "unavailable" ? "grok_unavailable" : result.reason);
   }
 }
 

--- a/docs/plans/2026-04-28-001-feat-desktop-out-of-band-thread-naming-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-out-of-band-thread-naming-plan.md
@@ -1,0 +1,397 @@
+---
+title: feat: Add desktop-owned out-of-band thread naming
+type: feat
+status: active
+date: 2026-04-28
+---
+
+# feat: Add desktop-owned out-of-band thread naming
+
+## Overview
+
+Add a desktop-owned out-of-band title generation flow for new thread prompts. The desktop app should use the same provider family as the active backend, choose an appropriate lightweight model, generate a short title with the shared title prompt, and apply the result through the existing `thread/name/set` capability. The app-server protocol should not grow a "generate a title" method; app servers only need to support the already-existing "apply this name" mutation.
+
+## Problem Frame
+
+PwrAgnt currently has two different naming behaviors in play. The desktop can derive a local title from the first prompt, and Codex Desktop appears to make a separate ephemeral generation call that later applies a polished name through `thread/name/set`. The existing PwrAgnt code now has a shared title prompt, but no code sends that prompt to a model or applies the generated title.
+
+There is also an existing desktop out-of-band model-call pattern in the focused-diff feature. That path is xAI-specific today, possibly underused, but it already demonstrates the right desktop ownership boundary: a renderer or desktop workflow asks the main process for an ephemeral model decision, the main process uses a short timeout, validates structured output, caches/falls back conservatively, and does not expose that decision as app-server protocol.
+
+## Requirements Trace
+
+- R1. Generate thread titles out of band from the user's first meaningful prompt, without blocking the user turn.
+- R2. Keep ownership in the desktop app; do not add an app-server protocol method for title generation.
+- R3. Apply generated names only through existing backend rename support, especially `thread/name/set`.
+- R4. Use the same provider family as the selected backend: Codex/OpenAI for Codex-backed threads and xAI/Grok for Grok-backed threads.
+- R5. Use appropriate lightweight defaults: `gpt-5.4-mini` with low reasoning and fast service tier for Codex; `grok-4-1-fast-non-reasoning` for Grok title generation unless implementation-time model availability says otherwise.
+- R6. Use the shared desktop thread-title prompt and enforce a 50-character, 6-word output limit with validation.
+- R7. Preserve user intent and ticket references, including JIRA keys, GitHub issue/PR numbers, bare numeric references, and textual references.
+- R8. Do not overwrite a user-supplied or already explicit thread name if the out-of-band request completes late.
+- R9. Fail soft: if title generation is unavailable, times out, returns invalid JSON, or returns an unusable title, keep the existing derived/fallback title behavior.
+- R10. Keep protocol capture and desktop tests able to distinguish user-visible backend traffic from desktop-owned ephemeral helper traffic.
+
+## Scope Boundaries
+
+- In scope: desktop main-process title generation orchestration, provider-specific generation adapters, race guards, structured output validation, and tests.
+- In scope: extending the existing desktop Codex client with a private helper for ephemeral generation using supported app-server fields such as `ephemeral` and `outputSchema`.
+- In scope: reusing or extracting focused-diff's xAI object-call pattern so Grok title generation is not a one-off.
+- Out of scope: adding a public app-server `thread/title/generate` method or changing the normalized desktop app-server contract for normal thread turns.
+- Out of scope: renderer UI controls for enabling/disabling automatic naming.
+- Out of scope: replacing local derived title fallback behavior; generated names improve the title when available but should not become a hard dependency.
+- Out of scope: changing the already-written title prompt beyond implementation-time fixes needed for schema compatibility.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/app-server/thread-title-prompt.md` and `apps/desktop/src/main/app-server/thread-title-prompt.ts` now hold the shared desktop title prompt and builder.
+- `apps/desktop/src/main/diff-focus/focused-diff-service.ts` is the current desktop-owned out-of-band model-call pattern. It uses `XaiAiSdkObjectClient`, a prompt version, a short timeout, a JSON schema, a prompt-cache key, a deterministic test override, validation, cache keys, and soft fallback.
+- `apps/desktop/src/main/__tests__/focused-diff-service.test.ts` proves the focused-diff path with injected clients and with xAI runtime config.
+- `packages/agent-core/src/providers/xai-ai-sdk-object-client.ts` wraps `generateObject` from the AI SDK, injects xAI prompt cache keys into Responses API calls, accepts a schema, and returns parsed object output plus cache token metadata.
+- `packages/agent-core/src/config/grok-app-server-config.ts` is already exported through `packages/agent-core/src/index.ts`, so desktop code can load the same xAI API key and base URL as the Grok app server without adding new config plumbing.
+- `apps/desktop/src/main/codex-app-server/client.ts` already centralizes Codex JSON-RPC requests, notification filtering, model defaults, `thread/start`, `turn/start`, and `thread/name/set`.
+- `packages/shared/src/generated/codex-app-server-protocol/v2/ThreadStartParams.ts` includes `ephemeral`, and `TurnStartParams.ts` includes `outputSchema`, `model`, `serviceTier`, and `effort`.
+- `apps/desktop/src/main/grok-app-server/client.ts`, `packages/agent-core/src/app-server/codex-app-server.ts`, and `packages/agent-core/src/app-server/session-state.ts` already support `thread/name/set` and `thread/name/updated`.
+- `apps/desktop/src/main/app-server/backend-registry.ts` is the desktop composition boundary for `startTurn`, backend model defaults, backend client selection, rename routing, and agent-event broadcasting.
+- `docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md` established `explicit`, `derived`, and `fallback` title states and kept app-server naming semantics separate from desktop normalization.
+
+### Institutional Learnings
+
+- No `docs/solutions/` artifacts exist yet for reusable desktop ephemeral model calls or automatic thread naming.
+
+### External References
+
+- None. Local Codex protocol bindings and the existing focused-diff pattern are sufficient for planning.
+
+## Key Technical Decisions
+
+- Desktop-owned orchestration: implement title generation from `DesktopBackendRegistry` or a service it owns, not from `packages/agent-core` app-server methods. The desktop has the user prompt, selected backend, model settings, and rename routing context.
+- Provider-specific generation adapters behind one title service: use a common `ThreadTitleGenerationService` API with Codex and Grok adapters underneath. This keeps provider details isolated while giving the registry one place to schedule, validate, and apply titles.
+- Codex uses the Codex app-server as the OpenAI transport: start an ephemeral helper thread with `gpt-5.4-mini`, `serviceTier: fast`, and low reasoning, then start a structured-output turn using the title prompt. This avoids requiring separate OpenAI API credentials in the desktop app.
+- Grok uses the existing xAI structured object-call pattern: adapt or share the focused-diff object-call infrastructure with a default `grok-4-1-fast-non-reasoning` model, short timeout, schema validation, and soft fallback.
+- Keep provider adapters injected, not globally discovered: the registry should construct the title service with access to the same Codex default/full-access clients and Grok config helpers it already owns, so tests can inject deterministic adapters and replay mode can disable or stub generation.
+- Apply through rename only after validation and freshness checks: the generated title becomes user-visible only through the selected backend client's `renameThread` path, which maps to `thread/name/set`.
+- Do not override explicit names: before applying, refresh or inspect the current thread summary and skip if `titleSource` is `explicit`, if the name no longer looks like the prompt-derived placeholder, or if a newer pending generation superseded this request.
+- Suppress ephemeral helper noise: Codex helper threads and turns must not leak normal agent events into the renderer or thread list. The Codex client should route helper-thread notifications to the waiting generation request and keep them out of `onNotification` subscribers.
+- Keep fallback deterministic: if any model call fails, the current derived-title behavior remains the only visible result.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should title generation live in `packages/agent-core`? No. The user explicitly wants this owned by the desktop app and not exposed by the app-server protocol except through the existing name-apply mutation.
+- Should Grok title generation use the main Grok turn runner? No for the first implementation. The focused-diff pattern already provides a lighter object-call path that avoids creating transcript items or app-server turns.
+- Should Codex title generation call OpenAI directly? No for the first implementation. The desktop Codex integration should reuse the Codex app server so it uses the user's existing Codex provider/auth context.
+- Should generated names replace the explicit/derived/fallback title model? No. They become explicit names only after `thread/name/set`; derived/fallback remains the safety net.
+
+### Deferred to Implementation
+
+- Exact Codex notification shape for capturing the final structured title from an ephemeral `turn/start` response. The generated protocol types show the needed input fields, but implementation should verify the terminal notification path against captured traffic or focused tests.
+- Whether `gpt-5.4-mini` supports `serviceTier: fast` in all current Codex app-server environments. If the app server rejects the combination, fall back to the same model with no service tier before abandoning generation.
+- Whether `grok-4-1-fast-non-reasoning` is always available in configured xAI accounts. If unavailable, the implementation may fall back to another fast non-reasoning Grok model from backend metadata.
+- Whether title generation should be triggered only for the first user turn or also for previously created empty threads when their first turn arrives after app restart. The first implementation should cover first meaningful turn in the live desktop path and can broaden after tests expose a clean persisted-state signal.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Renderer
+    participant Registry as DesktopBackendRegistry
+    participant Title as ThreadTitleGenerationService
+    participant Backend as Backend client
+    participant Model as Lightweight provider call
+
+    Renderer->>Registry: startTurn(threadId, backend, input)
+    Registry->>Backend: turn/start
+    Backend-->>Registry: threadId + turnId
+    Registry-->>Renderer: startTurn response
+    Registry->>Title: schedule title generation
+    Title->>Model: ephemeral structured title request
+    Model-->>Title: { title }
+    Title->>Registry: valid title candidate
+    Registry->>Backend: thread/name/set
+    Backend-->>Renderer: thread/name/updated event
+```
+
+```mermaid
+flowchart TB
+    START["startTurn succeeds"] --> TEXT["extract first meaningful text input"]
+    TEXT --> EMPTY{"usable prompt?"}
+    EMPTY -- "no" --> STOP["do nothing"]
+    EMPTY -- "yes" --> GEN["generate title with backend provider"]
+    GEN --> VALID{"valid title under constraints?"}
+    VALID -- "no" --> KEEP["keep derived/fallback title"]
+    VALID -- "yes" --> CURRENT["refresh current thread summary"]
+    CURRENT --> EXPLICIT{"titleSource explicit?"}
+    EXPLICIT -- "yes" --> SKIP["skip late result"]
+    EXPLICIT -- "no" --> RENAME["apply via thread/name/set"]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Characterize and extract the ephemeral object-call pattern**
+
+**Goal:** Make the focused-diff out-of-band call pattern reusable enough for title generation without breaking focused diff.
+
+**Requirements:** R2, R4, R9, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/diff-focus/focused-diff-service.ts`
+- Create: `apps/desktop/src/main/app-server/ephemeral-object-call.ts`
+- Test: `apps/desktop/src/main/__tests__/focused-diff-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts`
+
+**Approach:**
+- Start with characterization coverage around focused-diff's current client injection, timeout fallback, prompt-cache key, schema forwarding, and config loading.
+- Extract only the common xAI object-call plumbing that title generation actually needs: runtime config resolution, injected client support, timeout handling, model override, prompt cache key, schema forwarding, and soft error mapping.
+- Keep focused-diff-specific eligibility, cache keys, hunk normalization, confidence thresholds, and test override behavior inside `FocusedDiffService`.
+- Do not generalize Codex app-server helper turns into this xAI object-call helper; Codex needs a separate adapter because its provider access comes through the Codex app server.
+
+**Execution note:** Characterization-first. Preserve focused-diff behavior before extracting shared plumbing because this path may be stale.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/diff-focus/focused-diff-service.ts`
+- `apps/desktop/src/main/__tests__/focused-diff-service.test.ts`
+- `packages/agent-core/src/providers/xai-ai-sdk-object-client.ts`
+
+**Test scenarios:**
+- Happy path: focused diff still sends the configured schema, prompt cache key, and model after the extraction.
+- Happy path: the extracted helper returns parsed object output and cached-token metadata from an injected client.
+- Edge case: missing xAI API key returns a soft unavailable result without throwing to the caller.
+- Error path: timeout or rejected model call becomes a typed failure result that focused diff can convert to its existing fallback response.
+- Regression: focused-diff cache behavior remains owned by `FocusedDiffService` and does not move into the generic helper.
+
+**Verification:**
+- Focused diff tests still pass, and the new helper has direct tests proving the reusable call boundary.
+
+- [ ] **Unit 2: Add a desktop thread-title generation service**
+
+**Goal:** Centralize prompt construction, model selection, structured-output validation, and title cleanup behind one desktop-owned service.
+
+**Requirements:** R1, R2, R4, R5, R6, R7, R9
+
+**Dependencies:** Unit 1 for the Grok/xAI helper path
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/thread-title-prompt.ts`
+- Create: `apps/desktop/src/main/app-server/thread-title-generation-service.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-title-prompt.test.ts`
+
+**Approach:**
+- Define a small service API that accepts backend kind, first user prompt text, and optional provider/client overrides for tests.
+- Model provider adapters explicitly, for example as Codex and Grok generator dependencies passed to the service constructor. The service should not reach into singleton registries or create backend clients on its own.
+- Use `buildThreadTitlePrompt()` as the prompt source and require structured JSON with a single `title` field.
+- Add output normalization that trims whitespace and quotes, rejects empty titles, strips trailing punctuation when needed, and enforces 50 characters and 6 words by rejecting or conservatively truncating only when doing so does not corrupt ticket references.
+- Preserve ticket references by validating that known references present in the prompt and title are not damaged by cleanup; if cleanup would break a reference, keep fallback derived behavior instead of applying a bad generated name.
+- Return a result object that distinguishes `generated`, `unavailable`, `invalid`, and `failed`, so the registry can log useful state without throwing.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/thread-title-prompt.ts`
+- `packages/shared/src/contracts/normalized-app-server.ts` for `AppServerBackendKind`
+- Focused-diff's structured response validation style
+
+**Test scenarios:**
+- Happy path: a valid `{ "title": "PROJECT-123 checkout crash" }` result is accepted.
+- Happy path: a title preserving `#123`, `issue 123`, `PR 456`, and a bare `456` reference survives normalization.
+- Edge case: output over 50 characters or over 6 words is rejected or safely normalized according to the service rule.
+- Edge case: title cleanup removes wrapper quotes and trailing punctuation without changing meaningful text.
+- Error path: malformed JSON, missing `title`, non-string `title`, or empty title returns `invalid` and does not throw.
+- Error path: adapter failure returns `failed` or `unavailable` with a reason.
+
+**Verification:**
+- Title prompt constraints are tested at the service boundary, not only by checking prompt file contents.
+
+- [ ] **Unit 3: Implement Codex app-server ephemeral title generation**
+
+**Goal:** Use Codex/OpenAI for Codex-backed thread naming without adding a direct OpenAI dependency or new app-server protocol method.
+
+**Requirements:** R2, R3, R4, R5, R9, R10
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+
+**Approach:**
+- Add a private or narrowly exposed Codex client method for ephemeral structured generation that the title service can call through an injected Codex title adapter. This can be represented as an optional capability on the desktop `BackendClient` type or as a separate adapter object owned by the registry; the key boundary is that normal app-server consumers still do not see a title-generation protocol method.
+- Start a helper thread with `ephemeral: true`, `model: "gpt-5.4-mini"`, `serviceTier: "fast"`, `experimentalRawEvents: false`, and `persistExtendedHistory: false`.
+- Start a helper turn with the built title prompt, `effort: "low"`, and an `outputSchema` requiring `{ "title": "string" }`.
+- Correlate terminal notifications for the helper thread/turn and resolve the waiting generation request with the final assistant text or structured object payload.
+- Suppress helper-thread notifications from normal `onNotification` subscribers so ephemeral generation does not create visible transcript activity or protocol-capture confusion in the main thread.
+- Apply fallback attempts conservatively: if the app server rejects `serviceTier: "fast"`, try once without `serviceTier`; if `ephemeral` or `outputSchema` is unsupported, return `unavailable` and leave local derived naming intact.
+- Keep generated title application outside this client method; the client should generate a candidate, and the registry should decide whether to call `thread/name/set` on the real thread.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/codex-app-server/client.ts` request fallback helpers and notification listener management
+- `packages/shared/src/generated/codex-app-server-protocol/v2/ThreadStartParams.ts`
+- `packages/shared/src/generated/codex-app-server-protocol/v2/TurnStartParams.ts`
+- `apps/desktop/src/main/__tests__/codex-client.test.ts` mock transport assertions
+
+**Test scenarios:**
+- Happy path: Codex title generation sends `thread/start` with `ephemeral: true`, `model: "gpt-5.4-mini"`, and fast service tier.
+- Happy path: Codex title generation sends `turn/start` with low effort, the title prompt, and an output schema.
+- Happy path: a helper turn completion resolves to the generated title candidate.
+- Edge case: helper-thread notifications are consumed by the pending generation and not forwarded to desktop event subscribers.
+- Error path: unsupported fast service tier falls back once without fast tier.
+- Error path: helper turn timeout or malformed completion returns a soft failure and cleans up pending waiters.
+
+**Verification:**
+- Codex-backed title generation uses the Codex app server and never requires separate OpenAI credentials.
+
+- [ ] **Unit 4: Implement Grok fast-model title generation**
+
+**Goal:** Use a lightweight Grok model for Grok-backed thread naming through the reusable desktop xAI object-call path.
+
+**Requirements:** R2, R3, R4, R5, R6, R7, R9
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/thread-title-generation-service.ts`
+- Modify: `apps/desktop/src/main/app-server/ephemeral-object-call.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts`
+
+**Approach:**
+- Add a Grok adapter that uses the extracted xAI object-call helper with `grok-4-1-fast-non-reasoning` as the default model.
+- Use `resolveGrokAppServerRuntimeConfig()` so the desktop-owned call uses the same configured xAI API key and base URL as the Grok app server.
+- Use a title-specific prompt cache key such as the prompt version, pass the title JSON schema, and keep timeout short so naming cannot stall the desktop.
+- Allow tests to inject an object client and model override without mutating global config.
+- Return unavailable when xAI credentials are absent; do not surface this as a user-visible error.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/diff-focus/focused-diff-service.ts`
+- `packages/agent-core/src/providers/xai-ai-sdk-object-client.ts`
+- `packages/agent-core/src/providers/xai-model-selection.ts`
+- `packages/agent-core/src/app-server/metadata-service.ts`
+
+**Test scenarios:**
+- Happy path: Grok generation calls xAI with `grok-4-1-fast-non-reasoning`, title schema, and prompt cache key.
+- Happy path: configured base URL and API key are read from the existing Grok runtime config.
+- Edge case: injected model override is used for tests or future model availability fallback.
+- Error path: missing xAI credentials returns unavailable and does not throw.
+- Error path: xAI rejection or invalid object output returns soft failure and leaves title application to fallback behavior.
+
+**Verification:**
+- Grok-backed title generation uses an xAI fast model and does not create transcript items or app-server turns.
+
+- [ ] **Unit 5: Schedule generation after first turn and apply names safely**
+
+**Goal:** Trigger provider-specific title generation from the desktop start-turn flow and apply valid names without races or user-name clobbering.
+
+**Requirements:** R1, R2, R3, R8, R9, R10
+
+**Dependencies:** Units 2-4
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/agent-ipc.test.ts`
+
+**Approach:**
+- Add a registry-owned `ThreadTitleGenerationService` dependency with constructor injection for tests.
+- After `startTurn` succeeds, extract the first meaningful text input and decide whether generation is eligible. Skip scheduling when the thread already has an explicit title, when another generation is already pending for the same first prompt, or when replay/test configuration disables background generation.
+- Schedule title generation asynchronously. Do not await it before returning the user's `startTurn` response.
+- Track pending generations by `backend:threadId` plus an input hash or generation token so older completions cannot apply after a newer prompt.
+- Before applying a generated title, refresh the current thread summary through the selected backend and skip if the title is already explicit, if the thread is archived or missing, or if a newer pending generation token exists.
+- Apply with the existing `renameWithClient` route so Codex and Grok both use their backend `renameThread` implementations and emit normal `thread/name/updated` notifications.
+- Log debug-level generation outcomes with backend, thread id, model family, elapsed time, and skip/failure reason, without logging the full prompt text.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/backend-registry.ts` dependency injection and client selection
+- `apps/desktop/src/main/app-server/backend-registry.ts` `renameWithClient`
+- `apps/desktop/src/main/ipc/agent-ipc.ts` event broadcast behavior
+
+**Test scenarios:**
+- Happy path: starting the first Codex turn returns immediately, then a valid generated title is applied through the Codex client's `renameThread`.
+- Happy path: starting the first Grok turn returns immediately, then a valid generated title is applied through the Grok client's `renameThread`.
+- Edge case: empty, image-only, or whitespace-only input does not schedule title generation.
+- Edge case: if the current thread summary reports `titleSource: "explicit"` before generation completes, the generated title is skipped.
+- Edge case: two quick turns on the same thread allow only the newest pending generation token to apply.
+- Error path: generation failure does not reject `startTurn` and does not emit a user-visible error event.
+- Integration: `thread/name/updated` from the backend still reaches the renderer through the existing event pipeline after generated title application.
+
+**Verification:**
+- Automatic naming improves thread titles after the first prompt while preserving normal turn latency and explicit user rename behavior.
+
+- [ ] **Unit 6: Capture and replay provider-specific naming behavior**
+
+**Goal:** Keep protocol capture, replay fixtures, and future debugging clear about what was user-thread traffic versus desktop-owned ephemeral naming traffic.
+
+**Requirements:** R9, R10
+
+**Dependencies:** Units 3-5
+
+**Files:**
+- Modify: `apps/desktop/src/main/testing/protocol-capture.ts`
+- Modify: `apps/desktop/src/main/testing/replay-client.ts`
+- Modify: `apps/desktop/src/main/testing/replay-runtime.ts`
+- Test: `apps/desktop/src/main/__tests__/protocol-capture.test.ts`
+- Test: `apps/desktop/src/main/__tests__/replay-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
+
+**Approach:**
+- Preserve raw capture of Codex app-server helper traffic for debugging, but tag or classify it as desktop-owned ephemeral title generation when enough metadata is available.
+- Ensure replay fixtures can either include deterministic title generation results or disable generation so existing replay tests are not made flaky by background model calls.
+- Add a test hook or injected title service for replay runtime rather than relying on live provider calls.
+- Make sure helper-thread suppression in the Codex client applies to renderer event broadcasting but does not hide raw protocol capture when capture is explicitly enabled.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/testing/protocol-capture.ts`
+- `apps/desktop/src/main/testing/replay-client.ts`
+- `apps/desktop/src/main/testing/replay-runtime.ts`
+- `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`
+
+**Test scenarios:**
+- Happy path: protocol capture records Codex helper requests with an ephemeral/title-generation classification.
+- Happy path: replay runtime can inject deterministic generated names without network calls.
+- Edge case: existing fixtures without title-generation records continue to replay with generation disabled or stubbed.
+- Error path: malformed helper records do not break replay of the main user thread.
+
+**Verification:**
+- Captures remain useful for debugging title generation without contaminating normal thread transcript behavior or making replay tests network-dependent.
+
+## System-Wide Impact
+
+- **Interaction graph:** renderer `startTurn` -> `DesktopBackendRegistry.startTurn` -> backend `turn/start` -> `ThreadTitleGenerationService` -> provider-specific ephemeral call -> backend `thread/name/set` -> existing `thread/name/updated` event pipeline.
+- **Error propagation:** generation errors stay inside desktop main logs and service result objects. They must not reject `startTurn`, fail the user turn, or create renderer error toasts.
+- **State lifecycle risks:** background generation must clean up pending waiters and tokens on success, timeout, registry close, and backend client close. Codex helper threads must not enter normal thread lists or renderer transcript state.
+- **API surface parity:** the app-server protocol remains unchanged except for using existing `thread/name/set`; Codex-specific ephemeral generation uses already-generated protocol fields internally in the desktop Codex adapter.
+- **Integration coverage:** backend-registry tests need to prove asynchronous application and race guards because unit tests for adapters alone will not catch user-name clobbering.
+- **Unchanged invariants:** explicit user renames always win; derived/fallback titles remain available; missing provider credentials or unsupported helper fields degrade silently.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Codex ephemeral helper notifications leak into the real thread UI. | Track helper thread/turn ids in the Codex client and route those notifications only to the pending generator while still allowing raw protocol capture. |
+| Generated title overwrites a user rename. | Refresh current thread summary before apply, require non-explicit title state, and use generation tokens to skip stale completions. |
+| Title generation slows normal turn submission. | Schedule after successful `startTurn` response and never await generation before returning to the renderer. |
+| Grok config is missing or xAI rejects the fast model. | Return unavailable/failure and keep derived titles; optionally fall back to another fast non-reasoning model when backend metadata supports it. |
+| Shared helper extraction breaks focused diff. | Start with characterization coverage and keep focused-diff-specific logic in `FocusedDiffService`. |
+| Protocol capture becomes confusing because helper traffic appears unrelated to the user turn. | Add capture classification and replay controls for desktop-owned title generation traffic. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation is required for the first implementation because automatic naming should be transparent.
+- Developer notes should mention that title generation is desktop-owned and provider-specific, while the only backend mutation is `thread/name/set`.
+- If replay fixtures are refreshed for title generation, use the project-local desktop E2E fixture seeding workflow so captured helper traffic is classified consistently.
+
+## Sources & References
+
+- Related prompt: `apps/desktop/src/main/app-server/thread-title-prompt.md`
+- Related prompt reader: `apps/desktop/src/main/app-server/thread-title-prompt.ts`
+- Existing out-of-band pattern: `apps/desktop/src/main/diff-focus/focused-diff-service.ts`
+- Existing out-of-band tests: `apps/desktop/src/main/__tests__/focused-diff-service.test.ts`
+- xAI object-call wrapper: `packages/agent-core/src/providers/xai-ai-sdk-object-client.ts`
+- Grok runtime config: `packages/agent-core/src/config/grok-app-server-config.ts`
+- Codex client boundary: `apps/desktop/src/main/codex-app-server/client.ts`
+- Grok client boundary: `apps/desktop/src/main/grok-app-server/client.ts`
+- Desktop orchestration boundary: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Existing title-state plan: `docs/plans/2026-04-16-004-feat-thread-naming-parity-plan.md`

--- a/docs/plans/2026-04-28-001-feat-desktop-out-of-band-thread-naming-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-out-of-band-thread-naming-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add desktop-owned out-of-band thread naming
 type: feat
-status: active
+status: completed
 date: 2026-04-28
 ---
 
@@ -131,7 +131,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Characterize and extract the ephemeral object-call pattern**
+- [x] **Unit 1: Characterize and extract the ephemeral object-call pattern**
 
 **Goal:** Make the focused-diff out-of-band call pattern reusable enough for title generation without breaking focused diff.
 
@@ -168,7 +168,7 @@ flowchart TB
 **Verification:**
 - Focused diff tests still pass, and the new helper has direct tests proving the reusable call boundary.
 
-- [ ] **Unit 2: Add a desktop thread-title generation service**
+- [x] **Unit 2: Add a desktop thread-title generation service**
 
 **Goal:** Centralize prompt construction, model selection, structured-output validation, and title cleanup behind one desktop-owned service.
 
@@ -206,7 +206,7 @@ flowchart TB
 **Verification:**
 - Title prompt constraints are tested at the service boundary, not only by checking prompt file contents.
 
-- [ ] **Unit 3: Implement Codex app-server ephemeral title generation**
+- [x] **Unit 3: Implement Codex app-server ephemeral title generation**
 
 **Goal:** Use Codex/OpenAI for Codex-backed thread naming without adding a direct OpenAI dependency or new app-server protocol method.
 
@@ -244,7 +244,7 @@ flowchart TB
 **Verification:**
 - Codex-backed title generation uses the Codex app server and never requires separate OpenAI credentials.
 
-- [ ] **Unit 4: Implement Grok fast-model title generation**
+- [x] **Unit 4: Implement Grok fast-model title generation**
 
 **Goal:** Use a lightweight Grok model for Grok-backed thread naming through the reusable desktop xAI object-call path.
 
@@ -281,7 +281,7 @@ flowchart TB
 **Verification:**
 - Grok-backed title generation uses an xAI fast model and does not create transcript items or app-server turns.
 
-- [ ] **Unit 5: Schedule generation after first turn and apply names safely**
+- [x] **Unit 5: Schedule generation after first turn and apply names safely**
 
 **Goal:** Trigger provider-specific title generation from the desktop start-turn flow and apply valid names without races or user-name clobbering.
 
@@ -320,7 +320,7 @@ flowchart TB
 **Verification:**
 - Automatic naming improves thread titles after the first prompt while preserving normal turn latency and explicit user rename behavior.
 
-- [ ] **Unit 6: Capture and replay provider-specific naming behavior**
+- [x] **Unit 6: Capture and replay provider-specific naming behavior**
 
 **Goal:** Keep protocol capture, replay fixtures, and future debugging clear about what was user-thread traffic versus desktop-owned ephemeral naming traffic.
 


### PR DESCRIPTION
## Summary

I added desktop-owned out-of-band thread title generation so new threads can move from prompt placeholders to short generated titles without putting naming turns into the user transcript.

The implementation uses:
- the shared desktop title prompt with a 50-character / 6-word target
- Codex app-server ephemeral helper threads with `gpt-5.4-mini`
- Grok fast-model structured object calls through a reusable xAI helper
- safe registry scheduling that only renames eligible derived/fallback titles and preserves explicit user names

I also fixed the Codex derived-name indexing path so new Codex threads can show a prompt-derived title while the generated title is pending.

## Details

- Extracted the focused-diff xAI object-call pattern into a reusable ephemeral object caller.
- Added a thread title generation service with structured output validation, quote/punctuation cleanup, word/character limits, same-language prompt guidance, and ticket/work-item reference preservation for `PROJECT-123`, `#123`, bare numeric references, `issue 123`, `PR 456`, and `pull request #456`.
- Added Codex helper-turn title generation that suppresses helper notifications from normal desktop listeners while still allowing protocol capture to see the raw JSON-RPC traffic.
- Wired desktop backend turn start to schedule title generation after successful turns, re-check thread eligibility before apply, and use existing rename paths for Codex and Grok.
- Disabled automatic title generation for replay clients so deterministic fixture replay does not accidentally make live provider calls.
- Marked the implementation plan complete.

## Verification

I verified:

- `pnpm vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/ephemeral-object-call.test.ts apps/desktop/src/main/__tests__/focused-diff-service.test.ts apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts apps/desktop/src/main/__tests__/thread-title-prompt.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
