### PR TITLE
fix(desktop): stretch sidebar to viewport bottom

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -59,7 +59,9 @@ textarea {
 .app-shell {
   display: grid;
   grid-template-columns: var(--sidebar-width, 408px) minmax(0, 1fr);
+  align-items: stretch;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   background: var(--bg-app);
   color: var(--text-primary);
@@ -68,7 +70,9 @@ textarea {
 .sidebar {
   display: flex;
   position: relative;
+  align-self: stretch;
   flex-direction: column;
+  height: 100%;
   min-height: 0;
   padding: 16px;
   overflow: hidden;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -206,6 +206,11 @@ textarea {
 
 .sidebar__brand {
   margin: 0;
+  color: var(--accent-bright);
+  font-size: 17px;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: none;
 }
 
 .thread-header__title,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -74,7 +74,7 @@ textarea {
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 16px;
+  padding: 16px 16px 0;
   overflow: hidden;
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border-subtle);


### PR DESCRIPTION
## Summary

I fixed the desktop shell so the left sidebar and its navigation list stretch to the bottom of the renderer viewport, then made the sidebar product name feel more intentional and readable.

## What changed

- Added explicit stretch alignment to the two-column app shell.
- Switched the shell height to prefer `100dvh` with the existing `100vh` fallback.
- Set the sidebar to stretch and fill the shell height.
- Removed the sidebar's bottom padding so the thread browser surface reaches the viewport bottom like the right rail.
- Promoted the sidebar brand from the tiny generic eyebrow style to a stronger mixed-case `PwrAgnt` wordmark treatment.

## Verification

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop build`
- Launched the built Electron app with Playwright at a wide, short viewport and verified `.sidebar`, `.sidebar__section--fill`, `.sidebar__scroll-region`, `.sidebar-list--dense`, and `.context-rail` all have a `0px` bottom gap against the renderer viewport.
- Launched the built Electron app with Playwright and verified the sidebar brand renders as `PwrAgnt` with `17px` font size, `800` font weight, and no uppercase transform.
