### PR TITLE
feat(desktop): MCP request support

### DIFF
--- a/apps/desktop/e2e/fixtures/README.md
+++ b/apps/desktop/e2e/fixtures/README.md
@@ -146,6 +146,8 @@ desktop replay scenarios do not exercise Codex sidebar directory identity.
   hide low-signal hunks via the focused diff path
 - `thread-image-fit/`: pasted transcript image preview preserves its natural
   aspect ratio and fits within the preview container without cropping
+- `mcp-elicitation/`: Codex MCP elicitation request for Playwright
+  `browser_tabs`, including MCP-shaped approval handling and progress rendering
 
 ## Visual System Guard
 

--- a/apps/desktop/e2e/fixtures/mcp-elicitation/capture-recipe.md
+++ b/apps/desktop/e2e/fixtures/mcp-elicitation/capture-recipe.md
@@ -1,0 +1,41 @@
+# MCP Elicitation Capture Recipe
+
+## Purpose
+
+Capture a Codex app-server turn that starts a Playwright MCP tool call, emits
+`mcpServer/elicitation/request`, and resumes after the operator accepts the
+request. The checked-in replay fixture is synthetic until a clean live capture
+is promoted.
+
+## Setup
+
+Launch the desktop app with protocol capture enabled:
+
+```bash
+PWRAGNT_PROTOCOL_CAPTURE=true \
+PWRAGNT_PROTOCOL_CAPTURE_ROOT=/tmp/pwragnt-protocol-captures \
+pnpm dev
+```
+
+Use a disposable thread. Do not sign in to third-party services or paste tokens
+while recording this scenario.
+
+## Steps
+
+1. Open a Codex-backed thread.
+2. Ask Codex to inspect or list browser tabs with the Playwright MCP tool.
+3. Wait for a visible MCP approval prompt for `playwright` / `browser_tabs`.
+4. Accept the request.
+5. Wait for one MCP progress or completion event to appear.
+6. Stop capture before any page content, credentials, cookies, or private URLs
+   appear in the transcript.
+
+## Promotion Notes
+
+- Keep the replay window tight: initialize, thread list/read, turn start,
+  `item/started` for the MCP tool call, `mcpServer/elicitation/request`, one
+  progress or completion notification, then stop.
+- Redact URL query strings, hashes, cookies, tokens, and machine-specific paths.
+- Do not check in `raw.capture.jsonl` until it has been reviewed for secrets.
+- If only URL-mode elicitation is captured, keep credentials out of PwrAgnt and
+  assert only the redacted display URL plus accept/decline/cancel controls.

--- a/apps/desktop/e2e/fixtures/mcp-elicitation/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/mcp-elicitation/replay.fixture.json
@@ -1,0 +1,239 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "mcp-elicitation",
+    "sourceCaptureId": "synthetic-mcp-elicitation-playwright-browser-tabs",
+    "threadId": "thread-mcp-elicitation"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start",
+          "mcpServerStatus/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-mcp-elicitation",
+          "title": "MCP elicitation replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded MCP elicitation prompt",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000003000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Use the browser tabs MCP tool."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready to request MCP approval."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Use the browser tabs MCP tool."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready to request MCP approval."
+          }
+        ],
+        "lastUserMessage": "Use the browser tabs MCP tool.",
+        "lastAssistantMessage": "Ready to request MCP approval.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-mcp-elicitation",
+        "turnId": "turn-mcp-2"
+      }
+    },
+    {
+      "id": "status-active-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "status": {
+            "type": "active",
+            "activeFlags": []
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "turnId": "turn-mcp-2",
+          "turn": {
+            "id": "turn-mcp-2",
+            "status": "inProgress"
+          }
+        }
+      }
+    },
+    {
+      "id": "mcp-startup-1",
+      "kind": "notification",
+      "notification": {
+        "method": "mcpServer/startupStatus/updated",
+        "params": {
+          "name": "playwright",
+          "status": "starting",
+          "error": null
+        }
+      }
+    },
+    {
+      "id": "mcp-tool-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/started",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "turnId": "turn-mcp-2",
+          "item": {
+            "id": "call-mcp-browser-tabs",
+            "type": "mcpToolCall",
+            "server": "playwright",
+            "tool": "browser_tabs",
+            "status": "in_progress",
+            "arguments": {
+              "action": "list"
+            },
+            "result": null,
+            "error": null
+          }
+        }
+      }
+    },
+    {
+      "id": "mcp-elicitation-1",
+      "kind": "request",
+      "request": {
+        "method": "mcpServer/elicitation/request",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "turnId": "turn-mcp-2",
+          "requestId": "mcp-elicitation-request-1",
+          "serverName": "playwright",
+          "mode": "form",
+          "_meta": {
+            "codex_approval_kind": "mcp_tool_call",
+            "persist": [
+              "serverName",
+              "toolName"
+            ],
+            "tool_description": "List, create, close, or select a browser tab.",
+            "tool_params": {
+              "action": "list"
+            },
+            "tool_params_display": [
+              {
+                "label": "action",
+                "value": "list"
+              }
+            ]
+          },
+          "message": "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+          "requestedSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    },
+    {
+      "id": "mcp-progress-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/mcpToolCall/progress",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "turnId": "turn-mcp-2",
+          "itemId": "call-mcp-browser-tabs",
+          "message": "Listing browser tabs"
+        }
+      }
+    },
+    {
+      "id": "mcp-tool-completed-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/completed",
+        "params": {
+          "threadId": "thread-mcp-elicitation",
+          "turnId": "turn-mcp-2",
+          "item": {
+            "id": "call-mcp-browser-tabs",
+            "type": "mcpToolCall",
+            "server": "playwright",
+            "tool": "browser_tabs",
+            "status": "completed",
+            "arguments": {
+              "action": "list"
+            },
+            "result": {
+              "tabs": [
+                {
+                  "title": "Replay tab"
+                }
+              ]
+            },
+            "error": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/mcp-elicitation.spec.ts
+++ b/apps/desktop/e2e/mcp-elicitation.spec.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const mcpElicitationSpecDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function openMcpElicitationReplay() {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      mcpElicitationSpecDir,
+      "fixtures/mcp-elicitation/replay.fixture.json"
+    )
+  });
+
+  await app.window
+    .getByRole("button", { name: /MCP elicitation replay/i })
+    .first()
+    .click();
+
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: "MCP elicitation replay"
+    })
+  ).toBeVisible();
+
+  await app.window
+    .getByLabel("Reply")
+    .fill("Use the browser tabs MCP tool.");
+  await app.window.getByRole("button", { name: "Send" }).click();
+
+  await app.advance({ stepId: "status-active-1" });
+  await app.advance({ stepId: "turn-started-1" });
+  await app.advance({ stepId: "mcp-startup-1" });
+  await app.advance({ stepId: "mcp-tool-started-1" });
+  await app.advance({ stepId: "mcp-elicitation-1" });
+
+  const pendingMcp = app.window.getByRole("group", {
+    name: "Pending MCP interaction"
+  });
+  await expect(pendingMcp).toBeVisible();
+  await expect(pendingMcp.getByText("MCP approval")).toBeVisible();
+  await expect(pendingMcp.getByText(/browser_tabs/)).toBeVisible();
+  await expect(app.window.getByRole("group", { name: "Pending input" })).toHaveCount(0);
+  await expect(app.window.getByRole("group", { name: "Pending approval" })).toHaveCount(0);
+
+  return app;
+}
+
+test("accepts MCP elicitations and resumes MCP progress", async () => {
+  const app = await openMcpElicitationReplay();
+
+  try {
+    const pendingMcp = app.window.getByRole("group", {
+      name: "Pending MCP interaction"
+    });
+
+    await pendingMcp.getByRole("button", { name: "Allow" }).click();
+    await expect(pendingMcp).toHaveCount(0);
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+    await expect
+      .poll(async () => await app.getPendingRequest())
+      .toBeUndefined();
+
+    await app.advance({ stepId: "mcp-progress-1" });
+    await expect(app.window.getByText("MCP Listing browser tabs").first()).toBeVisible();
+
+    await app.advance({ stepId: "mcp-tool-completed-1" });
+    await expect(
+      app.window.getByText(/Used MCP playwright\/browser_tabs/)
+    ).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test("declines MCP elicitations without showing approval or questionnaire UI", async () => {
+  const app = await openMcpElicitationReplay();
+
+  try {
+    const pendingMcp = app.window.getByRole("group", {
+      name: "Pending MCP interaction"
+    });
+
+    await pendingMcp.getByRole("button", { name: "Decline" }).click();
+    await expect(pendingMcp).toHaveCount(0);
+    await expect(app.window.getByRole("group", { name: "Pending input" })).toHaveCount(0);
+    await expect(app.window.getByRole("group", { name: "Pending approval" })).toHaveCount(0);
+    await expect
+      .poll(async () => await app.getPendingRequest())
+      .toBeUndefined();
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay.test.ts
@@ -285,4 +285,120 @@ describe("DesktopBackendRegistry replay integration", () => {
     expect(replayClient.getPendingRequest()).toBeUndefined();
     await registry.close();
   });
+
+  it("preserves MCP elicitation payloads through registry events", async () => {
+    const replayClient = ReplayClient.fromFixture({
+      metadata: {
+        backend: "codex",
+        scenario: "registry-mcp-elicitation-replay"
+      },
+      steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: {
+              name: "Replay Codex",
+              version: "1.0.0"
+            },
+            methods: ["thread/read"]
+          }
+        },
+        {
+          id: "read-1",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          }
+        },
+        {
+          id: "req-mcp-1",
+          kind: "request",
+          request: {
+            method: "mcpServer/elicitation/request",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              requestId: "mcp-request-1",
+              serverName: "playwright",
+              mode: "form",
+              _meta: {
+                tool_description: "List, create, close, or select a browser tab.",
+                tool_params_display: [
+                  {
+                    label: "action",
+                    value: "list"
+                  }
+                ]
+              },
+              message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+              requestedSchema: {
+                type: "object",
+                properties: {}
+              }
+            }
+          }
+        }
+      ]
+    });
+
+    const registry = new DesktopBackendRegistry({
+      codexClient: replayClient,
+      codexFullAccessClient: createPassiveClient() as any,
+      grokClient: createPassiveClient() as any,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: Array<{ method: string; params: Record<string, unknown> }> = [];
+    registry.onEvent((event) => {
+      events.push({
+        method: event.notification.method,
+        params: event.notification.params as Record<string, unknown>,
+      });
+    });
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1"
+    });
+    await replayClient.advance({ stepId: "req-mcp-1" });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        method: "mcpServer/elicitation/request",
+        params: expect.objectContaining({
+          requestId: "mcp-request-1",
+          serverName: "playwright",
+          mode: "form",
+          message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+          requestedSchema: {
+            type: "object",
+            properties: {}
+          }
+        })
+      })
+    );
+
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "mcp-request-1",
+      response: {
+        action: "accept",
+        content: {},
+        _meta: null
+      }
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(replayClient.getPendingRequest()).toBeUndefined();
+    await registry.close();
+  });
 });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3424,6 +3424,159 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("normalizes MCP elicitation requests and returns MCP-shaped responses", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onRequest((request) => {
+      requests.push(request as { method: string; params: Record<string, unknown> });
+      return {
+        action: "accept",
+        content: {},
+        _meta: null
+      };
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      id: "0",
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-mcp",
+        turnId: "turn-mcp",
+        serverName: "playwright",
+        mode: "form",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          tool_description: "List, create, close, or select a browser tab.",
+          tool_params: {
+            action: "list"
+          },
+          tool_params_display: [
+            {
+              label: "action",
+              value: "list"
+            }
+          ]
+        },
+        message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+        requestedSchema: {
+          type: "object",
+          properties: {}
+        }
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requests).toEqual([
+      {
+        method: "mcpServer/elicitation/request",
+        params: expect.objectContaining({
+          threadId: "thread-mcp",
+          turnId: "turn-mcp",
+          requestId: "0",
+          serverName: "playwright",
+          mode: "form",
+          message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+          requestedSchema: {
+            type: "object",
+            properties: {}
+          },
+          _meta: expect.objectContaining({
+            tool_description: "List, create, close, or select a browser tab."
+          })
+        })
+      }
+    ]);
+    expect(
+      transport!.sentMessages
+        .map((message) => JSON.parse(message) as { id?: string; result?: unknown })
+        .find((message) => message.id === "0")
+    ).toEqual({
+      jsonrpc: "2.0",
+      id: "0",
+      result: {
+        action: "accept",
+        content: {},
+        _meta: null
+      }
+    });
+
+    await client.close();
+  });
+
+  it("preserves URL-mode MCP elicitation requests", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onRequest((request) => {
+      requests.push(request as { method: string; params: Record<string, unknown> });
+      return {
+        action: "cancel",
+        content: null,
+        _meta: null
+      };
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      id: "mcp-url-1",
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-mcp",
+        turnId: null,
+        serverName: "github",
+        mode: "url",
+        _meta: null,
+        message: "Authorize GitHub access in the browser.",
+        url: "https://example.test/oauth/start?state=secret-state",
+        elicitationId: "elicitation-1"
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requests).toEqual([
+      {
+        method: "mcpServer/elicitation/request",
+        params: expect.objectContaining({
+          threadId: "thread-mcp",
+          turnId: null,
+          requestId: "mcp-url-1",
+          serverName: "github",
+          mode: "url",
+          message: "Authorize GitHub access in the browser.",
+          url: "https://example.test/oauth/start?state=secret-state",
+          elicitationId: "elicitation-1",
+          _meta: null
+        })
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("normalizes approval requests from rpc envelope ids and nested thread metadata", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -161,6 +161,8 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "item/commandExecution/outputDelta",
   "item/commandExecution/terminalInteraction",
   "item/fileChange/outputDelta",
+  "item/mcpToolCall/progress",
+  "mcpServer/oauthLogin/completed",
   "mcpServer/startupStatus/updated",
 ]);
 const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
@@ -205,7 +207,11 @@ function isApprovalLikeMethod(method: string): boolean {
 }
 
 function isHandledServerRequestMethod(method: string): boolean {
-  return isApprovalLikeMethod(method) || method === "item/tool/requestUserInput";
+  return (
+    isApprovalLikeMethod(method) ||
+    method === "item/tool/requestUserInput" ||
+    method === "mcpServer/elicitation/request"
+  );
 }
 
 function isKnownCodexNotificationMethod(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -101,6 +101,7 @@ export function App() {
           loadingMore={session.loadingMore}
           messageCount={session.messages.length}
           pendingAssistantMessage={session.pendingAssistantMessage}
+          pendingMcpInteraction={session.pendingMcpInteraction}
           pendingRequest={session.pendingRequest}
           pendingUserInput={session.pendingUserInput}
           pendingStatusText={session.pendingStatusText}
@@ -145,6 +146,7 @@ export function App() {
           onRestoreWorktree={navigation.restoreWorktree}
           onTranscriptViewportChange={session.setViewport}
           onUpdateLaunchpad={navigation.updateDirectoryLaunchpad}
+          onUpdatePendingMcpInteraction={session.updatePendingMcpInteraction}
           onUpdatePendingUserInput={session.updatePendingUserInput}
           removeOptimisticMessage={session.removeOptimisticMessage}
           transcriptViewport={session.viewport}

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingMcpInteraction.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingMcpInteraction.tsx
@@ -1,0 +1,308 @@
+import {
+  canAcceptMcpElicitation,
+  redactDisplayValue,
+  updateMcpFieldValue,
+  type PendingMcpField,
+  type PendingMcpInteractionState,
+} from "./mcp-elicitation";
+
+type PendingMcpInteractionProps = {
+  busy?: boolean;
+  state: PendingMcpInteractionState;
+  onChange: (state: PendingMcpInteractionState) => void;
+  onSubmit: (
+    state: PendingMcpInteractionState,
+    action: "accept" | "decline" | "cancel"
+  ) => Promise<void> | void;
+};
+
+export function PendingMcpInteraction(props: PendingMcpInteractionProps) {
+  const canAccept = canAcceptMcpElicitation(props.state);
+  const toolDescription = readStringMeta(props.state._meta, "tool_description");
+  const toolParams = readToolParamsDisplay(props.state._meta);
+
+  return (
+    <div className="transcript-mcp" role="group" aria-label="Pending MCP interaction">
+      <div className="transcript-mcp__header">
+        <span className="thread-row__chip thread-row__chip--mode">
+          {props.state.mode === "url" ? "MCP login" : "MCP approval"}
+        </span>
+        <span className="transcript-message__time">
+          {props.state.serverName} / {props.state.mode}
+        </span>
+      </div>
+
+      <div className="transcript-mcp__prompt">
+        {toolDescription ? <p className="eyebrow">{toolDescription}</p> : null}
+        <h3>{props.state.message}</h3>
+      </div>
+
+      {toolParams.length > 0 ? (
+        <dl className="transcript-mcp__params">
+          {toolParams.map((param) => (
+            <div key={param.label}>
+              <dt>{param.label}</dt>
+              <dd>{redactDisplayValue(param.value)}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {props.state.url ? (
+        <div className="transcript-mcp__url">
+          <span>{props.state.url.displayUrl}</span>
+          <a
+            className="button button--ghost"
+            href={props.state.url.url}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open
+          </a>
+        </div>
+      ) : null}
+
+      {props.state.form && props.state.form.fields.length > 0 ? (
+        <div className="transcript-mcp__fields">
+          {props.state.form.fields.map((field) => (
+            <PendingMcpFieldControl
+              key={field.key}
+              busy={props.busy}
+              field={field}
+              state={props.state}
+              onChange={props.onChange}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <div className="transcript-mcp__actions">
+        <button
+          className="button button--primary"
+          disabled={props.busy || !canAccept}
+          type="button"
+          onClick={() => {
+            void props.onSubmit(props.state, "accept");
+          }}
+        >
+          Allow
+        </button>
+        <button
+          className="button button--ghost"
+          disabled={props.busy}
+          type="button"
+          onClick={() => {
+            void props.onSubmit(props.state, "decline");
+          }}
+        >
+          Decline
+        </button>
+        <button
+          className="button button--ghost"
+          disabled={props.busy}
+          type="button"
+          onClick={() => {
+            void props.onSubmit(props.state, "cancel");
+          }}
+        >
+          Cancel turn
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type PendingMcpFieldControlProps = {
+  busy?: boolean;
+  field: PendingMcpField;
+  state: PendingMcpInteractionState;
+  onChange: (state: PendingMcpInteractionState) => void;
+};
+
+function PendingMcpFieldControl(props: PendingMcpFieldControlProps) {
+  const descriptionId = `${props.state.requestId}-${props.field.key}-description`;
+  const requiredText = props.field.required ? "Required" : "Optional";
+
+  if (props.field.kind === "unsupported") {
+    return (
+      <div className="transcript-mcp__field">
+        <div className="transcript-mcp__field-label">
+          <span>{props.field.label}</span>
+          <span>{requiredText}</span>
+        </div>
+        <p className="transcript-mcp__field-help">
+          {props.field.description || "This MCP schema field is not supported yet."}
+        </p>
+      </div>
+    );
+  }
+
+  if (props.field.kind === "boolean") {
+    return (
+      <label className="transcript-mcp__toggle">
+        <input
+          checked={props.field.value}
+          disabled={props.busy}
+          type="checkbox"
+          onChange={(event) => {
+            props.onChange(
+              updateMcpFieldValue(props.state, props.field.key, event.target.checked)
+            );
+          }}
+        />
+        <span>{props.field.label}</span>
+        <span>{requiredText}</span>
+      </label>
+    );
+  }
+
+  if (props.field.kind === "singleSelect") {
+    return (
+      <label className="transcript-mcp__field">
+        <span className="transcript-mcp__field-label">
+          <span>{props.field.label}</span>
+          <span>{requiredText}</span>
+        </span>
+        <select
+          aria-describedby={props.field.description ? descriptionId : undefined}
+          disabled={props.busy}
+          value={props.field.value}
+          onChange={(event) => {
+            props.onChange(
+              updateMcpFieldValue(props.state, props.field.key, event.target.value)
+            );
+          }}
+        >
+          <option value="">Choose...</option>
+          {props.field.options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {props.field.description ? (
+          <span id={descriptionId} className="transcript-mcp__field-help">
+            {props.field.description}
+          </span>
+        ) : null}
+      </label>
+    );
+  }
+
+  if (props.field.kind === "multiSelect") {
+    const field = props.field;
+    return (
+      <fieldset className="transcript-mcp__field">
+        <legend className="transcript-mcp__field-label">
+          <span>{field.label}</span>
+          <span>{requiredText}</span>
+        </legend>
+        <div className="transcript-mcp__options">
+          {field.options.map((option) => {
+            const selected = field.value.includes(option.value);
+            return (
+              <button
+                key={option.value}
+                className={`transcript-questionnaire__option${
+                  selected ? " is-selected" : ""
+                }`}
+                type="button"
+                aria-pressed={selected}
+                disabled={props.busy}
+                onClick={() => {
+                  const nextValue = selected
+                    ? field.value.filter((value: string) => value !== option.value)
+                    : [...field.value, option.value];
+                  props.onChange(
+                    updateMcpFieldValue(props.state, field.key, nextValue)
+                  );
+                }}
+              >
+                <span className="transcript-questionnaire__option-label">
+                  {option.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {field.description ? (
+          <span className="transcript-mcp__field-help">{field.description}</span>
+        ) : null}
+      </fieldset>
+    );
+  }
+
+  const field = props.field as Extract<PendingMcpField, { kind: "string" | "number" }>;
+
+  return (
+    <label className="transcript-mcp__field">
+      <span className="transcript-mcp__field-label">
+        <span>{field.label}</span>
+        <span>{field.required ? "Required" : "Optional"}</span>
+      </span>
+      <input
+        aria-describedby={field.description ? descriptionId : undefined}
+        disabled={props.busy}
+        max={field.kind === "number" ? field.maximum : undefined}
+        maxLength={field.kind === "string" ? field.maxLength : undefined}
+        min={field.kind === "number" ? field.minimum : undefined}
+        minLength={field.kind === "string" ? field.minLength : undefined}
+        step={field.kind === "number" && field.integer ? 1 : undefined}
+        type={field.kind === "number" ? "number" : "text"}
+        value={field.value ?? ""}
+        onChange={(event) => {
+          const nextValue =
+            field.kind === "number"
+              ? event.target.value
+                ? Number(event.target.value)
+                : null
+              : event.target.value;
+          props.onChange(
+            updateMcpFieldValue(props.state, field.key, nextValue)
+          );
+        }}
+      />
+      {field.description ? (
+        <span id={descriptionId} className="transcript-mcp__field-help">
+          {field.description}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+function readStringMeta(
+  meta: Record<string, unknown> | null,
+  key: string
+): string | undefined {
+  const value = meta?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readToolParamsDisplay(
+  meta: Record<string, unknown> | null
+): Array<{ label: string; value: unknown }> {
+  const raw = meta?.tool_params_display;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+    const record = entry as Record<string, unknown>;
+    const label =
+      typeof record.label === "string" && record.label.trim()
+        ? record.label.trim()
+        : typeof record.name === "string" && record.name.trim()
+          ? record.name.trim()
+          : typeof record.key === "string" && record.key.trim()
+            ? record.key.trim()
+            : undefined;
+    if (!label) {
+      return [];
+    }
+    return [{ label, value: record.value }];
+  });
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -305,6 +305,23 @@ function summarizeToolOutput(text: string | undefined): string | undefined {
   return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
 }
 
+function summarizeJsonValue(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return summarizeToolOutput(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return summarizeToolOutput(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
 function formatLiveToolName(
   toolName: string,
   status: AppServerThreadActivityDetail["status"],
@@ -319,6 +336,15 @@ function formatLiveToolName(
     return "Ran command";
   }
   return toolName.replace(/_/g, " ");
+}
+
+function formatMcpToolName(
+  serverName: string | undefined,
+  toolName: string,
+  status: AppServerThreadActivityDetail["status"],
+): string {
+  const action = status === "in_progress" ? "Using MCP" : "Used MCP";
+  return `${action} ${serverName ? `${serverName}/` : ""}${toolName}`;
 }
 
 function buildLiveToolLabel(
@@ -336,6 +362,11 @@ function buildLiveToolLabel(
     );
   }
 
+  if (itemType === "mcptoolcall") {
+    const serverName = readString(item, "server") ?? readString(item, "serverName");
+    return formatMcpToolName(serverName, toolName, status);
+  }
+
   return formatLiveToolName(toolName, status);
 }
 
@@ -343,19 +374,27 @@ function buildLiveToolDetails(
   item: Record<string, unknown>,
 ): AppServerThreadActivityDetail[] {
   const itemType = readString(item, "type")?.replace(/[-_\s]/g, "").toLowerCase();
-  if (itemType !== "dynamictoolcall" && itemType !== "commandexecution") {
+  if (
+    itemType !== "dynamictoolcall" &&
+    itemType !== "commandexecution" &&
+    itemType !== "mcptoolcall"
+  ) {
     return [];
   }
 
   const itemId = readString(item, "id") ?? readString(item, "itemId") ?? "tool";
   const toolName =
+    readString(item, "tool") ??
     readString(item, "toolName") ??
     readString(item, "tool_name") ??
     readString(item, "name") ??
     "tool";
   const status = normalizeItemStatus(item.status);
   const query = readToolArgument(item, "query") ?? readToolArgument(item, "q");
-  const preview = summarizeToolOutput(readToolOutputText(item));
+  const preview =
+    itemType === "mcptoolcall"
+      ? summarizeJsonValue(item.error) ?? summarizeJsonValue(item.result)
+      : summarizeToolOutput(readToolOutputText(item));
   const elapsedMs = readElapsedMs(item);
   const details: AppServerThreadActivityDetail[] = [
     {
@@ -391,6 +430,90 @@ function buildLiveToolDetails(
   }
 
   return details;
+}
+
+function buildMcpProgressDetail(
+  params: Record<string, unknown>
+): AppServerThreadActivityDetail | undefined {
+  const itemId = readString(params, "itemId");
+  const message = readString(params, "message");
+  if (!itemId || !message) {
+    return undefined;
+  }
+
+  return {
+    id: itemId,
+    kind: "command",
+    label: `MCP ${message}`,
+    status: "in_progress",
+  };
+}
+
+function buildMcpServerStatusActivityEntry(params: Record<string, unknown>): AppServerThreadActivityEntry | undefined {
+  const serverName = readString(params, "name") ?? readString(params, "serverName");
+  const status = readString(params, "status") ?? "updated";
+  if (!serverName) {
+    return undefined;
+  }
+
+  const error = readString(params, "error");
+  const detailStatus: AppServerThreadActivityDetail["status"] =
+    status === "failed" || error
+      ? "failed"
+      : status === "cancelled"
+        ? "cancelled"
+        : status === "ready"
+          ? "completed"
+          : "in_progress";
+  const label = error
+    ? `MCP ${serverName} ${status}: ${error}`
+    : `MCP ${serverName} ${status}`;
+
+  return {
+    type: "activity",
+    id: `live-mcp-status-${serverName}`,
+    createdAt: Date.now(),
+    summary: label,
+    status: detailStatus,
+    details: [
+      {
+        id: `live-mcp-status-${serverName}-detail`,
+        kind: "command",
+        label,
+        status: detailStatus,
+      },
+    ],
+  };
+}
+
+function buildMcpOauthActivityEntry(params: Record<string, unknown>): AppServerThreadActivityEntry | undefined {
+  const serverName = readString(params, "name") ?? readString(params, "serverName");
+  if (!serverName) {
+    return undefined;
+  }
+
+  const success = params.success === true;
+  const error = readString(params, "error");
+  const label = success
+    ? `MCP ${serverName} login completed`
+    : `MCP ${serverName} login failed${error ? `: ${error}` : ""}`;
+  const status: AppServerThreadActivityDetail["status"] = success ? "completed" : "failed";
+
+  return {
+    type: "activity",
+    id: `live-mcp-oauth-${serverName}`,
+    createdAt: Date.now(),
+    summary: label,
+    status,
+    details: [
+      {
+        id: `live-mcp-oauth-${serverName}-detail`,
+        kind: "command",
+        label,
+        status,
+      },
+    ],
+  };
 }
 
 function summarizeActivityStatus(
@@ -963,10 +1086,35 @@ export function ThreadView(props: ThreadViewProps) {
           ? event.notification.params.threadId
           : undefined;
 
+      const isGlobalMcpStatus =
+        notificationThreadId == null &&
+        (event.notification.method === "mcpServer/startupStatus/updated" ||
+          event.notification.method === "mcpServer/oauthLogin/completed");
+
       if (
         event.backend !== selectedThread.source ||
-        notificationThreadId !== selectedThread.id
+        (notificationThreadId !== selectedThread.id && !isGlobalMcpStatus)
       ) {
+        return;
+      }
+
+      if (event.notification.method === "mcpServer/startupStatus/updated") {
+        const entry = buildMcpServerStatusActivityEntry(
+          event.notification.params as Record<string, unknown>
+        );
+        if (entry) {
+          setPendingProtocolActivityEntry(entry);
+        }
+        return;
+      }
+
+      if (event.notification.method === "mcpServer/oauthLogin/completed") {
+        const entry = buildMcpOauthActivityEntry(
+          event.notification.params as Record<string, unknown>
+        );
+        if (entry) {
+          setPendingProtocolActivityEntry(entry);
+        }
         return;
       }
 
@@ -1084,6 +1232,36 @@ export function ThreadView(props: ThreadViewProps) {
           });
           setPendingToolActivityEntry((current) => {
             const mergedDetails = mergeActivityDetails(current?.details ?? [], details);
+            return {
+              type: "activity",
+              id: current?.id ?? `live-tools-${turnId}`,
+              createdAt: current?.createdAt ?? Date.now(),
+              summary: summarizeLiveToolActivity(mergedDetails),
+              status: summarizeActivityStatus(mergedDetails),
+              details: mergedDetails,
+              ...(current?.turn ?? turn ? { turn: current?.turn ?? turn } : {}),
+            };
+          });
+        }
+        return;
+      }
+
+      if (event.notification.method === "item/mcpToolCall/progress") {
+        const detail = buildMcpProgressDetail(
+          event.notification.params as Record<string, unknown>
+        );
+        if (detail) {
+          const params = event.notification.params as Record<string, unknown>;
+          const turnId =
+            typeof params.turnId === "string"
+              ? params.turnId
+              : props.activeTurnId ?? selectedThread.id;
+          const turn = buildLiveTurnMetadata({
+            turnId,
+            activeTurnStartedAt: props.activeTurnStartedAt,
+          });
+          setPendingToolActivityEntry((current) => {
+            const mergedDetails = mergeActivityDetails(current?.details ?? [], [detail]);
             return {
               type: "activity",
               id: current?.id ?? `live-tools-${turnId}`,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -33,6 +33,10 @@ import {
   buildQuestionnaireResponse,
   type PendingQuestionnaireState,
 } from "./questionnaire";
+import {
+  buildMcpElicitationResponse,
+  type PendingMcpInteractionState,
+} from "./mcp-elicitation";
 
 function arePlanEntriesEquivalent(
   left: AppServerThreadPlanEntry,
@@ -783,6 +787,7 @@ type ThreadViewProps = {
   loadingMore: boolean;
   messageCount: number;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
@@ -813,6 +818,10 @@ type ThreadViewProps = {
   onUpdatePendingUserInput?: (
     requestId: string,
     updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+  ) => void;
+  onUpdatePendingMcpInteraction?: (
+    requestId: string,
+    updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
   ) => void;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
   onSetThreadModelSettings?: (
@@ -1276,6 +1285,40 @@ export function ThreadView(props: ThreadViewProps) {
     }
   }
 
+  async function submitPendingMcpInteraction(
+    pendingMcpInteraction: PendingMcpInteractionState,
+    action: "accept" | "decline" | "cancel"
+  ): Promise<void> {
+    if (!props.desktopApi?.submitServerRequest || !selectedThread) {
+      setPendingRequestError("Desktop bridge is missing submitServerRequest().");
+      return;
+    }
+
+    setPendingRequestBusy(true);
+    setPendingRequestError(undefined);
+
+    try {
+      await props.desktopApi.submitServerRequest({
+        backend: selectedThread.source,
+        threadId: selectedThread.id,
+        turnId:
+          typeof pendingMcpInteraction.turnId === "string"
+            ? pendingMcpInteraction.turnId
+            : undefined,
+        requestId: pendingMcpInteraction.requestId,
+        response: buildMcpElicitationResponse(pendingMcpInteraction, action),
+      });
+      props.clearPendingRequest(
+        pendingMcpInteraction.requestId,
+        action === "accept" ? "Thinking" : undefined
+      );
+    } catch (error) {
+      setPendingRequestError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPendingRequestBusy(false);
+    }
+  }
+
   if (!selectedThread && !selectedLaunchpad) {
     return (
       <section className="thread-empty-state">
@@ -1411,6 +1454,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingActivityEntry={pendingToolActivityEntry ?? pendingActivityEntry}
               pendingAssistantMessage={props.pendingAssistantMessage}
               pendingPlanEntry={pendingPlanEntry}
+              pendingMcpInteraction={props.pendingMcpInteraction}
               pendingRequest={props.pendingRequest}
               pendingRequestBusy={pendingRequestBusy}
               pendingUserInput={props.pendingUserInput}
@@ -1422,6 +1466,10 @@ export function ThreadView(props: ThreadViewProps) {
               onLoadOlder={props.onLoadOlder}
               onOpenImage={setExpandedImage}
               onRespondToPendingRequest={respondToPendingRequest}
+              onPendingMcpInteractionChange={(state) => {
+                props.onUpdatePendingMcpInteraction?.(state.requestId, () => state);
+              }}
+              onSubmitPendingMcpInteraction={submitPendingMcpInteraction}
               onPendingUserInputChange={(state) => {
                 props.onUpdatePendingUserInput?.(state.requestId, () => state);
               }}
@@ -1447,7 +1495,9 @@ export function ThreadView(props: ThreadViewProps) {
             onSetExecutionMode={props.onSetExecutionMode}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
             pendingRequestActive={Boolean(props.pendingRequest)}
-            pendingUserInputActive={Boolean(props.pendingUserInput)}
+            pendingUserInputActive={Boolean(
+              props.pendingUserInput || props.pendingMcpInteraction
+            )}
             removeOptimisticMessage={props.removeOptimisticMessage}
             setExecutionModeError={props.setExecutionModeError}
             threadModelSettingsError={props.setThreadModelSettingsError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@pwragnt/shared";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { PendingQuestionnaire } from "./PendingQuestionnaire";
+import { PendingMcpInteraction } from "./PendingMcpInteraction";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptMessage } from "./TranscriptMessage";
@@ -18,6 +19,7 @@ import { TranscriptPlan } from "./TranscriptPlan";
 import { TranscriptReview } from "./TranscriptReview";
 import { TranscriptWorkPhaseGroup } from "./TranscriptWorkPhaseGroup";
 import type { PendingQuestionnaireState } from "./questionnaire";
+import type { PendingMcpInteractionState } from "./mcp-elicitation";
 import { buildTranscriptRenderItems } from "./transcript-render-items";
 
 type TranscriptListProps = {
@@ -33,6 +35,7 @@ type TranscriptListProps = {
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingRequestBusy?: boolean;
+  pendingMcpInteraction?: PendingMcpInteractionState;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   pagination?: AppServerThreadReplayPagination;
@@ -48,6 +51,11 @@ type TranscriptListProps = {
     scrollTop: number;
   }) => void;
   onRespondToPendingRequest?: (decision: "approve" | "decline" | "cancel") => Promise<void>;
+  onPendingMcpInteractionChange?: (state: PendingMcpInteractionState) => void;
+  onSubmitPendingMcpInteraction?: (
+    state: PendingMcpInteractionState,
+    action: "accept" | "decline" | "cancel"
+  ) => Promise<void>;
   onPendingUserInputChange?: (state: PendingQuestionnaireState) => void;
   onSubmitPendingUserInput?: (state: PendingQuestionnaireState) => Promise<void>;
   onLoadOlder: () => Promise<void>;
@@ -185,6 +193,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingAssistantMessage ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
+      props.pendingMcpInteraction ||
       props.pendingUserInput ||
       props.pendingStatusText
   );
@@ -321,6 +330,7 @@ export function TranscriptList(props: TranscriptListProps) {
       (props.pendingPlanEntry ? 1 : 0) +
       (props.pendingStatusText ? 1 : 0) +
       (props.pendingRequest ? 1 : 0) +
+      (props.pendingMcpInteraction ? 1 : 0) +
       (props.pendingUserInput ? 1 : 0);
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
@@ -345,6 +355,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
+    props.pendingMcpInteraction,
     props.pendingUserInput,
     props.pendingStatusText,
     props.threadId
@@ -437,6 +448,7 @@ export function TranscriptList(props: TranscriptListProps) {
               (props.pendingPlanEntry ? 1 : 0) +
               (props.pendingStatusText ? 1 : 0) +
               (props.pendingRequest ? 1 : 0) +
+              (props.pendingMcpInteraction ? 1 : 0) +
               (props.pendingUserInput ? 1 : 0))
     );
     const hasGrownWhileFollowingBottom = Boolean(
@@ -492,6 +504,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.pendingRequest,
+    props.pendingMcpInteraction,
     props.pendingUserInput,
     props.pendingStatusText,
     props.restoredViewport,
@@ -583,6 +596,18 @@ export function TranscriptList(props: TranscriptListProps) {
             }}
             onSubmit={async (state) => {
               await props.onSubmitPendingUserInput?.(state);
+            }}
+          />
+        ) : null}
+        {props.pendingMcpInteraction ? (
+          <PendingMcpInteraction
+            busy={props.pendingRequestBusy}
+            state={props.pendingMcpInteraction}
+            onChange={(state) => {
+              props.onPendingMcpInteractionChange?.(state);
+            }}
+            onSubmit={async (state, action) => {
+              await props.onSubmitPendingMcpInteraction?.(state, action);
             }}
           />
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-elicitation.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-elicitation.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerMcpElicitationRequestNotification } from "@pwragnt/shared";
+import {
+  buildMcpElicitationResponse,
+  canAcceptMcpElicitation,
+  createMcpElicitationState,
+  redactDisplayValue,
+  updateMcpFieldValue,
+} from "../mcp-elicitation";
+
+function buildRequest(
+  params: Partial<AppServerMcpElicitationRequestNotification["params"]>
+): AppServerMcpElicitationRequestNotification {
+  return {
+    method: "mcpServer/elicitation/request",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "mcp-request-1",
+      serverName: "playwright",
+      mode: "form",
+      _meta: null,
+      message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+      requestedSchema: {
+        type: "object",
+        properties: {},
+      },
+      ...params,
+    },
+  };
+}
+
+describe("MCP elicitation helpers", () => {
+  it("accepts empty-schema form approvals with MCP response shape", () => {
+    const state = createMcpElicitationState(buildRequest({}));
+
+    expect(state).toBeDefined();
+    expect(state?.form).toMatchObject({
+      empty: true,
+      fields: [],
+    });
+    expect(canAcceptMcpElicitation(state!)).toBe(true);
+    expect(buildMcpElicitationResponse(state!, "accept")).toEqual({
+      action: "accept",
+      content: {},
+      _meta: null,
+    });
+  });
+
+  it("declines and cancels with null content", () => {
+    const state = createMcpElicitationState(buildRequest({}))!;
+
+    expect(buildMcpElicitationResponse(state, "decline")).toEqual({
+      action: "decline",
+      content: null,
+      _meta: null,
+    });
+    expect(buildMcpElicitationResponse(state, "cancel")).toEqual({
+      action: "cancel",
+      content: null,
+      _meta: null,
+    });
+  });
+
+  it("validates required string fields and submits content", () => {
+    const state = createMcpElicitationState(
+      buildRequest({
+        requestedSchema: {
+          type: "object",
+          required: ["query"],
+          properties: {
+            query: {
+              type: "string",
+              title: "Search query",
+              description: "The search text.",
+              minLength: 2,
+            },
+          },
+        },
+      })
+    )!;
+
+    expect(canAcceptMcpElicitation(state)).toBe(false);
+
+    const answered = updateMcpFieldValue(state, "query", "tabs");
+
+    expect(canAcceptMcpElicitation(answered)).toBe(true);
+    expect(buildMcpElicitationResponse(answered, "accept")).toEqual({
+      action: "accept",
+      content: {
+        query: "tabs",
+      },
+      _meta: null,
+    });
+  });
+
+  it("preserves boolean, number, and enum field values", () => {
+    const state = createMcpElicitationState(
+      buildRequest({
+        requestedSchema: {
+          type: "object",
+          required: ["count", "target"],
+          properties: {
+            includeClosed: {
+              type: "boolean",
+              title: "Include closed",
+              default: true,
+            },
+            count: {
+              type: "integer",
+              title: "Count",
+              minimum: 1,
+              maximum: 10,
+            },
+            target: {
+              type: "string",
+              title: "Target",
+              oneOf: [
+                { const: "tabs", title: "Tabs" },
+                { const: "windows", title: "Windows" },
+              ],
+            },
+          },
+        },
+      })
+    )!;
+
+    const withCount = updateMcpFieldValue(state, "count", 3);
+    const answered = updateMcpFieldValue(withCount, "target", "tabs");
+
+    expect(canAcceptMcpElicitation(answered)).toBe(true);
+    expect(buildMcpElicitationResponse(answered, "accept")).toEqual({
+      action: "accept",
+      content: {
+        includeClosed: true,
+        count: 3,
+        target: "tabs",
+      },
+      _meta: null,
+    });
+  });
+
+  it("supports multi-select enum arrays", () => {
+    const state = createMcpElicitationState(
+      buildRequest({
+        requestedSchema: {
+          type: "object",
+          required: ["scopes"],
+          properties: {
+            scopes: {
+              type: "array",
+              title: "Scopes",
+              minItems: 1,
+              items: {
+                anyOf: [
+                  { const: "repo", title: "Repository" },
+                  { const: "issues", title: "Issues" },
+                ],
+              },
+            },
+          },
+        },
+      })
+    )!;
+
+    expect(canAcceptMcpElicitation(state)).toBe(false);
+
+    const answered = updateMcpFieldValue(state, "scopes", ["repo", "issues"]);
+
+    expect(canAcceptMcpElicitation(answered)).toBe(true);
+    expect(buildMcpElicitationResponse(answered, "accept")).toEqual({
+      action: "accept",
+      content: {
+        scopes: ["repo", "issues"],
+      },
+      _meta: null,
+    });
+  });
+
+  it("preserves URL mode without embedding URL details in response content", () => {
+    const state = createMcpElicitationState(
+      buildRequest({
+        turnId: null,
+        serverName: "github",
+        mode: "url",
+        message: "Authorize GitHub access.",
+        requestedSchema: undefined,
+        url: "https://example.test/oauth/start?state=secret-state#fragment",
+        elicitationId: "elicitation-1",
+      })
+    );
+
+    expect(state).toBeDefined();
+    expect(state?.url).toEqual({
+      url: "https://example.test/oauth/start?state=secret-state#fragment",
+      displayUrl: "https://example.test/oauth/start",
+      elicitationId: "elicitation-1",
+    });
+    expect(canAcceptMcpElicitation(state!)).toBe(true);
+    expect(buildMcpElicitationResponse(state!, "accept")).toEqual({
+      action: "accept",
+      content: {},
+      _meta: null,
+    });
+  });
+
+  it("blocks required unsupported fields", () => {
+    const state = createMcpElicitationState(
+      buildRequest({
+        requestedSchema: {
+          type: "object",
+          required: ["payload"],
+          properties: {
+            payload: {
+              type: "object",
+              title: "Payload",
+            },
+          },
+        },
+      })
+    );
+
+    expect(state).toBeDefined();
+    expect(state?.form?.fields[0]).toMatchObject({
+      kind: "unsupported",
+      key: "payload",
+      required: true,
+    });
+    expect(canAcceptMcpElicitation(state!)).toBe(false);
+  });
+
+  it("rejects malformed requests", () => {
+    expect(
+      createMcpElicitationState(
+        buildRequest({
+          requestId: "",
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      createMcpElicitationState(
+        buildRequest({
+          requestedSchema: undefined,
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      createMcpElicitationState(
+        buildRequest({
+          mode: "url",
+          requestedSchema: undefined,
+          url: "",
+          elicitationId: "elicitation-1",
+        })
+      )
+    ).toBeUndefined();
+  });
+
+  it("redacts tokens and URL query strings for display", () => {
+    expect(redactDisplayValue("Bearer abc123")).toBe("[redacted]");
+    expect(redactDisplayValue("abc123def456ghi789jkl012mno345pq")).toBe("[redacted]");
+    expect(redactDisplayValue("https://example.test/path?token=secret#frag")).toBe(
+      "https://example.test/path"
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-mcp-interaction.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-mcp-interaction.test.tsx
@@ -1,0 +1,106 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PendingMcpInteraction } from "../PendingMcpInteraction";
+import { createMcpElicitationState } from "../mcp-elicitation";
+import type { AppServerMcpElicitationRequestNotification } from "@pwragnt/shared";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PendingMcpInteraction", () => {
+  it("renders metadata, redacts sensitive values, and submits accept", () => {
+    const onChange = vi.fn();
+    const onSubmit = vi.fn();
+    const state = createMcpElicitationState({
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "mcp-request-1",
+        serverName: "playwright",
+        mode: "form",
+        message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+        requestedSchema: {
+          type: "object",
+          properties: {},
+        },
+        _meta: {
+          tool_description: "List, create, close, or select a browser tab.",
+          tool_params_display: [
+            { label: "token", value: "Bearer super-secret-token" },
+          ],
+        },
+      },
+    } satisfies AppServerMcpElicitationRequestNotification);
+
+    render(
+      <PendingMcpInteraction state={state!} onChange={onChange} onSubmit={onSubmit} />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending MCP interaction" })).toBeInTheDocument();
+    expect(screen.getByText("MCP approval")).toBeInTheDocument();
+    expect(screen.getByText(/browser_tabs/)).toBeInTheDocument();
+    expect(screen.getByText("[redacted]")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(state, "accept");
+  });
+
+  it("updates required fields before allowing submit", () => {
+    let state = createMcpElicitationState({
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-1",
+        turnId: null,
+        requestId: "mcp-request-1",
+        serverName: "github",
+        mode: "form",
+        message: "Provide issue details.",
+        requestedSchema: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: {
+              type: "string",
+              title: "Title",
+            },
+          },
+        },
+        _meta: {},
+      },
+    } satisfies AppServerMcpElicitationRequestNotification)!;
+    const onSubmit = vi.fn();
+
+    const { rerender } = render(
+      <PendingMcpInteraction
+        state={state}
+        onChange={(nextState) => {
+          state = nextState;
+        }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Allow" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Title/), {
+      target: { value: "Fix the tabs flow" },
+    });
+    rerender(
+      <PendingMcpInteraction
+        state={state}
+        onChange={(nextState) => {
+          state = nextState;
+        }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(state, "accept");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1258,6 +1258,256 @@ describe("ThreadView", () => {
     );
   });
 
+  it("renders MCP tool-call item and progress activity", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Browser task",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Use Playwright."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            item: {
+              id: "call-mcp-browser-tabs",
+              type: "mcpToolCall",
+              server: "playwright",
+              tool: "browser_tabs",
+              status: "in_progress",
+              arguments: { action: "list" },
+              result: null,
+              error: null,
+            },
+          },
+        } as AppServerNotification,
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/mcpToolCall/progress",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            itemId: "call-mcp-browser-tabs",
+            message: "Listing browser tabs",
+          },
+        },
+      });
+    });
+
+    expect(screen.getAllByText("MCP Listing browser tabs").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /MCP Listing browser tabs/ }));
+    expect(screen.getAllByText("MCP Listing browser tabs").length).toBeGreaterThan(0);
+  });
+
+  it("renders global MCP startup and OAuth status for the selected backend", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Browser task",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Use Playwright."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "grok",
+        notification: {
+          method: "mcpServer/startupStatus/updated",
+          params: {
+            name: "ignored",
+            status: "ready",
+            error: null,
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "mcpServer/startupStatus/updated",
+          params: {
+            name: "playwright",
+            status: "starting",
+            error: null,
+          },
+        },
+      });
+    });
+
+    expect(screen.getByText("MCP playwright starting")).toBeInTheDocument();
+    expect(screen.queryByText("MCP ignored ready")).not.toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "mcpServer/oauthLogin/completed",
+          params: {
+            name: "playwright",
+            success: true,
+          },
+        },
+      });
+    });
+
+    expect(screen.getByText("MCP playwright login completed")).toBeInTheDocument();
+  });
+
   it("renders live Codex command execution activity without falling back to tool", async () => {
     const selectedThread = {
       id: "thread-2",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerNotification, AppServerPendingRequestNotification } from "@pwragnt/shared";
+import type { PendingMcpInteractionState } from "../mcp-elicitation";
 import type { PendingQuestionnaireState } from "../questionnaire";
 import { ThreadView } from "../ThreadView";
 
@@ -2445,6 +2446,227 @@ describe("ThreadView", () => {
       ).not.toBeInTheDocument();
     });
     expect(clearPendingRequest).toHaveBeenCalledWith("input-request-1", "Thinking");
+  });
+
+  it("submits pending MCP interactions through the server request bridge", async () => {
+    let currentPendingMcpInteraction: PendingMcpInteractionState | undefined = {
+      method: "mcpServer/elicitation/request",
+      threadId: "thread-2",
+      turnId: "turn-1",
+      requestId: "mcp-request-1",
+      serverName: "playwright",
+      message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+      mode: "form",
+      _meta: {
+        tool_description: "List, create, close, or select a browser tab.",
+      },
+      form: {
+        empty: true,
+        fields: [],
+      },
+      url: null,
+    };
+    let currentPendingStatus = "Waiting for MCP approval";
+    const submitServerRequest = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-2",
+      turnId: "turn-1",
+      requestId: "mcp-request-1",
+    }));
+    const clearPendingRequest = vi.fn((_requestId: string, nextStatus?: string) => {
+      currentPendingMcpInteraction = undefined;
+      currentPendingStatus = nextStatus ?? "";
+      rerenderThreadView();
+    });
+    const updatePendingMcpInteraction = vi.fn(
+      (
+        _requestId: string,
+        updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
+      ) => {
+        if (currentPendingMcpInteraction) {
+          currentPendingMcpInteraction = updater(currentPendingMcpInteraction);
+          rerenderThreadView();
+        }
+      }
+    );
+
+    const { rerender } = render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+          submitServerRequest,
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        pendingMcpInteraction={currentPendingMcpInteraction}
+        pendingStatusText={currentPendingStatus}
+        selectedThread={{
+          id: "thread-2",
+          title: "Plan the app-server protocol",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false
+          }
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Use the browser"
+          }
+        ]}
+        clearPendingRequest={clearPendingRequest}
+        onLoadOlder={async () => undefined}
+        onUpdatePendingMcpInteraction={updatePendingMcpInteraction}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    const rerenderThreadView = () => {
+      rerender(
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: true,
+                multiDirectoryThreads: true
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            }
+          ]}
+          composerDisabled={false}
+          desktopApi={{
+            startTurn: async () => ({
+              backend: "codex",
+              threadId: "thread-2",
+              turnId: "turn-1",
+            }),
+            submitServerRequest,
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          pendingMcpInteraction={currentPendingMcpInteraction}
+          pendingStatusText={currentPendingStatus}
+          selectedThread={{
+            id: "thread-2",
+            title: "Plan the app-server protocol",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false
+            }
+          }}
+          skills={[]}
+          transcriptEntries={[
+            {
+              type: "message",
+              id: "message-1",
+              role: "user",
+              text: "Use the browser"
+            }
+          ]}
+          clearPendingRequest={clearPendingRequest}
+          onLoadOlder={async () => undefined}
+          onUpdatePendingMcpInteraction={updatePendingMcpInteraction}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    };
+
+    expect(
+      screen.getByRole("group", { name: "Pending MCP interaction" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    await waitFor(() => {
+      expect(submitServerRequest).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-2",
+        turnId: "turn-1",
+        requestId: "mcp-request-1",
+        response: {
+          action: "accept",
+          content: {},
+          _meta: null,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("group", { name: "Pending MCP interaction" })
+      ).not.toBeInTheDocument();
+    });
+    expect(clearPendingRequest).toHaveBeenCalledWith("mcp-request-1", "Thinking");
   });
 
   it("clears a stale approval card when assistant output resumes", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1586,4 +1586,40 @@ describe("TranscriptList", () => {
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Decline" })).not.toBeInTheDocument();
   });
+
+  it("renders pending MCP interaction without shell approval actions", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingMcpInteraction={{
+          method: "mcpServer/elicitation/request",
+          threadId: "thread-1",
+          requestId: "mcp-request-1",
+          serverName: "playwright",
+          message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+          mode: "form",
+          turnId: "turn-1",
+          _meta: {
+            tool_description: "List, create, close, or select a browser tab.",
+          },
+          form: {
+            empty: true,
+            fields: [],
+          },
+          url: null,
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(
+      screen.getByRole("group", { name: "Pending MCP interaction" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("MCP approval")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Allow" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/mcp-elicitation.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/mcp-elicitation.ts
@@ -1,0 +1,497 @@
+import type {
+  AppServerMcpElicitationRequestNotification,
+  AppServerMcpElicitationResponse,
+} from "@pwragnt/shared";
+
+export type PendingMcpFieldOption = {
+  value: string;
+  label: string;
+};
+
+export type PendingMcpField =
+  | {
+      kind: "string";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+      minLength?: number;
+      maxLength?: number;
+      value: string;
+    }
+  | {
+      kind: "number";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+      integer: boolean;
+      minimum?: number;
+      maximum?: number;
+      value: number | null;
+    }
+  | {
+      kind: "boolean";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+      value: boolean;
+    }
+  | {
+      kind: "singleSelect";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+      options: PendingMcpFieldOption[];
+      value: string;
+    }
+  | {
+      kind: "multiSelect";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+      options: PendingMcpFieldOption[];
+      minItems?: number;
+      maxItems?: number;
+      value: string[];
+    }
+  | {
+      kind: "unsupported";
+      key: string;
+      label: string;
+      description: string;
+      required: boolean;
+    };
+
+export type PendingMcpInteractionState = {
+  method: "mcpServer/elicitation/request";
+  requestId: string;
+  threadId: string;
+  turnId?: string | null;
+  serverName: string;
+  message: string;
+  mode: "form" | "url";
+  _meta: Record<string, unknown> | null;
+  form: {
+    empty: boolean;
+    fields: PendingMcpField[];
+  } | null;
+  url: {
+    url: string;
+    displayUrl: string;
+    elicitationId: string;
+  } | null;
+};
+
+type FieldValue = string | number | boolean | string[] | null;
+
+export function createMcpElicitationState(
+  request: AppServerMcpElicitationRequestNotification
+): PendingMcpInteractionState | undefined {
+  const requestId = trimString(request.params.requestId);
+  const threadId = trimString(request.params.threadId);
+  const serverName = trimString(request.params.serverName);
+  const message = trimString(request.params.message);
+  if (!requestId || !threadId || !serverName || !message) {
+    return undefined;
+  }
+
+  if (request.params.mode === "url") {
+    const url = trimString(request.params.url);
+    const elicitationId = trimString(request.params.elicitationId);
+    if (!url || !elicitationId) {
+      return undefined;
+    }
+
+    return baseState(request, {
+      form: null,
+      url: {
+        url,
+        displayUrl: redactUrl(url),
+        elicitationId,
+      },
+    });
+  }
+
+  const schema = request.params.requestedSchema;
+  if (!schema || schema.type !== "object") {
+    return undefined;
+  }
+
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+  const properties = asRecord(schema.properties) ?? {};
+  const fields = Object.entries(properties).map(([key, value]) =>
+    buildField(key, asRecord(value) ?? {}, required.has(key))
+  );
+
+  return baseState(request, {
+    form: {
+      empty: fields.length === 0,
+      fields,
+    },
+    url: null,
+  });
+}
+
+export function updateMcpFieldValue(
+  state: PendingMcpInteractionState,
+  key: string,
+  value: FieldValue
+): PendingMcpInteractionState {
+  if (!state.form) {
+    return state;
+  }
+
+  return {
+    ...state,
+    form: {
+      ...state.form,
+      fields: state.form.fields.map((field) => {
+        if (field.key !== key || field.kind === "unsupported") {
+          return field;
+        }
+        return updateFieldValue(field, value);
+      }),
+    },
+  };
+}
+
+export function canAcceptMcpElicitation(
+  state: PendingMcpInteractionState
+): boolean {
+  if (state.mode === "url") {
+    return Boolean(state.url?.url);
+  }
+  if (!state.form) {
+    return false;
+  }
+  return state.form.fields.every(fieldIsValid);
+}
+
+export function buildMcpElicitationResponse(
+  state: PendingMcpInteractionState,
+  action: "accept" | "decline" | "cancel"
+): AppServerMcpElicitationResponse {
+  if (action !== "accept") {
+    return {
+      action,
+      content: null,
+      _meta: null,
+    };
+  }
+
+  if (state.mode === "url") {
+    return {
+      action,
+      content: {},
+      _meta: null,
+    };
+  }
+
+  return {
+    action,
+    content: Object.fromEntries(
+      state.form?.fields
+        .filter((field) => field.kind !== "unsupported")
+        .map((field) => [field.key, fieldContentValue(field)]) ?? []
+    ),
+    _meta: null,
+  };
+}
+
+export function redactDisplayValue(value: unknown): string {
+  if (typeof value !== "string") {
+    return String(value ?? "");
+  }
+
+  if (looksSecret(value)) {
+    return "[redacted]";
+  }
+
+  return redactUrl(value);
+}
+
+function baseState(
+  request: AppServerMcpElicitationRequestNotification,
+  modeState: Pick<PendingMcpInteractionState, "form" | "url">
+): PendingMcpInteractionState {
+  return {
+    method: request.method,
+    requestId: request.params.requestId,
+    threadId: request.params.threadId,
+    turnId: request.params.turnId,
+    serverName: request.params.serverName,
+    message: request.params.message.trim(),
+    mode: request.params.mode,
+    _meta: asRecord(request.params._meta),
+    ...modeState,
+  };
+}
+
+function buildField(
+  key: string,
+  schema: Record<string, unknown>,
+  required: boolean
+): PendingMcpField {
+  const label = trimString(schema.title) || key;
+  const description = trimString(schema.description);
+
+  if (schema.type === "string") {
+    const enumOptions = readStringOptions(schema);
+    if (enumOptions.length > 0) {
+      return {
+        kind: "singleSelect",
+        key,
+        label,
+        description,
+        required,
+        options: enumOptions,
+        value: trimString(schema.default),
+      };
+    }
+
+    return {
+      kind: "string",
+      key,
+      label,
+      description,
+      required,
+      minLength: readNumber(schema.minLength),
+      maxLength: readNumber(schema.maxLength),
+      value: trimString(schema.default),
+    };
+  }
+
+  if (schema.type === "number" || schema.type === "integer") {
+    return {
+      kind: "number",
+      key,
+      label,
+      description,
+      required,
+      integer: schema.type === "integer",
+      minimum: readNumber(schema.minimum),
+      maximum: readNumber(schema.maximum),
+      value: readNumber(schema.default) ?? null,
+    };
+  }
+
+  if (schema.type === "boolean") {
+    return {
+      kind: "boolean",
+      key,
+      label,
+      description,
+      required,
+      value: typeof schema.default === "boolean" ? schema.default : false,
+    };
+  }
+
+  if (schema.type === "array") {
+    const options = readArrayOptions(schema);
+    if (options.length > 0) {
+      return {
+        kind: "multiSelect",
+        key,
+        label,
+        description,
+        required,
+        options,
+        minItems: readBigIntLike(schema.minItems),
+        maxItems: readBigIntLike(schema.maxItems),
+        value: Array.isArray(schema.default)
+          ? schema.default.filter((entry): entry is string => typeof entry === "string")
+          : [],
+      };
+    }
+  }
+
+  return {
+    kind: "unsupported",
+    key,
+    label,
+    description,
+    required,
+  };
+}
+
+function updateFieldValue(field: Exclude<PendingMcpField, { kind: "unsupported" }>, value: FieldValue): PendingMcpField {
+  if (field.kind === "string" && typeof value === "string") {
+    return { ...field, value };
+  }
+  if (field.kind === "number" && (typeof value === "number" || value === null)) {
+    return { ...field, value };
+  }
+  if (field.kind === "boolean" && typeof value === "boolean") {
+    return { ...field, value };
+  }
+  if (field.kind === "singleSelect" && typeof value === "string") {
+    return { ...field, value };
+  }
+  if (
+    field.kind === "multiSelect" &&
+    Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+  ) {
+    return { ...field, value };
+  }
+  return field;
+}
+
+function fieldIsValid(field: PendingMcpField): boolean {
+  if (field.kind === "unsupported") {
+    return !field.required;
+  }
+  if (field.kind === "boolean") {
+    return true;
+  }
+  if (field.kind === "number") {
+    if (field.value == null) {
+      return !field.required;
+    }
+    if (field.integer && !Number.isInteger(field.value)) {
+      return false;
+    }
+    if (field.minimum != null && field.value < field.minimum) {
+      return false;
+    }
+    if (field.maximum != null && field.value > field.maximum) {
+      return false;
+    }
+    return true;
+  }
+  if (field.kind === "multiSelect") {
+    if (field.required && field.value.length === 0) {
+      return false;
+    }
+    if (field.minItems != null && field.value.length < field.minItems) {
+      return false;
+    }
+    if (field.maxItems != null && field.value.length > field.maxItems) {
+      return false;
+    }
+    return field.value.every((entry) =>
+      field.options.some((option) => option.value === entry)
+    );
+  }
+
+  const value = field.value.trim();
+  if (field.required && !value) {
+    return false;
+  }
+  if (field.kind === "string") {
+    if (field.minLength != null && value.length < field.minLength) {
+      return false;
+    }
+    if (field.maxLength != null && value.length > field.maxLength) {
+      return false;
+    }
+  }
+  if (field.kind === "singleSelect" && value) {
+    return field.options.some((option) => option.value === value);
+  }
+  return true;
+}
+
+function fieldContentValue(field: Exclude<PendingMcpField, { kind: "unsupported" }>): unknown {
+  if (field.kind === "string" || field.kind === "singleSelect") {
+    return field.value;
+  }
+  return field.value;
+}
+
+function readStringOptions(schema: Record<string, unknown>): PendingMcpFieldOption[] {
+  if (Array.isArray(schema.oneOf)) {
+    return schema.oneOf.flatMap((entry) => {
+      const record = asRecord(entry);
+      const value = trimString(record?.const);
+      if (!value) {
+        return [];
+      }
+      return [{ value, label: trimString(record?.title) || value }];
+    });
+  }
+
+  if (Array.isArray(schema.enum)) {
+    const names = Array.isArray(schema.enumNames) ? schema.enumNames : [];
+    return schema.enum.flatMap((entry, index) => {
+      if (typeof entry !== "string") {
+        return [];
+      }
+      return [{ value: entry, label: trimString(names[index]) || entry }];
+    });
+  }
+
+  return [];
+}
+
+function readArrayOptions(schema: Record<string, unknown>): PendingMcpFieldOption[] {
+  const items = asRecord(schema.items);
+  if (!items) {
+    return [];
+  }
+
+  if (Array.isArray(items.anyOf)) {
+    return items.anyOf.flatMap((entry) => {
+      const record = asRecord(entry);
+      const value = trimString(record?.const);
+      if (!value) {
+        return [];
+      }
+      return [{ value, label: trimString(record?.title) || value }];
+    });
+  }
+
+  if (Array.isArray(items.enum)) {
+    return items.enum.flatMap((entry) =>
+      typeof entry === "string" ? [{ value: entry, label: entry }] : []
+    );
+  }
+
+  return [];
+}
+
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function looksSecret(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    /^bearer\s+/i.test(trimmed) ||
+    /^[A-Za-z0-9_-]{32,}$/.test(trimmed) ||
+    /(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)=/i.test(trimmed)
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readBigIntLike(value: unknown): number | undefined {
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  return readNumber(value);
+}
+
+function trimString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1707,6 +1707,96 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingStatusText).toBe("Thinking");
   });
 
+  it("clears pending MCP interactions when the turn is cancelled", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "mcpServer/elicitation/request",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              requestId: "mcp-request-cancelled",
+              serverName: "playwright",
+              mode: "form",
+              _meta: null,
+              message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+              requestedSchema: {
+                type: "object",
+                properties: {},
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingMcpInteraction?.requestId).toBe(
+      "mcp-request-cancelled"
+    );
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/cancelled",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "cancelled",
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingMcpInteraction).toBeUndefined();
+    expect(result.current.pendingRequest).toBeUndefined();
+    expect(result.current.pendingUserInput).toBeUndefined();
+    expect(result.current.pendingStatusText).toBeUndefined();
+  });
+
   it("updates and clears pending MCP interactions", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1611,6 +1611,198 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingStatusText).toBe("Thinking");
   });
 
+  it("surfaces MCP elicitations as pending MCP interactions instead of approval", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "mcpServer/elicitation/request",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              requestId: "mcp-request-1",
+              serverName: "playwright",
+              mode: "form",
+              _meta: {
+                tool_description: "List, create, close, or select a browser tab.",
+              },
+              message: "Allow the playwright MCP server to run tool \"browser_tabs\"?",
+              requestedSchema: {
+                type: "object",
+                properties: {},
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Waiting for MCP approval");
+    expect(result.current.pendingRequest).toBeUndefined();
+    expect(result.current.pendingUserInput).toBeUndefined();
+    expect(result.current.pendingMcpInteraction).toMatchObject({
+      method: "mcpServer/elicitation/request",
+      requestId: "mcp-request-1",
+      serverName: "playwright",
+      mode: "form",
+      form: {
+        empty: true,
+        fields: [],
+      },
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "serverRequest/resolved",
+            params: {
+              threadId: "thread-1",
+              requestId: "mcp-request-1",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingMcpInteraction).toBeUndefined();
+    expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
+  it("updates and clears pending MCP interactions", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "mcpServer/elicitation/request",
+            params: {
+              threadId: "thread-1",
+              turnId: null,
+              requestId: "mcp-request-2",
+              serverName: "github",
+              mode: "form",
+              _meta: null,
+              message: "Provide a repository.",
+              requestedSchema: {
+                type: "object",
+                required: ["repo"],
+                properties: {
+                  repo: {
+                    type: "string",
+                    title: "Repository",
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+    });
+
+    act(() => {
+      result.current.updatePendingMcpInteraction("mcp-request-2", (state) => ({
+        ...state,
+        form: state.form
+          ? {
+              ...state.form,
+              fields: state.form.fields.map((field) =>
+                field.key === "repo" && field.kind === "string"
+                  ? { ...field, value: "pwrdrvr/PwrAgnt" }
+                  : field
+              ),
+            }
+          : state.form,
+      }));
+    });
+
+    expect(result.current.pendingMcpInteraction?.form?.fields[0]).toMatchObject({
+      key: "repo",
+      value: "pwrdrvr/PwrAgnt",
+    });
+
+    act(() => {
+      result.current.clearPendingRequest("mcp-request-2", "Thinking");
+    });
+
+    expect(result.current.pendingMcpInteraction).toBeUndefined();
+    expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
   it("rereads a partially hydrated transcript after turn completion when only the user message is present", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AppServerMcpElicitationRequestNotification,
   AppServerPendingRequestNotification,
   AppServerReadThreadResponse,
   AppServerReviewOutput,
@@ -19,6 +20,10 @@ import {
   type PendingQuestionnaireState,
 } from "../features/thread-detail/questionnaire";
 import { normalizeReviewDisplayText } from "../../../shared/review-command";
+import {
+  createMcpElicitationState,
+  type PendingMcpInteractionState,
+} from "../features/thread-detail/mcp-elicitation";
 
 const MAX_VIEW_ONLY_THREADS = 10;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
@@ -48,6 +53,7 @@ type ThreadSessionEntry = {
   needsHydrationAfterCompletion: boolean;
   optimisticEntries: AppServerThreadEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
@@ -200,6 +206,7 @@ function hasHydratedTranscriptContent(session: ThreadSessionEntry): boolean {
     session.response?.replay.entries.length ||
       session.optimisticEntries.length ||
       session.pendingAssistantMessage ||
+      session.pendingMcpInteraction ||
       session.pendingRequest ||
       session.pendingUserInput
   );
@@ -210,6 +217,7 @@ function hasThinkingState(session: ThreadSessionEntry): boolean {
     session.activeTurnId ||
       session.pendingStatusText ||
       session.pendingAssistantMessage ||
+      session.pendingMcpInteraction ||
       session.pendingRequest ||
       session.pendingUserInput ||
       (session.expectOwnUpdate && session.optimisticEntries.length > 0)
@@ -559,6 +567,19 @@ function isRequestUserInputNotification(
   );
 }
 
+function isMcpElicitationNotification(
+  notification: { method: string; params: Record<string, unknown> }
+): notification is AppServerMcpElicitationRequestNotification {
+  return (
+    notification.method === "mcpServer/elicitation/request" &&
+    typeof notification.params.threadId === "string" &&
+    typeof notification.params.requestId === "string" &&
+    typeof notification.params.serverName === "string" &&
+    typeof notification.params.message === "string" &&
+    (notification.params.mode === "form" || notification.params.mode === "url")
+  );
+}
+
 function readCompletedTurnText(
   notification: AppServerPendingRequestNotification | AppServerReadThreadResponse["backend"] | unknown
 ): string | undefined {
@@ -615,6 +636,7 @@ export function useThreadSessionState(params: {
   loadOlder: () => Promise<void>;
   messages: AppServerThreadMessage[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
@@ -624,6 +646,10 @@ export function useThreadSessionState(params: {
   updatePendingUserInput: (
     requestId: string,
     updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
+  ) => void;
+  updatePendingMcpInteraction: (
+    requestId: string,
+    updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
   ) => void;
   setPendingStatusText: (status?: string) => void;
   thinkingThreadKeys: Record<string, boolean>;
@@ -912,6 +938,21 @@ export function useThreadSessionState(params: {
           };
         }
 
+        if (isMcpElicitationNotification(event.notification)) {
+          const pendingMcpInteraction = createMcpElicitationState(event.notification);
+          if (!pendingMcpInteraction) {
+            return current;
+          }
+
+          return {
+            ...current,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingMcpInteraction,
+            pendingStatusText: "Waiting for MCP approval",
+          };
+        }
+
         if (
           event.notification.method === "item/agentMessage/delta" &&
           typeof event.notification.params.itemId === "string" &&
@@ -1000,6 +1041,10 @@ export function useThreadSessionState(params: {
               current.pendingRequest?.params.requestId === event.notification.params.requestId
                 ? undefined
                 : current.pendingRequest,
+            pendingMcpInteraction:
+              current.pendingMcpInteraction?.requestId === event.notification.params.requestId
+                ? undefined
+                : current.pendingMcpInteraction,
             pendingUserInput:
               current.pendingUserInput?.requestId === event.notification.params.requestId
                 ? undefined
@@ -1119,6 +1164,7 @@ export function useThreadSessionState(params: {
               ...current,
               optimisticEntries: [],
               pendingAssistantMessage: undefined,
+              pendingMcpInteraction: undefined,
               pendingRequest: undefined,
               pendingUserInput: undefined,
               response: nextResponse,
@@ -1143,6 +1189,7 @@ export function useThreadSessionState(params: {
               !completedText || shouldHydrateUnknownPhaseAssistant,
             optimisticEntries: [],
             pendingAssistantMessage: undefined,
+            pendingMcpInteraction: undefined,
             pendingRequest: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
@@ -1167,6 +1214,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion: false,
             pendingAssistantMessage: undefined,
+            pendingMcpInteraction: undefined,
             pendingRequest: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
@@ -1184,6 +1232,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion: false,
             pendingAssistantMessage: undefined,
+            pendingMcpInteraction: undefined,
             pendingRequest: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
@@ -1419,6 +1468,10 @@ export function useThreadSessionState(params: {
           current.pendingRequest?.params.requestId === requestId
             ? undefined
             : current.pendingRequest,
+        pendingMcpInteraction:
+          current.pendingMcpInteraction?.requestId === requestId
+            ? undefined
+            : current.pendingMcpInteraction,
         pendingUserInput:
           current.pendingUserInput?.requestId === requestId
             ? undefined
@@ -1447,6 +1500,30 @@ export function useThreadSessionState(params: {
           ...current,
           lastTouchedAt: Date.now(),
           pendingUserInput: updater(current.pendingUserInput),
+        };
+      });
+    },
+    [threadKey, updateSession]
+  );
+
+  const updatePendingMcpInteraction = useCallback(
+    (
+      requestId: string,
+      updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
+    ): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => {
+        if (current.pendingMcpInteraction?.requestId !== requestId) {
+          return current;
+        }
+
+        return {
+          ...current,
+          lastTouchedAt: Date.now(),
+          pendingMcpInteraction: updater(current.pendingMcpInteraction),
         };
       });
     },
@@ -1552,6 +1629,7 @@ export function useThreadSessionState(params: {
     loadOlder,
     messages,
     pendingAssistantMessage: selectedSession?.pendingAssistantMessage,
+    pendingMcpInteraction: selectedSession?.pendingMcpInteraction,
     pendingRequest: selectedSession?.pendingRequest,
     pendingUserInput: selectedSession?.pendingUserInput,
     pendingStatusText,
@@ -1559,6 +1637,7 @@ export function useThreadSessionState(params: {
     response: selectedSession?.response,
     setActiveTurnId,
     updatePendingUserInput,
+    updatePendingMcpInteraction,
     setPendingStatusText,
     thinkingThreadKeys,
     setViewport,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1817,7 +1817,8 @@ textarea {
   background: var(--bg-row-active);
 }
 
-.transcript-questionnaire {
+.transcript-questionnaire,
+.transcript-mcp {
   width: min(100%, 760px);
   display: flex;
   flex-direction: column;
@@ -1864,6 +1865,8 @@ textarea {
 .transcript-request__actions,
 .transcript-questionnaire__header,
 .transcript-questionnaire__actions,
+.transcript-mcp__header,
+.transcript-mcp__actions,
 .context-mode-switch {
   display: flex;
   align-items: center;
@@ -1872,12 +1875,14 @@ textarea {
 
 .transcript-request__header,
 .transcript-questionnaire__header,
+.transcript-mcp__header,
 .context-mode-switch {
   flex-wrap: wrap;
 }
 
 .transcript-request__header,
-.transcript-questionnaire__header {
+.transcript-questionnaire__header,
+.transcript-mcp__header {
   justify-content: space-between;
 }
 
@@ -1890,25 +1895,140 @@ textarea {
 }
 
 .transcript-request__actions,
-.transcript-questionnaire__actions {
+.transcript-questionnaire__actions,
+.transcript-mcp__actions {
   justify-content: flex-start;
 }
 
-.transcript-questionnaire__prompt {
+.transcript-questionnaire__prompt,
+.transcript-mcp__prompt {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.transcript-questionnaire__prompt .eyebrow {
+.transcript-questionnaire__prompt .eyebrow,
+.transcript-mcp__prompt .eyebrow {
   margin: 0;
 }
 
-.transcript-questionnaire__prompt h3 {
+.transcript-questionnaire__prompt h3,
+.transcript-mcp__prompt h3 {
   margin: 0;
   color: var(--text-primary);
   font-size: 16px;
   line-height: 1.35;
+}
+
+.transcript-mcp__params {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.transcript-mcp__params div {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.3fr) minmax(0, 1fr);
+  gap: 10px;
+}
+
+.transcript-mcp__params dt {
+  color: var(--text-muted);
+  font-weight: 650;
+}
+
+.transcript-mcp__params dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+}
+
+.transcript-mcp__url {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.transcript-mcp__url span {
+  min-width: 0;
+  flex: 1 1 220px;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.transcript-mcp__fields {
+  display: grid;
+  gap: 10px;
+}
+
+.transcript-mcp__field {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.transcript-mcp__field-label,
+.transcript-mcp__toggle {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.transcript-mcp__field-label span:last-child,
+.transcript-mcp__toggle span:last-child {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.transcript-mcp__field input,
+.transcript-mcp__field select {
+  min-height: 36px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font: inherit;
+  padding: 8px 10px;
+}
+
+.transcript-mcp__field input:focus,
+.transcript-mcp__field select:focus {
+  border-color: var(--accent-border);
+  outline: none;
+}
+
+.transcript-mcp__toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.transcript-mcp__field-help {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.transcript-mcp__options {
+  display: grid;
+  gap: 8px;
 }
 
 .transcript-questionnaire__options {

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -318,7 +318,7 @@ flowchart TB
 **Verification:**
 - Renderer tests prove MCP UI renders and submits protocol-correct responses without affecting existing approvals or questionnaires.
 
-- [ ] **Unit 5: Render MCP tool progress, startup status, OAuth completion, and metadata**
+- [x] **Unit 5: Render MCP tool progress, startup status, OAuth completion, and metadata**
 
 **Goal:** Make MCP activity visible and understandable during live turns, even when no elicitation is pending.
 

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -269,7 +269,7 @@ flowchart TB
 **Verification:**
 - Hook tests prove MCP pending lifecycle is isolated from approval and questionnaire lifecycle.
 
-- [ ] **Unit 4: Add MCP pending interaction UI and submit path**
+- [x] **Unit 4: Add MCP pending interaction UI and submit path**
 
 **Goal:** Render MCP elicitations in the thread view and submit MCP-shaped responses through `submitServerRequest`.
 

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -233,7 +233,7 @@ flowchart TB
 **Verification:**
 - MCP response formatting is fully testable without React or Electron and cannot accidentally call approval or questionnaire response builders.
 
-- [ ] **Unit 3: Wire MCP pending state into thread session lifecycle**
+- [x] **Unit 3: Wire MCP pending state into thread session lifecycle**
 
 **Goal:** Store pending MCP interactions in thread session state and clear them on response, terminal turn state, or matching server resolution.
 

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -1,0 +1,436 @@
+---
+title: feat: Add desktop MCP request support
+type: feat
+status: active
+date: 2026-04-28
+origin: docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md
+deepened: 2026-04-28
+---
+
+# feat: Add desktop MCP request support
+
+## Overview
+
+Add first-class desktop support for Codex app-server MCP request flows, starting with the observed `mcpServer/elicitation/request` approval for the Playwright `browser_tabs` MCP tool and extending the same path to structured form elicitations, URL-mode elicitations, MCP tool-call progress, OAuth/login status, and status metadata. The implementation should make the desktop app a correct Codex app-server client for MCP interactions without implementing a full MCP runtime inside the Electron app.
+
+## Problem Frame
+
+The desktop app currently receives Codex MCP activity but does not complete the protocol loop. A live Codex turn emitted an `item/started` notification for an `mcpToolCall`, then sent a JSON-RPC request with method `mcpServer/elicitation/request` asking whether the `playwright` MCP server could run tool `browser_tabs`. The Codex adapter recognized the method as part of the generated protocol, but logged it as an unhandled inbound request and the renderer did not surface it as pending user action.
+
+This is a protocol-parity issue, not a request to build Playwright MCP inside PwrAgnt. For the Codex backend, Codex app-server owns MCP server startup and tool execution; PwrAgnt must act as the client/UI that displays approvals or input requests, submits the right response shape, and renders MCP progress. For the Grok app-server, MCP can remain status-shape-compatible until a separate plan adds a real MCP runtime.
+
+## Requirements Trace
+
+- R1, R2, R4 from the origin protocol-parity requirements: use supported Codex app-server request/notification behavior as the source of truth for desktop behavior.
+- R6 from the origin requirements: mirror the Codex Desktop protocol contract instead of approximating with local heuristics.
+- R15, R16 from the origin requirements: verify runtime behavior with targeted unit, replay, and E2E coverage while keeping fixture refresh targeted.
+- RM1. Surface `mcpServer/elicitation/request` as a pending MCP interaction instead of logging it as unhandled.
+- RM2. Preserve Codex response compatibility by returning `McpServerElicitationRequestResponse` with `action`, `content`, and `_meta`, not approval-shaped `{ decision }`.
+- RM3. Support form-mode elicitations for both empty-schema approvals and structured non-secret input.
+- RM4. Support URL-mode elicitations by showing the server, message, URL, and elicitation id, then allowing accept/decline/cancel without passing credentials through the client.
+- RM5. Render MCP tool-call items and progress notifications with enough context for the user to understand which server/tool is waiting or running.
+- RM6. Keep command/file approvals, Plan questionnaires, permissions approvals, and MCP elicitations separated so response shapes cannot cross.
+- RM7. Maintain stable empty-or-derived MCP status metadata for backends that do not yet implement an MCP runtime.
+
+## Scope Boundaries
+
+- In scope: desktop handling for Codex `mcpServer/elicitation/request`, `item/mcpToolCall/progress`, `mcpServer/startupStatus/updated`, `mcpServer/oauthLogin/completed`, and MCP tool-call activity normalization.
+- In scope: normalized shared contracts, renderer state, thread UI, response formatting, replay fixtures, and E2E coverage.
+- In scope: preserving `mcpServerStatus/list` as stable metadata for Codex and Grok, with richer rendering when data is available.
+- Out of scope: implementing a real MCP server runtime in `packages/agent-core` or the Electron app.
+- Out of scope: storing third-party credentials, OAuth tokens, or browser-session secrets in PwrAgnt.
+- Out of scope: changing Codex app-server generated protocol types by hand; generated files remain generated.
+- Out of scope: automatic allow rules for MCP tools. This pass should be explicit and user-visible.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/codex-app-server/client.ts` owns JSON-RPC request normalization. It lists `mcpServer/elicitation/request` in `GENERATED_CODEX_SERVER_REQUEST_METHODS`, but `isHandledServerRequestMethod` currently handles only `*requestApproval` and `item/tool/requestUserInput`.
+- `apps/desktop/src/main/codex-app-server/json-rpc.ts` already passes the JSON-RPC id into the request handler and returns the handler result to Codex, which is the right transport seam for MCP elicitation responses.
+- `apps/desktop/src/main/app-server/backend-registry.ts` already stores pending server requests and resolves them through `submitServerRequest`, so MCP should reuse that pending-request bridge rather than adding a new transport.
+- `packages/shared/src/contracts/normalized-app-server.ts` has generic `AppServerPendingRequestNotification` plus dedicated `AppServerToolRequestUserInputNotification` types. MCP needs the same dedicated typed shape because its response contract is not approval-shaped.
+- `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts` intentionally separates supported approval requests from `item/tool/requestUserInput`; MCP should extend this pattern with a third pending state instead of widening approval matching.
+- `apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts` is good prior art for pure response builders and request-state helpers that are testable without React or Electron.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` currently has separate submit paths for approvals and Plan questionnaires. MCP should add a separate submit path and not call `buildPendingRequestResponse`.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx` renders pending approvals and pending questionnaires in the transcript. MCP needs a compact thread-native pending card following the same UI density.
+- `apps/desktop/e2e/request-user-input.spec.ts` and `apps/desktop/e2e/fixtures/request-user-input/replay.fixture.json` provide the closest replay-backed pattern for inbound JSON-RPC requests that are not approvals.
+- `packages/agent-core/src/app-server/metadata-service.ts` already returns `{ data: [] }` for `mcpServerStatus/list`; this is acceptable for Grok until a separate MCP runtime exists.
+
+### Institutional Learnings
+
+- No `docs/solutions/` artifacts exist yet for MCP request support.
+- The completed Plan questionnaire plan (`docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md`) established the important local pattern: requests with distinct response contracts should have distinct renderer state, pure response builders, and explicit regression coverage proving they do not render approval controls.
+- The active app-server compatibility plan (`docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md`) treats `mcpServerStatus/list` as a stable metadata endpoint even before a real MCP subsystem exists.
+
+### External References
+
+- MCP 2025-11-25 Elicitation spec: form mode supports structured user input, URL mode supports sensitive out-of-band interactions, clients should provide clear server context and approval controls.
+- MCP 2025-11-25 Authorization spec: MCP authorization is transport-level and optional; stdio transports should generally obtain credentials from environment rather than the HTTP OAuth flow.
+- MCP 2025-11-25 changelog: URL-mode elicitation and updated `ElicitResult`/enum schema behavior are current protocol features, so the desktop plan should not assume form-only elicitation.
+
+## Key Technical Decisions
+
+- **Treat MCP elicitations as their own pending interaction type.** Approval cards return `{ decision }`, Plan questionnaires return `{ answers }`, and MCP elicitations return `{ action, content, _meta }`. The UI state and response builders must make those impossible to mix accidentally.
+- **Handle empty-schema form elicitations as approvals.** The observed Playwright request has `mode: "form"` and an empty object schema. The user-facing affordance can be Approve/Decline/Cancel, but the submitted payload must still be MCP-shaped.
+- **Handle non-empty form schemas as structured MCP input.** MCP form elicitations can request non-secret structured fields. The first implementation should support the generated schema primitives already present in `@pwragnt/shared/codex-app-server-protocol/v2`, with validation helpers kept pure and narrowly tested.
+- **Handle URL mode as out-of-band user action.** URL mode should display the URL and allow the user to open it externally, but PwrAgnt must not ask for or collect credentials. Accept means the user has completed or wants to continue the out-of-band flow; decline/cancel remain available.
+- **Keep MCP runtime ownership explicit.** Codex app-server runs MCP servers and tools. PwrAgnt desktop displays status, approvals, and progress. Grok app-server keeps shape-compatible metadata until a separate plan adds a real MCP client/server runtime.
+- **Preserve generated protocol ownership.** Use generated Codex app-server protocol types as inputs at the adapter boundary. Add normalized PwrAgnt contracts in `packages/shared/src/contracts/normalized-app-server.ts`; do not hand-edit generated protocol files.
+- **Prefer replay-backed verification over live-only MCP runs.** A live Playwright MCP request is useful for capture, but CI should use deterministic replay fixtures for the request/response UI path.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Are MCPs implemented by the desktop client or the app server?** For the Codex backend, Codex app-server owns MCP server lifecycle and tool execution. The desktop client owns request presentation, approval/input collection, response submission, and status/progress rendering.
+- **Should `mcpServer/elicitation/request` be handled?** Yes. It is a known generated Codex server request and currently blocks because PwrAgnt does not surface or answer it correctly.
+- **Can the observed empty-schema elicitation use approval buttons?** Yes, as UI language, as long as the wire response is MCP-shaped.
+- **Should Grok gain a real MCP runtime in this plan?** No. Keep stable empty status metadata for Grok; real MCP runtime support is a larger provider/runtime project.
+
+### Deferred to Implementation
+
+- The exact first-pass coverage of every generated `McpElicitationPrimitiveSchema` variant after inspecting representative Codex captures.
+- The final compact UI copy for URL mode after a screenshot pass.
+- Whether Codex returns additional `_meta.persist` rules that should later drive remembered approvals. This plan should preserve `_meta`, but not implement persistence rules automatically.
+- Whether `mcpServer/oauthLogin/completed` needs a visible toast, transcript item, or only state cleanup in the first pass.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Codex as Codex app-server
+    participant Main as CodexAppServerClient
+    participant Registry as DesktopBackendRegistry
+    participant Session as useThreadSessionState
+    participant UI as Thread MCP card
+
+    Codex->>Main: item/started(mcpToolCall)
+    Main->>Session: normalized activity
+    Codex->>Main: mcpServer/elicitation/request(params, rpc id)
+    Main->>Registry: pending MCP interaction
+    Registry->>Session: AgentEvent
+    Session->>UI: pendingMcpInteraction
+    UI->>Registry: submitServerRequest({ action, content, _meta })
+    Registry->>Codex: JSON-RPC result
+    Codex->>Main: serverRequest/resolved or terminal tool item
+    Main->>Session: clear pending MCP state
+```
+
+The pending request surfaces should stay intentionally separate:
+
+| Method family | Renderer state | User action shape | JSON-RPC response shape |
+|---|---|---|---|
+| `item/commandExecution/requestApproval`, `item/fileChange/requestApproval`, legacy approval aliases | `pendingRequest` | approve / decline / cancel | `{ decision: string }` |
+| `item/tool/requestUserInput` | `pendingUserInput` | answer questionnaire | `{ answers: Record<string, { answers: string[] }> }` |
+| `mcpServer/elicitation/request` | `pendingMcpInteraction` | accept / decline / cancel plus optional content | `{ action: "accept" | "decline" | "cancel", content: JsonValue | null, _meta: JsonValue | null }` |
+
+## Phased Delivery
+
+### Phase 1: Unblock observed MCP approvals
+
+- Handle `mcpServer/elicitation/request` in the Codex adapter without unhandled-request logging.
+- Support empty-schema form-mode MCP approvals end to end with MCP-shaped accept/decline/cancel responses.
+- Add isolated pending MCP session state, a compact pending card, and replay-backed coverage for the observed Playwright `browser_tabs` flow.
+- Preserve existing approval and Plan questionnaire behavior unchanged.
+
+### Phase 2: Complete elicitation mode coverage
+
+- Add structured non-secret form input support for generated MCP primitive schema variants.
+- Add URL-mode rendering and response handling for sensitive out-of-band interactions.
+- Strengthen redaction and fixture hygiene for URLs, `_meta`, and tool parameters.
+
+### Phase 3: Broaden MCP activity visibility
+
+- Render MCP tool-call progress, startup status, OAuth completion, and metadata in the thread view.
+- Keep Grok shape-compatible but empty for MCP status until a separate runtime plan adds real MCP support.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Normalize MCP request and notification contracts"] --> U2["Unit 2: Add pure MCP elicitation model and response helpers"]
+    U2 --> U3["Unit 3: Wire MCP pending state into thread sessions"]
+    U3 --> U4["Unit 4: Add MCP pending interaction UI"]
+    U3 --> U5["Unit 5: Render MCP tool progress and status"]
+    U4 --> U6["Unit 6: Add replay and E2E coverage"]
+    U5 --> U6
+```
+
+- [ ] **Unit 1: Normalize MCP request and notification contracts**
+
+**Goal:** Represent MCP elicitations and progress explicitly across shared contracts and the Codex adapter.
+
+**Requirements:** RM1, RM2, RM5, RM6, RM7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/normalized-app-server.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
+
+**Approach:**
+- Add normalized shared types for `AppServerMcpElicitationRequestNotification`, MCP form/url modes, MCP elicitation response, and MCP progress/status notifications.
+- Update `isHandledServerRequestMethod` so `mcpServer/elicitation/request` is handled rather than logged as unhandled.
+- Preserve `threadId`, nullable `turnId`, `serverName`, `mode`, `_meta`, `message`, `requestedSchema`, `url`, and `elicitationId` from the generated Codex payload.
+- Add `item/mcpToolCall/progress`, `mcpServer/oauthLogin/completed`, and any missing MCP status notification methods to known notification handling so important MCP events are not downgraded to unknown logs.
+- Keep `AppServerPendingRequestNotification` generic enough for the registry bridge, but add discriminated types and helpers so the renderer can branch safely.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/codex-app-server/client.ts`
+- `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- `packages/shared/src/contracts/normalized-app-server.ts`
+
+**Test scenarios:**
+- Happy path: an inbound `mcpServer/elicitation/request` with JSON-RPC id `0`, server `playwright`, form mode, and empty schema emits a pending MCP notification with request id `0`.
+- Happy path: a URL-mode elicitation preserves `url`, `elicitationId`, `message`, `serverName`, and `_meta`.
+- Happy path: the request handler returns the exact MCP response object from the registered listener to the JSON-RPC transport.
+- Regression: command/file approval requests and `item/tool/requestUserInput` continue to normalize unchanged.
+- Regression: permissions approvals remain excluded from generic approval UI unless a dedicated permissions implementation exists.
+- Edge case: nullable `turnId` stays nullable in normalized MCP params rather than being coerced to an invalid string.
+
+**Verification:**
+- Main-process tests prove MCP elicitations are no longer logged as unhandled and can round-trip a valid MCP response through the existing request bridge.
+
+- [ ] **Unit 2: Add pure MCP elicitation model and response helpers**
+
+**Goal:** Build testable helpers for turning MCP elicitation params into renderer state, validating user input, and formatting protocol-correct responses.
+
+**Requirements:** RM2, RM3, RM4, RM6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/mcp-elicitation.ts`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-elicitation.test.ts`
+
+**Approach:**
+- Create a `PendingMcpInteractionState` model with method, request id, thread id, turn id, server name, message, mode, `_meta`, and mode-specific form/url details.
+- Treat form mode with an empty `properties` object as an approval-style confirmation that needs no `content` on accept beyond `{}`.
+- For non-empty form schemas, derive fields from generated MCP primitive schema variants. Support string, number, boolean, single-select enum, multi-select enum, required fields, defaults, descriptions, min/max where the generated type exposes them, and a validation result that can be rendered without React-specific state.
+- For URL mode, preserve URL and elicitation id and build responses without collecting credentials or tokens.
+- Build `buildMcpElicitationResponse` so accept/decline/cancel always return `{ action, content, _meta }`, with `content: null` for decline/cancel.
+- Preserve request `_meta` only where the protocol expects client metadata; do not invent persistence or auto-approval behavior.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.ts`
+
+**Test scenarios:**
+- Happy path: empty-schema form approval accepts with `action: "accept"`, `content: {}`, and `_meta: null`.
+- Happy path: declining or cancelling any mode returns `content: null`.
+- Happy path: a required string field with user input appears in the accepted `content`.
+- Happy path: a boolean field and enum field preserve typed values rather than converting everything to display strings.
+- Happy path: URL mode accepts without embedding URL contents, tokens, or credentials in `content`.
+- Edge case: required form fields block accept until valid.
+- Edge case: unsupported schema variants render a safe unsupported-field message and block accept for required unsupported fields.
+- Error path: malformed params produce no pending MCP state and leave the turn available for server-side failure handling.
+
+**Verification:**
+- MCP response formatting is fully testable without React or Electron and cannot accidentally call approval or questionnaire response builders.
+
+- [ ] **Unit 3: Wire MCP pending state into thread session lifecycle**
+
+**Goal:** Store pending MCP interactions in thread session state and clear them on response, terminal turn state, or matching server resolution.
+
+**Requirements:** RM1, RM2, RM6
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Approach:**
+- Add `pendingMcpInteraction?: PendingMcpInteractionState` to `ThreadSessionEntry`.
+- Add `isMcpElicitationNotification` beside the existing approval and request-user-input guards.
+- On `mcpServer/elicitation/request`, create pending MCP state and set pending status text to a short waiting-for-MCP status.
+- Clear only the matching MCP request when `serverRequest/resolved` arrives, when the user submits successfully, or when the active turn fails, cancels, or completes.
+- Keep composer disabled while MCP input is pending, matching existing pending approval/user-input behavior.
+- Ensure events for another backend, thread, or request id do not clear the selected thread's MCP interaction.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Test scenarios:**
+- Happy path: `mcpServer/elicitation/request` creates `pendingMcpInteraction` and does not create `pendingRequest` or `pendingUserInput`.
+- Happy path: matching `serverRequest/resolved` clears only the MCP interaction with the same request id.
+- Regression: command/file approval still creates `pendingRequest`.
+- Regression: Plan questionnaire still creates `pendingUserInput`.
+- Edge case: nullable `turnId` MCP requests still attach to the thread and can be submitted.
+- Edge case: events for another thread or backend do not alter the current pending MCP state.
+- Edge case: turn failure/cancellation clears stale MCP pending state.
+
+**Verification:**
+- Hook tests prove MCP pending lifecycle is isolated from approval and questionnaire lifecycle.
+
+- [ ] **Unit 4: Add MCP pending interaction UI and submit path**
+
+**Goal:** Render MCP elicitations in the thread view and submit MCP-shaped responses through `submitServerRequest`.
+
+**Requirements:** RM1, RM2, RM3, RM4, RM6
+
+**Dependencies:** Units 2 and 3
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/thread-detail/PendingMcpInteraction.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts` only if stronger response typing is useful
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-mcp-interaction.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Render a compact pending card that identifies the MCP server, user-facing message, optional tool description, and displayed tool parameters from `_meta.tool_params_display` when present.
+- Redact credential-like keys, URL query strings, bearer-looking values, and long opaque tokens before displaying `_meta`, tool parameters, arguments, or URLs in compact transcript summaries.
+- For empty-schema form mode, show Accept, Decline, and Cancel controls with user-facing copy appropriate to allowing an MCP tool call.
+- For structured form mode, render compact field controls based on the pure model helpers and show validation feedback only where required to proceed.
+- For URL mode, show the URL as an explicit external destination and provide an Open control plus Accept/Decline/Cancel. The UI should not ask for credentials or imply PwrAgnt can inspect the out-of-band result.
+- Add a `submitPendingMcpInteraction` handler separate from approval and questionnaire handlers.
+- Preserve the pending card and entered form values if `submitServerRequest` rejects.
+- Follow the desktop style guide: dense thread-native surface, no browser-default controls in shipped UI, radius at or below 8px, no scaffold narration.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx`
+- `docs/design/desktop-style-guide.md`
+- `docs/UI-THEME.md`
+
+**Test scenarios:**
+- Happy path: the observed Playwright `browser_tabs` request renders as an MCP approval card with server, message, and no Plan questionnaire UI.
+- Happy path: Accept submits `{ action: "accept", content: {}, _meta: null }` for empty-schema form mode.
+- Happy path: Decline submits `{ action: "decline", content: null, _meta: null }`.
+- Happy path: URL mode renders the external URL and submits an MCP-shaped response after accept.
+- Happy path: structured form mode collects a required string value and submits it in `content`.
+- Edge case: required structured fields disable Accept until valid.
+- Error path: bridge failure leaves the card visible with values preserved and shows an inline error.
+- Regression: Approve/Decline command approval tests still submit approval-shaped decisions.
+- Accessibility: controls expose stable role/name selectors suitable for Testing Library and Playwright.
+
+**Verification:**
+- Renderer tests prove MCP UI renders and submits protocol-correct responses without affecting existing approvals or questionnaires.
+
+- [ ] **Unit 5: Render MCP tool progress, startup status, OAuth completion, and metadata**
+
+**Goal:** Make MCP activity visible and understandable during live turns, even when no elicitation is pending.
+
+**Requirements:** RM5, RM7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/ipc/agent-ipc.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Ensure `mcpToolCall` thread items normalize into activity entries with server, tool, status, arguments, result/error summary, and duration where available.
+- Handle `item/mcpToolCall/progress` as a live progress update tied to item id and turn id.
+- Handle `mcpServer/startupStatus/updated` and `mcpServer/oauthLogin/completed` as non-fatal status notifications that can update live state or append compact activity where useful.
+- Keep `mcpServerStatus/list` stable for both Codex and Grok; Grok may still return empty data, while Codex should pass through whatever the app-server provides.
+- Avoid exposing raw credential-like values from arguments, `_meta`, or URL query strings in transcript summaries.
+
+**Patterns to follow:**
+- Existing activity normalization for `commandExecution`, `dynamicToolCall`, and `webSearch` in `apps/desktop/src/main/codex-app-server/client.ts`
+- Message-phase eliding plan: `docs/plans/2026-04-22-001-feat-message-phase-eliding-plan.md`
+
+**Test scenarios:**
+- Happy path: an in-progress `mcpToolCall` item renders as live work-bearing activity with server/tool labels.
+- Happy path: `item/mcpToolCall/progress` updates the matching activity status/message.
+- Happy path: a completed MCP tool call with result renders as completed activity.
+- Error path: a failed MCP tool call with error renders failure state without crashing the transcript.
+- Edge case: progress for an unknown item id is ignored or stored safely without corrupting current state.
+- Security regression: URL query strings or credential-like values are not displayed verbatim in compact summaries.
+- Metadata: `mcpServerStatus/list` empty data still renders/flows without errors.
+
+**Verification:**
+- Live MCP activity is visible in the thread as work in progress, and MCP status notifications no longer look like mysterious protocol noise.
+
+- [ ] **Unit 6: Add replay-backed E2E coverage and capture guidance**
+
+**Goal:** Lock the full Electron path for MCP elicitation and progress with deterministic replay fixtures, plus document how to refresh live MCP captures.
+
+**Requirements:** R15, R16, RM1, RM2, RM3, RM4, RM5, RM6
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Create: `apps/desktop/e2e/fixtures/mcp-elicitation/replay.fixture.json`
+- Create: `apps/desktop/e2e/mcp-elicitation.spec.ts`
+- Modify: `apps/desktop/src/main/__tests__/fixture-derivation.test.ts` if fixture derivation needs MCP request support
+- Modify: `apps/desktop/e2e/fixtures/README.md`
+- Create or update: `apps/desktop/e2e/fixtures/mcp-elicitation/capture-recipe.md`
+
+**Approach:**
+- Build a replay fixture around the observed Playwright `browser_tabs` request: user prompt, turn start, `item/started` for `mcpToolCall`, `mcpServer/elicitation/request`, accepted response, progress or completion, and terminal turn state.
+- Add a second replay path or fixture step for URL mode if a representative payload is available; otherwise include unit coverage for URL mode and document the capture gap.
+- E2E should verify the MCP card appears, existing approval/questionnaire controls do not appear, Accept submits and clears the pending request, and MCP tool progress renders.
+- Document how to capture a live MCP run using existing protocol capture tooling without adding secrets or private tokens to fixtures.
+- Use the project-local desktop E2E fixture seeding skill when refreshing replay-backed desktop fixtures from a live captured session.
+
+**Patterns to follow:**
+- `apps/desktop/e2e/request-user-input.spec.ts`
+- `apps/desktop/e2e/fixtures/request-user-input/replay.fixture.json`
+- `apps/desktop/e2e/fixtures/request-user-input/capture-recipe.md`
+- `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`
+
+**Test scenarios:**
+- Full path: MCP elicitation appears, Accept resolves the pending request, and the thread resumes.
+- Regression: no Plan questionnaire or command/file approval card appears for `mcpServer/elicitation/request`.
+- Full path: MCP tool progress or completion activity appears in the transcript.
+- Edge case: Decline keeps the app stable and sends an MCP-shaped decline response.
+- Fixture hygiene: raw captures used for fixtures do not include tokens, credentials, or private URL query strings.
+
+**Verification:**
+- Electron E2E can exercise the real renderer/main-process bridge for MCP elicitations without relying on a live MCP server in CI.
+
+## System-Wide Impact
+
+- **Interaction graph:** Codex app-server JSON-RPC requests flow through `CodexAppServerClient`, `DesktopBackendRegistry`, IPC, `useThreadSessionState`, and thread-detail UI. MCP support should reuse this graph instead of adding a parallel bridge.
+- **Error propagation:** JSON-RPC handler errors still return JSON-RPC errors to Codex. User decline/cancel is not an exception; it is a valid MCP response. Bridge submission failures should remain visible in the pending card.
+- **State lifecycle risks:** Pending MCP interactions must be keyed by backend, thread id, and request id so a request from one thread cannot clear another. Stale requests clear on matching resolution or terminal turn state.
+- **API surface parity:** Generated Codex request/notification types stay at the adapter boundary. Normalized PwrAgnt contracts gain MCP-specific discriminated types so downstream UI does not parse generated blobs.
+- **Integration coverage:** Unit tests cover response builders and session lifecycle; replay/E2E covers JSON-RPC request through renderer submit and pending-state cleanup.
+- **Unchanged invariants:** Command/file approvals still use approval responses, Plan questionnaires still use answer-map responses, permissions approvals remain excluded until separately implemented, and Grok does not claim a real MCP runtime.
+- **Security handling:** MCP interactions cross a third-party tool boundary. The desktop should show enough context for informed consent while redacting secret-like values, avoiding credential collection in form mode, and treating URL mode as an out-of-band action whose credentials never pass through PwrAgnt.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Response shape drift blocks Codex turns | Use generated `McpServerElicitationRequestResponse` semantics and exact main-process tests for `{ action, content, _meta }`. |
+| Approval, questionnaire, and MCP request paths get mixed | Maintain separate state fields, type guards, response builders, submit handlers, and regression tests. |
+| Form-mode elicitations accidentally collect secrets | Follow MCP guidance: form mode should not be used for secrets; URL mode is the supported sensitive-flow path. UI copy and validation should not ask for credentials. |
+| URL mode leaks sensitive URLs or tokens into logs/fixtures | Redact query strings or credential-like values in compact summaries and fixture recipes; do not store live private URLs in checked-in fixtures. |
+| MCP progress creates noisy transcript output | Render compact work-bearing activity and reuse existing message-phase eliding/activity grouping patterns. |
+| Grok users infer MCP support that does not exist | Keep Grok `mcpServerStatus/list` shape-compatible but empty, and avoid UI that claims available MCP servers for Grok until a real runtime lands. |
+| Current MCP spec continues to evolve | Keep protocol-specific handling at the Codex adapter boundary and rely on generated types after running protocol regeneration when needed. |
+
+## Documentation / Operational Notes
+
+- Update fixture capture docs with a short MCP section once replay coverage lands.
+- Do not document an MCP runtime for Grok in user-facing copy until a separate runtime plan implements it.
+- If implementation discovers Codex `_meta.persist` semantics for remembered MCP approvals, record them as a follow-up requirement rather than silently enabling automatic approvals.
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md](../brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md)
+- Related plan: [docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md](2026-04-20-001-feat-plan-questionnaire-navigation-plan.md)
+- Related plan: [docs/plans/2026-04-16-002-feat-app-server-protocol-compatibility-plan.md](2026-04-16-002-feat-app-server-protocol-compatibility-plan.md)
+- Codex adapter guidance: [apps/desktop/src/main/codex-app-server/AGENTS.md](../../apps/desktop/src/main/codex-app-server/AGENTS.md)
+- MCP Elicitation specification: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation
+- MCP Authorization specification: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+- MCP 2025-11-25 changelog: https://modelcontextprotocol.io/specification/2025-11-25/changelog

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add desktop MCP request support
 type: feat
-status: active
+status: completed
 date: 2026-04-28
 origin: docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md
 deepened: 2026-04-28
@@ -359,7 +359,7 @@ flowchart TB
 **Verification:**
 - Live MCP activity is visible in the thread as work in progress, and MCP status notifications no longer look like mysterious protocol noise.
 
-- [ ] **Unit 6: Add replay-backed E2E coverage and capture guidance**
+- [x] **Unit 6: Add replay-backed E2E coverage and capture guidance**
 
 **Goal:** Lock the full Electron path for MCP elicitation and progress with deterministic replay fixtures, plus document how to refresh live MCP captures.
 

--- a/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
+++ b/docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md
@@ -159,7 +159,7 @@ flowchart TB
     U5 --> U6
 ```
 
-- [ ] **Unit 1: Normalize MCP request and notification contracts**
+- [x] **Unit 1: Normalize MCP request and notification contracts**
 
 **Goal:** Represent MCP elicitations and progress explicitly across shared contracts and the Codex adapter.
 
@@ -196,7 +196,7 @@ flowchart TB
 **Verification:**
 - Main-process tests prove MCP elicitations are no longer logged as unhandled and can round-trip a valid MCP response through the existing request bridge.
 
-- [ ] **Unit 2: Add pure MCP elicitation model and response helpers**
+- [x] **Unit 2: Add pure MCP elicitation model and response helpers**
 
 **Goal:** Build testable helpers for turning MCP elicitation params into renderer state, validating user input, and formatting protocol-correct responses.
 

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  AppServerMcpElicitationResponse,
   AppServerNotification,
   ThreadExecutionMode,
   AppServerReviewDelivery,
@@ -115,7 +116,7 @@ export type SubmitServerRequestRequest = {
   threadId: ThreadIdentifier;
   turnId?: string;
   requestId: string;
-  response: Record<string, unknown>;
+  response: Record<string, unknown> | AppServerMcpElicitationResponse;
 };
 
 export type SubmitServerRequestResponse = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -680,8 +680,10 @@ export type AppServerNotification =
   | {
       method: "mcpServer/startupStatus/updated";
       params: {
+        name?: string;
         serverName?: string;
-        status?: unknown;
+        status?: "starting" | "ready" | "failed" | "cancelled";
+        error?: string | null;
         [key: string]: unknown;
       };
     }
@@ -690,6 +692,8 @@ export type AppServerNotification =
       params: {
         name?: string;
         serverName?: string;
+        success?: boolean;
+        error?: string;
         [key: string]: unknown;
       };
     }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -393,7 +393,7 @@ export type AppServerPendingRequestNotification = {
   method: string;
   params: {
     threadId: string;
-    turnId?: string;
+    turnId?: string | null;
     requestId: string;
     prompt?: string;
     options?: string[];
@@ -429,6 +429,35 @@ export type AppServerToolRequestUserInputNotification = {
     turnId?: string;
     itemId?: string;
     questions: AppServerToolRequestUserInputQuestion[];
+  };
+};
+
+export type AppServerMcpElicitationAction = "accept" | "decline" | "cancel";
+
+export type AppServerMcpElicitationSchema = {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+};
+
+export type AppServerMcpElicitationResponse = {
+  action: AppServerMcpElicitationAction;
+  content: Record<string, unknown> | null;
+  _meta: Record<string, unknown> | null;
+};
+
+export type AppServerMcpElicitationRequestNotification = {
+  method: "mcpServer/elicitation/request";
+  params: AppServerPendingRequestNotification["params"] & {
+    turnId: string | null;
+    serverName: string;
+    mode: "form" | "url";
+    _meta: Record<string, unknown> | null;
+    message: string;
+    requestedSchema?: AppServerMcpElicitationSchema;
+    url?: string;
+    elicitationId?: string;
   };
 };
 
@@ -567,6 +596,7 @@ export type AppServerNotification =
       params: AppServerPendingRequestNotification["params"];
     }
   | AppServerToolRequestUserInputNotification
+  | AppServerMcpElicitationRequestNotification
   | {
       method: "thread/status/changed";
       params: {
@@ -636,6 +666,31 @@ export type AppServerNotification =
         turnId?: string;
         itemId: string;
         delta: string;
+      };
+    }
+  | {
+      method: "item/mcpToolCall/progress";
+      params: {
+        threadId: string;
+        turnId: string;
+        itemId: string;
+        message: string;
+      };
+    }
+  | {
+      method: "mcpServer/startupStatus/updated";
+      params: {
+        serverName?: string;
+        status?: unknown;
+        [key: string]: unknown;
+      };
+    }
+  | {
+      method: "mcpServer/oauthLogin/completed";
+      params: {
+        name?: string;
+        serverName?: string;
+        [key: string]: unknown;
       };
     }
   | {


### PR DESCRIPTION
## Summary

I added first-class desktop handling for Codex MCP elicitation requests. The desktop now treats `mcpServer/elicitation/request` as its own pending interaction path, separate from command approvals and request-user-input questionnaires, and replies with the MCP-shaped `{ action, content, _meta }` response.

I also added visible MCP activity for tool calls, progress, startup status, and OAuth completion, plus replay-backed Electron coverage for the observed Playwright `browser_tabs` flow.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry-replay.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-elicitation.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-mcp-interaction.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm --filter @pwragnt/desktop build && pnpm --filter @pwragnt/desktop test:e2e -- mcp-elicitation.spec.ts`
