### PR TITLE
feat(desktop): show dev runtime identity in desktop masthead

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -11,6 +11,8 @@ const disposeImageNormalizationIpcHandlersMock = vi.fn();
 const registerPreloadLogIpcHandlersMock = vi.fn();
 const disposePreloadLogIpcHandlersMock = vi.fn();
 const registerRendererErrorIpcHandlersMock = vi.fn();
+const registerRuntimeIdentityIpcHandlersMock = vi.fn();
+const disposeRuntimeIdentityIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
 const setApplicationMenuMock = vi.fn();
 const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
@@ -74,6 +76,11 @@ vi.mock("../ipc/renderer-error", () => ({
   registerRendererErrorIpcHandlers: registerRendererErrorIpcHandlersMock,
 }));
 
+vi.mock("../ipc/runtime-identity", () => ({
+  registerRuntimeIdentityIpcHandlers: registerRuntimeIdentityIpcHandlersMock,
+  disposeRuntimeIdentityIpcHandlers: disposeRuntimeIdentityIpcHandlersMock,
+}));
+
 vi.mock("../log", () => ({
   initializeMainLogger: initializeMainLoggerMock,
 }));
@@ -101,6 +108,8 @@ describe("bootstrapApp", () => {
     registerPreloadLogIpcHandlersMock.mockReset();
     disposePreloadLogIpcHandlersMock.mockReset();
     registerRendererErrorIpcHandlersMock.mockReset();
+    registerRuntimeIdentityIpcHandlersMock.mockReset();
+    disposeRuntimeIdentityIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
     setApplicationMenuMock.mockReset();
     buildFromTemplateMock.mockClear();
@@ -146,6 +155,7 @@ describe("bootstrapApp", () => {
     expect(registerImageNormalizationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerPreloadLogIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRendererErrorIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -126,6 +126,7 @@ describe("bootstrapApp", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("awaits startup CPU profiling before creating the first window", async () => {
@@ -179,5 +180,18 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenNthCalledWith(2, {
       startupCpuProfiler: startupProfilerInstance,
     });
+  });
+
+  it("does not register runtime identity IPC in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(registerRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
+
+    appEventHandlers.get("before-quit")?.();
+    expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const execFileSyncMock = vi.fn();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+describe("runtime identity ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    execFileSyncMock.mockReset();
+  });
+
+  it("resolves cwd and the current git branch", async () => {
+    execFileSyncMock.mockReturnValue("codex/show-runtime-identity\n");
+    const { resolveRuntimeIdentity } = await import("../ipc/runtime-identity");
+
+    expect(resolveRuntimeIdentity("/repo/PwrAgnt")).toEqual({
+      branch: "codex/show-runtime-identity",
+      cwd: "/repo/PwrAgnt",
+    });
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/repo/PwrAgnt", "branch", "--show-current"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }
+    );
+  });
+
+  it("falls back to the short commit when HEAD is detached", async () => {
+    execFileSyncMock
+      .mockReturnValueOnce("\n")
+      .mockImplementationOnce(() => {
+        throw new Error("not symbolic");
+      })
+      .mockReturnValueOnce("ab12cd3\n");
+    const { resolveRuntimeIdentity } = await import("../ipc/runtime-identity");
+
+    expect(resolveRuntimeIdentity("/repo/PwrAgnt")).toEqual({
+      branch: "ab12cd3",
+      cwd: "/repo/PwrAgnt",
+    });
+  });
+
+  it("registers and disposes the IPC handler", async () => {
+    execFileSyncMock.mockReturnValue("main\n");
+    const { registerRuntimeIdentityIpcHandlers, disposeRuntimeIdentityIpcHandlers } =
+      await import("../ipc/runtime-identity");
+    const { RUNTIME_IDENTITY_CHANNEL } = await import("../../shared/ipc");
+
+    registerRuntimeIdentityIpcHandlers();
+    await expect(handlers.get(RUNTIME_IDENTITY_CHANNEL)?.({})).resolves.toMatchObject({
+      branch: "main",
+    });
+
+    disposeRuntimeIdentityIpcHandlers();
+    expect(handlers.has(RUNTIME_IDENTITY_CHANNEL)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
@@ -48,12 +48,13 @@ describe("runtime identity ipc", () => {
       .mockImplementationOnce(() => {
         throw new Error("not symbolic");
       })
-      .mockReturnValueOnce("ab12cd3\n");
+      .mockReturnValueOnce("ab12cd3344556677889900aabbccddeeff001122\n");
     const { resolveRuntimeIdentity } = await import("../ipc/runtime-identity");
 
     expect(resolveRuntimeIdentity("/repo/PwrAgnt")).toEqual({
-      branch: "ab12cd3",
+      commitSha: "ab12cd3344556677889900aabbccddeeff001122",
       cwd: "/repo/PwrAgnt",
+      detachedHead: true,
     });
   });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,6 +10,10 @@ import {
   registerPreloadLogIpcHandlers,
 } from "./ipc/preload-log";
 import { registerRendererErrorIpcHandlers } from "./ipc/renderer-error";
+import {
+  disposeRuntimeIdentityIpcHandlers,
+  registerRuntimeIdentityIpcHandlers,
+} from "./ipc/runtime-identity";
 import { initializeMainLogger } from "./log";
 import { StartupCpuProfiler } from "./diagnostics/startup-cpu-profiler";
 import { createMainWindow } from "./window";
@@ -53,6 +57,7 @@ export function bootstrapApp(): void {
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
     registerRendererErrorIpcHandlers();
+    registerRuntimeIdentityIpcHandlers();
     createMainWindow({
       startupCpuProfiler,
     });
@@ -76,6 +81,7 @@ export function bootstrapApp(): void {
     disposeAgentIpcHandlers();
     disposeImageNormalizationIpcHandlers();
     disposePreloadLogIpcHandlers();
+    disposeRuntimeIdentityIpcHandlers();
     void disposeAppServerIpcHandlers();
   });
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -20,6 +20,7 @@ import { createMainWindow } from "./window";
 
 const APP_NAME = "PwrAgnt";
 const isMac = process.platform === "darwin";
+const isDevelopment = process.env.NODE_ENV !== "production";
 
 function installApplicationMenu(): void {
   const template: Electron.MenuItemConstructorOptions[] = [
@@ -57,7 +58,9 @@ export function bootstrapApp(): void {
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
     registerRendererErrorIpcHandlers();
-    registerRuntimeIdentityIpcHandlers();
+    if (isDevelopment) {
+      registerRuntimeIdentityIpcHandlers();
+    }
     createMainWindow({
       startupCpuProfiler,
     });
@@ -81,7 +84,9 @@ export function bootstrapApp(): void {
     disposeAgentIpcHandlers();
     disposeImageNormalizationIpcHandlers();
     disposePreloadLogIpcHandlers();
-    disposeRuntimeIdentityIpcHandlers();
+    if (isDevelopment) {
+      disposeRuntimeIdentityIpcHandlers();
+    }
     void disposeAppServerIpcHandlers();
   });
 }

--- a/apps/desktop/src/main/ipc/runtime-identity.ts
+++ b/apps/desktop/src/main/ipc/runtime-identity.ts
@@ -1,0 +1,41 @@
+import { ipcMain } from "electron";
+import { execFileSync } from "node:child_process";
+import { RUNTIME_IDENTITY_CHANNEL } from "../../shared/ipc";
+import type { RuntimeIdentity } from "../../shared/runtime-identity";
+
+function readGitValue(cwd: string, args: string[]): string | undefined {
+  try {
+    const value = execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveRuntimeIdentity(cwd = process.cwd()): RuntimeIdentity {
+  const branch =
+    readGitValue(cwd, ["branch", "--show-current"]) ??
+    readGitValue(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]) ??
+    readGitValue(cwd, ["rev-parse", "--short", "HEAD"]);
+
+  return {
+    branch,
+    cwd,
+  };
+}
+
+export function registerRuntimeIdentityIpcHandlers(): void {
+  ipcMain.removeHandler(RUNTIME_IDENTITY_CHANNEL);
+  ipcMain.handle(
+    RUNTIME_IDENTITY_CHANNEL,
+    async (): Promise<RuntimeIdentity> => resolveRuntimeIdentity(),
+  );
+}
+
+export function disposeRuntimeIdentityIpcHandlers(): void {
+  ipcMain.removeHandler(RUNTIME_IDENTITY_CHANNEL);
+}

--- a/apps/desktop/src/main/ipc/runtime-identity.ts
+++ b/apps/desktop/src/main/ipc/runtime-identity.ts
@@ -19,12 +19,21 @@ function readGitValue(cwd: string, args: string[]): string | undefined {
 export function resolveRuntimeIdentity(cwd = process.cwd()): RuntimeIdentity {
   const branch =
     readGitValue(cwd, ["branch", "--show-current"]) ??
-    readGitValue(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]) ??
-    readGitValue(cwd, ["rev-parse", "--short", "HEAD"]);
+    readGitValue(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+
+  if (branch) {
+    return {
+      branch,
+      cwd,
+    };
+  }
+
+  const commitSha = readGitValue(cwd, ["rev-parse", "HEAD"]);
 
   return {
-    branch,
+    commitSha,
     cwd,
+    detachedHead: Boolean(commitSha),
   };
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -106,13 +106,19 @@ recordPreloadLog("info", "start", {
   electron: process.versions.electron
 });
 
+const isDevelopment = process.env.NODE_ENV !== "production";
+
 const desktopApi = Object.freeze({
   ping: () => "pong",
   copyText: async (text: string): Promise<void> => {
     clipboard.writeText(text);
   },
-  getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>
-    await ipcRenderer.invoke(RUNTIME_IDENTITY_CHANNEL),
+  ...(isDevelopment
+    ? {
+        getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>
+          await ipcRenderer.invoke(RUNTIME_IDENTITY_CHANNEL),
+      }
+    : {}),
   listThreads: async (
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -83,8 +83,10 @@ import {
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
   PRELOAD_LOG_CHANNEL,
   RENDERER_ERROR_REPORT_CHANNEL,
+  RUNTIME_IDENTITY_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
 } from "../shared/ipc";
+import type { RuntimeIdentity } from "../shared/runtime-identity";
 
 function recordPreloadLog(
   level: "info" | "warn",
@@ -109,6 +111,8 @@ const desktopApi = Object.freeze({
   copyText: async (text: string): Promise<void> => {
     clipboard.writeText(text);
   },
+  getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>
+    await ipcRenderer.invoke(RUNTIME_IDENTITY_CHANNEL),
   listThreads: async (
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from "./features/navigation/Sidebar";
 import { ThreadView } from "./features/thread-detail/ThreadView";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi } from "./lib/desktop-api";
+import { useRuntimeIdentity } from "./lib/runtime-identity";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
@@ -10,6 +11,7 @@ import { useThreadSkills } from "./lib/useThreadSkills";
 export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(408);
   const desktopApi = useDesktopApi();
+  const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
   const session = useThreadSessionState({
@@ -60,6 +62,7 @@ export function App() {
         inboxThreads={navigation.inboxThreads}
         archiveThreadError={navigation.archiveThreadError}
         renameThreadError={navigation.renameThreadError}
+        runtimeIdentity={runtimeIdentity}
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
         selectedItemKey={navigation.selectedItemKey}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -289,8 +289,8 @@ describe("App", () => {
       })
     ).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
-    expect(await screen.findByText(".worktrees/pwragnt-fix...moioth2352")).toBeInTheDocument();
-    expect(screen.getByText("codex/fix-th...g-ephemeral")).toBeInTheDocument();
+    expect(await screen.findByText(".worktrees/pwragnt-fix-th...ng-moioth2352")).toBeInTheDocument();
+    expect(screen.getByText("codex/fix-thread-naming-ephemeral")).toBeInTheDocument();
     expect(screen.getAllByText("codex/build-codex-client").length).toBeGreaterThan(0);
     expect(screen.queryByRole("heading", { level: 3, name: "Transcript" })).not.toBeInTheDocument();
     const transcript = screen.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -144,6 +144,10 @@ describe("App", () => {
       configurable: true,
       value: {
         copyText,
+        getRuntimeIdentity: async () => ({
+          branch: "codex/fix-thread-naming-ephemeral",
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352",
+        }),
         ping: () => "pong",
         listSkills,
         listBackends: async () => ({
@@ -285,6 +289,8 @@ describe("App", () => {
       })
     ).toBeInTheDocument();
     expect(screen.getAllByText("PwrAgnt").length).toBeGreaterThan(0);
+    expect(await screen.findByText(".worktrees/pwragnt-fix...moioth2352")).toBeInTheDocument();
+    expect(screen.getByText("codex/fix-th...g-ephemeral")).toBeInTheDocument();
     expect(screen.getAllByText("codex/build-codex-client").length).toBeGreaterThan(0);
     expect(screen.queryByRole("heading", { level: 3, name: "Transcript" })).not.toBeInTheDocument();
     const transcript = screen.getByRole("region", { name: "Transcript" });

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -7,7 +7,13 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
+import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
+import { copyText } from "../../lib/copy-text";
 import type { BrowseMode } from "../../lib/useThreadNavigation";
+import {
+  formatRuntimeBranch,
+  formatRuntimePath,
+} from "../../lib/runtime-identity";
 import { DirectoriesList } from "./DirectoriesList";
 import { InboxList } from "./InboxList";
 import { RecentsList } from "./RecentsList";
@@ -27,6 +33,7 @@ type SidebarProps = {
   launchpadError?: string;
   archiveThreadError?: string;
   renameThreadError?: string;
+  runtimeIdentity?: RuntimeIdentity;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -67,6 +74,19 @@ export function Sidebar(props: SidebarProps) {
   );
   const onArchiveThread = props.onArchiveThread ?? (async () => undefined);
   const onRenameThread = props.onRenameThread ?? (async () => undefined);
+  const [copiedRuntimeValue, setCopiedRuntimeValue] = useState<"branch" | "cwd">();
+
+  useEffect(() => {
+    if (!copiedRuntimeValue) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopiedRuntimeValue(undefined);
+    }, 1200);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [copiedRuntimeValue]);
 
   const canRenameThread = (thread: NavigationThreadSummary): boolean =>
     props.backends.some(
@@ -178,7 +198,30 @@ export function Sidebar(props: SidebarProps) {
         onPointerDown={props.onResizeStart}
       />
       <header className="sidebar__masthead">
-        <p className="eyebrow sidebar__brand">PwrAgnt</p>
+        <div className="sidebar__identity">
+          <p className="eyebrow sidebar__brand">PwrAgnt</p>
+
+          {props.runtimeIdentity ? (
+            <div className="runtime-identity" aria-label="Runtime identity">
+              <RuntimeIdentityButton
+                copied={copiedRuntimeValue === "cwd"}
+                label={formatRuntimePath(props.runtimeIdentity.cwd)}
+                value={props.runtimeIdentity.cwd}
+                valueKind="cwd"
+                onCopied={setCopiedRuntimeValue}
+              />
+              {props.runtimeIdentity.branch ? (
+                <RuntimeIdentityButton
+                  copied={copiedRuntimeValue === "branch"}
+                  label={formatRuntimeBranch(props.runtimeIdentity.branch)}
+                  value={props.runtimeIdentity.branch}
+                  valueKind="branch"
+                  onCopied={setCopiedRuntimeValue}
+                />
+              ) : null}
+            </div>
+          ) : null}
+        </div>
 
         <div className="sidebar__masthead-actions">
           <div className="sidebar__new-thread">
@@ -359,5 +402,34 @@ export function Sidebar(props: SidebarProps) {
       ) : null}
 
     </aside>
+  );
+}
+
+function RuntimeIdentityButton(props: {
+  copied: boolean;
+  label: string;
+  value: string;
+  valueKind: "branch" | "cwd";
+  onCopied: (valueKind: "branch" | "cwd") => void;
+}) {
+  return (
+    <button
+      aria-label={`Copy ${props.valueKind === "cwd" ? "working directory" : "branch name"}`}
+      className="runtime-identity__button path-copy-target tooltip-target"
+      data-tooltip={
+        props.copied
+          ? "Copied"
+          : `${props.value}\nClick to copy to clipboard`
+      }
+      type="button"
+      onClick={() => {
+        void copyText(props.value).then(() => props.onCopied(props.valueKind));
+      }}
+    >
+      <span aria-hidden="true" className="runtime-identity__icon">
+        {props.valueKind === "cwd" ? "/" : "#"}
+      </span>
+      <span className="runtime-identity__text">{props.label}</span>
+    </button>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -11,8 +11,9 @@ import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import type { BrowseMode } from "../../lib/useThreadNavigation";
 import {
-  formatRuntimeBranch,
+  formatRuntimeGitRef,
   formatRuntimePath,
+  runtimeGitRefCopyValue,
 } from "../../lib/runtime-identity";
 import { DirectoriesList } from "./DirectoriesList";
 import { InboxList } from "./InboxList";
@@ -75,6 +76,12 @@ export function Sidebar(props: SidebarProps) {
   const onArchiveThread = props.onArchiveThread ?? (async () => undefined);
   const onRenameThread = props.onRenameThread ?? (async () => undefined);
   const [copiedRuntimeValue, setCopiedRuntimeValue] = useState<"branch" | "cwd">();
+  const runtimeGitRefLabel = props.runtimeIdentity
+    ? formatRuntimeGitRef(props.runtimeIdentity)
+    : undefined;
+  const runtimeGitRefValue = props.runtimeIdentity
+    ? runtimeGitRefCopyValue(props.runtimeIdentity)
+    : undefined;
 
   useEffect(() => {
     if (!copiedRuntimeValue) {
@@ -210,11 +217,14 @@ export function Sidebar(props: SidebarProps) {
                 valueKind="cwd"
                 onCopied={setCopiedRuntimeValue}
               />
-              {props.runtimeIdentity.branch ? (
+              {runtimeGitRefLabel && runtimeGitRefValue ? (
                 <RuntimeIdentityButton
                   copied={copiedRuntimeValue === "branch"}
-                  label={formatRuntimeBranch(props.runtimeIdentity.branch)}
-                  value={props.runtimeIdentity.branch}
+                  copyLabel={
+                    props.runtimeIdentity.detachedHead ? "commit SHA" : "branch name"
+                  }
+                  label={runtimeGitRefLabel}
+                  value={runtimeGitRefValue}
                   valueKind="branch"
                   onCopied={setCopiedRuntimeValue}
                 />
@@ -407,6 +417,7 @@ export function Sidebar(props: SidebarProps) {
 
 function RuntimeIdentityButton(props: {
   copied: boolean;
+  copyLabel?: string;
   label: string;
   value: string;
   valueKind: "branch" | "cwd";
@@ -414,7 +425,9 @@ function RuntimeIdentityButton(props: {
 }) {
   return (
     <button
-      aria-label={`Copy ${props.valueKind === "cwd" ? "working directory" : "branch name"}`}
+      aria-label={`Copy ${
+        props.copyLabel ?? (props.valueKind === "cwd" ? "working directory" : "branch name")
+      }`}
       className="runtime-identity__button path-copy-target tooltip-target"
       data-tooltip={
         props.copied

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -640,6 +640,52 @@ describe("Sidebar", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows compact runtime identity chips that copy full values", async () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        runtimeIdentity={{
+          branch: "codex/fix-thread-naming-ephemeral",
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352",
+        }}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getByText(".worktrees/pwragnt-fix...moioth2352")).toBeInTheDocument();
+    expect(screen.getByText("codex/fix-th...g-ephemeral")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy working directory" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy branch name" }));
+
+    expect(copyText).toHaveBeenNthCalledWith(
+      1,
+      "/Users/huntharo/pwrdrvr/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352"
+    );
+    expect(copyText).toHaveBeenNthCalledWith(2, "codex/fix-thread-naming-ephemeral");
+    expect(await screen.findAllByText("PwrAgnt")).not.toHaveLength(0);
+  });
+
   it("shows when the local branch diverged from the codex thread branch", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -672,8 +672,8 @@ describe("Sidebar", () => {
       />
     );
 
-    expect(screen.getByText(".worktrees/pwragnt-fix...moioth2352")).toBeInTheDocument();
-    expect(screen.getByText("codex/fix-th...g-ephemeral")).toBeInTheDocument();
+    expect(screen.getByText(".worktrees/pwragnt-fix-th...ng-moioth2352")).toBeInTheDocument();
+    expect(screen.getByText("codex/fix-thread-naming-ephemeral")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Copy working directory" }));
     fireEvent.click(screen.getByRole("button", { name: "Copy branch name" }));
@@ -684,6 +684,44 @@ describe("Sidebar", () => {
     );
     expect(copyText).toHaveBeenNthCalledWith(2, "codex/fix-thread-naming-ephemeral");
     expect(await screen.findAllByText("PwrAgnt")).not.toHaveLength(0);
+  });
+
+  it("labels detached HEAD and copies the full commit SHA", () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        runtimeIdentity={{
+          commitSha: "ab12cd3344556677889900aabbccddeeff001122",
+          cwd: "/Users/huntharo/.codex/worktrees/5d4b/PwrAgnt",
+          detachedHead: true,
+        }}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getByText("HEAD")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Copy commit SHA" }));
+    expect(copyText).toHaveBeenCalledWith("ab12cd3344556677889900aabbccddeeff001122");
   });
 
   it("shows when the local branch diverged from the codex thread branch", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatRuntimeBranch, formatRuntimePath } from "../runtime-identity";
+import {
+  formatRuntimeBranch,
+  formatRuntimeGitRef,
+  formatRuntimePath,
+  runtimeGitRefCopyValue,
+} from "../runtime-identity";
 
 describe("runtime identity formatting", () => {
   it("shows the distinctive worktree directory segment", () => {
@@ -7,7 +12,7 @@ describe("runtime identity formatting", () => {
       formatRuntimePath(
         "/Users/huntharo/pwrdrvr/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352"
       )
-    ).toBe(".worktrees/pwragnt-fix...moioth2352");
+    ).toBe(".worktrees/pwragnt-fix-th...ng-moioth2352");
   });
 
   it("shows the codex worktree id and repo for codex-managed worktrees", () => {
@@ -18,7 +23,20 @@ describe("runtime identity formatting", () => {
 
   it("middle-truncates branch names", () => {
     expect(formatRuntimeBranch("codex/fix-thread-naming-ephemeral")).toBe(
-      "codex/fix-th...g-ephemeral"
+      "codex/fix-thread-naming-ephemeral"
+    );
+  });
+
+  it("labels a detached ref as HEAD while copying the commit SHA", () => {
+    const identity = {
+      commitSha: "ab12cd3344556677889900aabbccddeeff001122",
+      cwd: "/repo/PwrAgnt",
+      detachedHead: true,
+    };
+
+    expect(formatRuntimeGitRef(identity)).toBe("HEAD");
+    expect(runtimeGitRefCopyValue(identity)).toBe(
+      "ab12cd3344556677889900aabbccddeeff001122"
     );
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatRuntimeBranch, formatRuntimePath } from "../runtime-identity";
+
+describe("runtime identity formatting", () => {
+  it("shows the distinctive worktree directory segment", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/pwrdrvr/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352"
+      )
+    ).toBe(".worktrees/pwragnt-fix...moioth2352");
+  });
+
+  it("shows the codex worktree id and repo for codex-managed worktrees", () => {
+    expect(formatRuntimePath("/Users/huntharo/.codex/worktrees/5d4b/PwrAgnt")).toBe(
+      "5d4b/PwrAgnt"
+    );
+  });
+
+  it("middle-truncates branch names", () => {
+    expect(formatRuntimeBranch("codex/fix-thread-naming-ephemeral")).toBe(
+      "codex/fix-th...g-ephemeral"
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -53,9 +53,11 @@ import type {
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragnt/shared";
+import type { RuntimeIdentity } from "../../../shared/runtime-identity";
 
 export type DesktopApi = {
   copyText?: (text: string) => Promise<void>;
+  getRuntimeIdentity?: () => Promise<RuntimeIdentity>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/runtime-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-identity.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import type { RuntimeIdentity } from "../../../shared/runtime-identity";
+import type { DesktopApi } from "./desktop-api";
+
+export function useRuntimeIdentity(desktopApi?: DesktopApi): RuntimeIdentity | undefined {
+  const [identity, setIdentity] = useState<RuntimeIdentity>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!desktopApi?.getRuntimeIdentity) {
+      setIdentity(undefined);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    desktopApi
+      .getRuntimeIdentity()
+      .then((nextIdentity) => {
+        if (!cancelled) {
+          setIdentity(nextIdentity);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIdentity(undefined);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi]);
+
+  return identity;
+}
+
+export function formatRuntimePath(cwd: string): string {
+  const segments = cwd.split("/").filter(Boolean);
+  const worktreesIndex = segments.lastIndexOf(".worktrees");
+
+  if (worktreesIndex >= 0 && segments[worktreesIndex + 1]) {
+    return `.worktrees/${elideMiddle(segments[worktreesIndex + 1], 24)}`;
+  }
+
+  const codexWorktreesIndex = segments.lastIndexOf("worktrees");
+  if (
+    codexWorktreesIndex >= 0 &&
+    segments[codexWorktreesIndex - 1] === ".codex" &&
+    segments[codexWorktreesIndex + 1] &&
+    segments[codexWorktreesIndex + 2]
+  ) {
+    return `${segments[codexWorktreesIndex + 1]}/${segments[codexWorktreesIndex + 2]}`;
+  }
+
+  return segments.slice(-2).join("/") || cwd;
+}
+
+export function formatRuntimeBranch(branch: string): string {
+  return elideMiddle(branch, 26);
+}
+
+function elideMiddle(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const visible = Math.max(8, maxLength - 3);
+  const left = Math.ceil(visible / 2);
+  const right = Math.floor(visible / 2);
+  return `${text.slice(0, left)}...${text.slice(-right)}`;
+}

--- a/apps/desktop/src/renderer/src/lib/runtime-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-identity.ts
@@ -41,7 +41,7 @@ export function formatRuntimePath(cwd: string): string {
   const worktreesIndex = segments.lastIndexOf(".worktrees");
 
   if (worktreesIndex >= 0 && segments[worktreesIndex + 1]) {
-    return `.worktrees/${elideMiddle(segments[worktreesIndex + 1], 24)}`;
+    return `.worktrees/${elideMiddle(segments[worktreesIndex + 1], 30)}`;
   }
 
   const codexWorktreesIndex = segments.lastIndexOf("worktrees");
@@ -58,7 +58,23 @@ export function formatRuntimePath(cwd: string): string {
 }
 
 export function formatRuntimeBranch(branch: string): string {
-  return elideMiddle(branch, 26);
+  return elideMiddle(branch, 34);
+}
+
+export function formatRuntimeGitRef(identity: RuntimeIdentity): string | undefined {
+  if (identity.detachedHead && identity.commitSha) {
+    return "HEAD";
+  }
+
+  return identity.branch ? formatRuntimeBranch(identity.branch) : undefined;
+}
+
+export function runtimeGitRefCopyValue(identity: RuntimeIdentity): string | undefined {
+  if (identity.detachedHead && identity.commitSha) {
+    return identity.commitSha;
+  }
+
+  return identity.branch;
 }
 
 function elideMiddle(text: string, maxLength: number): string {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -222,7 +222,7 @@ textarea {
 
 .runtime-identity {
   display: flex;
-  max-width: min(252px, calc(var(--sidebar-width, 408px) - 156px));
+  max-width: min(320px, calc(var(--sidebar-width, 408px) - 136px));
   min-width: 0;
   align-items: center;
   gap: 6px;
@@ -230,8 +230,9 @@ textarea {
 
 .runtime-identity__button {
   display: inline-flex;
+  flex: 1 1 0;
   min-width: 0;
-  max-width: 138px;
+  max-width: 170px;
   height: 22px;
   align-items: center;
   appearance: none;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -137,6 +137,13 @@ textarea {
   border-bottom: 1px solid var(--border-subtle);
 }
 
+.sidebar__identity {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
 .sidebar__masthead-actions {
   display: flex;
   align-items: flex-start;
@@ -211,6 +218,60 @@ textarea {
   font-weight: 800;
   line-height: 1;
   text-transform: none;
+}
+
+.runtime-identity {
+  display: flex;
+  max-width: min(252px, calc(var(--sidebar-width, 408px) - 156px));
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.runtime-identity__button {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 138px;
+  height: 22px;
+  align-items: center;
+  appearance: none;
+  cursor: pointer;
+  gap: 5px;
+  padding: 0 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1;
+}
+
+.runtime-identity__button:hover,
+.runtime-identity__button:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.runtime-identity__button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.runtime-identity__icon {
+  flex: 0 0 auto;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  opacity: 0.9;
+}
+
+.runtime-identity__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
 }
 
 .thread-header__title,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -260,6 +260,19 @@ textarea {
   outline-offset: 2px;
 }
 
+.runtime-identity__button.tooltip-target[data-tooltip]::after {
+  top: calc(100% + 8px);
+  bottom: auto;
+  left: 0;
+  max-width: min(360px, calc(var(--sidebar-width, 408px) - 32px));
+  transform: translateY(-4px);
+}
+
+.runtime-identity__button.tooltip-target[data-tooltip]:hover::after,
+.runtime-identity__button.tooltip-target[data-tooltip]:focus-visible::after {
+  transform: translateY(0);
+}
+
 .runtime-identity__icon {
   flex: 0 0 auto;
   color: var(--accent-bright);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -264,6 +264,7 @@ textarea {
   top: calc(100% + 8px);
   bottom: auto;
   left: 0;
+  width: min(360px, calc(var(--sidebar-width, 408px) - 64px));
   max-width: min(360px, calc(var(--sidebar-width, 408px) - 32px));
   transform: translateY(-4px);
 }
@@ -728,6 +729,7 @@ textarea {
   font-size: 12px;
   font-weight: 500;
   line-height: 1.45;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
   text-align: left;
   opacity: 0;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -32,3 +32,4 @@ export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =
   "image-upload:normalization-log";
 export const PRELOAD_LOG_CHANNEL = "preload:log";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";
+export const RUNTIME_IDENTITY_CHANNEL = "runtime:get-identity";

--- a/apps/desktop/src/shared/runtime-identity.ts
+++ b/apps/desktop/src/shared/runtime-identity.ts
@@ -1,4 +1,6 @@
 export type RuntimeIdentity = {
   branch?: string;
+  commitSha?: string;
   cwd: string;
+  detachedHead?: boolean;
 };

--- a/apps/desktop/src/shared/runtime-identity.ts
+++ b/apps/desktop/src/shared/runtime-identity.ts
@@ -1,0 +1,4 @@
+export type RuntimeIdentity = {
+  branch?: string;
+  cwd: string;
+};


### PR DESCRIPTION
## Summary

- Added a desktop runtime identity bridge so the app can read its launch working directory and current git branch.
- Displayed compact, copyable working-directory and branch chips beside the PwrAgnt masthead.
- Covered the identity resolver, formatting, sidebar copy behavior, and app shell rendering with tests.

## Verification

- pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts apps/desktop/src/main/__tests__/index.test.ts
- pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
- pnpm --filter @pwragnt/desktop typecheck
- pnpm --filter @pwragnt/desktop build
