### PR TITLE
fix(desktop): suppress stale archived threads

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2664,6 +2664,61 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("forwards Codex archive lifecycle notifications", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "thread/archived",
+      params: {
+        threadId: "thread-2",
+      },
+    });
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "thread/unarchived",
+      params: {
+        threadId: "thread-2",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(notifications).toEqual([
+      {
+        method: "thread/archived",
+        params: {
+          threadId: "thread-2",
+        },
+      },
+      {
+        method: "thread/unarchived",
+        params: {
+          threadId: "thread-2",
+        },
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("restores threads through the Codex app server", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/main-process-heap-monitor.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-heap-monitor.test.ts
@@ -110,6 +110,35 @@ async function advance(ms: number) {
   await vi.advanceTimersByTimeAsync(ms);
 }
 
+async function waitForEvent(
+  eventsPath: string,
+  predicate: (event: { type?: string; detail?: Record<string, unknown> }) => boolean,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const events = (await fs.readFile(eventsPath, "utf8"))
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { type?: string; detail?: Record<string, unknown> });
+      if (events.some(predicate)) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Timed out waiting for heap monitor event in ${eventsPath}.`);
+}
+
 describe("MainProcessHeapMonitor", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -362,6 +391,13 @@ describe("MainProcessHeapMonitor", () => {
         "utf8",
       ),
     ).resolves.toContain('"snapshot":true');
+
+    await waitForEvent(
+      created.session.eventsPath,
+      (event) =>
+        event.type === "snapshot-completed" &&
+        event.detail?.filename === "main-heap-0001.heapsnapshot",
+    );
 
     const eventLines = (
       await fs.readFile(path.join(created.session.directoryPath, "events.ndjson"), "utf8")

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -174,6 +174,8 @@ const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
   "turn/diff/updated",
   "serverRequest/resolved",
   "thread/compacted",
+  "thread/archived",
+  "thread/unarchived",
   "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -340,6 +340,102 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.id).not.toBe("thread-1");
   });
 
+  it("keeps an archived thread hidden when the post-archive refresh is stale", async () => {
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-archived"],
+      threads: [
+        {
+          id: "thread-archived",
+          title: "Archived thread",
+          titleSource: "explicit" as const,
+          summary: "This thread is archived before the backend list catches up",
+          source: "codex" as const,
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/github/PwrAgnt",
+              kind: "local" as const,
+            },
+          ],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 2_000,
+        },
+        {
+          id: "thread-remaining",
+          title: "Remaining thread",
+          titleSource: "explicit" as const,
+          summary: "This thread stays in navigation",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [
+        {
+          key: "directory:/Users/huntharo/github/PwrAgnt",
+          kind: "directory" as const,
+          label: "PwrAgnt",
+          path: "/Users/huntharo/github/PwrAgnt",
+          threadKeys: ["codex:thread-archived"],
+          needsAttentionCount: 1,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-archived",
+      archivedAt: 3_000,
+      cleanup: [],
+    }));
+
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-archived",
+        "thread-remaining",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!);
+    });
+
+    expect(archiveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-archived",
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "thread-remaining",
+    ]);
+    expect(result.current.inboxThreads).toHaveLength(0);
+    expect(result.current.directories[0]?.threadKeys).toEqual([]);
+    expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
+  });
+
   it("renames a thread and refreshes navigation with the explicit title", async () => {
     let threadTitle = "First thread";
     const renameThread = vi.fn(async ({ name }: { name: string }) => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -259,6 +259,50 @@ function removeThreadFromSnapshot(
   };
 }
 
+function removeThreadKeysFromSnapshot(
+  snapshot: NavigationSnapshot,
+  threadKeysToRemove: ReadonlySet<string>
+): NavigationSnapshot {
+  if (threadKeysToRemove.size === 0) {
+    return snapshot;
+  }
+
+  const threads = snapshot.threads.filter(
+    (thread) => !threadKeysToRemove.has(buildThreadIdentityKey(thread.source, thread.id))
+  );
+  if (threads.length === snapshot.threads.length) {
+    return snapshot;
+  }
+
+  const threadInboxByKey = new Map(
+    threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread.inbox.inInbox,
+    ])
+  );
+
+  return {
+    ...snapshot,
+    directories: snapshot.directories.map((directory) => {
+      const threadKeys = directory.threadKeys.filter(
+        (candidate) => !threadKeysToRemove.has(candidate)
+      );
+      return {
+        ...directory,
+        threadKeys,
+        needsAttentionCount: threadKeys.reduce(
+          (count, candidate) => count + (threadInboxByKey.get(candidate) ? 1 : 0),
+          0
+        ),
+      };
+    }),
+    inboxThreadKeys: snapshot.inboxThreadKeys.filter(
+      (candidate) => !threadKeysToRemove.has(candidate)
+    ),
+    threads,
+  };
+}
+
 function getFallbackSelectionAfterRemoval(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -703,6 +747,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       }
     | undefined
   >(undefined);
+  const suppressedArchivedThreadKeysRef = useRef<Set<string>>(new Set());
   const scheduledRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
@@ -758,7 +803,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       }));
 
       try {
-        const response = await desktopApi.getNavigationSnapshot();
+        const response = removeThreadKeysFromSnapshot(
+          await desktopApi.getNavigationSnapshot(),
+          suppressedArchivedThreadKeysRef.current
+        );
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
         const optimisticThreadKey = optimisticSelection
           ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
@@ -938,6 +986,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           threadId: string;
         };
         const threadKey = buildThreadIdentityKey(event.backend, threadId);
+        suppressedArchivedThreadKeysRef.current.add(threadKey);
 
         setState((current) => ({
           ...current,
@@ -970,6 +1019,12 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       }
 
       if (method === "thread/unarchived") {
+        const { threadId } = event.notification.params as {
+          threadId: string;
+        };
+        suppressedArchivedThreadKeysRef.current.delete(
+          buildThreadIdentityKey(event.backend, threadId)
+        );
         scheduleRefresh();
         return;
       }
@@ -1401,6 +1456,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         ? buildThreadIdentityKey(optimisticThread.source, optimisticThread.id)
         : undefined;
 
+      suppressedArchivedThreadKeysRef.current.add(threadKey);
       setArchiveThreadError(undefined);
       setCreateThreadError(undefined);
       setLaunchpadError(undefined);
@@ -1436,6 +1492,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         });
         await refresh();
       } catch (error) {
+        suppressedArchivedThreadKeysRef.current.delete(threadKey);
         setArchiveThreadError(error instanceof Error ? error.message : String(error));
         await refresh(threadKey);
       }


### PR DESCRIPTION
## Summary

I fixed a desktop navigation race where archived threads could disappear optimistically, then reappear when the immediate post-archive navigation refresh returned a stale snapshot.

The renderer now tracks locally archived thread keys and filters them out of refreshed snapshots until an unarchive notification arrives or the archive call fails. I also marked Codex `thread/archived` and `thread/unarchived` notifications as generated/known notifications so they no longer show up as unknown notification warnings while still being forwarded to the app.

## Tests

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm typecheck`
