### PR TITLE
fix(desktop): stop treating bare numbers as title refs

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -75,10 +75,10 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
-  it("preserves bare numeric references", async () => {
+  it("allows bare numbers to be omitted from generated titles", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {
-        codex: makeGenerator({ title: "456 rename followup" }),
+        codex: makeGenerator({ title: "Rename behavior" }),
       },
     });
 
@@ -89,7 +89,26 @@ describe("ThreadTitleGenerationService", () => {
       })
     ).resolves.toMatchObject({
       status: "generated",
-      title: "456 rename followup",
+      title: "Rename behavior",
+    });
+  });
+
+  it("does not treat arbitrary prompt numbers as ticket references", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "Thread rename rejection" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt:
+          "At 19:36:47.622 thread title generation rejected a rename for thread 019dd673-a098-7021-a344-a09e4d8ec850.",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "Thread rename rejection",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
@@ -13,9 +13,9 @@ describe("thread title prompt", () => {
     expect(prompt).toContain("6 words or fewer");
     expect(prompt).toContain("PROJECT-123");
     expect(prompt).toContain("#123");
-    expect(prompt).toContain("456");
     expect(prompt).toContain("issue 123");
     expect(prompt).toContain("PR 456");
+    expect(prompt).not.toContain("bare numeric");
     expect(prompt).not.toMatch(/\bfix\b/i);
     expect(prompt).not.toMatch(/\badd\b/i);
     expect(prompt).not.toMatch(/\bimperative\b/i);

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -255,7 +255,6 @@ function extractTicketReferences(value: string): string[] {
   const patterns = [
     /\b[A-Z][A-Z0-9]+-\d+\b/g,
     /#\d+\b/g,
-    /\b\d{2,}\b/g,
     /\b(?:issue|pr|pull request)\s+#?\d+\b/gi,
   ];
 

--- a/apps/desktop/src/main/app-server/thread-title-prompt.md
+++ b/apps/desktop/src/main/app-server/thread-title-prompt.md
@@ -18,7 +18,7 @@ Requirements:
 - Capture the main task, question, bug, artifact, or decision.
 - Prefer specific nouns from the prompt over generic wording.
 - Preserve code identifiers, filenames, product names, and proper nouns when they are central to the request.
-- Preserve ticket and work item references when present, including JIRA-style keys such as `PROJECT-123`, GitHub-style references such as `#123`, bare numeric issue or PR references such as `456`, and textual references such as `issue 123`, `Issue #123`, `PR 456`, or `pull request #456`.
+- Preserve ticket and work item references when present, including JIRA-style keys such as `PROJECT-123`, GitHub-style references such as `#123`, and textual references such as `issue 123`, `Issue #123`, `PR 456`, or `pull request #456`.
 - If the user explicitly provides a title, use it unless it conflicts with the length limits.
 - Do not answer the prompt or explain the title.
 - Do not include markdown, quotes, labels, or trailing punctuation in the title.


### PR DESCRIPTION
Fixes thread auto-title rejection when prompts contain incidental numbers like timestamps, log counters, or thread IDs. The title validator now preserves explicit work item references only, such as `PROJECT-123`, `#123`, `issue 123`, or `PR 456`, instead of treating every standalone multi-digit number as a required ticket reference.

The prompt text and tests were updated to match that narrower behavior, including a regression case for the timestamp/thread-ID shape that caused `ticket_reference_missing`.

Verification:
- `pnpm test apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts apps/desktop/src/main/__tests__/thread-title-prompt.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)
