### PR TITLE
fix(desktop): runtime path trimming

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
@@ -15,10 +15,30 @@ describe("runtime identity formatting", () => {
     ).toBe(".worktrees/pwragnt-fix-th...ng-moioth2352");
   });
 
+  it("ignores the desktop app package when showing the runtime workspace", () => {
+    expect(formatRuntimePath("/Users/huntharo/github/PwrAgnt/apps/desktop")).toBe(
+      "github/PwrAgnt"
+    );
+  });
+
+  it("ignores the desktop app package below a repo worktree", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/github/PwrAgnt/.worktrees/pwragnt-fix-thread-naming-moioth2352/apps/desktop"
+      )
+    ).toBe(".worktrees/pwragnt-fix-th...ng-moioth2352");
+  });
+
   it("shows the codex worktree id and repo for codex-managed worktrees", () => {
     expect(formatRuntimePath("/Users/huntharo/.codex/worktrees/5d4b/PwrAgnt")).toBe(
       "5d4b/PwrAgnt"
     );
+  });
+
+  it("ignores the desktop app package below a codex-managed worktree", () => {
+    expect(
+      formatRuntimePath("/Users/huntharo/.codex/worktrees/5d4b/PwrAgnt/apps/desktop")
+    ).toBe("5d4b/PwrAgnt");
   });
 
   it("middle-truncates branch names", () => {

--- a/apps/desktop/src/renderer/src/lib/runtime-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-identity.ts
@@ -37,7 +37,7 @@ export function useRuntimeIdentity(desktopApi?: DesktopApi): RuntimeIdentity | u
 }
 
 export function formatRuntimePath(cwd: string): string {
-  const segments = cwd.split("/").filter(Boolean);
+  const segments = workspaceDisplaySegments(cwd);
   const worktreesIndex = segments.lastIndexOf(".worktrees");
 
   if (worktreesIndex >= 0 && segments[worktreesIndex + 1]) {
@@ -55,6 +55,23 @@ export function formatRuntimePath(cwd: string): string {
   }
 
   return segments.slice(-2).join("/") || cwd;
+}
+
+function workspaceDisplaySegments(cwd: string): string[] {
+  const segments = cwd.split("/").filter(Boolean);
+  const desktopAppSuffix = ["apps", "desktop"];
+
+  if (
+    segments.length > desktopAppSuffix.length &&
+    desktopAppSuffix.every(
+      (segment, index) =>
+        segments[segments.length - desktopAppSuffix.length + index] === segment
+    )
+  ) {
+    return segments.slice(0, -desktopAppSuffix.length);
+  }
+
+  return segments;
 }
 
 export function formatRuntimeBranch(branch: string): string {


### PR DESCRIPTION
## Summary

I fixed the desktop runtime identity chip so it ignores the Electron package suffix when the app is launched from `apps/desktop`. The displayed workspace now points at the repo or worktree identity instead of showing the package directory.

## Changes

- Strip a trailing `apps/desktop` before formatting the runtime cwd label.
- Preserve the full cwd as the copy value for the runtime identity button.
- Add formatter coverage for plain repo paths, repo worktrees, and Codex-managed worktrees with the desktop app suffix.

## Verification

- `pnpm --dir apps/desktop exec vitest run src/renderer/src/lib/__tests__/runtime-identity.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `git diff --check`
