### PR TITLE
fix(desktop): preserve pasted composer images

### DIFF
--- a/apps/desktop/e2e/composer-image-thread-switch.spec.ts
+++ b/apps/desktop/e2e/composer-image-thread-switch.spec.ts
@@ -291,7 +291,7 @@ async function pasteDelayedImage(page: import("@playwright/test").Page): Promise
   });
 }
 
-test("clears a pasted composer image after switching away from a newly created thread", async () => {
+test("keeps a pasted composer image after switching away from a newly created thread", async () => {
   const fixture = await createComposerImageThreadSwitchFixture();
   const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
 
@@ -346,8 +346,8 @@ test("clears a pasted composer image after switching away from a newly created t
     ).toBeVisible();
 
     await app.window.waitForTimeout(700);
-    await expect(app.window.getByLabel("Pasted images")).toHaveCount(0);
-    await expect(app.window.getByAltText("switch-race.png")).toHaveCount(0);
+    await expect(app.window.getByLabel("Pasted images")).toHaveCount(1);
+    await expect(app.window.getByAltText("switch-race.png")).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/composer-image-thread-switch.spec.ts
+++ b/apps/desktop/e2e/composer-image-thread-switch.spec.ts
@@ -1,0 +1,355 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createComposerImageThreadSwitchFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-composer-image-switch-"));
+  const fixturePath = path.join(rootDir, "composer-image-thread-switch.fixture.json");
+  await mkdir(rootDir, { recursive: true });
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "composer-image-thread-switch",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-existing",
+                title: "Existing companion thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing companion thread is ready.",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing companion thread is ready.",
+                },
+              ],
+              lastAssistantMessage: "Existing companion thread is ready.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-start-1",
+            kind: "response",
+            method: "thread/start",
+            result: {
+              threadId: "thread-created",
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-created",
+              turnId: "turn-created-1",
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-created",
+                title: "Thread composer regression",
+                titleSource: "derived",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-existing",
+                title: "Existing companion thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [],
+              messages: [],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-created",
+                turn: {
+                  id: "turn-created-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "assistant-message-1",
+            kind: "notification",
+            notification: {
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "First replay response is streaming. ",
+                itemId: "assistant-created-1",
+                threadId: "thread-created",
+                turnId: "turn-created-1",
+              },
+            },
+          },
+          {
+            id: "assistant-message-2",
+            kind: "notification",
+            notification: {
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "Second response completed.",
+                itemId: "assistant-created-1",
+                threadId: "thread-created",
+                turnId: "turn-created-1",
+              },
+            },
+          },
+          {
+            id: "turn-completed-1",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-created",
+                turnId: "turn-created-1",
+                turn: {
+                  id: "turn-created-1",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-read-3",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-created-message-1",
+                  role: "user",
+                  text: "Start the regression thread",
+                },
+                {
+                  type: "message",
+                  id: "thread-created-message-2",
+                  role: "assistant",
+                  text: "First replay response is streaming. Second response completed.",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-created-message-1",
+                  role: "user",
+                  text: "Start the regression thread",
+                },
+                {
+                  id: "thread-created-message-2",
+                  role: "assistant",
+                  text: "First replay response is streaming. Second response completed.",
+                },
+              ],
+              lastUserMessage: "Start the regression thread",
+              lastAssistantMessage: "First replay response is streaming. Second response completed.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function pasteDelayedImage(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate(async () => {
+    const textarea = document.querySelector<HTMLTextAreaElement>("#thread-composer");
+    if (!textarea) {
+      throw new Error("Reply textarea not found");
+    }
+
+    const originalToBlob = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.toBlob = function delayedToBlob(callback, type, quality) {
+      window.setTimeout(() => {
+        originalToBlob.call(this, callback, type, quality);
+      }, 500);
+    };
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 1600;
+    canvas.height = 900;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Canvas context not available");
+    }
+    context.fillStyle = "#245b55";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "#f8fafc";
+    context.font = "96px sans-serif";
+    context.fillText("switch race", 96, 180);
+
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      originalToBlob.call(
+        canvas,
+        (value) => {
+          if (!value) {
+            reject(new Error("Could not create PNG blob"));
+            return;
+          }
+          resolve(value);
+        },
+        "image/png",
+      );
+    });
+    const file = new File([blob], "switch-race.png", { type: "image/png" });
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    textarea.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer,
+      }),
+    );
+  });
+}
+
+test("clears a pasted composer image after switching away from a newly created thread", async () => {
+  const fixture = await createComposerImageThreadSwitchFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Existing companion thread",
+      }),
+    ).toBeVisible();
+
+    await app.window.getByRole("button", { name: "New thread" }).click();
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("Start the regression thread");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Thread composer regression",
+      }),
+    ).toBeVisible();
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "assistant-message-1" });
+    await app.advance({ stepId: "assistant-message-2" });
+    await expect(transcript).toContainText("Second response completed.");
+    await app.advance({ stepId: "turn-completed-1" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toHaveCount(0);
+
+    await pasteDelayedImage(app.window);
+    await app.window
+      .getByRole("button", { name: /Existing companion thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Existing companion thread",
+      }),
+    ).toBeVisible();
+    await app.window
+      .getByRole("button", { name: /Thread composer regression/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Thread composer regression",
+      }),
+    ).toBeVisible();
+
+    await app.window.waitForTimeout(700);
+    await expect(app.window.getByLabel("Pasted images")).toHaveCount(0);
+    await expect(app.window.getByAltText("switch-race.png")).toHaveCount(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -116,6 +116,11 @@ type ReviewConfigState = {
   target?: ReviewTargetChoice;
 };
 
+type ComposerDraftState = {
+  draft: string;
+  imageAttachments: ComposerImageAttachment[];
+};
+
 const DEFAULT_REASONING_EFFORT = "medium";
 
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
@@ -305,6 +310,8 @@ export function Composer(props: ComposerProps) {
     : props.thread
       ? `thread:${props.thread.source}:${props.thread.id}`
       : "empty";
+  const activeComposerScopeKeyRef = useRef(composerScopeKey);
+  const scopedThreadDraftsRef = useRef(new Map<string, ComposerDraftState>());
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
@@ -328,6 +335,28 @@ export function Composer(props: ComposerProps) {
   );
 
   const selectionStart = inputRef.current?.selectionStart ?? draft.length;
+  const isThreadComposerScope = (scopeKey: string): boolean =>
+    scopeKey.startsWith("thread:");
+  const saveThreadComposerDraft = (
+    scopeKey: string,
+    state: ComposerDraftState,
+  ): void => {
+    if (!isThreadComposerScope(scopeKey)) {
+      return;
+    }
+
+    if (!state.draft.trim() && state.imageAttachments.length === 0) {
+      scopedThreadDraftsRef.current.delete(scopeKey);
+      return;
+    }
+
+    scopedThreadDraftsRef.current.set(scopeKey, state);
+  };
+  const clearThreadComposerDraft = (scopeKey: string): void => {
+    if (isThreadComposerScope(scopeKey)) {
+      scopedThreadDraftsRef.current.delete(scopeKey);
+    }
+  };
   const updateActiveTurnId = (nextTurnId?: string): void => {
     activeTurnIdRef.current = nextTurnId;
     setActiveTurnId(nextTurnId);
@@ -398,15 +427,33 @@ export function Composer(props: ComposerProps) {
   const isBareReviewCommand = draft.trim() === "/review";
 
   useEffect(() => {
-    const current = pasteScopeRef.current;
-    if (current.key === composerScopeKey) {
+    const previousScopeKey = activeComposerScopeKeyRef.current;
+    if (previousScopeKey === composerScopeKey) {
       return;
     }
 
+    saveThreadComposerDraft(previousScopeKey, {
+      draft,
+      imageAttachments,
+    });
+
+    activeComposerScopeKeyRef.current = composerScopeKey;
+    const current = pasteScopeRef.current;
     pasteScopeRef.current = {
       key: composerScopeKey,
       version: current.version + 1,
     };
+
+    if (props.thread) {
+      const saved = scopedThreadDraftsRef.current.get(composerScopeKey);
+      setDraft(saved?.draft ?? "");
+      setImageAttachments(saved?.imageAttachments ?? []);
+    }
+    setSending(false);
+    setInterrupting(false);
+    updateActiveTurnId(undefined);
+    setActiveOptimisticMessageId(undefined);
+    setReviewConfig(undefined);
   }, [composerScopeKey]);
 
   useEffect(() => {
@@ -460,14 +507,8 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    setDraft("");
-    setSending(false);
-    setInterrupting(false);
-    updateActiveTurnId(undefined);
-    setActiveOptimisticMessageId(undefined);
-    setReviewConfig(undefined);
-    setImageAttachments([]);
-  }, [props.thread?.id, props.thread?.source]);
+    activeComposerScopeKeyRef.current = composerScopeKey;
+  }, [composerScopeKey, props.thread]);
 
   useEffect(() => {
     updateActiveTurnId(props.activeTurnId);
@@ -638,6 +679,7 @@ export function Composer(props: ComposerProps) {
       });
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
+      clearThreadComposerDraft(composerScopeKey);
       setDraft("");
       setReviewConfig(undefined);
     } catch (error) {
@@ -747,6 +789,7 @@ export function Composer(props: ComposerProps) {
       });
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
+      clearThreadComposerDraft(composerScopeKey);
       setDraft("");
       setImageAttachments([]);
       if (collaborationMode) {
@@ -852,6 +895,10 @@ export function Composer(props: ComposerProps) {
   const removeImageAttachment = (id: string): void => {
     setImageAttachments((current) => {
       const nextAttachments = current.filter((attachment) => attachment.id !== id);
+      saveThreadComposerDraft(composerScopeKey, {
+        draft,
+        imageAttachments: nextAttachments,
+      });
       persistLaunchpadImageAttachments(nextAttachments);
       return nextAttachments;
     });
@@ -921,23 +968,29 @@ export function Composer(props: ComposerProps) {
         })
       );
 
-      if (
-        pasteScopeRef.current.key !== pasteScope.key ||
-        pasteScopeRef.current.version !== pasteScope.version
-      ) {
+      if (activeComposerScopeKeyRef.current !== pasteScope.key) {
+        const saved = scopedThreadDraftsRef.current.get(pasteScope.key) ?? {
+          draft: "",
+          imageAttachments: [],
+        };
+        saveThreadComposerDraft(pasteScope.key, {
+          draft: saved.draft,
+          imageAttachments: [...saved.imageAttachments, ...nextAttachments],
+        });
         return;
       }
 
       setImageAttachments((current) => {
         const mergedAttachments = [...current, ...nextAttachments];
+        saveThreadComposerDraft(pasteScope.key, {
+          draft,
+          imageAttachments: mergedAttachments,
+        });
         persistLaunchpadImageAttachments(mergedAttachments);
         return mergedAttachments;
       });
     } catch (error) {
-      if (
-        pasteScopeRef.current.key !== pasteScope.key ||
-        pasteScopeRef.current.version !== pasteScope.version
-      ) {
+      if (activeComposerScopeKeyRef.current !== pasteScope.key) {
         return;
       }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -300,6 +300,12 @@ export function Composer(props: ComposerProps) {
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
+  const composerScopeKey = props.launchpad
+    ? `launchpad:${props.launchpad.directoryKey}`
+    : props.thread
+      ? `thread:${props.thread.source}:${props.thread.id}`
+      : "empty";
+  const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
@@ -390,6 +396,18 @@ export function Composer(props: ComposerProps) {
     [props.directory, props.thread]
   );
   const isBareReviewCommand = draft.trim() === "/review";
+
+  useEffect(() => {
+    const current = pasteScopeRef.current;
+    if (current.key === composerScopeKey) {
+      return;
+    }
+
+    pasteScopeRef.current = {
+      key: composerScopeKey,
+      version: current.version + 1,
+    };
+  }, [composerScopeKey]);
 
   useEffect(() => {
     setActiveSkillIndex(0);
@@ -864,6 +882,8 @@ export function Composer(props: ComposerProps) {
   };
 
   const attachPastedImages = async (files: PastedImageFile[]): Promise<void> => {
+    const pasteScope = pasteScopeRef.current;
+
     try {
       const nextAttachments = await Promise.all(
         files.map(async ({ file, type }, index) => {
@@ -901,12 +921,26 @@ export function Composer(props: ComposerProps) {
         })
       );
 
+      if (
+        pasteScopeRef.current.key !== pasteScope.key ||
+        pasteScopeRef.current.version !== pasteScope.version
+      ) {
+        return;
+      }
+
       setImageAttachments((current) => {
         const mergedAttachments = [...current, ...nextAttachments];
         persistLaunchpadImageAttachments(mergedAttachments);
         return mergedAttachments;
       });
     } catch (error) {
+      if (
+        pasteScopeRef.current.key !== pasteScope.key ||
+        pasteScopeRef.current.version !== pasteScope.version
+      ) {
+        return;
+      }
+
       setSendError(
         error instanceof Error ? error.message : "The pasted image could not be read."
       );

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -930,6 +930,10 @@ export function Composer(props: ComposerProps) {
 
   const attachPastedImages = async (files: PastedImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
+    const pasteDraft = draft;
+    const pasteImageAttachments = imageAttachments;
+    const pasteLaunchpad = props.launchpad;
+    const updateLaunchpad = props.onUpdateLaunchpad;
 
     try {
       const nextAttachments = await Promise.all(
@@ -969,6 +973,15 @@ export function Composer(props: ComposerProps) {
       );
 
       if (activeComposerScopeKeyRef.current !== pasteScope.key) {
+        if (pasteLaunchpad && updateLaunchpad) {
+          const mergedAttachments = [...pasteImageAttachments, ...nextAttachments];
+          void updateLaunchpad(pasteLaunchpad.directoryKey, {
+            imageAttachments: mergedAttachments.length > 0 ? mergedAttachments : undefined,
+            prompt: pasteDraft,
+          });
+          return;
+        }
+
         const saved = scopedThreadDraftsRef.current.get(pasteScope.key) ?? {
           draft: "",
           imageAttachments: [],

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -7,6 +7,7 @@ import type {
   StartTurnRequest,
 } from "@pwragnt/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeImageFile } from "../../../lib/image-normalization";
 import { Composer } from "../Composer";
 
 vi.mock("../../../lib/image-normalization", () => ({
@@ -28,6 +29,7 @@ vi.mock("../../../lib/image-normalization", () => ({
 }));
 
 afterEach(() => {
+  vi.mocked(normalizeImageFile).mockClear();
   cleanup();
 });
 
@@ -797,6 +799,168 @@ describe("Composer", () => {
       "Review the pasted mockup"
     );
     expect(screen.getByAltText("mockup.png")).toBeInTheDocument();
+  });
+
+  it("persists launchpad pasted images that finish after switching away", async () => {
+    let resolveNormalization: (file: File) => void = () => undefined;
+    vi.mocked(normalizeImageFile).mockImplementationOnce(
+      async () =>
+        await new Promise((resolve) => {
+          resolveNormalization = (file: File) => {
+            resolve({
+              conversionPath: "renderer",
+              dataUrl: "data:image/png;base64,AQID",
+              height: 24,
+              mimeType: "image/png",
+              original: {
+                height: 24,
+                mimeType: file.type || "image/png",
+                name: file.name,
+                size: file.size,
+                width: 32,
+              },
+              size: 3,
+              width: 32,
+            });
+          };
+        })
+    );
+
+    const launchpads = new Map<string, NavigationLaunchpadDraft>([
+      [
+        "directory:/repo-a",
+        {
+          directoryKey: "directory:/repo-a",
+          directoryKind: "directory",
+          directoryLabel: "Repo A",
+          directoryPath: "/repo-a",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      [
+        "directory:/repo-b",
+        {
+          directoryKey: "directory:/repo-b",
+          directoryKind: "directory",
+          directoryLabel: "Repo B",
+          directoryPath: "/repo-b",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    ]);
+    const onUpdateLaunchpad = vi.fn(async (directoryKey, patch) => {
+      const current = launchpads.get(directoryKey);
+      if (!current) {
+        throw new Error(`Unknown launchpad ${directoryKey}`);
+      }
+      launchpads.set(directoryKey, {
+        ...current,
+        ...patch,
+        updatedAt: current.updatedAt + 1,
+      });
+    });
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "slow-mockup.png", {
+      type: "image/png",
+    });
+
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-a",
+          kind: "directory",
+          label: "Repo A",
+          path: "/repo-a",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-a")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Review the slow mockup" },
+    });
+    fireEvent.paste(screen.getByLabelText("New thread"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-b",
+          kind: "directory",
+          label: "Repo B",
+          path: "/repo-b",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-b")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    await act(async () => {
+      resolveNormalization(imageFile);
+    });
+
+    await waitFor(() => {
+      expect(launchpads.get("directory:/repo-a")?.imageAttachments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "slow-mockup.png" }),
+        ])
+      );
+    });
+    expect(launchpads.get("directory:/repo-a")?.prompt).toBe(
+      "Review the slow mockup"
+    );
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo-a",
+          kind: "directory",
+          label: "Repo A",
+          path: "/repo-a",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpads.get("directory:/repo-a")!}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("New thread")).toHaveValue(
+      "Review the slow mockup"
+    );
+    expect(screen.getByAltText("slow-mockup.png")).toBeInTheDocument();
   });
 
   it("keeps active launchpad edits stable when an autosave rerenders the same draft", () => {


### PR DESCRIPTION
Fixes a race where pasted image attachments disappear from a newly created thread composer after switching away and then returning.

The composer now keeps unsent draft text and pasted image attachments scoped by thread, and persists launchpad-originated pasted images back to their launchpad draft if normalization finishes after navigation. If image normalization finishes while another thread or launchpad is selected, the attachment is stored with the originating composer instead of being dropped or applied to the wrong composer. I also added an Electron E2E regression that creates a thread, sends the first message, receives streamed responses, starts a delayed image paste, switches threads, and verifies the original composer still has the pasted image when reselected.

Verified with:

- `pnpm --filter @pwragnt/desktop test:e2e -- composer-image-thread-switch.spec.ts`
- `pnpm --filter @pwragnt/desktop test:e2e -- composer-image-normalization.spec.ts`
- `pnpm test -- apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 Codex via [Codex](https://openai.com/codex)
