### PR TITLE
feat(desktop): GIF attachment support

### DIFF
--- a/apps/desktop/e2e/composer-image-normalization.spec.ts
+++ b/apps/desktop/e2e/composer-image-normalization.spec.ts
@@ -174,3 +174,68 @@ test("pasted WebP image is uploaded as bounded JPEG or PNG", async () => {
     await fixture.cleanup();
   }
 });
+
+test("dropped GIF image is uploaded as GIF and previewed without normalization", async () => {
+  const fixture = await createComposerImageFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await app.window.getByRole("button", { name: "Image normalization" }).first().click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Image normalization",
+      }),
+    ).toBeVisible();
+    await app.window.getByLabel("Reply").waitFor();
+
+    await app.window.evaluate(async () => {
+      const textarea = document.querySelector<HTMLTextAreaElement>("#thread-composer");
+      if (!textarea) {
+        throw new Error("Reply textarea not found");
+      }
+
+      const gifBytes = Uint8Array.from([
+        0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x21, 0xff, 0x0b, 0x4e, 0x45,
+        0x54, 0x53, 0x43, 0x41, 0x50, 0x45, 0x32, 0x2e, 0x30, 0x03, 0x01, 0x00,
+        0x00, 0x00, 0x21, 0xf9, 0x04, 0x04, 0x0a, 0x00, 0x00, 0x00, 0x2c, 0x00,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44, 0x01,
+        0x00, 0x21, 0xf9, 0x04, 0x04, 0x0a, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x81, 0xff, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3b,
+      ]);
+      const file = new File([gifBytes], "loop.gif", { type: "image/gif" });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      textarea.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+    });
+
+    const preview = app.window.getByAltText("loop.gif");
+    await expect(preview).toBeVisible();
+    await expect(preview).toHaveAttribute("src", /^data:image\/gif;base64,/);
+
+    await app.window.getByLabel("Reply").fill("Describe the dropped gif");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await expect.poll(async () => await app.getLastStartTurn()).not.toBeNull();
+    const request = await app.getLastStartTurn();
+    const imageItem = (request as { input: Array<{ type: string; url?: string }> }).input.find(
+      (item) => item.type === "image",
+    );
+    const imageUrl = imageItem?.url;
+    if (!imageUrl) {
+      throw new Error("Expected turn/start payload to include a GIF data URL");
+    }
+    expect(imageUrl).toMatch(/^data:image\/gif;base64,/);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,4 +1,11 @@
-import { type ClipboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ClipboardEvent,
+  type DragEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerReviewTarget,
@@ -99,7 +106,7 @@ type PendingSteerDraft = QueuedTurnDraft & {
   status: "pending" | "steering";
 };
 
-type PastedImageFile = {
+type ComposerImageFile = {
   file: File;
   type: string;
 };
@@ -1205,17 +1212,37 @@ export function Composer(props: ComposerProps) {
   };
 
   const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>): void => {
-    const pastedFiles = getPastedImageFiles(event.clipboardData);
+    const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
     if (pastedFiles.length === 0) {
       return;
     }
 
     event.preventDefault();
     setSendError(undefined);
-    void attachPastedImages(pastedFiles);
+    void attachImages(pastedFiles);
   };
 
-  const attachPastedImages = async (files: PastedImageFile[]): Promise<void> => {
+  const handleDragOver = (event: DragEvent<HTMLTextAreaElement>): void => {
+    if (!hasImageFiles(event.dataTransfer)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDrop = (event: DragEvent<HTMLTextAreaElement>): void => {
+    const droppedFiles = getImageFilesFromDataTransfer(event.dataTransfer);
+    if (droppedFiles.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    setSendError(undefined);
+    void attachImages(droppedFiles);
+  };
+
+  const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
     const pasteDraft = draft;
     const pasteImageAttachments = imageAttachments;
@@ -1225,11 +1252,22 @@ export function Composer(props: ComposerProps) {
     try {
       const nextAttachments = await Promise.all(
         files.map(async ({ file, type }, index) => {
+          const fallbackName = formatPastedImageName(type, index);
+          if (isGifFile(file, type)) {
+            return {
+              id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+              name: file.name || fallbackName,
+              size: file.size,
+              type: "image/gif",
+              url: await readFileAsImageDataUrl(file, "image/gif"),
+            };
+          }
+
           const normalized = await normalizeImageFile(file, {
             fallback: props.desktopApi?.normalizeImageForUpload,
           });
           void props.desktopApi?.recordImageUploadNormalization?.({
-            fileName: file.name || formatPastedImageName(type, index),
+            fileName: file.name || fallbackName,
             original: {
               height: normalized.original.height,
               mimeType: normalized.original.mimeType,
@@ -1249,7 +1287,7 @@ export function Composer(props: ComposerProps) {
           });
           return {
             id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
-            name: file.name || formatPastedImageName(type, index),
+            name: file.name || fallbackName,
             size: normalized.size,
             type: normalized.mimeType,
             url: normalized.dataUrl,
@@ -1505,6 +1543,8 @@ export function Composer(props: ComposerProps) {
             setSendError(undefined);
           }}
           onPaste={handlePaste}
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
           onClick={() => {
             setActiveSkillIndex(0);
             setActiveSlashIndex(0);
@@ -2140,13 +2180,13 @@ export function Composer(props: ComposerProps) {
   );
 }
 
-function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
-  const files: PastedImageFile[] = [];
+function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImageFile[] {
+  const files: ComposerImageFile[] = [];
   const seenFiles = new Set<string>();
   let foundImageItem = false;
 
-  for (const item of Array.from(clipboardData.items)) {
-    if (item.kind !== "file" || !item.type.startsWith("image/")) {
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind !== "file") {
       continue;
     }
 
@@ -2155,10 +2195,15 @@ function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
       continue;
     }
 
+    const type = isImageMimeType(item.type) ? item.type : inferTransferImageType(file);
+    if (!type) {
+      continue;
+    }
+
     foundImageItem = true;
     const key = buildFileKey(file);
     if (!seenFiles.has(key)) {
-      files.push({ file, type: item.type });
+      files.push({ file, type });
       seenFiles.add(key);
     }
   }
@@ -2167,14 +2212,15 @@ function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
     return files;
   }
 
-  for (const file of Array.from(clipboardData.files)) {
-    if (!file.type.startsWith("image/")) {
+  for (const file of Array.from(dataTransfer.files)) {
+    const type = inferTransferImageType(file);
+    if (!type) {
       continue;
     }
 
     const key = buildFileKey(file);
     if (!seenFiles.has(key)) {
-      files.push({ file, type: file.type });
+      files.push({ file, type });
       seenFiles.add(key);
     }
   }
@@ -2182,8 +2228,58 @@ function getPastedImageFiles(clipboardData: DataTransfer): PastedImageFile[] {
   return files;
 }
 
+function hasImageFiles(dataTransfer: DataTransfer): boolean {
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind === "file" && (!item.type || isImageMimeType(item.type))) {
+      return true;
+    }
+  }
+
+  return Array.from(dataTransfer.files).some((file) => Boolean(inferTransferImageType(file)));
+}
+
 function buildFileKey(file: File): string {
   return `${file.name}:${file.type}:${file.size}:${file.lastModified}`;
+}
+
+function inferTransferImageType(file: File): string | undefined {
+  if (isImageMimeType(file.type)) {
+    return file.type;
+  }
+
+  const extension = file.name.toLowerCase().split(".").pop();
+  return extension === "gif" ? "image/gif" : undefined;
+}
+
+function isImageMimeType(type: string): boolean {
+  return type.toLowerCase().startsWith("image/");
+}
+
+function isGifFile(file: File, type: string): boolean {
+  return inferTransferImageType(file) === "image/gif" || type.toLowerCase() === "image/gif";
+}
+
+function readFileAsImageDataUrl(file: File, mimeType: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        if (reader.result.startsWith(`data:${mimeType}`)) {
+          resolve(reader.result);
+          return;
+        }
+        if (/^data:[^,]*,/i.test(reader.result)) {
+          resolve(reader.result.replace(/^data:[^,]*,/i, `data:${mimeType};base64,`));
+          return;
+        }
+      }
+      reject(new Error("The image did not produce an image data URL."));
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("The image could not be read."));
+    });
+    reader.readAsDataURL(file);
+  });
 }
 
 function formatPastedImageName(type: string, index: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1746,6 +1746,69 @@ describe("Composer", () => {
     });
   });
 
+  it("keeps dropped GIF images animated by preserving the original data URL", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const gifFile = new File([new Uint8Array([71, 73, 70, 56])], "demo.gif", {
+      type: "image/gif",
+    });
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.drop(textarea, {
+      dataTransfer: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/gif",
+            getAsFile: () => gifFile,
+          },
+        ],
+      },
+    });
+
+    const preview = await screen.findByAltText("demo.gif");
+    expect(preview).toHaveAttribute("src", expect.stringMatching(/^data:image\/gif;base64,/));
+    expect(normalizeImageFile).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "image",
+            url: expect.stringMatching(/^data:image\/gif;base64,/),
+          },
+        ],
+      });
+    });
+  });
+
   it("does not duplicate a pasted image when clipboard items and files both expose it", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,


### PR DESCRIPTION
## Summary

- I added drop handling to the desktop composer so image files dragged into the reply box become attachments.
- I preserve GIF files as `data:image/gif` instead of normalizing them through canvas, which keeps animated previews intact.
- I added renderer and Electron E2E coverage for dropped GIF attachment behavior.

## Why

Dragging a GIF into the chat entry previously was not accepted because the composer only handled pasted image files. GIFs also need to avoid the normal image canvas path because that path flattens animated images to a single frame.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/composer-image-normalization.spec.ts`
