### PR TITLE
fix(desktop): load archived thread metadata asynchronously

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -874,8 +874,8 @@ describe("CodexAppServerClient", () => {
     });
     expect(renamedThread).toMatchObject({
       id: "thread-renamed",
-      title: "Spud up the thread",
-      titleSource: "explicit",
+      title: "Name this thread something funny and spunky. Something about potatoes",
+      titleSource: "derived",
     });
     expect(archivedThread).toBeUndefined();
 
@@ -896,14 +896,6 @@ describe("CodexAppServerClient", () => {
             sourceKinds: ["cli", "vscode"],
           }
         }),
-        expect.objectContaining({
-          params: {
-            archived: true,
-            limit: 50,
-            sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
-          }
-        })
       ])
     );
 
@@ -1073,15 +1065,6 @@ describe("CodexAppServerClient", () => {
             sourceKinds: ["cli", "vscode"],
           }
         }),
-        expect.objectContaining({
-          params: {
-            searchTerm: "web-app",
-            archived: true,
-            limit: 50,
-            sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
-          }
-        })
       ])
     );
 
@@ -1324,7 +1307,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("hydrates archived threads so persisted explicit names survive reload", async () => {
+  it("hydrates archived thread metadata after the initial active-thread load", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -1342,21 +1325,34 @@ describe("CodexAppServerClient", () => {
           : []
     });
 
-    const threads = await client.listThreads();
+    const initialThreads = await client.listThreads();
 
-    expect(threads.find((thread) => thread.id === "thread-renamed")).toMatchObject({
+    expect(initialThreads.find((thread) => thread.id === "thread-renamed")).toMatchObject({
       id: "thread-renamed",
-      title: "Spud up the thread",
-      titleSource: "explicit",
       source: "codex",
     });
-    expect(threads.find((thread) => thread.id === "thread-archive")).toBeUndefined();
+    expect(
+      initialThreads.find((thread) => thread.id === "thread-renamed")?.titleSource
+    ).not.toBe("explicit");
+    expect(initialThreads.find((thread) => thread.id === "thread-archive")).toBeUndefined();
 
     const threadListRequests = MockTransport.instances[0]?.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: { archived?: boolean } })
       .filter((message) => message.method === "thread/list");
     expect(threadListRequests?.some((message) => message.params?.archived === false)).toBe(true);
-    expect(threadListRequests?.some((message) => message.params?.archived === true)).toBe(true);
+    expect(threadListRequests?.some((message) => message.params?.archived === true)).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const hydratedThreads = await client.listThreads();
+
+    expect(hydratedThreads.find((thread) => thread.id === "thread-renamed")).toMatchObject({
+      id: "thread-renamed",
+      title: "Spud up the thread",
+      titleSource: "explicit",
+      source: "codex",
+    });
+    expect(hydratedThreads.find((thread) => thread.id === "thread-archive")).toBeUndefined();
 
     await client.close();
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2363,6 +2363,10 @@ function mergeArchivedThreadMetadata(params: {
     .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
 }
 
+function buildThreadMetadataCacheKey(filter?: string): string {
+  return filter?.trim() || "";
+}
+
 function normalizeGitOriginUrl(value?: string): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -2788,6 +2792,14 @@ export class CodexAppServerClient {
   private readonly threadDirectoryEnricher: (
     projectKey?: string
   ) => Promise<ThreadDirectoryEnrichment>;
+  private readonly archivedThreadMetadataByFilter = new Map<
+    string,
+    RawCodexThreadSummary[]
+  >();
+  private readonly archivedThreadMetadataInFlightByFilter = new Map<
+    string,
+    Promise<RawCodexThreadSummary[]>
+  >();
   private initialized = false;
   private initializationPromise: Promise<void> | null = null;
   private initializeResult: InitializeResult | null = null;
@@ -3123,22 +3135,60 @@ export class CodexAppServerClient {
       return await this.enrichThreads(extractThreadsFromValue(archivedResult));
     }
 
-    const [activeResult, archivedResult] = await Promise.all([
-      requestWithFallbacks({
-        ...requestParams,
-        payloads: buildThreadDiscoveryPayloads(params?.filter, false),
-      }),
-      requestWithFallbacks({
-        ...requestParams,
-        payloads: buildThreadDiscoveryPayloads(params?.filter, true),
-      }).catch(() => undefined),
-    ]);
+    const activeResult = await requestWithFallbacks({
+      ...requestParams,
+      payloads: buildThreadDiscoveryPayloads(params?.filter, false),
+    });
     const threads = mergeArchivedThreadMetadata({
       activeThreads: extractThreadsFromValue(activeResult),
-      archivedThreads: extractThreadsFromValue(archivedResult),
+      archivedThreads: this.getCachedArchivedThreadMetadata(params?.filter),
     });
+    this.scheduleArchivedThreadMetadataRefresh(params?.filter);
 
     return await this.enrichThreads(threads);
+  }
+
+  private getCachedArchivedThreadMetadata(filter?: string): RawCodexThreadSummary[] {
+    return this.archivedThreadMetadataByFilter.get(buildThreadMetadataCacheKey(filter)) ?? [];
+  }
+
+  private scheduleArchivedThreadMetadataRefresh(filter?: string): void {
+    setTimeout(() => {
+      void this.refreshArchivedThreadMetadata(filter).catch((error) => {
+        codexClientLog.warn("archived thread metadata refresh failed", {
+          error: error instanceof Error ? error.message : String(error),
+          filter: filter?.trim() || null,
+        });
+      });
+    }, 0);
+  }
+
+  private async refreshArchivedThreadMetadata(
+    filter?: string,
+  ): Promise<RawCodexThreadSummary[]> {
+    const cacheKey = buildThreadMetadataCacheKey(filter);
+    const inFlight = this.archivedThreadMetadataInFlightByFilter.get(cacheKey);
+    if (inFlight) {
+      return await inFlight;
+    }
+
+    const requestPromise = requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/list"] as CodexClientRequestMethod[],
+      payloads: buildThreadDiscoveryPayloads(filter, true),
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    })
+      .then((result) => {
+        const threads = extractThreadsFromValue(result);
+        this.archivedThreadMetadataByFilter.set(cacheKey, threads);
+        return threads;
+      })
+      .finally(() => {
+        this.archivedThreadMetadataInFlightByFilter.delete(cacheKey);
+      });
+
+    this.archivedThreadMetadataInFlightByFilter.set(cacheKey, requestPromise);
+    return await requestPromise;
   }
 
   private async enrichThreads(


### PR DESCRIPTION
## Summary

I changed the desktop Codex thread listing path so startup only waits for active threads. Archived thread metadata is now refreshed in the background and cached for later list refreshes, which preserves the narrow title-hydration behavior without blocking the sidebar load on the slower archived `thread/list` request.

## Verification

I verified this with:

- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `git diff --check`
