### PR TITLE
feat(desktop): Sync thinking scanner animation

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -1,8 +1,74 @@
+import { useEffect } from "react";
+
 type ThinkingScannerProps = {
   compact?: boolean;
 };
 
+const SCAN_DURATION_MS = 1800;
+const FULL_SCAN_TRAVEL_PX = 44;
+const MINI_SCAN_TRAVEL_PX = 10;
+let activeScannerCount = 0;
+let animationFrameId: number | undefined;
+
+function easedPingPong(progress: number): number {
+  const linear = progress < 0.5 ? progress * 2 : (1 - progress) * 2;
+
+  return 0.5 - Math.cos(linear * Math.PI) / 2;
+}
+
+function setThinkingScannerProgress(timestamp: number) {
+  const progress = (timestamp % SCAN_DURATION_MS) / SCAN_DURATION_MS;
+  const easedProgress = easedPingPong(progress);
+  const rootStyle = document.documentElement.style;
+
+  rootStyle.setProperty("--thinking-scanner-progress", easedProgress.toFixed(4));
+  rootStyle.setProperty(
+    "--thinking-scanner-full-offset",
+    `${(easedProgress * FULL_SCAN_TRAVEL_PX).toFixed(2)}px`
+  );
+  rootStyle.setProperty(
+    "--thinking-scanner-mini-offset",
+    `${(easedProgress * MINI_SCAN_TRAVEL_PX).toFixed(2)}px`
+  );
+
+  animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
+}
+
+function startThinkingScannerClock() {
+  activeScannerCount += 1;
+
+  if (activeScannerCount === 1) {
+    animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
+  }
+}
+
+function stopThinkingScannerClock() {
+  activeScannerCount = Math.max(0, activeScannerCount - 1);
+
+  if (activeScannerCount === 0 && animationFrameId !== undefined) {
+    window.cancelAnimationFrame(animationFrameId);
+    animationFrameId = undefined;
+  }
+}
+
 export function ThinkingScanner(props: ThinkingScannerProps = {}) {
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof document === "undefined" ||
+      typeof window.requestAnimationFrame !== "function" ||
+      typeof window.cancelAnimationFrame !== "function"
+    ) {
+      return;
+    }
+
+    startThinkingScannerClock();
+
+    return () => {
+      stopThinkingScannerClock();
+    };
+  }, []);
+
   return (
     <div
       aria-hidden="true"

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -125,4 +125,20 @@ describe("Tangerine Terminal theme contract", () => {
       /\.transcript-list__items\s*\{[\s\S]*?padding-bottom:\s*(?:[4-9]\d|\d{3,})px;[\s\S]*?\}/
     );
   });
+
+  it("keeps thinking scanner variants on one shared visible sweep", () => {
+    expect(css).toContain("--thinking-scanner-progress: 0;");
+    expect(css).toContain("--thinking-scanner-full-offset: 0px;");
+    expect(css).toContain("--thinking-scanner-mini-offset: 0px;");
+    expect(css).not.toContain("@keyframes pwragnt-kitt-scan");
+    expect(css).toMatch(
+      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-offset:\s*var\(--thinking-scanner-full-offset\);[\s\S]*?width:\s*62px;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.thinking-scanner--mini\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*6px;[\s\S]*?--thinking-scanner-offset:\s*var\(--thinking-scanner-mini-offset\);[\s\S]*?width:\s*16px;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.thinking-scanner__beam\s*\{[\s\S]*?transform:\s*translateX\(var\(--thinking-scanner-offset\)\);[\s\S]*?\}/
+    );
+  });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -30,6 +30,11 @@
   --info-text: #9fc8ff;
   --button-text: #120800;
   --shadow-popover: 0 18px 48px rgba(0, 0, 0, 0.42);
+  --thinking-scanner-beam-width: 18px;
+  --thinking-scanner-full-offset: 0px;
+  --thinking-scanner-mini-offset: 0px;
+  --thinking-scanner-offset: var(--thinking-scanner-full-offset);
+  --thinking-scanner-progress: 0;
 }
 
 * {
@@ -2004,19 +2009,10 @@ textarea {
   outline: none;
 }
 
-@keyframes pwragnt-kitt-scan {
-  0% { transform: translateX(0); }
-  50% { transform: translateX(44px); }
-  100% { transform: translateX(0); }
-}
-
-@keyframes pwragnt-kitt-glow {
-  0%, 100% { opacity: 0.72; }
-  50% { opacity: 1; }
-}
-
 .thinking-scanner {
   position: relative;
+  --thinking-scanner-beam-width: 18px;
+  --thinking-scanner-offset: var(--thinking-scanner-full-offset);
   width: 62px;
   height: 6px;
   flex: 0 0 auto;
@@ -2027,7 +2023,9 @@ textarea {
 }
 
 .thinking-scanner--mini {
-  width: 14px;
+  --thinking-scanner-beam-width: 6px;
+  --thinking-scanner-offset: var(--thinking-scanner-mini-offset);
+  width: 16px;
   height: 6px;
 }
 
@@ -2035,7 +2033,7 @@ textarea {
   position: absolute;
   top: 0;
   left: 0;
-  width: 18px;
+  width: var(--thinking-scanner-beam-width);
   height: 100%;
   border-radius: 999px;
   background: linear-gradient(
@@ -2047,13 +2045,12 @@ textarea {
   box-shadow:
     0 0 10px rgba(255, 138, 31, 0.42),
     0 0 18px rgba(255, 138, 31, 0.22);
-  animation:
-    pwragnt-kitt-scan 1.35s cubic-bezier(0.4, 0, 0.2, 1) infinite,
-    pwragnt-kitt-glow 0.7s ease-in-out infinite;
+  opacity: calc(0.76 + (var(--thinking-scanner-progress, 0) * 0.24));
+  transform: translateX(var(--thinking-scanner-offset));
+  will-change: opacity, transform;
 }
 
 .thinking-scanner--mini .thinking-scanner__beam {
-  width: 8px;
   box-shadow:
     0 0 8px rgba(255, 138, 31, 0.42),
     0 0 14px rgba(255, 138, 31, 0.22);


### PR DESCRIPTION
## Summary

- Replaced independent CSS keyframe scanner motion with a shared renderer animation clock.
- Added full-size and mini scanner offsets so transcript and list indicators sample the same phase while using rail-specific travel distances.
- Tightened the compact thread-list scanner so the beam stays visible across the whole sweep.
- Added theme contract coverage for the shared scanner variables and compact geometry.

## Root Cause

The thread-list thinking indicator reused the transcript scanner keyframes inside a much shorter clipped container. Its 44px translate distance pushed most of the mini beam offscreen, and each CSS animation instance could start on its own schedule, leaving list and transcript indicators visually out of sync.

## Validation

- pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
- pnpm --filter @pwragnt/desktop typecheck
- pnpm --filter @pwragnt/desktop build
- Ran an Electron frame sampler against a replay fixture with three live thinking indicators; confirmed all indicators used the same root progress and both mini beams stayed inside their rails across sampled frames.
