### PR TITLE
feat(desktop): show context window moon

### DIFF
--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -218,6 +218,48 @@ test("keeps transient turn UI through metadata and premature idle notifications"
   }
 });
 
+test("renders the context window moon from token usage notifications", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      turnLifecycleSpecDir,
+      "fixtures/turn-lifecycle/replay.fixture.json"
+    ),
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Turn lifecycle replay/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Turn lifecycle replay",
+      })
+    ).toBeVisible();
+
+    await app.window
+      .getByLabel("Reply")
+      .fill(
+        "Create /tmp/pwragnt-turn-lifecycle.txt with exactly the text lifecycle second turn."
+      );
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "token-usage-1" });
+
+    await expect(
+      app.window.getByRole("img", {
+        name: /Context window 0% full, 1\.2k\/258\.4k tokens, new/,
+      })
+    ).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
 test("keeps the in-thread thinking indicator visible for active turns without pending text", async () => {
   const fixture = await createActiveTurnThinkingFixture();
   const app = await launchElectronApp({ fixturePath: fixture.fixturePath });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7,6 +7,8 @@ import type {
   AppServerThreadSummary,
   AppServerReviewTarget,
   AppServerTurnInputItem,
+  BackendAccountSummary,
+  BackendRateLimitSummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   ThreadOverlayState,
@@ -224,6 +226,8 @@ class MockBackendClient {
         supportsReasoning?: boolean;
         supportsFast?: boolean;
       }>;
+      account?: BackendAccountSummary;
+      rateLimits?: BackendRateLimitSummary[];
       setThreadPermissionsError?: Error;
     }
   ) {}
@@ -271,6 +275,14 @@ class MockBackendClient {
   async listModels() {
     this.listModelsCallCount += 1;
     return this.options.models ?? [];
+  }
+
+  async readAccount(): Promise<BackendAccountSummary> {
+    return this.options.account ?? {};
+  }
+
+  async readRateLimits(): Promise<BackendRateLimitSummary[]> {
+    return this.options.rateLimits ?? [];
   }
 
   onNotification(
@@ -372,6 +384,30 @@ describe("DesktopBackendRegistry", () => {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
         methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
       },
+      account: {
+        type: "chatgpt",
+        email: "user@example.com",
+        planType: "pro",
+        requiresOpenaiAuth: false,
+      },
+      rateLimits: [
+        {
+          name: "5h limit",
+          usedPercent: 15,
+          remaining: 85,
+          resetAt: new Date("2026-04-29T14:00:00-04:00").getTime(),
+          windowSeconds: 18_000,
+          windowMinutes: 300,
+        },
+        {
+          name: "Weekly limit",
+          usedPercent: 9,
+          remaining: 91,
+          resetAt: new Date("2026-05-01T14:00:00-04:00").getTime(),
+          windowSeconds: 604_800,
+          windowMinutes: 10_080,
+        },
+      ],
     });
     const codexFullAccessClient = new MockBackendClient({
       initializeResult: {
@@ -398,6 +434,24 @@ describe("DesktopBackendRegistry", () => {
         kind: "codex",
         label: "OpenAI",
         available: true,
+        account: {
+          type: "chatgpt",
+          email: "user@example.com",
+          planType: "pro",
+          requiresOpenaiAuth: false,
+        },
+        rateLimits: [
+          {
+            name: "5h limit",
+            usedPercent: 15,
+            remaining: 85,
+          },
+          {
+            name: "Weekly limit",
+            usedPercent: 9,
+            remaining: 91,
+          },
+        ],
         serverName: "Codex App Server",
         serverVersion: "1.0.0",
         methods: ["thread/list", "thread/read", "thread/start", "turn/start"],

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -62,6 +62,9 @@ class MockTransport implements JsonRpcTransport {
   static modelListResult: unknown = {
     data: []
   };
+  static rateLimitsResult: unknown = {
+    rateLimitsByLimitId: {}
+  };
   static turnInterruptResponseMode: "success" | "timeout" = "success";
 
   readonly sentMessages: string[] = [];
@@ -450,6 +453,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "account/rateLimits/read") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.rateLimitsResult,
+        })
+      );
+      return;
+    }
+
     if (payload.method === "thread/read") {
       const threadId = (JSON.parse(message) as { params?: { threadId?: string } }).params?.threadId;
       const readThreadError = threadId
@@ -817,6 +831,9 @@ describe("CodexAppServerClient", () => {
     MockTransport.modelListResult = {
       data: []
     };
+    MockTransport.rateLimitsResult = {
+      rateLimitsByLimitId: {}
+    };
     MockTransport.turnInterruptResponseMode = "success";
   });
 
@@ -1033,6 +1050,46 @@ describe("CodexAppServerClient", () => {
         label: "GPT-5.2",
         current: undefined,
         supportsReasoning: true,
+      },
+    ]);
+  });
+
+  it("normalizes 10080 minute rate-limit windows as weekly limits", async () => {
+    MockTransport.rateLimitsResult = {
+      rateLimitsByLimitId: {
+        codex: {
+          limitName: "Codex",
+          primary: {
+            usedPercent: 15,
+            windowDurationMins: 300,
+            resetsAt: "2026-04-29T14:00:00-04:00",
+          },
+          secondary: {
+            usedPercent: 9,
+            windowDurationMins: 10_080,
+            resetsAt: "2026-05-01T14:00:00-04:00",
+          },
+        },
+      },
+    };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+    });
+
+    await expect(client.readRateLimits()).resolves.toMatchObject([
+      {
+        name: "5h limit",
+        remaining: 85,
+        usedPercent: 15,
+        windowMinutes: 300,
+      },
+      {
+        name: "Weekly limit",
+        remaining: 91,
+        usedPercent: 9,
+        windowMinutes: 10_080,
       },
     ]);
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17,9 +17,11 @@ import {
   type AppServerTurnInputItem,
   type AppServerBackendKind,
   type AppServerCollaborationModeRequest,
+  type BackendAccountSummary,
   type BackendCapabilities,
   type BackendLaunchpadOptions,
   type BackendModelOption,
+  type BackendRateLimitSummary,
   type BackendSummary,
   type ListBackendsRequest,
   type ListBackendsResponse,
@@ -142,6 +144,8 @@ type BackendClient = {
     delivery?: StartReviewRequest["delivery"];
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
   listModels?(): Promise<BackendModelOption[]>;
+  readAccount?(): Promise<BackendAccountSummary>;
+  readRateLimits?(): Promise<BackendRateLimitSummary[]>;
   interruptTurn(params: {
     threadId: string;
     turnId: string;
@@ -464,6 +468,33 @@ async function readClientModels(client: BackendClient): Promise<BackendModelOpti
     return [];
   }
   return await client.listModels();
+}
+
+async function readClientAccount(
+  client: BackendClient
+): Promise<BackendAccountSummary | undefined> {
+  if (!client.readAccount) {
+    return undefined;
+  }
+  return await client.readAccount();
+}
+
+function isMeaningfulAccountSummary(
+  account: BackendAccountSummary | undefined
+): account is BackendAccountSummary {
+  return Boolean(
+    account?.type ||
+      account?.email ||
+      account?.planType ||
+      typeof account?.requiresOpenaiAuth === "boolean"
+  );
+}
+
+async function readClientRateLimits(client: BackendClient): Promise<BackendRateLimitSummary[]> {
+  if (!client.readRateLimits) {
+    return [];
+  }
+  return await client.readRateLimits();
 }
 
 type ModelSettings = {
@@ -1533,10 +1564,18 @@ export class DesktopBackendRegistry {
   }
 
   private async describeCodexBackend(): Promise<BackendSummary> {
-    const [defaultResult, fullAccessResult, defaultModelsResult] = await Promise.allSettled([
+    const [
+      defaultResult,
+      fullAccessResult,
+      defaultModelsResult,
+      defaultAccountResult,
+      defaultRateLimitsResult,
+    ] = await Promise.allSettled([
       this.codexDefaultClient.getInitializeResult(),
       this.codexFullAccessClient.getInitializeResult(),
       readClientModels(this.codexDefaultClient),
+      readClientAccount(this.codexDefaultClient),
+      readClientRateLimits(this.codexDefaultClient),
     ]);
     const successful = [defaultResult, fullAccessResult].flatMap((result) =>
       result.status === "fulfilled" ? [result.value] : [],
@@ -1558,6 +1597,15 @@ export class DesktopBackendRegistry {
       kind: "codex",
       label: BACKEND_LABELS.codex,
       available,
+      account:
+        defaultAccountResult.status === "fulfilled" &&
+        isMeaningfulAccountSummary(defaultAccountResult.value)
+          ? defaultAccountResult.value
+          : undefined,
+      rateLimits:
+        defaultRateLimitsResult.status === "fulfilled"
+          ? defaultRateLimitsResult.value
+          : undefined,
       serverName: successful[0]?.serverInfo?.name,
       serverVersion: successful[0]?.serverInfo?.version,
       methods,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -29,7 +29,9 @@ import type {
   AppServerCollaborationModeRequest,
   AppServerReviewDelivery,
   AppServerReviewTarget,
+  BackendAccountSummary,
   BackendModelOption,
+  BackendRateLimitSummary,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
 import { getMainLogger } from "../log";
@@ -157,6 +159,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "thread/tokenUsage/updated",
   "turn/requestApproval",
   "review/requestApproval",
+  "account/updated",
   "account/rateLimits/updated",
   "item/commandExecution/outputDelta",
   "item/commandExecution/terminalInteraction",
@@ -183,6 +186,7 @@ const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
   "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",
+  "account/updated",
   "account/rateLimits/updated",
   "item/commandExecution/outputDelta",
   "item/commandExecution/terminalInteraction",
@@ -394,6 +398,19 @@ function pickNumber(
   return undefined;
 }
 
+function pickFiniteNumber(
+  record: Record<string, unknown>,
+  keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function pickBoolean(
   record: Record<string, unknown>,
   keys: string[]
@@ -500,6 +517,202 @@ function normalizeEpochTimestamp(value: number | undefined): number | undefined 
     return undefined;
   }
   return value < 1_000_000_000_000 ? value * 1_000 : value;
+}
+
+function findFirstNestedValue(value: unknown, keys: string[], depth = 0): unknown {
+  if (depth > 8) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const nested = findFirstNestedValue(entry, keys, depth + 1);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    if (record[key] !== undefined) {
+      return record[key];
+    }
+  }
+  for (const child of Object.values(record)) {
+    const nested = findFirstNestedValue(child, keys, depth + 1);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function formatRateLimitWindowName(params: {
+  limitId?: string;
+  limitName?: string;
+  windowKey: "primary" | "secondary";
+  windowMinutes?: number;
+}): string {
+  const rawId = params.limitId?.trim();
+  const rawName = params.limitName?.trim();
+  let windowLabel: string;
+  const minutes = params.windowMinutes;
+  if (typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0) {
+    if (minutes % 1440 === 0) {
+      windowLabel = `${Math.round(minutes / 1440)}d limit`;
+    } else if (minutes % 60 === 0) {
+      windowLabel = `${Math.round(minutes / 60)}h limit`;
+    } else {
+      windowLabel = `${minutes}m limit`;
+    }
+  } else {
+    windowLabel = params.windowKey === "primary" ? "Primary limit" : "Secondary limit";
+  }
+  if (!rawId || rawId.toLowerCase() === "codex") {
+    return windowLabel;
+  }
+  return `${rawName ?? rawId} ${windowLabel}`.trim();
+}
+
+function extractRateLimitSummaries(value: unknown): BackendRateLimitSummary[] {
+  const out = new Map<string, BackendRateLimitSummary>();
+  const addWindow = (
+    windowValue: unknown,
+    params: { limitId?: string; limitName?: string; windowKey: "primary" | "secondary" }
+  ): void => {
+    const window = asRecord(windowValue);
+    if (!window) {
+      return;
+    }
+    const usedPercent = pickFiniteNumber(window, ["usedPercent", "used_percent"]);
+    const windowMinutes = pickFiniteNumber(window, [
+      "windowDurationMins",
+      "window_duration_mins",
+      "windowMinutes",
+      "window_minutes",
+    ]);
+    const name = formatRateLimitWindowName({
+      limitId: params.limitId,
+      limitName: params.limitName,
+      windowKey: params.windowKey,
+      windowMinutes,
+    });
+    out.set(name, {
+      name,
+      limitId: params.limitId,
+      usedPercent,
+      remaining:
+        typeof usedPercent === "number" ? Math.max(0, Math.round(100 - usedPercent)) : undefined,
+      resetAt: normalizeEpochTimestamp(
+        pickNumber(window, ["resetsAt", "resets_at", "resetAt", "reset_at"])
+      ),
+      windowSeconds: typeof windowMinutes === "number" ? Math.round(windowMinutes * 60) : undefined,
+      windowMinutes,
+    });
+  };
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach((entry) => visit(entry));
+      return;
+    }
+    const record = asRecord(node);
+    if (!record) {
+      return;
+    }
+    if ("primary" in record || "secondary" in record) {
+      const limitId = pickString(record, ["limitId", "limit_id", "id"]);
+      const limitName = pickString(record, ["limitName", "limit_name", "name", "label"]);
+      addWindow(record.primary, { limitId, limitName, windowKey: "primary" });
+      addWindow(record.secondary, { limitId, limitName, windowKey: "secondary" });
+    }
+    const byLimitId = asRecord(record.rateLimitsByLimitId ?? record.rate_limits_by_limit_id);
+    if (byLimitId) {
+      for (const [limitId, snapshot] of Object.entries(byLimitId)) {
+        const snapshotRecord = asRecord(snapshot);
+        if (!snapshotRecord) {
+          continue;
+        }
+        const limitName = pickString(snapshotRecord, ["limitName", "limit_name", "name", "label"]);
+        addWindow(snapshotRecord.primary, { limitId, limitName, windowKey: "primary" });
+        addWindow(snapshotRecord.secondary, { limitId, limitName, windowKey: "secondary" });
+      }
+    }
+    const remaining = pickFiniteNumber(record, [
+      "remaining",
+      "remainingCount",
+      "remaining_count",
+      "available",
+    ]);
+    const limit = pickFiniteNumber(record, ["limit", "max", "quota", "capacity"]);
+    const used = pickFiniteNumber(record, ["used", "consumed", "count"]);
+    const resetAt = pickNumber(record, [
+      "resetAt",
+      "reset_at",
+      "resetsAt",
+      "resets_at",
+      "nextResetAt",
+    ]);
+    const windowSeconds = pickFiniteNumber(record, [
+      "windowSeconds",
+      "window_seconds",
+      "resetInSeconds",
+      "retryAfterSeconds",
+    ]);
+    const name =
+      pickString(record, ["name", "label", "scope", "resource", "model", "id"]) ??
+      (typeof remaining === "number" ||
+      typeof limit === "number" ||
+      typeof used === "number" ||
+      typeof resetAt === "number"
+        ? `limit-${out.size + 1}`
+        : undefined);
+    if (name) {
+      const existing = out.get(name);
+      out.set(name, {
+        name,
+        limitId: existing?.limitId,
+        remaining: remaining ?? existing?.remaining,
+        limit: limit ?? existing?.limit,
+        used: used ?? existing?.used,
+        usedPercent: existing?.usedPercent,
+        resetAt: normalizeEpochTimestamp(resetAt) ?? existing?.resetAt,
+        windowSeconds: windowSeconds ?? existing?.windowSeconds,
+        windowMinutes: existing?.windowMinutes,
+      });
+    }
+    for (const key of [
+      "limits",
+      "items",
+      "data",
+      "results",
+      "entries",
+      "buckets",
+      "rateLimits",
+      "rate_limits",
+      "rateLimitsByLimitId",
+      "rate_limits_by_limit_id",
+    ]) {
+      visit(record[key]);
+    }
+  };
+  visit(value);
+  return [...out.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function extractAccountSummary(value: unknown): BackendAccountSummary {
+  const root = asRecord(value) ?? {};
+  const account =
+    asRecord(findFirstNestedValue(value, ["account"])) ?? asRecord(root.account) ?? undefined;
+  const type = pickString(account ?? {}, ["type"]);
+  return {
+    type: type === "apiKey" || type === "chatgpt" ? type : undefined,
+    email: pickString(account ?? {}, ["email"]),
+    planType: pickString(account ?? {}, ["planType", "plan_type"]),
+    requiresOpenaiAuth: pickBoolean(root, ["requiresOpenaiAuth", "requires_openai_auth"]),
+  };
 }
 
 function collectText(value: unknown): string[] {
@@ -3263,6 +3476,32 @@ export class CodexAppServerClient {
     });
 
     return models;
+  }
+
+  async readAccount(): Promise<BackendAccountSummary> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["account/read"],
+      payloads: [{ refreshToken: false }, { refresh_token: false }, {}],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    });
+
+    return extractAccountSummary(result);
+  }
+
+  async readRateLimits(): Promise<BackendRateLimitSummary[]> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["account/rateLimits/read"],
+      payloads: [{}],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    });
+
+    return extractRateLimitSummaries(result);
   }
 
   async readThread(params: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -561,7 +561,9 @@ function formatRateLimitWindowName(params: {
   let windowLabel: string;
   const minutes = params.windowMinutes;
   if (typeof minutes === "number" && Number.isFinite(minutes) && minutes > 0) {
-    if (minutes % 1440 === 0) {
+    if (minutes === 10_080) {
+      windowLabel = "Weekly limit";
+    } else if (minutes % 1440 === 0) {
       windowLabel = `${Math.round(minutes / 1440)}d limit`;
     } else if (minutes % 60 === 0) {
       windowLabel = `${Math.round(minutes / 60)}h limit`;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -100,6 +100,7 @@ export function App() {
           loading={session.loading}
           loadingMore={session.loadingMore}
           messageCount={session.messages.length}
+          contextWindow={session.contextWindow}
           pendingAssistantMessage={session.pendingAssistantMessage}
           pendingMcpInteraction={session.pendingMcpInteraction}
           pendingRequest={session.pendingRequest}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2210,12 +2210,15 @@ function ContextWindowMoon({
     contextWindow.totalTokens
   )}/${formatCompactNumber(contextWindow.modelContextWindow)}`;
   const label = `Context window ${percentLabel} full, ${tokenLabel} tokens, ${phaseLabel}`;
+  const tooltip = buildContextWindowTooltip(contextWindow, phaseLabel);
 
   return (
     <div
       aria-label={label}
-      className="context-window-moon"
+      className="context-window-moon tooltip-target"
+      data-tooltip={tooltip}
       role="img"
+      tabIndex={0}
       title={label}
     >
       <span
@@ -2227,6 +2230,53 @@ function ContextWindowMoon({
       <span className="context-window-moon__label">{percentLabel}</span>
     </div>
   );
+}
+
+function buildContextWindowTooltip(
+  contextWindow: ThreadContextWindowState,
+  phaseLabel: string
+): string {
+  const lines = [
+    `Context window: ${Math.round(contextWindow.usedPercent)}% full (${phaseLabel})`,
+    `Current snapshot: ${formatCompactNumber(contextWindow.totalTokens)} / ${formatCompactNumber(
+      contextWindow.modelContextWindow
+    )} tokens`,
+  ];
+
+  if (typeof contextWindow.remainingTokens === "number") {
+    const remainingPercent =
+      typeof contextWindow.remainingPercent === "number"
+        ? `, ${Math.round(contextWindow.remainingPercent)}% remaining`
+        : "";
+    lines.push(
+      `Remaining: ${formatCompactNumber(contextWindow.remainingTokens)} tokens${remainingPercent}`
+    );
+  }
+
+  const breakdown = [
+    formatOptionalTokenDetail("input", contextWindow.inputTokens),
+    formatOptionalTokenDetail("cached", contextWindow.cachedInputTokens),
+    formatOptionalTokenDetail("output", contextWindow.outputTokens),
+    formatOptionalTokenDetail("reasoning", contextWindow.reasoningOutputTokens),
+  ].filter((detail): detail is string => Boolean(detail));
+
+  if (breakdown.length > 0) {
+    lines.push(`Current breakdown: ${breakdown.join(", ")}`);
+  }
+
+  if (typeof contextWindow.cumulativeTotalTokens === "number") {
+    lines.push(
+      `Cumulative usage reported: ${formatCompactNumber(
+        contextWindow.cumulativeTotalTokens
+      )} tokens`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function formatOptionalTokenDetail(label: string, value: number | undefined): string | undefined {
+  return typeof value === "number" ? `${formatCompactNumber(value)} ${label}` : undefined;
 }
 
 function formatCompactNumber(value: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -23,6 +23,7 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { normalizeImageFile } from "../../lib/image-normalization";
+import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import {
   findSkillTrigger,
   hydrateSkillLabelsWithMarkdown,
@@ -43,6 +44,7 @@ type ComposerProps = {
   desktopApi?: DesktopApi;
   directory?: NavigationDirectorySummary;
   disabled?: boolean;
+  contextWindow?: ThreadContextWindowState;
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
   onActiveTurnIdChange?: (turnId?: string) => void;
@@ -124,6 +126,17 @@ type SlashCommandSuggestion = {
 
 type AutocompleteKind = "skills" | "slash";
 type ReviewTargetChoice = AppServerReviewTarget["type"];
+
+const CONTEXT_MOON_PHASES = [
+  "new",
+  "waxing crescent",
+  "first quarter",
+  "waxing gibbous",
+  "near full",
+  "full",
+  "overfull",
+  "critical",
+] as const;
 
 type ReviewConfigState = {
   branch: string;
@@ -2143,6 +2156,7 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       <div className="composer__actions">
+        <ContextWindowMoon contextWindow={props.contextWindow} />
         {activeTurnId ? (
           <button
             className="button button--ghost"
@@ -2178,6 +2192,53 @@ export function Composer(props: ComposerProps) {
       </div>
     </form>
   );
+}
+
+function ContextWindowMoon({
+  contextWindow,
+}: {
+  contextWindow?: ThreadContextWindowState;
+}) {
+  if (!contextWindow) {
+    return null;
+  }
+
+  const phase = Math.min(7, Math.max(0, contextWindow.phase));
+  const phaseLabel = CONTEXT_MOON_PHASES[phase];
+  const percentLabel = `${Math.round(contextWindow.usedPercent)}%`;
+  const tokenLabel = `${formatCompactNumber(
+    contextWindow.totalTokens
+  )}/${formatCompactNumber(contextWindow.modelContextWindow)}`;
+  const label = `Context window ${percentLabel} full, ${tokenLabel} tokens, ${phaseLabel}`;
+
+  return (
+    <div
+      aria-label={label}
+      className="context-window-moon"
+      role="img"
+      title={label}
+    >
+      <span
+        aria-hidden="true"
+        className={`context-window-moon__sprite context-window-moon__sprite--phase-${phase}`}
+      >
+        <span className="context-window-moon__disc" />
+      </span>
+      <span className="context-window-moon__label">{percentLabel}</span>
+    </div>
+  );
+}
+
+function formatCompactNumber(value: number): string {
+  if (value >= 1_000_000) {
+    return `${Math.round(value / 100_000) / 10}M`;
+  }
+
+  if (value >= 1_000) {
+    return `${Math.round(value / 100) / 10}k`;
+  }
+
+  return String(Math.round(value));
 }
 
 function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImageFile[] {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -70,6 +70,38 @@ function backendSummary(
 }
 
 describe("Composer", () => {
+  it("shows an orange moon for reported context window usage", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        contextWindow={{
+          modelContextWindow: 128_000,
+          phase: 4,
+          totalTokens: 64_000,
+          usedPercent: 50,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Context usage",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "Context window 50% full, 64k/128k tokens, near full",
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
   it("shows OpenAI model and reasoning defaults without a Default option", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -75,8 +75,14 @@ describe("Composer", () => {
       <Composer
         backends={[backendSummary("codex")]}
         contextWindow={{
+          cachedInputTokens: 32_000,
+          cumulativeTotalTokens: 80_000,
+          inputTokens: 63_000,
           modelContextWindow: 128_000,
+          outputTokens: 1_000,
           phase: 4,
+          remainingPercent: 50,
+          remainingTokens: 64_000,
           totalTokens: 64_000,
           usedPercent: 50,
         }}
@@ -99,6 +105,16 @@ describe("Composer", () => {
         name: "Context window 50% full, 64k/128k tokens, near full",
       })
     ).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "data-tooltip",
+      [
+        "Context window: 50% full (near full)",
+        "Current snapshot: 64k / 128k tokens",
+        "Remaining: 64k tokens, 50% remaining",
+        "Current breakdown: 63k input, 32k cached, 1k output",
+        "Cumulative usage reported: 80k tokens",
+      ].join("\n")
+    );
     expect(screen.getByText("50%")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -443,6 +443,34 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         ? "Available"
                         : backend.unavailableReason ?? "Unavailable"}
                     </p>
+                    {backend.available &&
+                    (backend.account || (backend.rateLimits?.length ?? 0) > 0) ? (
+                      <div className="backend-status-list__metadata">
+                        {backend.account ? (
+                          <dl className="backend-status-list__metadata-grid">
+                            <div>
+                              <dt>Account</dt>
+                              <dd>{formatBackendAccountText(backend.account)}</dd>
+                            </div>
+                            {backend.account.planType ? (
+                              <div>
+                                <dt>Plan</dt>
+                                <dd>{backend.account.planType}</dd>
+                              </div>
+                            ) : null}
+                          </dl>
+                        ) : null}
+                        {backend.rateLimits?.length ? (
+                          <ul className="backend-status-list__limits">
+                            {selectVisibleRateLimits(backend).map((limit) => (
+                              <li key={`${limit.limitId ?? "limit"}:${limit.name}`}>
+                                {formatRateLimitLine(limit)}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </li>
                 ))}
               </ul>
@@ -543,6 +571,106 @@ function formatTimestamp(timestamp: number): string {
     hour: "numeric",
     minute: "2-digit"
   }).format(timestamp);
+}
+
+function formatBackendAccountText(
+  account: NonNullable<BackendSummary["account"]>
+): string {
+  if (account.type === "chatgpt" && account.email?.trim()) {
+    return formatMaskedEmail(account.email);
+  }
+  if (account.type === "apiKey") {
+    return "API key";
+  }
+  if (account.requiresOpenaiAuth === false) {
+    return "Not required";
+  }
+  if (account.requiresOpenaiAuth === true) {
+    return "Not signed in";
+  }
+  return "Unknown";
+}
+
+function formatMaskedEmail(email: string): string {
+  const trimmed = email.trim();
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex <= 1) {
+    return trimmed;
+  }
+  const local = trimmed.slice(0, atIndex);
+  return `${local.slice(0, 2)}...${trimmed.slice(atIndex)}`;
+}
+
+function splitRateLimitName(name: string): {
+  label: string;
+  labelOrder: number;
+  prefix: string;
+} {
+  const trimmed = name.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.endsWith("5h limit")) {
+    const prefix = trimmed.slice(0, Math.max(0, trimmed.length - "5h limit".length)).trim();
+    return { label: "5h limit", labelOrder: 0, prefix };
+  }
+  if (lower.endsWith("weekly limit")) {
+    const prefix = trimmed.slice(0, Math.max(0, trimmed.length - "weekly limit".length)).trim();
+    return { label: "Weekly limit", labelOrder: 1, prefix };
+  }
+  return { label: trimmed, labelOrder: 99, prefix: "" };
+}
+
+function selectVisibleRateLimits(
+  backend: BackendSummary
+): NonNullable<BackendSummary["rateLimits"]> {
+  return [...(backend.rateLimits ?? [])]
+    .filter((limit) => {
+      const { label } = splitRateLimitName(limit.name);
+      return label === "5h limit" || label === "Weekly limit";
+    })
+    .sort((left, right) => {
+      const leftName = splitRateLimitName(left.name);
+      const rightName = splitRateLimitName(right.name);
+      if (leftName.labelOrder !== rightName.labelOrder) {
+        return leftName.labelOrder - rightName.labelOrder;
+      }
+      return left.name.localeCompare(right.name);
+    });
+}
+
+function formatRateLimitLine(limit: NonNullable<BackendSummary["rateLimits"]>[number]): string {
+  const { label } = splitRateLimitName(limit.name);
+  const resetText = formatRateLimitReset(limit.resetAt);
+  if (typeof limit.usedPercent === "number") {
+    const remaining = Math.max(0, Math.round(100 - limit.usedPercent));
+    return `${label}: ${remaining}% left${resetText ? `, resets ${resetText}` : ""}`;
+  }
+  if (typeof limit.remaining === "number" && typeof limit.limit === "number") {
+    return `${label}: ${limit.remaining}/${limit.limit} remaining${
+      resetText ? `, resets ${resetText}` : ""
+    }`;
+  }
+  return `${label}: unavailable`;
+}
+
+function formatRateLimitReset(resetAt: number | undefined): string | undefined {
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt)) {
+    return undefined;
+  }
+  const date = new Date(resetAt);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  const now = new Date();
+  if (now.toDateString() === date.toDateString()) {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
 }
 
 function findSnapshotForWorktree(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -22,6 +22,7 @@ import type {
   ThreadExecutionMode,
 } from "@pwragnt/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { Composer } from "../composer/Composer";
@@ -909,6 +910,7 @@ type ThreadViewProps = {
   loading: boolean;
   loadingMore: boolean;
   messageCount: number;
+  contextWindow?: ThreadContextWindowState;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -1667,6 +1669,7 @@ export function ThreadView(props: ThreadViewProps) {
             desktopApi={props.desktopApi}
             directory={props.selectedDirectory}
             disabled={props.composerDisabled}
+            contextWindow={props.contextWindow}
             onActiveTurnIdChange={props.onActiveTurnIdChange}
             onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
             onPendingStatusChange={props.onPendingStatusChange}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -35,6 +35,28 @@ describe("ThreadView", () => {
             kind: "codex",
             label: "Codex app server",
             available: true,
+            account: {
+              type: "chatgpt",
+              email: "user@example.com",
+              planType: "pro",
+              requiresOpenaiAuth: false,
+            },
+            rateLimits: [
+              {
+                name: "5h limit",
+                usedPercent: 15,
+                resetAt: Date.now() + 60 * 60 * 1000,
+                windowSeconds: 18_000,
+                windowMinutes: 300,
+              },
+              {
+                name: "Weekly limit",
+                usedPercent: 9,
+                resetAt: Date.now() + 3 * 24 * 60 * 60 * 1000,
+                windowSeconds: 604_800,
+                windowMinutes: 10_080,
+              },
+            ],
             methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
             capabilities: {
               listThreads: true,
@@ -189,6 +211,10 @@ describe("ThreadView", () => {
     expect(screen.getByRole("heading", { level: 3, name: "Execution context" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pin context rail" })).toBeInTheDocument();
     expect(screen.getByText("Codex app server")).toBeInTheDocument();
+    expect(screen.getByText("us...@example.com")).toBeInTheDocument();
+    expect(screen.getByText("pro")).toBeInTheDocument();
+    expect(screen.getByText(/5h limit: 85% left/)).toBeInTheDocument();
+    expect(screen.getByText(/Weekly limit: 91% left/)).toBeInTheDocument();
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -66,6 +66,38 @@ describe("useBackendSummaries", () => {
             executionModes: [],
           },
         ],
+      })
+      .mockResolvedValueOnce({
+        fetchedAt: 3,
+        backends: [
+          {
+            kind: "codex",
+            label: "OpenAI",
+            available: true,
+            account: {
+              type: "chatgpt",
+              email: "user@example.com",
+              planType: "team",
+            },
+            rateLimits: [{ name: "5h limit", usedPercent: 10, remaining: 90 }],
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ],
       });
     const desktopApi: DesktopApi = {
       listBackends,
@@ -91,12 +123,29 @@ describe("useBackendSummaries", () => {
           },
         },
       },
-    } as AgentEvent);
+    });
 
     await waitFor(() => {
       expect(listBackends).toHaveBeenCalledTimes(2);
     });
     expect(result.current.backends[0]?.account?.planType).toBe("pro");
     expect(result.current.backends[0]?.rateLimits?.[0]?.remaining).toBe(85);
+
+    eventHandler?.({
+      backend: "codex",
+      notification: {
+        method: "account/updated",
+        params: {
+          account: {
+            planType: "team",
+          },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(3);
+    });
+    expect(result.current.backends[0]?.account?.planType).toBe("team");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -126,10 +126,9 @@ describe("useBackendSummaries", () => {
     });
 
     await waitFor(() => {
-      expect(listBackends).toHaveBeenCalledTimes(2);
+      expect(result.current.backends[0]?.account?.planType).toBe("pro");
+      expect(result.current.backends[0]?.rateLimits?.[0]?.remaining).toBe(85);
     });
-    expect(result.current.backends[0]?.account?.planType).toBe("pro");
-    expect(result.current.backends[0]?.rateLimits?.[0]?.remaining).toBe(85);
 
     eventHandler?.({
       backend: "codex",
@@ -144,8 +143,8 @@ describe("useBackendSummaries", () => {
     });
 
     await waitFor(() => {
-      expect(listBackends).toHaveBeenCalledTimes(3);
+      expect(result.current.backends[0]?.account?.planType).toBe("team");
+      expect(result.current.backends[0]?.rateLimits?.[0]?.remaining).toBe(90);
     });
-    expect(result.current.backends[0]?.account?.planType).toBe("team");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@pwragnt/shared";
+import type { DesktopApi } from "../desktop-api";
+import { useBackendSummaries } from "../useBackendSummaries";
+
+describe("useBackendSummaries", () => {
+  it("refreshes backend details when Codex rate limits update", async () => {
+    let eventHandler: ((event: AgentEvent) => void) | undefined;
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValueOnce({
+        fetchedAt: 1,
+        backends: [
+          {
+            kind: "codex",
+            label: "OpenAI",
+            available: true,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        fetchedAt: 2,
+        backends: [
+          {
+            kind: "codex",
+            label: "OpenAI",
+            available: true,
+            account: {
+              type: "chatgpt",
+              email: "user@example.com",
+              planType: "pro",
+            },
+            rateLimits: [{ name: "5h limit", usedPercent: 15, remaining: 85 }],
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ],
+      });
+    const desktopApi: DesktopApi = {
+      listBackends,
+      onAgentEvent: (callback) => {
+        eventHandler = callback;
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() => useBackendSummaries(desktopApi));
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(1);
+    });
+
+    eventHandler?.({
+      backend: "codex",
+      notification: {
+        method: "account/rateLimits/updated",
+        params: {
+          rateLimits: {
+            limitId: "codex",
+          },
+        },
+      },
+    } as AgentEvent);
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.backends[0]?.account?.planType).toBe("pro");
+    expect(result.current.backends[0]?.rateLimits?.[0]?.remaining).toBe(85);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1281,6 +1281,84 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeTurnId).toBeUndefined();
   });
 
+  it("shows a transcript status when context compaction starts", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "compact-turn-1",
+              item: {
+                id: "compact-item-1",
+                type: "contextCompaction",
+              },
+            },
+          },
+        } as any);
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Compacting context");
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/compacted",
+            params: {
+              threadId: "thread-1",
+              itemId: "compact-item-1",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.contextWindow).toBeUndefined();
+  });
+
   it("surfaces failed turn errors in the transcript state", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2249,8 +2249,15 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.contextWindow).toEqual({
+      cachedInputTokens: undefined,
+      cumulativeTotalTokens: undefined,
+      inputTokens: undefined,
       modelContextWindow: 128_000,
+      outputTokens: undefined,
       phase: 6,
+      reasoningOutputTokens: undefined,
+      remainingPercent: 25,
+      remainingTokens: 32_000,
       totalTokens: 96_000,
       usedPercent: 75,
     });
@@ -2309,10 +2316,89 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.contextWindow).toEqual({
+      cachedInputTokens: undefined,
+      cumulativeTotalTokens: undefined,
+      inputTokens: 1_200,
       modelContextWindow: 258_400,
+      outputTokens: 12,
       phase: 0,
+      reasoningOutputTokens: undefined,
+      remainingPercent: ((258_400 - 1_212) / 258_400) * 100,
+      remainingTokens: 258_400 - 1_212,
       totalTokens: 1_212,
       usedPercent: (1_212 / 258_400) * 100,
+    });
+  });
+
+  it("prefers last token usage over cumulative session usage for context fill", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 20_663,
+                cached_input_tokens: 20_352,
+                output_tokens: 45,
+                total_tokens: 20_708,
+              },
+              total_token_usage: {
+                input_tokens: 41_267,
+                cached_input_tokens: 23_808,
+                output_tokens: 75,
+                total_tokens: 41_342,
+              },
+              model_context_window: 258_400,
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.contextWindow).toMatchObject({
+      cachedInputTokens: 20_352,
+      cumulativeTotalTokens: 41_342,
+      inputTokens: 20_663,
+      modelContextWindow: 258_400,
+      outputTokens: 45,
+      phase: 0,
+      totalTokens: 20_708,
+      usedPercent: (20_708 / 258_400) * 100,
     });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2196,4 +2196,123 @@ describe("useThreadSessionState", () => {
       }),
     ]);
   });
+
+  it("stores context window usage from token usage notifications", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              total: {
+                totalTokens: 96_000,
+              },
+              modelContextWindow: 128_000,
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.contextWindow).toEqual({
+      modelContextWindow: 128_000,
+      phase: 6,
+      totalTokens: 96_000,
+      usedPercent: 75,
+    });
+  });
+
+  it("derives context window usage from captured input and output token breakdowns", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(desktopApi.readThread).toHaveBeenCalled();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              total: {
+                inputTokens: 1_200,
+                outputTokens: 12,
+              },
+              modelContextWindow: 258_400,
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.contextWindow).toEqual({
+      modelContextWindow: 258_400,
+      phase: 0,
+      totalTokens: 1_212,
+      usedPercent: (1_212 / 258_400) * 100,
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -41,5 +41,20 @@ export function useBackendSummaries(desktopApi?: DesktopApi): BackendSummaryStat
     void refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
+    return desktopApi.onAgentEvent((event) => {
+      if (
+        event.backend === "codex" &&
+        (event.notification.method === "account/rateLimits/updated" ||
+          event.notification.method === "account/updated")
+      ) {
+        void refresh();
+      }
+    });
+  }, [desktopApi, refresh]);
+
   return state;
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -39,8 +39,15 @@ export type ThreadViewportState = {
 };
 
 export type ThreadContextWindowState = {
+  cachedInputTokens?: number;
+  cumulativeTotalTokens?: number;
+  inputTokens?: number;
   modelContextWindow: number;
+  outputTokens?: number;
   phase: number;
+  reasoningOutputTokens?: number;
+  remainingPercent?: number;
+  remainingTokens?: number;
   totalTokens: number;
   usedPercent: number;
 };
@@ -253,43 +260,112 @@ function readFiniteNumber(record: Record<string, unknown>, keys: string[]): numb
   return undefined;
 }
 
-function readTokenBreakdownTotal(record: Record<string, unknown>): number | undefined {
-  const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
-  if (explicitTotal !== undefined) {
-    return explicitTotal;
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function findFirstNestedValue(value: unknown, keys: string[]): unknown {
+  const record = readRecord(value);
+  if (!record) {
+    return undefined;
   }
 
-  const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]) ?? 0;
-  const outputTokens = readFiniteNumber(record, ["outputTokens", "output_tokens"]) ?? 0;
-  const reasoningOutputTokens =
-    readFiniteNumber(record, [
-      "reasoningOutputTokens",
-      "reasoning_output_tokens",
-    ]) ?? 0;
-  const totalTokens = inputTokens + outputTokens + reasoningOutputTokens;
+  for (const key of keys) {
+    if (record[key] !== undefined) {
+      return record[key];
+    }
+  }
 
-  return totalTokens > 0 ? totalTokens : undefined;
+  for (const child of Object.values(record)) {
+    const nested = findFirstNestedValue(child, keys);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}
+
+type TokenUsageBreakdown = {
+  cachedInputTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+};
+
+function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
+  const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
+  const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
+  const cachedInputTokens = readFiniteNumber(record, [
+    "cachedInputTokens",
+    "cached_input_tokens",
+  ]);
+  const outputTokens = readFiniteNumber(record, ["outputTokens", "output_tokens"]);
+  const reasoningOutputTokens = readFiniteNumber(record, [
+    "reasoningOutputTokens",
+    "reasoning_output_tokens",
+  ]);
+  const derivedTotal =
+    (inputTokens ?? 0) + (outputTokens ?? 0) + (reasoningOutputTokens ?? 0);
+  const totalTokens = explicitTotal ?? (derivedTotal > 0 ? derivedTotal : undefined);
+
+  if (
+    totalTokens === undefined &&
+    inputTokens === undefined &&
+    cachedInputTokens === undefined &&
+    outputTokens === undefined &&
+    reasoningOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    cachedInputTokens,
+    inputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+  };
 }
 
 function normalizeThreadContextWindowState(
   tokenUsage: unknown
 ): ThreadContextWindowState | undefined {
-  if (!tokenUsage || typeof tokenUsage !== "object" || Array.isArray(tokenUsage)) {
+  const root =
+    readRecord(findFirstNestedValue(tokenUsage, ["tokenUsage", "token_usage", "info"])) ??
+    readRecord(tokenUsage);
+  if (!root) {
     return undefined;
   }
 
-  const usageRecord = tokenUsage as Record<string, unknown>;
-  const modelContextWindow = readFiniteNumber(usageRecord, [
+  const currentUsageRecord =
+    readRecord(findFirstNestedValue(root, ["last", "last_token_usage"])) ??
+    readRecord(root.last) ??
+    readRecord(root.last_token_usage) ??
+    readRecord(findFirstNestedValue(root, ["total", "total_token_usage"])) ??
+    readRecord(root.total) ??
+    readRecord(root.total_token_usage);
+  const totalUsageRecord =
+    readRecord(findFirstNestedValue(root, ["total", "total_token_usage"])) ??
+    readRecord(root.total) ??
+    readRecord(root.total_token_usage);
+  const currentUsage = currentUsageRecord ? readTokenBreakdown(currentUsageRecord) : undefined;
+  const totalUsage = totalUsageRecord ? readTokenBreakdown(totalUsageRecord) : undefined;
+  const nestedModelContextWindow = findFirstNestedValue(root, [
     "modelContextWindow",
     "model_context_window",
   ]);
-  const total = usageRecord.total;
-  const totalTokens =
-    total && typeof total === "object" && !Array.isArray(total)
-      ? readTokenBreakdownTotal(total as Record<string, unknown>)
-      : undefined;
+  const modelContextWindow =
+    readFiniteNumber(root, ["modelContextWindow", "model_context_window"]) ??
+    (typeof nestedModelContextWindow === "number" && Number.isFinite(nestedModelContextWindow)
+      ? nestedModelContextWindow
+      : undefined);
+  const totalTokens = currentUsage?.totalTokens;
 
-  if (!modelContextWindow || modelContextWindow <= 0 || totalTokens === undefined) {
+  if (!currentUsage || !modelContextWindow || modelContextWindow <= 0 || totalTokens === undefined) {
     return undefined;
   }
 
@@ -297,10 +373,25 @@ function normalizeThreadContextWindowState(
     0,
     Math.min(100, (totalTokens / modelContextWindow) * 100)
   );
+  const remainingTokens = Math.max(0, modelContextWindow - totalTokens);
+  const remainingPercent = Math.max(
+    0,
+    Math.min(100, (remainingTokens / modelContextWindow) * 100)
+  );
 
   return {
+    cachedInputTokens: currentUsage.cachedInputTokens,
+    cumulativeTotalTokens:
+      totalUsage?.totalTokens !== undefined && totalUsage.totalTokens !== totalTokens
+        ? totalUsage.totalTokens
+        : undefined,
+    inputTokens: currentUsage.inputTokens,
     modelContextWindow,
+    outputTokens: currentUsage.outputTokens,
     phase: Math.min(7, Math.max(0, Math.floor(usedPercent / 12.5))),
+    reasoningOutputTokens: currentUsage.reasoningOutputTokens,
+    remainingPercent,
+    remainingTokens,
     totalTokens,
     usedPercent,
   };

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -38,10 +38,18 @@ export type ThreadViewportState = {
   scrollTop: number;
 };
 
+export type ThreadContextWindowState = {
+  modelContextWindow: number;
+  phase: number;
+  totalTokens: number;
+  usedPercent: number;
+};
+
 type ThreadSessionEntry = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   completionHydrationRetries: number;
+  contextWindow?: ThreadContextWindowState;
   error?: string;
   expectOwnUpdate: boolean;
   failedHydrationVersion?: number | "unknown";
@@ -233,6 +241,69 @@ function normalizeNotificationTimestamp(value: unknown): number | undefined {
 
 function normalizeNotificationDuration(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readFiniteNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readTokenBreakdownTotal(record: Record<string, unknown>): number | undefined {
+  const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
+  if (explicitTotal !== undefined) {
+    return explicitTotal;
+  }
+
+  const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]) ?? 0;
+  const outputTokens = readFiniteNumber(record, ["outputTokens", "output_tokens"]) ?? 0;
+  const reasoningOutputTokens =
+    readFiniteNumber(record, [
+      "reasoningOutputTokens",
+      "reasoning_output_tokens",
+    ]) ?? 0;
+  const totalTokens = inputTokens + outputTokens + reasoningOutputTokens;
+
+  return totalTokens > 0 ? totalTokens : undefined;
+}
+
+function normalizeThreadContextWindowState(
+  tokenUsage: unknown
+): ThreadContextWindowState | undefined {
+  if (!tokenUsage || typeof tokenUsage !== "object" || Array.isArray(tokenUsage)) {
+    return undefined;
+  }
+
+  const usageRecord = tokenUsage as Record<string, unknown>;
+  const modelContextWindow = readFiniteNumber(usageRecord, [
+    "modelContextWindow",
+    "model_context_window",
+  ]);
+  const total = usageRecord.total;
+  const totalTokens =
+    total && typeof total === "object" && !Array.isArray(total)
+      ? readTokenBreakdownTotal(total as Record<string, unknown>)
+      : undefined;
+
+  if (!modelContextWindow || modelContextWindow <= 0 || totalTokens === undefined) {
+    return undefined;
+  }
+
+  const usedPercent = Math.max(
+    0,
+    Math.min(100, (totalTokens / modelContextWindow) * 100)
+  );
+
+  return {
+    modelContextWindow,
+    phase: Math.min(7, Math.max(0, Math.floor(usedPercent / 12.5))),
+    totalTokens,
+    usedPercent,
+  };
 }
 
 function buildTurnMetadata(params: {
@@ -635,6 +706,7 @@ export function useThreadSessionState(params: {
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
   messages: AppServerThreadMessage[];
+  contextWindow?: ThreadContextWindowState;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -1266,10 +1338,26 @@ export function useThreadSessionState(params: {
         if (event.notification.method === "thread/compacted") {
           return {
             ...current,
+            contextWindow: undefined,
             failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
             response: undefined,
+          };
+        }
+
+        if (event.notification.method === "thread/tokenUsage/updated") {
+          const contextWindow = normalizeThreadContextWindowState(
+            event.notification.params.tokenUsage
+          );
+          if (!contextWindow) {
+            return current;
+          }
+
+          return {
+            ...current,
+            contextWindow,
+            lastTouchedAt: nextLastTouchedAt,
           };
         }
 
@@ -1628,6 +1716,7 @@ export function useThreadSessionState(params: {
     loadingMore: selectedSession?.loadingMore ?? false,
     loadOlder,
     messages,
+    contextWindow: selectedSession?.contextWindow,
     pendingAssistantMessage: selectedSession?.pendingAssistantMessage,
     pendingMcpInteraction: selectedSession?.pendingMcpInteraction,
     pendingRequest: selectedSession?.pendingRequest,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AppServerNotification,
   AppServerMcpElicitationRequestNotification,
   AppServerPendingRequestNotification,
   AppServerReadThreadResponse,
@@ -395,6 +396,22 @@ function normalizeThreadContextWindowState(
     totalTokens,
     usedPercent,
   };
+}
+
+function isContextCompactionItemNotification(
+  notification: AppServerNotification
+): notification is Extract<AppServerNotification, { method: "item/started" | "item/completed" }> {
+  if (notification.method !== "item/started" && notification.method !== "item/completed") {
+    return false;
+  }
+  const item =
+    typeof notification.params.item === "object" &&
+    notification.params.item !== null &&
+    !Array.isArray(notification.params.item)
+      ? notification.params.item as Record<string, unknown>
+      : undefined;
+  const itemType = typeof item?.type === "string" ? item.type : undefined;
+  return itemType?.replace(/[-_\s]/g, "").toLowerCase() === "contextcompaction";
 }
 
 function buildTurnMetadata(params: {
@@ -1117,6 +1134,19 @@ export function useThreadSessionState(params: {
         }
 
         if (
+          event.notification.method === "item/started" &&
+          isContextCompactionItemNotification(event.notification)
+        ) {
+          return {
+            ...current,
+            expectOwnUpdate: true,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            pendingStatusText: "Compacting context",
+          };
+        }
+
+        if (
           event.notification.method === "item/agentMessage/delta" &&
           typeof event.notification.params.itemId === "string" &&
           typeof event.notification.params.delta === "string"
@@ -1429,10 +1459,13 @@ export function useThreadSessionState(params: {
         if (event.notification.method === "thread/compacted") {
           return {
             ...current,
+            activeTurnId: undefined,
+            activeTurnStartedAt: undefined,
             contextWindow: undefined,
             failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
+            pendingStatusText: undefined,
             response: undefined,
           };
         }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2841,6 +2841,49 @@ textarea {
   line-height: 1.45;
 }
 
+.backend-status-list__metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 16px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.backend-status-list__metadata-grid {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 4px 8px;
+  margin: 0;
+}
+
+.backend-status-list__metadata-grid div {
+  display: contents;
+}
+
+.backend-status-list__metadata-grid dt {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.backend-status-list__metadata-grid dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.backend-status-list__limits {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .composer {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3271,7 +3271,106 @@ textarea {
 
 .composer__actions {
   display: flex;
+  align-items: center;
+  gap: 8px;
   justify-content: flex-end;
+}
+
+.context-window-moon {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.context-window-moon__sprite {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.context-window-moon__disc {
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 179, 92, 0.44);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 38% 34%,
+    var(--accent-bright) 0%,
+    var(--accent-strong) 42%,
+    var(--accent) 100%
+  );
+  box-shadow:
+    0 0 8px rgba(255, 138, 31, 0.28),
+    inset 0 0 3px rgba(255, 243, 220, 0.26);
+}
+
+.context-window-moon__disc::after {
+  position: absolute;
+  inset: -1px auto -1px -1px;
+  width: var(--context-window-moon-shadow, 100%);
+  border-radius: 50%;
+  background: var(--bg-input);
+  box-shadow: inset -1px 0 2px rgba(255, 138, 31, 0.16);
+  content: "";
+}
+
+.context-window-moon__sprite--phase-0 .context-window-moon__disc {
+  background: rgba(255, 138, 31, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 138, 31, 0.14);
+}
+
+.context-window-moon__sprite--phase-0 .context-window-moon__disc::after {
+  width: 100%;
+}
+
+.context-window-moon__sprite--phase-1 {
+  --context-window-moon-shadow: 86%;
+}
+
+.context-window-moon__sprite--phase-2 {
+  --context-window-moon-shadow: 64%;
+}
+
+.context-window-moon__sprite--phase-3 {
+  --context-window-moon-shadow: 42%;
+}
+
+.context-window-moon__sprite--phase-4 {
+  --context-window-moon-shadow: 20%;
+}
+
+.context-window-moon__sprite--phase-5,
+.context-window-moon__sprite--phase-6,
+.context-window-moon__sprite--phase-7 {
+  --context-window-moon-shadow: 0%;
+}
+
+.context-window-moon__sprite--phase-6 .context-window-moon__disc {
+  border-color: var(--accent-strong);
+}
+
+.context-window-moon__sprite--phase-7 .context-window-moon__disc {
+  border-color: var(--accent-bright);
+  box-shadow:
+    0 0 10px rgba(255, 138, 31, 0.42),
+    inset 0 0 3px rgba(255, 243, 220, 0.34);
+}
+
+.context-window-moon__label {
+  max-width: 4ch;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .composer__error {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -36,10 +36,31 @@ export type BackendLaunchpadOptions = {
   supportsFastMode?: boolean;
 };
 
+export type BackendAccountSummary = {
+  type?: "apiKey" | "chatgpt";
+  email?: string;
+  planType?: string;
+  requiresOpenaiAuth?: boolean;
+};
+
+export type BackendRateLimitSummary = {
+  name: string;
+  limitId?: string;
+  remaining?: number;
+  limit?: number;
+  used?: number;
+  usedPercent?: number;
+  resetAt?: number;
+  windowSeconds?: number;
+  windowMinutes?: number;
+};
+
 export type BackendSummary = {
   kind: AppServerBackendKind;
   label: string;
   available: boolean;
+  account?: BackendAccountSummary;
+  rateLimits?: BackendRateLimitSummary[];
   serverName?: string;
   serverVersion?: string;
   methods: string[];

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -641,6 +641,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "account/updated";
+      params: {
+        account?: unknown;
+      };
+    }
+  | {
       method: "item/commandExecution/outputDelta";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

I added a desktop context-window indicator to the composer, shown as an orange moon phase next to the Stop / Send controls.

The moon is driven by Codex token usage notifications and fills through phases as the reported context snapshot grows. The tooltip exposes the current snapshot, remaining tokens, token breakdown, and cumulative protocol usage when that differs from the live context fill. That keeps the visible state useful while still making odd protocol numbers debuggable.

I also aligned the renderer parsing with the logic we had in OpenClaw: prefer `last_token_usage` / `last` for context fill, then fall back to cumulative `total_token_usage` / `total`. This fixes the observed case where a second tiny prompt jumped from 8% to 16% because the UI was rendering cumulative session usage.

I extended the right context rail's App servers section for OpenAI with account metadata and 5h / weekly rate-limit rows. The desktop backend now reads `account/read` and `account/rateLimits/read`, using the same primary/secondary window extraction shape from the OpenClaw Codex app-server plugin, and refreshes the rail when Codex emits account or rate-limit updates.

I also surface automatic context compaction in the transcript: when Codex emits an `item/started` notification for `contextCompaction`, the transcript shows a live "Compacting context" status until `thread/compacted` arrives and the thread is rehydrated.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/turn-lifecycle.spec.ts -g "renders the context window moon"`

Note: `pnpm --filter @pwragnt/desktop lint` does not exist for this package.
