### PR TITLE
fix(desktop): Guard thread title generation attempts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -779,6 +779,57 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("does not retry Codex title generation for a thread after one generated attempt", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Leopard tea button",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() => titleService.generateTitle.mock.calls.length === 1);
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(titleService.generateTitle).toHaveBeenCalledTimes(1);
+
+    await registry.close();
+  });
+
   it("applies generated titles when Codex exposes the prompt as an explicit title", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -642,6 +642,7 @@ export class DesktopBackendRegistry {
       token: number;
     }
   >();
+  private readonly attemptedTitleGenerations = new Set<string>();
   private titleGenerationSequence = 0;
 
   constructor(options?: {
@@ -1800,12 +1801,17 @@ export class DesktopBackendRegistry {
     }
 
     const key = buildTitleGenerationKey(params.backend, params.threadId);
-    const promptHash = buildPromptHash(prompt);
-    const current = this.pendingTitleGenerations.get(key);
-    if (current?.promptHash === promptHash) {
+    if (this.attemptedTitleGenerations.has(key)) {
       return;
     }
 
+    const promptHash = buildPromptHash(prompt);
+    const current = this.pendingTitleGenerations.get(key);
+    if (current) {
+      return;
+    }
+
+    this.attemptedTitleGenerations.add(key);
     const token = ++this.titleGenerationSequence;
     this.pendingTitleGenerations.set(key, {
       promptHash,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -6,7 +6,18 @@ type ThreadHeaderProps = {
   thread: NavigationThreadSummary;
 };
 
+function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (!projectKey || thread.linkedDirectories.length > 0) {
+    return undefined;
+  }
+
+  return projectKey;
+}
+
 export function ThreadHeader(props: ThreadHeaderProps) {
+  const missingPath = missingDirectoryPath(props.thread);
+
   return (
     <header className="thread-header">
       <div>
@@ -21,6 +32,12 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             {formatExecutionModeLabel(props.thread.executionMode)}
           </span>
         </div>
+        {missingPath ? (
+          <p className="thread-header__warning" role="alert">
+            This thread is linked to a directory that no longer exists:{" "}
+            <code>{missingPath}</code>
+          </p>
+        ) : null}
       </div>
     </header>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -273,6 +273,10 @@ describe("ThreadView", () => {
       />
     );
 
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This thread is linked to a directory that no longer exists: /Users/huntharo/.codex/worktrees/be87/search-product"
+    );
+
     fireEvent.click(screen.getByRole("button", { name: "Open context rail" }));
 
     expect(screen.getByText("Recorded working directory is no longer available.")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1118,6 +1118,24 @@ textarea {
   white-space: nowrap;
 }
 
+.thread-header__warning {
+  max-width: min(72vw, 760px);
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.thread-header__warning code {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
 .thread-header__stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(104px, 1fr));


### PR DESCRIPTION
## Summary

I added a one-shot guard around desktop thread title generation so a backend/thread can only schedule one helper title-generation attempt.

This prevents stale thread-list metadata from kicking off repeated ephemeral Codex title turns after a generated title was already attempted or applied.

I also added a visible thread-header warning when a thread still has a recorded project directory but the backend no longer exposes a usable linked directory, which is what happens when the underlying worktree has been removed or archived elsewhere.

## Validation

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
