### PR TITLE
Aggregate MCP startup status updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -450,6 +450,42 @@ function buildMcpProgressDetail(
   };
 }
 
+function buildMcpProtocolActivityEntry(
+  details: AppServerThreadActivityDetail[],
+  createdAt = Date.now(),
+): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: "live-mcp-protocol-status",
+    createdAt,
+    summary: summarizeMcpProtocolActivity(details),
+    status: summarizeActivityStatus(details),
+    details,
+  };
+}
+
+function summarizeMcpProtocolActivity(details: AppServerThreadActivityDetail[]): string {
+  if (details.length === 1 && details[0]) {
+    return details[0].label;
+  }
+
+  return `MCP status updates (${details.length})`;
+}
+
+function mergeMcpProtocolActivityEntry(
+  current: AppServerThreadActivityEntry | undefined,
+  next: AppServerThreadActivityEntry,
+): AppServerThreadActivityEntry {
+  if (current?.id !== "live-mcp-protocol-status") {
+    return next;
+  }
+
+  return buildMcpProtocolActivityEntry(
+    mergeActivityDetails(current.details, next.details),
+    current.createdAt ?? next.createdAt
+  );
+}
+
 function buildMcpServerStatusActivityEntry(params: Record<string, unknown>): AppServerThreadActivityEntry | undefined {
   const serverName = readString(params, "name") ?? readString(params, "serverName");
   const status = readString(params, "status") ?? "updated";
@@ -470,21 +506,14 @@ function buildMcpServerStatusActivityEntry(params: Record<string, unknown>): App
     ? `MCP ${serverName} ${status}: ${error}`
     : `MCP ${serverName} ${status}`;
 
-  return {
-    type: "activity",
-    id: `live-mcp-status-${serverName}`,
-    createdAt: Date.now(),
-    summary: label,
-    status: detailStatus,
-    details: [
-      {
-        id: `live-mcp-status-${serverName}-detail`,
-        kind: "command",
-        label,
-        status: detailStatus,
-      },
-    ],
-  };
+  return buildMcpProtocolActivityEntry([
+    {
+      id: `live-mcp-status-${serverName}`,
+      kind: "command",
+      label,
+      status: detailStatus,
+    },
+  ]);
 }
 
 function buildMcpOauthActivityEntry(params: Record<string, unknown>): AppServerThreadActivityEntry | undefined {
@@ -500,21 +529,14 @@ function buildMcpOauthActivityEntry(params: Record<string, unknown>): AppServerT
     : `MCP ${serverName} login failed${error ? `: ${error}` : ""}`;
   const status: AppServerThreadActivityDetail["status"] = success ? "completed" : "failed";
 
-  return {
-    type: "activity",
-    id: `live-mcp-oauth-${serverName}`,
-    createdAt: Date.now(),
-    summary: label,
-    status,
-    details: [
-      {
-        id: `live-mcp-oauth-${serverName}-detail`,
-        kind: "command",
-        label,
-        status,
-      },
-    ],
-  };
+  return buildMcpProtocolActivityEntry([
+    {
+      id: `live-mcp-oauth-${serverName}`,
+      kind: "command",
+      label,
+      status,
+    },
+  ]);
 }
 
 function summarizeActivityStatus(
@@ -1105,7 +1127,9 @@ export function ThreadView(props: ThreadViewProps) {
           event.notification.params as Record<string, unknown>
         );
         if (entry) {
-          setPendingProtocolActivityEntry(entry);
+          setPendingProtocolActivityEntry((current) =>
+            mergeMcpProtocolActivityEntry(current, entry)
+          );
         }
         return;
       }
@@ -1115,7 +1139,9 @@ export function ThreadView(props: ThreadViewProps) {
           event.notification.params as Record<string, unknown>
         );
         if (entry) {
-          setPendingProtocolActivityEntry(entry);
+          setPendingProtocolActivityEntry((current) =>
+            mergeMcpProtocolActivityEntry(current, entry)
+          );
         }
         return;
       }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1535,7 +1535,113 @@ describe("ThreadView", () => {
       });
     });
 
+    fireEvent.click(screen.getByRole("button", { name: /MCP status updates \(2\)/ }));
     expect(screen.getByText("MCP playwright login completed")).toBeInTheDocument();
+  });
+
+  it("keeps multiple global MCP startup statuses visible", async () => {
+    const selectedThread = {
+      id: "thread-2",
+      title: "Browser task",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false
+      }
+    };
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: false,
+              multiDirectoryThreads: true
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          }
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-2",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "Start a new thread."
+          }
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await act(async () => {
+      for (const name of ["browser-use", "playwright", "codex_apps"]) {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "mcpServer/startupStatus/updated",
+            params: {
+              name,
+              status: "ready",
+              error: null,
+            },
+          },
+        });
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /MCP status updates \(3\)/ }));
+    expect(screen.getByText("MCP browser-use ready")).toBeInTheDocument();
+    expect(screen.getByText("MCP playwright ready")).toBeInTheDocument();
+    expect(screen.getByText("MCP codex_apps ready")).toBeInTheDocument();
   });
 
   it("renders live Codex command execution activity without falling back to tool", async () => {


### PR DESCRIPTION
## Summary

I fixed live MCP startup/status rendering so multiple global MCP server notifications remain visible instead of replacing each other with only the last status.

The thread view now aggregates MCP startup/OAuth status updates into one transient activity group, with each server status preserved as an expandable detail.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx -t "global MCP|multiple global MCP"`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
