### PR TITLE
feat(desktop): Add thread context menu copy actions

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -161,6 +161,11 @@ export function Sidebar(props: SidebarProps) {
     void onArchiveThread(thread);
   };
 
+  const copyFromContextMenu = (value: string): void => {
+    setContextMenu(undefined);
+    void copyText(value);
+  };
+
   const submitRename = (): void => {
     if (!renameThread) {
       return;
@@ -184,6 +189,12 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanArchive = contextMenu
     ? canArchiveThread(contextMenu.thread)
     : false;
+  const contextMenuLocalPath = contextMenu?.thread.linkedDirectories[0]?.path;
+  const contextMenuWorktreePath = contextMenu?.thread.linkedDirectories.find(
+    (directory) => directory.kind === "worktree" && directory.worktreePath
+  )?.worktreePath;
+  const contextMenuBranchName = contextMenu?.thread.gitBranch;
+  const contextMenuHasTopActions = contextMenuCanRename || contextMenuCanArchive;
 
   return (
     <aside className="sidebar" aria-label="Threads">
@@ -315,7 +326,7 @@ export function Sidebar(props: SidebarProps) {
         </div>
       </section>
 
-      {contextMenu && (contextMenuCanRename || contextMenuCanArchive) ? (
+      {contextMenu ? (
         <div
           className="thread-context-menu"
           role="menu"
@@ -325,24 +336,67 @@ export function Sidebar(props: SidebarProps) {
           }}
           onClick={(event) => event.stopPropagation()}
         >
-          {contextMenuCanRename ? (
+          {contextMenuHasTopActions ? (
+            <div className="thread-context-menu__section">
+              {contextMenuCanRename ? (
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() => requestRenameFromContextMenu(contextMenu.thread)}
+                >
+                  Rename Thread
+                </button>
+              ) : null}
+              {contextMenuCanArchive ? (
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() => archiveFromContextMenu(contextMenu.thread)}
+                >
+                  Archive Thread
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {contextMenuHasTopActions ? (
+            <div className="thread-context-menu__separator" role="separator" />
+          ) : null}
+          <div className="thread-context-menu__section">
             <button
               role="menuitem"
               type="button"
-              onClick={() => requestRenameFromContextMenu(contextMenu.thread)}
+              onClick={() => copyFromContextMenu(contextMenu.thread.id)}
             >
-              Rename Thread
+              Copy Thread ID
             </button>
-          ) : null}
-          {contextMenuCanArchive ? (
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() => archiveFromContextMenu(contextMenu.thread)}
-            >
-              Archive Thread
-            </button>
-          ) : null}
+            {contextMenuWorktreePath ? (
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => copyFromContextMenu(contextMenuWorktreePath)}
+              >
+                Copy Worktree Path
+              </button>
+            ) : null}
+            {contextMenuLocalPath ? (
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => copyFromContextMenu(contextMenuLocalPath)}
+              >
+                Copy Local Path
+              </button>
+            ) : null}
+            {contextMenuBranchName ? (
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => copyFromContextMenu(contextMenuBranchName)}
+              >
+                Copy Branch Name
+              </button>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -93,7 +93,7 @@ const sharedThread = {
       label: "PwrAgnt",
       path: "/Users/huntharo/pwrdrvr/PwrAgnt",
       worktreePath: "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt",
-      kind: "local" as const,
+      kind: "worktree" as const,
     },
   ],
 };
@@ -363,6 +363,152 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Archive Thread" }));
 
     expect(onArchiveThread).toHaveBeenCalledWith(sharedThread);
+  });
+
+  it("shows copy actions below the thread context menu divider", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onArchiveThread={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByRole("separator")).toBeInTheDocument();
+    expect(within(menu).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Rename Thread",
+      "Archive Thread",
+      "Copy Thread ID",
+      "Copy Worktree Path",
+      "Copy Local Path",
+      "Copy Branch Name",
+    ]);
+  });
+
+  it("copies thread context menu values", () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragnt", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+
+    const renderMenu = (): void => {
+      render(
+        <Sidebar
+          backends={backends}
+          browseMode="recents"
+          createThreadError={undefined}
+          directories={directories}
+          inboxThreads={[sharedThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-1"
+          threads={[sharedThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+          onArchiveThread={async () => undefined}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+    };
+
+    renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Thread ID" }));
+    cleanup();
+
+    renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Worktree Path" }));
+    cleanup();
+
+    renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Local Path" }));
+    cleanup();
+
+    renderMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Branch Name" }));
+
+    expect(copyText).toHaveBeenNthCalledWith(1, "thread-1");
+    expect(copyText).toHaveBeenNthCalledWith(
+      2,
+      "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt"
+    );
+    expect(copyText).toHaveBeenNthCalledWith(3, "/Users/huntharo/pwrdrvr/PwrAgnt");
+    expect(copyText).toHaveBeenNthCalledWith(4, "codex/thread-centric-ui");
+  });
+
+  it("hides optional copy actions without matching thread metadata", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[
+          {
+            ...sharedThread,
+            gitBranch: undefined,
+            linkedDirectories: [
+              {
+                id: "dir-a",
+                label: "PwrAgnt",
+                path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                kind: "local" as const,
+              },
+            ],
+          },
+        ]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[
+          {
+            ...sharedThread,
+            gitBranch: undefined,
+            linkedDirectories: [
+              {
+                id: "dir-a",
+                label: "PwrAgnt",
+                path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+                kind: "local" as const,
+              },
+            ],
+          },
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onArchiveThread={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Copy Worktree Path" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Copy Branch Name" })).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Thread ID" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Local Path" })).toBeInTheDocument();
   });
 
   it("hides archive actions when the backend does not support archiving", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1016,6 +1016,12 @@ textarea {
   background: var(--bg-panel-hover);
 }
 
+.thread-context-menu__separator {
+  height: 1px;
+  margin: 6px 0;
+  background: var(--border-subtle);
+}
+
 .rename-thread-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary

I added a second section to the thread context menu for copying thread metadata. Rename and Archive stay grouped at the top, followed by a horizontal divider and copy actions for the thread ID, worktree path when the thread is backed by a worktree, local path, and branch name when the thread has Git metadata.

## Testing

I verified this tested cleanly:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
