### PR TITLE
fix(desktop): label Spark rate limits

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -462,7 +462,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         ) : null}
                         {backend.rateLimits?.length ? (
                           <ul className="backend-status-list__limits">
-                            {selectVisibleRateLimits(backend).map((limit) => (
+                            {selectVisibleRateLimits(backend, props.thread).map((limit) => (
                               <li key={`${limit.limitId ?? "limit"}:${limit.name}`}>
                                 {formatRateLimitLine(limit)}
                               </li>
@@ -620,16 +620,32 @@ function splitRateLimitName(name: string): {
 }
 
 function selectVisibleRateLimits(
-  backend: BackendSummary
+  backend: BackendSummary,
+  thread: NavigationThreadSummary
 ): NonNullable<BackendSummary["rateLimits"]> {
-  return [...(backend.rateLimits ?? [])]
+  const limits = backend.rateLimits ?? [];
+  const currentThreadUsesSpark = backend.kind === "codex" && isSparkName(thread.model);
+  const sparkHasUsage = limits.some((limit) => isSparkRateLimit(limit) && hasRateLimitUsage(limit));
+
+  return [...limits]
     .filter((limit) => {
       const { label } = splitRateLimitName(limit.name);
-      return label === "5h limit" || label === "Weekly limit";
+      if (label !== "5h limit" && label !== "Weekly limit") {
+        return false;
+      }
+      if (!isSparkRateLimit(limit)) {
+        return true;
+      }
+      return currentThreadUsesSpark || sparkHasUsage;
     })
     .sort((left, right) => {
       const leftName = splitRateLimitName(left.name);
       const rightName = splitRateLimitName(right.name);
+      const leftFamilyOrder = rateLimitFamilyOrder(left);
+      const rightFamilyOrder = rateLimitFamilyOrder(right);
+      if (leftFamilyOrder !== rightFamilyOrder) {
+        return leftFamilyOrder - rightFamilyOrder;
+      }
       if (leftName.labelOrder !== rightName.labelOrder) {
         return leftName.labelOrder - rightName.labelOrder;
       }
@@ -639,17 +655,43 @@ function selectVisibleRateLimits(
 
 function formatRateLimitLine(limit: NonNullable<BackendSummary["rateLimits"]>[number]): string {
   const { label } = splitRateLimitName(limit.name);
+  const displayLabel = isSparkRateLimit(limit) ? `Spark ${label}` : label;
   const resetText = formatRateLimitReset(limit.resetAt);
   if (typeof limit.usedPercent === "number") {
     const remaining = Math.max(0, Math.round(100 - limit.usedPercent));
-    return `${label}: ${remaining}% left${resetText ? `, resets ${resetText}` : ""}`;
+    return `${displayLabel}: ${remaining}% left${resetText ? `, resets ${resetText}` : ""}`;
   }
   if (typeof limit.remaining === "number" && typeof limit.limit === "number") {
-    return `${label}: ${limit.remaining}/${limit.limit} remaining${
+    return `${displayLabel}: ${limit.remaining}/${limit.limit} remaining${
       resetText ? `, resets ${resetText}` : ""
     }`;
   }
-  return `${label}: unavailable`;
+  return `${displayLabel}: unavailable`;
+}
+
+function isSparkRateLimit(limit: NonNullable<BackendSummary["rateLimits"]>[number]): boolean {
+  return isSparkName(limit.limitId) || isSparkName(limit.name);
+}
+
+function isSparkName(value: string | undefined): boolean {
+  return value?.toLowerCase().includes("spark") ?? false;
+}
+
+function hasRateLimitUsage(limit: NonNullable<BackendSummary["rateLimits"]>[number]): boolean {
+  if (typeof limit.usedPercent === "number") {
+    return limit.usedPercent > 0;
+  }
+  if (typeof limit.used === "number") {
+    return limit.used > 0;
+  }
+  if (typeof limit.remaining === "number" && typeof limit.limit === "number") {
+    return limit.remaining < limit.limit;
+  }
+  return false;
+}
+
+function rateLimitFamilyOrder(limit: NonNullable<BackendSummary["rateLimits"]>[number]): number {
+  return isSparkRateLimit(limit) ? 1 : 0;
 }
 
 function formatRateLimitReset(resetAt: number | undefined): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1,0 +1,128 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BackendSummary, NavigationThreadSummary } from "@pwragnt/shared";
+import { ThreadContextPanel } from "../ThreadContextPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+const baseThread: NavigationThreadSummary = {
+  id: "thread-1",
+  title: "Thread",
+  titleSource: "explicit",
+  source: "codex",
+  linkedDirectories: [],
+  inbox: {
+    inInbox: false,
+  },
+};
+
+const baseBackend: BackendSummary = {
+  kind: "codex",
+  label: "OpenAI",
+  available: true,
+  account: {
+    type: "chatgpt",
+    email: "user@example.com",
+    planType: "pro",
+    requiresOpenaiAuth: false,
+  },
+  methods: ["thread/list", "thread/read"],
+  capabilities: {
+    listThreads: true,
+    createThread: true,
+    resumeThread: true,
+    renameThread: true,
+    readThread: true,
+    startTurn: true,
+    interruptTurn: true,
+    steerTurn: true,
+    transcriptPagination: true,
+    toolUse: true,
+    approvalRequests: true,
+    multiDirectoryThreads: true,
+  },
+  executionModes: [
+    {
+      mode: "default",
+      label: "Default",
+      available: true,
+      isDefault: true,
+    },
+  ],
+  rateLimits: [
+    {
+      name: "5h limit",
+      usedPercent: 7,
+      windowMinutes: 300,
+    },
+    {
+      name: "Weekly limit",
+      usedPercent: 12,
+      windowMinutes: 10_080,
+    },
+    {
+      name: "gpt-5.3-codex-spark 5h limit",
+      limitId: "gpt-5.3-codex-spark",
+      usedPercent: 0,
+      windowMinutes: 300,
+    },
+    {
+      name: "gpt-5.3-codex-spark Weekly limit",
+      limitId: "gpt-5.3-codex-spark",
+      usedPercent: 0,
+      windowMinutes: 10_080,
+    },
+  ],
+};
+
+describe("ThreadContextPanel", () => {
+  it("hides unused Spark rate limits on non-Spark threads", () => {
+    render(<ThreadContextPanel backends={[baseBackend]} pinned thread={baseThread} />);
+
+    expect(screen.getByText(/5h limit: 93% left/)).toBeInTheDocument();
+    expect(screen.getByText(/Weekly limit: 88% left/)).toBeInTheDocument();
+    expect(screen.queryByText(/Spark 5h limit/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Spark Weekly limit/)).not.toBeInTheDocument();
+  });
+
+  it("labels Spark rate limits when the current thread uses Spark", () => {
+    render(
+      <ThreadContextPanel
+        backends={[baseBackend]}
+        pinned
+        thread={{
+          ...baseThread,
+          model: "gpt-5.3-codex-spark",
+        }}
+      />
+    );
+
+    expect(screen.getByText(/Spark 5h limit: 100% left/)).toBeInTheDocument();
+    expect(screen.getByText(/Spark Weekly limit: 100% left/)).toBeInTheDocument();
+  });
+
+  it("labels Spark rate limits when Spark has usage", () => {
+    render(
+      <ThreadContextPanel
+        backends={[
+          {
+            ...baseBackend,
+            rateLimits: baseBackend.rateLimits?.map((limit) =>
+              limit.limitId === "gpt-5.3-codex-spark" && limit.windowMinutes === 300
+                ? { ...limit, usedPercent: 2 }
+                : limit
+            ),
+          },
+        ]}
+        pinned
+        thread={baseThread}
+      />
+    );
+
+    expect(screen.getByText(/Spark 5h limit: 98% left/)).toBeInTheDocument();
+    expect(screen.getByText(/Spark Weekly limit: 100% left/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

I fixed the OpenAI rate-limit display in the right context rail so the regular Codex buckets and GPT-5.3-Codex-Spark buckets are not shown with identical labels.

- Keep the base buckets as `5h limit` and `Weekly limit`
- Render Spark buckets as `Spark 5h limit` and `Spark Weekly limit`
- Hide unused Spark buckets unless the current thread is using a Spark model
- Still show Spark buckets if the Spark limits indicate real usage

## Verification

- User verified manually that Spark limits appear when selecting a Spark model
- `pnpm test -- --project desktop-renderer ThreadContextPanel.test.tsx`
- `pnpm typecheck`

Note: the non-100% Spark usage fallback is covered by the new renderer unit test, but was not manually exercised because Spark was selected without consuming Spark quota.
