### PR TITLE
feat(desktop): refine context moon indicator

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,6 +1,5 @@
 import {
   type ClipboardEvent,
-  type CSSProperties,
   type DragEvent,
   useEffect,
   useMemo,
@@ -129,14 +128,14 @@ type AutocompleteKind = "skills" | "slash";
 type ReviewTargetChoice = AppServerReviewTarget["type"];
 
 const CONTEXT_MOON_PHASES = [
-  "new",
-  "sliver",
-  "crescent",
-  "partly full",
-  "half full",
-  "near full",
-  "full",
-  "critical",
+  "new moon",
+  "waxing crescent",
+  "first quarter",
+  "waxing gibbous",
+  "full moon",
+  "waning gibbous",
+  "third quarter",
+  "waning crescent",
 ] as const;
 
 type ReviewConfigState = {
@@ -2207,10 +2206,6 @@ function ContextWindowMoon({
   const phase = Math.min(7, Math.max(0, contextWindow.phase));
   const phaseLabel = CONTEXT_MOON_PHASES[phase];
   const percentLabel = `${Math.round(contextWindow.usedPercent)}%`;
-  const litPercent = Math.max(0, Math.min(100, contextWindow.usedPercent));
-  const moonStyle = {
-    "--context-window-moon-shadow": `${100 - litPercent}%`,
-  } as CSSProperties;
   const tokenLabel = `${formatCompactNumber(
     contextWindow.totalTokens
   )}/${formatCompactNumber(contextWindow.modelContextWindow)}`;
@@ -2229,7 +2224,6 @@ function ContextWindowMoon({
       <span
         aria-hidden="true"
         className={`context-window-moon__sprite context-window-moon__sprite--phase-${phase}`}
-        style={moonStyle}
       >
         <span className="context-window-moon__disc" />
       </span>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -136,6 +136,7 @@ const CONTEXT_MOON_PHASES = [
   "waning gibbous",
   "third quarter",
   "waning crescent",
+  "critical",
 ] as const;
 
 type ReviewConfigState = {
@@ -2203,7 +2204,7 @@ function ContextWindowMoon({
     return null;
   }
 
-  const phase = Math.min(7, Math.max(0, contextWindow.phase));
+  const phase = Math.min(CONTEXT_MOON_PHASES.length - 1, Math.max(0, contextWindow.phase));
   const phaseLabel = CONTEXT_MOON_PHASES[phase];
   const percentLabel = `${Math.round(contextWindow.usedPercent)}%`;
   const tokenLabel = `${formatCompactNumber(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -132,9 +132,9 @@ const CONTEXT_MOON_PHASES = [
   "waxing crescent",
   "first quarter",
   "waxing gibbous",
+  "mostly full",
   "near full",
   "full",
-  "overfull",
   "critical",
 ] as const;
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,5 +1,6 @@
 import {
   type ClipboardEvent,
+  type CSSProperties,
   type DragEvent,
   useEffect,
   useMemo,
@@ -129,10 +130,10 @@ type ReviewTargetChoice = AppServerReviewTarget["type"];
 
 const CONTEXT_MOON_PHASES = [
   "new",
-  "waxing crescent",
-  "first quarter",
-  "waxing gibbous",
-  "mostly full",
+  "sliver",
+  "crescent",
+  "partly full",
+  "half full",
   "near full",
   "full",
   "critical",
@@ -2206,6 +2207,10 @@ function ContextWindowMoon({
   const phase = Math.min(7, Math.max(0, contextWindow.phase));
   const phaseLabel = CONTEXT_MOON_PHASES[phase];
   const percentLabel = `${Math.round(contextWindow.usedPercent)}%`;
+  const litPercent = Math.max(0, Math.min(100, contextWindow.usedPercent));
+  const moonStyle = {
+    "--context-window-moon-shadow": `${100 - litPercent}%`,
+  } as CSSProperties;
   const tokenLabel = `${formatCompactNumber(
     contextWindow.totalTokens
   )}/${formatCompactNumber(contextWindow.modelContextWindow)}`;
@@ -2224,6 +2229,7 @@ function ContextWindowMoon({
       <span
         aria-hidden="true"
         className={`context-window-moon__sprite context-window-moon__sprite--phase-${phase}`}
+        style={moonStyle}
       >
         <span className="context-window-moon__disc" />
       </span>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -102,13 +102,16 @@ describe("Composer", () => {
 
     expect(
       screen.getByRole("img", {
-        name: "Context window 50% full, 64k/128k tokens, mostly full",
+        name: "Context window 50% full, 64k/128k tokens, half full",
       })
     ).toBeInTheDocument();
+    expect(screen.getByRole("img").querySelector(".context-window-moon__sprite")).toHaveStyle({
+      "--context-window-moon-shadow": "50%",
+    });
     expect(screen.getByRole("img")).toHaveAttribute(
       "data-tooltip",
       [
-        "Context window: 50% full (mostly full)",
+        "Context window: 50% full (half full)",
         "Current snapshot: 64k / 128k tokens",
         "Remaining: 64k tokens, 50% remaining",
         "Current breakdown: 63k input, 32k cached, 1k output",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -102,16 +102,13 @@ describe("Composer", () => {
 
     expect(
       screen.getByRole("img", {
-        name: "Context window 50% full, 64k/128k tokens, half full",
+        name: "Context window 50% full, 64k/128k tokens, full moon",
       })
     ).toBeInTheDocument();
-    expect(screen.getByRole("img").querySelector(".context-window-moon__sprite")).toHaveStyle({
-      "--context-window-moon-shadow": "50%",
-    });
     expect(screen.getByRole("img")).toHaveAttribute(
       "data-tooltip",
       [
-        "Context window: 50% full (half full)",
+        "Context window: 50% full (full moon)",
         "Current snapshot: 64k / 128k tokens",
         "Remaining: 64k tokens, 50% remaining",
         "Current breakdown: 63k input, 32k cached, 1k output",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -102,13 +102,13 @@ describe("Composer", () => {
 
     expect(
       screen.getByRole("img", {
-        name: "Context window 50% full, 64k/128k tokens, near full",
+        name: "Context window 50% full, 64k/128k tokens, mostly full",
       })
     ).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "data-tooltip",
       [
-        "Context window: 50% full (near full)",
+        "Context window: 50% full (mostly full)",
         "Current snapshot: 64k / 128k tokens",
         "Remaining: 64k tokens, 50% remaining",
         "Current breakdown: 63k input, 32k cached, 1k output",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -47,9 +47,9 @@ describe("useThreadSessionState", () => {
     expect(getContextWindowMoonPhase(84.99)).toBe(6);
     expect(getContextWindowMoonPhase(85)).toBe(7);
     expect(getContextWindowMoonPhase(97.49)).toBe(7);
-    expect(getContextWindowMoonPhase(97.5)).toBe(0);
-    expect(getContextWindowMoonPhase(100)).toBe(0);
-    expect(getContextWindowMoonPhase(100.01)).toBe(0);
+    expect(getContextWindowMoonPhase(97.5)).toBe(8);
+    expect(getContextWindowMoonPhase(100)).toBe(8);
+    expect(getContextWindowMoonPhase(100.01)).toBe(8);
   });
 
   it("keeps the optimistic user message ahead of the completed assistant reply", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2,7 +2,10 @@ import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useThreadSessionState } from "../useThreadSessionState";
+import {
+  getContextWindowMoonPhase,
+  useThreadSessionState,
+} from "../useThreadSessionState";
 
 function buildThread(params: {
   id: string;
@@ -25,6 +28,24 @@ function buildThread(params: {
 describe("useThreadSessionState", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("maps context window moon phases to explicit fill thresholds", () => {
+    expect(getContextWindowMoonPhase(0)).toBe(0);
+    expect(getContextWindowMoonPhase(9.99)).toBe(0);
+    expect(getContextWindowMoonPhase(10)).toBe(1);
+    expect(getContextWindowMoonPhase(19.99)).toBe(1);
+    expect(getContextWindowMoonPhase(20)).toBe(2);
+    expect(getContextWindowMoonPhase(34.99)).toBe(2);
+    expect(getContextWindowMoonPhase(35)).toBe(3);
+    expect(getContextWindowMoonPhase(49.99)).toBe(3);
+    expect(getContextWindowMoonPhase(50)).toBe(4);
+    expect(getContextWindowMoonPhase(69.99)).toBe(4);
+    expect(getContextWindowMoonPhase(70)).toBe(5);
+    expect(getContextWindowMoonPhase(89.99)).toBe(5);
+    expect(getContextWindowMoonPhase(90)).toBe(6);
+    expect(getContextWindowMoonPhase(100)).toBe(6);
+    expect(getContextWindowMoonPhase(100.01)).toBe(7);
   });
 
   it("keeps the optimistic user message ahead of the completed assistant reply", async () => {
@@ -2332,7 +2353,7 @@ describe("useThreadSessionState", () => {
       inputTokens: undefined,
       modelContextWindow: 128_000,
       outputTokens: undefined,
-      phase: 6,
+      phase: 5,
       reasoningOutputTokens: undefined,
       remainingPercent: 25,
       remainingTokens: 32_000,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -34,18 +34,22 @@ describe("useThreadSessionState", () => {
     expect(getContextWindowMoonPhase(0)).toBe(0);
     expect(getContextWindowMoonPhase(9.99)).toBe(0);
     expect(getContextWindowMoonPhase(10)).toBe(1);
-    expect(getContextWindowMoonPhase(19.99)).toBe(1);
-    expect(getContextWindowMoonPhase(20)).toBe(2);
+    expect(getContextWindowMoonPhase(22.49)).toBe(1);
+    expect(getContextWindowMoonPhase(22.5)).toBe(2);
     expect(getContextWindowMoonPhase(34.99)).toBe(2);
     expect(getContextWindowMoonPhase(35)).toBe(3);
-    expect(getContextWindowMoonPhase(49.99)).toBe(3);
-    expect(getContextWindowMoonPhase(50)).toBe(4);
-    expect(getContextWindowMoonPhase(69.99)).toBe(4);
-    expect(getContextWindowMoonPhase(70)).toBe(5);
-    expect(getContextWindowMoonPhase(89.99)).toBe(5);
-    expect(getContextWindowMoonPhase(90)).toBe(6);
-    expect(getContextWindowMoonPhase(100)).toBe(6);
-    expect(getContextWindowMoonPhase(100.01)).toBe(7);
+    expect(getContextWindowMoonPhase(47.49)).toBe(3);
+    expect(getContextWindowMoonPhase(47.5)).toBe(4);
+    expect(getContextWindowMoonPhase(59.99)).toBe(4);
+    expect(getContextWindowMoonPhase(60)).toBe(5);
+    expect(getContextWindowMoonPhase(72.49)).toBe(5);
+    expect(getContextWindowMoonPhase(72.5)).toBe(6);
+    expect(getContextWindowMoonPhase(84.99)).toBe(6);
+    expect(getContextWindowMoonPhase(85)).toBe(7);
+    expect(getContextWindowMoonPhase(97.49)).toBe(7);
+    expect(getContextWindowMoonPhase(97.5)).toBe(0);
+    expect(getContextWindowMoonPhase(100)).toBe(0);
+    expect(getContextWindowMoonPhase(100.01)).toBe(0);
   });
 
   it("keeps the optimistic user message ahead of the completed assistant reply", async () => {
@@ -2353,7 +2357,7 @@ describe("useThreadSessionState", () => {
       inputTokens: undefined,
       modelContextWindow: 128_000,
       outputTokens: undefined,
-      phase: 5,
+      phase: 6,
       reasoningOutputTokens: undefined,
       remainingPercent: 25,
       remainingTokens: 32_000,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -59,7 +59,7 @@ export function getContextWindowMoonPhase(usedPercent: number): number {
   if (usedPercent < 97.5) {
     return 7;
   }
-  return 0;
+  return 8;
 }
 
 export type ThreadViewportState = {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -34,6 +34,31 @@ const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
   "item/fileChange/requestApproval",
 ]);
 
+export function getContextWindowMoonPhase(usedPercent: number): number {
+  if (usedPercent < 10) {
+    return 0;
+  }
+  if (usedPercent < 20) {
+    return 1;
+  }
+  if (usedPercent < 35) {
+    return 2;
+  }
+  if (usedPercent < 50) {
+    return 3;
+  }
+  if (usedPercent < 70) {
+    return 4;
+  }
+  if (usedPercent < 90) {
+    return 5;
+  }
+  if (usedPercent <= 100) {
+    return 6;
+  }
+  return 7;
+}
+
 export type ThreadViewportState = {
   distanceFromBottom: number;
   scrollTop: number;
@@ -370,10 +395,8 @@ function normalizeThreadContextWindowState(
     return undefined;
   }
 
-  const usedPercent = Math.max(
-    0,
-    Math.min(100, (totalTokens / modelContextWindow) * 100)
-  );
+  const rawUsedPercent = (totalTokens / modelContextWindow) * 100;
+  const usedPercent = Math.max(0, Math.min(100, rawUsedPercent));
   const remainingTokens = Math.max(0, modelContextWindow - totalTokens);
   const remainingPercent = Math.max(
     0,
@@ -389,7 +412,7 @@ function normalizeThreadContextWindowState(
     inputTokens: currentUsage.inputTokens,
     modelContextWindow,
     outputTokens: currentUsage.outputTokens,
-    phase: Math.min(7, Math.max(0, Math.floor(usedPercent / 12.5))),
+    phase: getContextWindowMoonPhase(rawUsedPercent),
     reasoningOutputTokens: currentUsage.reasoningOutputTokens,
     remainingPercent,
     remainingTokens,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -38,25 +38,28 @@ export function getContextWindowMoonPhase(usedPercent: number): number {
   if (usedPercent < 10) {
     return 0;
   }
-  if (usedPercent < 20) {
+  if (usedPercent < 22.5) {
     return 1;
   }
   if (usedPercent < 35) {
     return 2;
   }
-  if (usedPercent < 50) {
+  if (usedPercent < 47.5) {
     return 3;
   }
-  if (usedPercent < 70) {
+  if (usedPercent < 60) {
     return 4;
   }
-  if (usedPercent < 90) {
+  if (usedPercent < 72.5) {
     return 5;
   }
-  if (usedPercent <= 100) {
+  if (usedPercent < 85) {
     return 6;
   }
-  return 7;
+  if (usedPercent < 97.5) {
+    return 7;
+  }
+  return 0;
 }
 
 export type ThreadViewportState = {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3384,13 +3384,13 @@ textarea {
 
 .context-window-moon__disc::after {
   position: absolute;
-  inset: -1px auto -1px -1px;
-  width: var(--context-window-moon-shadow, 100%);
-  border-radius: 50%;
+  inset: -1px auto -1px var(--context-window-moon-shadow-left, -1px);
+  width: var(--context-window-moon-shadow-width, 100%);
+  border-radius: var(--context-window-moon-shadow-radius, 50%);
   background: var(--bg-input);
   box-shadow:
-    1px 0 3px rgba(255, 169, 79, 0.18),
-    inset -1px 0 2px rgba(255, 138, 31, 0.16);
+    var(--context-window-moon-terminator-glow, 1px 0 3px rgba(255, 169, 79, 0.18)),
+    inset var(--context-window-moon-shadow-inset, -1px 0 2px) rgba(255, 138, 31, 0.16);
   content: "";
 }
 
@@ -3402,18 +3402,56 @@ textarea {
 }
 
 .context-window-moon__sprite--phase-0 .context-window-moon__disc::after {
-  width: 100%;
+  --context-window-moon-shadow-width: 100%;
 }
 
-.context-window-moon__sprite--phase-6 .context-window-moon__disc {
+.context-window-moon__sprite--phase-1 {
+  --context-window-moon-shadow-width: 76%;
+}
+
+.context-window-moon__sprite--phase-2 {
+  --context-window-moon-shadow-radius: 0;
+  --context-window-moon-shadow-width: 50%;
+}
+
+.context-window-moon__sprite--phase-3 {
+  --context-window-moon-shadow-width: 24%;
+}
+
+.context-window-moon__sprite--phase-4 {
+  --context-window-moon-shadow-width: 0%;
+}
+
+.context-window-moon__sprite--phase-5 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-width: 24%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+
+.context-window-moon__sprite--phase-5 .context-window-moon__disc::after,
+.context-window-moon__sprite--phase-6 .context-window-moon__disc::after,
+.context-window-moon__sprite--phase-7 .context-window-moon__disc::after {
+  right: -1px;
+}
+
+.context-window-moon__sprite--phase-6 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-radius: 0;
+  --context-window-moon-shadow-width: 50%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+
+.context-window-moon__sprite--phase-7 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-width: 76%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+
+.context-window-moon__sprite--phase-4 .context-window-moon__disc {
   border-color: var(--accent-strong);
-}
-
-.context-window-moon__sprite--phase-7 .context-window-moon__disc {
-  border-color: var(--accent-bright);
-  box-shadow:
-    0 0 10px rgba(255, 138, 31, 0.42),
-    inset 0 0 3px rgba(255, 243, 220, 0.34);
 }
 
 .context-window-moon__label {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3450,8 +3450,19 @@ textarea {
   --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
 }
 
-.context-window-moon__sprite--phase-4 .context-window-moon__disc {
+.context-window-moon__sprite--phase-4 .context-window-moon__disc,
+.context-window-moon__sprite--phase-8 .context-window-moon__disc {
   border-color: var(--accent-strong);
+}
+
+.context-window-moon__sprite--phase-8 {
+  --context-window-moon-shadow-width: 0%;
+}
+
+.context-window-moon__sprite--phase-8 .context-window-moon__disc {
+  box-shadow:
+    0 0 12px rgba(255, 138, 31, 0.48),
+    inset 0 0 4px rgba(255, 243, 220, 0.34);
 }
 
 .context-window-moon__label {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3353,15 +3353,29 @@ textarea {
   overflow: hidden;
   border: 1px solid rgba(255, 179, 92, 0.44);
   border-radius: 50%;
-  background: radial-gradient(
-    circle at 38% 34%,
-    var(--accent-bright) 0%,
-    var(--accent-strong) 42%,
-    var(--accent) 100%
-  );
+  background:
+    radial-gradient(circle at 34% 28%, rgba(255, 241, 203, 0.72) 0 8%, transparent 17%),
+    radial-gradient(circle at 68% 62%, rgba(132, 58, 13, 0.28) 0 7%, transparent 13%),
+    radial-gradient(circle at 48% 76%, rgba(94, 42, 13, 0.2) 0 5%, transparent 11%),
+    radial-gradient(circle at 72% 30%, rgba(255, 205, 128, 0.36) 0 6%, transparent 14%),
+    radial-gradient(circle at 38% 34%, var(--accent-bright) 0%, var(--accent-strong) 42%, var(--accent) 100%);
   box-shadow:
     0 0 8px rgba(255, 138, 31, 0.28),
     inset 0 0 3px rgba(255, 243, 220, 0.26);
+}
+
+.context-window-moon__disc::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 63% 34%, rgba(71, 28, 7, 0.36) 0 1px, rgba(255, 207, 139, 0.18) 1px 2px, transparent 3px),
+    radial-gradient(circle at 42% 58%, rgba(77, 33, 10, 0.3) 0 1px, rgba(255, 218, 153, 0.14) 1px 2px, transparent 3px),
+    radial-gradient(circle at 78% 78%, rgba(80, 34, 9, 0.28) 0 1px, transparent 3px),
+    radial-gradient(circle at 50% 22%, rgba(255, 229, 171, 0.22) 0 1px, transparent 3px);
+  content: "";
+  mix-blend-mode: multiply;
+  opacity: 0.72;
 }
 
 .context-window-moon__disc::after {
@@ -3375,7 +3389,9 @@ textarea {
 }
 
 .context-window-moon__sprite--phase-0 .context-window-moon__disc {
-  background: rgba(255, 138, 31, 0.08);
+  background:
+    radial-gradient(circle at 60% 36%, rgba(255, 138, 31, 0.08) 0 2px, transparent 3px),
+    rgba(255, 138, 31, 0.08);
   box-shadow: inset 0 0 0 1px rgba(255, 138, 31, 0.14);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3399,7 +3399,10 @@ textarea {
   --context-window-moon-shadow: 20%;
 }
 
-.context-window-moon__sprite--phase-5,
+.context-window-moon__sprite--phase-5 {
+  --context-window-moon-shadow: 8%;
+}
+
 .context-window-moon__sprite--phase-6,
 .context-window-moon__sprite--phase-7 {
   --context-window-moon-shadow: 0%;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3327,19 +3327,23 @@ textarea {
 
 .context-window-moon {
   display: inline-flex;
+  min-height: 34px;
   min-width: 0;
   align-items: center;
-  gap: 6px;
+  align-self: center;
+  gap: 7px;
   color: var(--text-muted);
   font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 34px;
+  margin-right: 4px;
 }
 
 .context-window-moon__sprite {
   display: inline-flex;
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -3348,8 +3352,8 @@ textarea {
 .context-window-moon__disc {
   position: relative;
   display: block;
-  width: 14px;
-  height: 14px;
+  width: 22px;
+  height: 22px;
   overflow: hidden;
   border: 1px solid rgba(255, 179, 92, 0.44);
   border-radius: 50%;
@@ -3360,8 +3364,8 @@ textarea {
     radial-gradient(circle at 72% 30%, rgba(255, 205, 128, 0.36) 0 6%, transparent 14%),
     radial-gradient(circle at 38% 34%, var(--accent-bright) 0%, var(--accent-strong) 42%, var(--accent) 100%);
   box-shadow:
-    0 0 8px rgba(255, 138, 31, 0.28),
-    inset 0 0 3px rgba(255, 243, 220, 0.26);
+    0 0 10px rgba(255, 138, 31, 0.3),
+    inset 0 0 4px rgba(255, 243, 220, 0.26);
 }
 
 .context-window-moon__disc::before {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3388,7 +3388,9 @@ textarea {
   width: var(--context-window-moon-shadow, 100%);
   border-radius: 50%;
   background: var(--bg-input);
-  box-shadow: inset -1px 0 2px rgba(255, 138, 31, 0.16);
+  box-shadow:
+    1px 0 3px rgba(255, 169, 79, 0.18),
+    inset -1px 0 2px rgba(255, 138, 31, 0.16);
   content: "";
 }
 
@@ -3401,31 +3403,6 @@ textarea {
 
 .context-window-moon__sprite--phase-0 .context-window-moon__disc::after {
   width: 100%;
-}
-
-.context-window-moon__sprite--phase-1 {
-  --context-window-moon-shadow: 86%;
-}
-
-.context-window-moon__sprite--phase-2 {
-  --context-window-moon-shadow: 64%;
-}
-
-.context-window-moon__sprite--phase-3 {
-  --context-window-moon-shadow: 42%;
-}
-
-.context-window-moon__sprite--phase-4 {
-  --context-window-moon-shadow: 20%;
-}
-
-.context-window-moon__sprite--phase-5 {
-  --context-window-moon-shadow: 8%;
-}
-
-.context-window-moon__sprite--phase-6,
-.context-window-moon__sprite--phase-7 {
-  --context-window-moon-shadow: 0%;
 }
 
 .context-window-moon__sprite--phase-6 .context-window-moon__disc {


### PR DESCRIPTION
## Summary

I refined the desktop context-window moon indicator so it communicates context usage more clearly and reads better in the composer action row.

This PR:
- changes the context moon thresholding to use the full lunar phase set: new moon, waxing crescent, first quarter, waxing gibbous, full moon, waning gibbous, third quarter, and waning crescent
- maps context usage through a complete lunar cycle instead of only growing from new moon to full moon
- uses the correct lit-side direction for waxing versus waning phases, with quarter phases using a straight terminator and crescent/gibbous phases using curved shadows
- keeps the new moon visible for the low-usage range and cycles back toward new moon near a full context window
- adds subtle crater and texture styling so the icon reads as a moon instead of a flat orange dot
- enlarges and aligns the moon and percent label with the Stop/Send action buttons

## Screenshot

<img width="750" height="305" alt="image" src="https://github.com/user-attachments/assets/2ba129a7-2d8a-49ae-b33a-3d5f99b8914c" />

## Verification

I verified the renderer changes with:

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm vitest run --environment jsdom apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm vitest run --globals apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
