### PR TITLE
feat(desktop): flag threads waiting for approval

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -24,6 +24,9 @@ type LaunchResult = {
   getLastStartReview: (params?: {
     executionMode?: ThreadExecutionMode;
   }) => Promise<unknown>;
+  getLastRenameThread: (params?: {
+    executionMode?: ThreadExecutionMode;
+  }) => Promise<unknown>;
   respondToPendingRequest: (params: {
     executionMode?: ThreadExecutionMode;
     requestId: string;
@@ -126,6 +129,12 @@ export async function launchElectronApp(params: {
       await electronApp.evaluate(
         (_electron, value) =>
           globalThis.__PWRAGNT_REPLAY_DRIVER__?.getLastStartReview(value),
+        requestParams
+      ),
+    getLastRenameThread: async (requestParams) =>
+      await electronApp.evaluate(
+        (_electron, value) =>
+          globalThis.__PWRAGNT_REPLAY_DRIVER__?.getLastRenameThread(value),
         requestParams
       ),
     respondToPendingRequest: async (requestParams) => {

--- a/apps/desktop/e2e/thread-title-generation.spec.ts
+++ b/apps/desktop/e2e/thread-title-generation.spec.ts
@@ -1,0 +1,161 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const PROMPT =
+  "Run `npm view dive` - You'll need to ask to leave the network sandbox";
+
+async function createThreadTitleGenerationFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-thread-title-"));
+  const fixturePath = path.join(rootDir, "thread-title-generation.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-title-generation",
+          threadId: "thread-title",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "turn/start", "thread/name/set"],
+            },
+          },
+          {
+            id: "thread-list-initial",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-title",
+                title: PROMPT,
+                titleSource: "explicit",
+                summary: "A thread still using its prompt as the title",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-title-user-1",
+                  role: "user",
+                  text: PROMPT,
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-title-user-1",
+                  role: "user",
+                  text: PROMPT,
+                },
+              ],
+              lastUserMessage: PROMPT,
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-title",
+              turnId: "turn-title-1",
+            },
+          },
+          {
+            id: "thread-list-title-current",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-title",
+                title: PROMPT,
+                titleSource: "explicit",
+                summary: "A thread still using its prompt as the title",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-list-title-latest-empty",
+            kind: "response",
+            method: "thread/list",
+            result: [],
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
+test("applies a generated title even when the latest title lookup has not caught up", async () => {
+  const fixture = await createThreadTitleGenerationFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGNT_REPLAY_THREAD_TITLE: "Dive package lookup",
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: new RegExp(PROMPT) }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: PROMPT,
+      })
+    ).toBeVisible();
+
+    await app.window.getByLabel("Reply").fill(PROMPT);
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await expect
+      .poll(async () => await app.getLastRenameThread())
+      .toEqual({
+        threadId: "thread-title",
+        name: "Dive package lookup",
+      });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -85,6 +85,7 @@ type InitializeResult = {
 };
 
 const isDevelopment = process.env.NODE_ENV !== "production";
+const REPLAY_THREAD_TITLE_ENV = "PWRAGNT_REPLAY_THREAD_TITLE";
 const backendRegistryLog = getMainLogger("pwragnt:backend-registry");
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -600,6 +601,20 @@ function buildTitleEligibilityLogDetails(
   };
 }
 
+function createReplayThreadTitleService(): ThreadTitleService | undefined {
+  const title = process.env[REPLAY_THREAD_TITLE_ENV]?.trim();
+  if (!title) {
+    return undefined;
+  }
+
+  return {
+    generateTitle: async () => ({
+      status: "generated",
+      title,
+    }),
+  };
+}
+
 function getDefaultModelOption(
   backend: AppServerBackendKind,
   options?: BackendLaunchpadOptions,
@@ -769,7 +784,7 @@ export class DesktopBackendRegistry {
         ? undefined
         : options?.threadTitleGenerationService ??
           (replayClients
-            ? undefined
+            ? createReplayThreadTitleService()
             : new ThreadTitleGenerationService({
                 generators: {
                   codex: this.codexDefaultClient.generateTitle
@@ -1929,7 +1944,7 @@ export class DesktopBackendRegistry {
         backend: params.backend,
         threadId: params.threadId,
       });
-      if (!latestThread || !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
+      if (latestThread && !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
         this.logThreadTitleGeneration(
           "skipped",
           params,

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -52,6 +52,10 @@ export class ReplayClient {
     target: AppServerReviewTarget;
     delivery?: AppServerReviewDelivery;
   };
+  private lastRenameThreadParams?: {
+    threadId: string;
+    name: string;
+  };
 
   constructor(private readonly controller: ReplayController) {}
 
@@ -172,6 +176,15 @@ export class ReplayClient {
     };
   }
 
+  async renameThread(params: {
+    threadId: string;
+    name: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+    this.lastRenameThreadParams = params;
+    return { threadId: params.threadId };
+  }
+
   async advance(params: {
     stepId?: string;
     override?: ReplayStepOverride;
@@ -218,6 +231,15 @@ export class ReplayClient {
       }
     | undefined {
     return this.lastStartReviewParams;
+  }
+
+  getLastRenameThreadParams():
+    | {
+        threadId: string;
+        name: string;
+      }
+    | undefined {
+    return this.lastRenameThreadParams;
   }
 
   async respondToPendingRequest(requestId: string): Promise<void> {

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -49,6 +49,15 @@ type ReplayDriver = {
         delivery?: AppServerReviewDelivery;
       }
     | undefined;
+  getLastRenameThread(params?: {
+    backend?: AppServerBackendKind;
+    executionMode?: ThreadExecutionMode;
+  }):
+    | {
+        threadId: string;
+        name: string;
+      }
+    | undefined;
   getPendingRequest(params?: {
     backend?: AppServerBackendKind;
     executionMode?: ThreadExecutionMode;
@@ -83,6 +92,12 @@ type ReplayRuntimeClient = {
         threadId: string;
         target: AppServerReviewTarget;
         delivery?: AppServerReviewDelivery;
+      }
+    | undefined;
+  getLastRenameThreadParams?():
+    | {
+        threadId: string;
+        name: string;
       }
     | undefined;
   getInitializeResult(): Promise<{
@@ -140,6 +155,10 @@ type ReplayRuntimeClient = {
     threadId: string;
     turnId: string;
   }): Promise<{ threadId: string; turnId: string }>;
+  renameThread?(params: {
+    threadId: string;
+    name: string;
+  }): Promise<{ threadId: string }>;
   respondToPendingRequest?(requestId: string): Promise<void>;
 };
 
@@ -195,6 +214,13 @@ export function createReplayClientsFromEnv():
         executionMode: params?.executionMode,
       });
       return client.getLastStartReviewParams?.();
+    },
+    getLastRenameThread: (params) => {
+      const client = getReplayClient(clients, {
+        backend: params?.backend,
+        executionMode: params?.executionMode,
+      });
+      return client.getLastRenameThreadParams?.();
     },
     respondToPendingRequest: async (params) => {
       const client = getReplayClient(clients, {
@@ -276,6 +302,7 @@ function createUnavailableReplayClient(
     getPendingRequest: () => undefined,
     getLastStartTurnParams: () => undefined,
     getLastStartReviewParams: () => undefined,
+    getLastRenameThreadParams: () => undefined,
     getInitializeResult: async () => {
       throw new Error(message);
     },
@@ -300,6 +327,9 @@ function createUnavailableReplayClient(
       throw new Error(message);
     },
     interruptTurn: async () => {
+      throw new Error(message);
+    },
+    renameThread: async () => {
       throw new Error(message);
     },
     respondToPendingRequest: async () => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -65,6 +65,7 @@ export function App() {
         runtimeIdentity={runtimeIdentity}
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
+        approvalRequestThreadKeys={session.approvalRequestThreadKeys}
         selectedItemKey={navigation.selectedItemKey}
         thinkingThreadKeys={session.thinkingThreadKeys}
         threads={navigation.threads}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -8,6 +8,7 @@ import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
+  approvalRequestThreadKeys?: Record<string, boolean>;
   directories: NavigationDirectorySummary[];
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
@@ -145,6 +146,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     {visibleThreads.map((thread) => (
                       <ThreadRow
                         key={`${directory.key}:${buildThreadIdentityKey(thread.source, thread.id)}`}
+                        approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                         compact
                         selectedThreadKey={props.selectedItemKey}
                         thinkingThreadKeys={props.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
@@ -3,6 +3,7 @@ import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThreadRow } from "./ThreadRow";
 
 type InboxListProps = {
+  approvalRequestThreadKeys?: Record<string, boolean>;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -27,6 +28,7 @@ export function InboxList(props: InboxListProps) {
       {props.threads.map((thread) => (
         <ThreadRow
           key={buildThreadIdentityKey(thread.source, thread.id)}
+          approvalRequestThreadKeys={props.approvalRequestThreadKeys}
           includeLinkedDirectories
           selectedThreadKey={props.selectedThreadKey}
           thinkingThreadKeys={props.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -3,6 +3,7 @@ import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
+  approvalRequestThreadKeys?: Record<string, boolean>;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -19,6 +20,7 @@ export function RecentsList(props: RecentsListProps) {
       {props.threads.map((thread) => (
         <ThreadRow
           key={buildThreadIdentityKey(thread.source, thread.id)}
+          approvalRequestThreadKeys={props.approvalRequestThreadKeys}
           includeLinkedDirectories
           selectedThreadKey={props.selectedThreadKey}
           thinkingThreadKeys={props.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -35,6 +35,7 @@ type SidebarProps = {
   archiveThreadError?: string;
   renameThreadError?: string;
   runtimeIdentity?: RuntimeIdentity;
+  approvalRequestThreadKeys?: Record<string, boolean>;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -294,6 +295,7 @@ export function Sidebar(props: SidebarProps) {
             <p className="sidebar-error">{props.error}</p>
           ) : props.browseMode === "inbox" ? (
             <InboxList
+              approvalRequestThreadKeys={props.approvalRequestThreadKeys}
               selectedThreadKey={props.selectedItemKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
               threads={props.inboxThreads}
@@ -302,6 +304,7 @@ export function Sidebar(props: SidebarProps) {
             />
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
+              approvalRequestThreadKeys={props.approvalRequestThreadKeys}
               directories={props.directories}
               selectedItemKey={props.selectedItemKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
@@ -315,6 +318,7 @@ export function Sidebar(props: SidebarProps) {
               <p className="sidebar-empty">No threads yet.</p>
             ) : (
               <RecentsList
+                approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}
                 threads={props.threads}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -4,11 +4,13 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 
 type ThreadMetaChipsProps = {
+  hasApprovalRequest?: boolean;
   includeLinkedDirectories?: boolean;
   thread: NavigationThreadSummary;
 };
 
 export function ThreadMetaChips({
+  hasApprovalRequest = false,
   includeLinkedDirectories = false,
   thread,
 }: ThreadMetaChipsProps) {
@@ -89,6 +91,19 @@ export function ThreadMetaChips({
       <span className="thread-row__chip thread-row__chip--backend">
         {formatBackendLabel(thread.source)}
       </span>
+
+      {hasApprovalRequest ? (
+        <span
+          aria-label="Waiting for approval"
+          className="thread-row__chip thread-row__chip--approval"
+          title="Waiting for approval"
+        >
+          <span aria-hidden="true" className="thread-row__chip-icon">
+            !
+          </span>
+          Waiting for approval
+        </span>
+      ) : null}
 
       {linkedDirectoryChips}
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -4,6 +4,7 @@ import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
 type ThreadRowProps = {
+  approvalRequestThreadKeys?: Record<string, boolean>;
   compact?: boolean;
   includeLinkedDirectories?: boolean;
   selectedThreadKey?: string;
@@ -17,9 +18,9 @@ type ThreadRowProps = {
 };
 
 export function ThreadRow(props: ThreadRowProps) {
+  const threadKey = buildThreadIdentityKey(props.thread.source, props.thread.id);
   const selected =
-    buildThreadIdentityKey(props.thread.source, props.thread.id) ===
-    props.selectedThreadKey;
+    threadKey === props.selectedThreadKey;
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
 
   return (
@@ -53,6 +54,7 @@ export function ThreadRow(props: ThreadRowProps) {
         </span>
 
         <ThreadMetaChips
+          hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
           includeLinkedDirectories={props.includeLinkedDirectories}
           thread={props.thread}
         />

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -235,6 +235,37 @@ describe("Sidebar", () => {
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
+  it("shows an approval chip for threads waiting on an approval request", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        approvalRequestThreadKeys={{ "codex:thread-1": true }}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    const approvalChip = within(threadButton).getByTitle("Waiting for approval");
+    expect(approvalChip).toHaveTextContent("Waiting for approval");
+    expect(approvalChip).toHaveAttribute("title", "Waiting for approval");
+  });
+
   it("does not duplicate new-thread inbox membership as an attention marker in recents", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1502,6 +1502,9 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.pendingStatusText).toBe("Waiting for approval");
+    expect(result.current.approvalRequestThreadKeys).toEqual({
+      "codex:thread-1": true,
+    });
     expect(result.current.pendingRequest).toMatchObject({
       method: "item/commandExecution/requestApproval",
       params: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -820,6 +820,7 @@ export function useThreadSessionState(params: {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  approvalRequestThreadKeys: Record<string, boolean>;
   removeOptimisticMessage: (id: string) => void;
   response?: AppServerReadThreadResponse;
   setActiveTurnId: (turnId?: string) => void;
@@ -1824,6 +1825,15 @@ export function useThreadSessionState(params: {
       ),
     [sessions]
   );
+  const approvalRequestThreadKeys = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(sessions)
+          .filter(([, session]) => Boolean(session.pendingRequest))
+          .map(([sessionThreadKey]) => [sessionThreadKey, true])
+      ),
+    [sessions]
+  );
   const pendingStatusText =
     selectedSession?.pendingStatusText ??
     (selectedSession?.activeTurnId ? "Thinking" : undefined);
@@ -1846,6 +1856,7 @@ export function useThreadSessionState(params: {
     pendingRequest: selectedSession?.pendingRequest,
     pendingUserInput: selectedSession?.pendingUserInput,
     pendingStatusText,
+    approvalRequestThreadKeys,
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveTurnId,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -701,6 +701,13 @@ textarea {
   font-weight: 600;
 }
 
+.thread-row__chip--approval {
+  border: 1px solid var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 .path-copy-target {
   position: relative;
 }


### PR DESCRIPTION
## Summary

- I surface unresolved approval requests from renderer session state as a per-thread map.
- I render a `Waiting for approval` chip on matching thread rows across Inbox, Recents, and Directories.
- I fixed generated thread titles being skipped when the post-generation `thread/list` lookup has not caught up yet.
- I added focused coverage for the session-state map, sidebar chip rendering, replay rename observability, and the stale-list title-generation regression.

## Verification

- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/thread-title-generation.spec.ts`
- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/backend-registry.test.ts src/main/__tests__/replay-client.test.ts`
- `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/navigation/__tests__/sidebar.test.tsx src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm typecheck`
