### PR TITLE
fix(desktop): tighten desktop launchpad submit flow

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -544,13 +544,27 @@ describe("App", () => {
   });
 
   it("creates and sends on a new Grok thread", async () => {
-    const materializeDirectoryLaunchpad = vi.fn(async () => ({
-      backend: "grok" as const,
-      threadId: "thread-2",
-      executionMode: "default" as const,
-      workMode: "local" as const,
-      turnId: "turn-1",
-    }));
+    let resolveMaterializeLaunchpad: (() => void) | undefined;
+    const materializeDirectoryLaunchpad = vi.fn(
+      () =>
+        new Promise<{
+          backend: "grok";
+          threadId: string;
+          executionMode: "default";
+          workMode: "local";
+          turnId: string;
+        }>((resolve) => {
+          resolveMaterializeLaunchpad = () => {
+            resolve({
+              backend: "grok" as const,
+              threadId: "thread-2",
+              executionMode: "default" as const,
+              workMode: "local" as const,
+              turnId: "turn-1",
+            });
+          };
+        })
+    );
     const startTurn = vi.fn(
       async ({
         backend,
@@ -875,6 +889,11 @@ describe("App", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
 
+    expect(
+      await screen.findByRole("region", { name: "Preparing transcript" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "New thread" })).not.toBeInTheDocument();
+
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
         directoryKey: "unlinked:new-thread",
@@ -885,6 +904,9 @@ describe("App", () => {
           },
         ],
       });
+    });
+    await act(async () => {
+      resolveMaterializeLaunchpad?.();
     });
     expect(
       await screen.findByRole("heading", { level: 2, name: "Investigate Grok thread" })

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1422,6 +1422,7 @@ export function Composer(props: ComposerProps) {
     Boolean(backend?.capabilities.steerTurn) &&
     selectedModelOption?.supportsSteering !== false &&
     props.thread?.source !== "grok";
+  const launchpadSubmitting = isLaunchpad && sending;
   const launchpadWorkspaceOptions = props.launchpad
     ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
     : [];
@@ -1540,7 +1541,7 @@ export function Composer(props: ComposerProps) {
           ref={inputRef}
           id="thread-composer"
           className="composer__input"
-          disabled={props.disabled && !draft}
+          disabled={launchpadSubmitting || (props.disabled && !draft)}
           placeholder={
             isLaunchpad
               ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
@@ -1858,6 +1859,7 @@ export function Composer(props: ComposerProps) {
               id="composer-provider"
               aria-label="Provider"
               className="composer__select"
+              disabled={launchpadSubmitting}
               value={props.launchpad.backend}
               onChange={(event) => {
                 const currentLaunchpad = props.launchpad;
@@ -1903,7 +1905,7 @@ export function Composer(props: ComposerProps) {
             <select
               aria-label="Access mode"
               className="composer__select composer__select--compact"
-              disabled={Boolean(props.updatingExecutionMode)}
+              disabled={launchpadSubmitting || Boolean(props.updatingExecutionMode)}
               value={
                 props.launchpad?.executionMode ??
                 props.thread?.executionMode ??
@@ -1939,7 +1941,11 @@ export function Composer(props: ComposerProps) {
             <select
               aria-label="Workspace mode"
               className="composer__select composer__select--compact"
-              disabled={!props.onUpdateLaunchpad || launchpadWorkspaceOptions.length <= 1}
+              disabled={
+                launchpadSubmitting ||
+                !props.onUpdateLaunchpad ||
+                launchpadWorkspaceOptions.length <= 1
+              }
               value={props.launchpad.workMode}
               onChange={(event) => {
                 handleLaunchpadPatch({
@@ -1972,6 +1978,7 @@ export function Composer(props: ComposerProps) {
               aria-label="Base branch"
               id="launchpad-branch"
               className="composer__select composer__select--compact"
+              disabled={launchpadSubmitting}
               value={
                 props.launchpad.branchName ??
                 props.directory?.gitStatus?.currentBranch ??
@@ -1994,6 +2001,7 @@ export function Composer(props: ComposerProps) {
               id="composer-model"
               aria-label="Model"
               className="composer__select"
+              disabled={launchpadSubmitting}
               value={selectedModelOption?.id ?? ""}
               onChange={(event) => {
                 const model = event.target.value;
@@ -2038,6 +2046,7 @@ export function Composer(props: ComposerProps) {
               id="composer-reasoning"
               aria-label="Reasoning"
               className="composer__select"
+              disabled={launchpadSubmitting}
               value={selectedReasoningEffort ?? ""}
               onChange={(event) => {
                 const reasoningEffort = event.target.value;
@@ -2061,6 +2070,7 @@ export function Composer(props: ComposerProps) {
               id="composer-service-tier"
               aria-label="Service tier"
               className="composer__select"
+              disabled={launchpadSubmitting}
               value={selectedServiceTier ?? ""}
               onChange={(event) => {
                 const serviceTier = event.target.value;
@@ -2083,6 +2093,7 @@ export function Composer(props: ComposerProps) {
             <label className="composer__checkbox">
               <input
                 checked={Boolean(currentSettings?.fastMode)}
+                disabled={launchpadSubmitting}
                 type="checkbox"
                 onChange={(event) => {
                   if (props.launchpad) {
@@ -2149,10 +2160,6 @@ export function Composer(props: ComposerProps) {
         <p className="composer__meta">
           Waiting for input before this turn can continue.
         </p>
-      ) : props.launchpad ? (
-        <p className="composer__meta">
-          Changes here become the default for future new-thread launchpads. Existing threads keep their current settings.
-        </p>
       ) : null}
 
       <div className="composer__actions">
@@ -2171,14 +2178,14 @@ export function Composer(props: ComposerProps) {
         ) : null}
         <button
           className="button button--primary"
-        disabled={
-          props.disabled ||
-          steering ||
-          (!activeTurnId && sending) ||
-          (!draft.trim() && imageAttachments.length === 0)
-        }
-        type="submit"
-      >
+          disabled={
+            props.disabled ||
+            steering ||
+            (!activeTurnId && sending) ||
+            (!draft.trim() && imageAttachments.length === 0)
+          }
+          type="submit"
+        >
           {activeTurnId
             ? "Queue"
             : sending

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1008,6 +1008,7 @@ type ThreadViewProps = {
         | "branchName"
         | "directoryLabel"
         | "directoryPath"
+        | "imageAttachments"
       >
     >
   ) => Promise<void>;
@@ -1033,6 +1034,7 @@ export function ThreadView(props: ThreadViewProps) {
   const [contextRailPinned, setContextRailPinned] = useState(false);
   const [contextRailResizing, setContextRailResizing] = useState(false);
   const [contextRailWidth, setContextRailWidth] = useState(380);
+  const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
 
   useEffect(() => {
     setPendingActivityEntry(undefined);
@@ -1044,6 +1046,7 @@ export function ThreadView(props: ThreadViewProps) {
     setContextRailPinned(false);
     setContextRailResizing(false);
     setExpandedImage(undefined);
+    setLaunchpadMaterializing(false);
   }, [
     props.selectedLaunchpad?.directoryKey,
     props.selectedThread?.id,
@@ -1543,10 +1546,30 @@ export function ThreadView(props: ThreadViewProps) {
       (backend) => backend.kind === selectedLaunchpad.backend
     );
     const syncLabel = formatDirectorySync(props.selectedDirectory);
+    const handleMaterializeLaunchpad: NonNullable<
+      ThreadViewProps["onMaterializeLaunchpad"]
+    > = async (directoryKey, input, collaborationMode, reviewTarget) => {
+      if (!props.onMaterializeLaunchpad) {
+        return;
+      }
+
+      setLaunchpadMaterializing(true);
+      try {
+        await props.onMaterializeLaunchpad(
+          directoryKey,
+          input,
+          collaborationMode,
+          reviewTarget
+        );
+      } catch (error) {
+        setLaunchpadMaterializing(false);
+        throw error;
+      }
+    };
 
     return (
-      <section className="thread-view">
-        <header className="thread-header">
+      <section className="thread-view thread-view--launchpad">
+        <header className="thread-header thread-header--launchpad">
           <div>
             <div className="thread-header__eyebrow-row">
               <p className="eyebrow">New thread</p>
@@ -1558,9 +1581,6 @@ export function ThreadView(props: ThreadViewProps) {
               </span>
             </div>
             <h2 className="thread-header__title">{selectedLaunchpad.directoryLabel}</h2>
-            <p className="thread-header__summary">
-              Start a thread in this directory. Unsent prompt and setup changes stay attached to this launchpad until the first send.
-            </p>
           </div>
 
           <div className="thread-header__stats">
@@ -1583,15 +1603,22 @@ export function ThreadView(props: ThreadViewProps) {
           </div>
         </header>
 
-        <div className="launchpad-panel">
-          <div className="launchpad-panel__header">
+        <div className="launchpad-panel launchpad-panel--compact">
+          <div className="launchpad-panel__summary">
             <div>
-              <h3>Directory</h3>
-              <p>
+              <span className="launchpad-panel__label">Project</span>
+              <strong>{selectedLaunchpad.directoryLabel}</strong>
+            </div>
+            <div>
+              <span className="launchpad-panel__label">Threads</span>
+              <strong>
                 {props.selectedDirectory.threadKeys.length} thread
                 {props.selectedDirectory.threadKeys.length === 1 ? "" : "s"}
-                {syncLabel ? ` • ${syncLabel}` : ""}
-              </p>
+              </strong>
+            </div>
+            <div>
+              <span className="launchpad-panel__label">Status</span>
+              <strong>{syncLabel ?? "Directory context only"}</strong>
             </div>
           </div>
 
@@ -1615,20 +1642,33 @@ export function ThreadView(props: ThreadViewProps) {
           </dl>
         </div>
 
-        <Composer
-          backends={props.backends}
-          desktopApi={props.desktopApi}
-          directory={props.selectedDirectory}
-          disabled={!launchpadBackend?.available}
-          launchpad={selectedLaunchpad}
-          launchpadError={props.launchpadError}
-          onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
-          onMaterializeLaunchpad={props.onMaterializeLaunchpad}
-          onUpdateLaunchpad={props.onUpdateLaunchpad}
-          skillError={props.skillError}
-          skillLoading={props.skillLoading}
-          skills={props.skills}
-        />
+        {launchpadMaterializing ? (
+          <section
+            className="transcript-panel transcript-panel--pending"
+            aria-label="Preparing transcript"
+          >
+            <div className="launchpad-pending">
+              <p className="eyebrow">Preparing transcript</p>
+              <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
+              <p>Your prompt was sent. The transcript will appear here when the thread is ready.</p>
+            </div>
+          </section>
+        ) : (
+          <Composer
+            backends={props.backends}
+            desktopApi={props.desktopApi}
+            directory={props.selectedDirectory}
+            disabled={!launchpadBackend?.available}
+            launchpad={selectedLaunchpad}
+            launchpadError={props.launchpadError}
+            onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+            onMaterializeLaunchpad={handleMaterializeLaunchpad}
+            onUpdateLaunchpad={props.onUpdateLaunchpad}
+            skillError={props.skillError}
+            skillLoading={props.skillLoading}
+            skills={props.skills}
+          />
+        )}
       </section>
     );
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1105,9 +1105,23 @@ textarea {
   overflow: hidden;
 }
 
+.thread-view--launchpad {
+  gap: 12px;
+  padding-right: 24px;
+}
+
 .thread-header__title {
   font-size: 40px;
   font-weight: 700;
+}
+
+.thread-header--launchpad {
+  align-items: center;
+}
+
+.thread-header--launchpad .thread-header__title {
+  font-size: 34px;
+  line-height: 1.05;
 }
 
 .thread-header__eyebrow-row {
@@ -1202,6 +1216,12 @@ textarea {
   background: var(--bg-panel);
 }
 
+.launchpad-panel--compact {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(0, 1.6fr);
+  align-items: stretch;
+}
+
 .launchpad-panel__header {
   display: flex;
   align-items: flex-start;
@@ -1218,11 +1238,37 @@ textarea {
   line-height: 1.45;
 }
 
+.launchpad-panel__summary {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.launchpad-panel__summary strong {
+  display: block;
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launchpad-panel__label {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
 .launchpad-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  padding: 16px;
+  gap: 10px 14px;
+  padding: 14px 16px;
 }
 
 .launchpad-grid dt {
@@ -1245,6 +1291,31 @@ textarea {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+}
+
+.transcript-panel--pending {
+  align-items: center;
+  justify-content: center;
+}
+
+.launchpad-pending {
+  width: min(100%, 520px);
+  padding: 24px;
+  text-align: center;
+}
+
+.launchpad-pending h3 {
+  margin: 6px 0 0;
+  color: var(--text-primary);
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.launchpad-pending p:last-child {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.45;
 }
 
 .transcript-list {
@@ -3496,6 +3567,16 @@ textarea {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .launchpad-panel--compact {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .launchpad-panel__summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
   .context-rail,
   .context-rail.is-open {
     position: static;
@@ -3558,6 +3639,18 @@ textarea {
 
   .thread-header__title {
     font-size: 32px;
+  }
+
+  .thread-header--launchpad {
+    align-items: flex-start;
+  }
+
+  .thread-header--launchpad .thread-header__title {
+    font-size: 30px;
+  }
+
+  .launchpad-panel__summary {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .composer__review-options {


### PR DESCRIPTION
## Summary

I tightened the desktop new-thread launchpad so it fits the available viewport and transitions out of the editable form immediately after send.

## What changed

- Collapsed the large directory card into compact project metadata under the launchpad header.
- Removed the extra launchpad instruction copy from the header and composer.
- Added a preparing-transcript placeholder that replaces the launchpad composer as soon as materialization starts.
- Disabled launchpad composer controls while submit is in progress.
- Added regression coverage for the pending materialization state.

## Root cause

The launchpad stayed mounted and editable until `materializeDirectoryLaunchpad` finished. In the meantime, Enter could send the prompt while leaving the textbox and controls visible, and the tall directory panel could push the Start Thread button out of view.

## Verification

- `pnpm typecheck`
- `pnpm vitest run apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx --config vitest.workspace.ts`
- `pnpm --filter @pwragnt/desktop build`
- Electron screenshot pass against a replay fixture at 1532x1019
