### PR TITLE
fix(desktop): place root drafts in workspaces

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -902,6 +902,41 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("keeps workspace launchpads in workspace mode even when directory drafts prefer worktrees", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { workMode: "worktree" },
+    });
+
+    const workspace = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "workspace:/Users/test/.pwragnt/projects",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: "/Users/test/.pwragnt/projects",
+    });
+
+    expect(workspace.defaults.workMode).toBe("worktree");
+    expect(workspace.launchpad.directoryKind).toBe("workspace");
+    expect(workspace.launchpad.directoryLabel).toBe("Workspaces");
+    expect(workspace.launchpad.workMode).toBe("local");
+    expect(workspace.launchpad.branchName).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("creates a scratch workspace for Codex thread creation when cwd is omitted", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -589,6 +589,15 @@ function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): bo
   );
 }
 
+function defaultLaunchpadWorkMode(
+  request: Pick<EnsureDirectoryLaunchpadRequest, "directoryKind" | "directoryPath">,
+  defaults: NavigationLaunchpadDefaults
+): NavigationLaunchpadDraft["workMode"] {
+  return request.directoryKind === "directory" && request.directoryPath
+    ? defaults.workMode ?? "local"
+    : "local";
+}
+
 function extractFirstMeaningfulTextInput(input: AppServerTurnInputItem[]): string | undefined {
   const text = input
     .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
@@ -1542,13 +1551,16 @@ export class DesktopBackendRegistry {
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
         const refreshed: NavigationLaunchpadDraft = {
           ...existing,
+          directoryKind: request.directoryKind,
+          directoryLabel: request.directoryLabel,
+          directoryPath: request.directoryPath,
           backend: request.preferredBackend ?? defaults.backend,
           executionMode: defaults.executionMode,
           model: defaults.model,
           reasoningEffort: defaults.reasoningEffort,
           serviceTier: defaults.serviceTier,
           fastMode: defaults.fastMode,
-          workMode: defaults.workMode ?? "local",
+          workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
           updatedAt: Date.now(),
         };
@@ -1577,7 +1589,7 @@ export class DesktopBackendRegistry {
       serviceTier: defaults.serviceTier,
       fastMode: defaults.fastMode,
       prompt: "",
-      workMode: defaults.workMode ?? "local",
+      workMode: defaultLaunchpadWorkMode(request, defaults),
       branchName: request.currentBranch,
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -600,9 +600,9 @@ describe("App", () => {
       })
     );
     let launchpadState = {
-      directoryKey: "unlinked:new-thread",
-      directoryKind: "unlinked" as const,
-      directoryLabel: "New thread",
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace" as const,
+      directoryLabel: "Workspaces",
       backend: "grok" as const,
       executionMode: "default" as const,
       prompt: "",
@@ -896,7 +896,7 @@ describe("App", () => {
 
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
-        directoryKey: "unlinked:new-thread",
+        directoryKey: "workspace:new-thread",
         input: [
           {
             type: "text",
@@ -1226,9 +1226,9 @@ describe("App", () => {
         }),
         ensureDirectoryLaunchpad: async () => ({
           launchpad: {
-            directoryKey: "unlinked:new-thread",
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
+            directoryKey: "workspace:new-thread",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
             backend: "codex" as const,
             executionMode: "default" as const,
             prompt: "",
@@ -1250,8 +1250,8 @@ describe("App", () => {
         }) => ({
           launchpad: {
             directoryKey,
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
             backend: "codex" as const,
             executionMode: "default" as const,
             prompt: typeof patch.prompt === "string" ? patch.prompt : "",
@@ -1294,7 +1294,7 @@ describe("App", () => {
 
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
-        directoryKey: "unlinked:new-thread",
+        directoryKey: "workspace:new-thread",
         input: [{ type: "text", text: "hello new codex thread" }]
       });
     });
@@ -1513,9 +1513,9 @@ describe("App", () => {
         }),
         ensureDirectoryLaunchpad: async () => ({
           launchpad: {
-            directoryKey: "unlinked:new-thread",
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
+            directoryKey: "workspace:new-thread",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
             backend: "codex" as const,
             executionMode: "default" as const,
             prompt: "",
@@ -1537,8 +1537,8 @@ describe("App", () => {
         }) => ({
           launchpad: {
             directoryKey,
-            directoryKind: "unlinked" as const,
-            directoryLabel: "New thread",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
             backend: "codex" as const,
             executionMode: "default" as const,
             prompt: typeof patch.prompt === "string" ? patch.prompt : "",
@@ -1578,7 +1578,7 @@ describe("App", () => {
 
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
-        directoryKey: "unlinked:new-thread",
+        directoryKey: "workspace:new-thread",
         input: [
           {
             type: "text",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2743,6 +2743,10 @@ function formatLaunchpadWorkspaceLabel(
     return "New worktree";
   }
 
+  if (directory?.kind === "workspace") {
+    return "Workspace";
+  }
+
   return directory?.gitStatus?.currentBranch
     ? `Local (${directory.gitStatus.currentBranch})`
     : "Local";

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1938,6 +1938,16 @@ export function ThreadView(props: ThreadViewProps) {
       (backend) => backend.kind === selectedLaunchpad.backend
     );
     const syncLabel = formatDirectorySync(props.selectedDirectory);
+    const workspaceLabel =
+      props.selectedDirectory.kind === "workspace"
+        ? "Workspace"
+        : selectedLaunchpad.workMode === "worktree"
+          ? "New worktree"
+          : "Local checkout";
+    const launchpadTitle =
+      props.selectedDirectory.kind === "workspace"
+        ? "New thread"
+        : selectedLaunchpad.directoryLabel;
     const handleMaterializeLaunchpad: NonNullable<
       ThreadViewProps["onMaterializeLaunchpad"]
     > = async (directoryKey, input, collaborationMode, reviewTarget) => {
@@ -1972,15 +1982,13 @@ export function ThreadView(props: ThreadViewProps) {
                 {formatExecutionModeLabel(selectedLaunchpad.executionMode)}
               </span>
             </div>
-            <h2 className="thread-header__title">{selectedLaunchpad.directoryLabel}</h2>
+            <h2 className="thread-header__title">{launchpadTitle}</h2>
           </div>
 
           <div className="thread-header__stats">
             <div>
               <span className="thread-header__stat-label">Workspace</span>
-              <strong>
-                {selectedLaunchpad.workMode === "worktree" ? "New worktree" : "Local checkout"}
-              </strong>
+              <strong>{workspaceLabel}</strong>
             </div>
             <div>
               <span className="thread-header__stat-label">Branch</span>

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -687,6 +687,83 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad).toBeUndefined();
   });
 
+  it("opens masthead new-thread drafts inside the Workspaces directory", async () => {
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "workspace:/Users/test/.pwragnt/projects",
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        directoryPath: "/Users/test/.pwragnt/projects",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "workspace:/Users/test/.pwragnt/projects",
+          kind: "workspace" as const,
+          label: "Workspaces",
+          path: "/Users/test/.pwragnt/projects",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.label).toBe("Workspaces");
+    });
+
+    await act(async () => {
+      await result.current.createThread();
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:/Users/test/.pwragnt/projects",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: "/Users/test/.pwragnt/projects",
+      preferredBackend: undefined,
+    });
+    expect(result.current.selectedItemKey).toBe(
+      "launchpad:workspace:/Users/test/.pwragnt/projects"
+    );
+    expect(result.current.selectedDirectory?.label).toBe("Workspaces");
+    expect(result.current.selectedLaunchpad?.directoryKind).toBe("workspace");
+    expect(result.current.directories.map((directory) => directory.label)).toEqual([
+      "Workspaces",
+    ]);
+    expect(result.current.directories.some((directory) => directory.kind === "unlinked")).toBe(
+      false
+    );
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -19,7 +19,8 @@ import type { DesktopApi } from "./desktop-api";
 
 export type BrowseMode = "inbox" | "recents" | "directories";
 
-const ROOT_NEW_THREAD_LAUNCHPAD_KEY = "unlinked:new-thread";
+const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
+const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 
 type NavigationState = {
   loading: boolean;
@@ -526,7 +527,7 @@ function projectOptimisticThreadIntoDirectories(
 
     nextDirectories.push({
       key: directoryKey,
-      kind: "directory",
+      kind: directoryKey.startsWith("workspace:") ? "workspace" : "directory",
       label: linkedDirectory.label,
       path: linkedDirectory.path,
       threadKeys: [threadKey],
@@ -599,12 +600,12 @@ function buildOptimisticThreadFromLaunchpad(params: {
     serviceTier: params.launchpad.serviceTier,
     fastMode: params.launchpad.fastMode,
     optimisticUserMessage: params.optimisticUserMessage,
-    linkedDirectories: params.launchpad.directoryPath
+    linkedDirectories: params.launchpad.directoryPath || params.launchpad.directoryKind === "workspace"
       ? [
           {
             id: `launchpad:${params.launchpad.directoryKey}`,
             label: params.launchpad.directoryLabel,
-            path: params.launchpad.directoryPath,
+            path: params.launchpad.directoryPath ?? "",
             kind: params.workMode === "worktree" ? "worktree" : "local",
           },
         ]
@@ -1277,10 +1278,16 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       setSetThreadModelSettingsError(undefined);
 
       try {
+        const workspaceDirectory = directories.find(
+          (directory) => directory.kind === "workspace"
+        );
+        const directoryKey =
+          workspaceDirectory?.key ?? ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY;
         const response = await desktopApi.ensureDirectoryLaunchpad({
-          directoryKey: ROOT_NEW_THREAD_LAUNCHPAD_KEY,
-          directoryKind: "unlinked",
-          directoryLabel: "New thread",
+          directoryKey,
+          directoryKind: "workspace",
+          directoryLabel: workspaceDirectory?.label ?? ROOT_NEW_THREAD_WORKSPACE_LABEL,
+          directoryPath: workspaceDirectory?.path,
           preferredBackend: backend,
         });
         let launchpad = response.launchpad;
@@ -1290,7 +1297,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           desktopApi.updateDirectoryLaunchpad
         ) {
           const updated = await desktopApi.updateDirectoryLaunchpad({
-            directoryKey: ROOT_NEW_THREAD_LAUNCHPAD_KEY,
+            directoryKey,
             patch: { executionMode },
           });
           launchpad = updated.launchpad;
@@ -1300,14 +1307,14 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           ...current,
           response: applyLaunchpadUpdate(current.response, launchpad, defaults),
         }));
-        setSelectedItemKey(buildLaunchpadSelectionKey(ROOT_NEW_THREAD_LAUNCHPAD_KEY));
+        setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
       } catch (error) {
         setCreateThreadError(error instanceof Error ? error.message : String(error));
       } finally {
         setCreatingThread(undefined);
       }
     },
-    [desktopApi]
+    [desktopApi, directories]
   );
 
   const openDirectoryLaunchpad = useCallback(


### PR DESCRIPTION
## Summary

I fixed the top-level New thread flow so it opens a Workspaces launchpad instead of creating a standalone unlinked "New thread" group in the Directories lens.

I also tightened the workspace launchpad copy and defaults so workspace drafts show as Workspace, and directory-specific New worktree defaults do not leak into non-git workspace drafts.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
