### PR TITLE
fix(desktop): context rail slide reflow

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2550,17 +2550,17 @@ textarea {
   bottom: 0;
   z-index: 10;
   flex: 0 0 auto;
-  width: 48px;
-  min-width: 48px;
+  width: min(var(--context-rail-width, 380px), calc(100% - 32px));
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
   border: 0;
   border-left: 1px solid var(--border-subtle);
   border-radius: 0;
   background: var(--bg-panel);
+  transform: translateX(calc(100% - 48px));
   transition:
-    width 160ms ease,
-    flex-basis 160ms ease,
+    transform 160ms ease,
     border-color 140ms ease,
     background 140ms ease;
 }
@@ -2570,6 +2570,7 @@ textarea {
   z-index: 30;
   overflow: visible;
   box-shadow: var(--shadow-popover);
+  transform: translateX(0);
 }
 
 .context-rail.is-pinned {
@@ -2582,6 +2583,7 @@ textarea {
   width: min(var(--context-rail-width, 380px), 42vw);
   overflow: hidden;
   box-shadow: none;
+  transform: translateX(0);
 }
 
 .context-rail.is-resizing {
@@ -3641,6 +3643,7 @@ textarea {
     flex-basis: auto;
     margin-left: 0;
     box-shadow: none;
+    transform: none;
   }
 
   .context-rail__spine {


### PR DESCRIPTION
## Summary

I fixed the auto-hiding context rail so it lays out at its final expanded width before it slides into view.

The rail now keeps the expanded width and animates with `transform`, which prevents thread IDs, branch names, and other context text from re-wrapping through intermediate widths while the rail opens or closes.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragnt/desktop build`
