### PR TITLE
fix(desktop): Remove duplicate context moon tooltip

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2227,7 +2227,6 @@ function ContextWindowMoon({
       data-tooltip={tooltip}
       role="img"
       tabIndex={0}
-      title={label}
     >
       <span
         aria-hidden="true"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -115,6 +115,7 @@ describe("Composer", () => {
         "Cumulative usage reported: 80k tokens",
       ].join("\n")
     );
+    expect(screen.getByRole("img")).not.toHaveAttribute("title");
     expect(screen.getByText("50%")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

I removed the native browser tooltip from the context moon indicator so only the custom rich tooltip appears on hover/focus.

This PR:
- removes the `title` attribute from the context moon indicator
- keeps the accessible `aria-label` and custom `data-tooltip`
- adds a regression assertion that the indicator does not emit a native tooltip

## Screenshot

<img width="442" height="266" alt="image" src="https://github.com/user-attachments/assets/99a5d9e6-bef7-44fe-9eb9-25f52066b54f" />


## Verification

I verified this with:

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm vitest run --environment jsdom apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
