### PR TITLE
fix(desktop): clear compacting status when compaction completes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1384,6 +1384,111 @@ describe("useThreadSessionState", () => {
     expect(result.current.contextWindow).toBeUndefined();
   });
 
+  it("returns to thinking when context compaction completes and the turn continues", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "in_progress",
+              },
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.activeTurnId).toBe("turn-1");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              item: {
+                id: "compact-item-1",
+                type: "contextCompaction",
+              },
+            },
+          },
+        } as any);
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Compacting context");
+    expect(result.current.activeTurnId).toBe("turn-1");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              item: {
+                id: "compact-item-1",
+                type: "contextCompaction",
+              },
+            },
+          },
+        } as any);
+      }
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+  });
+
   it("surfaces failed turn errors in the transcript state", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -426,7 +426,7 @@ function normalizeThreadContextWindowState(
 
 function isContextCompactionItemNotification(
   notification: AppServerNotification
-): notification is Extract<AppServerNotification, { method: "item/started" | "item/completed" }> {
+): boolean {
   if (notification.method !== "item/started" && notification.method !== "item/completed") {
     return false;
   }
@@ -1274,6 +1274,20 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "item/completed") {
+          if (isContextCompactionItemNotification(event.notification)) {
+            return {
+              ...current,
+              activeTurnId: current.activeTurnId ?? event.notification.params.turnId,
+              expectOwnUpdate: true,
+              interacted: true,
+              lastTouchedAt: nextLastTouchedAt,
+              pendingStatusText:
+                current.activeTurnId || event.notification.params.turnId
+                  ? "Thinking"
+                  : undefined,
+            };
+          }
+
           const reviewEntry = reviewEntryFromCompletedItem(event.notification.params);
           if (reviewEntry) {
             const nextResponse = appendThreadEntries(


### PR DESCRIPTION
## Summary

I fixed the desktop turn status reducer so a completed `contextCompaction` item switches the live transcript status from `Compacting context` back to `Thinking` when the Codex turn continues.

## What changed

- Handle `item/completed` with `item.type === "contextCompaction"` as the protocol signal that compaction work has finished.
- Preserve the active turn and thinking state instead of waiting for `thread/compacted`, which is a separate cache-reset notification.
- Add a regression test for a turn that starts, switches to `Compacting context`, then resumes as `Thinking` after the compaction item completes.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer`
- `pnpm --filter @pwragnt/desktop typecheck`
