### PR TITLE
fix(desktop): cache Codex model list

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -226,6 +226,7 @@ class MockBackendClient {
         supportsReasoning?: boolean;
         supportsFast?: boolean;
       }>;
+      modelListErrors?: Error[];
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
       setThreadPermissionsError?: Error;
@@ -274,6 +275,10 @@ class MockBackendClient {
 
   async listModels() {
     this.listModelsCallCount += 1;
+    const error = this.options.modelListErrors?.shift();
+    if (error) {
+      throw error;
+    }
     return this.options.models ?? [];
   }
 
@@ -601,6 +606,54 @@ describe("DesktopBackendRegistry", () => {
       },
     ]);
     expect(secondResponse.backends[0]?.launchpadOptions?.models).toMatchObject([
+      {
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+      },
+    ]);
+    expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
+
+    await registry.close();
+  });
+
+  it("retries Codex model discovery after a transient startup failure", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+      modelListErrors: [new Error("Codex is still starting")],
+      models: [
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      createScratchProjectDirectory: async () => "/tmp/pwragnt-scratch",
+    });
+
+    await flushAsync();
+    const response = await registry.listBackends({ includeUnavailable: true });
+    await registry.startThread({ backend: "codex" });
+
+    expect(codexClient.listModelsCallCount).toBe(2);
+    expect(codexFullAccessClient.listModelsCallCount).toBe(0);
+    expect(response.backends[0]?.launchpadOptions?.models).toMatchObject([
       {
         id: "gpt-5.4",
         label: "GPT-5.4",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -552,6 +552,65 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("reads Codex models once from the default client and reuses them", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+      models: [
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+      models: [
+        {
+          id: "gpt-full-access-only",
+          label: "Full Access Only",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      createScratchProjectDirectory: async () => "/tmp/pwragnt-scratch",
+    });
+
+    const firstResponse = await registry.listBackends({ includeUnavailable: true });
+    const secondResponse = await registry.listBackends({ includeUnavailable: true });
+    await registry.startThread({ backend: "codex" });
+
+    expect(codexClient.listModelsCallCount).toBe(1);
+    expect(codexFullAccessClient.listModelsCallCount).toBe(0);
+    expect(firstResponse.backends[0]?.launchpadOptions?.models).toMatchObject([
+      {
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+      },
+    ]);
+    expect(secondResponse.backends[0]?.launchpadOptions?.models).toMatchObject([
+      {
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+      },
+    ]);
+    expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
+
+    await registry.close();
+  });
+
   it("assumes Codex can create threads when initialize omits methods", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -675,6 +675,7 @@ export class DesktopBackendRegistry {
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
+  private readonly codexDefaultModelsPromise: Promise<BackendModelOption[]>;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -795,6 +796,8 @@ export class DesktopBackendRegistry {
                     : undefined,
                 },
               }));
+
+    this.codexDefaultModelsPromise = readClientModels(this.codexDefaultClient).catch(() => []);
 
     this.subscribeClient("codex", this.codexDefaultClient);
     this.subscribeClient("codex", this.codexFullAccessClient);
@@ -1515,7 +1518,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
   ): Promise<BackendLaunchpadOptions | undefined> {
     if (backend === "codex") {
-      const models = await readClientModels(this.codexDefaultClient).catch(() => []);
+      const models = await this.codexDefaultModelsPromise;
       return buildLaunchpadOptions(backend, models);
     }
 
@@ -1588,7 +1591,7 @@ export class DesktopBackendRegistry {
     ] = await Promise.allSettled([
       this.codexDefaultClient.getInitializeResult(),
       this.codexFullAccessClient.getInitializeResult(),
-      readClientModels(this.codexDefaultClient),
+      this.codexDefaultModelsPromise,
       readClientAccount(this.codexDefaultClient),
       readClientRateLimits(this.codexDefaultClient),
     ]);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -675,7 +675,8 @@ export class DesktopBackendRegistry {
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
-  private readonly codexDefaultModelsPromise: Promise<BackendModelOption[]>;
+  private codexDefaultModels?: BackendModelOption[];
+  private codexDefaultModelsPromise?: Promise<BackendModelOption[]>;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -797,7 +798,7 @@ export class DesktopBackendRegistry {
                 },
               }));
 
-    this.codexDefaultModelsPromise = readClientModels(this.codexDefaultClient).catch(() => []);
+    void this.readCodexDefaultModelsOnce().catch(() => undefined);
 
     this.subscribeClient("codex", this.codexDefaultClient);
     this.subscribeClient("codex", this.codexFullAccessClient);
@@ -1514,11 +1515,29 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private readCodexDefaultModelsOnce(): Promise<BackendModelOption[]> {
+    if (this.codexDefaultModels) {
+      return Promise.resolve(this.codexDefaultModels);
+    }
+
+    this.codexDefaultModelsPromise ??= readClientModels(this.codexDefaultClient)
+      .then((models) => {
+        this.codexDefaultModels = models;
+        return models;
+      })
+      .catch((error) => {
+        this.codexDefaultModelsPromise = undefined;
+        throw error;
+      });
+
+    return this.codexDefaultModelsPromise;
+  }
+
   private async getBackendLaunchpadOptions(
     backend: AppServerBackendKind,
   ): Promise<BackendLaunchpadOptions | undefined> {
     if (backend === "codex") {
-      const models = await this.codexDefaultModelsPromise;
+      const models = await this.readCodexDefaultModelsOnce().catch(() => []);
       return buildLaunchpadOptions(backend, models);
     }
 
@@ -1591,7 +1610,7 @@ export class DesktopBackendRegistry {
     ] = await Promise.allSettled([
       this.codexDefaultClient.getInitializeResult(),
       this.codexFullAccessClient.getInitializeResult(),
-      this.codexDefaultModelsPromise,
+      this.readCodexDefaultModelsOnce(),
       readClientAccount(this.codexDefaultClient),
       readClientRateLimits(this.codexDefaultClient),
     ]);


### PR DESCRIPTION
Fixes repeated `model/list` calls from the desktop backend registry by caching the default Codex model list for the app process lifetime. The model list is still loaded from the default Codex app-server instance, while full-access remains available for execution-mode checks without contributing its own model list.

I also added regression coverage that calls backend summaries repeatedly and starts a thread, verifying the default Codex client lists models once and the full-access client never does.

Verified:
- `pnpm test -- --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)
