### PR TITLE
fix(desktop): thread action menu edge placement

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -19,6 +19,12 @@ import { DirectoriesList } from "./DirectoriesList";
 import { InboxList } from "./InboxList";
 import { RecentsList } from "./RecentsList";
 
+type ThreadContextMenuPosition = {
+  x: number;
+  y: number;
+  anchorTop?: number;
+};
+
 type SidebarProps = {
   backends: BackendSummary[];
   browseMode: BrowseMode;
@@ -53,10 +59,12 @@ type SidebarProps = {
 };
 
 export function Sidebar(props: SidebarProps) {
+  const contextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const [contextMenu, setContextMenu] = useState<
     | {
-        position: { x: number; y: number };
+        requestedPosition: ThreadContextMenuPosition;
+        position?: { x: number; y: number };
         thread: NavigationThreadSummary;
       }
     | undefined
@@ -133,6 +141,35 @@ export function Sidebar(props: SidebarProps) {
   }, [contextMenu]);
 
   useLayoutEffect(() => {
+    if (!contextMenu) {
+      return;
+    }
+
+    const menu = contextMenuRef.current;
+    if (!menu) {
+      return;
+    }
+
+    const menuRect = menu.getBoundingClientRect();
+    const nextPosition = placeThreadContextMenu(
+      contextMenu.requestedPosition,
+      menuRect
+    );
+
+    if (
+      contextMenu.position?.x === nextPosition.x &&
+      contextMenu.position.y === nextPosition.y
+    ) {
+      return;
+    }
+
+    setContextMenu({
+      ...contextMenu,
+      position: nextPosition,
+    });
+  }, [contextMenu]);
+
+  useLayoutEffect(() => {
     if (!renameThread) {
       return;
     }
@@ -144,10 +181,10 @@ export function Sidebar(props: SidebarProps) {
 
   const openThreadContextMenu = (
     thread: NavigationThreadSummary,
-    position: { x: number; y: number }
+    position: ThreadContextMenuPosition
   ): void => {
     setRenameThread(undefined);
-    setContextMenu({ position, thread });
+    setContextMenu({ requestedPosition: position, thread });
   };
 
   const requestRenameFromContextMenu = (thread: NavigationThreadSummary): void => {
@@ -332,11 +369,13 @@ export function Sidebar(props: SidebarProps) {
 
       {contextMenu ? (
         <div
+          ref={contextMenuRef}
           className="thread-context-menu"
           role="menu"
           style={{
-            left: contextMenu.position.x,
-            top: contextMenu.position.y,
+            left: contextMenu.position?.x ?? contextMenu.requestedPosition.x,
+            top: contextMenu.position?.y ?? contextMenu.requestedPosition.y,
+            visibility: contextMenu.position ? undefined : "hidden",
           }}
           onClick={(event) => event.stopPropagation()}
         >
@@ -471,6 +510,34 @@ export function Sidebar(props: SidebarProps) {
 
     </aside>
   );
+}
+
+function placeThreadContextMenu(
+  requestedPosition: ThreadContextMenuPosition,
+  menuRect: DOMRect
+): { x: number; y: number } {
+  const viewportMargin = 8;
+  const triggerGap = 4;
+  const menuWidth = menuRect.width || 168;
+  const menuHeight = menuRect.height;
+  const maxX = window.innerWidth - menuWidth - viewportMargin;
+  const maxY = window.innerHeight - menuHeight - viewportMargin;
+
+  const belowTop = requestedPosition.y;
+  const wouldOverflowBottom =
+    menuHeight > 0 && belowTop + menuHeight + viewportMargin > window.innerHeight;
+  const flippedTop =
+    requestedPosition.anchorTop !== undefined
+      ? requestedPosition.anchorTop - menuHeight - triggerGap
+      : requestedPosition.y - menuHeight - triggerGap;
+
+  return {
+    x: Math.max(viewportMargin, Math.min(requestedPosition.x, maxX)),
+    y: Math.max(
+      viewportMargin,
+      Math.min(wouldOverflowBottom ? flippedTop : belowTop, maxY)
+    ),
+  };
 }
 
 function RuntimeIdentityButton(props: {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -12,7 +12,7 @@ type ThreadRowProps = {
   thread: NavigationThreadSummary;
   onOpenContextMenu: (
     thread: NavigationThreadSummary,
-    position: { x: number; y: number }
+    position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onSelectThread: (thread: NavigationThreadSummary) => void;
 };
@@ -72,6 +72,7 @@ export function ThreadRow(props: ThreadRowProps) {
           props.onOpenContextMenu(props.thread, {
             x: rect.left,
             y: rect.bottom + 4,
+            anchorTop: rect.top,
           });
         }}
       >

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -128,6 +128,7 @@ const directories: NavigationDirectorySummary[] = [
 ];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   cleanup();
 });
 
@@ -429,6 +430,85 @@ describe("Sidebar", () => {
       "Copy Local Path",
       "Copy Branch Name",
     ]);
+  });
+
+  it("flips the thread actions menu above the overflow button near the viewport bottom", () => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 600,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 640,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains("thread-context-menu")) {
+          return {
+            bottom: 680,
+            height: 150,
+            left: 420,
+            right: 588,
+            top: 530,
+            width: 168,
+            x: 420,
+            y: 530,
+            toJSON: () => ({}),
+          };
+        }
+        if (this.getAttribute("aria-label") === "Open thread actions") {
+          return {
+            bottom: 530,
+            height: 26,
+            left: 420,
+            right: 450,
+            top: 500,
+            width: 30,
+            x: 420,
+            y: 500,
+            toJSON: () => ({}),
+          };
+        }
+        return {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      }
+    );
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onArchiveThread={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+
+    expect(screen.getByRole("menu")).toHaveStyle({
+      left: "420px",
+      top: "346px",
+    });
   });
 
   it("copies thread context menu values", () => {


### PR DESCRIPTION
## Summary

This fixes thread action menu placement when the three-dots trigger is near the bottom edge of the desktop window. The menu now measures itself, flips above the trigger when opening downward would overflow the viewport, and clamps within the visible window.

## Changes

- Added measured placement for the thread context menu in the desktop sidebar.
- Passed the overflow button's top edge as an anchor so bottom-edge menus can open above the trigger.
- Added a renderer regression test for the bottom-of-viewport placement case.

## Verification

- I ran `pnpm --filter @pwragnt/desktop typecheck`.
- I ran `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
