### PR TITLE
fix(desktop): Match Codex review transcript handling

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1988,8 +1988,8 @@ describe("CodexAppServerClient", () => {
               },
               {
                 type: "userMessage",
-                id: "hidden-custom-review-prompt",
-                message: "Use the local review instructions from the prompt file.",
+                id: "visible-review-steer",
+                message: "Also check the desktop renderer path.",
               },
               {
                 type: "response_item",
@@ -2048,6 +2048,14 @@ describe("CodexAppServerClient", () => {
         turn,
       },
       {
+        type: "message",
+        id: "visible-review-steer",
+        role: "user",
+        text: "Also check the desktop renderer path.",
+        createdAt: 1_763_509_850_000,
+        turn,
+      },
+      {
         type: "review",
         id: "exited-review",
         review: reviewOutput.overall_explanation,
@@ -2056,7 +2064,13 @@ describe("CodexAppServerClient", () => {
         turn,
       },
     ]);
-    expect(replay.messages).toEqual([]);
+    expect(replay.messages).toEqual([
+      expect.objectContaining({
+        id: "visible-review-steer",
+        role: "user",
+        text: "Also check the desktop renderer path.",
+      }),
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1987,6 +1987,11 @@ describe("CodexAppServerClient", () => {
                 },
               },
               {
+                type: "userMessage",
+                id: "hidden-custom-review-prompt",
+                message: "Use the local review instructions from the prompt file.",
+              },
+              {
                 type: "response_item",
                 id: "review-action",
                 payload: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -996,10 +996,6 @@ function shouldSuppressConversationMessage(
   );
 }
 
-function containsReviewModeEvent(items: Record<string, unknown>[]): boolean {
-  return items.some((item) => Boolean(normalizeReviewEventItem(item)));
-}
-
 function normalizeRenderableImageUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -1115,9 +1111,9 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
   const output: AppServerThreadReplay["messages"] = [];
   const suppressedAssistantTexts = collectReviewSuppressionTexts(value);
 
-  const visit = (node: unknown, insideReviewTurn = false): void => {
+  const visit = (node: unknown): void => {
     if (Array.isArray(node)) {
-      node.forEach((entry) => visit(entry, insideReviewTurn));
+      node.forEach((entry) => visit(entry));
       return;
     }
 
@@ -1126,13 +1122,6 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       return;
     }
 
-    const childItems = Array.isArray(record.items)
-      ? record.items
-          .map((entry) => asRecord(entry))
-          .filter((entry): entry is Record<string, unknown> => entry !== null)
-      : [];
-    const childrenInsideReviewTurn =
-      insideReviewTurn || containsReviewModeEvent(childItems);
     const role = normalizeConversationRole(
       pickString(record, ["role", "author", "speaker", "source", "type"])
     );
@@ -1140,7 +1129,6 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
     if (
       role &&
       (content.text || content.parts?.length) &&
-      !(insideReviewTurn && role === "user") &&
       !shouldSuppressConversationMessage(record, suppressedAssistantTexts)
     ) {
       output.push({
@@ -1172,7 +1160,7 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       "response",
       "result"
     ]) {
-      visit(record[key], childrenInsideReviewTurn);
+      visit(record[key]);
     }
   };
 
@@ -2154,7 +2142,6 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
           .map((entry) => asRecord(entry))
           .filter((entry): entry is Record<string, unknown> => entry !== null)
       : [];
-    const turnHasReviewMode = containsReviewModeEvent(rawItems);
     const suppressedAssistantTexts = collectReviewSuppressionTexts(rawItems);
     const pendingActivityItems: Record<string, unknown>[] = [];
 
@@ -2175,10 +2162,7 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       const role = normalizeConversationRole(itemType);
       if (role) {
         flushActivityItems();
-        if (
-          (turnHasReviewMode && role === "user") ||
-          shouldSuppressConversationMessage(item, suppressedAssistantTexts)
-        ) {
+        if (shouldSuppressConversationMessage(item, suppressedAssistantTexts)) {
           continue;
         }
         const content = buildMessageContent(item);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -996,6 +996,10 @@ function shouldSuppressConversationMessage(
   );
 }
 
+function containsReviewModeEvent(items: Record<string, unknown>[]): boolean {
+  return items.some((item) => Boolean(normalizeReviewEventItem(item)));
+}
+
 function normalizeRenderableImageUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -1111,9 +1115,9 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
   const output: AppServerThreadReplay["messages"] = [];
   const suppressedAssistantTexts = collectReviewSuppressionTexts(value);
 
-  const visit = (node: unknown): void => {
+  const visit = (node: unknown, insideReviewTurn = false): void => {
     if (Array.isArray(node)) {
-      node.forEach((entry) => visit(entry));
+      node.forEach((entry) => visit(entry, insideReviewTurn));
       return;
     }
 
@@ -1122,6 +1126,13 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       return;
     }
 
+    const childItems = Array.isArray(record.items)
+      ? record.items
+          .map((entry) => asRecord(entry))
+          .filter((entry): entry is Record<string, unknown> => entry !== null)
+      : [];
+    const childrenInsideReviewTurn =
+      insideReviewTurn || containsReviewModeEvent(childItems);
     const role = normalizeConversationRole(
       pickString(record, ["role", "author", "speaker", "source", "type"])
     );
@@ -1129,6 +1140,7 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
     if (
       role &&
       (content.text || content.parts?.length) &&
+      !(insideReviewTurn && role === "user") &&
       !shouldSuppressConversationMessage(record, suppressedAssistantTexts)
     ) {
       output.push({
@@ -1160,7 +1172,7 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       "response",
       "result"
     ]) {
-      visit(record[key]);
+      visit(record[key], childrenInsideReviewTurn);
     }
   };
 
@@ -2142,6 +2154,7 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
           .map((entry) => asRecord(entry))
           .filter((entry): entry is Record<string, unknown> => entry !== null)
       : [];
+    const turnHasReviewMode = containsReviewModeEvent(rawItems);
     const suppressedAssistantTexts = collectReviewSuppressionTexts(rawItems);
     const pendingActivityItems: Record<string, unknown>[] = [];
 
@@ -2162,7 +2175,10 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       const role = normalizeConversationRole(itemType);
       if (role) {
         flushActivityItems();
-        if (shouldSuppressConversationMessage(item, suppressedAssistantTexts)) {
+        if (
+          (turnHasReviewMode && role === "user") ||
+          shouldSuppressConversationMessage(item, suppressedAssistantTexts)
+        ) {
           continue;
         }
         const content = buildMessageContent(item);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -134,6 +134,7 @@ export function App() {
               : undefined
           }
           onLoadOlder={session.loadOlder}
+          onLiveTranscriptEntry={session.upsertLiveTranscriptEntry}
           onMaterializeLaunchpad={navigation.materializeDirectoryLaunchpad}
           onPendingStatusChange={session.setPendingStatusText}
           onRefreshNavigation={navigation.refresh}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
@@ -1116,6 +1116,7 @@ type ThreadViewProps = {
   onEnsureSkillsLoaded?: () => void | Promise<void>;
   onLoadOlder: () => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
+  onLiveTranscriptEntry?: (entry: AppServerThreadEntry) => void;
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: AppServerTurnInputItem[],
@@ -1367,6 +1368,17 @@ export function ThreadView(props: ThreadViewProps) {
     };
   }, [props.desktopApi, selectedLaunchpad, selectedThreadKey]);
 
+  const publishLiveTranscriptEntry = useCallback(<T extends AppServerThreadEntry,>(entry: T): T => {
+    props.onLiveTranscriptEntry?.(entry);
+    return entry;
+  }, [props.onLiveTranscriptEntry]);
+
+  const liveNotificationTurnId = useCallback(
+    (notificationTurnId?: string): string | undefined =>
+      props.activeTurnId ?? notificationTurnId,
+    [props.activeTurnId]
+  );
+
   useEffect(() => {
     if (!pendingActivityEntry) {
       return;
@@ -1479,19 +1491,48 @@ export function ThreadView(props: ThreadViewProps) {
         const turn = buildCompletedLiveTurnMetadata({
           activeTurnStartedAt: props.activeTurnStartedAt,
           fallbackTurnId:
-            typeof event.notification.params.turnId === "string"
+            props.activeTurnId ??
+            (typeof event.notification.params.turnId === "string"
               ? event.notification.params.turnId
-              : props.activeTurnId,
+              : undefined),
           turn: completedTurnRecord,
         });
-        if (turn) {
+        const liveTurn =
+          turn && props.activeTurnId && turn.id !== props.activeTurnId
+            ? { ...turn, id: props.activeTurnId }
+            : turn;
+        if (liveTurn) {
           const completeEntryTurn = <T extends { turn?: AppServerThreadTurnMetadata }>(
             entry: T | undefined
-          ): T | undefined => (entry ? { ...entry, turn } : undefined);
-          setPendingActivityEntry((current) => completeEntryTurn(current));
-          setPendingToolActivityEntry((current) => completeEntryTurn(current));
-          setPendingProtocolActivityEntry((current) => completeEntryTurn(current));
-          setPendingPlanEntry((current) => completeEntryTurn(current));
+          ): T | undefined => (entry ? { ...entry, turn: liveTurn } : undefined);
+          setPendingActivityEntry((current) => {
+            const next = completeEntryTurn(current);
+            if (next) {
+              publishLiveTranscriptEntry(next);
+            }
+            return next;
+          });
+          setPendingToolActivityEntry((current) => {
+            const next = completeEntryTurn(current);
+            if (next) {
+              publishLiveTranscriptEntry(next);
+            }
+            return next;
+          });
+          setPendingProtocolActivityEntry((current) => {
+            const next = completeEntryTurn(current);
+            if (next) {
+              publishLiveTranscriptEntry(next);
+            }
+            return next;
+          });
+          setPendingPlanEntry((current) => {
+            const next = completeEntryTurn(current);
+            if (next) {
+              publishLiveTranscriptEntry(next);
+            }
+            return next;
+          });
         }
         return;
       }
@@ -1527,9 +1568,11 @@ export function ThreadView(props: ThreadViewProps) {
             }`,
             turn: buildLiveTurnMetadata({
               turnId:
-                typeof event.notification.params.turnId === "string"
-                  ? event.notification.params.turnId
-                  : props.activeTurnId,
+                liveNotificationTurnId(
+                  typeof event.notification.params.turnId === "string"
+                    ? event.notification.params.turnId
+                    : undefined
+                ),
               activeTurnStartedAt: props.activeTurnStartedAt,
             }),
           })
@@ -1543,9 +1586,11 @@ export function ThreadView(props: ThreadViewProps) {
         }
 
         const turnId =
-          typeof event.notification.params.turnId === "string"
-            ? event.notification.params.turnId
-            : props.activeTurnId ?? selectedThread.id;
+          liveNotificationTurnId(
+            typeof event.notification.params.turnId === "string"
+              ? event.notification.params.turnId
+              : undefined
+          ) ?? selectedThread.id;
         setPendingProtocolActivityEntry(
           buildFileChangeOutputEntry({
             delta: event.notification.params.delta,
@@ -1565,9 +1610,9 @@ export function ThreadView(props: ThreadViewProps) {
         const details = item ? buildLiveToolDetails(item) : [];
         if (details.length > 0) {
           const turnId =
-            typeof params.turnId === "string"
-              ? params.turnId
-              : props.activeTurnId ?? selectedThread.id;
+            liveNotificationTurnId(
+              typeof params.turnId === "string" ? params.turnId : undefined
+            ) ?? selectedThread.id;
           const turn = buildLiveTurnMetadata({
             turnId,
             activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1595,9 +1640,9 @@ export function ThreadView(props: ThreadViewProps) {
         if (detail) {
           const params = event.notification.params as Record<string, unknown>;
           const turnId =
-            typeof params.turnId === "string"
-              ? params.turnId
-              : props.activeTurnId ?? selectedThread.id;
+            liveNotificationTurnId(
+              typeof params.turnId === "string" ? params.turnId : undefined
+            ) ?? selectedThread.id;
           const turn = buildLiveTurnMetadata({
             turnId,
             activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1631,9 +1676,9 @@ export function ThreadView(props: ThreadViewProps) {
         }
 
         const turnId =
-          typeof params.turnId === "string"
-            ? params.turnId
-            : props.activeTurnId ?? selectedThread.id;
+          liveNotificationTurnId(
+            typeof params.turnId === "string" ? params.turnId : undefined
+          ) ?? selectedThread.id;
         const turn = buildLiveTurnMetadata({
           turnId,
           activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1658,7 +1703,9 @@ export function ThreadView(props: ThreadViewProps) {
 
         const itemId = getPlanNotificationItemId(params);
         const turnId =
-          getPlanNotificationTurnId(params) ?? props.activeTurnId ?? itemId ?? selectedThread.id;
+          liveNotificationTurnId(getPlanNotificationTurnId(params)) ??
+          itemId ??
+          selectedThread.id;
         const turn = buildLiveTurnMetadata({
           turnId,
           activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1681,8 +1728,7 @@ export function ThreadView(props: ThreadViewProps) {
         if (markdown) {
           const itemId = getPlanNotificationItemId(params);
           const turnId =
-            getPlanNotificationTurnId(params) ??
-            props.activeTurnId ??
+            liveNotificationTurnId(getPlanNotificationTurnId(params)) ??
             itemId ??
             selectedThread.id;
           const turn = buildLiveTurnMetadata({
@@ -1705,9 +1751,9 @@ export function ThreadView(props: ThreadViewProps) {
         const details = item ? buildLiveToolDetails(item) : [];
         if (details.length > 0) {
           const turnId =
-            typeof params.turnId === "string"
-              ? params.turnId
-              : props.activeTurnId ?? selectedThread.id;
+            liveNotificationTurnId(
+              typeof params.turnId === "string" ? params.turnId : undefined
+            ) ?? selectedThread.id;
           const turn = buildLiveTurnMetadata({
             turnId,
             activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1752,9 +1798,11 @@ export function ThreadView(props: ThreadViewProps) {
       const steps = normalizeLivePlanSteps(planRecord.steps);
 
       const turnId =
-        typeof event.notification.params.turnId === "string"
-          ? event.notification.params.turnId
-          : props.activeTurnId ?? selectedThread.id;
+        liveNotificationTurnId(
+          typeof event.notification.params.turnId === "string"
+            ? event.notification.params.turnId
+            : undefined
+        ) ?? selectedThread.id;
       const turn = buildLiveTurnMetadata({
         turnId,
         activeTurnStartedAt: props.activeTurnStartedAt,
@@ -1773,6 +1821,8 @@ export function ThreadView(props: ThreadViewProps) {
     props.activeTurnId,
     props.activeTurnStartedAt,
     props.desktopApi,
+    liveNotificationTurnId,
+    publishLiveTranscriptEntry,
     selectedThread,
   ]);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1662,9 +1662,11 @@ describe("ThreadView", () => {
           notification: AppServerNotification;
         }) => void)
       | undefined;
+    const onLiveTranscriptEntry = vi.fn();
 
     render(
       <ThreadView
+        activeTurnId="review-turn"
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
           {
@@ -1723,6 +1725,7 @@ describe("ThreadView", () => {
         ]}
         clearPendingRequest={() => undefined}
         onLoadOlder={async () => undefined}
+        onLiveTranscriptEntry={onLiveTranscriptEntry}
         removeOptimisticMessage={(_id) => undefined}
       />
     );
@@ -1734,7 +1737,7 @@ describe("ThreadView", () => {
           method: "item/started",
           params: {
             threadId: "thread-2",
-            turnId: "turn-1",
+            turnId: "review-mode-turn",
             item: {
               id: "cmd-1",
               type: "commandExecution",
@@ -1756,7 +1759,7 @@ describe("ThreadView", () => {
           method: "item/commandExecution/outputDelta",
           params: {
             threadId: "thread-2",
-            turnId: "turn-1",
+            turnId: "review-mode-turn",
             itemId: "cmd-1",
             delta: "## main\n",
           },
@@ -1774,7 +1777,7 @@ describe("ThreadView", () => {
           method: "item/completed",
           params: {
             threadId: "thread-2",
-            turnId: "turn-1",
+            turnId: "review-mode-turn",
             item: {
               id: "cmd-1",
               type: "commandExecution",
@@ -1802,6 +1805,35 @@ describe("ThreadView", () => {
         ) ?? false
       ).length
     ).toBeGreaterThan(0);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-2",
+            turnId: "review-mode-turn",
+            turn: {
+              id: "review-mode-turn",
+              status: "completed",
+              durationMs: 5_000,
+            },
+          },
+        } as AppServerNotification,
+      });
+    });
+
+    expect(onLiveTranscriptEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "live-tools-review-turn",
+        type: "activity",
+        turn: expect.objectContaining({
+          id: "review-turn",
+          status: "completed",
+        }),
+      })
+    );
   });
 
   it("renders live Codex tool names when command execution items lack a command string", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { AppServerThreadActivityEntry } from "@pwragnt/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -157,6 +158,181 @@ describe("useThreadSessionState", () => {
       "user:Please fix transcript ordering.",
       "assistant:Transcript ordering is fixed.",
     ]);
+  });
+
+  it("keeps live protocol activity before hydrated review output after completion", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Review the branch.",
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Review the branch.",
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Review the branch.",
+              },
+              {
+                type: "review" as const,
+                id: "review-result",
+                review: "Review finding.",
+                turn: {
+                  id: "review-turn",
+                  status: "completed" as const,
+                  durationMs: 211_000,
+                },
+              },
+            ],
+            messages: [
+              {
+                id: `${threadId}-message-1`,
+                role: "user" as const,
+                text: "Review the branch.",
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+
+    const liveActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-tools-review-turn",
+      createdAt: 1_100,
+      summary: "Used 2 tools",
+      status: "in_progress",
+      details: [
+        {
+          id: "cmd-1",
+          kind: "read",
+          label: "Read SKILL.md",
+          status: "completed",
+        },
+      ],
+      turn: {
+        id: "review-turn",
+        status: "in_progress",
+        startedAt: 1_050,
+      },
+    };
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(liveActivity);
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "review-turn",
+            turn: {
+              id: "review-turn",
+              status: "completed",
+              output: [],
+              durationMs: 211_000,
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "thread-1-message-1",
+        "live-tools-review-turn",
+        "review-result",
+      ]);
+    });
+    expect(result.current.entries[1]).toMatchObject({
+      type: "activity",
+      summary: "Used 2 tools",
+      turn: {
+        id: "review-turn",
+        status: "completed",
+        durationMs: 211_000,
+      },
+    });
   });
 
   it("materializes a new thread in user-then-assistant order on completion", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -130,6 +130,52 @@ function mergeItems<T extends { id: string }>(olderItems: T[], newerItems: T[]):
   return [...deduped.values()];
 }
 
+function isTerminalTurnEntry(entry: AppServerThreadEntry): boolean {
+  if (entry.type === "review") {
+    return true;
+  }
+
+  return (
+    entry.type === "message" &&
+    entry.role === "assistant" &&
+    entry.phase === "final"
+  );
+}
+
+function mergeTranscriptEntries(
+  responseEntries: AppServerThreadEntry[],
+  optimisticEntries: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  const merged = [...responseEntries];
+
+  for (const optimisticEntry of optimisticEntries) {
+    const existingIndex = merged.findIndex((entry) => entry.id === optimisticEntry.id);
+    if (existingIndex !== -1) {
+      merged[existingIndex] = optimisticEntry;
+      continue;
+    }
+
+    const optimisticTurnId = optimisticEntry.turn?.id;
+    const shouldInsertBeforeTerminal =
+      Boolean(optimisticTurnId) && optimisticEntry.type !== "message";
+    const terminalIndex = shouldInsertBeforeTerminal
+      ? merged.findIndex(
+          (entry) =>
+            entry.turn?.id === optimisticTurnId && isTerminalTurnEntry(entry)
+        )
+      : -1;
+
+    if (terminalIndex !== -1) {
+      merged.splice(terminalIndex, 0, optimisticEntry);
+      continue;
+    }
+
+    merged.push(optimisticEntry);
+  }
+
+  return merged;
+}
+
 function buildEmptyResponse(params: {
   backend: NavigationThreadSummary["source"];
   threadId: NavigationThreadSummary["id"];
@@ -850,6 +896,7 @@ export function useThreadSessionState(params: {
   removeOptimisticMessage: (id: string) => void;
   response?: AppServerReadThreadResponse;
   setActiveTurnId: (turnId?: string) => void;
+  upsertLiveTranscriptEntry: (entry: AppServerThreadEntry) => void;
   updatePendingUserInput: (
     requestId: string,
     updater: (state: PendingQuestionnaireState) => PendingQuestionnaireState
@@ -1406,6 +1453,13 @@ export function useThreadSessionState(params: {
               pendingUserInput: undefined,
               response: nextResponse,
             });
+          const remainingOptimisticEntries = current.optimisticEntries
+            .filter((entry) => entry.type !== "message")
+            .map((entry) =>
+              entry.turn?.id === completedTurn?.id && completedTurn
+                ? { ...entry, turn: completedTurn }
+                : entry
+            );
 
           return {
             ...current,
@@ -1424,7 +1478,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion:
               !completedText || shouldHydrateUnknownPhaseAssistant,
-            optimisticEntries: [],
+            optimisticEntries: remainingOptimisticEntries,
             pendingAssistantMessage: undefined,
             pendingMcpInteraction: undefined,
             pendingRequest: undefined,
@@ -1678,6 +1732,23 @@ export function useThreadSessionState(params: {
     [thread, threadKey, updateSession]
   );
 
+  const upsertLiveTranscriptEntry = useCallback(
+    (entry: AppServerThreadEntry): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      updateSession(threadKey, (current) => ({
+        ...current,
+        expectOwnUpdate: true,
+        interacted: true,
+        lastTouchedAt: Date.now(),
+        optimisticEntries: mergeItems(current.optimisticEntries, [entry]),
+      }));
+    },
+    [threadKey, updateSession]
+  );
+
   const setPendingStatusText = useCallback(
     (status?: string): void => {
       if (!threadKey) {
@@ -1831,7 +1902,7 @@ export function useThreadSessionState(params: {
 
   const entries = useMemo(
     () => {
-      const mergedEntries = mergeItems(
+      const mergedEntries = mergeTranscriptEntries(
         selectedSession?.response?.replay.entries ?? [],
         visibleOptimisticEntries
       );
@@ -1903,6 +1974,7 @@ export function useThreadSessionState(params: {
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveTurnId,
+    upsertLiveTranscriptEntry,
     updatePendingUserInput,
     updatePendingMcpInteraction,
     setPendingStatusText,


### PR DESCRIPTION
## Summary
- Match Codex TUI review transcript behavior by suppressing only generated/internal review prompts while preserving real user steers.
- Preserve live notification-derived tool/file activity after turn completion and keep it ordered before same-turn final/review output when a thread is reselected.
- Add regression coverage for review replay suppression, live activity persistence, and review-mode turn id normalization.

## Verification
- pnpm test -- apps/desktop/src/main/__tests__/codex-client.test.ts --testNamePattern "review"
- pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
- pnpm --filter @pwragnt/desktop typecheck
- pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer

## CI
- GitHub Actions CI is green on the current branch head.
