### PR TITLE
fix(desktop): remove worktrees when archive repository path is the worktree

### DIFF
--- a/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
+++ b/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, stat, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, stat, writeFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -91,5 +91,31 @@ describe("WorktreeArchiveService", () => {
       false,
     );
     expect(await git(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+  });
+
+  it("resolves the primary repository when the repository path points at the worktree", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragnt-worktree-archive-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "repo-feature");
+    await mkdir(repoPath);
+    await git(repoPath, ["init", "-b", "main"]);
+    await git(repoPath, ["config", "user.email", "test@example.com"]);
+    await git(repoPath, ["config", "user.name", "Test User"]);
+    await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+    await git(repoPath, ["add", "."]);
+    await git(repoPath, ["commit", "-m", "initial"]);
+    await git(repoPath, ["worktree", "add", "--detach", worktreePath, "main"]);
+
+    const service = new WorktreeArchiveService();
+    const snapshot = await service.archive({
+      backend: "codex",
+      threadId: "thread-1",
+      repositoryPath: worktreePath,
+      worktreePath,
+      now: 1000,
+    });
+
+    expect(snapshot.repositoryPath).toBe(await realpath(repoPath));
+    expect(await pathExists(worktreePath)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -137,11 +137,14 @@ function findWorktree(
 export class WorktreeArchiveService {
   async archive(params: ArchiveWorktreeParams): Promise<WorktreeSnapshotSummary> {
     const worktreePath = await realpath(path.resolve(params.worktreePath));
-    const repositoryPath =
-      params.repositoryPath
-        ? await realpath(path.resolve(params.repositoryPath))
-        : await this.readRepositoryPath(worktreePath);
-    const worktrees = await this.listWorktrees(repositoryPath);
+    const worktreeListPath = params.repositoryPath
+      ? await realpath(path.resolve(params.repositoryPath))
+      : worktreePath;
+    const worktrees = await this.listWorktrees(worktreeListPath);
+    const repositoryPath = await this.resolvePrimaryRepositoryPath({
+      worktreeListPath,
+      worktrees,
+    });
     const worktree = findWorktree(worktrees, worktreePath);
 
     if (!worktree) {
@@ -270,14 +273,16 @@ export class WorktreeArchiveService {
     }
   }
 
-  private async readRepositoryPath(worktreePath: string): Promise<string> {
-    const output = await runGit(worktreePath, ["worktree", "list", "--porcelain"]);
-    const worktrees = parseWorktreeList(output.stdout);
-    const primary = worktrees[0]?.path;
+  private async resolvePrimaryRepositoryPath(params: {
+    worktreeListPath: string;
+    worktrees: WorktreeInfo[];
+  }): Promise<string> {
+    const primary = params.worktrees[0]?.path;
     if (!primary) {
-      throw new Error(`Unable to resolve repository root for ${worktreePath}.`);
+      throw new Error(`Unable to resolve repository root for ${params.worktreeListPath}.`);
     }
-    return primary;
+
+    return await realpath(path.resolve(primary));
   }
 
   private async listWorktrees(repositoryPath: string): Promise<WorktreeInfo[]> {


### PR DESCRIPTION
## Summary

I fixed thread/worktree archiving when the archive caller passes the linked worktree path as `repositoryPath`. The archive service now resolves the true primary checkout from `git worktree list --porcelain` before updating snapshot refs or removing the target worktree, so it no longer mistakes the target worktree for the primary checkout and skips cleanup.

## Testing

- `pnpm test apps/desktop/src/main/__tests__/worktree-archive-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`

## Notes

- I also ran the full `pnpm test`; one renderer test failed once in the full suite but passed when rerun directly, so I treated it as an existing order/global-state flake outside this archive path.
