### PR TITLE
fix(desktop): clarify worktree indicators

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -148,6 +148,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         key={`${directory.key}:${buildThreadIdentityKey(thread.source, thread.id)}`}
                         approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                         compact
+                        includeLinkedDirectories
+                        linkedDirectoryMode="kind"
                         selectedThreadKey={props.selectedItemKey}
                         thinkingThreadKeys={props.thinkingThreadKeys}
                         thread={thread}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -227,10 +227,14 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanArchive = contextMenu
     ? canArchiveThread(contextMenu.thread)
     : false;
-  const contextMenuLocalPath = contextMenu?.thread.linkedDirectories[0]?.path;
+  const contextMenuLocalPath = contextMenu?.thread.linkedDirectories.find(
+    (directory) => directory.kind === "local"
+  )?.path;
   const contextMenuWorktreePath = contextMenu?.thread.linkedDirectories.find(
-    (directory) => directory.kind === "worktree" && directory.worktreePath
-  )?.worktreePath;
+    (directory) => directory.kind === "worktree"
+  );
+  const contextMenuWorktreeCopyPath =
+    contextMenuWorktreePath?.worktreePath ?? contextMenuWorktreePath?.path;
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
   const contextMenuHasTopActions = contextMenuCanRename || contextMenuCanArchive;
 
@@ -412,11 +416,11 @@ export function Sidebar(props: SidebarProps) {
             >
               Copy Thread ID
             </button>
-            {contextMenuWorktreePath ? (
+            {contextMenuWorktreeCopyPath ? (
               <button
                 role="menuitem"
                 type="button"
-                onClick={() => copyFromContextMenu(contextMenuWorktreePath)}
+                onClick={() => copyFromContextMenu(contextMenuWorktreeCopyPath)}
               >
                 Copy Worktree Path
               </button>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,17 +1,18 @@
 import type { NavigationThreadSummary } from "@pwragnt/shared";
-import { Fragment } from "react";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 
 type ThreadMetaChipsProps = {
   hasApprovalRequest?: boolean;
   includeLinkedDirectories?: boolean;
+  linkedDirectoryMode?: "label" | "kind";
   thread: NavigationThreadSummary;
 };
 
 export function ThreadMetaChips({
   hasApprovalRequest = false,
   includeLinkedDirectories = false,
+  linkedDirectoryMode = "label",
   thread,
 }: ThreadMetaChipsProps) {
   const branchDrifted =
@@ -20,65 +21,95 @@ export function ThreadMetaChips({
     thread.observedGitBranch !== thread.gitBranch;
   const linkedDirectoryChips = includeLinkedDirectories
     ? thread.linkedDirectories.length > 0
-      ? thread.linkedDirectories.flatMap((directory) => [
-          (
-            <span
-              aria-label={`Copy path for ${directory.label}`}
-              key={`${thread.id}:${directory.id}:root`}
-              className="thread-row__chip path-copy-target tooltip-target"
-              role="button"
-              tabIndex={0}
-              data-tooltip={formatCopyTooltip(directory.path)}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                void copyText(directory.path);
-              }}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") {
-                  return;
-                }
+      ? linkedDirectoryMode === "kind"
+        ? [
+            ...new Map(
+              thread.linkedDirectories.map((directory) => [
+                directory.kind,
+                (
+                  <span
+                    aria-label={
+                      directory.kind === "worktree"
+                        ? `Copy path for worktree ${directory.label}`
+                        : `Copy local path for ${directory.label}`
+                    }
+                    key={`${thread.id}:${directory.kind}:location-kind`}
+                    className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+                    role="button"
+                    tabIndex={0}
+                    data-tooltip={formatCopyTooltip(
+                      directory.kind === "worktree"
+                        ? directory.worktreePath ?? directory.path
+                        : directory.path
+                    )}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      void copyText(
+                        directory.kind === "worktree"
+                          ? directory.worktreePath ?? directory.path
+                          : directory.path
+                      );
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") {
+                        return;
+                      }
 
-                event.preventDefault();
-                event.stopPropagation();
-                void copyText(directory.path);
-              }}
-            >
-              <span aria-hidden="true" className="thread-row__chip-icon">
-                {directory.worktreePath ? "🔀" : "📁"}
+                      event.preventDefault();
+                      event.stopPropagation();
+                      void copyText(
+                        directory.kind === "worktree"
+                          ? directory.worktreePath ?? directory.path
+                          : directory.path
+                      );
+                    }}
+                  >
+                    {directory.kind}
+                  </span>
+                ),
+              ]),
+            ).values(),
+          ]
+        : thread.linkedDirectories.map((directory) => {
+            const copyPath =
+              directory.kind === "worktree"
+                ? directory.worktreePath ?? directory.path
+                : directory.path;
+            return (
+              <span
+                aria-label={
+                  directory.kind === "worktree"
+                    ? `Copy path for worktree ${directory.label}`
+                    : `Copy path for ${directory.label}`
+                }
+                key={`${thread.id}:${directory.id}:root`}
+                className="thread-row__chip path-copy-target tooltip-target"
+                role="button"
+                tabIndex={0}
+                data-tooltip={formatCopyTooltip(copyPath)}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void copyText(copyPath);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void copyText(copyPath);
+                }}
+              >
+                <span aria-hidden="true" className="thread-row__chip-icon">
+                  {directory.kind === "worktree" ? "🔀" : "📁"}
+                </span>
+                {directory.label}
               </span>
-              {directory.label}
-            </span>
-          ),
-          directory.worktreePath ? (
-            <span
-              aria-label={`Copy path for worktree ${directory.label}`}
-              key={`${thread.id}:${directory.id}:worktree`}
-              className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
-              role="button"
-              tabIndex={0}
-              data-tooltip={formatCopyTooltip(directory.worktreePath ?? directory.path)}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                void copyText(directory.worktreePath ?? directory.path);
-              }}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") {
-                  return;
-                }
-
-                event.preventDefault();
-                event.stopPropagation();
-                void copyText(directory.worktreePath ?? directory.path);
-              }}
-            >
-              worktree
-            </span>
-          ) : (
-            <Fragment key={`${thread.id}:${directory.id}:worktree`} />
-          ),
-        ])
+            );
+          })
       : (
           <span className="thread-row__chip thread-row__chip--muted">
             No linked directory

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -7,6 +7,7 @@ type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
   compact?: boolean;
   includeLinkedDirectories?: boolean;
+  linkedDirectoryMode?: "label" | "kind";
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   thread: NavigationThreadSummary;
@@ -56,6 +57,7 @@ export function ThreadRow(props: ThreadRowProps) {
         <ThreadMetaChips
           hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
           includeLinkedDirectories={props.includeLinkedDirectories}
+          linkedDirectoryMode={props.linkedDirectoryMode}
           thread={props.thread}
         />
       </button>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -172,6 +172,92 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);
   });
 
+  it("keeps recents to a single worktree indicator on the directory chip", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    expect(within(threadButton).getByLabelText("Copy path for worktree PwrAgnt")).toHaveTextContent(
+      "PwrAgnt"
+    );
+    expect(within(threadButton).queryByText("worktree")).not.toBeInTheDocument();
+  });
+
+  it("shows local versus worktree location chips in directory rows", () => {
+    const localThread = {
+      ...sharedThread,
+      id: "thread-local",
+      title: "Local cleanup",
+      linkedDirectories: [
+        {
+          id: "dir-a",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          kind: "local" as const,
+        },
+      ],
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[
+          {
+            ...directories[0],
+            threadKeys: ["codex:thread-1", "codex:thread-local"],
+          },
+        ]}
+        inboxThreads={[sharedThread, localThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread, localThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    fireEvent.click(
+      within(browseSection as HTMLElement).getByRole("button", { name: "PwrAgnt1" })
+    );
+    const worktreeThreadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+    const localThreadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Local cleanup/i,
+    });
+
+    expect(within(worktreeThreadButton).getByText("worktree")).toBeInTheDocument();
+    expect(within(worktreeThreadButton).queryByText("PwrAgnt")).not.toBeInTheDocument();
+    expect(within(localThreadButton).getByText("local")).toBeInTheDocument();
+  });
+
   it("opens the directory launchpad from the plus button", () => {
     const onOpenLaunchpad = vi.fn(async () => undefined);
 
@@ -427,7 +513,6 @@ describe("Sidebar", () => {
       "Archive Thread",
       "Copy Thread ID",
       "Copy Worktree Path",
-      "Copy Local Path",
       "Copy Branch Name",
     ]);
   });
@@ -552,10 +637,6 @@ describe("Sidebar", () => {
     cleanup();
 
     renderMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Local Path" }));
-    cleanup();
-
-    renderMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy Branch Name" }));
 
     expect(copyText).toHaveBeenNthCalledWith(1, "thread-1");
@@ -563,8 +644,7 @@ describe("Sidebar", () => {
       2,
       "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt"
     );
-    expect(copyText).toHaveBeenNthCalledWith(3, "/Users/huntharo/pwrdrvr/PwrAgnt");
-    expect(copyText).toHaveBeenNthCalledWith(4, "codex/thread-centric-ui");
+    expect(copyText).toHaveBeenNthCalledWith(3, "codex/thread-centric-ui");
   });
 
   it("hides optional copy actions without matching thread metadata", () => {
@@ -887,11 +967,9 @@ describe("Sidebar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy path for PwrAgnt" }));
     fireEvent.click(screen.getByRole("button", { name: "Copy path for worktree PwrAgnt" }));
 
-    expect(copyText).toHaveBeenCalledWith("/Users/huntharo/pwrdrvr/PwrAgnt");
-    expect(copyText).toHaveBeenNthCalledWith(2, "/Users/huntharo/.codex/worktrees/0f38/PwrAgnt");
+    expect(copyText).toHaveBeenCalledWith("/Users/huntharo/.codex/worktrees/0f38/PwrAgnt");
     expect(
       screen.queryByText("Line up the desktop shell with the app server")
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

I clarified worktree indicators in the desktop thread browser so Recents and Directories each show the useful signal without duplicating it.

## Changes

- Removed the duplicate `worktree` chip from Recents while keeping the worktree icon on the project chip.
- Added `worktree` / `local` location chips to thread rows in the Directories tab.
- Fixed worktree-backed copy actions so worktree rows copy the worktree path instead of presenting it as a local folder.
- Updated sidebar tests for the Recents and Directories indicator behavior.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
