### PR TITLE
feat(desktop): add experimental skill chip composers

### DIFF
--- a/apps/desktop/e2e/composer-draft-settings.spec.ts
+++ b/apps/desktop/e2e/composer-draft-settings.spec.ts
@@ -163,6 +163,7 @@ test("keeps a thread reply draft after opening settings and returning to the thr
   try {
     const draft = "$ce:plan keep this draft through settings";
     const reply = app.window.getByRole("textbox", { name: "Reply" });
+    const replyValue = app.window.getByTestId("composer-tiptap-input");
 
     await app.window
       .getByRole("button", { name: /Draft survives settings thread/i })
@@ -192,7 +193,7 @@ test("keeps a thread reply draft after opening settings and returning to the thr
       .getByRole("button", { name: /Draft survives settings thread/i })
       .first()
       .click();
-    await expect(reply).toHaveValue(draft);
+    await expect(replyValue).toHaveAttribute("data-value", draft);
 
     await app.window.getByRole("button", { name: "Open settings" }).click();
     await expect(
@@ -222,7 +223,7 @@ test("keeps a thread reply draft after opening settings and returning to the thr
         name: "Draft survives settings thread",
       }),
     ).toBeVisible();
-    await expect(reply).toHaveValue(draft);
+    await expect(replyValue).toHaveAttribute("data-value", draft);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
+++ b/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
@@ -23,18 +23,18 @@ test("shows linked directory path tooltips in the context rail", async () => {
       name: "Thread context",
     });
 
-    await contextRail.getByLabel("Path for PwrAgnt", { exact: true }).hover();
+    await contextRail.getByLabel("Path for PwrAgnt", { exact: true }).focus();
     await expectVisibleTooltip(app.window, "/repo/PwrAgnt");
 
     await contextRail
       .getByRole("button", { name: "Copy path for PwrAgnt", exact: true })
-      .hover();
+      .focus();
     await expectVisibleTooltip(
       app.window,
       "/repo/PwrAgnt\nClick to copy to clipboard"
     );
 
-    await contextRail.getByLabel("Path for worktree PwrAgnt", { exact: true }).hover();
+    await contextRail.getByLabel("Path for worktree PwrAgnt", { exact: true }).focus();
     await expectVisibleTooltip(
       app.window,
       "/repo/PwrAgnt/.worktrees/feature-context-tooltips"
@@ -42,18 +42,18 @@ test("shows linked directory path tooltips in the context rail", async () => {
 
     await contextRail
       .getByRole("button", { name: "Copy path for worktree PwrAgnt", exact: true })
-      .hover();
+      .focus();
     await expectVisibleTooltip(
       app.window,
       "/repo/PwrAgnt/.worktrees/feature-context-tooltips\nClick to copy to clipboard"
     );
 
-    await contextRail.getByLabel("Path for local LocalCheckout", { exact: true }).hover();
+    await contextRail.getByLabel("Path for local LocalCheckout", { exact: true }).focus();
     await expectVisibleTooltip(app.window, "/repo/PwrAgnt");
 
     await contextRail
       .getByRole("button", { name: "Copy path for local LocalCheckout", exact: true })
-      .hover();
+      .focus();
     await expectVisibleTooltip(
       app.window,
       "/repo/PwrAgnt\nClick to copy to clipboard"

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -250,6 +250,7 @@ async function typeSkillChip(
   await option.focus();
   await expect(option).toBeFocused();
   await app.window.keyboard.press("Enter");
+  await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeFocused();
 }
 
 test("directory launchpad loads skill autocomplete from user and local scope", async () => {
@@ -409,6 +410,212 @@ test("directory launchpad renders Tiptap composer when enabled and keeps skill a
   } finally {
     await app.close();
     await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap composer selects focused skills as undoable inline chips", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await app.window.keyboard.type("$front");
+
+    const option = app.window.getByRole("button", { name: /\$frontend-design/i });
+    await option.focus();
+    await expect(option).toBeFocused();
+    await app.window.keyboard.press("Enter");
+
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeHidden();
+    const chip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$frontend-design",
+    });
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute(
+      "data-tooltip",
+      /\/Users\/huntharo\/\.codex\/skills\/frontend-design\/SKILL\.md$/,
+    );
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+
+    await textbox.focus();
+    await app.window.keyboard.press("Backspace");
+    await expect(chip).toBeHidden();
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+Z" : "Control+Z",
+    );
+    await expect(chip).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap composer preserves multiple skill chips across boundary edits", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" i like cats n dogs - ");
+    await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
+    await app.window.keyboard.type(" and more");
+
+    const planChip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:plan",
+    });
+    const brainstormChip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:brainstorm",
+    });
+    await expect(planChip).toBeVisible();
+    await expect(brainstormChip).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      " i like cats n dogs -  and more",
+    );
+
+    const clickPoint = await tiptapInput.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const textNode = Array.from(
+        {
+          [Symbol.iterator]: function* () {
+            let node = walker.nextNode();
+            while (node) {
+              yield node;
+              node = walker.nextNode();
+            }
+          },
+        } as Iterable<Node>,
+      ).find((node) => node.nodeValue?.includes("i like cats n dogs"));
+      if (!textNode) {
+        throw new Error("Expected text between skill chips");
+      }
+
+      const offset = textNode.nodeValue?.indexOf("cats") ?? -1;
+      if (offset < 0) {
+        throw new Error("Expected target word in text node");
+      }
+
+      const range = document.createRange();
+      range.setStart(textNode, offset);
+      range.setEnd(textNode, offset + 1);
+      const rect = range.getBoundingClientRect();
+      return {
+        x: rect.left + 1,
+        y: rect.top + rect.height / 2,
+      };
+    });
+
+    await app.window.mouse.click(clickPoint.x, clickPoint.y);
+    await app.window.keyboard.type("big ");
+
+    await expect(planChip).toBeVisible();
+    await expect(brainstormChip).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      " i like big cats n dogs -  and more",
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap composer select all delete clears chips without renderer crash", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" i like cats n dogs - ");
+    await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
+    await app.window.keyboard.type(" and more");
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__mention", {
+        hasText: "$ce:brainstorm",
+      }),
+    ).toBeVisible();
+
+    await textbox.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+
+    await expect(tiptapInput.locator(".composer-tiptap-input__mention")).toHaveCount(0);
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+    await expect(app.window.locator("body")).not.toContainText("Renderer error");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap composer deletes a persisted skill chip with repeated backspace", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-tiptap-saved-"));
+  await seedPersistedDirectoryLaunchpad({
+    repoDir: fixture.repoDir,
+    stateRoot,
+  });
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      ...TIPTAP_COMPOSER_ENV,
+      PWRAGNT_STATE_ROOT: stateRoot,
+    },
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    const chip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:brainstorm",
+    });
+    await expect(chip).toBeVisible();
+
+    await textbox.focus();
+    await app.window.keyboard.press("Backspace");
+    await app.window.keyboard.press("Backspace");
+
+    await expect(chip).toBeHidden();
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+    await expect(app.window.locator("body")).not.toContainText("Renderer error");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+    await rm(stateRoot, { recursive: true, force: true });
   }
 });
 

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -345,9 +345,11 @@ test("directory launchpad skill autocomplete supports active keyboard selection"
 
     await app.window.keyboard.press("ArrowDown");
     const secondActiveOption = listbox.locator('[aria-selected="true"]');
+    await expect
+      .poll(async () => await secondActiveOption.getAttribute("id"))
+      .not.toBe(firstActiveOptionId);
     const secondActiveOptionId = await secondActiveOption.getAttribute("id");
     expect(secondActiveOptionId).toBeTruthy();
-    expect(secondActiveOptionId).not.toBe(firstActiveOptionId);
     const secondActiveSkillLabel = (
       (await secondActiveOption
         .locator(".composer__autocomplete-title")

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -197,7 +197,7 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
   }
 });
 
-test("directory launchpad skill autocomplete selects focused options as removable inline chips", async () => {
+test("directory launchpad skill autocomplete selects focused options as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -236,9 +236,14 @@ test("directory launchpad skill autocomplete selects focused options as removabl
       inputBox.y + inputBox.height,
     );
 
-    await chip.getByRole("button", { name: "Remove $frontend-design" }).click();
+    await richInput.focus();
+    await app.window.keyboard.press("Backspace");
     await expect(chip).toBeHidden();
-    await expect(textbox).toHaveValue("");
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+Z" : "Control+Z",
+    );
+    await expect(chip).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -608,19 +608,26 @@ test("directory launchpad skill chips stay text-sized and baseline aligned", asy
         (bottom, rect) => Math.max(bottom, rect.bottom),
         0,
       );
+      const surroundingTop = textRects.reduce(
+        (top, rect) => Math.min(top, rect.top),
+        Number.POSITIVE_INFINITY,
+      );
 
       return {
         chipHeight: chipRect.height,
         fontSize: textStyle.fontSize,
         labelBottom: labelRect.bottom,
         labelFontSize: labelStyle.fontSize,
+        labelTop: labelRect.top,
         surroundingBottom,
+        surroundingTop,
       };
     });
 
     expect(metrics.labelFontSize).toBe(metrics.fontSize);
+    expect(Math.abs(metrics.labelTop - metrics.surroundingTop)).toBeLessThanOrEqual(1);
     expect(Math.abs(metrics.labelBottom - metrics.surroundingBottom)).toBeLessThanOrEqual(
-      3,
+      1,
     );
     expect(metrics.chipHeight).toBeLessThanOrEqual(22);
   } finally {

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -522,6 +522,14 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
 
     await expect(tiptapInput.locator("h2", { hasText: "Heading" })).toBeVisible();
     await expect(tiptapInput).toHaveAttribute("data-value", "## Heading");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("plain text");
+    await expect(tiptapInput.locator("h2", { hasText: "plain text" })).toHaveCount(0);
+    await expect(tiptapInput.locator("p", { hasText: "plain text" })).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "## Heading\n\nplain text",
+    );
 
     await app.window.keyboard.press(
       process.platform === "darwin" ? "Meta+A" : "Control+A",
@@ -554,6 +562,21 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
       tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
     ).toBeVisible();
     await expect(tiptapInput).toHaveAttribute("data-value", "Before  after");
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await app.window.keyboard.type("Cats");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("## Later");
+
+    await expect(tiptapInput.locator("h2", { hasText: "Later" })).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "Cats\n\n\n\n## Later",
+    );
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -586,13 +586,25 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
     await expect(tiptapInput.locator("li", { hasText: "Some item" })).toBeVisible();
 
     await app.window.keyboard.press("Shift+Enter");
-    await app.window.keyboard.type("after list");
+    await app.window.keyboard.type("Second item");
 
-    await expect(tiptapInput.locator("li", { hasText: "after list" })).toHaveCount(0);
-    await expect(tiptapInput.locator("p", { hasText: "after list" })).toBeVisible();
+    await expect(tiptapInput.locator("li")).toHaveCount(2);
+    await expect(tiptapInput.locator("li", { hasText: "Second item" })).toBeVisible();
     await expect(tiptapInput).toHaveAttribute(
       "data-value",
-      "- Some item\n\nafter list",
+      "- Some item\n- Second item",
+    );
+
+    await app.window.keyboard.press("Alt+Enter");
+    await app.window.keyboard.type("continued");
+
+    await expect(tiptapInput.locator("li")).toHaveCount(2);
+    await expect(
+      tiptapInput.locator("li", { hasText: /Second item\s*continued/ }),
+    ).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "- Some item\n- Second item\ncontinued",
     );
   } finally {
     await app.close();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -141,6 +141,13 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
                     scope: "user",
                   },
                   {
+                    name: "ce:plan",
+                    description: "Transform requirements into implementation plans.",
+                    path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+                    enabled: true,
+                    scope: "user",
+                  },
+                  {
                     name: "desktop-e2e-fixture-seeding",
                     description: "Replay-backed desktop E2E fixtures.",
                     path: path.join(
@@ -226,6 +233,18 @@ async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElect
   ).toBeVisible();
 }
 
+async function typeSkillChip(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+  triggerText: string,
+  optionName: RegExp,
+) {
+  await app.window.keyboard.type(triggerText);
+  const option = app.window.getByRole("button", { name: optionName });
+  await option.focus();
+  await expect(option).toBeFocused();
+  await app.window.keyboard.press("Enter");
+}
+
 test("directory launchpad loads skill autocomplete from user and local scope", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
@@ -270,6 +289,75 @@ test("directory launchpad keyboard typing updates the rich input once", async ()
     await expect(
       app.window.getByRole("button", { name: /\$ce:brainstorm/i }),
     ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad preserves multiple skill chips across boundary edits", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" i like cats n dogs - ");
+    await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
+
+    const planChip = richInput.locator(".skill-chip", { hasText: "$ce:plan" });
+    const brainstormChip = richInput.locator(".skill-chip", {
+      hasText: "$ce:brainstorm",
+    });
+    await expect(planChip).toBeVisible();
+    await expect(brainstormChip).toBeVisible();
+
+    await app.window.keyboard.type(" and more");
+    await expect(planChip).toBeVisible();
+    await expect(brainstormChip).toBeVisible();
+    await expect(richInput).toHaveAttribute(
+      "data-value",
+      " i like cats n dogs -  and more",
+    );
+
+    await richInput.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const textNode = Array.from(
+        {
+          [Symbol.iterator]: function* () {
+            let node = walker.nextNode();
+            while (node) {
+              yield node;
+              node = walker.nextNode();
+            }
+          },
+        } as Iterable<Node>,
+      ).find((node) => node.nodeValue?.includes("i like cats n dogs"));
+      if (!textNode) {
+        throw new Error("Expected text between skill chips");
+      }
+
+      element.focus();
+      const range = document.createRange();
+      range.setStart(textNode, textNode.nodeValue?.length ?? 0);
+      range.collapse(true);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    await app.window.keyboard.press("Backspace");
+
+    await expect(planChip).toBeVisible();
+    await expect(brainstormChip).toBeVisible();
+    await expect(richInput).toHaveAttribute(
+      "data-value",
+      " i like cats n dogs - and more",
+    );
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -635,3 +635,51 @@ test("directory launchpad skill autocomplete stays inside a small window and scr
     await fixture.cleanup();
   }
 });
+
+test("directory launchpad parks the composer at the bottom for skill autocomplete space", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: {
+      width: 1000,
+      height: 820,
+    },
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const composerSlot = app.window.locator(".thread-view__launchpad-composer");
+    const richInput = app.window.getByTestId("composer-rich-input");
+    const [composerBox, viewport] = await Promise.all([
+      composerSlot.boundingBox(),
+      app.window.evaluate(() => ({
+        height: globalThis.innerHeight,
+        width: globalThis.innerWidth,
+      })),
+    ]);
+    if (!composerBox) {
+      throw new Error("Expected launchpad composer slot to be measurable");
+    }
+    expect(composerBox.y + composerBox.height).toBeGreaterThan(viewport.height - 80);
+
+    await richInput.fill("$");
+    const listbox = app.window.getByRole("listbox", { name: "Skills" });
+    await expect(listbox).toBeVisible();
+
+    const [listboxBox, richInputBox] = await Promise.all([
+      listbox.boundingBox(),
+      richInput.boundingBox(),
+    ]);
+    if (!listboxBox || !richInputBox) {
+      throw new Error("Expected autocomplete and composer input to be measurable");
+    }
+
+    expect(listboxBox.y).toBeGreaterThanOrEqual(0);
+    expect(listboxBox.x + listboxBox.width).toBeLessThanOrEqual(viewport.width);
+    expect(listboxBox.y + listboxBox.height).toBeLessThanOrEqual(richInputBox.y);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -5,6 +5,13 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
+const CUSTOM_WIDGET_COMPOSER_ENV = {
+  PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "custom-widget-chips",
+};
+const TIPTAP_COMPOSER_ENV = {
+  PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-chips",
+};
+
 async function createDirectoryLaunchpadSkillsFixture(): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
@@ -248,6 +255,7 @@ async function typeSkillChip(
 test("directory launchpad loads skill autocomplete from user and local scope", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -271,6 +279,7 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
 test("directory launchpad keyboard typing updates the rich input once", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -298,6 +307,7 @@ test("directory launchpad keyboard typing updates the rich input once", async ()
 test("directory launchpad skill autocomplete supports active keyboard selection", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -374,9 +384,38 @@ test("directory launchpad skill autocomplete supports active keyboard selection"
   }
 });
 
+test("directory launchpad renders Tiptap composer when enabled and keeps skill autocomplete", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    await expect(app.window.locator(".composer")).toHaveAttribute(
+      "data-composer-implementation",
+      "tiptap-chips",
+    );
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await app.window.keyboard.type("$ce:pl");
+    await expect(tiptapInput).toHaveAttribute("data-value", "$ce:pl");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();
+    await expect(app.window.getByRole("button", { name: /\$ce:plan/i })).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad preserves multiple skill chips across boundary edits", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -446,6 +485,7 @@ test("directory launchpad preserves multiple skill chips across boundary edits",
 test("directory launchpad select all delete clears chips without renderer crash", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -488,6 +528,7 @@ test("directory launchpad select all delete clears chips without renderer crash"
 test("directory launchpad skill autocomplete selects focused options as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -539,6 +580,7 @@ test("directory launchpad skill autocomplete selects focused options as undoable
     await app.window.keyboard.press("Backspace");
     await expect(chip).toBeHidden();
 
+    await richInput.focus();
     await app.window.keyboard.press(
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
@@ -565,6 +607,7 @@ test("directory launchpad skill autocomplete selects focused options as undoable
 test("directory launchpad skill chips stay text-sized and baseline aligned", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -639,6 +682,7 @@ test("directory launchpad skill chips stay text-sized and baseline aligned", asy
 test("directory launchpad types at the clicked text caret between skill chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -703,6 +747,7 @@ test("directory launchpad deletes a persisted skill chip with repeated backspace
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
     env: {
+      ...CUSTOM_WIDGET_COMPOSER_ENV,
       PWRAGNT_STATE_ROOT: stateRoot,
     },
   });
@@ -738,6 +783,7 @@ test("directory launchpad deletes a persisted skill chip with repeated backspace
 test("directory launchpad does not intercept macOS ctrl-a as select all", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
   });
 
@@ -811,6 +857,7 @@ test("directory launchpad does not intercept macOS ctrl-a as select all", async 
 test("directory launchpad skill autocomplete stays inside a small window and scrolls", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
     windowSize: {
       width: 760,
@@ -855,6 +902,7 @@ test("directory launchpad skill autocomplete stays inside a small window and scr
 test("directory launchpad parks the composer at the bottom for skill autocomplete space", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
+    env: CUSTOM_WIDGET_COMPOSER_ENV,
     fixturePath: fixture.fixturePath,
     windowSize: {
       width: 1000,

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -319,6 +319,8 @@ test("directory launchpad skill autocomplete supports active keyboard selection"
       "aria-activedescendant",
       firstActiveOptionId ?? "",
     );
+    await expect(firstActiveOption).toHaveCSS("outline-style", "solid");
+    await expect(firstActiveOption).not.toHaveCSS("box-shadow", "none");
 
     await app.window.keyboard.press("ArrowDown");
     const secondActiveOption = listbox.locator('[aria-selected="true"]');

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -240,6 +240,7 @@ test("directory launchpad skill autocomplete selects focused options as undoable
     await app.window.keyboard.press("Backspace");
     await expect(chip).toBeHidden();
 
+    await richInput.focus();
     await app.window.keyboard.press(
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
@@ -254,6 +255,19 @@ test("directory launchpad skill autocomplete selects focused options as undoable
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
     await expect(chip).toBeVisible();
+
+    await app.window.waitForTimeout(300);
+    await app.window
+      .getByRole("button", { name: /Directory launchpad replay/i })
+      .first()
+      .click();
+    await openDirectoryLaunchpad(app);
+
+    await expect(chip).toBeVisible();
+    await chip.click();
+    await expect(chip).toBeFocused();
+    await app.window.keyboard.press("Backspace");
+    await expect(chip).toBeHidden();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -463,6 +463,48 @@ test("directory launchpad Tiptap composer keeps placeholder on the caret line", 
   }
 });
 
+test("directory launchpad Tiptap composer preserves pasted paragraph breaks", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await textbox.evaluate((element) => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData(
+        "text/html",
+        "<p>first paragraph</p><p>second paragraph</p>",
+      );
+      dataTransfer.setData("text/plain", "first paragraph\nsecond paragraph");
+      element.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dataTransfer,
+        }),
+      );
+    });
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__editor p"),
+    ).toHaveCount(2);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "first paragraph\nsecond paragraph",
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad Tiptap composer selects focused skills as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -319,8 +319,18 @@ test("directory launchpad skill autocomplete supports active keyboard selection"
       "aria-activedescendant",
       firstActiveOptionId ?? "",
     );
-    await expect(firstActiveOption).toHaveCSS("outline-style", "solid");
-    await expect(firstActiveOption).not.toHaveCSS("box-shadow", "none");
+    await expect(firstActiveOption).toHaveCSS("background-color", "rgb(18, 8, 0)");
+    await expect(firstActiveOption).not.toHaveCSS(
+      "border-top-color",
+      "rgba(0, 0, 0, 0)",
+    );
+    await expect
+      .poll(() =>
+        firstActiveOption.evaluate(
+          (element) => getComputedStyle(element, "::before").width,
+        )
+      )
+      .toBe("3px");
 
     await app.window.keyboard.press("ArrowDown");
     const secondActiveOption = listbox.locator('[aria-selected="true"]');

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -295,6 +295,73 @@ test("directory launchpad keyboard typing updates the rich input once", async ()
   }
 });
 
+test("directory launchpad skill autocomplete supports active keyboard selection", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await app.window.keyboard.type("$");
+
+    const listbox = app.window.getByRole("listbox", { name: "Skills" });
+    await expect(listbox).toBeVisible();
+    await expect(richInput).toHaveAttribute("aria-expanded", "true");
+
+    const firstActiveOption = listbox.locator('[aria-selected="true"]');
+    const firstActiveOptionId = await firstActiveOption.getAttribute("id");
+    expect(firstActiveOptionId).toBeTruthy();
+    await expect(richInput).toHaveAttribute(
+      "aria-activedescendant",
+      firstActiveOptionId ?? "",
+    );
+
+    await app.window.keyboard.press("ArrowDown");
+    const secondActiveOption = listbox.locator('[aria-selected="true"]');
+    const secondActiveOptionId = await secondActiveOption.getAttribute("id");
+    expect(secondActiveOptionId).toBeTruthy();
+    expect(secondActiveOptionId).not.toBe(firstActiveOptionId);
+    const secondActiveSkillLabel = (
+      (await secondActiveOption
+        .locator(".composer__autocomplete-title")
+        .textContent())?.match(/\$[A-Za-z0-9:_-]+/)?.[0] ??
+      ""
+    );
+    expect(secondActiveSkillLabel).toBeTruthy();
+    await expect(richInput).toHaveAttribute(
+      "aria-activedescendant",
+      secondActiveOptionId ?? "",
+    );
+
+    await app.window.keyboard.press("Tab");
+    await expect(listbox).toBeHidden();
+    await expect(
+      richInput.locator(".skill-chip", { hasText: secondActiveSkillLabel }),
+    ).toBeVisible();
+
+    await richInput.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await expect(richInput).toHaveAttribute("data-value", "");
+    await expect(richInput.locator(".skill-chip")).toHaveCount(0);
+
+    await app.window.keyboard.type("$ce:pl");
+    await app.window.keyboard.press("Enter");
+    await expect(
+      richInput.locator(".skill-chip", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad preserves multiple skill chips across boundary edits", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -11,6 +11,9 @@ const CUSTOM_WIDGET_COMPOSER_ENV = {
 const TIPTAP_COMPOSER_ENV = {
   PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-chips",
 };
+const TIPTAP_WYSIWYG_COMPOSER_ENV = {
+  PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-wysiwyg-markdown-chips",
+};
 
 async function createDirectoryLaunchpadSkillsFixture(): Promise<{
   cleanup: () => Promise<void>;
@@ -459,6 +462,98 @@ test("directory launchpad Tiptap composer keeps placeholder on the caret line", 
     expect(Math.abs(metrics.paragraphOffsetTop - metrics.paddingTop)).toBeLessThanOrEqual(
       1,
     );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap raw composer keeps markdown shortcuts literal", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await app.window.keyboard.type("## Heading");
+
+    await expect(tiptapInput).toHaveAttribute("data-value", "## Heading");
+    await expect(tiptapInput.locator("h2")).toHaveCount(0);
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await app.window.keyboard.type("``` ");
+
+    await expect(tiptapInput).toHaveAttribute("data-value", "``` ");
+    await expect(tiptapInput.locator("pre")).toHaveCount(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_WYSIWYG_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    await expect(app.window.locator(".composer")).toHaveAttribute(
+      "data-composer-implementation",
+      "tiptap-wysiwyg-markdown-chips",
+    );
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await app.window.keyboard.type("## Heading");
+
+    await expect(tiptapInput.locator("h2", { hasText: "Heading" })).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute("data-value", "## Heading");
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await app.window.keyboard.type("```js ");
+    await app.window.keyboard.type("const x = 1;");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("return x;");
+
+    const codeBlock = tiptapInput.locator("pre", {
+      hasText: "const x = 1;\nreturn x;",
+    });
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock).not.toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "```js\nconst x = 1;\nreturn x;\n```",
+    );
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await app.window.keyboard.type("Before ");
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" after");
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute("data-value", "Before  after");
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -249,6 +249,33 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
   }
 });
 
+test("directory launchpad keyboard typing updates the rich input once", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await app.window.keyboard.type("$ce");
+
+    await expect
+      .poll(async () =>
+        await textbox.evaluate((element) => (element as HTMLDivElement).textContent)
+      )
+      .toBe("$ce");
+    await expect(
+      app.window.getByRole("button", { name: /\$ce:brainstorm/i }),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad skill autocomplete selects focused options as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -12,6 +12,19 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-skills-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
   await mkdir(repoDir, { recursive: true });
+  const generatedSkills = Array.from({ length: 24 }, (_, index) => {
+    const skillNumber = String(index + 1).padStart(2, "0");
+    return {
+      name: `zz-scroll-skill-${skillNumber}`,
+      description: `Generated skill ${skillNumber} for autocomplete overflow coverage.`,
+      path: path.join(
+        rootDir,
+        `.codex/skills/zz-scroll-skill-${skillNumber}/SKILL.md`,
+      ),
+      enabled: true,
+      scope: "user",
+    };
+  });
 
   execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
   execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
@@ -129,6 +142,7 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
                     enabled: true,
                     scope: "local",
                   },
+                  ...generatedSkills,
                 ],
               },
             ],
@@ -149,6 +163,17 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
   };
 }
 
+async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElectronApp>>) {
+  await app.window.getByRole("button", { name: "directories" }).click();
+  await app.window
+    .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+    .click();
+
+  await expect(
+    app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+  ).toBeVisible();
+}
+
 test("directory launchpad loads skill autocomplete from user and local scope", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
@@ -156,14 +181,7 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
-    await app.window
-      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
-      .click();
-
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await openDirectoryLaunchpad(app);
 
     await app.window.getByRole("textbox", { name: "New thread" }).fill("$");
 
@@ -173,6 +191,98 @@ test("directory launchpad loads skill autocomplete from user and local scope", a
     await expect(
       app.window.getByRole("button", { name: /\$desktop-e2e-fixture-seeding/i }),
     ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad skill autocomplete selects focused options as removable inline chips", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.fill("$front");
+
+    const option = app.window.getByRole("button", { name: /\$frontend-design/i });
+    await option.focus();
+    await expect(option).toBeFocused();
+    await app.window.keyboard.press("Enter");
+
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeHidden();
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    const chip = richInput.locator(".skill-chip", { hasText: "$frontend-design" });
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute(
+      "data-tooltip",
+      /\/Users\/huntharo\/\.codex\/skills\/frontend-design\/SKILL\.md$/,
+    );
+
+    const [chipBox, inputBox] = await Promise.all([
+      chip.boundingBox(),
+      richInput.boundingBox(),
+    ]);
+    if (!chipBox || !inputBox) {
+      throw new Error("Expected selected skill chip and composer input to be measurable");
+    }
+    expect(chipBox.y).toBeGreaterThanOrEqual(inputBox.y);
+    expect(chipBox.y + chipBox.height).toBeLessThanOrEqual(
+      inputBox.y + inputBox.height,
+    );
+
+    await chip.getByRole("button", { name: "Remove $frontend-design" }).click();
+    await expect(chip).toBeHidden();
+    await expect(textbox).toHaveValue("");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad skill autocomplete stays inside a small window and scrolls", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: {
+      width: 760,
+      height: 520,
+    },
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    await app.window.getByRole("textbox", { name: "New thread" }).fill("$");
+
+    const listbox = app.window.getByRole("listbox", { name: "Skills" });
+    await expect(listbox).toBeVisible();
+
+    const [listboxBox, viewport, scrollMetrics] = await Promise.all([
+      listbox.boundingBox(),
+      app.window.evaluate(() => ({
+        height: globalThis.innerHeight,
+        width: globalThis.innerWidth,
+      })),
+      listbox.evaluate((element) => ({
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+      })),
+    ]);
+    if (!listboxBox) {
+      throw new Error("Expected autocomplete listbox to be measurable");
+    }
+
+    expect(listboxBox.x).toBeGreaterThanOrEqual(0);
+    expect(listboxBox.y).toBeGreaterThanOrEqual(0);
+    expect(listboxBox.x + listboxBox.width).toBeLessThanOrEqual(viewport.width);
+    expect(listboxBox.y + listboxBox.height).toBeLessThanOrEqual(viewport.height);
+    expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -636,6 +636,63 @@ test("directory launchpad skill chips stay text-sized and baseline aligned", asy
   }
 });
 
+test("directory launchpad types at the clicked text caret between skill chips", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
+    await app.window.keyboard.type(" Cats like hats. ");
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await expect(richInput).toHaveAttribute("data-value", " Cats like hats. ");
+
+    const clickPoint = await richInput.evaluate((element) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      const textNode = Array.from(
+        {
+          [Symbol.iterator]: function* () {
+            let node = walker.nextNode();
+            while (node) {
+              yield node;
+              node = walker.nextNode();
+            }
+          },
+        } as Iterable<Node>,
+      ).find((node) => node.nodeValue?.includes("Cats like hats"));
+      if (!textNode) {
+        throw new Error("Expected text between skill chips");
+      }
+
+      const offset = textNode.nodeValue?.indexOf("hats") ?? -1;
+      if (offset < 0) {
+        throw new Error("Expected target word in text node");
+      }
+
+      const range = document.createRange();
+      range.setStart(textNode, offset);
+      range.setEnd(textNode, offset + 1);
+      const rect = range.getBoundingClientRect();
+      return {
+        x: rect.left + 1,
+        y: rect.top + rect.height / 2,
+      };
+    });
+
+    await app.window.mouse.click(clickPoint.x, clickPoint.y);
+    await app.window.keyboard.type("I");
+    await expect(richInput).toHaveAttribute("data-value", " Cats like Ihats. ");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad deletes a persisted skill chip with repeated backspace", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-saved-launchpad-"));

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -520,7 +520,8 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
     await textbox.focus();
     await app.window.keyboard.type("## Heading");
 
-    await expect(tiptapInput.locator("h2", { hasText: "Heading" })).toBeVisible();
+    const heading2 = tiptapInput.locator("h2", { hasText: "Heading" });
+    await expect(heading2).toBeVisible();
     await expect(tiptapInput).toHaveAttribute("data-value", "## Heading");
     await app.window.keyboard.press("Shift+Enter");
     await app.window.keyboard.type("plain text");
@@ -529,6 +530,21 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
     await expect(tiptapInput).toHaveAttribute(
       "data-value",
       "## Heading\n\nplain text",
+    );
+
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("### Smaller heading");
+
+    const heading3 = tiptapInput.locator("h3", { hasText: "Smaller heading" });
+    await expect(heading3).toBeVisible();
+    const headingSizes = await Promise.all([
+      heading2.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize)),
+      heading3.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize)),
+    ]);
+    expect(headingSizes[0]).toBeGreaterThan(headingSizes[1]);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "## Heading\n\nplain text\n\n### Smaller heading",
     );
 
     await app.window.keyboard.press(

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -671,7 +671,7 @@ test("directory launchpad deletes a persisted skill chip with repeated backspace
   }
 });
 
-test("directory launchpad uses macOS ctrl-a as line navigation instead of select all", async () => {
+test("directory launchpad does not intercept macOS ctrl-a as select all", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -683,7 +683,26 @@ test("directory launchpad uses macOS ctrl-a as line navigation instead of select
     const richInput = app.window.getByTestId("composer-rich-input");
     await richInput.focus();
     await app.window.keyboard.type("alpha beta");
-    await richInput.evaluate((element) => {
+    const shortcutResults = await richInput.evaluate((element) => {
+      const originalPlatformDescriptor =
+        Object.getOwnPropertyDescriptor(window.navigator, "platform") ??
+        Object.getOwnPropertyDescriptor(Navigator.prototype, "platform");
+      const setPlatform = (platform: string): void => {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: platform,
+        });
+      };
+      const dispatchShortcut = (init: KeyboardEventInit): boolean =>
+        element.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            bubbles: true,
+            cancelable: true,
+            key: "a",
+            ...init,
+          }),
+        );
+
       Object.defineProperty(window.navigator, "platform", {
         configurable: true,
         value: "MacIntel",
@@ -695,17 +714,30 @@ test("directory launchpad uses macOS ctrl-a as line navigation instead of select
       const selection = document.getSelection();
       selection?.removeAllRanges();
       selection?.addRange(range);
+
+      const macCtrlAWasNotPrevented = dispatchShortcut({ ctrlKey: true });
+      const macMetaAWasNotPrevented = dispatchShortcut({ metaKey: true });
+      setPlatform("Linux x86_64");
+      const linuxCtrlAWasNotPrevented = dispatchShortcut({ ctrlKey: true });
+
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(
+          window.navigator,
+          "platform",
+          originalPlatformDescriptor,
+        );
+      }
+
+      return {
+        linuxCtrlAWasNotPrevented,
+        macCtrlAWasNotPrevented,
+        macMetaAWasNotPrevented,
+      };
     });
 
-    await app.window.keyboard.press("Control+A");
-
-    const selectedText = await richInput.evaluate(
-      () => document.getSelection()?.toString() ?? "",
-    );
-    expect(selectedText).not.toBe("alpha beta");
-
-    await app.window.keyboard.type("Z");
-    await expect(richInput).toHaveAttribute("data-value", "Zalpha beta");
+    expect(shortcutResults.macCtrlAWasNotPrevented).toBe(true);
+    expect(shortcutResults.macMetaAWasNotPrevented).toBe(false);
+    expect(shortcutResults.linuxCtrlAWasNotPrevented).toBe(false);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -562,6 +562,73 @@ test("directory launchpad skill autocomplete selects focused options as undoable
   }
 });
 
+test("directory launchpad skill chips stay text-sized and baseline aligned", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await app.window.keyboard.type("before ");
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" after");
+
+    const metrics = await richInput.evaluate((element) => {
+      const chip = element.querySelector<HTMLElement>(".skill-chip");
+      const label = element.querySelector<HTMLElement>(".skill-chip__label");
+      if (!chip || !label) {
+        throw new Error("Expected skill chip and label to render");
+      }
+
+      const textRects: DOMRect[] = [];
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      let node = walker.nextNode();
+      while (node) {
+        const text = node.nodeValue ?? "";
+        if (text.includes("before") || text.includes("after")) {
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          textRects.push(...Array.from(range.getClientRects()));
+        }
+        node = walker.nextNode();
+      }
+      if (textRects.length === 0) {
+        throw new Error("Expected surrounding text to be measurable");
+      }
+
+      const labelRect = label.getBoundingClientRect();
+      const chipRect = chip.getBoundingClientRect();
+      const textStyle = getComputedStyle(element);
+      const labelStyle = getComputedStyle(label);
+      const surroundingBottom = textRects.reduce(
+        (bottom, rect) => Math.max(bottom, rect.bottom),
+        0,
+      );
+
+      return {
+        chipHeight: chipRect.height,
+        fontSize: textStyle.fontSize,
+        labelBottom: labelRect.bottom,
+        labelFontSize: labelStyle.fontSize,
+        surroundingBottom,
+      };
+    });
+
+    expect(metrics.labelFontSize).toBe(metrics.fontSize);
+    expect(Math.abs(metrics.labelBottom - metrics.surroundingBottom)).toBeLessThanOrEqual(
+      3,
+    );
+    expect(metrics.chipHeight).toBeLessThanOrEqual(22);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad deletes a persisted skill chip with repeated backspace", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-saved-launchpad-"));
@@ -601,6 +668,47 @@ test("directory launchpad deletes a persisted skill chip with repeated backspace
     await app.close();
     await fixture.cleanup();
     await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("directory launchpad uses macOS ctrl-a as line navigation instead of select all", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await app.window.keyboard.type("alpha beta");
+    await richInput.evaluate((element) => {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
+      });
+      element.focus();
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      range.collapse(false);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+    await app.window.keyboard.press("Control+A");
+
+    const selectedText = await richInput.evaluate(
+      () => document.getSelection()?.toString() ?? "",
+    );
+    expect(selectedText).not.toBe("alpha beta");
+
+    await app.window.keyboard.type("Z");
+    await expect(richInput).toHaveAttribute("data-value", "Zalpha beta");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
   }
 });
 

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -364,6 +364,48 @@ test("directory launchpad preserves multiple skill chips across boundary edits",
   }
 });
 
+test("directory launchpad select all delete clears chips without renderer crash", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.focus();
+    await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
+    await app.window.keyboard.type(" i like cats n dogs - ");
+    await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
+    await app.window.keyboard.type(" and more");
+
+    await expect(
+      richInput.locator(".skill-chip", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(
+      richInput.locator(".skill-chip", { hasText: "$ce:brainstorm" }),
+    ).toBeVisible();
+    await expect(richInput).toHaveAttribute(
+      "data-value",
+      " i like cats n dogs -  and more",
+    );
+
+    await richInput.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+
+    await expect(richInput.locator(".skill-chip")).toHaveCount(0);
+    await expect(richInput).toHaveAttribute("data-value", "");
+    await expect(app.window.locator("body")).not.toContainText("Renderer error");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad skill autocomplete selects focused options as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -244,6 +244,16 @@ test("directory launchpad skill autocomplete selects focused options as undoable
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
     await expect(chip).toBeVisible();
+
+    await chip.click();
+    await expect(chip).toBeFocused();
+    await app.window.keyboard.press("Backspace");
+    await expect(chip).toBeHidden();
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+Z" : "Control+Z",
+    );
+    await expect(chip).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -577,6 +577,23 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
       "data-value",
       "Cats\n\n\n\n## Later",
     );
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Delete");
+    await app.window.keyboard.type("- Some item");
+    await expect(tiptapInput.locator("li", { hasText: "Some item" })).toBeVisible();
+
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("after list");
+
+    await expect(tiptapInput.locator("li", { hasText: "after list" })).toHaveCount(0);
+    await expect(tiptapInput.locator("p", { hasText: "after list" })).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "- Some item\n\nafter list",
+    );
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -537,14 +537,40 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
 
     const heading3 = tiptapInput.locator("h3", { hasText: "Smaller heading" });
     await expect(heading3).toBeVisible();
-    const headingSizes = await Promise.all([
-      heading2.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize)),
-      heading3.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize)),
-    ]);
-    expect(headingSizes[0]).toBeGreaterThan(headingSizes[1]);
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("#### Detail heading");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("##### Fine print heading");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("###### Quiet heading");
+
+    const heading4 = tiptapInput.locator("h4", { hasText: "Detail heading" });
+    const heading5 = tiptapInput.locator("h5", { hasText: "Fine print heading" });
+    const heading6 = tiptapInput.locator("h6", { hasText: "Quiet heading" });
+    await expect(heading4).toBeVisible();
+    await expect(heading5).toBeVisible();
+    await expect(heading6).toBeVisible();
+    const headingStyles = await Promise.all(
+      [heading2, heading3, heading4, heading5, heading6].map((heading) =>
+        heading.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return {
+            fontSize: Number.parseFloat(styles.fontSize),
+            fontStyle: styles.fontStyle,
+          };
+        })
+      )
+    );
+    for (let index = 1; index < headingStyles.length; index += 1) {
+      expect(headingStyles[index - 1].fontSize).toBeGreaterThan(
+        headingStyles[index].fontSize,
+      );
+    }
+    expect(headingStyles[3].fontStyle).toBe("italic");
+    expect(headingStyles[4].fontStyle).toBe("italic");
     await expect(tiptapInput).toHaveAttribute(
       "data-value",
-      "## Heading\n\nplain text\n\n### Smaller heading",
+      "## Heading\n\nplain text\n\n### Smaller heading\n\n#### Detail heading\n\n##### Fine print heading\n\n###### Quiet heading",
     );
 
     await app.window.keyboard.press(

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -792,19 +792,6 @@ test("directory launchpad skill autocomplete selects focused options as undoable
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
     await expect(chip).toBeVisible();
-
-    await app.window.waitForTimeout(300);
-    await app.window
-      .getByRole("button", { name: /Directory launchpad replay/i })
-      .first()
-      .click();
-    await openDirectoryLaunchpad(app);
-
-    await expect(chip).toBeVisible();
-    await chip.click();
-    await expect(chip).toBeFocused();
-    await app.window.keyboard.press("Backspace");
-    await expect(chip).toBeHidden();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -413,6 +413,56 @@ test("directory launchpad renders Tiptap composer when enabled and keeps skill a
   }
 });
 
+test("directory launchpad Tiptap composer keeps placeholder on the caret line", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const app = await launchElectronApp({
+    env: TIPTAP_COMPOSER_ENV,
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.focus();
+    await expect(tiptapInput).toHaveClass(/is-empty/);
+
+    const metrics = await tiptapInput.evaluate((element) => {
+      const editor = element.querySelector<HTMLElement>(
+        ".composer-tiptap-input__editor",
+      );
+      const paragraph = editor?.querySelector<HTMLElement>("p");
+      if (!editor || !paragraph) {
+        throw new Error("Expected empty Tiptap editor paragraph");
+      }
+
+      const editorRect = editor.getBoundingClientRect();
+      const paragraphRect = paragraph.getBoundingClientRect();
+      const editorStyle = getComputedStyle(editor);
+      const placeholderStyle = getComputedStyle(editor, "::before");
+
+      return {
+        paragraphOffsetTop: paragraphRect.top - editorRect.top,
+        placeholderContent: placeholderStyle.content,
+        placeholderPosition: placeholderStyle.position,
+        placeholderTop: Number.parseFloat(placeholderStyle.top),
+        paddingTop: Number.parseFloat(editorStyle.paddingTop),
+      };
+    });
+
+    expect(metrics.placeholderContent).toContain("Start a new thread in FixtureRepo");
+    expect(metrics.placeholderPosition).toBe("absolute");
+    expect(Math.abs(metrics.placeholderTop - metrics.paddingTop)).toBeLessThanOrEqual(1);
+    expect(Math.abs(metrics.paragraphOffsetTop - metrics.paddingTop)).toBeLessThanOrEqual(
+      1,
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad Tiptap composer selects focused skills as undoable inline chips", async () => {
   const fixture = await createDirectoryLaunchpadSkillsFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -8,6 +8,7 @@ import { launchElectronApp } from "./fixtures/electron-app";
 async function createDirectoryLaunchpadSkillsFixture(): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
+  repoDir: string;
 }> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-skills-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
@@ -133,6 +134,13 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
                     scope: "user",
                   },
                   {
+                    name: "ce:brainstorm",
+                    description: "Explore requirements before writing implementation plans.",
+                    path: "/Users/huntharo/.codex/skills/ce-brainstorm/SKILL.md",
+                    enabled: true,
+                    scope: "user",
+                  },
+                  {
                     name: "desktop-e2e-fixture-seeding",
                     description: "Replay-backed desktop E2E fixtures.",
                     path: path.join(
@@ -157,10 +165,54 @@ async function createDirectoryLaunchpadSkillsFixture(): Promise<{
 
   return {
     fixturePath,
+    repoDir,
     cleanup: async () => {
       await rm(rootDir, { recursive: true, force: true });
     },
   };
+}
+
+async function seedPersistedDirectoryLaunchpad(params: {
+  repoDir: string;
+  stateRoot: string;
+}): Promise<void> {
+  await mkdir(params.stateRoot, { recursive: true });
+  const directoryKey = `directory:${params.repoDir}`;
+  await writeFile(
+    path.join(params.stateRoot, "overlay-state.json"),
+    JSON.stringify(
+      {
+        version: 5,
+        backends: {},
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "full-access",
+          workMode: "worktree",
+          reasoningEffort: "high",
+        },
+        directoryLaunchpads: {
+          [directoryKey]: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "FixtureRepo",
+            directoryPath: params.repoDir,
+            backend: "codex",
+            executionMode: "full-access",
+            prompt: "[$ce:brainstorm](/Users/huntharo/.codex/skills/ce-brainstorm/SKILL.md) ",
+            workMode: "worktree",
+            branchName: "main",
+            reasoningEffort: "high",
+            createdAt: 1760000000000,
+            updatedAt: 1760000000000,
+          },
+        },
+        threads: {},
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
 }
 
 async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElectronApp>>) {
@@ -271,6 +323,48 @@ test("directory launchpad skill autocomplete selects focused options as undoable
   } finally {
     await app.close();
     await fixture.cleanup();
+  }
+});
+
+test("directory launchpad deletes a persisted skill chip with repeated backspace", async () => {
+  const fixture = await createDirectoryLaunchpadSkillsFixture();
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-saved-launchpad-"));
+  await seedPersistedDirectoryLaunchpad({
+    repoDir: fixture.repoDir,
+    stateRoot,
+  });
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      PWRAGNT_STATE_ROOT: stateRoot,
+    },
+  });
+
+  try {
+    await openDirectoryLaunchpad(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    const chip = richInput.locator(".skill-chip", { hasText: "$ce:brainstorm" });
+    await expect(chip).toBeVisible();
+
+    await richInput.evaluate((element) => {
+      element.focus();
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      range.collapse(false);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    await app.window.keyboard.press("Backspace");
+    await app.window.keyboard.press("Backspace");
+
+    await expect(chip).toBeHidden();
+    await expect(app.window.locator("body")).not.toContainText("Renderer error");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+    await rm(stateRoot, { recursive: true, force: true });
   }
 });
 

--- a/apps/desktop/e2e/fixtures/thread-markdown/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/thread-markdown/replay.fixture.json
@@ -100,7 +100,7 @@
             "type": "message",
             "id": "message-2",
             "role": "assistant",
-            "text": "The desktop client now renders **markdown** in transcript messages.\n\n- Preserves file links\n- Preserves [external links](https://example.com/transcript)\n- Keeps ![Transcript preview](https://example.com/preview.png) inert"
+            "text": "# Transcript heading 1\n\n## Transcript heading 2\n\n### Transcript heading 3\n\n#### Transcript heading 4\n\n##### Transcript heading 5\n\n###### Transcript heading 6\n\nThe desktop client now renders **markdown** in transcript messages.\n\n- Preserves file links\n- Preserves [external links](https://example.com/transcript)\n- Keeps ![Transcript preview](https://example.com/preview.png) inert"
           }
         ],
         "messages": [
@@ -112,7 +112,7 @@
           {
             "id": "message-2",
             "role": "assistant",
-            "text": "The desktop client now renders **markdown** in transcript messages.\n\n- Preserves file links\n- Preserves [external links](https://example.com/transcript)\n- Keeps ![Transcript preview](https://example.com/preview.png) inert"
+            "text": "# Transcript heading 1\n\n## Transcript heading 2\n\n### Transcript heading 3\n\n#### Transcript heading 4\n\n##### Transcript heading 5\n\n###### Transcript heading 6\n\nThe desktop client now renders **markdown** in transcript messages.\n\n- Preserves file links\n- Preserves [external links](https://example.com/transcript)\n- Keeps ![Transcript preview](https://example.com/preview.png) inert"
           }
         ],
         "lastUserMessage": "Inspect [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md) and open [`ce:work`](/Users/huntharo/.codex/skills/ce-work/SKILL.md).",

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -28,7 +28,7 @@ test("review command asks for target and preserves transcript order", async () =
 
     const reply = app.window.getByLabel("Reply");
     await reply.fill("/review");
-    await expect(reply).toHaveValue("/review");
+    await expect(reply).toHaveAttribute("data-value", "/review");
     await app.window.getByRole("button", { name: "Send" }).click();
 
     const reviewTarget = app.window.getByRole("group", { name: "Review target" });

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -28,7 +28,7 @@ test("review command asks for target and preserves transcript order", async () =
 
     const reply = app.window.getByLabel("Reply");
     await reply.fill("/review");
-    await expect(reply).toHaveAttribute("data-value", "/review");
+    await expect(reply).toHaveValue("/review");
     await app.window.getByRole("button", { name: "Send" }).click();
 
     const reviewTarget = app.window.getByRole("group", { name: "Review target" });

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -131,7 +131,6 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     const selectedRow = app.window.locator(".thread-row.is-selected").first();
     const primaryButton = app.window.locator(".button--primary").first();
     const composerInput = app.window.getByLabel("Reply");
-    const composerInputSurface = app.window.getByTestId("composer-rich-input");
     const sendButton = app.window.getByRole("button", { name: "Send" });
 
     await expect(shell).toHaveCSS("background-color", "rgb(0, 0, 0)");
@@ -168,7 +167,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     });
 
     await assertTangerineFocusRing(activeLens);
-    await assertTangerineFocusRing(composerInputSurface, composerInput);
+    await assertTangerineFocusRing(composerInput);
     await composerInput.fill("Focus ring check");
     await expect(sendButton).toBeEnabled();
     await assertTangerineFocusRing(sendButton);

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -81,8 +81,8 @@ async function assertReadableText(params: {
   ).toBeGreaterThanOrEqual(params.minimum ?? 4.5);
 }
 
-async function assertTangerineFocusRing(locator: Locator) {
-  await locator.focus();
+async function assertTangerineFocusRing(locator: Locator, focusTarget = locator) {
+  await focusTarget.focus();
   await expect(locator).toHaveCSS("outline-color", "rgb(255, 138, 31)");
   await expect(locator).toHaveCSS("outline-style", "solid");
 }
@@ -131,6 +131,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     const selectedRow = app.window.locator(".thread-row.is-selected").first();
     const primaryButton = app.window.locator(".button--primary").first();
     const composerInput = app.window.getByLabel("Reply");
+    const composerInputSurface = app.window.getByTestId("composer-rich-input");
     const sendButton = app.window.getByRole("button", { name: "Send" });
 
     await expect(shell).toHaveCSS("background-color", "rgb(0, 0, 0)");
@@ -167,7 +168,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     });
 
     await assertTangerineFocusRing(activeLens);
-    await assertTangerineFocusRing(composerInput);
+    await assertTangerineFocusRing(composerInputSurface, composerInput);
     await composerInput.fill("Focus ring check");
     await expect(sendButton).toBeEnabled();
     await assertTangerineFocusRing(sendButton);

--- a/apps/desktop/e2e/thread-markdown.spec.ts
+++ b/apps/desktop/e2e/thread-markdown.spec.ts
@@ -44,6 +44,32 @@ test("renders markdown content in thread summaries and transcript messages", asy
     await expect(
       transcript.getByRole("link", { name: "external links" })
     ).toHaveAttribute("href", "https://example.com/transcript");
+    const headingLocators = [1, 2, 3, 4, 5, 6].map((level) =>
+      transcript.locator(`h${level}.transcript-message__heading`, {
+        hasText: `Transcript heading ${level}`,
+      })
+    );
+    for (const heading of headingLocators) {
+      await expect(heading).toBeVisible();
+    }
+    const headingStyles = await Promise.all(
+      headingLocators.map((heading) =>
+        heading.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return {
+            fontSize: Number.parseFloat(styles.fontSize),
+            fontStyle: styles.fontStyle,
+          };
+        })
+      )
+    );
+    for (let index = 1; index < headingStyles.length; index += 1) {
+      expect(headingStyles[index - 1].fontSize).toBeGreaterThan(
+        headingStyles[index].fontSize
+      );
+    }
+    expect(headingStyles[4].fontStyle).toBe("italic");
+    expect(headingStyles[5].fontStyle).toBe("italic");
     await expect(transcript.getByText("Preserves file links")).toBeVisible();
     await expect(transcript).toContainText("Keeps");
     await expect(transcript).toContainText("inert");

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,10 @@
   "dependencies": {
     "@pwragnt/agent-core": "workspace:*",
     "@pwragnt/shared": "workspace:*",
+    "@tiptap/extension-mention": "^3.22.5",
+    "@tiptap/react": "^3.22.5",
+    "@tiptap/starter-kit": "^3.22.5",
+    "@tiptap/suggestion": "^3.22.5",
     "electron-log": "^5.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -357,6 +357,7 @@ function isDesktopChatReplyComposer(
   return (
     value === "textarea"
     || value === "tiptap-chips"
+    || value === "tiptap-wysiwyg-markdown-chips"
     || value === "custom-widget-chips"
   );
 }

--- a/apps/desktop/src/main/settings/desktop-settings-env.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-env.ts
@@ -88,6 +88,7 @@ function isDesktopChatReplyComposer(
   return (
     value === "textarea"
     || value === "tiptap-chips"
+    || value === "tiptap-wysiwyg-markdown-chips"
     || value === "custom-widget-chips"
   );
 }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -979,7 +979,11 @@ describe("App", () => {
         value: "Start a Grok-backed thread from the sidebar.",
       },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+    const startThreadButton = screen.getByRole("button", { name: "Start thread" });
+    await waitFor(() => {
+      expect(startThreadButton).toBeEnabled();
+    });
+    fireEvent.click(startThreadButton);
 
     expect(
       await screen.findByRole("region", { name: "Preparing transcript" })

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -46,6 +46,8 @@ import {
   type ComposerRichInputHandle,
   type ComposerSkillToken,
 } from "./ComposerRichInput";
+import { ComposerTextareaInput } from "./ComposerTextareaInput";
+import { ComposerTiptapInput } from "./ComposerTiptapInput";
 
 type ComposerProps = {
   activeTurnId?: string;
@@ -835,6 +837,8 @@ export function Composer(props: ComposerProps) {
   const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
   const launchpad = props.launchpad;
+  const composerImplementation = props.composerImplementation ?? "textarea";
+  const composerSupportsSkillTokens = composerImplementation !== "textarea";
   const backend = useMemo(
     () =>
       props.backends?.find((candidate) =>
@@ -850,12 +854,24 @@ export function Composer(props: ComposerProps) {
   const isThreadComposerScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
   const canonicalDraft = useMemo(
-    () => serializeDraftWithSkillTokens(draft, skillTokens),
-    [draft, skillTokens]
+    () =>
+      serializeDraftWithSkillTokens(
+        draft,
+        composerSupportsSkillTokens ? skillTokens : [],
+      ),
+    [composerSupportsSkillTokens, draft, skillTokens]
   );
-  const hasComposerContent = draft.trim().length > 0 || skillTokens.length > 0;
+  const hasComposerContent =
+    draft.trim().length > 0 ||
+    (composerSupportsSkillTokens && skillTokens.length > 0);
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
     deletedSkillTokenHistoryRef.current = [];
+    if (!composerSupportsSkillTokens) {
+      setDraft(nextDraft);
+      setSkillTokens([]);
+      return;
+    }
+
     const hydrated = hydrateComposerDraft(nextDraft, props.skills);
     setDraft(hydrated.draft);
     setSkillTokens(hydrated.skillTokens);
@@ -870,7 +886,9 @@ export function Composer(props: ComposerProps) {
     nextSkillTokens?: ComposerSkillToken[],
   ): void => {
     deletedSkillTokenHistoryRef.current = [];
-    if (nextSkillTokens) {
+    if (!composerSupportsSkillTokens) {
+      setSkillTokens([]);
+    } else if (nextSkillTokens) {
       setSkillTokens(nextSkillTokens);
     } else {
       setSkillTokens((current) =>
@@ -1041,6 +1059,25 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     setActiveSlashIndex(0);
   }, [slashTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  useEffect(() => {
+    deletedSkillTokenHistoryRef.current = [];
+    if (composerImplementation === "textarea") {
+      if (skillTokens.length > 0) {
+        setDraft(serializeDraftWithSkillTokens(draft, skillTokens));
+        setSkillTokens([]);
+      }
+      return;
+    }
+
+    if (skillTokens.length === 0 && draft.includes("](")) {
+      const hydrated = hydrateComposerDraft(draft, props.skills);
+      if (hydrated.skillTokens.length > 0) {
+        setDraft(hydrated.draft);
+        setSkillTokens(hydrated.skillTokens);
+      }
+    }
+  }, [composerImplementation]);
 
   useEffect(() => {
     if (!displayedAutocompleteKind) {
@@ -1716,8 +1753,26 @@ export function Composer(props: ComposerProps) {
       inputRef.current.selectionEnd ?? selectionStart,
       draft.length,
     );
-    const trigger = findSkillTrigger(draft, selectionStart);
+    const trigger =
+      findSkillTrigger(draft, selectionStart) ?? findSkillTrigger(draft, draft.length);
     if (!trigger) {
+      return;
+    }
+
+    if (!composerSupportsSkillTokens) {
+      const before = draft.slice(0, trigger.start);
+      const after = draft.slice(Math.max(trigger.end, selectionEnd));
+      const mention = buildSkillMentionMarkdown(skill);
+      const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
+      const nextDraft = `${before}${mention}${needsTrailingSpace ? " " : ""}${after}`;
+      const nextSelection = before.length + mention.length + (needsTrailingSpace ? 1 : 0);
+
+      updateVisibleDraft(nextDraft, []);
+      setActiveSkillIndex(0);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+      });
       return;
     }
 
@@ -1802,7 +1857,7 @@ export function Composer(props: ComposerProps) {
     });
   };
 
-  const handlePaste = (event: ClipboardEvent<HTMLDivElement>): void => {
+  const handlePaste = (event: ClipboardEvent<HTMLElement>): void => {
     const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
     if (pastedFiles.length === 0) {
       return;
@@ -1813,7 +1868,7 @@ export function Composer(props: ComposerProps) {
     void attachImages(pastedFiles);
   };
 
-  const handleDragOver = (event: DragEvent<HTMLDivElement>): void => {
+  const handleDragOver = (event: DragEvent<HTMLElement>): void => {
     if (!hasImageFiles(event.dataTransfer)) {
       return;
     }
@@ -1822,7 +1877,7 @@ export function Composer(props: ComposerProps) {
     event.dataTransfer.dropEffect = "copy";
   };
 
-  const handleDrop = (event: DragEvent<HTMLDivElement>): void => {
+  const handleDrop = (event: DragEvent<HTMLElement>): void => {
     const droppedFiles = getImageFilesFromDataTransfer(event.dataTransfer);
     if (droppedFiles.length === 0) {
       return;
@@ -2533,6 +2588,67 @@ export function Composer(props: ComposerProps) {
     }
   };
 
+  const composerDisabled =
+    launchpadSubmitting || (props.disabled && !hasComposerContent);
+  const composerPlaceholder = isLaunchpad
+    ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
+    : "Reply to this thread";
+  const handleComposerChange = (
+    nextDraft: string,
+    nextSkillTokens?: ComposerSkillToken[],
+  ): void => {
+    updateVisibleDraft(nextDraft, nextSkillTokens);
+    if (nextDraft.trim() !== "/review") {
+      setReviewConfig(undefined);
+    }
+    setSendError(undefined);
+  };
+  const handleComposerClick = (): void => {
+    setActiveSkillIndex(0);
+    setActiveSlashIndex(0);
+  };
+  const handlePlainComposerKeyDown = (
+    event: ReactKeyboardEvent<HTMLElement>,
+  ): void => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (!hasAutocomplete) {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        void submitTurn(event.metaKey ? "steer" : "default");
+      }
+      return;
+    }
+
+    handleAutocompleteKeyDown(event);
+  };
+  const handleCustomComposerKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ): void => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (restoreDeletedSkillToken(event)) {
+      return;
+    }
+
+    if (
+      event.key === "Backspace" &&
+      deleteEditorContent(event, "backward")
+    ) {
+      return;
+    }
+
+    if (event.key === "Delete" && deleteEditorContent(event, "forward")) {
+      return;
+    }
+
+    handlePlainComposerKeyDown(event);
+  };
+
   return (
     <form
       className="composer"
@@ -2638,117 +2754,111 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       <div className="composer__input-wrap" ref={inputWrapRef}>
-        <ComposerRichInput
-          ref={inputRef}
-          id="thread-composer"
-          ariaActiveDescendant={activeAutocompleteOptionId}
-          ariaControls={autocompleteListboxId}
-          ariaExpanded={hasAutocomplete}
-          disabled={launchpadSubmitting || (props.disabled && !hasComposerContent)}
-          label={isLaunchpad ? "New thread" : "Reply"}
-          placeholder={
-            isLaunchpad
-              ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
-              : "Reply to this thread"
-          }
-          skillTokens={skillTokens}
-          value={draft}
-          onChange={(nextDraft, nextSkillTokens) => {
-            updateVisibleDraft(nextDraft, nextSkillTokens);
-            if (nextDraft.trim() !== "/review") {
-              setReviewConfig(undefined);
-            }
-            setSendError(undefined);
-          }}
-          onPaste={handlePaste}
-          onDragOver={handleDragOver}
-          onDrop={handleDrop}
-          onClick={() => {
-            setActiveSkillIndex(0);
-            setActiveSlashIndex(0);
-          }}
-          onBeforeInputCapture={(event) => {
-            const inputType = (event.nativeEvent as InputEvent).inputType;
-            if (
-              inputType === "deleteContentBackward" &&
-              deleteEditorContent(event, "backward")
-            ) {
-              return;
-            }
-            if (
-              inputType === "deleteContentForward" &&
-              deleteEditorContent(event, "forward")
-            ) {
-              return;
-            }
-          }}
-          onBeforeInput={(event) => {
-            if (event.defaultPrevented) {
-              return;
-            }
-            const inputType = (event.nativeEvent as InputEvent).inputType;
-            if (
-              inputType === "deleteContentBackward" &&
-              deleteEditorContent(event, "backward")
-            ) {
-              return;
-            }
-            if (
-              inputType === "deleteContentForward" &&
-              deleteEditorContent(event, "forward")
-            ) {
-              return;
-            }
-          }}
-          onKeyDownCapture={(event) => {
-            if (
-              event.key === "Backspace" &&
-              deleteEditorContent(event, "backward")
-            ) {
-              return;
-            }
-
-            if (
-              event.key === "Delete" &&
-              deleteEditorContent(event, "forward")
-            ) {
-              return;
-            }
-          }}
-          onKeyDown={(event) => {
-            if (event.defaultPrevented) {
-              return;
-            }
-
-            if (restoreDeletedSkillToken(event)) {
-              return;
-            }
-
-            if (
-              event.key === "Backspace" &&
-              deleteEditorContent(event, "backward")
-            ) {
-              return;
-            }
-
-            if (
-              event.key === "Delete" &&
-              deleteEditorContent(event, "forward")
-            ) {
-              return;
-            }
-
-            if (!hasAutocomplete) {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                void submitTurn(event.metaKey ? "steer" : "default");
+        {composerImplementation === "custom-widget-chips" ? (
+          <ComposerRichInput
+            ref={inputRef}
+            id="thread-composer"
+            ariaActiveDescendant={activeAutocompleteOptionId}
+            ariaControls={autocompleteListboxId}
+            ariaExpanded={hasAutocomplete}
+            disabled={composerDisabled}
+            label={isLaunchpad ? "New thread" : "Reply"}
+            placeholder={composerPlaceholder}
+            skillTokens={skillTokens}
+            value={draft}
+            onChange={handleComposerChange}
+            onPaste={handlePaste}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onClick={handleComposerClick}
+            onBeforeInputCapture={(event) => {
+              const inputType = (event.nativeEvent as InputEvent).inputType;
+              if (
+                inputType === "deleteContentBackward" &&
+                deleteEditorContent(event, "backward")
+              ) {
+                return;
               }
-              return;
-            }
+              if (
+                inputType === "deleteContentForward" &&
+                deleteEditorContent(event, "forward")
+              ) {
+                return;
+              }
+            }}
+            onBeforeInput={(event) => {
+              if (event.defaultPrevented) {
+                return;
+              }
+              const inputType = (event.nativeEvent as InputEvent).inputType;
+              if (
+                inputType === "deleteContentBackward" &&
+                deleteEditorContent(event, "backward")
+              ) {
+                return;
+              }
+              if (
+                inputType === "deleteContentForward" &&
+                deleteEditorContent(event, "forward")
+              ) {
+                return;
+              }
+            }}
+            onKeyDownCapture={(event) => {
+              if (
+                event.key === "Backspace" &&
+                deleteEditorContent(event, "backward")
+              ) {
+                return;
+              }
 
-            handleAutocompleteKeyDown(event);
-          }}
-        />
+              if (
+                event.key === "Delete" &&
+                deleteEditorContent(event, "forward")
+              ) {
+                return;
+              }
+            }}
+            onKeyDown={handleCustomComposerKeyDown}
+          />
+        ) : composerImplementation === "tiptap-chips" ? (
+          <ComposerTiptapInput
+            ref={inputRef}
+            id="thread-composer"
+            ariaActiveDescendant={activeAutocompleteOptionId}
+            ariaControls={autocompleteListboxId}
+            ariaExpanded={hasAutocomplete}
+            disabled={composerDisabled}
+            label={isLaunchpad ? "New thread" : "Reply"}
+            placeholder={composerPlaceholder}
+            skillTokens={skillTokens}
+            value={draft}
+            onChange={handleComposerChange}
+            onPaste={handlePaste}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onClick={handleComposerClick}
+            onKeyDown={handlePlainComposerKeyDown}
+          />
+        ) : (
+          <ComposerTextareaInput
+            ref={inputRef}
+            id="thread-composer"
+            ariaActiveDescendant={activeAutocompleteOptionId}
+            ariaControls={autocompleteListboxId}
+            ariaExpanded={hasAutocomplete}
+            disabled={composerDisabled}
+            label={isLaunchpad ? "New thread" : "Reply"}
+            placeholder={composerPlaceholder}
+            value={draft}
+            onChange={(nextDraft) => handleComposerChange(nextDraft, [])}
+            onPaste={handlePaste}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            onClick={handleComposerClick}
+            onKeyDown={handlePlainComposerKeyDown}
+          />
+        )}
 
         {displayedAutocompleteKind === "skills" ? (
           <div

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
 import type {
   AppServerCollaborationModeRequest,
   AppServerReviewTarget,
@@ -1713,20 +1714,22 @@ export function Composer(props: ComposerProps) {
     const nextAfter = after.length > 0 && !/^\s/.test(after) ? ` ${after}` : after;
     const nextDraft = `${before}${nextAfter}`;
     const tokenIndex = before.length;
-    setSkillTokens((current) => [
+    const nextSkillTokens = [
       ...adjustSkillTokenIndexesForTextChange({
         currentDraft: draft,
         nextDraft,
-        skillTokens: current,
+        skillTokens,
       }),
       createComposerSkillToken(skill, tokenIndex),
-    ]);
-    setDraft(nextDraft);
-    setActiveSkillIndex(0);
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
+    ];
+
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveSkillIndex(0);
     });
+    inputRef.current?.focus();
+    inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
   };
 
   const applySlashCommand = (command: SlashCommandSuggestion): void => {
@@ -2157,22 +2160,6 @@ export function Composer(props: ComposerProps) {
     return tokenElement?.dataset.composerSkillTokenId;
   };
 
-  const shouldGuardBoundarySkillDeletion = (editor: HTMLElement): boolean => {
-    const selection = editor.ownerDocument.getSelection();
-    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
-      return false;
-    }
-
-    const range = selection.getRangeAt(0);
-    if (!editor.contains(range.startContainer)) {
-      return false;
-    }
-
-    return (
-      range.startContainer.nodeType !== Node.TEXT_NODE || range.startOffset === 0
-    );
-  };
-
   const shouldGuardNativeTextDeletion = (
     editor: HTMLElement,
     direction: "backward" | "forward",
@@ -2197,19 +2184,75 @@ export function Composer(props: ComposerProps) {
       : range.startOffset >= textLength;
   };
 
-  const findBoundarySkillToken = (
-    caret: number,
-    direction: "backward" | "forward",
-  ): ComposerSkillToken | undefined => {
-    if (direction === "forward") {
-      return [...skillTokens]
-        .sort((left, right) => left.index - right.index)
-        .find((candidate) => candidate.index >= caret);
+  const findTokenIdInNode = (node: Node | undefined): string | undefined => {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) {
+      return undefined;
     }
 
-    return [...skillTokens]
-      .sort((left, right) => right.index - left.index)
-      .find((candidate) => candidate.index <= caret);
+    const element = node as Element;
+    const tokenElement = element.matches(COMPOSER_SKILL_TOKEN_SELECTOR)
+      ? element
+      : element.querySelector(COMPOSER_SKILL_TOKEN_SELECTOR);
+    return tokenElement instanceof HTMLElement
+      ? tokenElement.dataset.composerSkillTokenId
+      : undefined;
+  };
+
+  const findEditorChildForNode = (
+    editor: HTMLElement,
+    node: Node,
+  ): Node | undefined => {
+    let current: Node | null = node;
+    while (current && current.parentNode !== editor) {
+      current = current.parentNode;
+    }
+    return current ?? undefined;
+  };
+
+  const findAdjacentSkillTokenId = (
+    editor: HTMLElement,
+    direction: "backward" | "forward",
+  ): string | undefined => {
+    const selection = editor.ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+      return undefined;
+    }
+
+    const range = selection.getRangeAt(0);
+    if (!editor.contains(range.startContainer)) {
+      return undefined;
+    }
+
+    if (range.startContainer === editor) {
+      const sibling =
+        direction === "backward"
+          ? editor.childNodes[range.startOffset - 1]
+          : editor.childNodes[range.startOffset];
+      return findTokenIdInNode(sibling);
+    }
+
+    if (range.startContainer.nodeType === Node.TEXT_NODE) {
+      const textLength = range.startContainer.nodeValue?.length ?? 0;
+      if (direction === "backward" && range.startOffset > 0) {
+        return undefined;
+      }
+      if (direction === "forward" && range.startOffset < textLength) {
+        return undefined;
+      }
+    }
+
+    const editorChild = findEditorChildForNode(editor, range.startContainer);
+    if (!editorChild) {
+      return undefined;
+    }
+
+    const siblings = Array.from(editor.childNodes);
+    const childIndex = siblings.indexOf(editorChild as ChildNode);
+    const sibling =
+      direction === "backward"
+        ? siblings[childIndex - 1]
+        : siblings[childIndex + 1];
+    return findTokenIdInNode(sibling);
   };
 
   const removeSkillToken = (
@@ -2238,18 +2281,16 @@ export function Composer(props: ComposerProps) {
       return false;
     }
 
-    const caret = Math.min(inputRef.current.selectionStart, draft.length);
     const tokenId =
       findEventTargetSkillTokenId(event) ??
-      findSelectedSkillTokenId(event.currentTarget);
+      findSelectedSkillTokenId(event.currentTarget) ??
+      findAdjacentSkillTokenId(event.currentTarget, direction);
     const token =
-      (tokenId
+      tokenId
         ? skillTokens.find((candidate) => candidate.id === tokenId)
-        : undefined) ??
-      skillTokens.find((candidate) => candidate.index === caret) ??
-      (shouldGuardBoundarySkillDeletion(event.currentTarget)
-        ? findBoundarySkillToken(caret, direction)
-        : undefined);
+        : draft.length === 0 && skillTokens.length === 1
+          ? skillTokens[0]
+          : undefined;
     if (!token) {
       if (tokenId) {
         event.preventDefault();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -144,6 +144,13 @@ type DeletedSkillTokenHistoryEntry = {
   skillTokens: ComposerSkillToken[];
 };
 
+type PendingProgrammaticComposerChange = {
+  expectedDraft: string;
+  expectedSkillTokensSignature: string;
+  staleDraft: string;
+  staleSkillTokensSignature: string;
+};
+
 const COMPOSER_SKILL_TOKEN_SELECTOR = "[data-composer-skill-token-id]";
 
 type SkillTokenDeletionEvent = {
@@ -489,6 +496,17 @@ function createComposerSkillToken(
   };
 }
 
+function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
+  return JSON.stringify(
+    skillTokens.map((token) => ({
+      id: token.id,
+      index: token.index,
+      name: token.name,
+      path: token.path,
+    })),
+  );
+}
+
 function clampSkillTokenIndex(index: number, draft: string): number {
   return Math.max(0, Math.min(index, draft.length));
 }
@@ -794,6 +812,8 @@ export function Composer(props: ComposerProps) {
   const skillListboxId = useId();
   const slashListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
+  const pendingProgrammaticComposerChangeRef =
+    useRef<PendingProgrammaticComposerChange | undefined>(undefined);
   const composerScopeKey = props.launchpad
     ? `launchpad:${props.launchpad.directoryKey}`
     : props.thread
@@ -1790,13 +1810,27 @@ export function Composer(props: ComposerProps) {
       createComposerSkillToken(skill, tokenIndex),
     ];
 
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
     flushSync(() => {
       setSkillTokens(nextSkillTokens);
       setDraft(nextDraft);
       setActiveSkillIndex(0);
     });
-    inputRef.current?.focus();
-    inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
+    const restoreSelection = (): void => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
+    };
+    if (composerImplementation === "tiptap-chips") {
+      requestAnimationFrame(restoreSelection);
+    } else {
+      restoreSelection();
+    }
   };
 
   const applySlashCommand = (command: SlashCommandSuggestion): void => {
@@ -2597,7 +2631,46 @@ export function Composer(props: ComposerProps) {
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
   ): void => {
+    const pendingProgrammaticChange =
+      pendingProgrammaticComposerChangeRef.current;
+    if (pendingProgrammaticChange && nextSkillTokens) {
+      const nextSkillTokensSignature =
+        getComposerSkillTokensSignature(nextSkillTokens);
+      if (
+        nextDraft === pendingProgrammaticChange.staleDraft &&
+        nextSkillTokensSignature ===
+          pendingProgrammaticChange.staleSkillTokensSignature
+      ) {
+        return;
+      }
+      pendingProgrammaticComposerChangeRef.current = undefined;
+    }
+
+    const deletedSkillTokenHistoryEntry =
+      composerSupportsSkillTokens &&
+      nextSkillTokens &&
+      nextSkillTokens.length < skillTokens.length
+        ? (() => {
+            const nextTokenIds = new Set(
+              nextSkillTokens.map((token) => token.id),
+            );
+            const deletedToken = skillTokens.find(
+              (token) => !nextTokenIds.has(token.id),
+            );
+            return deletedToken
+              ? {
+                  draft,
+                  selectionStart: deletedToken.index,
+                  skillTokens,
+                }
+              : undefined;
+          })()
+        : undefined;
+
     updateVisibleDraft(nextDraft, nextSkillTokens);
+    if (deletedSkillTokenHistoryEntry) {
+      deletedSkillTokenHistoryRef.current.push(deletedSkillTokenHistoryEntry);
+    }
     if (nextDraft.trim() !== "/review") {
       setReviewConfig(undefined);
     }
@@ -2643,6 +2716,19 @@ export function Composer(props: ComposerProps) {
     }
 
     if (event.key === "Delete" && deleteEditorContent(event, "forward")) {
+      return;
+    }
+
+    handlePlainComposerKeyDown(event);
+  };
+  const handleTiptapComposerKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ): void => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (restoreDeletedSkillToken(event)) {
       return;
     }
 
@@ -2838,7 +2924,7 @@ export function Composer(props: ComposerProps) {
             onDragOver={handleDragOver}
             onDrop={handleDrop}
             onClick={handleComposerClick}
-            onKeyDown={handlePlainComposerKeyDown}
+            onKeyDown={handleTiptapComposerKeyDown}
           />
         ) : (
           <ComposerTextareaInput

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -586,6 +586,40 @@ function adjustSkillTokenIndexesForTextChange(params: {
   });
 }
 
+function rankSkillAutocompleteMatch(
+  skill: AppServerSkillSummary,
+  normalizedQuery: string,
+): number | undefined {
+  if (!normalizedQuery) {
+    return 0;
+  }
+
+  const name = skill.name.toLowerCase();
+  const shortDescription = skill.shortDescription?.toLowerCase() ?? "";
+  const description = skill.description?.toLowerCase() ?? "";
+
+  if (name === normalizedQuery) {
+    return 0;
+  }
+  if (name.startsWith(`${normalizedQuery}:`)) {
+    return 1;
+  }
+  if (name.startsWith(normalizedQuery)) {
+    return 2;
+  }
+  if (name.includes(normalizedQuery)) {
+    return 3;
+  }
+  if (shortDescription.includes(normalizedQuery)) {
+    return 4;
+  }
+  if (description.includes(normalizedQuery)) {
+    return 5;
+  }
+
+  return undefined;
+}
+
 function useDismissableMenu<T extends HTMLElement>(
   open: boolean,
   onDismiss: () => void,
@@ -851,21 +885,25 @@ export function Composer(props: ComposerProps) {
     }
 
     const normalizedQuery = trigger.query.trim().toLowerCase();
-    return props.skills.filter((skill) => {
-      if (!skill.path) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      return (
-        skill.name.toLowerCase().includes(normalizedQuery) ||
-        skill.description?.toLowerCase().includes(normalizedQuery) ||
-        skill.shortDescription?.toLowerCase().includes(normalizedQuery)
-      );
-    });
+    return props.skills
+      .map((skill, index) => ({
+        index,
+        score: skill.path
+          ? rankSkillAutocompleteMatch(skill, normalizedQuery)
+          : undefined,
+        skill,
+      }))
+      .filter(
+        (match): match is { index: number; score: number; skill: AppServerSkillSummary } =>
+          match.score !== undefined
+      )
+      .sort((left, right) => {
+        if (left.score !== right.score) {
+          return left.score - right.score;
+        }
+        return left.index - right.index;
+      })
+      .map((match) => match.skill);
   }, [props.skills, trigger]);
   const filteredSlashCommands = useMemo(() => {
     if (!slashTrigger) {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -859,6 +859,7 @@ export function Composer(props: ComposerProps) {
   const launchpad = props.launchpad;
   const composerImplementation = props.composerImplementation ?? "textarea";
   const composerSupportsSkillTokens = composerImplementation !== "textarea";
+  const composerUsesTiptap = composerImplementation.startsWith("tiptap-");
   const backend = useMemo(
     () =>
       props.backends?.find((candidate) =>
@@ -1826,7 +1827,7 @@ export function Composer(props: ComposerProps) {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
     };
-    if (composerImplementation === "tiptap-chips") {
+    if (composerUsesTiptap) {
       requestAnimationFrame(restoreSelection);
     } else {
       restoreSelection();
@@ -2907,8 +2908,9 @@ export function Composer(props: ComposerProps) {
             }}
             onKeyDown={handleCustomComposerKeyDown}
           />
-        ) : composerImplementation === "tiptap-chips" ? (
+        ) : composerUsesTiptap ? (
           <ComposerTiptapInput
+            key={composerImplementation}
             ref={inputRef}
             id="thread-composer"
             ariaActiveDescendant={activeAutocompleteOptionId}
@@ -2916,6 +2918,9 @@ export function Composer(props: ComposerProps) {
             ariaExpanded={hasAutocomplete}
             disabled={composerDisabled}
             label={isLaunchpad ? "New thread" : "Reply"}
+            markdownConversion={
+              composerImplementation === "tiptap-wysiwyg-markdown-chips"
+            }
             placeholder={composerPlaceholder}
             skillTokens={skillTokens}
             value={draft}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -41,6 +41,7 @@ import {
 import { parseReviewCommand } from "../../../../shared/review-command";
 import {
   ComposerRichInput,
+  type ComposerRichInputHandle,
   type ComposerSkillToken,
 } from "./ComposerRichInput";
 
@@ -131,6 +132,12 @@ type QueuedTurnDraft = {
 
 type PendingSteerDraft = QueuedTurnDraft & {
   status: "pending" | "steering";
+};
+
+type DeletedSkillTokenHistoryEntry = {
+  draft: string;
+  selectionStart: number;
+  skillTokens: ComposerSkillToken[];
 };
 
 type ComposerImageFile = {
@@ -767,7 +774,7 @@ function ComposerApplicationButton(props: {
 }
 
 export function Composer(props: ComposerProps) {
-  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const inputRef = useRef<ComposerRichInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -780,6 +787,7 @@ export function Composer(props: ComposerProps) {
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const scopedThreadDraftsRef = useRef(new Map<string, ComposerDraftState>());
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
+  const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
   const [draft, setDraft] = useState("");
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const workspaceMenuRef = useDismissableMenu<HTMLDivElement>(
@@ -822,7 +830,10 @@ export function Composer(props: ComposerProps) {
     [props.backends, props.launchpad?.backend, props.thread?.source]
   );
 
-  const selectionStart = inputRef.current?.selectionStart ?? draft.length;
+  const selectionStart = Math.min(
+    inputRef.current?.selectionStart ?? draft.length,
+    draft.length,
+  );
   const isThreadComposerScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
   const canonicalDraft = useMemo(
@@ -831,22 +842,32 @@ export function Composer(props: ComposerProps) {
   );
   const hasComposerContent = draft.trim().length > 0 || skillTokens.length > 0;
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
+    deletedSkillTokenHistoryRef.current = [];
     const hydrated = hydrateComposerDraft(nextDraft, props.skills);
     setDraft(hydrated.draft);
     setSkillTokens(hydrated.skillTokens);
   };
   const clearComposerDraft = (): void => {
+    deletedSkillTokenHistoryRef.current = [];
     setDraft("");
     setSkillTokens([]);
   };
-  const updateVisibleDraft = (nextDraft: string): void => {
-    setSkillTokens((current) =>
-      adjustSkillTokenIndexesForTextChange({
-        currentDraft: draft,
-        nextDraft,
-        skillTokens: current,
-      })
-    );
+  const updateVisibleDraft = (
+    nextDraft: string,
+    nextSkillTokens?: ComposerSkillToken[],
+  ): void => {
+    deletedSkillTokenHistoryRef.current = [];
+    if (nextSkillTokens) {
+      setSkillTokens(nextSkillTokens);
+    } else {
+      setSkillTokens((current) =>
+        adjustSkillTokenIndexesForTextChange({
+          currentDraft: draft,
+          nextDraft,
+          skillTokens: current,
+        })
+      );
+    }
     setDraft(nextDraft);
   };
   const saveThreadComposerDraft = (
@@ -1664,8 +1685,14 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const selectionStart = inputRef.current.selectionStart ?? draft.length;
-    const selectionEnd = inputRef.current.selectionEnd ?? selectionStart;
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
     const trigger = findSkillTrigger(draft, selectionStart);
     if (!trigger) {
       return;
@@ -1697,8 +1724,14 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const selectionStart = inputRef.current.selectionStart ?? draft.length;
-    const selectionEnd = inputRef.current.selectionEnd ?? selectionStart;
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
     const trigger = findSlashCommandTrigger(draft, selectionStart);
     if (!trigger) {
       return;
@@ -1744,7 +1777,7 @@ export function Composer(props: ComposerProps) {
     });
   };
 
-  const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>): void => {
+  const handlePaste = (event: ClipboardEvent<HTMLDivElement>): void => {
     const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
     if (pastedFiles.length === 0) {
       return;
@@ -1755,7 +1788,7 @@ export function Composer(props: ComposerProps) {
     void attachImages(pastedFiles);
   };
 
-  const handleDragOver = (event: DragEvent<HTMLTextAreaElement>): void => {
+  const handleDragOver = (event: DragEvent<HTMLDivElement>): void => {
     if (!hasImageFiles(event.dataTransfer)) {
       return;
     }
@@ -1764,7 +1797,7 @@ export function Composer(props: ComposerProps) {
     event.dataTransfer.dropEffect = "copy";
   };
 
-  const handleDrop = (event: DragEvent<HTMLTextAreaElement>): void => {
+  const handleDrop = (event: DragEvent<HTMLDivElement>): void => {
     const droppedFiles = getImageFilesFromDataTransfer(event.dataTransfer);
     if (droppedFiles.length === 0) {
       return;
@@ -2059,35 +2092,6 @@ export function Composer(props: ComposerProps) {
     !sourceBranch ||
     (handoffDialog === "local-to-worktree" && !leaveLocalBranch);
 
-  const removeSkillToken = (id: string): void => {
-    setSkillTokens((current) => current.filter((skill) => skill.id !== id));
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-    });
-  };
-
-  const removeAdjacentSkillToken = (key: "Backspace" | "Delete"): boolean => {
-    const input = inputRef.current;
-    if (!input || input.selectionStart !== input.selectionEnd) {
-      return false;
-    }
-
-    const caret = input.selectionStart ?? draft.length;
-    const token = skillTokens.find((candidate) => candidate.index === caret);
-    if (!token) {
-      return false;
-    }
-
-    setSkillTokens((current) =>
-      current.filter((candidate) => candidate.id !== token.id)
-    );
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(caret, caret);
-    });
-    return key === "Backspace" || key === "Delete";
-  };
-
   const commitActiveAutocomplete = (): void => {
     if (autocompleteKind === "skills") {
       applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
@@ -2099,10 +2103,69 @@ export function Composer(props: ComposerProps) {
     );
   };
 
+  const removeAdjacentSkillToken = (
+    event: ReactKeyboardEvent<HTMLElement>,
+  ): boolean => {
+    if (
+      event.key !== "Backspace" ||
+      !inputRef.current ||
+      inputRef.current.selectionStart !== inputRef.current.selectionEnd
+    ) {
+      return false;
+    }
+
+    const caret = Math.min(inputRef.current.selectionStart, draft.length);
+    const token = skillTokens.find((candidate) => candidate.index === caret);
+    if (!token) {
+      return false;
+    }
+
+    event.preventDefault();
+    deletedSkillTokenHistoryRef.current.push({
+      draft,
+      selectionStart: caret,
+      skillTokens,
+    });
+    setSkillTokens((current) =>
+      current.filter((candidate) => candidate.id !== token.id)
+    );
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(caret, caret);
+    });
+    return true;
+  };
+
+  const restoreDeletedSkillToken = (
+    event: ReactKeyboardEvent<HTMLElement>,
+  ): boolean => {
+    if (
+      event.key.toLowerCase() !== "z" ||
+      (!event.metaKey && !event.ctrlKey) ||
+      event.shiftKey ||
+      deletedSkillTokenHistoryRef.current.length === 0
+    ) {
+      return false;
+    }
+
+    const previous = deletedSkillTokenHistoryRef.current.pop()!;
+    event.preventDefault();
+    setDraft(previous.draft);
+    setSkillTokens(previous.skillTokens);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(
+        previous.selectionStart,
+        previous.selectionStart,
+      );
+    });
+    return true;
+  };
+
   const handleAutocompleteKeyDown = (
     event: ReactKeyboardEvent<HTMLElement>,
   ): void => {
-    if (!hasAutocomplete) {
+    if (!hasAutocomplete && event.key !== "Escape") {
       return;
     }
 
@@ -2141,7 +2204,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const optionHasFocus = event.currentTarget !== inputRef.current;
+    const optionHasFocus = event.currentTarget instanceof HTMLButtonElement;
     if (
       (event.key === "Enter" && !event.shiftKey) ||
       (event.key === " " && optionHasFocus)
@@ -2261,7 +2324,6 @@ export function Composer(props: ComposerProps) {
           id="thread-composer"
           disabled={launchpadSubmitting || (props.disabled && !hasComposerContent)}
           label={isLaunchpad ? "New thread" : "Reply"}
-          onRemoveSkillToken={removeSkillToken}
           placeholder={
             isLaunchpad
               ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
@@ -2269,8 +2331,8 @@ export function Composer(props: ComposerProps) {
           }
           skillTokens={skillTokens}
           value={draft}
-          onChange={(nextDraft) => {
-            updateVisibleDraft(nextDraft);
+          onChange={(nextDraft, nextSkillTokens) => {
+            updateVisibleDraft(nextDraft, nextSkillTokens);
             if (nextDraft.trim() !== "/review") {
               setReviewConfig(undefined);
             }
@@ -2284,18 +2346,19 @@ export function Composer(props: ComposerProps) {
             setActiveSlashIndex(0);
           }}
           onKeyDown={(event) => {
+            if (restoreDeletedSkillToken(event)) {
+              return;
+            }
+
             if (!hasAutocomplete) {
-              if (
-                (event.key === "Backspace" || event.key === "Delete") &&
-                removeAdjacentSkillToken(event.key)
-              ) {
-                event.preventDefault();
+              if (removeAdjacentSkillToken(event)) {
                 return;
               }
+
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
                 void submitTurn(event.metaKey ? "steer" : "default");
-            }
+              }
               return;
             }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2,6 +2,7 @@ import {
   type ReactNode,
   type ClipboardEvent,
   type DragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   useId,
   useMemo,
@@ -33,11 +34,15 @@ import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import {
   findSkillTrigger,
   hydrateSkillLabelsWithMarkdown,
-  insertSkillLabel,
   listMentionedSkills,
+  parseSkillMentionParts,
+  buildSkillMentionMarkdown,
 } from "../../lib/skill-mentions";
 import { parseReviewCommand } from "../../../../shared/review-command";
-import { SkillChip } from "./SkillChip";
+import {
+  ComposerRichInput,
+  type ComposerSkillToken,
+} from "./ComposerRichInput";
 
 type ComposerProps = {
   activeTurnId?: string;
@@ -169,6 +174,7 @@ type ReviewConfigState = {
 type ComposerDraftState = {
   draft: string;
   imageAttachments: ComposerImageAttachment[];
+  skillTokens: ComposerSkillToken[];
 };
 
 const DEFAULT_REASONING_EFFORT = "medium";
@@ -452,6 +458,134 @@ function HighlightedAutocompleteLabel(props: {
   );
 }
 
+function createComposerSkillToken(
+  skill: AppServerSkillSummary,
+  index: number,
+): ComposerSkillToken {
+  return {
+    ...skill,
+    id: `${skill.path ?? skill.name}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+function clampSkillTokenIndex(index: number, draft: string): number {
+  return Math.max(0, Math.min(index, draft.length));
+}
+
+function serializeDraftWithSkillTokens(
+  draft: string,
+  skillTokens: ComposerSkillToken[],
+): string {
+  if (skillTokens.length === 0) {
+    return draft;
+  }
+
+  const sortedTokens = [...skillTokens].sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  let output = "";
+  let cursor = 0;
+  for (const token of sortedTokens) {
+    const index = clampSkillTokenIndex(token.index, draft);
+    output += draft.slice(cursor, index);
+    output += buildSkillMentionMarkdown(token);
+    cursor = index;
+  }
+
+  output += draft.slice(cursor);
+  return output;
+}
+
+function hydrateComposerDraft(
+  canonicalDraft: string,
+  skills: AppServerSkillSummary[],
+): {
+  draft: string;
+  skillTokens: ComposerSkillToken[];
+} {
+  let draft = "";
+  const skillTokens: ComposerSkillToken[] = [];
+
+  for (const part of parseSkillMentionParts(canonicalDraft)) {
+    if (part.type === "text") {
+      draft += part.text;
+      continue;
+    }
+
+    const matchingSkill =
+      skills.find((skill) => skill.path === part.path) ??
+      skills.find((skill) => skill.name === part.name);
+    skillTokens.push(
+      createComposerSkillToken(
+        matchingSkill ?? {
+          name: part.name,
+          path: part.path,
+        },
+        draft.length,
+      ),
+    );
+  }
+
+  return { draft, skillTokens };
+}
+
+function adjustSkillTokenIndexesForTextChange(params: {
+  currentDraft: string;
+  nextDraft: string;
+  skillTokens: ComposerSkillToken[];
+}): ComposerSkillToken[] {
+  const { currentDraft, nextDraft, skillTokens } = params;
+  if (currentDraft === nextDraft || skillTokens.length === 0) {
+    return skillTokens;
+  }
+
+  let prefixLength = 0;
+  while (
+    prefixLength < currentDraft.length &&
+    prefixLength < nextDraft.length &&
+    currentDraft[prefixLength] === nextDraft[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < currentDraft.length - prefixLength &&
+    suffixLength < nextDraft.length - prefixLength &&
+    currentDraft[currentDraft.length - 1 - suffixLength] ===
+      nextDraft[nextDraft.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  const currentChangedEnd = currentDraft.length - suffixLength;
+  const nextChangedEnd = nextDraft.length - suffixLength;
+  const delta = nextChangedEnd - currentChangedEnd;
+
+  return skillTokens.map((token) => {
+    if (token.index <= prefixLength) {
+      return token;
+    }
+
+    if (token.index >= currentChangedEnd) {
+      return {
+        ...token,
+        index: clampSkillTokenIndex(token.index + delta, nextDraft),
+      };
+    }
+
+    return {
+      ...token,
+      index: clampSkillTokenIndex(prefixLength, nextDraft),
+    };
+  });
+}
+
 function useDismissableMenu<T extends HTMLElement>(
   open: boolean,
   onDismiss: () => void,
@@ -600,6 +734,7 @@ function ComposerApplicationButton(props: {
 
 export function Composer(props: ComposerProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const inputWrapRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
@@ -633,8 +768,14 @@ export function Composer(props: ComposerProps) {
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
+  const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>([]);
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
+  const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
+  const [autocompleteLayout, setAutocompleteLayout] = useState<{
+    maxHeight: number;
+    placement: "above" | "below";
+  }>({ maxHeight: 320, placement: "above" });
   const [activeOptimisticMessageId, setActiveOptimisticMessageId] = useState<string>();
   const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
@@ -650,6 +791,30 @@ export function Composer(props: ComposerProps) {
   const selectionStart = inputRef.current?.selectionStart ?? draft.length;
   const isThreadComposerScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
+  const canonicalDraft = useMemo(
+    () => serializeDraftWithSkillTokens(draft, skillTokens),
+    [draft, skillTokens]
+  );
+  const hasComposerContent = draft.trim().length > 0 || skillTokens.length > 0;
+  const setComposerDraftFromCanonical = (nextDraft: string): void => {
+    const hydrated = hydrateComposerDraft(nextDraft, props.skills);
+    setDraft(hydrated.draft);
+    setSkillTokens(hydrated.skillTokens);
+  };
+  const clearComposerDraft = (): void => {
+    setDraft("");
+    setSkillTokens([]);
+  };
+  const updateVisibleDraft = (nextDraft: string): void => {
+    setSkillTokens((current) =>
+      adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens: current,
+      })
+    );
+    setDraft(nextDraft);
+  };
   const saveThreadComposerDraft = (
     scopeKey: string,
     state: ComposerDraftState,
@@ -658,7 +823,11 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    if (!state.draft.trim() && state.imageAttachments.length === 0) {
+    if (
+      !state.draft.trim() &&
+      state.skillTokens.length === 0 &&
+      state.imageAttachments.length === 0
+    ) {
       scopedThreadDraftsRef.current.delete(scopeKey);
       return;
     }
@@ -710,11 +879,24 @@ export function Composer(props: ComposerProps) {
         command.description.toLowerCase().includes(typed.slice(1))
     );
   }, [draft, slashTrigger]);
-  const displayedAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
+  const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
       ? "slash"
       : undefined;
+  const autocompleteKey =
+    availableAutocompleteKind === "skills" && trigger
+      ? `skills:${trigger.start}:${trigger.end}:${trigger.query}`
+      : availableAutocompleteKind === "slash" && slashTrigger
+        ? `slash:${slashTrigger.start}:${slashTrigger.end}:${draft.slice(
+            slashTrigger.start,
+            slashTrigger.end,
+          )}`
+        : undefined;
+  const displayedAutocompleteKind =
+    autocompleteKey && autocompleteKey === dismissedAutocompleteKey
+      ? undefined
+      : availableAutocompleteKind;
   const autocompleteKind: AutocompleteKind | undefined =
     displayedAutocompleteKind === "slash" &&
     parseReviewCommand(draft) &&
@@ -726,10 +908,6 @@ export function Composer(props: ComposerProps) {
     displayedAutocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
   const autocompleteLength =
     displayedAutocompleteKind === "skills" ? filteredSkills.length : filteredSlashCommands.length;
-  const mentionedSkills = useMemo(
-    () => listMentionedSkills(draft, props.skills),
-    [draft, props.skills]
-  );
   const reviewBranchOptions = useMemo(
     () => buildReviewBranchOptions({
       directory: props.directory,
@@ -748,6 +926,7 @@ export function Composer(props: ComposerProps) {
     saveThreadComposerDraft(previousScopeKey, {
       draft,
       imageAttachments,
+      skillTokens,
     });
 
     activeComposerScopeKeyRef.current = composerScopeKey;
@@ -761,6 +940,7 @@ export function Composer(props: ComposerProps) {
       const saved = scopedThreadDraftsRef.current.get(composerScopeKey);
       setDraft(saved?.draft ?? "");
       setImageAttachments(saved?.imageAttachments ?? []);
+      setSkillTokens(saved?.skillTokens ?? []);
     }
     setSending(false);
     setInterrupting(false);
@@ -770,7 +950,7 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
     setPendingSteer(undefined);
-  }, [composerScopeKey]);
+  }, [composerScopeKey, draft, imageAttachments, skillTokens]);
 
   useEffect(() => {
     setActiveSkillIndex(0);
@@ -788,6 +968,38 @@ export function Composer(props: ComposerProps) {
     autocompleteOptionRefs.current[activeAutocompleteIndex]?.scrollIntoView?.({
       block: "nearest",
     });
+  }, [activeAutocompleteIndex, displayedAutocompleteKind]);
+
+  useEffect(() => {
+    if (!displayedAutocompleteKind) {
+      return;
+    }
+
+    const updateAutocompleteLayout = (): void => {
+      const inputWrap = inputWrapRef.current;
+      if (!inputWrap) {
+        return;
+      }
+
+      const viewportPadding = 12;
+      const gap = 10;
+      const rect = inputWrap.getBoundingClientRect();
+      const availableAbove = rect.top - viewportPadding - gap;
+      const availableBelow = window.innerHeight - rect.bottom - viewportPadding - gap;
+      const placement =
+        availableAbove >= 180 || availableAbove >= availableBelow ? "above" : "below";
+      const available = placement === "above" ? availableAbove : availableBelow;
+      setAutocompleteLayout({
+        placement,
+        maxHeight: Math.max(140, Math.min(320, available)),
+      });
+    };
+
+    updateAutocompleteLayout();
+    window.addEventListener("resize", updateAutocompleteLayout);
+    return () => {
+      window.removeEventListener("resize", updateAutocompleteLayout);
+    };
   }, [activeAutocompleteIndex, displayedAutocompleteKind]);
 
   useEffect(() => {
@@ -809,7 +1021,7 @@ export function Composer(props: ComposerProps) {
     }
 
     hydratedLaunchpadKeyRef.current = props.launchpad?.directoryKey;
-    setDraft(props.launchpad?.prompt ?? "");
+    setComposerDraftFromCanonical(props.launchpad?.prompt ?? "");
     setImageAttachments(props.launchpad?.imageAttachments ?? []);
     setSending(false);
     setInterrupting(false);
@@ -819,7 +1031,7 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
     setPendingSteer(undefined);
-  }, [isLaunchpad, props.launchpad?.directoryKey]);
+  }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.prompt, props.skills]);
 
   useEffect(() => {
     if (!props.thread) {
@@ -913,7 +1125,7 @@ export function Composer(props: ComposerProps) {
         setSteering(false);
         if (pendingSteer?.status === "pending") {
           if (queuedTurn) {
-            setDraft(pendingSteer.text);
+            setComposerDraftFromCanonical(pendingSteer.text);
             setImageAttachments(pendingSteer.imageAttachments);
           } else {
             setQueuedTurn({
@@ -963,21 +1175,21 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    if (draft === launchpad.prompt) {
+    if (canonicalDraft === launchpad.prompt) {
       return;
     }
 
     const timeout = window.setTimeout(() => {
       void props.onUpdateLaunchpad?.(launchpad.directoryKey, {
         imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
-        prompt: draft,
+        prompt: canonicalDraft,
       });
     }, 250);
 
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [draft, imageAttachments, launchpad, props.onUpdateLaunchpad]);
+  }, [canonicalDraft, imageAttachments, launchpad, props.onUpdateLaunchpad]);
 
   const submitReviewCommand = async (reviewCommand: {
     displayText: string;
@@ -1003,7 +1215,7 @@ export function Composer(props: ComposerProps) {
           undefined,
           reviewCommand.target
         );
-        setDraft("");
+        clearComposerDraft();
         setReviewConfig(undefined);
         setImageAttachments([]);
       } catch (error) {
@@ -1035,7 +1247,7 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
       clearThreadComposerDraft(composerScopeKey);
-      setDraft("");
+      clearComposerDraft();
       setReviewConfig(undefined);
     } catch (error) {
       if (optimisticReviewId) {
@@ -1080,7 +1292,7 @@ export function Composer(props: ComposerProps) {
 
     const payload = queued
       ? buildTurnPayload(queued.text, queued.imageAttachments)
-      : buildTurnPayload(draft, imageAttachments);
+      : buildTurnPayload(canonicalDraft, imageAttachments);
     if (payload.input.length === 0 || props.disabled) {
       return;
     }
@@ -1127,7 +1339,7 @@ export function Composer(props: ComposerProps) {
         setQueuedTurn(undefined);
       } else {
         clearThreadComposerDraft(composerScopeKey);
-        setDraft("");
+        clearComposerDraft();
         setImageAttachments([]);
         if (collaborationMode) {
           setPlanModeEnabled(false);
@@ -1160,7 +1372,7 @@ export function Composer(props: ComposerProps) {
   }, [activeTurnId, queuedTurn, sending, props.disabled, props.launchpad]);
 
   const queueCurrentDraft = (): void => {
-    if (!draft.trim() && imageAttachments.length === 0) {
+    if (!hasComposerContent && imageAttachments.length === 0) {
       return;
     }
     if (queuedTurn) {
@@ -1169,11 +1381,11 @@ export function Composer(props: ComposerProps) {
     }
 
     setQueuedTurn({
-      text: draft,
+      text: canonicalDraft,
       imageAttachments,
     });
     clearThreadComposerDraft(composerScopeKey);
-    setDraft("");
+    clearComposerDraft();
     setImageAttachments([]);
     setReviewConfig(undefined);
     setSendError(undefined);
@@ -1263,7 +1475,7 @@ export function Composer(props: ComposerProps) {
       status: "pending",
     });
     clearThreadComposerDraft(composerScopeKey);
-    setDraft("");
+    clearComposerDraft();
     setImageAttachments([]);
     setReviewConfig(undefined);
     return true;
@@ -1282,7 +1494,7 @@ export function Composer(props: ComposerProps) {
     }
 
     createPendingSteer({
-      text: draft,
+      text: canonicalDraft,
       imageAttachments,
     });
   };
@@ -1330,7 +1542,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const payload = buildTurnPayload(draft, imageAttachments);
+    const payload = buildTurnPayload(canonicalDraft, imageAttachments);
     const collaborationMode = planModeEnabled && supportsPlanMode
       ? ({
           mode: "plan",
@@ -1354,7 +1566,7 @@ export function Composer(props: ComposerProps) {
           payload.input,
           collaborationMode
         );
-        setDraft("");
+        clearComposerDraft();
         setImageAttachments([]);
         if (collaborationMode) {
           setPlanModeEnabled(false);
@@ -1414,21 +1626,31 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const inserted = insertSkillLabel({
-      draft,
-      skill,
-      selectionStart: inputRef.current.selectionStart ?? draft.length,
-      selectionEnd: inputRef.current.selectionEnd ?? draft.length,
-    });
-    if (!inserted) {
+    const selectionStart = inputRef.current.selectionStart ?? draft.length;
+    const selectionEnd = inputRef.current.selectionEnd ?? selectionStart;
+    const trigger = findSkillTrigger(draft, selectionStart);
+    if (!trigger) {
       return;
     }
 
-    setDraft(inserted.nextDraft);
+    const before = draft.slice(0, trigger.start);
+    const after = draft.slice(Math.max(trigger.end, selectionEnd));
+    const nextAfter = after.length > 0 && !/^\s/.test(after) ? ` ${after}` : after;
+    const nextDraft = `${before}${nextAfter}`;
+    const tokenIndex = before.length;
+    setSkillTokens((current) => [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens: current,
+      }),
+      createComposerSkillToken(skill, tokenIndex),
+    ]);
+    setDraft(nextDraft);
     setActiveSkillIndex(0);
     requestAnimationFrame(() => {
       inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(inserted.nextSelection, inserted.nextSelection);
+      inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
     });
   };
 
@@ -1450,7 +1672,7 @@ export function Composer(props: ComposerProps) {
     const nextDraft = `${before}${command.insertText}${needsTrailingSpace ? " " : ""}${after}`;
     const nextSelection = before.length + command.insertText.length + (needsTrailingSpace ? 1 : 0);
 
-    setDraft(nextDraft);
+    updateVisibleDraft(nextDraft);
     setActiveSlashIndex(0);
     requestAnimationFrame(() => {
       inputRef.current?.focus();
@@ -1464,6 +1686,7 @@ export function Composer(props: ComposerProps) {
       saveThreadComposerDraft(composerScopeKey, {
         draft,
         imageAttachments: nextAttachments,
+        skillTokens,
       });
       persistLaunchpadImageAttachments(nextAttachments);
       return nextAttachments;
@@ -1479,7 +1702,7 @@ export function Composer(props: ComposerProps) {
 
     void props.onUpdateLaunchpad(props.launchpad.directoryKey, {
       imageAttachments: attachments.length > 0 ? attachments : undefined,
-      prompt: draft,
+      prompt: canonicalDraft,
     });
   };
 
@@ -1516,7 +1739,7 @@ export function Composer(props: ComposerProps) {
 
   const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
-    const pasteDraft = draft;
+    const pasteDraft = canonicalDraft;
     const pasteImageAttachments = imageAttachments;
     const pasteLaunchpad = props.launchpad;
     const updateLaunchpad = props.onUpdateLaunchpad;
@@ -1582,10 +1805,12 @@ export function Composer(props: ComposerProps) {
         const saved = scopedThreadDraftsRef.current.get(pasteScope.key) ?? {
           draft: "",
           imageAttachments: [],
+          skillTokens: [],
         };
         saveThreadComposerDraft(pasteScope.key, {
           draft: saved.draft,
           imageAttachments: [...saved.imageAttachments, ...nextAttachments],
+          skillTokens: saved.skillTokens,
         });
         return;
       }
@@ -1595,6 +1820,7 @@ export function Composer(props: ComposerProps) {
         saveThreadComposerDraft(pasteScope.key, {
           draft,
           imageAttachments: mergedAttachments,
+          skillTokens,
         });
         persistLaunchpadImageAttachments(mergedAttachments);
         return mergedAttachments;
@@ -1795,6 +2021,98 @@ export function Composer(props: ComposerProps) {
     !sourceBranch ||
     (handoffDialog === "local-to-worktree" && !leaveLocalBranch);
 
+  const removeSkillToken = (id: string): void => {
+    setSkillTokens((current) => current.filter((skill) => skill.id !== id));
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  };
+
+  const removeAdjacentSkillToken = (key: "Backspace" | "Delete"): boolean => {
+    const input = inputRef.current;
+    if (!input || input.selectionStart !== input.selectionEnd) {
+      return false;
+    }
+
+    const caret = input.selectionStart ?? draft.length;
+    const token = skillTokens.find((candidate) => candidate.index === caret);
+    if (!token) {
+      return false;
+    }
+
+    setSkillTokens((current) =>
+      current.filter((candidate) => candidate.id !== token.id)
+    );
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(caret, caret);
+    });
+    return key === "Backspace" || key === "Delete";
+  };
+
+  const commitActiveAutocomplete = (): void => {
+    if (autocompleteKind === "skills") {
+      applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
+      return;
+    }
+
+    applySlashCommand(
+      filteredSlashCommands[activeSlashIndex] ?? filteredSlashCommands[0]!
+    );
+  };
+
+  const handleAutocompleteKeyDown = (
+    event: ReactKeyboardEvent<HTMLElement>,
+  ): void => {
+    if (!hasAutocomplete) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (autocompleteKind === "skills") {
+        setActiveSkillIndex((current) =>
+          Math.min(current + 1, autocompleteLength - 1)
+        );
+      } else {
+        setActiveSlashIndex((current) =>
+          Math.min(current + 1, autocompleteLength - 1)
+        );
+      }
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (autocompleteKind === "skills") {
+        setActiveSkillIndex((current) => Math.max(current - 1, 0));
+      } else {
+        setActiveSlashIndex((current) => Math.max(current - 1, 0));
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (autocompleteKey) {
+        setDismissedAutocompleteKey(autocompleteKey);
+      }
+      setActiveSkillIndex(0);
+      setActiveSlashIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+      return;
+    }
+
+    const optionHasFocus = event.currentTarget !== inputRef.current;
+    if (
+      (event.key === "Enter" && !event.shiftKey) ||
+      (event.key === " " && optionHasFocus)
+    ) {
+      event.preventDefault();
+      commitActiveAutocomplete();
+    }
+  };
+
   return (
     <form
       className="composer"
@@ -1829,7 +2147,7 @@ export function Composer(props: ComposerProps) {
                   className="composer__secondary-action"
                   type="button"
                   onClick={() => {
-                    setDraft(pendingSteer.text);
+                    setComposerDraftFromCanonical(pendingSteer.text);
                     setImageAttachments(pendingSteer.imageAttachments);
                     setPendingSteer(undefined);
                     requestAnimationFrame(() => inputRef.current?.focus());
@@ -1878,7 +2196,7 @@ export function Composer(props: ComposerProps) {
               className="composer__secondary-action"
               type="button"
               onClick={() => {
-                setDraft(queuedTurn.text);
+                setComposerDraftFromCanonical(queuedTurn.text);
                 setImageAttachments(queuedTurn.imageAttachments);
                 setQueuedTurn(undefined);
                 requestAnimationFrame(() => inputRef.current?.focus());
@@ -1899,29 +2217,22 @@ export function Composer(props: ComposerProps) {
         </div>
       ) : null}
 
-      {mentionedSkills.length > 0 ? (
-        <div className="composer__mentioned-skills" aria-label="Mentioned skills">
-          {mentionedSkills.map((skill) => (
-            <SkillChip key={skill.path ?? skill.name} skill={skill} />
-          ))}
-        </div>
-      ) : null}
-
-      <div className="composer__input-wrap">
-        <textarea
+      <div className="composer__input-wrap" ref={inputWrapRef}>
+        <ComposerRichInput
           ref={inputRef}
           id="thread-composer"
-          className="composer__input"
-          disabled={launchpadSubmitting || (props.disabled && !draft)}
+          disabled={launchpadSubmitting || (props.disabled && !hasComposerContent)}
+          label={isLaunchpad ? "New thread" : "Reply"}
+          onRemoveSkillToken={removeSkillToken}
           placeholder={
             isLaunchpad
               ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
               : "Reply to this thread"
           }
+          skillTokens={skillTokens}
           value={draft}
-          onChange={(event) => {
-            const nextDraft = event.target.value;
-            setDraft(nextDraft);
+          onChange={(nextDraft) => {
+            updateVisibleDraft(nextDraft);
             if (nextDraft.trim() !== "/review") {
               setReviewConfig(undefined);
             }
@@ -1936,59 +2247,31 @@ export function Composer(props: ComposerProps) {
           }}
           onKeyDown={(event) => {
             if (!hasAutocomplete) {
+              if (
+                (event.key === "Backspace" || event.key === "Delete") &&
+                removeAdjacentSkillToken(event.key)
+              ) {
+                event.preventDefault();
+                return;
+              }
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
                 void submitTurn(event.metaKey ? "steer" : "default");
-              }
+            }
               return;
             }
 
-            if (event.key === "ArrowDown") {
-              event.preventDefault();
-              if (autocompleteKind === "skills") {
-                setActiveSkillIndex((current) =>
-                  Math.min(current + 1, autocompleteLength - 1)
-                );
-              } else {
-                setActiveSlashIndex((current) =>
-                  Math.min(current + 1, autocompleteLength - 1)
-                );
-              }
-              return;
-            }
-
-            if (event.key === "ArrowUp") {
-              event.preventDefault();
-              if (autocompleteKind === "skills") {
-                setActiveSkillIndex((current) => Math.max(current - 1, 0));
-              } else {
-                setActiveSlashIndex((current) => Math.max(current - 1, 0));
-              }
-              return;
-            }
-
-            if (event.key === "Escape") {
-              event.preventDefault();
-              setActiveSkillIndex(0);
-              setActiveSlashIndex(0);
-              return;
-            }
-
-            if (event.key === "Enter" && !event.shiftKey) {
-              event.preventDefault();
-              if (autocompleteKind === "skills") {
-                applySkill(filteredSkills[activeSkillIndex] ?? filteredSkills[0]!);
-              } else {
-                applySlashCommand(
-                  filteredSlashCommands[activeSlashIndex] ?? filteredSlashCommands[0]!
-                );
-              }
-            }
+            handleAutocompleteKeyDown(event);
           }}
         />
 
         {displayedAutocompleteKind === "skills" ? (
-          <div className="composer__autocomplete" role="listbox" aria-label="Skills">
+          <div
+            className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            role="listbox"
+            aria-label="Skills"
+            style={{ maxHeight: autocompleteLayout.maxHeight }}
+          >
             {filteredSkills.map((skill, index) => (
               <button
                 key={skill.path ?? skill.name}
@@ -1997,6 +2280,7 @@ export function Composer(props: ComposerProps) {
                 }}
                 aria-selected={index === activeSkillIndex}
                 className={`composer__autocomplete-option${index === activeSkillIndex ? " is-active" : ""}`}
+                tabIndex={index === activeSkillIndex ? 0 : -1}
                 type="button"
                 onMouseDown={(event) => {
                   event.preventDefault();
@@ -2005,6 +2289,10 @@ export function Composer(props: ComposerProps) {
                 onClick={() => {
                   applySkill(skill);
                 }}
+                onFocus={() => {
+                  setActiveSkillIndex(index);
+                }}
+                onKeyDown={handleAutocompleteKeyDown}
               >
                 <span className="composer__autocomplete-title">
                   <span aria-hidden="true">🧰</span>
@@ -2020,7 +2308,12 @@ export function Composer(props: ComposerProps) {
             ))}
           </div>
         ) : displayedAutocompleteKind === "slash" ? (
-          <div className="composer__autocomplete" role="listbox" aria-label="Commands">
+          <div
+            className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            role="listbox"
+            aria-label="Commands"
+            style={{ maxHeight: autocompleteLayout.maxHeight }}
+          >
             {filteredSlashCommands.map((command, index) => (
               <button
                 key={command.id}
@@ -2029,6 +2322,7 @@ export function Composer(props: ComposerProps) {
                 }}
                 aria-selected={index === activeSlashIndex}
                 className={`composer__autocomplete-option${index === activeSlashIndex ? " is-active" : ""}`}
+                tabIndex={index === activeSlashIndex ? 0 : -1}
                 type="button"
                 onMouseDown={(event) => {
                   event.preventDefault();
@@ -2037,6 +2331,10 @@ export function Composer(props: ComposerProps) {
                 onClick={() => {
                   applySlashCommand(command);
                 }}
+                onFocus={() => {
+                  setActiveSlashIndex(index);
+                }}
+                onKeyDown={handleAutocompleteKeyDown}
               >
                 <span className="composer__autocomplete-title">
                   <span className="composer__autocomplete-token" aria-hidden="true">/</span>
@@ -2679,7 +2977,7 @@ export function Composer(props: ComposerProps) {
               props.disabled ||
               steering ||
               (!activeTurnId && sending) ||
-              (!draft.trim() && imageAttachments.length === 0)
+              (!hasComposerContent && imageAttachments.length === 0)
             }
             type="submit"
           >

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -143,6 +143,13 @@ type DeletedSkillTokenHistoryEntry = {
 
 const COMPOSER_SKILL_TOKEN_SELECTOR = "[data-composer-skill-token-id]";
 
+type SkillTokenDeletionEvent = {
+  currentTarget: HTMLElement;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+  target: EventTarget | null;
+};
+
 type ComposerImageFile = {
   file: File;
   type: string;
@@ -2106,26 +2113,38 @@ export function Composer(props: ComposerProps) {
     );
   };
 
-  const findEventTargetSkillToken = (
-    event: ReactKeyboardEvent<HTMLElement> | ReactFormEvent<HTMLElement>,
-  ): ComposerSkillToken | undefined => {
+  const findEventTargetSkillTokenId = (
+    event: SkillTokenDeletionEvent,
+  ): string | undefined => {
     const target = event.target;
     if (!(target instanceof Element)) {
       return undefined;
     }
 
     const tokenElement = target.closest(COMPOSER_SKILL_TOKEN_SELECTOR);
-    const tokenId = tokenElement instanceof HTMLElement
+    return tokenElement instanceof HTMLElement
       ? tokenElement.dataset.composerSkillTokenId
-      : undefined;
-    return tokenId
-      ? skillTokens.find((candidate) => candidate.id === tokenId)
       : undefined;
   };
 
-  const findSelectedSkillToken = (
+  const selectionBelongsToEditor = (editor: HTMLElement): boolean => {
+    const ownerDocument = editor.ownerDocument;
+    const selection = ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return editor.contains(ownerDocument.activeElement);
+    }
+
+    const range = selection.getRangeAt(0);
+    return (
+      editor.contains(range.startContainer) ||
+      editor.contains(range.endContainer) ||
+      range.intersectsNode(editor)
+    );
+  };
+
+  const findSelectedSkillTokenId = (
     editor: HTMLElement,
-  ): ComposerSkillToken | undefined => {
+  ): string | undefined => {
     const selection = editor.ownerDocument.getSelection();
     if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
       return undefined;
@@ -2135,10 +2154,62 @@ export function Composer(props: ComposerProps) {
     const tokenElement = Array.from(
       editor.querySelectorAll<HTMLElement>(COMPOSER_SKILL_TOKEN_SELECTOR),
     ).find((candidate) => range.intersectsNode(candidate));
-    const tokenId = tokenElement?.dataset.composerSkillTokenId;
-    return tokenId
-      ? skillTokens.find((candidate) => candidate.id === tokenId)
-      : undefined;
+    return tokenElement?.dataset.composerSkillTokenId;
+  };
+
+  const shouldGuardBoundarySkillDeletion = (editor: HTMLElement): boolean => {
+    const selection = editor.ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+      return false;
+    }
+
+    const range = selection.getRangeAt(0);
+    if (!editor.contains(range.startContainer)) {
+      return false;
+    }
+
+    return (
+      range.startContainer.nodeType !== Node.TEXT_NODE || range.startOffset === 0
+    );
+  };
+
+  const shouldGuardNativeTextDeletion = (
+    editor: HTMLElement,
+    direction: "backward" | "forward",
+  ): boolean => {
+    const selection = editor.ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) {
+      return false;
+    }
+
+    const range = selection.getRangeAt(0);
+    if (!editor.contains(range.startContainer)) {
+      return false;
+    }
+
+    if (range.startContainer.nodeType !== Node.TEXT_NODE) {
+      return true;
+    }
+
+    const textLength = range.startContainer.nodeValue?.length ?? 0;
+    return direction === "backward"
+      ? range.startOffset === 0
+      : range.startOffset >= textLength;
+  };
+
+  const findBoundarySkillToken = (
+    caret: number,
+    direction: "backward" | "forward",
+  ): ComposerSkillToken | undefined => {
+    if (direction === "forward") {
+      return [...skillTokens]
+        .sort((left, right) => left.index - right.index)
+        .find((candidate) => candidate.index >= caret);
+    }
+
+    return [...skillTokens]
+      .sort((left, right) => right.index - left.index)
+      .find((candidate) => candidate.index <= caret);
   };
 
   const removeSkillToken = (
@@ -2160,7 +2231,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const removeEditorSkillToken = (
-    event: ReactKeyboardEvent<HTMLElement> | ReactFormEvent<HTMLElement>,
+    event: SkillTokenDeletionEvent,
     direction: "backward" | "forward",
   ): boolean => {
     if (!inputRef.current) {
@@ -2168,19 +2239,136 @@ export function Composer(props: ComposerProps) {
     }
 
     const caret = Math.min(inputRef.current.selectionStart, draft.length);
+    const tokenId =
+      findEventTargetSkillTokenId(event) ??
+      findSelectedSkillTokenId(event.currentTarget);
     const token =
-      findEventTargetSkillToken(event) ??
-      findSelectedSkillToken(event.currentTarget) ??
-      skillTokens.find((candidate) => candidate.index === caret);
+      (tokenId
+        ? skillTokens.find((candidate) => candidate.id === tokenId)
+        : undefined) ??
+      skillTokens.find((candidate) => candidate.index === caret) ??
+      (shouldGuardBoundarySkillDeletion(event.currentTarget)
+        ? findBoundarySkillToken(caret, direction)
+        : undefined);
     if (!token) {
+      if (tokenId) {
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+      }
       return false;
     }
 
     event.preventDefault();
+    event.stopPropagation();
     removeSkillToken(token, token.index);
     void direction;
     return true;
   };
+
+  const deleteEditorText = (
+    event: SkillTokenDeletionEvent,
+    direction: "backward" | "forward",
+  ): boolean => {
+    if (!inputRef.current) {
+      return false;
+    }
+
+    const caret = Math.min(inputRef.current.selectionStart, draft.length);
+    const deleteStart = direction === "backward" ? Math.max(0, caret - 1) : caret;
+    const deleteEnd =
+      direction === "backward" ? caret : Math.min(draft.length, caret + 1);
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (deleteStart === deleteEnd) {
+      return true;
+    }
+
+    const nextDraft = `${draft.slice(0, deleteStart)}${draft.slice(deleteEnd)}`;
+    updateVisibleDraft(nextDraft);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(deleteStart, deleteStart);
+    });
+    return true;
+  };
+
+  const deleteEditorContent = (
+    event: SkillTokenDeletionEvent,
+    direction: "backward" | "forward",
+  ): boolean =>
+    removeEditorSkillToken(event, direction) ||
+    (shouldGuardNativeTextDeletion(event.currentTarget, direction)
+      ? deleteEditorText(event, direction)
+      : false);
+
+  useEffect(() => {
+    const ownerDocument = inputWrapRef.current?.ownerDocument ?? document;
+    const getEditor = (): HTMLElement | undefined =>
+      inputWrapRef.current?.querySelector<HTMLElement>(
+        '[data-testid="composer-rich-input"]',
+      ) ?? undefined;
+
+    const handleDocumentKeyDown = (event: KeyboardEvent): void => {
+      if (
+        event.defaultPrevented ||
+        (event.key !== "Backspace" && event.key !== "Delete")
+      ) {
+        return;
+      }
+
+      const editor = getEditor();
+      if (!editor || !selectionBelongsToEditor(editor)) {
+        return;
+      }
+
+      deleteEditorContent(
+        {
+          currentTarget: editor,
+          target: event.target,
+          preventDefault: () => event.preventDefault(),
+          stopPropagation: () => event.stopPropagation(),
+        },
+        event.key === "Backspace" ? "backward" : "forward",
+      );
+    };
+    const handleDocumentBeforeInput = (event: InputEvent): void => {
+      if (
+        event.defaultPrevented ||
+        (event.inputType !== "deleteContentBackward" &&
+          event.inputType !== "deleteContentForward")
+      ) {
+        return;
+      }
+
+      const editor = getEditor();
+      if (!editor || !selectionBelongsToEditor(editor)) {
+        return;
+      }
+
+      deleteEditorContent(
+        {
+          currentTarget: editor,
+          target: event.target,
+          preventDefault: () => event.preventDefault(),
+          stopPropagation: () => event.stopPropagation(),
+        },
+        event.inputType === "deleteContentBackward" ? "backward" : "forward",
+      );
+    };
+
+    ownerDocument.addEventListener("keydown", handleDocumentKeyDown, true);
+    ownerDocument.addEventListener("beforeinput", handleDocumentBeforeInput, true);
+    return () => {
+      ownerDocument.removeEventListener("keydown", handleDocumentKeyDown, true);
+      ownerDocument.removeEventListener(
+        "beforeinput",
+        handleDocumentBeforeInput,
+        true,
+      );
+    };
+  });
 
   const restoreDeletedSkillToken = (
     event: ReactKeyboardEvent<HTMLElement>,
@@ -2391,36 +2579,73 @@ export function Composer(props: ComposerProps) {
             setActiveSkillIndex(0);
             setActiveSlashIndex(0);
           }}
-          onBeforeInput={(event) => {
+          onBeforeInputCapture={(event) => {
             const inputType = (event.nativeEvent as InputEvent).inputType;
             if (
               inputType === "deleteContentBackward" &&
-              removeEditorSkillToken(event, "backward")
+              deleteEditorContent(event, "backward")
             ) {
               return;
             }
             if (
               inputType === "deleteContentForward" &&
-              removeEditorSkillToken(event, "forward")
+              deleteEditorContent(event, "forward")
             ) {
               return;
             }
           }}
-          onKeyDown={(event) => {
-            if (restoreDeletedSkillToken(event)) {
+          onBeforeInput={(event) => {
+            if (event.defaultPrevented) {
               return;
             }
-
+            const inputType = (event.nativeEvent as InputEvent).inputType;
+            if (
+              inputType === "deleteContentBackward" &&
+              deleteEditorContent(event, "backward")
+            ) {
+              return;
+            }
+            if (
+              inputType === "deleteContentForward" &&
+              deleteEditorContent(event, "forward")
+            ) {
+              return;
+            }
+          }}
+          onKeyDownCapture={(event) => {
             if (
               event.key === "Backspace" &&
-              removeEditorSkillToken(event, "backward")
+              deleteEditorContent(event, "backward")
             ) {
               return;
             }
 
             if (
               event.key === "Delete" &&
-              removeEditorSkillToken(event, "forward")
+              deleteEditorContent(event, "forward")
+            ) {
+              return;
+            }
+          }}
+          onKeyDown={(event) => {
+            if (event.defaultPrevented) {
+              return;
+            }
+
+            if (restoreDeletedSkillToken(event)) {
+              return;
+            }
+
+            if (
+              event.key === "Backspace" &&
+              deleteEditorContent(event, "backward")
+            ) {
+              return;
+            }
+
+            if (
+              event.key === "Delete" &&
+              deleteEditorContent(event, "forward")
             ) {
               return;
             }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -789,6 +789,8 @@ export function Composer(props: ComposerProps) {
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const skillListboxId = useId();
+  const slashListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
   const composerScopeKey = props.launchpad
     ? `launchpad:${props.launchpad.directoryKey}`
@@ -978,6 +980,16 @@ export function Composer(props: ComposerProps) {
     displayedAutocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
   const autocompleteLength =
     displayedAutocompleteKind === "skills" ? filteredSkills.length : filteredSlashCommands.length;
+  const autocompleteListboxId =
+    displayedAutocompleteKind === "skills"
+      ? skillListboxId
+      : displayedAutocompleteKind === "slash"
+        ? slashListboxId
+        : undefined;
+  const activeAutocompleteOptionId =
+    autocompleteListboxId && displayedAutocompleteKind
+      ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
+      : undefined;
   const reviewBranchOptions = useMemo(
     () => buildReviewBranchOptions({
       directory: props.directory,
@@ -2509,9 +2521,13 @@ export function Composer(props: ComposerProps) {
 
     const optionHasFocus = event.currentTarget instanceof HTMLButtonElement;
     if (
-      (event.key === "Enter" && !event.shiftKey) ||
+      (event.key === "Tab" && !event.shiftKey) ||
+      event.key === "Enter" ||
       (event.key === " " && optionHasFocus)
     ) {
+      if (event.key === "Enter" && event.shiftKey) {
+        return;
+      }
       event.preventDefault();
       commitActiveAutocomplete();
     }
@@ -2625,6 +2641,9 @@ export function Composer(props: ComposerProps) {
         <ComposerRichInput
           ref={inputRef}
           id="thread-composer"
+          ariaActiveDescendant={activeAutocompleteOptionId}
+          ariaControls={autocompleteListboxId}
+          ariaExpanded={hasAutocomplete}
           disabled={launchpadSubmitting || (props.disabled && !hasComposerContent)}
           label={isLaunchpad ? "New thread" : "Reply"}
           placeholder={
@@ -2736,11 +2755,13 @@ export function Composer(props: ComposerProps) {
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
             role="listbox"
             aria-label="Skills"
+            id={skillListboxId}
             style={{ maxHeight: autocompleteLayout.maxHeight }}
           >
             {filteredSkills.map((skill, index) => (
               <button
                 key={skill.path ?? skill.name}
+                id={`${skillListboxId}-option-${index}`}
                 ref={(node) => {
                   autocompleteOptionRefs.current[index] = node;
                 }}
@@ -2778,11 +2799,13 @@ export function Composer(props: ComposerProps) {
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
             role="listbox"
             aria-label="Commands"
+            id={slashListboxId}
             style={{ maxHeight: autocompleteLayout.maxHeight }}
           >
             {filteredSlashCommands.map((command, index) => (
               <button
                 key={command.id}
+                id={`${slashListboxId}-option-${index}`}
                 ref={(node) => {
                   autocompleteOptionRefs.current[index] = node;
                 }}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2,6 +2,7 @@ import {
   type ReactNode,
   type ClipboardEvent,
   type DragEvent,
+  type FormEvent as ReactFormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   useId,
@@ -139,6 +140,8 @@ type DeletedSkillTokenHistoryEntry = {
   selectionStart: number;
   skillTokens: ComposerSkillToken[];
 };
+
+const COMPOSER_SKILL_TOKEN_SELECTOR = "[data-composer-skill-token-id]";
 
 type ComposerImageFile = {
   file: File;
@@ -2103,27 +2106,48 @@ export function Composer(props: ComposerProps) {
     );
   };
 
-  const removeAdjacentSkillToken = (
-    event: ReactKeyboardEvent<HTMLElement>,
-  ): boolean => {
-    if (
-      event.key !== "Backspace" ||
-      !inputRef.current ||
-      inputRef.current.selectionStart !== inputRef.current.selectionEnd
-    ) {
-      return false;
+  const findEventTargetSkillToken = (
+    event: ReactKeyboardEvent<HTMLElement> | ReactFormEvent<HTMLElement>,
+  ): ComposerSkillToken | undefined => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return undefined;
     }
 
-    const caret = Math.min(inputRef.current.selectionStart, draft.length);
-    const token = skillTokens.find((candidate) => candidate.index === caret);
-    if (!token) {
-      return false;
+    const tokenElement = target.closest(COMPOSER_SKILL_TOKEN_SELECTOR);
+    const tokenId = tokenElement instanceof HTMLElement
+      ? tokenElement.dataset.composerSkillTokenId
+      : undefined;
+    return tokenId
+      ? skillTokens.find((candidate) => candidate.id === tokenId)
+      : undefined;
+  };
+
+  const findSelectedSkillToken = (
+    editor: HTMLElement,
+  ): ComposerSkillToken | undefined => {
+    const selection = editor.ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+      return undefined;
     }
 
-    event.preventDefault();
+    const range = selection.getRangeAt(0);
+    const tokenElement = Array.from(
+      editor.querySelectorAll<HTMLElement>(COMPOSER_SKILL_TOKEN_SELECTOR),
+    ).find((candidate) => range.intersectsNode(candidate));
+    const tokenId = tokenElement?.dataset.composerSkillTokenId;
+    return tokenId
+      ? skillTokens.find((candidate) => candidate.id === tokenId)
+      : undefined;
+  };
+
+  const removeSkillToken = (
+    token: ComposerSkillToken,
+    selectionStart: number,
+  ): void => {
     deletedSkillTokenHistoryRef.current.push({
       draft,
-      selectionStart: caret,
+      selectionStart,
       skillTokens,
     });
     setSkillTokens((current) =>
@@ -2131,8 +2155,30 @@ export function Composer(props: ComposerProps) {
     );
     requestAnimationFrame(() => {
       inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(caret, caret);
+      inputRef.current?.setSelectionRange(selectionStart, selectionStart);
     });
+  };
+
+  const removeEditorSkillToken = (
+    event: ReactKeyboardEvent<HTMLElement> | ReactFormEvent<HTMLElement>,
+    direction: "backward" | "forward",
+  ): boolean => {
+    if (!inputRef.current) {
+      return false;
+    }
+
+    const caret = Math.min(inputRef.current.selectionStart, draft.length);
+    const token =
+      findEventTargetSkillToken(event) ??
+      findSelectedSkillToken(event.currentTarget) ??
+      skillTokens.find((candidate) => candidate.index === caret);
+    if (!token) {
+      return false;
+    }
+
+    event.preventDefault();
+    removeSkillToken(token, token.index);
+    void direction;
     return true;
   };
 
@@ -2345,13 +2391,38 @@ export function Composer(props: ComposerProps) {
             setActiveSkillIndex(0);
             setActiveSlashIndex(0);
           }}
+          onBeforeInput={(event) => {
+            const inputType = (event.nativeEvent as InputEvent).inputType;
+            if (
+              inputType === "deleteContentBackward" &&
+              removeEditorSkillToken(event, "backward")
+            ) {
+              return;
+            }
+            if (
+              inputType === "deleteContentForward" &&
+              removeEditorSkillToken(event, "forward")
+            ) {
+              return;
+            }
+          }}
           onKeyDown={(event) => {
             if (restoreDeletedSkillToken(event)) {
               return;
             }
 
             if (!hasAutocomplete) {
-              if (removeAdjacentSkillToken(event)) {
+              if (
+                event.key === "Backspace" &&
+                removeEditorSkillToken(event, "backward")
+              ) {
+                return;
+              }
+
+              if (
+                event.key === "Delete" &&
+                removeEditorSkillToken(event, "forward")
+              ) {
                 return;
               }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2160,6 +2160,20 @@ export function Composer(props: ComposerProps) {
     return tokenElement?.dataset.composerSkillTokenId;
   };
 
+  const hasRangedEditorSelection = (editor: HTMLElement): boolean => {
+    const selection = editor.ownerDocument.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+      return false;
+    }
+
+    const range = selection.getRangeAt(0);
+    return (
+      editor.contains(range.startContainer) ||
+      editor.contains(range.endContainer) ||
+      range.intersectsNode(editor)
+    );
+  };
+
   const shouldGuardNativeTextDeletion = (
     editor: HTMLElement,
     direction: "backward" | "forward",
@@ -2281,6 +2295,10 @@ export function Composer(props: ComposerProps) {
       return false;
     }
 
+    if (hasRangedEditorSelection(event.currentTarget)) {
+      return false;
+    }
+
     const tokenId =
       findEventTargetSkillTokenId(event) ??
       findSelectedSkillTokenId(event.currentTarget) ??
@@ -2338,11 +2356,21 @@ export function Composer(props: ComposerProps) {
   const deleteEditorContent = (
     event: SkillTokenDeletionEvent,
     direction: "backward" | "forward",
-  ): boolean =>
-    removeEditorSkillToken(event, direction) ||
-    (shouldGuardNativeTextDeletion(event.currentTarget, direction)
-      ? deleteEditorText(event, direction)
-      : false);
+  ): boolean => {
+    if (inputRef.current && hasRangedEditorSelection(event.currentTarget)) {
+      event.preventDefault();
+      event.stopPropagation();
+      inputRef.current.deleteSelection(direction);
+      return true;
+    }
+
+    return (
+      removeEditorSkillToken(event, direction) ||
+      (shouldGuardNativeTextDeletion(event.currentTarget, direction)
+        ? deleteEditorText(event, direction)
+        : false)
+    );
+  };
 
   useEffect(() => {
     const ownerDocument = inputWrapRef.current?.ownerDocument ?? document;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2411,21 +2411,21 @@ export function Composer(props: ComposerProps) {
               return;
             }
 
+            if (
+              event.key === "Backspace" &&
+              removeEditorSkillToken(event, "backward")
+            ) {
+              return;
+            }
+
+            if (
+              event.key === "Delete" &&
+              removeEditorSkillToken(event, "forward")
+            ) {
+              return;
+            }
+
             if (!hasAutocomplete) {
-              if (
-                event.key === "Backspace" &&
-                removeEditorSkillToken(event, "backward")
-              ) {
-                return;
-              }
-
-              if (
-                event.key === "Delete" &&
-                removeEditorSkillToken(event, "forward")
-              ) {
-                return;
-              }
-
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
                 void submitTurn(event.metaKey ? "steer" : "default");

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -28,6 +28,9 @@ export type ComposerRichInputHandle = {
 };
 
 type ComposerRichInputProps = {
+  ariaActiveDescendant?: string;
+  ariaControls?: string;
+  ariaExpanded?: boolean;
   disabled?: boolean;
   id: string;
   label: string;
@@ -778,6 +781,9 @@ export const ComposerRichInput = forwardRef<
       ref={editorRef}
       id={props.id}
       aria-label={props.label}
+      aria-activedescendant={props.ariaActiveDescendant}
+      aria-controls={props.ariaControls}
+      aria-expanded={props.ariaExpanded}
       aria-multiline="true"
       className={`composer-rich-input${props.disabled ? " is-disabled" : ""}${props.value || props.skillTokens.length > 0 ? "" : " is-empty"}`}
       contentEditable={!props.disabled}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -788,6 +788,11 @@ export const ComposerRichInput = forwardRef<
     replaceSelection(event.currentTarget, event.key);
   };
 
+  const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
+    pendingSelectionIndexRef.current = undefined;
+    props.onClick?.(event);
+  };
+
   return (
     <div
       ref={editorRef}
@@ -805,7 +810,7 @@ export const ComposerRichInput = forwardRef<
       role="textbox"
       suppressContentEditableWarning
       tabIndex={props.disabled ? -1 : 0}
-      onClick={props.onClick}
+      onClick={handleClick}
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
       onChange={handleInput}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -468,6 +468,20 @@ function getSkillTokenSignature(skillTokens: ComposerSkillToken[]): string {
     .join("|");
 }
 
+function isMacPlatform(): boolean {
+  return /\bMac/.test(window.navigator.platform);
+}
+
+function isSelectAllShortcut(event: KeyboardEvent<HTMLDivElement>): boolean {
+  if (event.altKey || event.shiftKey || event.key.toLowerCase() !== "a") {
+    return false;
+  }
+
+  return isMacPlatform()
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+}
+
 export const ComposerRichInput = forwardRef<
   ComposerRichInputHandle,
   ComposerRichInputProps
@@ -744,9 +758,7 @@ export const ComposerRichInput = forwardRef<
     if (
       !event.defaultPrevented &&
       !props.disabled &&
-      event.key.toLowerCase() === "a" &&
-      (event.metaKey || event.ctrlKey) &&
-      !event.altKey
+      isSelectAllShortcut(event)
     ) {
       event.preventDefault();
       selectAllPendingRef.current = true;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -1,0 +1,71 @@
+import {
+  forwardRef,
+  type ClipboardEvent,
+  type DragEvent,
+  type KeyboardEvent,
+} from "react";
+import type { AppServerSkillSummary } from "@pwragnt/shared";
+import { SkillChip } from "./SkillChip";
+
+export type ComposerSkillToken = AppServerSkillSummary & {
+  id: string;
+  index: number;
+};
+
+type ComposerRichInputProps = {
+  disabled?: boolean;
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  onClick?: () => void;
+  onDragOver?: (event: DragEvent<HTMLTextAreaElement>) => void;
+  onDrop?: (event: DragEvent<HTMLTextAreaElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
+  onRemoveSkillToken: (id: string) => void;
+  placeholder: string;
+  skillTokens: ComposerSkillToken[];
+  value: string;
+};
+
+export const ComposerRichInput = forwardRef<
+  HTMLTextAreaElement,
+  ComposerRichInputProps
+>(function ComposerRichInput(props, ref) {
+  return (
+    <div
+      className={`composer-rich-input${props.disabled ? " is-disabled" : ""}`}
+      data-testid="composer-rich-input"
+    >
+      {props.skillTokens.length > 0 ? (
+        <div className="composer-rich-input__chips" aria-label="Selected skills">
+          {props.skillTokens.map((skill) => (
+            <SkillChip
+              key={skill.id}
+              label={`$${skill.name}`}
+              onRemove={() => props.onRemoveSkillToken(skill.id)}
+              skill={skill}
+            />
+          ))}
+        </div>
+      ) : null}
+      <textarea
+        ref={ref}
+        id={props.id}
+        aria-label={props.label}
+        className="composer__input composer-rich-input__textarea"
+        disabled={props.disabled}
+        placeholder={props.placeholder}
+        value={props.value}
+        onChange={(event) => {
+          props.onChange(event.target.value);
+        }}
+        onPaste={props.onPaste}
+        onDragOver={props.onDragOver}
+        onDrop={props.onDrop}
+        onClick={props.onClick}
+        onKeyDown={props.onKeyDown}
+      />
+    </div>
+  );
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -257,6 +257,69 @@ function getSelectionIndex(
   return index;
 }
 
+function getBoundaryIndex(
+  editor: HTMLElement,
+  container: Node,
+  offset: number,
+  knownTokens: Map<string, ComposerSkillToken>,
+): number {
+  if (container.nodeType === Node.TEXT_NODE) {
+    return getNodeStartIndex(editor, container, knownTokens) + offset;
+  }
+
+  let index = getNodeStartIndex(editor, container, knownTokens);
+  const childNodes = Array.from(container.childNodes).slice(0, offset);
+  childNodes.forEach((node) => {
+    walkEditorContent({
+      knownTokens,
+      node,
+      onText: (text) => {
+        index += text.length;
+      },
+      onToken: () => undefined,
+    });
+  });
+
+  return index;
+}
+
+function getSelectionIndexes(
+  editor: HTMLElement,
+  knownTokens: Map<string, ComposerSkillToken>,
+): {
+  end: number;
+  start: number;
+} {
+  const fallback = readEditorContent(editor, knownTokens).value.length;
+  const selection = editor.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return { start: fallback, end: fallback };
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!editor.contains(range.startContainer)) {
+    return { start: fallback, end: fallback };
+  }
+
+  const start = getBoundaryIndex(
+    editor,
+    range.startContainer,
+    range.startOffset,
+    knownTokens,
+  );
+  const end = getBoundaryIndex(
+    editor,
+    range.endContainer,
+    range.endOffset,
+    knownTokens,
+  );
+
+  return {
+    start: Math.min(start, end),
+    end: Math.max(start, end),
+  };
+}
+
 function setSelectionIndex(
   editor: HTMLElement | null,
   knownTokens: Map<string, ComposerSkillToken>,
@@ -327,6 +390,40 @@ function setSelectionIndex(
   void knownTokens;
 }
 
+function clampTokenIndex(index: number, value: string): number {
+  return Math.max(0, Math.min(index, value.length));
+}
+
+function adjustTokensForReplacement(params: {
+  end: number;
+  nextValue: string;
+  replacementLength: number;
+  skillTokens: ComposerSkillToken[];
+  start: number;
+}): ComposerSkillToken[] {
+  const removedLength = params.end - params.start;
+  const delta = params.replacementLength - removedLength;
+  const insertedEnd = params.start + params.replacementLength;
+
+  return params.skillTokens.map((token) => {
+    if (token.index <= params.start) {
+      return token;
+    }
+
+    if (token.index >= params.end) {
+      return {
+        ...token,
+        index: clampTokenIndex(token.index + delta, params.nextValue),
+      };
+    }
+
+    return {
+      ...token,
+      index: clampTokenIndex(insertedEnd, params.nextValue),
+    };
+  });
+}
+
 export const ComposerRichInput = forwardRef<
   ComposerRichInputHandle,
   ComposerRichInputProps
@@ -336,6 +433,7 @@ export const ComposerRichInput = forwardRef<
   const onChangeRef = useRef(props.onChange);
   const pendingAssignedValueRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
+  const handledKeyInputRef = useRef<string | undefined>(undefined);
   const parts = useMemo(
     () => buildInlineParts(props.value, props.skillTokens),
     [props.skillTokens, props.value]
@@ -457,6 +555,109 @@ export const ComposerRichInput = forwardRef<
     onChangeRef.current(next.value, next.skillTokens);
   };
 
+  const replaceSelection = (
+    editor: HTMLElement,
+    replacement: string,
+    selection = getSelectionIndexes(editor, knownTokensRef.current),
+  ): void => {
+    const nextValue = `${props.value.slice(0, selection.start)}${replacement}${props.value.slice(selection.end)}`;
+    const nextSelection = selection.start + replacement.length;
+    pendingSelectionIndexRef.current = nextSelection;
+    onChangeRef.current(
+      nextValue,
+      adjustTokensForReplacement({
+        end: selection.end,
+        nextValue,
+        replacementLength: replacement.length,
+        skillTokens: props.skillTokens,
+        start: selection.start,
+      }),
+    );
+  };
+
+  const deleteSelection = (
+    editor: HTMLElement,
+    direction: "backward" | "forward",
+  ): void => {
+    const selection = getSelectionIndexes(editor, knownTokensRef.current);
+    if (selection.start !== selection.end) {
+      replaceSelection(editor, "", selection);
+      return;
+    }
+
+    const start =
+      direction === "backward" ? Math.max(0, selection.start - 1) : selection.start;
+    const end =
+      direction === "backward"
+        ? selection.end
+        : Math.min(props.value.length, selection.end + 1);
+    replaceSelection(editor, "", { start, end });
+  };
+
+  const handleBeforeInputCapture = (event: FormEvent<HTMLDivElement>): void => {
+    props.onBeforeInputCapture?.(event);
+    if (event.defaultPrevented || props.disabled) {
+      return;
+    }
+
+    const inputEvent = event.nativeEvent as InputEvent;
+    if (inputEvent.inputType === "insertText") {
+      event.preventDefault();
+      if (
+        handledKeyInputRef.current !== undefined &&
+        handledKeyInputRef.current === (inputEvent.data ?? "")
+      ) {
+        handledKeyInputRef.current = undefined;
+        return;
+      }
+      replaceSelection(event.currentTarget, inputEvent.data ?? "");
+      return;
+    }
+
+    if (
+      inputEvent.inputType === "insertLineBreak" ||
+      inputEvent.inputType === "insertParagraph"
+    ) {
+      event.preventDefault();
+      replaceSelection(event.currentTarget, "\n");
+      return;
+    }
+
+    if (inputEvent.inputType === "deleteContentBackward") {
+      event.preventDefault();
+      deleteSelection(event.currentTarget, "backward");
+      return;
+    }
+
+    if (inputEvent.inputType === "deleteContentForward") {
+      event.preventDefault();
+      deleteSelection(event.currentTarget, "forward");
+    }
+  };
+
+  const handleKeyDownCapture = (event: KeyboardEvent<HTMLDivElement>): void => {
+    props.onKeyDownCapture?.(event);
+    if (
+      event.defaultPrevented ||
+      props.disabled ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.key.length !== 1
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    handledKeyInputRef.current = event.key;
+    window.setTimeout(() => {
+      if (handledKeyInputRef.current === event.key) {
+        handledKeyInputRef.current = undefined;
+      }
+    }, 0);
+    replaceSelection(event.currentTarget, event.key);
+  };
+
   return (
     <div
       ref={editorRef}
@@ -475,10 +676,10 @@ export const ComposerRichInput = forwardRef<
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
       onChange={handleInput}
-      onBeforeInputCapture={props.onBeforeInputCapture}
+      onBeforeInputCapture={handleBeforeInputCapture}
       onBeforeInput={props.onBeforeInput}
       onInput={handleInput}
-      onKeyDownCapture={props.onKeyDownCapture}
+      onKeyDownCapture={handleKeyDownCapture}
       onKeyDown={props.onKeyDown}
       onPaste={props.onPaste}
     >

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -31,6 +31,7 @@ type ComposerRichInputProps = {
   id: string;
   label: string;
   onChange: (value: string, skillTokens?: ComposerSkillToken[]) => void;
+  onBeforeInput?: (event: FormEvent<HTMLDivElement>) => void;
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;
   onDragOver?: (event: DragEvent<HTMLDivElement>) => void;
   onDrop?: (event: DragEvent<HTMLDivElement>) => void;
@@ -472,6 +473,7 @@ export const ComposerRichInput = forwardRef<
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
       onChange={handleInput}
+      onBeforeInput={props.onBeforeInput}
       onInput={handleInput}
       onKeyDown={props.onKeyDown}
       onPaste={props.onPaste}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -32,10 +32,12 @@ type ComposerRichInputProps = {
   label: string;
   onChange: (value: string, skillTokens?: ComposerSkillToken[]) => void;
   onBeforeInput?: (event: FormEvent<HTMLDivElement>) => void;
+  onBeforeInputCapture?: (event: FormEvent<HTMLDivElement>) => void;
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;
   onDragOver?: (event: DragEvent<HTMLDivElement>) => void;
   onDrop?: (event: DragEvent<HTMLDivElement>) => void;
   onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onKeyDownCapture?: (event: KeyboardEvent<HTMLDivElement>) => void;
   onPaste?: (event: ClipboardEvent<HTMLDivElement>) => void;
   placeholder: string;
   skillTokens: ComposerSkillToken[];
@@ -473,8 +475,10 @@ export const ComposerRichInput = forwardRef<
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
       onChange={handleInput}
+      onBeforeInputCapture={props.onBeforeInputCapture}
       onBeforeInput={props.onBeforeInput}
       onInput={handleInput}
+      onKeyDownCapture={props.onKeyDownCapture}
       onKeyDown={props.onKeyDown}
       onPaste={props.onPaste}
     >

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -20,6 +20,7 @@ export type ComposerSkillToken = AppServerSkillSummary & {
 };
 
 export type ComposerRichInputHandle = {
+  deleteSelection: (direction: "backward" | "forward") => void;
   focus: () => void;
   readonly selectionEnd: number;
   readonly selectionStart: number;
@@ -297,27 +298,53 @@ function getSelectionIndexes(
   }
 
   const range = selection.getRangeAt(0);
-  if (!editor.contains(range.startContainer)) {
+  const containsStart = editor.contains(range.startContainer);
+  const containsEnd = editor.contains(range.endContainer);
+  if (!containsStart && !containsEnd) {
+    if (range.intersectsNode(editor)) {
+      return { start: 0, end: fallback };
+    }
     return { start: fallback, end: fallback };
   }
 
-  const start = getBoundaryIndex(
-    editor,
-    range.startContainer,
-    range.startOffset,
-    knownTokens,
-  );
-  const end = getBoundaryIndex(
-    editor,
-    range.endContainer,
-    range.endOffset,
-    knownTokens,
-  );
+  const start = containsStart
+    ? getBoundaryIndex(
+        editor,
+        range.startContainer,
+        range.startOffset,
+        knownTokens,
+      )
+    : 0;
+  const end = containsEnd
+    ? getBoundaryIndex(
+        editor,
+        range.endContainer,
+        range.endOffset,
+        knownTokens,
+      )
+    : fallback;
 
   return {
     start: Math.min(start, end),
     end: Math.max(start, end),
   };
+}
+
+function getSelectedTokenIds(editor: HTMLElement): Set<string> {
+  const selection = editor.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return new Set();
+  }
+
+  const range = selection.getRangeAt(0);
+  return new Set(
+    Array.from(
+      editor.querySelectorAll<HTMLElement>("[data-composer-skill-token-id]"),
+    )
+      .filter((candidate) => range.intersectsNode(candidate))
+      .map((candidate) => candidate.dataset.composerSkillTokenId)
+      .filter((tokenId): tokenId is string => Boolean(tokenId)),
+  );
 }
 
 function setSelectionIndex(
@@ -390,6 +417,14 @@ function setSelectionIndex(
   void knownTokens;
 }
 
+function selectEditorContents(editor: HTMLElement): void {
+  const range = editor.ownerDocument.createRange();
+  range.selectNodeContents(editor);
+  const selection = editor.ownerDocument.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
 function clampTokenIndex(index: number, value: string): number {
   return Math.max(0, Math.min(index, value.length));
 }
@@ -441,6 +476,7 @@ export const ComposerRichInput = forwardRef<
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
   const handledKeyInputRef = useRef<string | undefined>(undefined);
   const localEditValueRef = useRef<string | undefined>(undefined);
+  const selectAllPendingRef = useRef(false);
   const valueRef = useRef(props.value);
   const skillTokensRef = useRef(props.skillTokens);
   const parts = useMemo(
@@ -558,7 +594,86 @@ export const ComposerRichInput = forwardRef<
     setSelectionIndex(editorRef.current, knownTokensRef.current, nextSelection);
   }, [parts]);
 
+  const handleInput = (event: FormEvent<HTMLDivElement>): void => {
+    const nextSelection = getSelectionIndex(
+      event.currentTarget,
+      knownTokensRef.current,
+    );
+    const next = readEditorContent(event.currentTarget, knownTokensRef.current);
+    selectAllPendingRef.current = false;
+    pendingSelectionIndexRef.current = nextSelection;
+    valueRef.current = next.value;
+    skillTokensRef.current = next.skillTokens;
+    localEditValueRef.current = next.value;
+    onChangeRef.current(next.value, next.skillTokens);
+  };
+
+  const replaceSelection = (
+    editor: HTMLElement,
+    replacement: string,
+    selection?: { end: number; start: number },
+    selectedTokenIds = new Set<string>(),
+  ): void => {
+    const currentSelection =
+      selection ??
+      (pendingSelectionIndexRef.current !== undefined
+        ? {
+            start: pendingSelectionIndexRef.current,
+            end: pendingSelectionIndexRef.current,
+          }
+        : getSelectionIndexes(editor, knownTokensRef.current));
+    const currentValue = valueRef.current;
+    const currentSkillTokens = skillTokensRef.current;
+    const nextValue = `${currentValue.slice(0, currentSelection.start)}${replacement}${currentValue.slice(currentSelection.end)}`;
+    const nextSelection = currentSelection.start + replacement.length;
+    const nextSkillTokens = adjustTokensForReplacement({
+      end: currentSelection.end,
+      nextValue,
+      replacementLength: replacement.length,
+      skillTokens: currentSkillTokens.filter(
+        (token) => !selectedTokenIds.has(token.id),
+      ),
+      start: currentSelection.start,
+    });
+    pendingSelectionIndexRef.current = nextSelection;
+    valueRef.current = nextValue;
+    skillTokensRef.current = nextSkillTokens;
+    localEditValueRef.current = nextValue;
+    onChangeRef.current(nextValue, nextSkillTokens);
+  };
+
+  const deleteSelection = (
+    editor: HTMLElement,
+    direction: "backward" | "forward",
+  ): void => {
+    const selection = selectAllPendingRef.current
+      ? { start: 0, end: valueRef.current.length }
+      : getSelectionIndexes(editor, knownTokensRef.current);
+    const selectedTokenIds = selectAllPendingRef.current
+      ? new Set(skillTokensRef.current.map((token) => token.id))
+      : getSelectedTokenIds(editor);
+    selectAllPendingRef.current = false;
+    if (selection.start !== selection.end || selectedTokenIds.size > 0) {
+      replaceSelection(editor, "", selection, selectedTokenIds);
+      return;
+    }
+
+    const start =
+      direction === "backward" ? Math.max(0, selection.start - 1) : selection.start;
+    const end =
+      direction === "backward"
+        ? selection.end
+        : Math.min(valueRef.current.length, selection.end + 1);
+    replaceSelection(editor, "", { start, end });
+  };
+
   useImperativeHandle(ref, () => ({
+    deleteSelection: (direction) => {
+      const editor = editorRef.current;
+      if (editor) {
+        deleteSelection(editor, direction);
+      }
+    },
     focus: () => {
       editorRef.current?.focus();
     },
@@ -579,69 +694,6 @@ export const ComposerRichInput = forwardRef<
       setSelectionIndex(editorRef.current, knownTokensRef.current, start);
     },
   }));
-
-  const handleInput = (event: FormEvent<HTMLDivElement>): void => {
-    const nextSelection = getSelectionIndex(
-      event.currentTarget,
-      knownTokensRef.current,
-    );
-    const next = readEditorContent(event.currentTarget, knownTokensRef.current);
-    pendingSelectionIndexRef.current = nextSelection;
-    valueRef.current = next.value;
-    skillTokensRef.current = next.skillTokens;
-    localEditValueRef.current = next.value;
-    onChangeRef.current(next.value, next.skillTokens);
-  };
-
-  const replaceSelection = (
-    editor: HTMLElement,
-    replacement: string,
-    selection?: { end: number; start: number },
-  ): void => {
-    const currentSelection =
-      selection ??
-      (pendingSelectionIndexRef.current !== undefined
-        ? {
-            start: pendingSelectionIndexRef.current,
-            end: pendingSelectionIndexRef.current,
-          }
-        : getSelectionIndexes(editor, knownTokensRef.current));
-    const currentValue = valueRef.current;
-    const currentSkillTokens = skillTokensRef.current;
-    const nextValue = `${currentValue.slice(0, currentSelection.start)}${replacement}${currentValue.slice(currentSelection.end)}`;
-    const nextSelection = currentSelection.start + replacement.length;
-    const nextSkillTokens = adjustTokensForReplacement({
-      end: currentSelection.end,
-      nextValue,
-      replacementLength: replacement.length,
-      skillTokens: currentSkillTokens,
-      start: currentSelection.start,
-    });
-    pendingSelectionIndexRef.current = nextSelection;
-    valueRef.current = nextValue;
-    skillTokensRef.current = nextSkillTokens;
-    localEditValueRef.current = nextValue;
-    onChangeRef.current(nextValue, nextSkillTokens);
-  };
-
-  const deleteSelection = (
-    editor: HTMLElement,
-    direction: "backward" | "forward",
-  ): void => {
-    const selection = getSelectionIndexes(editor, knownTokensRef.current);
-    if (selection.start !== selection.end) {
-      replaceSelection(editor, "", selection);
-      return;
-    }
-
-    const start =
-      direction === "backward" ? Math.max(0, selection.start - 1) : selection.start;
-    const end =
-      direction === "backward"
-        ? selection.end
-        : Math.min(valueRef.current.length, selection.end + 1);
-    replaceSelection(editor, "", { start, end });
-  };
 
   const handleBeforeInputCapture = (event: FormEvent<HTMLDivElement>): void => {
     props.onBeforeInputCapture?.(event);
@@ -686,6 +738,20 @@ export const ComposerRichInput = forwardRef<
 
   const handleKeyDownCapture = (event: KeyboardEvent<HTMLDivElement>): void => {
     props.onKeyDownCapture?.(event);
+    if (
+      !event.defaultPrevented &&
+      !props.disabled &&
+      event.key.toLowerCase() === "a" &&
+      (event.metaKey || event.ctrlKey) &&
+      !event.altKey
+    ) {
+      event.preventDefault();
+      selectAllPendingRef.current = true;
+      pendingSelectionIndexRef.current = undefined;
+      selectEditorContents(event.currentTarget);
+      return;
+    }
+
     if (
       event.defaultPrevented ||
       props.disabled ||

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -424,6 +424,12 @@ function adjustTokensForReplacement(params: {
   });
 }
 
+function getSkillTokenSignature(skillTokens: ComposerSkillToken[]): string {
+  return skillTokens
+    .map((token) => `${token.id}:${token.index}:${token.name}:${token.path ?? ""}`)
+    .join("|");
+}
+
 export const ComposerRichInput = forwardRef<
   ComposerRichInputHandle,
   ComposerRichInputProps
@@ -434,6 +440,9 @@ export const ComposerRichInput = forwardRef<
   const pendingAssignedValueRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
   const handledKeyInputRef = useRef<string | undefined>(undefined);
+  const localEditValueRef = useRef<string | undefined>(undefined);
+  const valueRef = useRef(props.value);
+  const skillTokensRef = useRef(props.skillTokens);
   const parts = useMemo(
     () => buildInlineParts(props.value, props.skillTokens),
     [props.skillTokens, props.value]
@@ -443,11 +452,34 @@ export const ComposerRichInput = forwardRef<
     onChangeRef.current = props.onChange;
   }, [props.onChange]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     for (const token of props.skillTokens) {
       knownTokensRef.current.set(token.id, token);
     }
   }, [props.skillTokens]);
+
+  useLayoutEffect(() => {
+    const localEditValue = localEditValueRef.current;
+    const propsTokenSignature = getSkillTokenSignature(props.skillTokens);
+    const currentTokenSignature = getSkillTokenSignature(skillTokensRef.current);
+    if (
+      localEditValue !== undefined &&
+      props.value !== localEditValue &&
+      propsTokenSignature === currentTokenSignature
+    ) {
+      return;
+    }
+
+    if (
+      props.value === localEditValue ||
+      propsTokenSignature !== currentTokenSignature
+    ) {
+      localEditValueRef.current = undefined;
+    }
+
+    valueRef.current = props.value;
+    skillTokensRef.current = props.skillTokens;
+  }, [props.skillTokens, props.value]);
 
   useLayoutEffect(() => {
     const editor = editorRef.current;
@@ -471,6 +503,7 @@ export const ComposerRichInput = forwardRef<
       setSelectionRange: {
         configurable: true,
         value: (start: number) => {
+          pendingSelectionIndexRef.current = start;
           setSelectionIndex(editor, knownTokensRef.current, start);
         },
       },
@@ -495,6 +528,8 @@ export const ComposerRichInput = forwardRef<
       if (assignedValue !== undefined) {
         pendingAssignedValueRef.current = undefined;
         pendingSelectionIndexRef.current = assignedValue.length;
+        valueRef.current = assignedValue;
+        skillTokensRef.current = [];
         onChangeRef.current(assignedValue, []);
         return;
       }
@@ -502,6 +537,8 @@ export const ComposerRichInput = forwardRef<
       const nextSelection = getSelectionIndex(editor, knownTokensRef.current);
       const next = readEditorContent(editor, knownTokensRef.current);
       pendingSelectionIndexRef.current = nextSelection;
+      valueRef.current = next.value;
+      skillTokensRef.current = next.skillTokens;
       onChangeRef.current(next.value, next.skillTokens);
     };
 
@@ -539,9 +576,7 @@ export const ComposerRichInput = forwardRef<
     },
     setSelectionRange: (start: number) => {
       pendingSelectionIndexRef.current = start;
-      requestAnimationFrame(() => {
-        setSelectionIndex(editorRef.current, knownTokensRef.current, start);
-      });
+      setSelectionIndex(editorRef.current, knownTokensRef.current, start);
     },
   }));
 
@@ -552,27 +587,41 @@ export const ComposerRichInput = forwardRef<
     );
     const next = readEditorContent(event.currentTarget, knownTokensRef.current);
     pendingSelectionIndexRef.current = nextSelection;
+    valueRef.current = next.value;
+    skillTokensRef.current = next.skillTokens;
+    localEditValueRef.current = next.value;
     onChangeRef.current(next.value, next.skillTokens);
   };
 
   const replaceSelection = (
     editor: HTMLElement,
     replacement: string,
-    selection = getSelectionIndexes(editor, knownTokensRef.current),
+    selection?: { end: number; start: number },
   ): void => {
-    const nextValue = `${props.value.slice(0, selection.start)}${replacement}${props.value.slice(selection.end)}`;
-    const nextSelection = selection.start + replacement.length;
-    pendingSelectionIndexRef.current = nextSelection;
-    onChangeRef.current(
+    const currentSelection =
+      selection ??
+      (pendingSelectionIndexRef.current !== undefined
+        ? {
+            start: pendingSelectionIndexRef.current,
+            end: pendingSelectionIndexRef.current,
+          }
+        : getSelectionIndexes(editor, knownTokensRef.current));
+    const currentValue = valueRef.current;
+    const currentSkillTokens = skillTokensRef.current;
+    const nextValue = `${currentValue.slice(0, currentSelection.start)}${replacement}${currentValue.slice(currentSelection.end)}`;
+    const nextSelection = currentSelection.start + replacement.length;
+    const nextSkillTokens = adjustTokensForReplacement({
+      end: currentSelection.end,
       nextValue,
-      adjustTokensForReplacement({
-        end: selection.end,
-        nextValue,
-        replacementLength: replacement.length,
-        skillTokens: props.skillTokens,
-        start: selection.start,
-      }),
-    );
+      replacementLength: replacement.length,
+      skillTokens: currentSkillTokens,
+      start: currentSelection.start,
+    });
+    pendingSelectionIndexRef.current = nextSelection;
+    valueRef.current = nextValue;
+    skillTokensRef.current = nextSkillTokens;
+    localEditValueRef.current = nextValue;
+    onChangeRef.current(nextValue, nextSkillTokens);
   };
 
   const deleteSelection = (
@@ -590,7 +639,7 @@ export const ComposerRichInput = forwardRef<
     const end =
       direction === "backward"
         ? selection.end
-        : Math.min(props.value.length, selection.end + 1);
+        : Math.min(valueRef.current.length, selection.end + 1);
     replaceSelection(editor, "", { start, end });
   };
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -27,7 +27,7 @@ export type ComposerRichInputHandle = {
   setSelectionRange: (start: number, end: number) => void;
 };
 
-type ComposerRichInputProps = {
+export type ComposerRichInputProps = {
   ariaActiveDescendant?: string;
   ariaControls?: string;
   ariaExpanded?: boolean;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -1,8 +1,15 @@
 import {
   forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
   type ClipboardEvent,
   type DragEvent,
+  type FormEvent,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 import type { AppServerSkillSummary } from "@pwragnt/shared";
 import { SkillChip } from "./SkillChip";
@@ -12,60 +19,478 @@ export type ComposerSkillToken = AppServerSkillSummary & {
   index: number;
 };
 
+export type ComposerRichInputHandle = {
+  focus: () => void;
+  readonly selectionEnd: number;
+  readonly selectionStart: number;
+  setSelectionRange: (start: number, end: number) => void;
+};
+
 type ComposerRichInputProps = {
   disabled?: boolean;
   id: string;
   label: string;
-  onChange: (value: string) => void;
-  onClick?: () => void;
-  onDragOver?: (event: DragEvent<HTMLTextAreaElement>) => void;
-  onDrop?: (event: DragEvent<HTMLTextAreaElement>) => void;
-  onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
-  onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
-  onRemoveSkillToken: (id: string) => void;
+  onChange: (value: string, skillTokens?: ComposerSkillToken[]) => void;
+  onClick?: (event: MouseEvent<HTMLDivElement>) => void;
+  onDragOver?: (event: DragEvent<HTMLDivElement>) => void;
+  onDrop?: (event: DragEvent<HTMLDivElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onPaste?: (event: ClipboardEvent<HTMLDivElement>) => void;
   placeholder: string;
   skillTokens: ComposerSkillToken[];
   value: string;
 };
 
+type InlinePart =
+  | {
+      key: string;
+      text: string;
+      type: "text";
+    }
+  | {
+      key: string;
+      skill: ComposerSkillToken;
+      type: "skill";
+    };
+
+function buildInlineParts(
+  value: string,
+  skillTokens: ComposerSkillToken[],
+): InlinePart[] {
+  const sortedTokens = [...skillTokens].sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  const parts: InlinePart[] = [];
+  let cursor = 0;
+  sortedTokens.forEach((skill, tokenIndex) => {
+    const index = Math.max(0, Math.min(skill.index, value.length));
+    if (index > cursor) {
+      parts.push({
+        key: `text:${cursor}:${index}:${value.slice(cursor, index)}`,
+        text: value.slice(cursor, index),
+        type: "text",
+      });
+    }
+    parts.push({
+      key: `skill:${skill.id}:${tokenIndex}`,
+      skill,
+      type: "skill",
+    });
+    cursor = index;
+  });
+
+  if (cursor < value.length) {
+    parts.push({
+      key: `text:${cursor}:end:${value.slice(cursor)}`,
+      text: value.slice(cursor),
+      type: "text",
+    });
+  }
+
+  return parts;
+}
+
+function isSkillTokenElement(node: Node): boolean {
+  return (
+    node.nodeType === Node.ELEMENT_NODE &&
+    (node as Element).hasAttribute("data-composer-skill-token-id")
+  );
+}
+
+function walkEditorContent(params: {
+  knownTokens: Map<string, ComposerSkillToken>;
+  node: Node;
+  onText: (text: string) => void;
+  onToken: (token: ComposerSkillToken) => void;
+}): void {
+  const { knownTokens, node, onText, onToken } = params;
+  if (node.nodeType === Node.TEXT_NODE) {
+    onText(node.nodeValue ?? "");
+    return;
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    Array.from(node.childNodes).forEach((child) =>
+      walkEditorContent({ knownTokens, node: child, onText, onToken })
+    );
+    return;
+  }
+
+  const element = node as Element;
+
+  if (isSkillTokenElement(element)) {
+    const tokenId = (element as HTMLElement).dataset.composerSkillTokenId;
+    const token = tokenId ? knownTokens.get(tokenId) : undefined;
+    if (token) {
+      onToken(token);
+    }
+    return;
+  }
+
+  if (element.nodeName === "BR") {
+    onText("\n");
+    return;
+  }
+
+  Array.from(element.childNodes).forEach((child) =>
+    walkEditorContent({ knownTokens, node: child, onText, onToken })
+  );
+}
+
+function readEditorContent(
+  editor: HTMLElement,
+  knownTokens: Map<string, ComposerSkillToken>,
+): {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+} {
+  let value = "";
+  const skillTokens: ComposerSkillToken[] = [];
+
+  editor.childNodes.forEach((node) =>
+    walkEditorContent({
+      knownTokens,
+      node,
+      onText: (text) => {
+        value += text;
+      },
+      onToken: (token) => {
+        skillTokens.push({
+          ...token,
+          index: value.length,
+        });
+      },
+    })
+  );
+
+  return { value, skillTokens };
+}
+
+function getNodeStartIndex(
+  editor: HTMLElement,
+  targetNode: Node,
+  knownTokens: Map<string, ComposerSkillToken>,
+): number {
+  let index = 0;
+  let found = false;
+
+  const visit = (node: Node): void => {
+    if (found) {
+      return;
+    }
+    if (node === targetNode) {
+      found = true;
+      return;
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      index += node.nodeValue?.length ?? 0;
+      return;
+    }
+    if (isSkillTokenElement(node)) {
+      return;
+    }
+    if (node instanceof HTMLElement && node.tagName === "BR") {
+      index += 1;
+      return;
+    }
+    node.childNodes.forEach(visit);
+  };
+
+  editor.childNodes.forEach((node) => {
+    if (!found) {
+      visit(node);
+    }
+  });
+
+  // Keep the token map in the signature so this mirrors the content walker;
+  // token nodes are intentionally zero-width in the composer draft.
+  void knownTokens;
+  return index;
+}
+
+function getSelectionIndex(
+  editor: HTMLElement | null,
+  knownTokens: Map<string, ComposerSkillToken>,
+): number {
+  if (!editor) {
+    return 0;
+  }
+
+  const selection = editor.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return readEditorContent(editor, knownTokens).value.length;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!editor.contains(range.startContainer)) {
+    return readEditorContent(editor, knownTokens).value.length;
+  }
+
+  if (range.startContainer.nodeType === Node.TEXT_NODE) {
+    return (
+      getNodeStartIndex(editor, range.startContainer, knownTokens) +
+      range.startOffset
+    );
+  }
+
+  const container = range.startContainer;
+  let index = getNodeStartIndex(editor, container, knownTokens);
+  const childNodes = Array.from(container.childNodes).slice(0, range.startOffset);
+  childNodes.forEach((node) => {
+    walkEditorContent({
+      knownTokens,
+      node,
+      onText: (text) => {
+        index += text.length;
+      },
+      onToken: () => undefined,
+    });
+  });
+
+  return index;
+}
+
+function setSelectionIndex(
+  editor: HTMLElement | null,
+  knownTokens: Map<string, ComposerSkillToken>,
+  requestedIndex: number,
+): void {
+  if (!editor) {
+    return;
+  }
+
+  const index = Math.max(0, requestedIndex);
+  const document = editor.ownerDocument;
+  const range = document.createRange();
+  let cursor = 0;
+  let placed = false;
+
+  const placeAfter = (node: Node): void => {
+    range.setStartAfter(node);
+    range.collapse(true);
+    placed = true;
+  };
+
+  const visit = (node: Node): void => {
+    if (placed) {
+      return;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const length = node.nodeValue?.length ?? 0;
+      if (index < cursor + length) {
+        range.setStart(node, Math.max(0, index - cursor));
+        range.collapse(true);
+        placed = true;
+        return;
+      }
+      cursor += length;
+      return;
+    }
+
+    if (isSkillTokenElement(node)) {
+      if (index <= cursor) {
+        placeAfter(node);
+      }
+      return;
+    }
+
+    if (node instanceof HTMLElement && node.tagName === "BR") {
+      if (index <= cursor + 1) {
+        placeAfter(node);
+        return;
+      }
+      cursor += 1;
+      return;
+    }
+
+    node.childNodes.forEach(visit);
+  };
+
+  editor.childNodes.forEach(visit);
+
+  if (!placed) {
+    range.selectNodeContents(editor);
+    range.collapse(false);
+  }
+
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  void knownTokens;
+}
+
 export const ComposerRichInput = forwardRef<
-  HTMLTextAreaElement,
+  ComposerRichInputHandle,
   ComposerRichInputProps
 >(function ComposerRichInput(props, ref) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const knownTokensRef = useRef(new Map<string, ComposerSkillToken>());
+  const onChangeRef = useRef(props.onChange);
+  const pendingAssignedValueRef = useRef<string | undefined>(undefined);
+  const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
+  const parts = useMemo(
+    () => buildInlineParts(props.value, props.skillTokens),
+    [props.skillTokens, props.value]
+  );
+
+  useEffect(() => {
+    onChangeRef.current = props.onChange;
+  }, [props.onChange]);
+
+  useEffect(() => {
+    for (const token of props.skillTokens) {
+      knownTokensRef.current.set(token.id, token);
+    }
+  }, [props.skillTokens]);
+
+  useLayoutEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    Object.defineProperties(editor, {
+      selectionEnd: {
+        configurable: true,
+        get: () =>
+          pendingSelectionIndexRef.current ??
+          getSelectionIndex(editor, knownTokensRef.current),
+      },
+      selectionStart: {
+        configurable: true,
+        get: () =>
+          pendingSelectionIndexRef.current ??
+          getSelectionIndex(editor, knownTokensRef.current),
+      },
+      setSelectionRange: {
+        configurable: true,
+        value: (start: number) => {
+          setSelectionIndex(editor, knownTokensRef.current, start);
+        },
+      },
+      value: {
+        configurable: true,
+        get: () => readEditorContent(editor, knownTokensRef.current).value,
+        set: (nextValue: string) => {
+          pendingAssignedValueRef.current = nextValue;
+        },
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+
+    const handleNativeChange = (): void => {
+      const assignedValue = pendingAssignedValueRef.current;
+      if (assignedValue !== undefined) {
+        pendingAssignedValueRef.current = undefined;
+        pendingSelectionIndexRef.current = assignedValue.length;
+        onChangeRef.current(assignedValue, []);
+        return;
+      }
+
+      const nextSelection = getSelectionIndex(editor, knownTokensRef.current);
+      const next = readEditorContent(editor, knownTokensRef.current);
+      pendingSelectionIndexRef.current = nextSelection;
+      onChangeRef.current(next.value, next.skillTokens);
+    };
+
+    editor.addEventListener("change", handleNativeChange);
+    return () => {
+      editor.removeEventListener("change", handleNativeChange);
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const nextSelection = pendingSelectionIndexRef.current;
+    if (nextSelection === undefined) {
+      return;
+    }
+
+    pendingSelectionIndexRef.current = undefined;
+    setSelectionIndex(editorRef.current, knownTokensRef.current, nextSelection);
+  }, [parts]);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      editorRef.current?.focus();
+    },
+    get selectionEnd() {
+      return (
+        pendingSelectionIndexRef.current ??
+        getSelectionIndex(editorRef.current, knownTokensRef.current)
+      );
+    },
+    get selectionStart() {
+      return (
+        pendingSelectionIndexRef.current ??
+        getSelectionIndex(editorRef.current, knownTokensRef.current)
+      );
+    },
+    setSelectionRange: (start: number) => {
+      pendingSelectionIndexRef.current = start;
+      requestAnimationFrame(() => {
+        setSelectionIndex(editorRef.current, knownTokensRef.current, start);
+      });
+    },
+  }));
+
+  const handleInput = (event: FormEvent<HTMLDivElement>): void => {
+    const nextSelection = getSelectionIndex(
+      event.currentTarget,
+      knownTokensRef.current,
+    );
+    const next = readEditorContent(event.currentTarget, knownTokensRef.current);
+    pendingSelectionIndexRef.current = nextSelection;
+    onChangeRef.current(next.value, next.skillTokens);
+  };
+
   return (
     <div
-      className={`composer-rich-input${props.disabled ? " is-disabled" : ""}`}
+      ref={editorRef}
+      id={props.id}
+      aria-label={props.label}
+      aria-multiline="true"
+      className={`composer-rich-input${props.disabled ? " is-disabled" : ""}${props.value || props.skillTokens.length > 0 ? "" : " is-empty"}`}
+      contentEditable={!props.disabled}
+      data-placeholder={props.placeholder}
       data-testid="composer-rich-input"
+      data-value={props.value}
+      role="textbox"
+      suppressContentEditableWarning
+      tabIndex={props.disabled ? -1 : 0}
+      onClick={props.onClick}
+      onDragOver={props.onDragOver}
+      onDrop={props.onDrop}
+      onChange={handleInput}
+      onInput={handleInput}
+      onKeyDown={props.onKeyDown}
+      onPaste={props.onPaste}
     >
-      {props.skillTokens.length > 0 ? (
-        <div className="composer-rich-input__chips" aria-label="Selected skills">
-          {props.skillTokens.map((skill) => (
-            <SkillChip
-              key={skill.id}
-              label={`$${skill.name}`}
-              onRemove={() => props.onRemoveSkillToken(skill.id)}
-              skill={skill}
-            />
-          ))}
-        </div>
-      ) : null}
-      <textarea
-        ref={ref}
-        id={props.id}
-        aria-label={props.label}
-        className="composer__input composer-rich-input__textarea"
-        disabled={props.disabled}
-        placeholder={props.placeholder}
-        value={props.value}
-        onChange={(event) => {
-          props.onChange(event.target.value);
-        }}
-        onPaste={props.onPaste}
-        onDragOver={props.onDragOver}
-        onDrop={props.onDrop}
-        onClick={props.onClick}
-        onKeyDown={props.onKeyDown}
-      />
+      {parts.map((part) =>
+        part.type === "text" ? (
+          <span key={part.key}>{part.text}</span>
+        ) : (
+          <span
+            key={part.key}
+            className="composer-rich-input__token"
+            contentEditable={false}
+            data-composer-skill-token-id={part.skill.id}
+            suppressContentEditableWarning
+          >
+            <SkillChip label={`$${part.skill.name}`} skill={part.skill} />
+          </span>
+        )
+      )}
     </div>
   );
 });

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTextareaInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTextareaInput.tsx
@@ -1,0 +1,96 @@
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type ClipboardEvent,
+  type DragEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import type { ComposerRichInputHandle } from "./ComposerRichInput";
+
+type ComposerTextareaInputProps = {
+  ariaActiveDescendant?: string;
+  ariaControls?: string;
+  ariaExpanded?: boolean;
+  disabled?: boolean;
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  onClick?: (event: MouseEvent<HTMLTextAreaElement>) => void;
+  onDragOver?: (event: DragEvent<HTMLTextAreaElement>) => void;
+  onDrop?: (event: DragEvent<HTMLTextAreaElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
+  placeholder: string;
+  value: string;
+};
+
+export const ComposerTextareaInput = forwardRef<
+  ComposerRichInputHandle,
+  ComposerTextareaInputProps
+>(function ComposerTextareaInput(props, ref) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    deleteSelection: (direction) => {
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      if (start !== end) {
+        textarea.setRangeText("", start, end, "start");
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        return;
+      }
+
+      const deleteStart =
+        direction === "backward" ? Math.max(0, start - 1) : start;
+      const deleteEnd =
+        direction === "backward" ? start : Math.min(textarea.value.length, start + 1);
+      if (deleteStart === deleteEnd) {
+        return;
+      }
+
+      textarea.setRangeText("", deleteStart, deleteEnd, "start");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    focus: () => {
+      textareaRef.current?.focus();
+    },
+    get selectionEnd() {
+      return textareaRef.current?.selectionEnd ?? props.value.length;
+    },
+    get selectionStart() {
+      return textareaRef.current?.selectionStart ?? props.value.length;
+    },
+    setSelectionRange: (start: number, end: number) => {
+      textareaRef.current?.setSelectionRange(start, end);
+    },
+  }));
+
+  return (
+    <textarea
+      ref={textareaRef}
+      id={props.id}
+      aria-activedescendant={props.ariaActiveDescendant}
+      aria-controls={props.ariaControls}
+      aria-expanded={props.ariaExpanded}
+      aria-label={props.label}
+      className="composer__input"
+      data-testid="composer-textarea-input"
+      disabled={props.disabled}
+      placeholder={props.placeholder}
+      value={props.value}
+      onChange={(event) => props.onChange(event.target.value)}
+      onClick={props.onClick}
+      onDragOver={props.onDragOver}
+      onDrop={props.onDrop}
+      onKeyDown={props.onKeyDown}
+      onPaste={props.onPaste}
+    />
+  );
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -385,10 +385,12 @@ function insertWysiwygLineBreak(editor: TiptapEditor): boolean {
   }
 
   if (editor.isActive("listItem")) {
-    if (editor.chain().splitListItem("listItem").liftListItem("listItem").run()) {
-      return true;
-    }
-    return editor.commands.liftListItem("listItem");
+    return editor.commands.first(({ commands }) => [
+      () => commands.splitListItem("listItem"),
+      () => commands.createParagraphNear(),
+      () => commands.liftEmptyBlock(),
+      () => commands.splitBlock(),
+    ]);
   }
 
   return editor.commands.first(({ commands }) => [
@@ -396,6 +398,10 @@ function insertWysiwygLineBreak(editor: TiptapEditor): boolean {
     () => commands.liftEmptyBlock(),
     () => commands.splitBlock(),
   ]);
+}
+
+function insertWysiwygSoftBreak(editor: TiptapEditor): boolean {
+  return editor.commands.setHardBreak();
 }
 
 function getDraftIndexAtPosition(
@@ -584,11 +590,16 @@ export const ComposerTiptapInput = forwardRef<
           if (
             propsRef.current.markdownConversion &&
             event.key === "Enter" &&
-            event.shiftKey
+            (event.shiftKey || event.altKey)
           ) {
             event.preventDefault();
             const currentEditor = editorRef.current;
-            return currentEditor ? insertWysiwygLineBreak(currentEditor) : false;
+            if (!currentEditor) {
+              return false;
+            }
+            return event.altKey
+              ? insertWysiwygSoftBreak(currentEditor)
+              : insertWysiwygLineBreak(currentEditor);
           }
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           return event.defaultPrevented;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   type ClipboardEvent,
@@ -41,8 +42,25 @@ const SkillMention = Mention.extend({
     };
   },
 }).configure({
+  deleteTriggerWithBackspace: true,
   HTMLAttributes: {
     class: "thread-row__chip skill-chip composer-tiptap-input__mention",
+  },
+  renderHTML: ({ node }) => {
+    const skill = getSkillSummary(node.attrs);
+    const tooltip = buildSkillTooltip(skill);
+    return [
+      "span",
+      {
+        class: "thread-row__chip skill-chip composer-tiptap-input__mention",
+        "data-type": "mention",
+        "data-composer-skill-token-id": String(node.attrs.id ?? ""),
+        "data-skill-name": skill.name,
+        ...(skill.path ? { "data-skill-path": skill.path } : {}),
+        ...(tooltip ? { "data-tooltip": tooltip } : {}),
+      },
+      `$${skill.name}`,
+    ];
   },
   renderText: ({ node }) => `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
   suggestion: {
@@ -212,7 +230,7 @@ function getPositionAtDraftIndex(
 
     if (node.isText) {
       const textLength = node.text?.length ?? 0;
-      if (draftIndex <= index + textLength) {
+      if (draftIndex < index + textLength) {
         position = pos + Math.max(0, draftIndex - index);
         found = true;
         return false;
@@ -228,6 +246,15 @@ function getPositionAtDraftIndex(
         return false;
       }
       index += 1;
+      return false;
+    }
+
+    if (node.type.name === "mention") {
+      if (draftIndex <= index) {
+        position = pos + node.nodeSize;
+        found = true;
+        return false;
+      }
       return false;
     }
 
@@ -251,12 +278,34 @@ function getSkillSummary(attrs: Record<string, unknown>): AppServerSkillSummary 
   };
 }
 
+function getContentSignature(params: {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+}): string {
+  return JSON.stringify({
+    value: params.value,
+    tokens: params.skillTokens.map((token) => ({
+      index: token.index,
+      name: token.name,
+      path: token.path,
+    })),
+  });
+}
+
 export const ComposerTiptapInput = forwardRef<
   ComposerRichInputHandle,
   ComposerRichInputProps
 >(function ComposerTiptapInput(props, ref) {
   const propsRef = useRef(props);
   const selectionIndexRef = useRef(props.value.length);
+  const pendingExternalSignatureRef = useRef<string | undefined>(undefined);
+  const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
+  const propsSignature = getContentSignature({
+    value: props.value,
+    skillTokens: props.skillTokens,
+  });
+
+  propsRef.current = props;
   const initialContent = useMemo(
     () => buildTiptapContent(props.value, props.skillTokens),
     []
@@ -299,11 +348,19 @@ export const ComposerTiptapInput = forwardRef<
     extensions: [StarterKit, SkillMention],
     onUpdate: ({ editor: nextEditor }) => {
       const next = readTiptapContent(nextEditor);
+      const pendingSignature = pendingExternalSignatureRef.current;
+      if (
+        pendingSignature &&
+        getContentSignature(next) !== pendingSignature
+      ) {
+        return;
+      }
+      pendingExternalSignatureRef.current = undefined;
       selectionIndexRef.current = getDraftIndexAtPosition(
         nextEditor,
         nextEditor.state.selection.from,
       );
-      props.onChange(next.value, next.skillTokens);
+      propsRef.current.onChange(next.value, next.skillTokens);
     },
     onSelectionUpdate: ({ editor: nextEditor }) => {
       selectionIndexRef.current = getDraftIndexAtPosition(
@@ -313,11 +370,7 @@ export const ComposerTiptapInput = forwardRef<
     },
   });
 
-  useEffect(() => {
-    propsRef.current = props;
-  }, [props]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!editor) {
       return;
     }
@@ -350,31 +403,28 @@ export const ComposerTiptapInput = forwardRef<
     }
 
     const current = readTiptapContent(editor);
-    const currentSignature = JSON.stringify({
-      value: current.value,
-      tokens: current.skillTokens.map((token) => ({
-        index: token.index,
-        name: token.name,
-        path: token.path,
-      })),
-    });
-    const nextSignature = JSON.stringify({
-      value: props.value,
-      tokens: props.skillTokens.map((token) => ({
-        index: token.index,
-        name: token.name,
-        path: token.path,
-      })),
-    });
-    if (currentSignature === nextSignature) {
+    const currentSignature = getContentSignature(current);
+    if (currentSignature === propsSignature) {
+      pendingExternalSignatureRef.current = undefined;
       return;
     }
 
+    pendingExternalSignatureRef.current = propsSignature;
     editor.commands.setContent(
       buildTiptapContent(props.value, props.skillTokens),
       { emitUpdate: false },
     );
-  }, [editor, props.skillTokens, props.value]);
+    pendingExternalSignatureRef.current = undefined;
+
+    if (pendingSelectionIndexRef.current !== undefined) {
+      const nextSelectionIndex = pendingSelectionIndexRef.current;
+      pendingSelectionIndexRef.current = undefined;
+      selectionIndexRef.current = nextSelectionIndex;
+      editor.commands.setTextSelection(
+        getPositionAtDraftIndex(editor, nextSelectionIndex),
+      );
+    }
+  }, [editor, props.skillTokens, props.value, propsSignature]);
 
   useEffect(() => {
     if (!editor) {
@@ -393,7 +443,7 @@ export const ComposerTiptapInput = forwardRef<
         const tooltip = buildSkillTooltip(
           getSkillSummary({
             name: node.textContent?.replace(/^\$/, ""),
-            path: attrs["data-path"],
+            path: attrs["data-skill-path"],
           }),
         );
         if (tooltip) {
@@ -407,6 +457,9 @@ export const ComposerTiptapInput = forwardRef<
       editor?.commands.deleteSelection();
     },
     focus: () => {
+      if (editor && getContentSignature(readTiptapContent(editor)) !== propsSignature) {
+        pendingExternalSignatureRef.current = propsSignature;
+      }
       editor?.commands.focus();
     },
     get selectionEnd() {
@@ -417,6 +470,13 @@ export const ComposerTiptapInput = forwardRef<
     },
     setSelectionRange: (start: number) => {
       if (!editor) {
+        return;
+      }
+      const current = readTiptapContent(editor);
+      if (getContentSignature(current) !== propsSignature) {
+        pendingExternalSignatureRef.current = propsSignature;
+        pendingSelectionIndexRef.current = start;
+        selectionIndexRef.current = start;
         return;
       }
       selectionIndexRef.current = start;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -379,6 +379,18 @@ function readTiptapContent(
     : readTiptapTextContent(editor);
 }
 
+function insertWysiwygLineBreak(editor: TiptapEditor): boolean {
+  if (editor.state.selection.$from.parent.type.name === "codeBlock") {
+    return editor.commands.newlineInCode();
+  }
+
+  return editor.commands.first(({ commands }) => [
+    () => commands.createParagraphNear(),
+    () => commands.liftEmptyBlock(),
+    () => commands.splitBlock(),
+  ]);
+}
+
 function getDraftIndexAtPosition(
   editor: NonNullable<ReturnType<typeof useEditor>>,
   position: number,
@@ -504,6 +516,7 @@ export const ComposerTiptapInput = forwardRef<
   ComposerTiptapInputProps
 >(function ComposerTiptapInput(props, ref) {
   const propsRef = useRef(props);
+  const editorRef = useRef<TiptapEditor | null>(null);
   const selectionIndexRef = useRef(props.value.length);
   const pendingExternalSignatureRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
@@ -564,12 +577,11 @@ export const ComposerTiptapInput = forwardRef<
           if (
             propsRef.current.markdownConversion &&
             event.key === "Enter" &&
-            event.shiftKey &&
-            view.state.selection.$from.parent.type.name === "codeBlock"
+            event.shiftKey
           ) {
             event.preventDefault();
-            view.dispatch(view.state.tr.insertText("\n"));
-            return true;
+            const currentEditor = editorRef.current;
+            return currentEditor ? insertWysiwygLineBreak(currentEditor) : false;
           }
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           return event.defaultPrevented;
@@ -606,6 +618,7 @@ export const ComposerTiptapInput = forwardRef<
       );
     },
   });
+  editorRef.current = editor;
 
   useLayoutEffect(() => {
     if (!editor) {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1,0 +1,437 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  type ClipboardEvent,
+  type DragEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import Mention from "@tiptap/extension-mention";
+import StarterKit from "@tiptap/starter-kit";
+import { EditorContent, useEditor, type JSONContent } from "@tiptap/react";
+import type { AppServerSkillSummary } from "@pwragnt/shared";
+import { buildSkillTooltip } from "../../lib/skill-mentions";
+import type {
+  ComposerRichInputHandle,
+  ComposerRichInputProps,
+  ComposerSkillToken,
+} from "./ComposerRichInput";
+
+const SkillMention = Mention.extend({
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+      },
+      name: {
+        default: null,
+      },
+      path: {
+        default: null,
+      },
+      description: {
+        default: null,
+      },
+      shortDescription: {
+        default: null,
+      },
+    };
+  },
+}).configure({
+  HTMLAttributes: {
+    class: "thread-row__chip skill-chip composer-tiptap-input__mention",
+  },
+  renderText: ({ node }) => `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
+  suggestion: {
+    char: "\uFFFF",
+    items: () => [],
+  },
+});
+
+function splitTextContent(text: string): JSONContent[] {
+  const nodes: JSONContent[] = [];
+  const lines = text.split("\n");
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      nodes.push({ type: "hardBreak" });
+    }
+    if (line) {
+      nodes.push({ type: "text", text: line });
+    }
+  });
+  return nodes;
+}
+
+function buildTiptapContent(
+  value: string,
+  skillTokens: ComposerSkillToken[],
+): JSONContent {
+  const sortedTokens = [...skillTokens].sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  const content: JSONContent[] = [];
+  let cursor = 0;
+  sortedTokens.forEach((skill) => {
+    const index = Math.max(0, Math.min(skill.index, value.length));
+    content.push(...splitTextContent(value.slice(cursor, index)));
+    content.push({
+      type: "mention",
+      attrs: {
+        id: skill.id,
+        name: skill.name,
+        path: skill.path ?? null,
+        description: skill.description ?? null,
+        shortDescription: skill.shortDescription ?? null,
+      },
+    });
+    cursor = index;
+  });
+  content.push(...splitTextContent(value.slice(cursor)));
+
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: content.length > 0 ? content : undefined,
+      },
+    ],
+  };
+}
+
+function mentionAttrsToSkill(
+  attrs: Record<string, unknown>,
+  index: number,
+): ComposerSkillToken {
+  const name = typeof attrs.name === "string" ? attrs.name : String(attrs.id ?? "skill");
+  return {
+    id: typeof attrs.id === "string" ? attrs.id : `${name}:${index}`,
+    index,
+    name,
+    path: typeof attrs.path === "string" ? attrs.path : undefined,
+    description:
+      typeof attrs.description === "string" ? attrs.description : undefined,
+    shortDescription:
+      typeof attrs.shortDescription === "string"
+        ? attrs.shortDescription
+        : undefined,
+  };
+}
+
+function readTiptapContent(editor: NonNullable<ReturnType<typeof useEditor>>): {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+} {
+  let value = "";
+  const skillTokens: ComposerSkillToken[] = [];
+
+  editor.state.doc.descendants((node) => {
+    if (node.isText) {
+      value += node.text ?? "";
+      return false;
+    }
+
+    if (node.type.name === "hardBreak") {
+      value += "\n";
+      return false;
+    }
+
+    if (node.type.name === "mention") {
+      skillTokens.push(mentionAttrsToSkill(node.attrs, value.length));
+      return false;
+    }
+
+    return true;
+  });
+
+  return { value, skillTokens };
+}
+
+function getDraftIndexAtPosition(
+  editor: NonNullable<ReturnType<typeof useEditor>>,
+  position: number,
+): number {
+  let index = 0;
+  let found = false;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (found) {
+      return false;
+    }
+
+    if (node.isText) {
+      const text = node.text ?? "";
+      const end = pos + text.length;
+      if (position <= end) {
+        index += Math.max(0, Math.min(text.length, position - pos));
+        found = true;
+        return false;
+      }
+      index += text.length;
+      return false;
+    }
+
+    if (node.type.name === "hardBreak") {
+      if (position <= pos + node.nodeSize) {
+        found = true;
+        return false;
+      }
+      index += 1;
+      return false;
+    }
+
+    if (node.type.name === "mention") {
+      return false;
+    }
+
+    return true;
+  });
+
+  return index;
+}
+
+function getPositionAtDraftIndex(
+  editor: NonNullable<ReturnType<typeof useEditor>>,
+  draftIndex: number,
+): number {
+  let index = 0;
+  let position = editor.state.doc.content.size;
+  let found = false;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (found) {
+      return false;
+    }
+
+    if (node.isText) {
+      const textLength = node.text?.length ?? 0;
+      if (draftIndex <= index + textLength) {
+        position = pos + Math.max(0, draftIndex - index);
+        found = true;
+        return false;
+      }
+      index += textLength;
+      return false;
+    }
+
+    if (node.type.name === "hardBreak") {
+      if (draftIndex <= index + 1) {
+        position = pos + node.nodeSize;
+        found = true;
+        return false;
+      }
+      index += 1;
+      return false;
+    }
+
+    return true;
+  });
+
+  return Math.max(1, position);
+}
+
+function getSkillSummary(attrs: Record<string, unknown>): AppServerSkillSummary {
+  const name = typeof attrs.name === "string" ? attrs.name : String(attrs.id ?? "skill");
+  return {
+    name,
+    path: typeof attrs.path === "string" ? attrs.path : undefined,
+    description:
+      typeof attrs.description === "string" ? attrs.description : undefined,
+    shortDescription:
+      typeof attrs.shortDescription === "string"
+        ? attrs.shortDescription
+        : undefined,
+  };
+}
+
+export const ComposerTiptapInput = forwardRef<
+  ComposerRichInputHandle,
+  ComposerRichInputProps
+>(function ComposerTiptapInput(props, ref) {
+  const propsRef = useRef(props);
+  const selectionIndexRef = useRef(props.value.length);
+  const initialContent = useMemo(
+    () => buildTiptapContent(props.value, props.skillTokens),
+    []
+  );
+  const editor = useEditor({
+    content: initialContent,
+    editorProps: {
+      attributes: {
+        "aria-activedescendant": props.ariaActiveDescendant ?? "",
+        "aria-controls": props.ariaControls ?? "",
+        "aria-expanded": String(Boolean(props.ariaExpanded)),
+        "aria-label": props.label,
+        class: `composer-tiptap-input__editor${props.disabled ? " is-disabled" : ""}`,
+        "data-placeholder": props.placeholder,
+        role: "textbox",
+      },
+      handleClick: (_view, _pos, event) => {
+        propsRef.current.onClick?.(event as unknown as MouseEvent<HTMLDivElement>);
+        return false;
+      },
+      handleDOMEvents: {
+        dragover: (_view, event) => {
+          propsRef.current.onDragOver?.(event as unknown as DragEvent<HTMLDivElement>);
+          return event.defaultPrevented;
+        },
+        drop: (_view, event) => {
+          propsRef.current.onDrop?.(event as unknown as DragEvent<HTMLDivElement>);
+          return event.defaultPrevented;
+        },
+        keydown: (_view, event) => {
+          propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
+          return event.defaultPrevented;
+        },
+        paste: (_view, event) => {
+          propsRef.current.onPaste?.(event as unknown as ClipboardEvent<HTMLDivElement>);
+          return event.defaultPrevented;
+        },
+      },
+    },
+    extensions: [StarterKit, SkillMention],
+    onUpdate: ({ editor: nextEditor }) => {
+      const next = readTiptapContent(nextEditor);
+      selectionIndexRef.current = getDraftIndexAtPosition(
+        nextEditor,
+        nextEditor.state.selection.from,
+      );
+      props.onChange(next.value, next.skillTokens);
+    },
+    onSelectionUpdate: ({ editor: nextEditor }) => {
+      selectionIndexRef.current = getDraftIndexAtPosition(
+        nextEditor,
+        nextEditor.state.selection.from,
+      );
+    },
+  });
+
+  useEffect(() => {
+    propsRef.current = props;
+  }, [props]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setEditable(!props.disabled);
+    editor.view.dom.setAttribute("aria-label", props.label);
+    editor.view.dom.setAttribute("aria-expanded", String(Boolean(props.ariaExpanded)));
+    if (props.ariaActiveDescendant) {
+      editor.view.dom.setAttribute("aria-activedescendant", props.ariaActiveDescendant);
+    } else {
+      editor.view.dom.removeAttribute("aria-activedescendant");
+    }
+    if (props.ariaControls) {
+      editor.view.dom.setAttribute("aria-controls", props.ariaControls);
+    } else {
+      editor.view.dom.removeAttribute("aria-controls");
+    }
+  }, [
+    editor,
+    props.ariaActiveDescendant,
+    props.ariaControls,
+    props.ariaExpanded,
+    props.disabled,
+    props.label,
+  ]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const current = readTiptapContent(editor);
+    const currentSignature = JSON.stringify({
+      value: current.value,
+      tokens: current.skillTokens.map((token) => ({
+        index: token.index,
+        name: token.name,
+        path: token.path,
+      })),
+    });
+    const nextSignature = JSON.stringify({
+      value: props.value,
+      tokens: props.skillTokens.map((token) => ({
+        index: token.index,
+        name: token.name,
+        path: token.path,
+      })),
+    });
+    if (currentSignature === nextSignature) {
+      return;
+    }
+
+    editor.commands.setContent(
+      buildTiptapContent(props.value, props.skillTokens),
+      { emitUpdate: false },
+    );
+  }, [editor, props.skillTokens, props.value]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.view.dom
+      .querySelectorAll<HTMLElement>(".composer-tiptap-input__mention")
+      .forEach((node) => {
+        const attrs = Object.fromEntries(
+          Array.from(node.attributes).map((attribute) => [
+            attribute.name,
+            attribute.value,
+          ]),
+        );
+        const tooltip = buildSkillTooltip(
+          getSkillSummary({
+            name: node.textContent?.replace(/^\$/, ""),
+            path: attrs["data-path"],
+          }),
+        );
+        if (tooltip) {
+          node.setAttribute("data-tooltip", tooltip);
+        }
+      });
+  }, [editor, props.skillTokens]);
+
+  useImperativeHandle(ref, () => ({
+    deleteSelection: () => {
+      editor?.commands.deleteSelection();
+    },
+    focus: () => {
+      editor?.commands.focus();
+    },
+    get selectionEnd() {
+      return selectionIndexRef.current;
+    },
+    get selectionStart() {
+      return selectionIndexRef.current;
+    },
+    setSelectionRange: (start: number) => {
+      if (!editor) {
+        return;
+      }
+      selectionIndexRef.current = start;
+      editor.commands.setTextSelection(getPositionAtDraftIndex(editor, start));
+    },
+  }));
+
+  return (
+    <div
+      className={`composer-tiptap-input${props.value || props.skillTokens.length > 0 ? "" : " is-empty"}`}
+      data-placeholder={props.placeholder}
+      data-testid="composer-tiptap-input"
+      data-value={props.value}
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -21,6 +21,22 @@ import type {
   ComposerSkillToken,
 } from "./ComposerRichInput";
 
+type ComposerTiptapInputProps = ComposerRichInputProps & {
+  markdownConversion?: boolean;
+};
+
+type TiptapReadMode = "markdown" | "text";
+
+type TiptapReadState = {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+};
+
+type TiptapEditor = NonNullable<ReturnType<typeof useEditor>>;
+type ProseMirrorNode = Parameters<
+  Parameters<TiptapEditor["state"]["doc"]["forEach"]>[0]
+>[0];
+
 const SkillMention = Mention.extend({
   addAttributes() {
     return {
@@ -143,7 +159,179 @@ function mentionAttrsToSkill(
   };
 }
 
-function readTiptapContent(editor: NonNullable<ReturnType<typeof useEditor>>): {
+function getMarkdownMarkDelimiters(
+  node: ProseMirrorNode,
+): { prefix: string; suffix: string } {
+  return node.marks.reduce(
+    (delimiters, mark) => {
+      if (mark.type.name === "bold") {
+        return {
+          prefix: `${delimiters.prefix}**`,
+          suffix: `**${delimiters.suffix}`,
+        };
+      }
+      if (mark.type.name === "italic") {
+        return {
+          prefix: `${delimiters.prefix}*`,
+          suffix: `*${delimiters.suffix}`,
+        };
+      }
+      if (mark.type.name === "strike") {
+        return {
+          prefix: `${delimiters.prefix}~~`,
+          suffix: `~~${delimiters.suffix}`,
+        };
+      }
+      if (mark.type.name === "code") {
+        return {
+          prefix: `${delimiters.prefix}\``,
+          suffix: `\`${delimiters.suffix}`,
+        };
+      }
+      return delimiters;
+    },
+    { prefix: "", suffix: "" },
+  );
+}
+
+function appendMarkdownInlineContent(
+  node: ProseMirrorNode,
+  state: TiptapReadState,
+): void {
+  node.forEach((child) => {
+    if (child.isText) {
+      const delimiters = getMarkdownMarkDelimiters(child);
+      state.value += `${delimiters.prefix}${child.text ?? ""}${delimiters.suffix}`;
+      return;
+    }
+
+    if (child.type.name === "hardBreak") {
+      state.value += "\n";
+      return;
+    }
+
+    if (child.type.name === "mention") {
+      state.skillTokens.push(mentionAttrsToSkill(child.attrs, state.value.length));
+      return;
+    }
+
+    appendMarkdownInlineContent(child, state);
+  });
+}
+
+function appendMarkdownListItem(
+  node: ProseMirrorNode,
+  state: TiptapReadState,
+): void {
+  let wroteFirstBlock = false;
+  node.forEach((child) => {
+    if (wroteFirstBlock) {
+      state.value += "\n  ";
+    }
+    wroteFirstBlock = true;
+    if (child.type.name === "paragraph") {
+      appendMarkdownInlineContent(child, state);
+      return;
+    }
+    appendMarkdownBlock(child, state, 0);
+  });
+}
+
+function appendMarkdownBlock(
+  node: ProseMirrorNode,
+  state: TiptapReadState,
+  index: number,
+): void {
+  if (index > 0) {
+    state.value += "\n\n";
+  }
+
+  if (node.type.name === "paragraph") {
+    appendMarkdownInlineContent(node, state);
+    return;
+  }
+
+  if (node.type.name === "heading") {
+    const level = typeof node.attrs.level === "number" ? node.attrs.level : 1;
+    state.value += `${"#".repeat(Math.min(Math.max(level, 1), 6))} `;
+    appendMarkdownInlineContent(node, state);
+    return;
+  }
+
+  if (node.type.name === "codeBlock") {
+    const language = typeof node.attrs.language === "string" ? node.attrs.language : "";
+    state.value += `\`\`\`${language}\n${node.textContent}\n\`\`\``;
+    return;
+  }
+
+  if (node.type.name === "bulletList") {
+    node.forEach((child, _offset, listIndex) => {
+      if (listIndex > 0) {
+        state.value += "\n";
+      }
+      state.value += "- ";
+      appendMarkdownListItem(child, state);
+    });
+    return;
+  }
+
+  if (node.type.name === "orderedList") {
+    const start = typeof node.attrs.start === "number" ? node.attrs.start : 1;
+    node.forEach((child, _offset, listIndex) => {
+      if (listIndex > 0) {
+        state.value += "\n";
+      }
+      state.value += `${start + listIndex}. `;
+      appendMarkdownListItem(child, state);
+    });
+    return;
+  }
+
+  if (node.type.name === "blockquote") {
+    const quotedState: TiptapReadState = { skillTokens: [], value: "" };
+    node.forEach((child, _offset, childIndex) => {
+      appendMarkdownBlock(child, quotedState, childIndex);
+    });
+    const quoteStart = state.value.length;
+    state.value += quotedState.value
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+    quotedState.skillTokens.forEach((token) => {
+      state.skillTokens.push({ ...token, index: quoteStart + token.index + 2 });
+    });
+    return;
+  }
+
+  appendMarkdownInlineContent(node, state);
+}
+
+function readTiptapMarkdownContent(
+  editor: NonNullable<ReturnType<typeof useEditor>>,
+): {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+} {
+  const state: TiptapReadState = { skillTokens: [], value: "" };
+  const nodes: ProseMirrorNode[] = [];
+  editor.state.doc.forEach((node) => {
+    nodes.push(node);
+  });
+  let lastContentIndex = nodes.length - 1;
+  while (
+    lastContentIndex >= 0 &&
+    nodes[lastContentIndex]?.type.name === "paragraph" &&
+    nodes[lastContentIndex]?.content.size === 0
+  ) {
+    lastContentIndex -= 1;
+  }
+  nodes.slice(0, lastContentIndex + 1).forEach((node, index) => {
+    appendMarkdownBlock(node, state, index);
+  });
+  return state;
+}
+
+function readTiptapTextContent(editor: NonNullable<ReturnType<typeof useEditor>>): {
   skillTokens: ComposerSkillToken[];
   value: string;
 } {
@@ -177,6 +365,18 @@ function readTiptapContent(editor: NonNullable<ReturnType<typeof useEditor>>): {
   });
 
   return { value, skillTokens };
+}
+
+function readTiptapContent(
+  editor: NonNullable<ReturnType<typeof useEditor>>,
+  mode: TiptapReadMode,
+): {
+  skillTokens: ComposerSkillToken[];
+  value: string;
+} {
+  return mode === "markdown"
+    ? readTiptapMarkdownContent(editor)
+    : readTiptapTextContent(editor);
 }
 
 function getDraftIndexAtPosition(
@@ -301,16 +501,34 @@ function getContentSignature(params: {
 
 export const ComposerTiptapInput = forwardRef<
   ComposerRichInputHandle,
-  ComposerRichInputProps
+  ComposerTiptapInputProps
 >(function ComposerTiptapInput(props, ref) {
   const propsRef = useRef(props);
   const selectionIndexRef = useRef(props.value.length);
   const pendingExternalSignatureRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
+  const readMode: TiptapReadMode = props.markdownConversion ? "markdown" : "text";
   const propsSignature = getContentSignature({
     value: props.value,
     skillTokens: props.skillTokens,
   });
+  const extensions = useMemo(
+    () => [
+      props.markdownConversion
+        ? StarterKit
+        : StarterKit.configure({
+            blockquote: false,
+            bulletList: false,
+            codeBlock: false,
+            heading: false,
+            horizontalRule: false,
+            listItem: false,
+            orderedList: false,
+          }),
+      SkillMention,
+    ],
+    [props.markdownConversion],
+  );
 
   propsRef.current = props;
   const initialContent = useMemo(
@@ -342,7 +560,17 @@ export const ComposerTiptapInput = forwardRef<
           propsRef.current.onDrop?.(event as unknown as DragEvent<HTMLDivElement>);
           return event.defaultPrevented;
         },
-        keydown: (_view, event) => {
+        keydown: (view, event) => {
+          if (
+            propsRef.current.markdownConversion &&
+            event.key === "Enter" &&
+            event.shiftKey &&
+            view.state.selection.$from.parent.type.name === "codeBlock"
+          ) {
+            event.preventDefault();
+            view.dispatch(view.state.tr.insertText("\n"));
+            return true;
+          }
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           return event.defaultPrevented;
         },
@@ -352,9 +580,11 @@ export const ComposerTiptapInput = forwardRef<
         },
       },
     },
-    extensions: [StarterKit, SkillMention],
+    enableInputRules: props.markdownConversion ? true : false,
+    enablePasteRules: props.markdownConversion ? true : false,
+    extensions,
     onUpdate: ({ editor: nextEditor }) => {
-      const next = readTiptapContent(nextEditor);
+      const next = readTiptapContent(nextEditor, readMode);
       const pendingSignature = pendingExternalSignatureRef.current;
       if (
         pendingSignature &&
@@ -409,7 +639,7 @@ export const ComposerTiptapInput = forwardRef<
       return;
     }
 
-    const current = readTiptapContent(editor);
+    const current = readTiptapContent(editor, readMode);
     const currentSignature = getContentSignature(current);
     if (currentSignature === propsSignature) {
       pendingExternalSignatureRef.current = undefined;
@@ -431,7 +661,7 @@ export const ComposerTiptapInput = forwardRef<
         getPositionAtDraftIndex(editor, nextSelectionIndex),
       );
     }
-  }, [editor, props.skillTokens, props.value, propsSignature]);
+  }, [editor, props.skillTokens, props.value, propsSignature, readMode]);
 
   useEffect(() => {
     if (!editor) {
@@ -464,7 +694,10 @@ export const ComposerTiptapInput = forwardRef<
       editor?.commands.deleteSelection();
     },
     focus: () => {
-      if (editor && getContentSignature(readTiptapContent(editor)) !== propsSignature) {
+      if (
+        editor &&
+        getContentSignature(readTiptapContent(editor, readMode)) !== propsSignature
+      ) {
         pendingExternalSignatureRef.current = propsSignature;
       }
       editor?.commands.focus();
@@ -479,7 +712,7 @@ export const ComposerTiptapInput = forwardRef<
       if (!editor) {
         return;
       }
-      const current = readTiptapContent(editor);
+      const current = readTiptapContent(editor, readMode);
       if (getContentSignature(current) !== propsSignature) {
         pendingExternalSignatureRef.current = propsSignature;
         pendingSelectionIndexRef.current = start;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -150,7 +150,14 @@ function readTiptapContent(editor: NonNullable<ReturnType<typeof useEditor>>): {
   let value = "";
   const skillTokens: ComposerSkillToken[] = [];
 
-  editor.state.doc.descendants((node) => {
+  editor.state.doc.descendants((node, _pos, parent, index) => {
+    if (node.type.name === "paragraph" && parent?.type.name === "doc") {
+      if (index > 0) {
+        value += "\n";
+      }
+      return true;
+    }
+
     if (node.isText) {
       value += node.text ?? "";
       return false;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -384,6 +384,13 @@ function insertWysiwygLineBreak(editor: TiptapEditor): boolean {
     return editor.commands.newlineInCode();
   }
 
+  if (editor.isActive("listItem")) {
+    if (editor.chain().splitListItem("listItem").liftListItem("listItem").run()) {
+      return true;
+    }
+    return editor.commands.liftListItem("listItem");
+  }
+
   return editor.commands.first(({ commands }) => [
     () => commands.createParagraphNear(),
     () => commands.liftEmptyBlock(),

--- a/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
@@ -3,6 +3,7 @@ import { buildSkillTooltip } from "../../lib/skill-mentions";
 
 type SkillChipProps = {
   label?: string;
+  onRemove?: () => void;
   skill: AppServerSkillSummary;
 };
 
@@ -11,14 +12,24 @@ export function SkillChip(props: SkillChipProps) {
 
   return (
     <span
-      className="thread-row__chip skill-chip tooltip-target"
+      className={`thread-row__chip skill-chip tooltip-target${props.onRemove ? " skill-chip--removable" : ""}`}
       data-tooltip={tooltip || undefined}
-      tabIndex={tooltip ? 0 : -1}
+      tabIndex={tooltip && !props.onRemove ? 0 : -1}
     >
       <span aria-hidden="true" className="thread-row__chip-icon">
         🧰
       </span>
-      {props.label ?? `$${props.skill.name}`}
+      <span className="skill-chip__label">{props.label ?? `$${props.skill.name}`}</span>
+      {props.onRemove ? (
+        <button
+          aria-label={`Remove $${props.skill.name}`}
+          className="skill-chip__remove"
+          type="button"
+          onClick={props.onRemove}
+        >
+          x
+        </button>
+      ) : null}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type {
   BackendSummary,
   NavigationLaunchpadDraft,
@@ -2176,8 +2176,14 @@ describe("Composer", () => {
     expect(screen.getByRole("listbox", { name: "Skills" })).toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(screen.getAllByText("$frontend-design").length).toBeGreaterThan(0);
-    expect(screen.getByLabelText("Reply")).toHaveValue("Use $frontend-design ");
+    const richInput = screen.getByTestId("composer-rich-input");
+    expect(within(richInput).getByText("$frontend-design")).toBeInTheDocument();
+    expect(within(richInput).getByText("$frontend-design").closest(".skill-chip")).toHaveAttribute(
+      "data-tooltip",
+      expect.stringContaining("/Users/huntharo/.codex/skills/frontend-design/SKILL.md")
+    );
+    expect(screen.getByLabelText("Reply")).toHaveValue("Use ");
+    expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
@@ -2191,6 +2197,61 @@ describe("Composer", () => {
             text: "Use [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md)",
           },
         ],
+      });
+    });
+  });
+
+  it("removes selected skill chips without leaving raw mention text", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[
+          {
+            name: "ce:plan",
+            description: "Turn feature descriptions into implementation plans.",
+            path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Use $ce:pl" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(within(screen.getByTestId("composer-rich-input")).getByText("$ce:plan")).toBeInTheDocument();
+    expect(textarea).toHaveValue("Use ");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove $ce:plan" }));
+
+    expect(screen.queryByText("$ce:plan")).not.toBeInTheDocument();
+    expect(textarea).toHaveValue("Use ");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Use" }],
       });
     });
   });
@@ -2597,9 +2658,53 @@ describe("Composer", () => {
 
     const option = screen.getByRole("button", { name: /\$ce:plan/i });
     option.focus();
-    fireEvent.click(option);
+    fireEvent.keyDown(option, { key: "Enter" });
 
-    expect(screen.getByLabelText("Reply")).toHaveValue("$ce:plan ");
+    expect(within(screen.getByTestId("composer-rich-input")).getByText("$ce:plan")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toHaveValue("");
+    expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
+  });
+
+  it("dismisses skill autocomplete when Escape is pressed from a focused option", () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[
+          {
+            name: "ce:plan",
+            description: "Turn feature descriptions into implementation plans.",
+            path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "$ce:pl" } });
+
+    const option = screen.getByRole("button", { name: /\$ce:plan/i });
+    option.focus();
+    fireEvent.keyDown(option, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
+    expect(textarea).toHaveValue("$ce:pl");
   });
 
   it("shows a stop button for an active turn and interrupts it", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2263,7 +2263,7 @@ describe("Composer", () => {
     expect(options.slice(2).join(" ")).toContain("$adversarial-document-reviewer");
   });
 
-  it("removes selected skill chips without leaving raw mention text", async () => {
+  it("renders selected skill chips without leaving raw mention text", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
@@ -2302,18 +2302,18 @@ describe("Composer", () => {
     expect(within(screen.getByTestId("composer-rich-input")).getByText("$ce:plan")).toBeInTheDocument();
     expect(textarea).toHaveValue("Use ");
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove $ce:plan" }));
-
-    expect(screen.queryByText("$ce:plan")).not.toBeInTheDocument();
-    expect(textarea).toHaveValue("Use ");
-
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
       expect(startTurn).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
-        input: [{ type: "text", text: "Use" }],
+        input: [
+          {
+            type: "text",
+            text: "Use [$ce:plan](/Users/huntharo/.codex/skills/ce-plan/SKILL.md)",
+          },
+        ],
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1223,6 +1223,7 @@ describe("Composer", () => {
 
     render(
       <Composer
+        composerImplementation="custom-widget-chips"
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,
@@ -2176,13 +2177,9 @@ describe("Composer", () => {
     expect(screen.getByRole("listbox", { name: "Skills" })).toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    const richInput = screen.getByTestId("composer-rich-input");
-    expect(within(richInput).getByText("$frontend-design")).toBeInTheDocument();
-    expect(within(richInput).getByText("$frontend-design").closest(".skill-chip")).toHaveAttribute(
-      "data-tooltip",
-      expect.stringContaining("/Users/huntharo/.codex/skills/frontend-design/SKILL.md")
+    expect(textarea).toHaveValue(
+      "Use [$frontend-design](/Users/huntharo/.codex/skills/frontend-design/SKILL.md) "
     );
-    expect(screen.getByLabelText("Reply")).toHaveValue("Use ");
     expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
@@ -2204,6 +2201,7 @@ describe("Composer", () => {
   it("prioritizes skill name prefix matches over description-only matches", () => {
     render(
       <Composer
+        composerImplementation="custom-widget-chips"
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn: async () => ({
@@ -2271,6 +2269,7 @@ describe("Composer", () => {
     }));
     render(
       <Composer
+        composerImplementation="custom-widget-chips"
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn,
@@ -2687,6 +2686,7 @@ describe("Composer", () => {
   it("applies the focused skill option when activated from the keyboard", async () => {
     render(
       <Composer
+        composerImplementation="custom-widget-chips"
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn: async () => ({

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2201,6 +2201,68 @@ describe("Composer", () => {
     });
   });
 
+  it("prioritizes skill name prefix matches over description-only matches", () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[
+          {
+            name: "adversarial-document-reviewer",
+            description: "Conditional reviewer used for CE document stress-testing.",
+            path: "/Users/huntharo/.codex/skills/adversarial-document-reviewer/SKILL.md",
+            enabled: true,
+          },
+          {
+            name: "ce:plan",
+            description: "Transform requirements into implementation plans.",
+            path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+            enabled: true,
+          },
+          {
+            name: "ce:work",
+            description: "Execute implementation plans.",
+            path: "/Users/huntharo/.codex/skills/ce-work/SKILL.md",
+            enabled: true,
+          },
+          {
+            name: "architecture-strategist",
+            description: "Analyzes patterns and design integrity.",
+            path: "/Users/huntharo/.codex/skills/architecture-strategist/SKILL.md",
+            enabled: true,
+          },
+        ]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "$ce" },
+    });
+
+    const options = within(screen.getByRole("listbox", { name: "Skills" }))
+      .getAllByRole("button")
+      .map((option) => option.textContent ?? "");
+
+    expect(options[0]).toContain("$ce:plan");
+    expect(options[1]).toContain("$ce:work");
+    expect(options.slice(2).join(" ")).toContain("$adversarial-document-reviewer");
+  });
+
   it("removes selected skill chips without leaving raw mention text", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -6,7 +6,11 @@ const COMPOSER_OPTIONS: Array<{
   value: DesktopChatReplyComposer;
 }> = [
   { label: "Textarea", value: "textarea" },
-  { label: "TipTap with chips", value: "tiptap-chips" },
+  { label: "TipTap raw Markdown + chips", value: "tiptap-chips" },
+  {
+    label: "TipTap WYSIWYG Markdown + chips",
+    value: "tiptap-wysiwyg-markdown-chips",
+  },
   { label: "Custom widget with chips", value: "custom-widget-chips" },
 ];
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -156,10 +156,19 @@ describe("SettingsScreen", () => {
     });
 
     fireEvent.click(within(sections).getByRole("button", { name: "Experimental" }));
-    fireEvent.click(screen.getByRole("radio", { name: "TipTap with chips" }));
+    fireEvent.click(screen.getByRole("radio", { name: "TipTap raw Markdown + chips" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { chatReplyComposer: "tiptap-chips" },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "TipTap WYSIWYG Markdown + chips" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { chatReplyComposer: "tiptap-wysiwyg-markdown-chips" },
       });
     });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1399,35 +1399,37 @@ export function ThreadView(props: ThreadViewProps) {
           </dl>
         </div>
 
-        {launchpadMaterializing ? (
-          <section
-            className="transcript-panel transcript-panel--pending"
-            aria-label="Preparing transcript"
-          >
-            <div className="launchpad-pending">
-              <p className="eyebrow">Preparing transcript</p>
-              <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
-              <p>Your prompt was sent. The transcript will appear here when the thread is ready.</p>
-            </div>
-          </section>
-        ) : (
-          <Composer
-            backends={props.backends}
-            applications={props.applications}
-            desktopApi={props.desktopApi}
-            composerImplementation={props.composerImplementation}
-            directory={props.selectedDirectory}
-            disabled={!launchpadBackend?.available}
-            launchpad={selectedLaunchpad}
-            launchpadError={props.launchpadError}
-            onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
-            onMaterializeLaunchpad={handleMaterializeLaunchpad}
-            onUpdateLaunchpad={props.onUpdateLaunchpad}
-            skillError={props.skillError}
-            skillLoading={props.skillLoading}
-            skills={props.skills}
-          />
-        )}
+        <div className="thread-view__launchpad-composer">
+          {launchpadMaterializing ? (
+            <section
+              className="transcript-panel transcript-panel--pending"
+              aria-label="Preparing transcript"
+            >
+              <div className="launchpad-pending">
+                <p className="eyebrow">Preparing transcript</p>
+                <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
+                <p>Your prompt was sent. The transcript will appear here when the thread is ready.</p>
+              </div>
+            </section>
+          ) : (
+            <Composer
+              backends={props.backends}
+              applications={props.applications}
+              desktopApi={props.desktopApi}
+              composerImplementation={props.composerImplementation}
+              directory={props.selectedDirectory}
+              disabled={!launchpadBackend?.available}
+              launchpad={selectedLaunchpad}
+              launchpadError={props.launchpadError}
+              onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+              onMaterializeLaunchpad={handleMaterializeLaunchpad}
+              onUpdateLaunchpad={props.onUpdateLaunchpad}
+              skillError={props.skillError}
+              skillLoading={props.skillLoading}
+              skills={props.skills}
+            />
+          )}
+        </div>
       </section>
     );
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1989,9 +1989,36 @@ textarea {
 }
 
 .transcript-message__heading {
-  font-size: 15px;
   font-weight: 700;
   line-height: 1.4;
+}
+
+.transcript-message__heading:is(h1) {
+  font-size: 1.35em;
+}
+
+.transcript-message__heading:is(h2) {
+  font-size: 1.22em;
+}
+
+.transcript-message__heading:is(h3) {
+  font-size: 1.12em;
+}
+
+.transcript-message__heading:is(h4) {
+  font-size: 1.04em;
+}
+
+.transcript-message__heading:is(h5) {
+  font-size: 0.98em;
+  font-style: italic;
+}
+
+.transcript-message__heading:is(h6) {
+  color: var(--text-secondary);
+  font-size: 0.94em;
+  font-style: italic;
+  font-weight: 650;
 }
 
 .thread-header__summary .transcript-message__heading {
@@ -3712,27 +3739,31 @@ textarea {
 }
 
 .composer-tiptap-input__editor h1 {
-  font-size: 1.25em;
+  font-size: 1.35em;
 }
 
 .composer-tiptap-input__editor h2 {
-  font-size: 1.15em;
+  font-size: 1.22em;
 }
 
 .composer-tiptap-input__editor h3 {
-  font-size: 1.07em;
+  font-size: 1.12em;
 }
 
 .composer-tiptap-input__editor h4 {
-  font-size: 1em;
+  font-size: 1.04em;
 }
 
 .composer-tiptap-input__editor h5 {
-  font-size: 0.94em;
+  font-size: 0.98em;
+  font-style: italic;
 }
 
 .composer-tiptap-input__editor h6 {
-  font-size: 0.9em;
+  color: var(--text-secondary);
+  font-size: 0.94em;
+  font-style: italic;
+  font-weight: 650;
 }
 
 .composer-tiptap-input__editor pre {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -426,6 +426,7 @@ textarea {
 .thread-row:focus,
 .transcript-activity__toggle:focus,
 .composer__input:focus,
+.composer-rich-input:focus-within,
 .composer__select:focus,
 .composer__review-input:focus,
 .composer__review-option:focus,
@@ -436,6 +437,7 @@ textarea {
 .thread-row:focus-visible,
 .transcript-activity__toggle:focus-visible,
 .composer__input:focus-visible,
+.composer-rich-input:focus-within,
 .composer__select:focus-visible,
 .composer__review-input:focus-visible,
 .composer__review-option:focus-visible,
@@ -804,7 +806,8 @@ textarea {
 }
 
 .tooltip-target[data-tooltip]:hover::after,
-.tooltip-target[data-tooltip]:focus-visible::after {
+.tooltip-target[data-tooltip]:focus-visible::after,
+.tooltip-target[data-tooltip]:focus-within::after {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
@@ -3135,6 +3138,42 @@ textarea {
   border: 1px solid var(--border-subtle);
 }
 
+.skill-chip--removable {
+  gap: 6px;
+  padding-right: 4px;
+}
+
+.skill-chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.skill-chip__remove {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.skill-chip__remove:hover,
+.skill-chip__remove:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
 .context-rail {
   display: flex;
   position: fixed;
@@ -3604,6 +3643,43 @@ textarea {
 
 .composer__input-wrap {
   position: relative;
+}
+
+.composer-rich-input {
+  display: flex;
+  min-height: 144px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-input);
+}
+
+.composer-rich-input.is-disabled {
+  opacity: 0.72;
+}
+
+.composer-rich-input__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 24px;
+}
+
+.composer-rich-input__textarea {
+  min-height: 0;
+  flex: 1 1 auto;
+  resize: vertical;
+  padding: 4px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+}
+
+.composer-rich-input__textarea:focus,
+.composer-rich-input__textarea:focus-visible {
+  outline: 0;
 }
 
 .composer__mentioned-skills {
@@ -4105,7 +4181,6 @@ textarea {
   position: absolute;
   right: 0;
   left: 0;
-  bottom: calc(100% + 10px);
   z-index: 20;
   display: flex;
   flex-direction: column;
@@ -4120,6 +4195,14 @@ textarea {
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
   scrollbar-color: var(--border-strong) transparent;
   scrollbar-width: thin;
+}
+
+.composer__autocomplete--above {
+  bottom: calc(100% + 10px);
+}
+
+.composer__autocomplete--below {
+  top: calc(100% + 10px);
 }
 
 .composer__autocomplete-option {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3665,11 +3665,6 @@ textarea {
   opacity: 0.72;
 }
 
-.composer-rich-input:focus,
-.composer-rich-input:focus-visible {
-  outline: 0;
-}
-
 .composer-rich-input.is-empty::before {
   content: attr(data-placeholder);
   color: var(--text-muted);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3687,6 +3687,7 @@ textarea {
 }
 
 .composer-tiptap-input__editor {
+  position: relative;
   min-height: 142px;
   padding: 12px;
   outline: none;
@@ -3700,6 +3701,9 @@ textarea {
 
 .composer-tiptap-input.is-empty .composer-tiptap-input__editor::before {
   content: attr(data-placeholder);
+  position: absolute;
+  top: 12px;
+  left: 12px;
   color: var(--text-muted);
   pointer-events: none;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4239,12 +4239,11 @@ textarea {
   flex-direction: column;
   gap: 4px;
   padding: 10px 12px;
-  border: 0;
+  border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
-  outline: 0;
   text-align: left;
 }
 
@@ -4253,22 +4252,20 @@ textarea {
 }
 
 .composer__autocomplete-option.is-active {
-  background:
-    linear-gradient(
-      90deg,
-      rgba(255, 138, 31, 0.28),
-      rgba(255, 138, 31, 0.16) 46%,
-      rgba(255, 138, 31, 0.08)
-    );
-  box-shadow:
-    inset 4px 0 0 var(--accent),
-    inset 0 0 0 1px var(--accent-border);
-  outline: 2px solid rgba(255, 179, 92, 0.65);
-  outline-offset: -2px;
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
 }
 
-.composer__autocomplete-option.is-active .composer__autocomplete-title {
-  color: var(--accent-bright);
+.composer__autocomplete-option.is-active::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 5px;
+  width: 3px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: "";
+  pointer-events: none;
 }
 
 .composer__autocomplete-title {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1543,6 +1543,19 @@ textarea {
   padding-right: 24px;
 }
 
+.thread-view__launchpad-composer {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  min-width: 0;
+  margin-top: auto;
+}
+
+.thread-view__launchpad-composer > .composer,
+.thread-view__launchpad-composer > .transcript-panel {
+  width: 100%;
+}
+
 .thread-header__title {
   font-size: 40px;
   font-weight: 700;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3688,7 +3688,7 @@ textarea {
   display: inline-flex;
   margin: 0 3px;
   line-height: inherit;
-  vertical-align: -0.1em;
+  vertical-align: 0.13em;
 }
 
 .composer-rich-input__token:first-child {
@@ -3700,7 +3700,7 @@ textarea {
   gap: 0.35em;
   padding: 0 0.5em;
   font-size: inherit;
-  line-height: 1;
+  line-height: normal;
 }
 
 .composer-rich-input .thread-row__chip-icon {
@@ -3710,7 +3710,7 @@ textarea {
 }
 
 .composer-rich-input .skill-chip__label {
-  line-height: 1;
+  line-height: normal;
 }
 
 .composer__mentioned-skills {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3673,12 +3673,25 @@ textarea {
 
 .composer-rich-input__token {
   display: inline-flex;
-  margin: 0 3px;
-  vertical-align: -0.22em;
+  margin: 0 2px;
+  line-height: 1;
+  vertical-align: -0.18em;
 }
 
 .composer-rich-input__token:first-child {
   margin-left: 0;
+}
+
+.composer-rich-input .skill-chip {
+  height: 22px;
+  gap: 5px;
+  padding: 0 7px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.composer-rich-input .thread-row__chip-icon {
+  font-size: 11px;
 }
 
 .composer__mentioned-skills {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3699,6 +3699,49 @@ textarea {
   margin: 0;
 }
 
+.composer-tiptap-input__editor h1,
+.composer-tiptap-input__editor h2,
+.composer-tiptap-input__editor h3,
+.composer-tiptap-input__editor h4,
+.composer-tiptap-input__editor h5,
+.composer-tiptap-input__editor h6 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: inherit;
+  font-weight: 700;
+  line-height: inherit;
+}
+
+.composer-tiptap-input__editor pre {
+  margin: 2px 0;
+  padding: 7px 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.94em;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.composer-tiptap-input__editor pre code {
+  font: inherit;
+}
+
+.composer-tiptap-input__editor blockquote {
+  margin: 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--border-strong);
+  color: var(--text-secondary);
+}
+
+.composer-tiptap-input__editor ul,
+.composer-tiptap-input__editor ol {
+  margin: 0;
+  padding-left: 20px;
+}
+
 .composer-tiptap-input.is-empty .composer-tiptap-input__editor::before {
   content: attr(data-placeholder);
   position: absolute;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4232,6 +4232,7 @@ textarea {
 
 .composer__autocomplete-option {
   display: flex;
+  position: relative;
   width: 100%;
   min-width: 0;
   flex: 0 0 auto;
@@ -4243,12 +4244,31 @@ textarea {
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
+  outline: 0;
   text-align: left;
 }
 
-.composer__autocomplete-option:hover,
+.composer__autocomplete-option:hover {
+  background: var(--bg-panel-hover);
+}
+
 .composer__autocomplete-option.is-active {
-  background: var(--bg-row-active);
+  background:
+    linear-gradient(
+      90deg,
+      rgba(255, 138, 31, 0.28),
+      rgba(255, 138, 31, 0.16) 46%,
+      rgba(255, 138, 31, 0.08)
+    );
+  box-shadow:
+    inset 4px 0 0 var(--accent),
+    inset 0 0 0 1px var(--accent-border);
+  outline: 2px solid rgba(255, 179, 92, 0.65);
+  outline-offset: -2px;
+}
+
+.composer__autocomplete-option.is-active .composer__autocomplete-title {
+  color: var(--accent-bright);
 }
 
 .composer__autocomplete-title {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3686,9 +3686,9 @@ textarea {
 
 .composer-rich-input__token {
   display: inline-flex;
-  margin: 0 2px;
-  line-height: 1;
-  vertical-align: -0.18em;
+  margin: 0 3px;
+  line-height: inherit;
+  vertical-align: -0.1em;
 }
 
 .composer-rich-input__token:first-child {
@@ -3696,15 +3696,21 @@ textarea {
 }
 
 .composer-rich-input .skill-chip {
-  height: 22px;
-  gap: 5px;
-  padding: 0 7px;
-  font-size: 12px;
+  height: 1.35em;
+  gap: 0.35em;
+  padding: 0 0.5em;
+  font-size: inherit;
   line-height: 1;
 }
 
 .composer-rich-input .thread-row__chip-icon {
-  font-size: 11px;
+  flex: 0 0 auto;
+  font-size: 0.72em;
+  line-height: 1;
+}
+
+.composer-rich-input .skill-chip__label {
+  line-height: 1;
 }
 
 .composer__mentioned-skills {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3707,9 +3707,32 @@ textarea {
 .composer-tiptap-input__editor h6 {
   margin: 0;
   color: var(--text-primary);
-  font-size: inherit;
   font-weight: 700;
   line-height: inherit;
+}
+
+.composer-tiptap-input__editor h1 {
+  font-size: 1.25em;
+}
+
+.composer-tiptap-input__editor h2 {
+  font-size: 1.15em;
+}
+
+.composer-tiptap-input__editor h3 {
+  font-size: 1.07em;
+}
+
+.composer-tiptap-input__editor h4 {
+  font-size: 1em;
+}
+
+.composer-tiptap-input__editor h5 {
+  font-size: 0.94em;
+}
+
+.composer-tiptap-input__editor h6 {
+  font-size: 0.9em;
 }
 
 .composer-tiptap-input__editor pre {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3674,6 +3674,47 @@ textarea {
   white-space: pre-wrap;
 }
 
+.composer-tiptap-input {
+  min-height: 144px;
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.composer-tiptap-input__editor {
+  min-height: 142px;
+  padding: 12px;
+  outline: none;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.composer-tiptap-input__editor p {
+  margin: 0;
+}
+
+.composer-tiptap-input.is-empty .composer-tiptap-input__editor::before {
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.composer-tiptap-input__mention {
+  display: inline-flex;
+  height: 1.35em;
+  gap: 0.35em;
+  margin: 0 3px;
+  padding: 0 0.5em;
+  font-size: inherit;
+  line-height: normal;
+  vertical-align: 0.13em;
+}
+
 .composer-rich-input.is-disabled {
   opacity: 0.72;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3646,40 +3646,44 @@ textarea {
 }
 
 .composer-rich-input {
-  display: flex;
+  display: block;
   min-height: 144px;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px;
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .composer-rich-input.is-disabled {
   opacity: 0.72;
 }
 
-.composer-rich-input__chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  min-height: 24px;
-}
-
-.composer-rich-input__textarea {
-  min-height: 0;
-  flex: 1 1 auto;
-  resize: vertical;
-  padding: 4px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-}
-
-.composer-rich-input__textarea:focus,
-.composer-rich-input__textarea:focus-visible {
+.composer-rich-input:focus,
+.composer-rich-input:focus-visible {
   outline: 0;
+}
+
+.composer-rich-input.is-empty::before {
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.composer-rich-input__token {
+  display: inline-flex;
+  margin: 0 3px;
+  vertical-align: -0.22em;
+}
+
+.composer-rich-input__token:first-child {
+  margin-left: 0;
 }
 
 .composer__mentioned-skills {

--- a/docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md
+++ b/docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Repair composer skill autocomplete interactions
 type: fix
-status: active
+status: complete
 date: 2026-04-30
 deepened: 2026-04-30
 ---
@@ -105,7 +105,7 @@ The important boundary is that `Draft` remains the source of truth. The visual e
 
 ## Implementation Units
 
-- [ ] **Unit 1: Introduce inline skill tokens in the composer input**
+- [x] **Unit 1: Introduce inline skill tokens in the composer input**
 
 **Goal:** Replace the detached `composer__mentioned-skills` mirror row with inline, deletable skill chips inside the composer text-entry surface while preserving canonical draft state.
 
@@ -154,7 +154,7 @@ The important boundary is that `Draft` remains the source of truth. The visual e
 - Screen-reader-oriented queries still find the composer as `Reply` or `New thread`, and chip delete controls have stable accessible names.
 - Existing composer tests for send, steer, slash command, image paste/drop, and draft persistence still pass.
 
-- [ ] **Unit 2: Make autocomplete keyboard selection focus-safe**
+- [x] **Unit 2: Make autocomplete keyboard selection focus-safe**
 
 **Goal:** Ensure Enter selects the active autocomplete item and closes the popup whether focus is on the textarea, listbox, or option button.
 
@@ -188,7 +188,7 @@ The important boundary is that `Draft` remains the source of truth. The visual e
 **Verification:**
 - There is no focus state where Enter submits the whole turn or does nothing while an autocomplete option is visually active.
 
-- [ ] **Unit 3: Make autocomplete placement viewport-aware and scrollable**
+- [x] **Unit 3: Make autocomplete placement viewport-aware and scrollable**
 
 **Goal:** Keep the autocomplete popup inside the Electron window and internally scrollable across desktop and narrow viewports.
 
@@ -224,7 +224,7 @@ The important boundary is that `Draft` remains the source of truth. The visual e
 - Visual inspection or Playwright screenshots show the popup fully within the app bounds at desktop and narrow viewport sizes.
 - Keyboard navigation can reach offscreen items through internal popup scrolling.
 
-- [ ] **Unit 4: Add focused E2E coverage for the reported interaction contract**
+- [x] **Unit 4: Add focused E2E coverage for the reported interaction contract**
 
 **Goal:** Prove the full user-reported flow in an Electron-backed scenario rather than relying only on component tests.
 

--- a/docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md
+++ b/docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md
@@ -1,0 +1,301 @@
+---
+title: fix: Repair composer skill autocomplete interactions
+type: fix
+status: active
+date: 2026-04-30
+deepened: 2026-04-30
+---
+
+# fix: Repair composer skill autocomplete interactions
+
+## Overview
+
+Make desktop skill autocomplete behave like a real composer affordance: selected skills become deletable chips inside the text-entry surface, each chip exposes the backing `SKILL.md` path in its tooltip, keyboard selection reliably commits the focused autocomplete item, and long autocomplete lists stay within the visible Electron window with internal scrolling.
+
+## Problem Frame
+
+The current composer treats skill selection mostly as plain text. Selecting `$ce:plan` inserts a `$ce:plan` token into the textarea, then `composer__mentioned-skills` mirrors the detected skill as a chip above the text entry. That misses the intended interaction: the selected skill should be visible as a chip within the entry itself, removable as one unit, and inspectable without leaving the composer.
+
+The current autocomplete list is also fragile around keyboard focus. Enter works when the textarea owns focus and `Composer.tsx` sees the key event, but the user-visible failure is that pressing Enter while navigating the autocomplete option itself does not reliably select the skill and close the popup. The list is styled with a capped `max-height`, but placement is only CSS-anchored above the textarea; it should be measured against the actual viewport so it cannot extend outside the window.
+
+## Requirements Trace
+
+- R1. Selecting a skill from autocomplete renders a compact, deletable skill chip inside the composer text-entry surface, not in a separate row above it.
+- R2. Skill chips expose a tooltip that includes the selected skill's backing path, including examples such as `SKILL.md`.
+- R3. Deleting a skill chip removes the whole skill mention from the composer draft without leaving partial markdown, stale `$name` text, or broken send payloads.
+- R4. Pressing Enter while autocomplete navigation or an autocomplete option has focus selects the active skill and closes the popup.
+- R5. Arrow key navigation, Escape dismissal, pointer selection, and textarea submission continue to work without regressing `/review` slash command autocomplete.
+- R6. The autocomplete popup stays within the visible desktop window, caps its height from available space, and scrolls internally for long skill lists.
+- R7. Existing send semantics remain intact: selected skills still reach `startTurn` as markdown links with the skill path, and plain text/image composer behavior does not change.
+- R8. The rich composer keeps the existing accessible labels, exposes a multiline textbox interaction, and provides keyboard-reachable chip deletion and tooltip inspection.
+
+## Scope Boundaries
+
+- This plan only covers desktop renderer composer interactions.
+- This plan does not change app-server skill discovery, `skills/list`, skill metadata shape, or lazy skill loading behavior.
+- This plan does not redesign transcript-rendered skill chips; it may reuse their tooltip styling and parsing helpers.
+- This plan does not introduce a general-purpose rich text editor dependency unless implementation proves the native approach cannot meet the tests cleanly.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` owns the textarea, autocomplete filtering, active option indexes, skill insertion, send payload construction, slash command autocomplete, and the current `composer__mentioned-skills` mirror row.
+- `apps/desktop/src/renderer/src/lib/skill-mentions.ts` is the canonical helper for skill trigger detection, mention markdown, draft hydration, parsing, and tooltips.
+- `apps/desktop/src/renderer/src/features/composer/SkillChip.tsx` already renders a compact skill chip with `buildSkillTooltip`, but it is non-deletable and optimized for transcript/sidebar-style display rather than editor tokens.
+- `apps/desktop/src/renderer/src/styles/app.css` already defines `composer__autocomplete` with a capped scroll container and shared tooltip/chip styles. The implementation should extend these styles rather than adding a separate visual language.
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` covers current skill insertion, send payload hydration, keyboard Enter submission, slash command autocomplete, and focused skill option activation.
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` covers directory launchpad skill autocomplete with user and local skills, which is the closest browser-level scenario for viewport and keyboard regressions.
+- `docs/UI-THEME.md` and `docs/design/desktop-style-guide.md` require compact, stable, black-first desktop controls, restrained tangerine focus state, no browser-default shipped controls, and no layout shift on hover/focus/selection.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this worktree, so there are no indexed institutional learnings to apply.
+- `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md` established that skill loading should remain lazy and thread-scoped. This plan preserves that boundary and only changes what happens after skills are available.
+- `docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md` already called out autocomplete as part of the composer visual system. This plan narrows that broad visual requirement into concrete interaction behavior.
+
+### External References
+
+- External research is not needed. The work is bounded to existing React renderer behavior, existing CSS tokens, and known browser/editor constraints.
+
+## Key Technical Decisions
+
+- Use a tokenized composer input surface for selected skills instead of the current detached mirror row: native textareas cannot contain real child chips, so the implementation needs a small composer-owned rich input layer that renders text segments and skill mentions while keeping a canonical draft string for send behavior.
+- Keep `skill-mentions.ts` as the canonical parser/formatter: selected skills should still serialize to markdown links with paths, parse back into `SkillMentionPart` segments, and use `buildSkillTooltip` for path-bearing tooltips.
+- Prefer a focused composer-specific editor over a general rich text dependency: the needed semantics are narrow enough -- plain text, newline support, skill tokens, caret-aware `$` autocomplete, paste/drop handoff, and deletion -- that a dependency would add more surface area than value for this fix.
+- Centralize autocomplete selection into one commit path: textarea Enter, option Enter, option click, and option pointer activation should all call the same skill/slash selection function, which clears the trigger state and returns focus to the composer.
+- Make autocomplete placement measured, not purely CSS anchored: use the composer input bounds and window dimensions to choose above/below placement and set a max height that fits the available viewport while preserving internal scroll.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the path tooltip live on the chip or only in autocomplete detail? It should live on the selected chip. The user specifically asked for the `SKILL.md` path on a tooltip once the chip exists in the text entry.
+- Should the current above-input `composer__mentioned-skills` row remain? No. It is the source of the reported mismatch and should be removed for composer-selected skill display once chips are rendered inside the entry.
+- Should the selected skill be stored as bare `$name` or markdown? Store the canonical draft as markdown for selected autocomplete skills so the path is preserved immediately and duplicate skill names do not rely on later hydration guesses. Existing bare `$name` typing can still hydrate on send for compatibility.
+
+### Deferred to Implementation
+
+- Exact caret restoration mechanics after chip deletion or insertion: implementation should choose the simplest reliable contenteditable/hidden-textarea synchronization once tests define the behavior.
+- Whether the first implementation can keep a native textarea underneath the visual token layer or should fully replace it with a contenteditable textbox: decide during implementation based on which path preserves multiline editing, paste/drop behavior, and selection tests with the least complexity.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Draft["Canonical draft string"]
+    Parser["skill-mentions parser"]
+    RichInput["Composer rich input surface"]
+    SkillChip["Inline deletable skill chip"]
+    Autocomplete["Viewport-aware autocomplete list"]
+    Send["startTurn payload"]
+
+    Draft --> Parser
+    Parser --> RichInput
+    RichInput --> Draft
+    RichInput --> SkillChip
+    RichInput --> Autocomplete
+    Autocomplete --> Draft
+    Draft --> Send
+```
+
+The important boundary is that `Draft` remains the source of truth. The visual editor may render chips, but send behavior, tests, draft persistence, launchpad hydration, and thread-scoped draft storage should still read/write one canonical draft value.
+
+## Implementation Units
+
+- [ ] **Unit 1: Introduce inline skill tokens in the composer input**
+
+**Goal:** Replace the detached `composer__mentioned-skills` mirror row with inline, deletable skill chips inside the composer text-entry surface while preserving canonical draft state.
+
+**Requirements:** R1, R2, R3, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/SkillChip.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/skill-mentions.ts`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerRichInput.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Add a composer-specific inline token rendering path that parses the canonical draft into text and skill mention parts, renders skill mentions as compact chips inside the input chrome, and keeps text editing synchronized back to the same draft state used today.
+- Keep the rich input boundary small and composer-owned. A `ComposerRichInput` helper is justified because token rendering, chip deletion, caret restoration, and autocomplete trigger reporting should be isolated from turn submission, attachment, workspace, and review-command logic in `Composer.tsx`.
+- Make selected autocomplete skills insert a path-bearing markdown mention into the canonical draft, displayed as a `$name` chip rather than raw markdown.
+- Add a delete affordance to composer-rendered skill chips. Keep transcript and thread chip usage non-deletable by making deletion optional rather than changing every `SkillChip` consumer.
+- Preserve the existing `Reply` and `New thread` accessible names by giving the rich input a textbox role, multiline semantics, focus-visible styling, and keyboard access to chip delete controls.
+- Remove or retire `composer__mentioned-skills` for selected composer mentions once the inline token surface is active.
+- Preserve plain text, newline, image attachment, launchpad prompt hydration, thread draft persistence, `/review`, and send/steer flows.
+
+**Execution note:** Start characterization-first around current skill insertion/send behavior, then add failing tests for inline chip deletion before changing the input surface.
+
+**Patterns to follow:**
+- `skill-mentions.ts` for mention parsing, markdown formatting, and tooltip text.
+- `SkillChip.tsx` and `thread-row__chip` styling for compact chip visuals.
+- Existing draft persistence and send code in `Composer.tsx`.
+
+**Test scenarios:**
+- Happy path: selecting `ce:plan` from autocomplete renders one `$ce:plan` chip inside the composer input surface with a tooltip containing `SKILL.md`.
+- Happy path: sending a draft with the inline `$ce:plan` chip calls `startTurn` with `[$ce:plan](...)` markdown containing the skill path.
+- Edge case: clicking the chip delete control removes the whole mention from the canonical draft and leaves neighboring text with sensible spacing.
+- Edge case: pressing Backspace or Delete when the caret is adjacent to a chip removes the whole chip rather than stepping through raw markdown characters.
+- Edge case: keyboard focus can reach a chip delete control and return to the rich input without losing the draft selection context.
+- Edge case: typing plain `$ce:plan` manually without selecting autocomplete remains compatible with existing send-time hydration when the skill is known.
+- Edge case: switching threads or launchpad directories preserves/restores drafts without duplicating chips or losing selected skill paths.
+- Error path: a malformed markdown-shaped skill mention in the draft does not crash the editor and falls back to safe editable text or a non-deletable parsed mention.
+
+**Verification:**
+- The selected skill appears inside the composer input border, not above it.
+- Deleting a chip updates the visible input and subsequent send payload.
+- Screen-reader-oriented queries still find the composer as `Reply` or `New thread`, and chip delete controls have stable accessible names.
+- Existing composer tests for send, steer, slash command, image paste/drop, and draft persistence still pass.
+
+- [ ] **Unit 2: Make autocomplete keyboard selection focus-safe**
+
+**Goal:** Ensure Enter selects the active autocomplete item and closes the popup whether focus is on the textarea, listbox, or option button.
+
+**Requirements:** R4, R5, R7, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Extract shared autocomplete commit helpers for skill and slash command selection so all input modes use one code path.
+- Use a predictable focus model for autocomplete navigation: either roving `tabIndex` on options or textarea-owned focus with `aria-activedescendant`, but do not split active index and DOM focus in a way that lets Enter fall through.
+- Add option/listbox `onKeyDown` handling for Enter, Space where appropriate, Escape, ArrowUp, and ArrowDown. Prevent default submission when autocomplete is open.
+- After a skill or slash command is committed, close the popup, reset active index for the next trigger, and restore focus to the composer input.
+- Keep `/review` behavior intact, including the current rule that a bare `/review` opens the review configuration instead of endlessly reselecting autocomplete.
+
+**Patterns to follow:**
+- Existing `activeSkillIndex`, `activeSlashIndex`, and `scrollIntoView({ block: "nearest" })` behavior in `Composer.tsx`.
+- Current slash command tests near the skill autocomplete tests.
+
+**Test scenarios:**
+- Happy path: type `$ce:pl`, move focus to the `ce:plan` option, press Enter -> the chip is inserted and the Skills listbox is gone.
+- Happy path: type `$`, press ArrowDown then Enter while the textarea owns focus -> the active skill is inserted.
+- Happy path: pointer selecting a skill uses the same commit behavior as keyboard selection and closes the popup.
+- Edge case: pressing Escape while an option has focus closes the popup and returns focus to the composer input without changing the draft.
+- Regression: pressing Enter with no autocomplete open still sends the reply; Shift+Enter still inserts a newline.
+- Regression: slash command autocomplete still inserts `/review ` and opens review configuration as it does today.
+
+**Verification:**
+- There is no focus state where Enter submits the whole turn or does nothing while an autocomplete option is visually active.
+
+- [ ] **Unit 3: Make autocomplete placement viewport-aware and scrollable**
+
+**Goal:** Keep the autocomplete popup inside the Electron window and internally scrollable across desktop and narrow viewports.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+
+**Approach:**
+- Measure the composer input wrapper and viewport when autocomplete opens, when the active option changes, and when the window resizes.
+- Choose above or below placement based on available space, preferring the current above-input placement when it fits.
+- Set max height from available viewport space with a small margin so the popup never extends beyond the window edge.
+- Keep the list internally scrollable and keep active option scrolling with `block: "nearest"`.
+- Preserve existing Tangerine Terminal styling while tightening layout constraints for long descriptions and long skill names.
+
+**Patterns to follow:**
+- Current `.composer__autocomplete` scroll container and `scrollbar-color`.
+- Existing context rail tooltip measurement in `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx` as a local example of viewport-aware overlay placement.
+
+**Test scenarios:**
+- Happy path: with a normal number of skills and enough space, the popup appears adjacent to the composer and all visible rows are selectable.
+- Edge case: with many skills, the popup has a bounded height, exposes internal scrolling, and does not enlarge the page or overlap outside the app window.
+- Edge case: when the composer is near the bottom edge, the popup flips or shrinks to stay visible.
+- Edge case: long skill descriptions and long paths truncate or wrap within the popup without horizontal overflow.
+- Integration: the directory launchpad skill autocomplete E2E scenario uses enough skills to prove scrolling and active-option visibility.
+
+**Verification:**
+- Visual inspection or Playwright screenshots show the popup fully within the app bounds at desktop and narrow viewport sizes.
+- Keyboard navigation can reach offscreen items through internal popup scrolling.
+
+- [ ] **Unit 4: Add focused E2E coverage for the reported interaction contract**
+
+**Goal:** Prove the full user-reported flow in an Electron-backed scenario rather than relying only on component tests.
+
+**Requirements:** R1, R2, R3, R4, R6, R7
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Create or modify: `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`
+- Create or modify: `apps/desktop/e2e/fixtures/*` only if an existing fixture cannot express the needed skill list
+
+**Approach:**
+- Reuse the replay fixture style from `directory-launchpad-skills.spec.ts` so tests can run deterministically without a live Codex backend.
+- Cover both an existing thread composer and a directory launchpad composer if fixture setup remains modest. If the work must choose one, prioritize the existing thread composer because that matches the screenshot and most frequent reply flow.
+- Assert geometry by comparing the autocomplete bounding box against the app viewport, not by snapshotting exact pixels.
+- Assert the selected chip is inside the composer input container and no detached mentioned-skill row is rendered above it.
+- Assert the tooltip exposes the skill path on hover or focus, and deleting the chip removes the mention before send.
+
+**Patterns to follow:**
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` for replay-backed skill data.
+- `apps/desktop/e2e/provider-model-selectors.spec.ts` and related composer E2E tests for interacting with composer controls.
+
+**Test scenarios:**
+- Integration: type `$ce:pl`, focus/navigate the autocomplete item, press Enter -> popup closes, inline chip appears, and the textarea/rich input remains focused for continued typing.
+- Integration: hover or focus the chip -> tooltip includes the `SKILL.md` path.
+- Integration: delete the chip -> the composer no longer contains the skill mention and send payload omits it.
+- Integration: seed a long skill list -> popup fits within the viewport and scrolls internally while ArrowDown keeps the active option visible.
+- Regression: after inserting a chip, typing additional text and sending still creates one text input payload with the skill markdown and the surrounding prose.
+
+**Verification:**
+- The targeted desktop E2E coverage passes for the skill autocomplete interaction contract.
+- The desktop app visually matches the intended contract from the user report: chip inside entry, popup closed after Enter, popup bounded and scrollable.
+
+## System-Wide Impact
+
+- **Interaction graph:** `useThreadSkills` remains the loader; `Composer.tsx` consumes loaded skills, renders the rich input, owns autocomplete state, and serializes the canonical draft to `startTurn`.
+- **Error propagation:** Skill loading errors remain `props.skillError`; rich input parse/render failures should degrade to editable text rather than blocking send.
+- **State lifecycle risks:** Thread-scoped drafts, launchpad hydration, active turn queueing, and image attachment paste/drop all share `Composer.tsx`; the inline token work must not reset or fork those state paths.
+- **Accessibility:** The composer must remain discoverable as a multiline textbox with the existing accessible names, while inline chip delete buttons and tooltips must be reachable by keyboard and not trap focus.
+- **API surface parity:** No app-server, preload, IPC, or shared contract changes are planned.
+- **Integration coverage:** Component tests cover canonical draft and keyboard state; E2E coverage proves actual focus, tooltip, geometry, and popup scrolling behavior in Electron.
+- **Unchanged invariants:** Enter submits when no autocomplete is open, Shift+Enter inserts a newline, slash command autocomplete keeps working, image attachments still send with text, and selected skills still serialize as markdown links with paths.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Replacing a textarea with a richer input surface could regress caret behavior, multiline editing, or paste/drop behavior. | Keep the canonical draft model unchanged, write characterization tests first, and scope the editor to plain text plus skill tokens only. |
+| Contenteditable behavior can be inconsistent across browsers and tests. | Keep a narrow command surface, avoid arbitrary rich formatting, isolate it in `ComposerRichInput`, and prove key operations through both component and Electron E2E tests. |
+| Replacing the textarea could regress screen-reader or keyboard affordances. | Preserve the existing accessible names, multiline textbox semantics, focus-visible styling, and keyboard-reachable chip deletion in tests. |
+| Keyboard focus could still diverge between visual active state and DOM focus. | Pick one focus model and route every Enter/Escape/Arrow path through shared commit/dismiss helpers. |
+| Tooltip and popup overlays could collide visually. | Reuse existing tooltip patterns and measure autocomplete against viewport; keep tooltip behavior limited to hover/focus on the chip. |
+| Long skill lists or descriptions could reintroduce viewport overflow. | Use measured max height, internal scrolling, wrapping/truncation, and E2E geometry assertions. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation is required.
+- If a new reusable rich input helper is introduced, keep it private to composer until another surface needs the same behavior.
+- If fixture capture is refreshed from a live session, use `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`; otherwise prefer deterministic replay fixture construction.
+
+## Sources & References
+
+- User report: inline deletable skill chip desired inside the composer entry; tooltip should include `SKILL.md`; Enter should select and close autocomplete; long autocomplete lists should fit in the window and scroll.
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/SkillChip.tsx`
+- Related code: `apps/desktop/src/renderer/src/lib/skill-mentions.ts`
+- Related styles: `apps/desktop/src/renderer/src/styles/app.css`
+- Related tests: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Related E2E: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Theme guidance: `docs/UI-THEME.md`
+- Desktop guidance: `docs/design/desktop-style-guide.md`
+- Related plan: `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md`
+- Related plan: `docs/plans/2026-04-20-001-feat-tangerine-terminal-visual-system-plan.md`

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -84,6 +84,7 @@ describe("desktop settings contracts", () => {
   it("validates the supported composer options", () => {
     expect(isDesktopChatReplyComposer("textarea")).toBe(true);
     expect(isDesktopChatReplyComposer("tiptap-chips")).toBe(true);
+    expect(isDesktopChatReplyComposer("tiptap-wysiwyg-markdown-chips")).toBe(true);
     expect(isDesktopChatReplyComposer("custom-widget-chips")).toBe(true);
     expect(isDesktopChatReplyComposer("markdown")).toBe(false);
   });

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1,6 +1,7 @@
 export const DESKTOP_CHAT_REPLY_COMPOSERS = [
   "textarea",
   "tiptap-chips",
+  "tiptap-wysiwyg-markdown-chips",
   "custom-widget-chips",
 ] as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,18 @@ importers:
       '@pwragnt/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@tiptap/extension-mention':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/react':
+        specifier: ^3.22.5
+        version: 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tiptap/starter-kit':
+        specifier: ^3.22.5
+        version: 3.22.5
+      '@tiptap/suggestion':
+        specifier: ^3.22.5
+        version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       electron-log:
         specifier: ^5.4.3
         version: 5.4.3
@@ -608,6 +620,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -915,6 +936,168 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tiptap/core@3.22.5':
+    resolution: {integrity: sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==}
+    peerDependencies:
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-blockquote@3.22.5':
+    resolution: {integrity: sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-bold@3.22.5':
+    resolution: {integrity: sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-bubble-menu@3.22.5':
+    resolution: {integrity: sha512-yrNlFQQJY5MmhBpmD8tnmaSmyUQrEvgyPKa3bzVeWEhDSG1CW4A0ZSMx3hrA9yFO0HWfw3IJmvSCycEZQBalpQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-bullet-list@3.22.5':
+    resolution: {integrity: sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-code-block@3.22.5':
+    resolution: {integrity: sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-code@3.22.5':
+    resolution: {integrity: sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-document@3.22.5':
+    resolution: {integrity: sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-dropcursor@3.22.5':
+    resolution: {integrity: sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-floating-menu@3.22.5':
+    resolution: {integrity: sha512-dhem4sTPhyQgQ+pFp2Oud4k4FSQz9PVMgeQAC9288SmGwxBkJNveDAw6sKTMrumqDvwkJrtslXIupq9TZYQnzg==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-gapcursor@3.22.5':
+    resolution: {integrity: sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==}
+    peerDependencies:
+      '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-hard-break@3.22.5':
+    resolution: {integrity: sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-heading@3.22.5':
+    resolution: {integrity: sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-horizontal-rule@3.22.5':
+    resolution: {integrity: sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-italic@3.22.5':
+    resolution: {integrity: sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-link@3.22.5':
+    resolution: {integrity: sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-list-item@3.22.5':
+    resolution: {integrity: sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-list-keymap@3.22.5':
+    resolution: {integrity: sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-list@3.22.5':
+    resolution: {integrity: sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-mention@3.22.5':
+    resolution: {integrity: sha512-rGTbTjyxLc5C/6QjfbQF53nMbxjVgJU1VK6Si1i1J2c5DU09COgEFlYvi4YHjb3xz39SprPfG+GTtgD96eg7Ww==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+      '@tiptap/suggestion': 3.22.5
+
+  '@tiptap/extension-ordered-list@3.22.5':
+    resolution: {integrity: sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-paragraph@3.22.5':
+    resolution: {integrity: sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-strike@3.22.5':
+    resolution: {integrity: sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-text@3.22.5':
+    resolution: {integrity: sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-underline@3.22.5':
+    resolution: {integrity: sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+
+  '@tiptap/extensions@3.22.5':
+    resolution: {integrity: sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/pm@3.22.5':
+    resolution: {integrity: sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==}
+
+  '@tiptap/react@3.22.5':
+    resolution: {integrity: sha512-36WHEs+vPmB//V1ff7Ujcnpz7Ey5g8lhpI/0+hoanSbdiPMTQ7qZVWwMovIkMKDlqWVp2fxBgeYM1861jyFzTw==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.22.5':
+    resolution: {integrity: sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==}
+
+  '@tiptap/suggestion@3.22.5':
+    resolution: {integrity: sha512-Uv79Ht/o4mx1GWIT65jeQTE67LMrA+K7d8p51XOe9PJw0H0fS3iCdeMJ8tAo3h6QrMJFejdsB7z8jJL9UbAnhA==}
+    peerDependencies:
+      '@tiptap/core': 3.22.5
+      '@tiptap/pm': 3.22.5
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -988,6 +1171,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1282,6 +1468,10 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
+
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
@@ -1498,6 +1688,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -1698,6 +1891,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -1745,6 +1941,42 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1824,6 +2056,9 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1978,6 +2213,11 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -2107,6 +2347,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2541,6 +2784,20 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/utils@0.2.11':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2741,6 +2998,188 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@tiptap/core@3.22.5(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-blockquote@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bold@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bubble-menu@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-code-block@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-code@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-document@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-dropcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-floating-menu@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-hard-break@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-heading@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-horizontal-rule@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-italic@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-link@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-list-keymap@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-mention@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+      '@tiptap/suggestion': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-ordered-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-paragraph@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-strike@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-text@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-underline@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/pm@3.22.5':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/react@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-floating-menu': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.22.5':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/extension-blockquote': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-bold': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-bullet-list': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-code': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-code-block': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-document': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-dropcursor': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-gapcursor': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-hard-break': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-heading': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-horizontal-rule': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-italic': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-link': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/extension-list-item': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-list-keymap': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-ordered-list': 3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-paragraph': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-strike': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-text': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extension-underline': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
+      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
+  '@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+    dependencies:
+      '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+      '@tiptap/pm': 3.22.5
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -2832,6 +3271,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -3163,6 +3604,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-equals@5.4.0: {}
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -3386,6 +3829,8 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  linkifyjs@4.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -3784,6 +4229,8 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  orderedmap@2.1.1: {}
+
   p-cancelable@2.1.1: {}
 
   parse-entities@4.0.2:
@@ -3831,6 +4278,75 @@ snapshots:
   progress@2.0.3: {}
 
   property-information@7.1.0: {}
+
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
 
   pump@3.0.4:
     dependencies:
@@ -3987,6 +4503,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rope-sequence@1.3.4: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -4135,6 +4653,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -4200,6 +4722,8 @@ snapshots:
       jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

I fixed the desktop skill autocomplete and inline skill-token composer flow, then put the non-native composer paths behind the new Experimental chat composer setting.

This PR:
- Keeps the default chat composer on the native textarea path.
- Wires the Experimental > Chat Reply Composer setting into thread replies and directory launchpads.
- Adds two experimental chip composer paths:
  - `custom-widget-chips` for the custom inline chip editor.
  - `tiptap-chips` for the TipTap-backed editor.
- Adds a TipTap WYSIWYG markdown mode that converts editor structure back to markdown for submitted prompts.
- Preserves autocomplete behavior across composer modes: keyboard selection is active from `$`, ArrowUp/ArrowDown move the active option, and Enter/Tab select the highlighted skill.
- Improves skill autocomplete ranking so near-prefix skill names like `$ce:` win over weaker matches.
- Keeps the skills popup bounded to the viewport, scrollable, and usable from the bottom-aligned launchpad composer.
- Makes inline skill chips deletable, undoable, text-sized, baseline-aligned, and safe across persisted drafts, select-all deletion, and clicked-caret edits.
- Preserves textarea mode behavior by sending selected skills as canonical path-bearing markdown links.
- Adds TipTap markdown handling for paragraph breaks, code blocks, headings, lists, Shift+Enter list behavior, and Alt+Enter soft breaks inside list items.
- Aligns WYSIWYG composer and transcript markdown heading styles so H1-H6 are visually distinct.

## Screenshots

### Skill Auto-Complete

#### After

Improved selection indication

<img width="961" height="903" alt="image" src="https://github.com/user-attachments/assets/f2ed20d7-5a4e-4d8e-b772-d90158a894a4" />

#### Before

<img width="953" height="904" alt="image" src="https://github.com/user-attachments/assets/a848e5e9-7fb6-4c25-98b8-b55b4eee8eb6" />

### Skill Chips

#### After - Tiptap

Presented inline within the composer

<img width="959" height="317" alt="image" src="https://github.com/user-attachments/assets/b0d3b92d-ab60-4e19-9429-a4274398eea0" />

#### Before

Presented above the composer

<img width="950" height="364" alt="image" src="https://github.com/user-attachments/assets/e05e700c-9100-46b9-8f39-a387c8bc1507" />

### Code Blocks

#### After

<img width="946" height="313" alt="image" src="https://github.com/user-attachments/assets/4359050e-7eb6-4b6c-a553-409fcc273058" />

### Italics / Bold / Strikethrough

#### After

<img width="948" height="321" alt="image" src="https://github.com/user-attachments/assets/fa7b4c7d-c255-4737-a2a8-4009de68ed38" />

### Headings - In Transcript

Markdown rendering was supported in the transcript before, but the styles were not set correctly for headers.

#### After

Different sizes

<img width="933" height="521" alt="image" src="https://github.com/user-attachments/assets/7ddf8b88-cd6d-49a7-ae2b-fede689ded97" />

#### Before

All headers same size

<img width="925" height="519" alt="image" src="https://github.com/user-attachments/assets/3480cbd5-51a0-494e-bc4b-4ddf1e5f6017" />

## Verification

I verified this with:

- `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/settings/__tests__/settings-screen.test.tsx src/main/__tests__/desktop-settings-service.test.ts src/main/__tests__/settings-ipc.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop test:e2e -- directory-launchpad-skills.spec.ts --reporter=line`
- `pnpm --filter @pwragnt/desktop test:e2e -- thread-markdown.spec.ts directory-launchpad-skills.spec.ts --reporter=line`
- `pnpm --filter @pwragnt/desktop test:e2e -- review-command-flow.spec.ts tangerine-terminal-theme.spec.ts --reporter=line`
- `pnpm --filter @pwragnt/desktop test:e2e -- plan-autocomplete-order.spec.ts --reporter=line`
- `pnpm typecheck`
- `git diff --check`

GitHub checks are green after rerunning the known unrelated Desktop E2E scroll-stability flake. All checkpoint commits on this branch are signed.
