### PR TITLE
fix(desktop): clipped thread title descenders

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -19,6 +19,16 @@ function extractRootTokens(source: string): Record<string, string> {
   );
 }
 
+function extractRuleBody(source: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const ruleMatch = source.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`));
+  if (!ruleMatch?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+
+  return ruleMatch.groups.body;
+}
+
 function expandHex(hex: string): string {
   const normalized = hex.replace("#", "");
   if (normalized.length === 3) {
@@ -124,6 +134,23 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?padding-bottom:\s*(?:[4-9]\d|\d{3,})px;[\s\S]*?\}/
     );
+  });
+
+  it("keeps thread header titles tall enough for descenders", () => {
+    const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
+    const threadRowTitleRule = extractRuleBody(css, ".thread-row__title");
+
+    expect(css).toMatch(
+      /\.thread-header__title,\s*\.thread-empty-state h2\s*\{[\s\S]*?line-height:\s*1\.16;[\s\S]*?\}/
+    );
+    expect(compactTitleRule).toContain("padding-bottom: 2px;");
+    expect(compactTitleRule).toContain("line-height: 1.25;");
+    expect(threadRowTitleRule).toContain("padding-bottom: 2px;");
+    expect(threadRowTitleRule).toContain("line-height: 1.25;");
+    expect(css).not.toMatch(
+      /\.thread-header--launchpad \.thread-header__title\s*\{[\s\S]*?line-height:\s*1\.05;[\s\S]*?\}/
+    );
+    expect(compactTitleRule).not.toContain("line-height: 1;");
   });
 
   it("keeps thinking scanner variants on one shared visible sweep", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -297,7 +297,7 @@ textarea {
 .thread-header__title,
 .thread-empty-state h2 {
   margin: 0;
-  line-height: 1.05;
+  line-height: 1.16;
 }
 
 .sidebar__section {
@@ -620,8 +620,10 @@ textarea {
 }
 
 .thread-row__title {
+  padding-bottom: 2px;
   font-size: 14px;
   font-weight: 600;
+  line-height: 1.25;
 }
 
 .thread-row__time,
@@ -1132,7 +1134,6 @@ textarea {
 
 .thread-header--launchpad .thread-header__title {
   font-size: 34px;
-  line-height: 1.05;
 }
 
 .thread-header__eyebrow-row {
@@ -1146,10 +1147,11 @@ textarea {
   min-width: 0;
   margin: 0;
   overflow: hidden;
+  padding-bottom: 2px;
   color: var(--text-primary);
   font-size: 14px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

I fixed clipped descenders in desktop thread header titles by giving the title line box enough vertical room for the current renderer font stack.

## Changes

- Increased the shared thread header title line-height from `1.05` to `1.16`.
- Removed the launchpad-specific title override that forced the tighter line-height back onto the affected header.
- Added descender-safe line-height and bottom paint room to the compact thread header title and sidebar thread row title, which are one-line clipped/ellipsized elements.
- Added a renderer CSS contract test so future typography tightening does not reintroduce clipped `g` and `p` descenders.

## Verification

- I ran `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`.
- I ran `git diff --check`.
- I ran `pnpm --filter @pwragnt/desktop build`.
- I launched the built Electron renderer with `ELECTRON_RENDERER_URL` cleared and confirmed `.thread-row__title` and `.thread-header__compact-title` compute to `line-height: 17.5px` and `padding-bottom: 2px`.
- I verified the commit signature is good.
