### PR TITLE
fix(desktop): stale thinking state after request resolution

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1998,6 +1998,114 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingStatusText).toBe("Thinking");
   });
 
+  it("does not reintroduce thinking when a request resolves after turn completion", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "input-1",
+              requestId: "input-request-1",
+              questions: [
+                {
+                  id: "approach",
+                  header: "Approach",
+                  question: "Which path should I take?",
+                  isOther: false,
+                  isSecret: false,
+                  options: [
+                    {
+                      label: "Small patch (Recommended)",
+                      description: "Keep this scoped.",
+                    },
+                  ],
+                },
+              ],
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-1");
+    expect(result.current.pendingStatusText).toBe("Waiting for input");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+        listener({
+          backend: "codex",
+          notification: {
+            method: "serverRequest/resolved",
+            params: {
+              threadId: "thread-1",
+              requestId: "input-request-1",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.activeTurnId).toBeUndefined();
+    expect(result.current.pendingUserInput).toBeUndefined();
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+  });
+
   it("surfaces MCP elicitations as pending MCP interactions instead of approval", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -325,6 +325,14 @@ function normalizeNotificationDuration(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function readNotificationTurnId(notification: {
+  params: Record<string, unknown>;
+}): string | undefined {
+  return typeof notification.params.turnId === "string"
+    ? notification.params.turnId
+    : undefined;
+}
+
 function readFiniteNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
   for (const key of keys) {
     const value = record[key];
@@ -1168,8 +1176,10 @@ export function useThreadSessionState(params: {
         const nextLastTouchedAt = Date.now();
 
         if (isApprovalRequestNotification(event.notification)) {
+          const notificationTurnId = readNotificationTurnId(event.notification);
           return {
             ...current,
+            activeTurnId: notificationTurnId ?? current.activeTurnId,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingRequest: event.notification,
@@ -1182,9 +1192,11 @@ export function useThreadSessionState(params: {
           if (!pendingUserInput) {
             return current;
           }
+          const notificationTurnId = readNotificationTurnId(event.notification);
 
           return {
             ...current,
+            activeTurnId: notificationTurnId ?? current.activeTurnId,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingStatusText: "Waiting for input",
@@ -1197,9 +1209,11 @@ export function useThreadSessionState(params: {
           if (!pendingMcpInteraction) {
             return current;
           }
+          const notificationTurnId = readNotificationTurnId(event.notification);
 
           return {
             ...current,
+            activeTurnId: notificationTurnId ?? current.activeTurnId,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingMcpInteraction,
@@ -1304,22 +1318,31 @@ export function useThreadSessionState(params: {
           event.notification.method === "serverRequest/resolved" &&
           "requestId" in event.notification.params
         ) {
+          const pendingRequestResolved =
+            current.pendingRequest?.params.requestId === event.notification.params.requestId;
+          const pendingMcpResolved =
+            current.pendingMcpInteraction?.requestId === event.notification.params.requestId;
+          const pendingUserInputResolved =
+            current.pendingUserInput?.requestId === event.notification.params.requestId;
+          const hasActiveTurnAfterResolve = Boolean(current.activeTurnId);
+          const resolvedKnownRequest =
+            pendingRequestResolved || pendingMcpResolved || pendingUserInputResolved;
+
           return {
             ...current,
             lastTouchedAt: nextLastTouchedAt,
             pendingRequest:
-              current.pendingRequest?.params.requestId === event.notification.params.requestId
-                ? undefined
-                : current.pendingRequest,
+              pendingRequestResolved ? undefined : current.pendingRequest,
             pendingMcpInteraction:
-              current.pendingMcpInteraction?.requestId === event.notification.params.requestId
-                ? undefined
-                : current.pendingMcpInteraction,
+              pendingMcpResolved ? undefined : current.pendingMcpInteraction,
             pendingUserInput:
-              current.pendingUserInput?.requestId === event.notification.params.requestId
-                ? undefined
-                : current.pendingUserInput,
-            pendingStatusText: "Thinking",
+              pendingUserInputResolved ? undefined : current.pendingUserInput,
+            pendingStatusText:
+              hasActiveTurnAfterResolve && resolvedKnownRequest
+                ? "Thinking"
+                : resolvedKnownRequest
+                  ? undefined
+                  : current.pendingStatusText,
           };
         }
 


### PR DESCRIPTION
## Summary

I fixed a stale renderer session-state path where a late `serverRequest/resolved` notification could reintroduce the sidebar thread-row thinking indicator after the turn had already completed.

## What changed

- Capture the notification `turnId` when pending approval, user-input, or MCP interactions are surfaced.
- Only return a resolved request to `Thinking` when the thread still has an active turn.
- Clear resolved pending status when the request resolves after turn completion.
- Add a regression test for a request resolving after `turn/completed` so the list thinking key stays cleared.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
