### PR TITLE
fix(desktop): transcript bottom glue behavior

### DIFF
--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -1,9 +1,21 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function expectAtTranscriptBottom(list: Locator) {
+  await expect
+    .poll(async () =>
+      await list.evaluate((element) =>
+        Math.round(
+          Math.max(element.scrollHeight - element.clientHeight - element.scrollTop, 0)
+        )
+      )
+    )
+    .toBeLessThanOrEqual(4);
+}
 
 test("preserves live assistant commentary messages, exploration activity, and final answer", async () => {
   const app = await launchElectronApp({
@@ -27,7 +39,9 @@ test("preserves live assistant commentary messages, exploration activity, and fi
     ).toBeVisible();
 
     const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const list = app.window.locator(".transcript-list__items");
     await expect(transcript).toContainText("Ready to brainstorm Telegram support.");
+    await expectAtTranscriptBottom(list);
     const hydratedWorkToggle = transcript.getByRole("button", {
       name: /Worked for 1m 10s/
     });
@@ -49,15 +63,18 @@ test("preserves live assistant commentary messages, exploration activity, and fi
 
     await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
+    await expectAtTranscriptBottom(list);
 
     await app.advance({ stepId: "turn-started-1" });
     await app.advance({ stepId: "tool-search-started-1" });
     await expect(transcript).toContainText("Explored 1 item");
+    await expectAtTranscriptBottom(list);
 
     await app.advance({ stepId: "assistant-message-1a" });
     await app.advance({ stepId: "assistant-message-1b" });
     await expect(transcript).toContainText("Using ce:brainstorm for this.");
     await expect(transcript).toContainText("What would it take to add Telegram support?");
+    await expectAtTranscriptBottom(list);
 
     await app.advance({ stepId: "tool-search-completed-1" });
     await app.advance({ stepId: "tool-command-started-1" });
@@ -74,12 +91,14 @@ test("preserves live assistant commentary messages, exploration activity, and fi
     expect(transcriptText.indexOf("The broad search was too noisy")).toBeGreaterThan(
       transcriptText.indexOf("Using ce:brainstorm for this.")
     );
+    await expectAtTranscriptBottom(list);
 
     await app.advance({ stepId: "tool-command-completed-1" });
     await app.advance({ stepId: "assistant-message-3" });
     await expect(transcript).toContainText("Using ce:brainstorm for this.");
     await expect(transcript).toContainText("The broad search was too noisy");
     await expect(transcript).toContainText("The existing product direction is thread-first");
+    await expectAtTranscriptBottom(list);
 
     await app.advance({ stepId: "assistant-message-4" });
     await app.advance({ stepId: "assistant-message-5" });
@@ -91,6 +110,7 @@ test("preserves live assistant commentary messages, exploration activity, and fi
     await expect(transcript.getByText("From the repo scan, Telegram should probably")).toBeVisible();
     await expect(transcript.getByText("The v1 shape should probably focus")).toBeVisible();
     await expect(transcript.getByText("I’m ready to turn that into requirements")).toBeVisible();
+    await expectAtTranscriptBottom(list);
 
     const commandSummary = transcript.getByRole("button", {
       name: /rg -n "Telegram\|telegram\|webhook" docs apps packages/i
@@ -106,6 +126,7 @@ test("preserves live assistant commentary messages, exploration activity, and fi
 
     await expect(app.window.getByRole("button", { name: "Stop" })).toHaveCount(0);
     await expect(app.window.getByText("Thinking")).toHaveCount(0);
+    await expectAtTranscriptBottom(list);
     const workedForToggle = transcript.getByRole("button", {
       name: /Worked for 8m/
     }).first();

--- a/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
+++ b/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
@@ -88,6 +88,14 @@ test("opens a long transcript at the bottom without downward drift and restores 
     const savedViewport = await list.evaluate((element) => {
       const maxScrollTop = Math.max(element.scrollHeight - element.clientHeight, 0);
       const targetScrollTop = Math.max(320, Math.floor(maxScrollTop / 3));
+      const rect = element.getBoundingClientRect();
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          clientX: rect.right - 2,
+          clientY: rect.top + 24,
+        })
+      );
       element.scrollTop = targetScrollTop;
       element.dispatchEvent(new Event("scroll", { bubbles: true }));
       return {

--- a/apps/desktop/e2e/thread-scroll-restore.spec.ts
+++ b/apps/desktop/e2e/thread-scroll-restore.spec.ts
@@ -69,6 +69,14 @@ test("restores the saved transcript viewport when reselecting a cached thread", 
       .toBe(true);
 
     await list.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      element.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          clientX: rect.right - 2,
+          clientY: rect.top + 24,
+        })
+      );
       element.scrollTop = 0;
       element.dispatchEvent(new Event("scroll", { bubbles: true }));
     });

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -59,6 +59,7 @@ type ComposerProps = {
     collaborationMode?: AppServerCollaborationModeRequest,
     reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
+  onBeforeSendTurn?: () => void;
   onPendingStatusChange?: (status?: string) => void;
   onUpdateLaunchpad?: (
     directoryKey: string,
@@ -996,6 +997,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    props.onBeforeSendTurn?.();
     props.onPendingStatusChange?.(collaborationMode ? "Planning" : "Thinking");
     const optimisticMessageId = props.addOptimisticUserMessage?.(
       payload.displayText,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -572,7 +572,10 @@ type ThreadViewProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   addOptimisticReviewEntry?: (displayText: string) => string;
-  addOptimisticUserMessage: (text: string) => string;
+  addOptimisticUserMessage: (
+    text: string,
+    imageParts?: AppServerThreadImagePart[]
+  ) => string;
   backendError?: string;
   backends: BackendSummary[];
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
@@ -645,6 +648,7 @@ type ThreadViewProps = {
   ) => Promise<void>;
   onTranscriptViewportChange?: (viewport?: {
     distanceFromBottom: number;
+    isGluedToBottom?: boolean;
     scrollTop: number;
   }) => void;
   onUpdateLaunchpad?: (
@@ -670,6 +674,7 @@ type ThreadViewProps = {
   removeOptimisticMessage: (id: string) => void;
   transcriptViewport?: {
     distanceFromBottom: number;
+    isGluedToBottom?: boolean;
     scrollTop: number;
   };
 };
@@ -694,6 +699,7 @@ export function ThreadView(props: ThreadViewProps) {
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
   const [contextRailPinned, setContextRailPinned] = useState(false);
   const [contextRailResizing, setContextRailResizing] = useState(false);
+  const [transcriptReglueRequestKey, setTranscriptReglueRequestKey] = useState(0);
   const [contextRailWidth, setContextRailWidth] = useState(380);
   const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
 
@@ -1456,6 +1462,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingUserInput={props.pendingUserInput}
               pendingStatusText={props.pendingStatusText}
               restoredViewport={props.transcriptViewport}
+              reglueRequestKey={transcriptReglueRequestKey}
               skills={props.skills}
               pendingProtocolActivityEntry={pendingProtocolActivityEntry}
               threadId={`${selectedThread!.source}:${selectedThread!.id}`}
@@ -1495,6 +1502,9 @@ export function ThreadView(props: ThreadViewProps) {
                 ? async () => !(await checkSelectedThreadBranchDrift("turn"))
                 : undefined
             }
+            onBeforeSendTurn={() => {
+              setTranscriptReglueRequestKey((current) => current + 1);
+            }}
             onSetExecutionMode={props.onSetExecutionMode}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
             pendingRequestActive={Boolean(props.pendingRequest)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent
+} from "react";
 import type {
   AppServerPendingRequestNotification,
   AppServerThreadActivityEntry,
@@ -22,6 +30,12 @@ import type { PendingQuestionnaireState } from "./questionnaire";
 import type { PendingMcpInteractionState } from "./mcp-elicitation";
 import { buildTranscriptRenderItems } from "./transcript-render-items";
 
+type TranscriptViewport = {
+  distanceFromBottom: number;
+  isGluedToBottom?: boolean;
+  scrollTop: number;
+};
+
 type TranscriptListProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
@@ -39,17 +53,12 @@ type TranscriptListProps = {
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   pagination?: AppServerThreadReplayPagination;
-  restoredViewport?: {
-    distanceFromBottom: number;
-    scrollTop: number;
-  };
+  restoredViewport?: TranscriptViewport;
+  reglueRequestKey?: number;
   threadId?: string;
   skills?: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
-  onViewportChange?: (viewport?: {
-    distanceFromBottom: number;
-    scrollTop: number;
-  }) => void;
+  onViewportChange?: (viewport?: TranscriptViewport) => void;
   onRespondToPendingRequest?: (decision: "approve" | "decline" | "cancel") => Promise<void>;
   onPendingMcpInteractionChange?: (state: PendingMcpInteractionState) => void;
   onSubmitPendingMcpInteraction?: (
@@ -74,6 +83,7 @@ type ScrollSnapshot = {
 };
 
 const BOTTOM_THRESHOLD_PX = 24;
+const SCROLLBAR_HIT_SLOP_PX = 16;
 type ScrollBottomMode = "instant" | "smooth";
 
 function isAssistantFinalMessage(entry: AppServerThreadEntry): boolean {
@@ -258,12 +268,12 @@ function pendingRequestPrompt(request: AppServerPendingRequestNotification): str
 export function TranscriptList(props: TranscriptListProps) {
   const skills = props.skills ?? [];
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollContentRef = useRef<HTMLDivElement>(null);
   const snapshotRef = useRef<ScrollSnapshot | undefined>(undefined);
-  const savedViewportsRef = useRef(
-    new Map<string, { distanceFromBottom: number; scrollTop: number }>()
-  );
+  const savedViewportsRef = useRef(new Map<string, TranscriptViewport>());
   const shouldScrollToBottomRef = useRef(true);
-  const isFollowingBottomRef = useRef(true);
+  const isGluedToBottomRef = useRef(true);
+  const pendingScrollbarUnglueRef = useRef(false);
   const [hasContentBelow, setHasContentBelow] = useState(false);
   const [expandedCommentaryGroupIds, setExpandedCommentaryGroupIds] = useState(
     () => new Set<string>()
@@ -396,13 +406,19 @@ export function TranscriptList(props: TranscriptListProps) {
   const syncScrollState = useCallback(() => {
     const snapshot = captureSnapshot();
     snapshotRef.current = snapshot;
-    isFollowingBottomRef.current = Boolean(
-      snapshot && snapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX
-    );
-    setHasContentBelow(Boolean(snapshot && snapshot.distanceFromBottom > BOTTOM_THRESHOLD_PX));
+    const isAtBottom = Boolean(snapshot && snapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX);
+    if (isAtBottom) {
+      isGluedToBottomRef.current = true;
+      pendingScrollbarUnglueRef.current = false;
+    } else if (pendingScrollbarUnglueRef.current) {
+      isGluedToBottomRef.current = false;
+      pendingScrollbarUnglueRef.current = false;
+    }
+    setHasContentBelow(Boolean(snapshot && !isAtBottom));
     if (snapshot?.threadId) {
       savedViewportsRef.current.set(snapshot.threadId, {
         distanceFromBottom: snapshot.distanceFromBottom,
+        isGluedToBottom: isGluedToBottomRef.current,
         scrollTop: snapshot.scrollTop,
       });
     }
@@ -423,15 +439,44 @@ export function TranscriptList(props: TranscriptListProps) {
       container.scrollTop = container.scrollHeight;
     }
 
-    isFollowingBottomRef.current = true;
+    isGluedToBottomRef.current = true;
+    pendingScrollbarUnglueRef.current = false;
     syncScrollState();
   }, [syncScrollState]);
+
+  const notePotentialScrollbarUnglue = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const container = scrollContainerRef.current;
+      if (!container || container.scrollHeight <= container.clientHeight) {
+        pendingScrollbarUnglueRef.current = false;
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      const distanceFromRight = rect.right - event.clientX;
+      const gutterWidth = Math.max(container.offsetWidth - container.clientWidth, 0);
+      const isInScrollbarGutter =
+        gutterWidth > 0
+          ? event.clientX >= rect.right - gutterWidth
+          : distanceFromRight >= 0 && distanceFromRight <= SCROLLBAR_HIT_SLOP_PX;
+      pendingScrollbarUnglueRef.current = isInScrollbarGutter;
+    },
+    []
+  );
 
   useEffect(() => {
     if (props.loading && props.entries.length === 0) {
       shouldScrollToBottomRef.current = true;
     }
   }, [props.entries.length, props.loading]);
+
+  useEffect(() => {
+    if (typeof props.reglueRequestKey !== "number" || props.reglueRequestKey <= 0) {
+      return;
+    }
+
+    scrollToBottom("instant");
+  }, [props.reglueRequestKey, scrollToBottom]);
 
   useEffect(() => {
     return () => {
@@ -449,7 +494,8 @@ export function TranscriptList(props: TranscriptListProps) {
     const container = scrollContainerRef.current;
     if (!container || props.entries.length === 0) {
       snapshotRef.current = undefined;
-      isFollowingBottomRef.current = true;
+      isGluedToBottomRef.current = true;
+      pendingScrollbarUnglueRef.current = false;
       setHasContentBelow(false);
       return;
     }
@@ -488,7 +534,7 @@ export function TranscriptList(props: TranscriptListProps) {
         previousSnapshot.threadId === props.threadId &&
         previousSnapshot.firstMessageId === firstMessageId &&
         !hasPrependedMessages &&
-        isFollowingBottomRef.current &&
+        isGluedToBottomRef.current &&
         container.scrollHeight > previousSnapshot.scrollHeight
     );
 
@@ -497,9 +543,15 @@ export function TranscriptList(props: TranscriptListProps) {
       container.scrollTop = previousSnapshot.scrollTop + heightDelta;
     } else if (previousSnapshot?.threadId !== props.threadId) {
       if (restoredViewport) {
-        if (restoredViewport.distanceFromBottom <= BOTTOM_THRESHOLD_PX) {
+        const shouldRestoreBottom =
+          restoredViewport.isGluedToBottom ??
+          restoredViewport.distanceFromBottom <= BOTTOM_THRESHOLD_PX;
+        if (shouldRestoreBottom) {
+          isGluedToBottomRef.current = true;
           scrollToBottom("instant");
         } else {
+          isGluedToBottomRef.current = false;
+          pendingScrollbarUnglueRef.current = false;
           container.scrollTop = Math.min(
             Math.max(0, restoredViewport.scrollTop),
             Math.max(container.scrollHeight - container.clientHeight, 0)
@@ -522,6 +574,7 @@ export function TranscriptList(props: TranscriptListProps) {
       return;
     } else if (
       (hasAppendedMessages && previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX) ||
+      (hasAppendedMessages && isGluedToBottomRef.current) ||
       hasGrownWhileFollowingBottom
     ) {
       scrollToBottom("instant");
@@ -544,6 +597,25 @@ export function TranscriptList(props: TranscriptListProps) {
     scrollToBottom,
     syncScrollState,
   ]);
+
+  useEffect(() => {
+    const content = scrollContentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (isGluedToBottomRef.current) {
+        scrollToBottom("instant");
+      } else {
+        syncScrollState();
+      }
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [scrollToBottom, syncScrollState]);
 
   if (props.loading && props.entries.length === 0 && !hasPendingContent) {
     return <p className="transcript-empty">Loading transcript…</p>;
@@ -578,119 +650,122 @@ export function TranscriptList(props: TranscriptListProps) {
         className="transcript-list__items"
         role="list"
         onScroll={syncScrollState}
+        onPointerDown={notePotentialScrollbarUnglue}
       >
-        {transcriptRenderItems.map((item) => {
-          if (item.type === "workPhaseGroup") {
-            return (
-              <TranscriptWorkPhaseGroup
-                key={item.id}
-                collapsible={item.collapsible}
-                entries={item.entries}
-                expanded={expandedCommentaryGroupIds.has(item.id)}
-                label={item.label}
+        <div ref={scrollContentRef} className="transcript-list__content">
+          {transcriptRenderItems.map((item) => {
+            if (item.type === "workPhaseGroup") {
+              return (
+                <TranscriptWorkPhaseGroup
+                  key={item.id}
+                  collapsible={item.collapsible}
+                  entries={item.entries}
+                  expanded={expandedCommentaryGroupIds.has(item.id)}
+                  label={item.label}
+                  skills={skills}
+                  onOpenImage={props.onOpenImage}
+                  onToggle={() => {
+                    toggleCommentaryGroup(item.id);
+                  }}
+                />
+              );
+            }
+
+            const entry = item.entry;
+            return entry.type === "activity" ? (
+              <TranscriptActivity key={entry.id} entry={entry} />
+            ) : entry.type === "plan" ? (
+              <TranscriptPlan key={entry.id} entry={entry} />
+            ) : entry.type === "review" ? (
+              <TranscriptReview key={entry.id} entry={entry} />
+            ) : (
+              <TranscriptMessage
+                key={entry.id}
+                message={entry}
                 skills={skills}
                 onOpenImage={props.onOpenImage}
-                onToggle={() => {
-                  toggleCommentaryGroup(item.id);
-                }}
               />
             );
-          }
-
-          const entry = item.entry;
-          return entry.type === "activity" ? (
-            <TranscriptActivity key={entry.id} entry={entry} />
-          ) : entry.type === "plan" ? (
-            <TranscriptPlan key={entry.id} entry={entry} />
-          ) : entry.type === "review" ? (
-            <TranscriptReview key={entry.id} entry={entry} />
-          ) : (
-            <TranscriptMessage
-              key={entry.id}
-              message={entry}
-              skills={skills}
-              onOpenImage={props.onOpenImage}
-            />
-          );
-        })}
-        {props.pendingStatusText ? (
-          <div className="transcript-list__pending" role="status">
-            <ThinkingScanner />
-            <span>{props.pendingStatusText}</span>
-          </div>
-        ) : null}
-        {props.pendingUserInput ? (
-          <PendingQuestionnaire
-            busy={props.pendingRequestBusy}
-            state={props.pendingUserInput}
-            onChange={(state) => {
-              props.onPendingUserInputChange?.(state);
-            }}
-            onSubmit={async (state) => {
-              await props.onSubmitPendingUserInput?.(state);
-            }}
-          />
-        ) : null}
-        {props.pendingMcpInteraction ? (
-          <PendingMcpInteraction
-            busy={props.pendingRequestBusy}
-            state={props.pendingMcpInteraction}
-            onChange={(state) => {
-              props.onPendingMcpInteractionChange?.(state);
-            }}
-            onSubmit={async (state, action) => {
-              await props.onSubmitPendingMcpInteraction?.(state, action);
-            }}
-          />
-        ) : null}
-        {props.pendingRequest ? (
-          <div className="transcript-request" role="group" aria-label="Pending approval">
-            <div className="transcript-request__header">
-              <span className="thread-row__chip thread-row__chip--mode">
-                Approval needed
-              </span>
-              <span className="transcript-message__time">
-                {props.pendingRequest.method}
-              </span>
+          })}
+          {props.pendingStatusText ? (
+            <div className="transcript-list__pending" role="status">
+              <ThinkingScanner />
+              <span>{props.pendingStatusText}</span>
             </div>
-            <ThreadMarkdown
-              className="transcript-request__prompt"
-              text={pendingRequestPrompt(props.pendingRequest)}
+          ) : null}
+          {props.pendingUserInput ? (
+            <PendingQuestionnaire
+              busy={props.pendingRequestBusy}
+              state={props.pendingUserInput}
+              onChange={(state) => {
+                props.onPendingUserInputChange?.(state);
+              }}
+              onSubmit={async (state) => {
+                await props.onSubmitPendingUserInput?.(state);
+              }}
             />
-            <div className="transcript-request__actions">
-              <button
-                className="button button--primary"
-                disabled={props.pendingRequestBusy}
-                type="button"
-                onClick={() => {
-                  void props.onRespondToPendingRequest?.("approve");
-                }}
-              >
-                Approve
-              </button>
-              <button
-                className="button button--ghost"
-                disabled={props.pendingRequestBusy}
-                type="button"
-                onClick={() => {
-                  void props.onRespondToPendingRequest?.("decline");
-                }}
-              >
-                Decline
-              </button>
-              <button
-                className="button button--ghost"
-                disabled={props.pendingRequestBusy}
-                type="button"
-                onClick={() => {
-                  void props.onRespondToPendingRequest?.("cancel");
-                }}
-              >
-                Cancel turn
-              </button>
+          ) : null}
+          {props.pendingMcpInteraction ? (
+            <PendingMcpInteraction
+              busy={props.pendingRequestBusy}
+              state={props.pendingMcpInteraction}
+              onChange={(state) => {
+                props.onPendingMcpInteractionChange?.(state);
+              }}
+              onSubmit={async (state, action) => {
+                await props.onSubmitPendingMcpInteraction?.(state, action);
+              }}
+            />
+          ) : null}
+          {props.pendingRequest ? (
+            <div className="transcript-request" role="group" aria-label="Pending approval">
+              <div className="transcript-request__header">
+                <span className="thread-row__chip thread-row__chip--mode">
+                  Approval needed
+                </span>
+                <span className="transcript-message__time">
+                  {props.pendingRequest.method}
+                </span>
+              </div>
+              <ThreadMarkdown
+                className="transcript-request__prompt"
+                text={pendingRequestPrompt(props.pendingRequest)}
+              />
+              <div className="transcript-request__actions">
+                <button
+                  className="button button--primary"
+                  disabled={props.pendingRequestBusy}
+                  type="button"
+                  onClick={() => {
+                    void props.onRespondToPendingRequest?.("approve");
+                  }}
+                >
+                  Approve
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={props.pendingRequestBusy}
+                  type="button"
+                  onClick={() => {
+                    void props.onRespondToPendingRequest?.("decline");
+                  }}
+                >
+                  Decline
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={props.pendingRequestBusy}
+                  type="button"
+                  onClick={() => {
+                    void props.onRespondToPendingRequest?.("cancel");
+                  }}
+                >
+                  Cancel turn
+                </button>
+              </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
 
       {hasContentBelow ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -6,13 +6,26 @@ import { TranscriptList } from "../TranscriptList";
 describe("TranscriptList", () => {
   let scrollHeight = 480;
   let clientHeight = 240;
+  let clientWidth = 320;
+  let offsetWidth = 336;
   let scrollToMock: ReturnType<typeof vi.fn>;
   let createObjectURLMock: ReturnType<typeof vi.fn>;
   let revokeObjectURLMock: ReturnType<typeof vi.fn>;
 
+  function scrollAwayWithScrollbar(element: HTMLElement, scrollTop: number) {
+    fireEvent.pointerDown(element, {
+      clientX: clientWidth + 8,
+      clientY: 24,
+    });
+    element.scrollTop = scrollTop;
+    fireEvent.scroll(element);
+  }
+
   beforeEach(() => {
     scrollHeight = 480;
     clientHeight = 240;
+    clientWidth = 320;
+    offsetWidth = 336;
     scrollToMock = vi.fn(function scrollTo(
       this: HTMLElement,
       options?: number | ScrollToOptions,
@@ -37,6 +50,37 @@ describe("TranscriptList", () => {
       configurable: true,
       get() {
         return clientHeight;
+      }
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return clientWidth;
+      }
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        return offsetWidth;
+      }
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value() {
+        return {
+          bottom: clientHeight,
+          height: clientHeight,
+          left: 0,
+          right: offsetWidth,
+          top: 0,
+          width: offsetWidth,
+          x: 0,
+          y: 0,
+          toJSON: () => undefined,
+        };
       }
     });
 
@@ -1180,8 +1224,7 @@ describe("TranscriptList", () => {
     );
 
     const list = screen.getByRole("list");
-    list.scrollTop = 72;
-    fireEvent.scroll(list);
+    scrollAwayWithScrollbar(list, 72);
 
     rerender(
       <TranscriptList
@@ -1241,6 +1284,77 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(72);
   });
 
+  it("restores a generically scrolled glued thread back to the bottom", () => {
+    const { rerender } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "thread-1-message-1",
+            role: "user",
+            text: "Thread one first message"
+          },
+          {
+            type: "message",
+            id: "thread-1-message-2",
+            role: "assistant",
+            text: "Thread one second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 60;
+    fireEvent.scroll(list);
+
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "thread-2-message-1",
+            role: "user",
+            text: "Thread two first message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-2"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "thread-1-message-1",
+            role: "user",
+            text: "Thread one first message"
+          },
+          {
+            type: "message",
+            id: "thread-1-message-2",
+            role: "assistant",
+            text: "Thread one second message"
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(480);
+  });
+
   it("does not re-arm auto-scroll while a cached transcript is refreshing", () => {
     const { rerender } = render(
       <TranscriptList
@@ -1272,8 +1386,7 @@ describe("TranscriptList", () => {
     );
 
     const list = screen.getByRole("list");
-    list.scrollTop = 72;
-    fireEvent.scroll(list);
+    scrollAwayWithScrollbar(list, 72);
     scrollToMock.mockClear();
 
     rerender(
@@ -1562,6 +1675,162 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(1340);
   });
 
+  it("does not unglue from generic scroll events while following the bottom", () => {
+    const entries = Array.from({ length: 24 }, (_, index) => ({
+      type: "message" as const,
+      id: `generic-scroll-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Generic scroll transcript message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+
+    list.scrollTop = 120;
+    fireEvent.scroll(list);
+
+    scrollHeight = 880;
+    rerender(
+      <TranscriptList
+        entries={[
+          ...entries,
+          {
+            type: "message",
+            id: "assistant-live-append",
+            role: "assistant",
+            text: "This live append should still pull the glued transcript to the bottom."
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(880);
+  });
+
+  it("reglues and scrolls to bottom when a send request arrives", () => {
+    const entries = Array.from({ length: 20 }, (_, index) => ({
+      type: "message" as const,
+      id: `reglue-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Reglue transcript message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    scrollAwayWithScrollbar(list, 96);
+
+    rerender(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        reglueRequestKey={1}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+    expect(list.scrollTop).toBe(720);
+
+    scrollHeight = 840;
+    rerender(
+      <TranscriptList
+        entries={[
+          ...entries,
+          {
+            type: "message",
+            id: "reglued-user-prompt",
+            role: "user",
+            text: "This prompt should stay at the bottom after send."
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        reglueRequestKey={1}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(840);
+  });
+
+  it("keeps the bottom pinned when rendered content grows after layout", () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+
+    try {
+      const entries = Array.from({ length: 18 }, (_, index) => ({
+        type: "message" as const,
+        id: `resize-message-${index + 1}`,
+        role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+        text: `Resize transcript message ${index + 1}`
+      }));
+      scrollHeight = 720;
+      render(
+        <TranscriptList
+          entries={entries}
+          loading={false}
+          loadingMore={false}
+          threadId="thread-1"
+          onLoadOlder={async () => undefined}
+        />
+      );
+
+      const list = screen.getByRole("list");
+      list.scrollTop = 480;
+      fireEvent.scroll(list);
+
+      scrollHeight = 860;
+      resizeCallback?.([], {} as ResizeObserver);
+
+      expect(list.scrollTop).toBe(860);
+    } finally {
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: OriginalResizeObserver,
+      });
+    }
+  });
+
   it("does not move the reader when new messages arrive below an older viewport", () => {
     const entries = Array.from({ length: 16 }, (_, index) => ({
       type: "message" as const,
@@ -1581,8 +1850,7 @@ describe("TranscriptList", () => {
     );
 
     const list = screen.getByRole("list");
-    list.scrollTop = 96;
-    fireEvent.scroll(list);
+    scrollAwayWithScrollbar(list, 96);
 
     scrollHeight = 920;
     rerender(

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -76,6 +76,7 @@ export function getContextWindowMoonPhase(usedPercent: number): number {
 
 export type ThreadViewportState = {
   distanceFromBottom: number;
+  isGluedToBottom?: boolean;
   scrollTop: number;
 };
 
@@ -2200,13 +2201,15 @@ export function useThreadSessionState(params: {
           Number.isFinite(viewport.distanceFromBottom)
             ? {
                 distanceFromBottom: Math.max(0, viewport.distanceFromBottom),
+                isGluedToBottom: viewport.isGluedToBottom,
                 scrollTop: Math.max(0, viewport.scrollTop),
               }
             : undefined;
 
         if (
           current.viewport?.scrollTop === nextViewport?.scrollTop &&
-          current.viewport?.distanceFromBottom === nextViewport?.distanceFromBottom
+          current.viewport?.distanceFromBottom === nextViewport?.distanceFromBottom &&
+          current.viewport?.isGluedToBottom === nextViewport?.isGluedToBottom
         ) {
           return current;
         }

--- a/docs/brainstorms/2026-04-30-transcript-bottom-glue-requirements.md
+++ b/docs/brainstorms/2026-04-30-transcript-bottom-glue-requirements.md
@@ -1,0 +1,170 @@
+---
+date: 2026-04-30
+topic: transcript-bottom-glue
+---
+
+# Transcript Bottom Glue
+
+## Problem Frame
+
+The desktop thread transcript can stop following the newest content during an active
+turn even when the user did not intentionally move away from the bottom. This makes
+live agent work feel broken: the user sends a prompt, the agent replies, but the
+latest reply, thinking indicator, or pasted screenshot can end up below the visible
+viewport.
+
+The existing refresh-model requirements already say that the transcript should
+append and auto-scroll when the user is at the bottom. This focused requirement
+tightens that behavior into an explicit bottom-glue state so planning does not
+recreate the current ambiguous "near bottom" heuristic.
+
+## Existing Context
+
+- `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`
+  includes R11-R13 for bottom-following and viewport preservation.
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+  already tracks bottom-related refs, saved per-thread viewports, prepend
+  anchoring, and a "jump to latest message" control.
+- The current implementation recalculates bottom-following from scroll position,
+  which is not strong enough for this bug because layout changes, stream growth,
+  image loading, or programmatic scroll events can make the view appear unglued
+  without a deliberate user scrollbar action.
+
+## Requirements
+
+**Bottom-Glue State**
+- R1. Every thread transcript starts with `isGluedToBottom` set to true.
+- R2. `isGluedToBottom` may change from true to false only when the user explicitly
+  clicks or drags the transcript scrollbar to move away from the bottom.
+- R3. Wheel, trackpad, keyboard, programmatic scrolling, content resize, message
+  append, pending-status changes, and layout changes must not change
+  `isGluedToBottom` from true to false.
+- R4. When the transcript is not glued, any user action that scrolls the bottom of
+  the newest transcript content into view sets `isGluedToBottom` back to true.
+- R5. Clicking the existing jump-to-latest control scrolls to the absolute bottom
+  and sets `isGluedToBottom` to true.
+
+**Prompt Send Behavior**
+- R6. Sending a prompt in an existing thread scrolls the transcript to the absolute
+  bottom and sets `isGluedToBottom` to true before live reply content is rendered.
+- R7. The just-sent user prompt, including image attachments or screenshots, must
+  be fully visible at the bottom after send.
+- R8. A queued or follow-up prompt sent while the transcript was previously unglued
+  still reglues the transcript and follows the new turn from the bottom.
+
+**Following Live Content**
+- R9. While `isGluedToBottom` is true, every append or size change at the bottom of
+  the transcript must keep the viewport at the absolute bottom.
+- R10. Bottom-following applies to finalized messages, streaming assistant deltas,
+  thinking or planning indicators, activity entries, pending approvals, pending
+  user-input forms, command output, rendered images, and any other transcript item
+  that can appear or grow at the newest end of the thread.
+- R11. Bottom-following must remain correct when content changes height after
+  initial render, especially image loading, markdown rendering, code wrapping, and
+  collapsible group changes near the bottom.
+- R12. When `isGluedToBottom` is false, appending new content preserves the user's
+  current reading viewport and keeps the jump-to-latest control available.
+- R13. Loading older transcript pages above the viewport preserves the existing
+  prepend anchoring behavior and does not force the transcript to the bottom unless
+  `isGluedToBottom` is true.
+
+**Ownership and Testability**
+- R14. Bottom-following must have one clear owner at the transcript-list level or
+  in a small transcript-scroll controller used by that list.
+- R15. Callers such as the composer and thread view may request "reglue and scroll
+  to bottom" for user-send events, but they must not need to remember each low-level
+  moment when streamed content or resized content requires another scroll.
+- R16. E2E coverage must reproduce the failure mode: send a prompt, receive multiple
+  replies or live updates, and verify the newest transcript content remains visible
+  at the bottom without any intentional user scrollbar interaction.
+- R17. E2E coverage must include at least one bottom-growing item that can change
+  height after initial render, such as an image attachment, screenshot, markdown
+  block, or pending indicator.
+- R18. E2E coverage must also prove the escape hatch: after explicit scrollbar
+  interaction moves the user away from the bottom, live appends preserve the reading
+  viewport until the user returns to the bottom or sends a new prompt.
+
+## Success Criteria
+
+- After the user sends a prompt, the transcript remains scrolled to the absolute
+  bottom through thinking, streaming, final replies, and image-height changes.
+- The latest visible transcript item is never hidden below the viewport while
+  `isGluedToBottom` is true.
+- The screenshot-backed failure case from the desktop E2E run is covered by a
+  regression test that fails before the fix and passes after it.
+- Users can still intentionally read older content by using the transcript scrollbar,
+  and new activity does not pull them away until they return to the bottom or send
+  another prompt.
+
+## Scope Boundaries
+
+- This work does not redesign thread refresh, transcript storage, or app-server
+  event contracts.
+- This work does not require transcript virtualization unless planning discovers
+  that the current DOM list cannot reliably support the required behavior.
+- This work does not add new visible product copy beyond the existing jump-to-latest
+  affordance.
+- This work does not change markdown, image, activity, approval, or pending-input
+  rendering except as needed to make their size changes participate in bottom glue.
+
+## Options Considered
+
+| Option | Fit | Tradeoffs |
+| --- | --- | --- |
+| Local transcript-scroll controller | Best fit | Preserves current renderer structure, keeps dependency surface small, and can encode the stricter "only scrollbar action unglues" rule directly. Requires careful tests around event intent and ResizeObserver/layout changes. |
+| `use-stick-to-bottom` | Plausible fallback | Purpose-built for AI chat, zero dependency, and ResizeObserver-aware. Its default behavior lets user scrolling cancel stickiness, which is broader than the required scrollbar-only unglue rule. |
+| `react-scroll-to-bottom` | Plausible but older fit | Provides sticky state, scroll-to-bottom hooks, and a follow button model. It is built around stickiness/position checks and recurring checks, not this product's stricter explicit-glue state. |
+| `react-virtuoso` | Overpowered for now | Has `followOutput`, bottom-state callbacks, inverse scrolling support, and virtualization. It would be useful if transcript size/performance becomes the primary problem, but it is a larger rewrite than this bug needs. |
+| TanStack Virtual | Poor first step | Excellent low-level virtualization primitives, but bottom-following chat behavior would still need custom glue logic on top. |
+
+## Key Decisions
+
+- Use an explicit bottom-glue state instead of deriving follow behavior solely from
+  current distance from the bottom.
+- Treat prompt send as an explicit user intent to return to the bottom and follow
+  the new turn.
+- Prefer a local transcript-scroll controller for the first fix because the product
+  rule is stricter than the default behavior of the researched packages.
+- Keep the existing "jump to latest" affordance, but make it a regluing action.
+
+## Dependencies / Assumptions
+
+- The browser can distinguish explicit scrollbar interaction well enough for this
+  product requirement, likely by inspecting pointer interaction with the scroll
+  gutter/thumb area during planning.
+- ResizeObserver is available in the Electron renderer and can be used to keep the
+  viewport pinned during bottom content growth.
+- The existing E2E harness can drive programmatic transcript appends and observe
+  `scrollTop`, `scrollHeight`, and visible transcript content deterministically.
+
+## Sources
+
+- React Virtuoso documents `followOutput`, `atBottomStateChange`, and bottom
+  thresholds for list bottom-following:
+  https://virtuoso.dev/react-virtuoso/api-reference/virtuoso/
+- `use-stick-to-bottom` documents an AI-chat-oriented hook with ResizeObserver-based
+  content resize handling and user-scroll cancellation:
+  https://github.com/stackblitz-labs/use-stick-to-bottom
+- `react-scroll-to-bottom` documents sticky state, scroll-to-bottom hooks, and a
+  `scroller` callback that runs when sticky content changes size:
+  https://app.unpkg.com/react-scroll-to-bottom-updated%404.2.1-main.b8336f2/files/README.md
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+None.
+
+### Deferred to Planning
+
+- [Affects R2][Technical] What exact DOM event test should classify "user clicked
+  the scrollbar" in Electron across overlay and non-overlay scrollbar styles?
+- [Affects R9][Technical] Should bottom pinning use direct `scrollTop =
+  scrollHeight`, a bottom sentinel with `scrollIntoView`, ResizeObserver, or a
+  combination?
+- [Affects R16][Technical] Which existing replay fixture should be extended, or
+  should a new focused replay fixture be added for send-plus-live-bottom-following?
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-04-30-001-fix-transcript-bottom-glue-plan.md
+++ b/docs/plans/2026-04-30-001-fix-transcript-bottom-glue-plan.md
@@ -1,0 +1,399 @@
+---
+title: fix: Make transcript bottom glue explicit
+type: fix
+status: active
+date: 2026-04-30
+origin: docs/brainstorms/2026-04-30-transcript-bottom-glue-requirements.md
+---
+
+# fix: Make transcript bottom glue explicit
+
+## Overview
+
+Replace the transcript's implicit "near bottom" follow behavior with an explicit
+bottom-glue state. When a thread is glued, the transcript should keep chasing the
+absolute bottom through prompt sends, streamed replies, thinking indicators, and
+content height changes. The only action that unglues the transcript is explicit
+scrollbar interaction that moves the user away from the bottom.
+
+## Problem Frame
+
+The current transcript scroll logic can stop following live content after a user
+sends a prompt even though the user did not intentionally scroll away from the
+bottom. `docs/brainstorms/2026-04-30-transcript-bottom-glue-requirements.md`
+sharpens the earlier refresh-model requirements into a concrete state rule:
+threads are born glued, prompt send reglues, bottom content growth stays pinned,
+and true-to-false happens only through scrollbar interaction.
+
+## Requirements Trace
+
+- R1-R5. Add explicit `isGluedToBottom` behavior and make the existing
+  jump-to-latest control reglue the transcript.
+- R6-R8. Treat prompt send as an explicit reglue event, including sends with image
+  attachments and queued/follow-up prompts.
+- R9-R13. Keep following appended and bottom-growing content while glued; preserve
+  reader position while intentionally unglued; preserve older-page prepend
+  anchoring.
+- R14-R15. Give bottom-following one transcript-level owner so callers only signal
+  high-level intent.
+- R16-R18. Add regression coverage for send-plus-live-following, bottom content
+  growth, and explicit scrollbar escape behavior.
+
+## Scope Boundaries
+
+- Do not redesign thread refresh, transcript storage, app-server events, markdown
+  rendering, image rendering, or approval/user-input rendering.
+- Do not add transcript virtualization in this fix.
+- Do not add a new scroll-management dependency unless implementation proves the
+  local controller cannot satisfy the requirements.
+- Do not add new user-facing copy beyond preserving the existing jump-to-latest
+  affordance.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+  currently owns scroll refs, saved viewport snapshots, bottom detection, prepend
+  anchoring, pending transcript item insertion, and the jump-to-latest button.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` passes the
+  selected thread key, restored viewport, pending items, and composer callbacks into
+  `TranscriptList`.
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` owns user send
+  lifecycle and already calls into thread state for optimistic user messages.
+- `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts` stores the selected
+  thread viewport as renderer-local session state.
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+  already has scroll anchoring tests for initial bottom open, saved viewport
+  restore, append while bottom-pinned, and append while reading older content.
+- `apps/desktop/e2e/live-agent-messages.spec.ts` reproduces the live replay shape
+  shown in the screenshot: prompt send, thinking status, multiple live replies, and
+  final turn completion.
+- `apps/desktop/e2e/thread-open-scroll-stability.spec.ts` and
+  `apps/desktop/e2e/thread-scroll-restore.spec.ts` cover long-transcript opening
+  and saved viewport stability.
+
+### Institutional Learnings
+
+- No matching `docs/solutions/` entry was found for transcript scroll or viewport
+  behavior.
+
+### External References
+
+- React Virtuoso supports `followOutput` and bottom-state callbacks, but adopting it
+  would be a larger list rewrite than this bug needs.
+- `use-stick-to-bottom` is purpose-built for AI chat and ResizeObserver-based
+  bottom sticking, but its default cancellation behavior treats general user
+  scrolling as unglue intent, which is broader than this product requirement.
+- `react-scroll-to-bottom` exposes sticky state and scroll-to-bottom hooks, but it
+  is also position/stickiness driven rather than the explicit scrollbar-only intent
+  rule required here.
+
+## Key Technical Decisions
+
+- Keep the fix local to the transcript surface: implement a small transcript-scroll
+  controller or hook used by `TranscriptList` instead of adopting a new list
+  package.
+- Persist glue state with the saved viewport state so switching threads preserves
+  the difference between "glued, restore to bottom" and "intentionally unglued,
+  restore this older viewport."
+- Detect unglue intent from pointer interaction with the transcript scrollbar
+  region, then confirm the resulting scroll position is away from the bottom.
+  Wheel, trackpad, keyboard, programmatic scroll, and layout-induced scroll events
+  should update visibility affordances but not flip glue from true to false.
+- Use a bottom content observer, likely `ResizeObserver` on an inner content wrapper
+  plus existing layout effects, so streamed text, image loading, markdown wrapping,
+  and pending-status growth keep pinned while glued without every caller issuing
+  scroll commands.
+- Introduce one high-level "reglue now" signal for user-send events. The composer or
+  thread view should trigger that signal when the user starts a turn, but low-level
+  live update handling stays inside the transcript controller.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this use a third-party scroll widget? No. The local controller is a better
+  first fix because the required unglue rule is stricter than the researched
+  packages' default user-scroll cancellation behavior.
+- Should prompt send rely on the next appended optimistic message to scroll? No.
+  Sending must be an explicit reglue event because it must override a previously
+  unglued viewport.
+- Should older-page prepend anchoring be replaced? No. It already has targeted
+  coverage and should be preserved as an invariant.
+
+### Deferred to Implementation
+
+- The exact scrollbar-hit test for Electron overlay and non-overlay scrollbars:
+  implementation should validate the coordinate heuristic against the renderer
+  behavior and adjust without changing the product rule.
+- The exact shape of the controller API: implementation may choose a local hook,
+  helper object, or small component-local reducer as long as `TranscriptList`
+  remains the owner.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    A["Thread transcript mounts"] --> B["Glue state starts true"]
+    B --> C{"User sends prompt?"}
+    C -- "Yes" --> D["Reglue and scroll absolute bottom"]
+    C -- "No" --> E{"Transcript content appended or resized?"}
+    D --> E
+    E -- "Glued" --> F["Scroll absolute bottom after layout"]
+    E -- "Unglued" --> G["Preserve reading viewport"]
+    F --> H{"Pointer used scrollbar and moved away?"}
+    G --> I{"Bottom comes back into view?"}
+    H -- "Yes" --> J["Set glued false"]
+    H -- "No" --> E
+    I -- "Yes" --> K["Set glued true"]
+    I -- "No" --> G
+    J --> G
+    K --> E
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Lock the failure down with focused scroll tests**
+
+**Goal:** Add tests that express the stricter bottom-glue contract before changing
+implementation behavior.
+
+**Requirements:** R1-R5, R9-R13, R16-R18
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Modify or create: `apps/desktop/e2e/live-agent-messages.spec.ts`
+- Optional create: `apps/desktop/e2e/thread-bottom-glue.spec.ts`
+
+**Approach:**
+- Extend the existing unit scroll tests to distinguish "scroll position changed"
+  from "user explicitly unglued with the scrollbar."
+- Add a unit test where non-scrollbar scroll or layout growth moves the element
+  away from bottom, then a live append/resize still snaps back because glue stayed
+  true.
+- Add a unit test where a scrollbar pointer interaction moves away from bottom,
+  then live append preserves the older viewport and shows jump-to-latest.
+- Add or extend E2E coverage around the live-agent replay so each reply advance
+  verifies the transcript is still at the absolute bottom.
+
+**Execution note:** Start test-first. At least one test should fail against the
+current implementation before Unit 2 changes behavior.
+
+**Patterns to follow:**
+- Scroll sampling helpers in `apps/desktop/e2e/thread-open-scroll-stability.spec.ts`.
+- Replay advancement pattern in `apps/desktop/e2e/live-agent-messages.spec.ts`.
+- Mocked scroll metrics in
+  `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`.
+
+**Test scenarios:**
+- Happy path: newly opened transcript starts at bottom and has no jump-to-latest
+  button.
+- Happy path: after send plus multiple live reply advances, `scrollHeight -
+  clientHeight - scrollTop` remains within the bottom threshold.
+- Edge case: changing `scrollTop` and dispatching a generic scroll event while glued
+  does not unglue; the next append returns to the bottom.
+- Edge case: pointer interaction in the scrollbar region followed by a scroll away
+  unglues; the next append preserves `scrollTop`.
+- Edge case: bottom content height increases after initial render while glued; the
+  viewport moves to the new absolute bottom.
+
+**Verification:**
+- The new unit or E2E test suite demonstrates the current regression before the
+  implementation change and describes the desired behavior without relying on
+  arbitrary timeouts.
+
+- [ ] **Unit 2: Add explicit bottom-glue ownership to the transcript list**
+
+**Goal:** Replace implicit bottom-following with a transcript-owned glue state and
+content growth observer.
+
+**Requirements:** R1-R5, R9-R15, R18
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css` only if an inner content
+  wrapper needs styling to preserve current layout.
+
+**Approach:**
+- Introduce an explicit glued state/ref initialized to true per thread.
+- Separate "is content below visible?" from "is the transcript glued?" The former
+  drives the jump button; the latter drives whether appends/resizes force bottom.
+- Add a content wrapper or equivalent observable bottom surface so resize events
+  caused by image load, markdown layout, or streaming text can request bottom
+  pinning while glued.
+- Preserve existing prepend anchoring by handling older-message prepends before
+  bottom-follow decisions.
+- Ensure the jump-to-latest button scrolls to bottom and sets glue true.
+- Treat generic scroll events as metric updates only. They may set glue true when
+  the bottom comes into view, but they do not set glue false unless a prior
+  scrollbar pointer interaction marked that scroll as explicit unglue intent.
+
+**Patterns to follow:**
+- Existing `captureSnapshot`, saved viewport, and prepend anchoring flow in
+  `TranscriptList.tsx`.
+- Current tests around `hasContentBelow` and smooth scrolling only for explicit
+  jump-to-latest.
+
+**Test scenarios:**
+- Happy path: append and resize while glued update `scrollTop` to the latest
+  `scrollHeight`.
+- Happy path: jump-to-latest smooth-scrolls and marks the transcript glued.
+- Edge case: prepending older messages preserves scroll position and does not
+  accidentally force bottom when unglued.
+- Edge case: thread switch restores a glued thread to bottom and restores an
+  intentionally unglued thread to its saved older viewport.
+- Edge case: pending request, pending user input, pending activity, and pending
+  assistant message all participate in item count/growth tracking.
+
+**Verification:**
+- Existing transcript-list tests still pass, and the new bottom-glue tests pass
+  without weakening the older viewport preservation assertions.
+
+- [ ] **Unit 3: Wire prompt send to reglue without scattering scroll calls**
+
+**Goal:** Make user send explicitly reglue and scroll bottom before live reply
+content begins, including prompts with image attachments.
+
+**Requirements:** R6-R8, R14-R15
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Modify: `apps/desktop/src/renderer/src/App.tsx` if the reglue signal belongs in
+  session state props.
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+
+**Approach:**
+- Add a single high-level reglue signal, such as a monotonically increasing request
+  key or explicit viewport state update, that `TranscriptList` consumes.
+- Trigger that signal from the user-send path when a turn starts or when the
+  optimistic user message is added.
+- Keep live event handlers and pending item rendering free of direct scroll calls;
+  they should rely on the transcript controller once glue is true.
+- Extend renderer-local viewport state to carry glue intent if needed for thread
+  switching and reselect behavior.
+
+**Patterns to follow:**
+- Existing composer callbacks for optimistic messages and pending status updates.
+- `useThreadSessionState.setViewport` as the current renderer-session persistence
+  point for transcript viewport state.
+
+**Test scenarios:**
+- Happy path: sending a prompt while already at bottom keeps the prompt visible and
+  follows the pending "Thinking" state.
+- Happy path: sending a prompt while intentionally unglued reglues and follows the
+  new turn.
+- Edge case: prompt with image attachment remains fully visible after send and does
+  not require a second caller-level scroll after image sizing.
+- Edge case: queued/follow-up send reglues the transcript before its assistant reply
+  grows.
+
+**Verification:**
+- User-send behavior works through a single reglue signal, not repeated low-level
+  scroll calls spread across composer, thread view, and live event handlers.
+
+- [ ] **Unit 4: Prove the live desktop regression end to end**
+
+**Goal:** Verify the fixed behavior in the Electron replay harness against the
+actual send/live-update flow that exposed the bug.
+
+**Requirements:** R6-R18
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `apps/desktop/e2e/live-agent-messages.spec.ts`
+- Optional create: `apps/desktop/e2e/thread-bottom-glue.spec.ts`
+- Optional modify: `apps/desktop/e2e/fixtures/live-agent-messages/replay.fixture.json`
+- Optional create: `apps/desktop/e2e/fixtures/thread-bottom-glue/replay.fixture.json`
+
+**Approach:**
+- Prefer extending `live-agent-messages.spec.ts` if it can assert bottom position
+  without making the existing transcript-order test brittle.
+- If the spec becomes too dense, create a focused `thread-bottom-glue.spec.ts` that
+  uses the same replay patterns and keeps assertions only about scroll behavior.
+- Include a bottom-growing visual item in the E2E path where practical. If image
+  loading is too nondeterministic in replay, cover image growth at unit level and
+  use live pending/markdown growth in E2E.
+- Add the explicit scrollbar escape E2E only if Playwright can drive the scrollbar
+  deterministically in Electron. Otherwise keep that path covered in unit tests and
+  document the limitation in the plan notes during implementation.
+
+**Patterns to follow:**
+- `apps/desktop/e2e/thread-open-scroll-stability.spec.ts` for stable scroll metric
+  sampling.
+- `apps/desktop/e2e/live-agent-messages.spec.ts` for replay turn advancement.
+- `apps/desktop/e2e/thread-image-fit.spec.ts` for transcript image rendering setup.
+
+**Test scenarios:**
+- Integration: send prompt, see optimistic user prompt at bottom, see Thinking at
+  bottom, advance several assistant/tool steps, and verify bottom distance remains
+  within threshold after each step.
+- Integration: final turn completion collapses work activity as today without
+  leaving the final answer below the viewport.
+- Integration: explicit jump-to-latest after unglue returns to bottom and resumes
+  following.
+- Integration: if supported by Playwright, scrollbar drag away from bottom prevents
+  automatic pull-down on the next live append.
+
+**Verification:**
+- Targeted desktop E2E passes and would have failed against the screenshot failure
+  mode.
+
+## System-Wide Impact
+
+- **Interaction graph:** Composer sends and live thread updates become high-level
+  inputs to a transcript-owned scroll controller. They should not gain direct
+  ownership of bottom-following.
+- **Error propagation:** Scroll controller failures should degrade to existing
+  visible transcript behavior, not block prompt sending or live event rendering.
+- **State lifecycle risks:** Saved viewport state must distinguish glued and
+  intentionally unglued threads so thread reselect does not erase user reading
+  position or fail to restore bottom-following.
+- **API surface parity:** This is renderer-local; no app-server or shared backend
+  contract changes are expected.
+- **Integration coverage:** Unit tests prove state transitions; Electron E2E proves
+  the real replay/send/live path.
+- **Unchanged invariants:** Older-message prepend anchoring, thread cache behavior,
+  pending approval rendering, pending user input rendering, and transcript item
+  ordering remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Scrollbar hit testing differs across macOS overlay scrollbar settings. | Keep the product rule stable, isolate the heuristic in one helper, and cover what can be simulated in unit tests plus Playwright where deterministic. |
+| ResizeObserver timing causes flaky tests. | Keep unit tests deterministic by exposing or mocking observer callbacks; in E2E, assert eventual bottom position with existing polling helpers. |
+| Reglue signal gets coupled to composer internals. | Route send intent through one prop/session signal and keep low-level scrolling inside `TranscriptList`. |
+| Fix regresses older viewport restore. | Preserve and extend existing restore tests before changing behavior. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation changes are required.
+- Keep the requirements doc and this plan linked in the PR body so future scroll
+  regressions have an explicit product contract to reference.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-30-transcript-bottom-glue-requirements.md`
+- Prior related requirements: `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
+- Related tests: `apps/desktop/e2e/live-agent-messages.spec.ts`
+- External docs: https://virtuoso.dev/react-virtuoso/api-reference/virtuoso/
+- External docs: https://github.com/stackblitz-labs/use-stick-to-bottom
+- External docs: https://app.unpkg.com/react-scroll-to-bottom-updated%404.2.1-main.b8336f2/files/README.md

--- a/docs/plans/2026-04-30-001-fix-transcript-bottom-glue-plan.md
+++ b/docs/plans/2026-04-30-001-fix-transcript-bottom-glue-plan.md
@@ -156,7 +156,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Lock the failure down with focused scroll tests**
+- [x] **Unit 1: Lock the failure down with focused scroll tests**
 
 **Goal:** Add tests that express the stricter bottom-glue contract before changing
 implementation behavior.
@@ -207,7 +207,7 @@ current implementation before Unit 2 changes behavior.
   implementation change and describes the desired behavior without relying on
   arbitrary timeouts.
 
-- [ ] **Unit 2: Add explicit bottom-glue ownership to the transcript list**
+- [x] **Unit 2: Add explicit bottom-glue ownership to the transcript list**
 
 **Goal:** Replace implicit bottom-following with a transcript-owned glue state and
 content growth observer.
@@ -257,7 +257,7 @@ content growth observer.
 - Existing transcript-list tests still pass, and the new bottom-glue tests pass
   without weakening the older viewport preservation assertions.
 
-- [ ] **Unit 3: Wire prompt send to reglue without scattering scroll calls**
+- [x] **Unit 3: Wire prompt send to reglue without scattering scroll calls**
 
 **Goal:** Make user send explicitly reglue and scroll bottom before live reply
 content begins, including prompts with image attachments.
@@ -304,7 +304,7 @@ content begins, including prompts with image attachments.
 - User-send behavior works through a single reglue signal, not repeated low-level
   scroll calls spread across composer, thread view, and live event handlers.
 
-- [ ] **Unit 4: Prove the live desktop regression end to end**
+- [x] **Unit 4: Prove the live desktop regression end to end**
 
 **Goal:** Verify the fixed behavior in the Electron replay harness against the
 actual send/live-update flow that exposed the bug.


### PR DESCRIPTION
## Summary

This fixes the desktop transcript bottom-following bug by making bottom glue an explicit transcript state instead of deriving it only from current scroll position.

I added a focused requirements doc and implementation plan, then implemented the fix so:

- new transcripts start glued to the bottom
- sending a prompt reglues the transcript and scrolls to the absolute bottom
- live assistant output, thinking status, and content growth keep following the bottom while glued
- generic scroll/layout events do not unglue the transcript
- explicit scrollbar interaction can unglue and preserve the older reading viewport
- jump-to-latest reglues the transcript

## Implementation Notes

The main behavior lives in `TranscriptList.tsx`. It now separates:

- whether more content is below the viewport, which drives the jump button
- whether the transcript is glued to bottom, which drives auto-follow behavior

`Composer` sends one high-level `onBeforeSendTurn` signal through `ThreadView` so prompt send reglues the transcript without scattering scroll calls across live update handlers. Viewport session state now carries the glue bit so switching threads preserves the difference between an intentionally unglued viewport and a glued transcript that should restore to bottom.

## Verification

I verified this locally with:

- `pnpm test -- transcript-list.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop test:e2e -- live-agent-messages.spec.ts thread-open-scroll-stability.spec.ts thread-scroll-restore.spec.ts`

I also confirmed the two commits are signed.