### PR TITLE
fix(desktop): restore context rail path tooltips

### DIFF
--- a/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
+++ b/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("shows linked directory path tooltips in the context rail", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/context-rail-linked-directory-tooltips/replay.fixture.json"
+    ),
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Linked directory tooltip thread/i })
+      .first()
+      .click();
+    await app.window.getByRole("button", { name: "Open context rail" }).click();
+    const contextRail = app.window.getByRole("complementary", {
+      name: "Thread context",
+    });
+
+    await contextRail.getByLabel("Path for PwrAgnt", { exact: true }).hover();
+    await expectVisibleTooltip(app.window, "/repo/PwrAgnt");
+
+    await contextRail
+      .getByRole("button", { name: "Copy path for PwrAgnt", exact: true })
+      .hover();
+    await expectVisibleTooltip(
+      app.window,
+      "/repo/PwrAgnt\nClick to copy to clipboard"
+    );
+
+    await contextRail.getByLabel("Path for worktree PwrAgnt", { exact: true }).hover();
+    await expectVisibleTooltip(
+      app.window,
+      "/repo/PwrAgnt/.worktrees/feature-context-tooltips"
+    );
+
+    await contextRail
+      .getByRole("button", { name: "Copy path for worktree PwrAgnt", exact: true })
+      .hover();
+    await expectVisibleTooltip(
+      app.window,
+      "/repo/PwrAgnt/.worktrees/feature-context-tooltips\nClick to copy to clipboard"
+    );
+
+    await contextRail.getByLabel("Path for local LocalCheckout", { exact: true }).hover();
+    await expectVisibleTooltip(app.window, "/repo/PwrAgnt");
+
+    await contextRail
+      .getByRole("button", { name: "Copy path for local LocalCheckout", exact: true })
+      .hover();
+    await expectVisibleTooltip(
+      app.window,
+      "/repo/PwrAgnt\nClick to copy to clipboard"
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+async function expectVisibleTooltip(page: Page, text: string) {
+  const tooltip = page.getByRole("tooltip");
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toHaveText(text);
+  await expect
+    .poll(async () =>
+      await tooltip.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          inBody: element.parentElement === document.body,
+          hasSize: rect.height > 0 && rect.width > 0,
+          visibility: getComputedStyle(element).visibility,
+        };
+      })
+    )
+    .toMatchObject({
+      hasSize: true,
+      inBody: true,
+      visibility: "visible",
+    });
+}

--- a/apps/desktop/e2e/fixtures/context-rail-linked-directory-tooltips/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/context-rail-linked-directory-tooltips/replay.fixture.json
@@ -1,0 +1,88 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "context-rail-linked-directory-tooltips",
+    "threadId": "thread-linked-directory-tooltips"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-linked-directory-tooltips",
+          "title": "Linked directory tooltip thread",
+          "titleSource": "explicit",
+          "summary": "Context rail linked directory tooltip regression",
+          "source": "codex",
+          "executionMode": "default",
+          "gitBranch": "feature/context-tooltips",
+          "linkedDirectories": [
+            {
+              "id": "worktree-dir",
+              "kind": "worktree",
+              "label": "PwrAgnt",
+              "path": "/repo/PwrAgnt",
+              "worktreePath": "/repo/PwrAgnt/.worktrees/feature-context-tooltips"
+            },
+            {
+              "id": "local-dir",
+              "kind": "local",
+              "label": "LocalCheckout",
+              "path": "/repo/PwrAgnt"
+            }
+          ],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "The linked directory tooltip fixture is loaded."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "The linked directory tooltip fixture is loaded."
+          }
+        ],
+        "lastAssistantMessage": "The linked directory tooltip fixture is loaded.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -7,7 +7,9 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type PointerEvent,
+  type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import type {
   BackendSummary,
   NavigationThreadSummary,
@@ -234,10 +236,17 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                           onCopy={handleCopyPath}
                           onShowTooltip={showRailTooltip}
                         />
-                        <span aria-hidden="true" className="context-list__icon">
-                          {directory.kind === "worktree" ? "🔀" : "📁"}
-                        </span>
-                        {directory.label}
+                        <TooltipValue
+                          label={`Path for ${directory.label}`}
+                          value={directory.path}
+                          onBlur={hideRailTooltip}
+                          onShowTooltip={showRailTooltip}
+                        >
+                          <span aria-hidden="true" className="context-list__icon">
+                            {directory.kind === "worktree" ? "🔀" : "📁"}
+                          </span>
+                          {directory.label}
+                        </TooltipValue>
                       </div>
                       <div className="context-list__actions">
                         {canRestore && snapshot ? (
@@ -263,7 +272,16 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                             onCopy={handleCopyPath}
                             onShowTooltip={showRailTooltip}
                           />
-                          {snapshot?.state === "archived" ? "archived" : directory.kind}
+                          <TooltipValue
+                            label={`Path for ${
+                              snapshot?.state === "archived" ? "archived" : directory.kind
+                            } ${directory.label}`}
+                            value={worktreePath}
+                            onBlur={hideRailTooltip}
+                            onShowTooltip={showRailTooltip}
+                          >
+                            {snapshot?.state === "archived" ? "archived" : directory.kind}
+                          </TooltipValue>
                         </span>
                       </div>
                     </li>
@@ -282,10 +300,17 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         onCopy={handleCopyPath}
                         onShowTooltip={showRailTooltip}
                       />
-                      <span aria-hidden="true" className="context-list__icon">
-                        📁
-                      </span>
-                      {pathBaseName(props.thread.projectKey)}
+                      <TooltipValue
+                        label="Recorded working directory path"
+                        value={props.thread.projectKey!}
+                        onBlur={hideRailTooltip}
+                        onShowTooltip={showRailTooltip}
+                      >
+                        <span aria-hidden="true" className="context-list__icon">
+                          📁
+                        </span>
+                        {pathBaseName(props.thread.projectKey)}
+                      </TooltipValue>
                     </div>
                     <span className="context-list__meta">
                       <CopyValueButton
@@ -295,7 +320,14 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         onCopy={handleCopyPath}
                         onShowTooltip={showRailTooltip}
                       />
-                      missing
+                      <TooltipValue
+                        label="Missing working directory path"
+                        value={props.thread.projectKey!}
+                        onBlur={hideRailTooltip}
+                        onShowTooltip={showRailTooltip}
+                      >
+                        missing
+                      </TooltipValue>
                     </span>
                   </li>
                 </ul>
@@ -481,31 +513,37 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         </div>
       ) : null}
 
-      {tooltip ? (
-        <div
-          ref={tooltipRef}
-          className="context-rail__tooltip"
-          role="tooltip"
-          style={{
-            left: tooltip.left,
-            top: tooltip.top,
-            visibility: tooltip.left === undefined ? "hidden" : undefined,
-          }}
-        >
-          {tooltip.text}
-        </div>
-      ) : null}
+      {tooltip && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={tooltipRef}
+              className="context-rail__tooltip"
+              role="tooltip"
+              style={{
+                left: tooltip.left,
+                top: tooltip.top,
+                visibility: tooltip.left === undefined ? "hidden" : undefined,
+              }}
+            >
+              {tooltip.text}
+            </div>,
+            document.body
+          )
+        : null}
     </aside>
   );
 
   function showRailTooltip(
     event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
     path: string,
-    maxLength?: number
+    maxLength?: number,
+    copyHint = true
   ): void {
     const rect = event.currentTarget.getBoundingClientRect();
     setTooltip({
-      text: formatCopyTooltip(path, maxLength),
+      text: copyHint
+        ? formatCopyTooltip(path, maxLength)
+        : formatTooltipValue(path, maxLength),
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
       targetTop: rect.top,
@@ -529,7 +567,8 @@ function CopyValueButton(props: {
   onShowTooltip: (
     event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
     value: string,
-    maxLength?: number
+    maxLength?: number,
+    copyHint?: boolean
   ) => void;
   value: string;
 }) {
@@ -555,6 +594,33 @@ function CopyValueButton(props: {
   );
 }
 
+function TooltipValue(props: {
+  children: ReactNode;
+  label: string;
+  onBlur: () => void;
+  onShowTooltip: (
+    event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
+    value: string,
+    maxLength?: number,
+    copyHint?: boolean
+  ) => void;
+  value: string;
+}) {
+  return (
+    <span
+      aria-label={props.label}
+      className="context-tooltip-value"
+      tabIndex={0}
+      onBlur={props.onBlur}
+      onFocus={(event) => props.onShowTooltip(event, props.value, undefined, false)}
+      onMouseEnter={(event) => props.onShowTooltip(event, props.value, undefined, false)}
+      onMouseLeave={props.onBlur}
+    >
+      {props.children}
+    </span>
+  );
+}
+
 async function handleCopyPath(
   event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
   path: string
@@ -562,6 +628,21 @@ async function handleCopyPath(
   event.preventDefault();
   event.stopPropagation();
   await copyText(path);
+}
+
+function formatTooltipValue(value: string, maxLength = 72): string {
+  return elideMiddle(value, maxLength);
+}
+
+function elideMiddle(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const visible = Math.max(8, maxLength - 1);
+  const left = Math.ceil(visible / 2);
+  const right = Math.floor(visible / 2);
+  return `${text.slice(0, left)}…${text.slice(-right)}`;
 }
 
 function formatTimestamp(timestamp: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragnt/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
@@ -79,6 +79,52 @@ const baseBackend: BackendSummary = {
 };
 
 describe("ThreadContextPanel", () => {
+  it("shows path tooltips on linked directory labels and kind badges", () => {
+    render(
+      <ThreadContextPanel
+        backends={[baseBackend]}
+        pinned
+        thread={{
+          ...baseThread,
+          linkedDirectories: [
+            {
+              id: "worktree-dir",
+              kind: "worktree",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/github/PwrAgnt",
+              worktreePath:
+                "/Users/huntharo/github/PwrAgnt/.worktrees/launchpad-pwragnt-main-molpnvyk",
+            },
+            {
+              id: "local-dir",
+              kind: "local",
+              label: "LocalOnly",
+              path: "/Users/huntharo/github/PwrAgnt",
+            },
+          ],
+        }}
+      />
+    );
+
+    fireEvent.mouseEnter(screen.getByLabelText("Path for PwrAgnt"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "/Users/huntharo/github/PwrAgnt"
+    );
+
+    fireEvent.mouseLeave(screen.getByLabelText("Path for PwrAgnt"));
+    fireEvent.mouseEnter(screen.getByLabelText("Path for worktree PwrAgnt"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("/Users/huntharo/github");
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "launchpad-pwragnt-main-molpnvyk"
+    );
+
+    fireEvent.mouseLeave(screen.getByLabelText("Path for worktree PwrAgnt"));
+    fireEvent.mouseEnter(screen.getByLabelText("Path for local LocalOnly"));
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "/Users/huntharo/github/PwrAgnt"
+    );
+  });
+
   it("hides unused Spark rate limits on non-Spark threads", () => {
     render(<ThreadContextPanel backends={[baseBackend]} pinned thread={baseThread} />);
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2928,6 +2928,20 @@ textarea {
   text-align: left;
 }
 
+.context-tooltip-value {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  cursor: default;
+}
+
+.context-tooltip-value:focus-visible {
+  border-radius: 5px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .context-list__icon {
   flex: 0 0 auto;
   line-height: 1;


### PR DESCRIPTION
## Summary

I restored the linked-directory path tooltips in the thread context rail. The previous context-rail refactor moved tooltip behavior onto explicit copy buttons, but the visible directory label and the `worktree` / `local` values were no longer tooltip targets, and we did not have E2E coverage proving the clipboard-icon tooltips worked either.

## Changes

- Added a focused `TooltipValue` affordance for context-rail linked directory labels and `worktree` / `local` metadata values.
- Kept the explicit clipboard buttons and their copy-oriented tooltip text.
- Rendered the measured context-rail tooltip through a `document.body` portal so it paints outside the transformed/clipped rail container.
- Added renderer coverage for label and kind badge tooltip rendering.
- Added a replay-backed Electron E2E fixture/spec that verifies both the visible label/meta tooltips and the clipboard icon tooltips in the actual context rail.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop test:e2e context-rail-linked-directory-tooltips.spec.ts`
