### PR TITLE
fix(desktop): restore transcript message alignment

### DIFF
--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -168,3 +168,70 @@ test("preserves live assistant commentary messages, exploration activity, and fi
     await app.close();
   }
 });
+
+test("does not pull the reader back to the bottom while assistant output streams", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/live-agent-messages/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 900,
+      height: 520,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Telegram brainstorm replay/i })
+      .first()
+      .click();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const list = app.window.locator(".transcript-list__items");
+
+    await app.window
+      .getByLabel("Reply")
+      .fill("What would it take to add Telegram support?");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "tool-search-started-1" });
+    await app.advance({ stepId: "assistant-message-1a" });
+    await app.advance({ stepId: "assistant-message-1b" });
+    await app.advance({ stepId: "tool-search-completed-1" });
+    await app.advance({ stepId: "tool-command-started-1" });
+    await app.advance({ stepId: "assistant-message-2" });
+    await app.advance({ stepId: "tool-command-completed-1" });
+    await app.advance({ stepId: "assistant-message-3" });
+
+    await expect(transcript).toContainText("The existing product direction is thread-first");
+
+    const beforeScroll = await list.evaluate((element) => {
+      const maxScrollTop = Math.max(element.scrollHeight - element.clientHeight, 0);
+      if (maxScrollTop <= 80) {
+        throw new Error("Expected streamed transcript to overflow before scroll-away");
+      }
+
+      return Math.round(element.scrollTop);
+    });
+    await list.hover();
+    await app.window.mouse.wheel(0, -320);
+
+    await expect
+      .poll(async () => await list.evaluate((element) => Math.round(element.scrollTop)))
+      .toBeLessThan(beforeScroll);
+    const savedScrollTop = await list.evaluate((element) => Math.round(element.scrollTop));
+
+    await app.advance({ stepId: "assistant-message-4" });
+    await app.advance({ stepId: "assistant-message-5" });
+    await app.advance({ stepId: "assistant-message-6" });
+
+    await expect(transcript).toContainText("I’m ready to turn that into requirements");
+    await expect
+      .poll(async () => await list.evaluate((element) => Math.round(element.scrollTop)))
+      .toBe(savedScrollTop);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/transcript-message-alignment.spec.ts
+++ b/apps/desktop/e2e/transcript-message-alignment.spec.ts
@@ -1,0 +1,91 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Locator } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+async function expectMessageDocked(params: {
+  message: Locator;
+  side: "left" | "right";
+}) {
+  await expect(params.message).toBeVisible();
+
+  await expect
+    .poll(async () =>
+      await params.message.evaluate((messageElement, side) => {
+        const listElement = messageElement.closest(".transcript-list__items");
+        if (!listElement) {
+          throw new Error("Expected transcript message inside transcript list");
+        }
+
+        const listRect = listElement.getBoundingClientRect();
+        const messageRect = messageElement.getBoundingClientRect();
+
+        const leftGap = Math.round(messageRect.left - listRect.left);
+        const rightGap = Math.round(listRect.right - messageRect.right);
+
+        return side === "left" ? leftGap < rightGap : rightGap < leftGap;
+      }, params.side)
+    )
+    .toBe(true);
+}
+
+test("visually docks user messages right and assistant messages left", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/live-agent-messages/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1440,
+      height: 900,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Telegram brainstorm replay/i })
+      .first()
+      .click();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const assistantMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Ready to brainstorm Telegram support." })
+      .first();
+
+    await expectMessageDocked({
+      message: assistantMessage,
+      side: "left",
+    });
+
+    await app.window
+      .getByLabel("Reply")
+      .fill("What would it take to add Telegram support?");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    const userMessage = transcript
+      .locator(".transcript-message--user")
+      .filter({ hasText: "What would it take to add Telegram support?" })
+      .first();
+
+    await expectMessageDocked({
+      message: userMessage,
+      side: "right",
+    });
+
+    const alignment = {
+      assistantLeft: await assistantMessage.evaluate((message) =>
+        Math.round(message.getBoundingClientRect().left)
+      ),
+      userLeft: await userMessage.evaluate((message) =>
+        Math.round(message.getBoundingClientRect().left)
+      ),
+    };
+
+    expect(alignment.userLeft).toBeGreaterThan(alignment.assistantLeft);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -5,7 +5,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type PointerEvent as ReactPointerEvent
 } from "react";
 import type {
   AppServerPendingRequestNotification,
@@ -83,7 +82,6 @@ type ScrollSnapshot = {
 };
 
 const BOTTOM_THRESHOLD_PX = 24;
-const SCROLLBAR_HIT_SLOP_PX = 16;
 type ScrollBottomMode = "instant" | "smooth";
 
 function isAssistantFinalMessage(entry: AppServerThreadEntry): boolean {
@@ -271,9 +269,9 @@ export function TranscriptList(props: TranscriptListProps) {
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const snapshotRef = useRef<ScrollSnapshot | undefined>(undefined);
   const savedViewportsRef = useRef(new Map<string, TranscriptViewport>());
+  const appliedReglueRequestKeyRef = useRef(0);
   const shouldScrollToBottomRef = useRef(true);
   const isGluedToBottomRef = useRef(true);
-  const pendingScrollbarUnglueRef = useRef(false);
   const [hasContentBelow, setHasContentBelow] = useState(false);
   const [expandedCommentaryGroupIds, setExpandedCommentaryGroupIds] = useState(
     () => new Set<string>()
@@ -409,10 +407,8 @@ export function TranscriptList(props: TranscriptListProps) {
     const isAtBottom = Boolean(snapshot && snapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX);
     if (isAtBottom) {
       isGluedToBottomRef.current = true;
-      pendingScrollbarUnglueRef.current = false;
-    } else if (pendingScrollbarUnglueRef.current) {
+    } else {
       isGluedToBottomRef.current = false;
-      pendingScrollbarUnglueRef.current = false;
     }
     setHasContentBelow(Boolean(snapshot && !isAtBottom));
     if (snapshot?.threadId) {
@@ -440,29 +436,12 @@ export function TranscriptList(props: TranscriptListProps) {
     }
 
     isGluedToBottomRef.current = true;
-    pendingScrollbarUnglueRef.current = false;
     syncScrollState();
   }, [syncScrollState]);
 
-  const notePotentialScrollbarUnglue = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const container = scrollContainerRef.current;
-      if (!container || container.scrollHeight <= container.clientHeight) {
-        pendingScrollbarUnglueRef.current = false;
-        return;
-      }
-
-      const rect = container.getBoundingClientRect();
-      const distanceFromRight = rect.right - event.clientX;
-      const gutterWidth = Math.max(container.offsetWidth - container.clientWidth, 0);
-      const isInScrollbarGutter =
-        gutterWidth > 0
-          ? event.clientX >= rect.right - gutterWidth
-          : distanceFromRight >= 0 && distanceFromRight <= SCROLLBAR_HIT_SLOP_PX;
-      pendingScrollbarUnglueRef.current = isInScrollbarGutter;
-    },
-    []
-  );
+  const disableBottomGlue = useCallback(() => {
+    isGluedToBottomRef.current = false;
+  }, []);
 
   useEffect(() => {
     if (props.loading && props.entries.length === 0) {
@@ -474,7 +453,11 @@ export function TranscriptList(props: TranscriptListProps) {
     if (typeof props.reglueRequestKey !== "number" || props.reglueRequestKey <= 0) {
       return;
     }
+    if (appliedReglueRequestKeyRef.current === props.reglueRequestKey) {
+      return;
+    }
 
+    appliedReglueRequestKeyRef.current = props.reglueRequestKey;
     scrollToBottom("instant");
   }, [props.reglueRequestKey, scrollToBottom]);
 
@@ -495,7 +478,6 @@ export function TranscriptList(props: TranscriptListProps) {
     if (!container || props.entries.length === 0) {
       snapshotRef.current = undefined;
       isGluedToBottomRef.current = true;
-      pendingScrollbarUnglueRef.current = false;
       setHasContentBelow(false);
       return;
     }
@@ -551,7 +533,6 @@ export function TranscriptList(props: TranscriptListProps) {
           scrollToBottom("instant");
         } else {
           isGluedToBottomRef.current = false;
-          pendingScrollbarUnglueRef.current = false;
           container.scrollTop = Math.min(
             Math.max(0, restoredViewport.scrollTop),
             Math.max(container.scrollHeight - container.clientHeight, 0)
@@ -573,9 +554,8 @@ export function TranscriptList(props: TranscriptListProps) {
       shouldScrollToBottomRef.current = false;
       return;
     } else if (
-      (hasAppendedMessages && previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX) ||
-      (hasAppendedMessages && isGluedToBottomRef.current) ||
-      hasGrownWhileFollowingBottom
+      isGluedToBottomRef.current &&
+      (hasAppendedMessages || hasGrownWhileFollowingBottom)
     ) {
       scrollToBottom("instant");
       return;
@@ -649,8 +629,12 @@ export function TranscriptList(props: TranscriptListProps) {
         ref={scrollContainerRef}
         className="transcript-list__items"
         role="list"
+        onWheel={(event) => {
+          if (event.deltaY < 0) {
+            disableBottomGlue();
+          }
+        }}
         onScroll={syncScrollState}
-        onPointerDown={notePotentialScrollbarUnglue}
       >
         <div ref={scrollContentRef} className="transcript-list__content">
           {transcriptRenderItems.map((item) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1284,7 +1284,7 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(72);
   });
 
-  it("restores a generically scrolled glued thread back to the bottom", () => {
+  it("restores a scrolled-away thread to its saved viewport", () => {
     const { rerender } = render(
       <TranscriptList
         entries={[
@@ -1352,7 +1352,7 @@ describe("TranscriptList", () => {
       />
     );
 
-    expect(list.scrollTop).toBe(480);
+    expect(list.scrollTop).toBe(60);
   });
 
   it("does not re-arm auto-scroll while a cached transcript is refreshing", () => {
@@ -1675,7 +1675,7 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(1340);
   });
 
-  it("does not unglue from generic scroll events while following the bottom", () => {
+  it("stops following the bottom as soon as the reader scrolls away", () => {
     const entries = Array.from({ length: 24 }, (_, index) => ({
       type: "message" as const,
       id: `generic-scroll-message-${index + 1}`,
@@ -1720,7 +1720,65 @@ describe("TranscriptList", () => {
       />
     );
 
-    expect(list.scrollTop).toBe(880);
+    expect(list.scrollTop).toBe(120);
+  });
+
+  it("does not pull the reader back down when a streamed assistant message grows after scroll-away", () => {
+    const entries = Array.from({ length: 24 }, (_, index) => ({
+      type: "message" as const,
+      id: `stream-scroll-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Stream scroll transcript message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-scroll-away",
+          role: "assistant",
+          phase: "final",
+          text: "Streaming starts."
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+
+    list.scrollTop = 120;
+    fireEvent.scroll(list);
+
+    scrollHeight = 920;
+    rerender(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-stream-scroll-away",
+          role: "assistant",
+          phase: "final",
+          text: [
+            "Streaming starts.",
+            "More text arrived while the reader was inspecting older transcript content."
+          ].join(" ")
+        }}
+        pendingStatusText="Thinking"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(120);
   });
 
   it("reglues and scrolls to bottom when a send request arrives", () => {
@@ -1778,6 +1836,54 @@ describe("TranscriptList", () => {
     );
 
     expect(list.scrollTop).toBe(840);
+  });
+
+  it("does not reuse a consumed reglue request after the reader scrolls away", () => {
+    const entries = Array.from({ length: 20 }, (_, index) => ({
+      type: "message" as const,
+      id: `consumed-reglue-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Consumed reglue transcript message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        reglueRequestKey={1}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    expect(list.scrollTop).toBe(720);
+
+    list.scrollTop = 120;
+    fireEvent.scroll(list);
+
+    scrollHeight = 920;
+    rerender(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "consumed-reglue-stream",
+          role: "assistant",
+          phase: "final",
+          text: "Streaming should not reuse the old send-time reglue request."
+        }}
+        pendingStatusText="Thinking"
+        reglueRequestKey={1}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(120);
   });
 
   it("keeps the bottom pinned when rendered content grows after layout", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1362,6 +1362,12 @@ textarea {
   padding-bottom: 4px;
 }
 
+.transcript-list__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .transcript-list__scroll-bottom {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
## Summary

- Restore the transcript user/assistant visual split by making the scroll-content wrapper preserve the transcript flex column layout.
- Add a desktop E2E regression that measures rendered message geometry so assistant messages must dock left and user messages must dock right.
- Stop reusing a send-time reglue request during streamed assistant updates after the reader scrolls away.
- Add renderer and desktop E2E coverage that verifies streamed assistant output does not pull a scrolled-away reader back to the bottom.

## Verification

- I verified the new E2E fails before the CSS fix for the intended alignment regression.
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --filter @pwragnt/desktop test:e2e -- transcript-message-alignment.spec.ts`
- `pnpm --filter @pwragnt/desktop test:e2e -- transcript-message-alignment.spec.ts live-agent-messages.spec.ts thread-open-scroll-stability.spec.ts thread-scroll-restore.spec.ts`
- `pnpm --filter @pwragnt/desktop test:e2e -- live-agent-messages.spec.ts thread-open-scroll-stability.spec.ts thread-scroll-restore.spec.ts transcript-message-alignment.spec.ts`
