### PR TITLE
fix(desktop): disambiguate repeated work groups

### DIFF
--- a/apps/desktop/e2e/transcript-activity-order.spec.ts
+++ b/apps/desktop/e2e/transcript-activity-order.spec.ts
@@ -32,7 +32,7 @@ test("tool activity stays in protocol order when transcript work is collapsed", 
     const userIndex = transcriptText.indexOf("Replay the captured order.");
     const firstActivityIndex = transcriptText.indexOf("Worked for 1m 10s");
     const interimIndex = transcriptText.indexOf("Interim answer after the first tool.");
-    const secondActivityIndex = transcriptText.indexOf("Worked for 1m 10s", firstActivityIndex + 1);
+    const secondActivityIndex = transcriptText.indexOf("More work", interimIndex + 1);
     const finalIndex = transcriptText.indexOf("Done.");
 
     expect(userIndex).toBeGreaterThanOrEqual(0);
@@ -46,7 +46,7 @@ test("tool activity stays in protocol order when transcript work is collapsed", 
     await expect(app.window.getByText("Read a.ts (1.2s)")).toBeVisible();
     await expect(app.window.getByText("Read b.ts (2.5s)")).toBeHidden();
 
-    await app.window.getByRole("button", { name: /Worked for 1m 10s/ }).last().click();
+    await app.window.getByRole("button", { name: /More work/ }).click();
     await app.window.getByRole("button", { name: /Explored 1 file/ }).last().click();
     await expect(app.window.getByText("Read b.ts (2.5s)")).toBeVisible();
   } finally {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -285,7 +285,99 @@ describe("buildTranscriptRenderItems", () => {
         id: "work:turn-1:tool-2:complete",
         collapsible: true,
         entries: [secondActivity],
+        label: "More work",
+      },
+    ]);
+  });
+
+  it("does not repeat elapsed labels for review-bounded work in one turn", () => {
+    const turn = completedTurn("turn-review", 74_000);
+    const startedReview = review(
+      "review-start",
+      "Review changes against main",
+      turn
+    );
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Read one file",
+      details: [],
+      turn,
+    };
+    const completedReview = review(
+      "review-complete",
+      "Code review",
+      turn
+    );
+    const secondActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-2",
+      summary: "Read another file",
+      details: [],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [startedReview, firstActivity, completedReview, secondActivity],
+    });
+
+    expect(items).toEqual([
+      { type: "entry", entry: startedReview },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-review:tool-1:complete",
+        collapsible: true,
+        entries: [firstActivity],
+        label: "Worked for 1m 14s",
+      },
+      { type: "entry", entry: completedReview },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-review:tool-2:complete",
+        collapsible: true,
+        entries: [secondActivity],
+        label: "More work",
+      },
+    ]);
+  });
+
+  it("keeps duplicate entry ids from colliding when grouping completed work", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-warning-thread-1",
+      summary: "Warning: first",
+      details: [],
+      turn,
+    };
+    const answer = final("f1", "Interim answer.", turn);
+    const secondActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-warning-thread-1",
+      summary: "Warning: second",
+      details: [],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [firstActivity, answer, secondActivity],
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:live-warning-thread-1:complete",
+        collapsible: true,
+        entries: [firstActivity],
         label: "Worked for 1m 10s",
+      },
+      { type: "entry", entry: answer },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:live-warning-thread-1:complete:1",
+        collapsible: true,
+        entries: [secondActivity],
+        label: "More work",
       },
     ]);
   });
@@ -343,6 +435,20 @@ function final(
     role: "assistant",
     phase: "final",
     text,
+    ...(turn ? { turn } : {}),
+  };
+}
+
+function review(
+  id: string,
+  displayText: string,
+  turn?: AppServerThreadMessageEntry["turn"]
+): AppServerThreadEntry {
+  return {
+    type: "review",
+    id,
+    displayText,
+    review: displayText,
     ...(turn ? { turn } : {}),
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -110,6 +110,8 @@ function buildCompletedGroups(
   excludeTurnId?: string
 ): RenderGroup[] {
   const groups: RenderGroup[] = [];
+  const groupIds = new Set<string>();
+  const completedWorkTurnIds = new Set<string>();
   let currentEntries: AppServerThreadEntry[] = [];
   let currentTurnId: string | undefined;
 
@@ -129,14 +131,23 @@ function buildCompletedGroups(
 
     const hasWork = hasConcreteWork(currentEntries);
     const firstEntryId = currentEntries[0]?.id ?? groups.length.toString();
+    const baseId = `${hasWork ? "work" : "commentary"}:${currentTurnId}:${firstEntryId}:complete`;
+    const repeatedWorkTurn = hasWork && completedWorkTurnIds.has(currentTurnId);
+    const id = groupIds.has(baseId) ? `${baseId}:${groups.length}` : baseId;
+    groupIds.add(id);
     groups.push({
       collapsible: true,
       entries: currentEntries,
-      id: `${hasWork ? "work" : "commentary"}:${currentTurnId}:${firstEntryId}:complete`,
+      id,
       label: hasWork
-        ? workGroupLabel(turn)
+        ? repeatedWorkTurn
+          ? "More work"
+          : workGroupLabel(turn)
         : previousMessagesLabel(currentEntries.filter(isAssistantCommentaryMessage).length),
     });
+    if (hasWork) {
+      completedWorkTurnIds.add(currentTurnId);
+    }
     currentEntries = [];
     currentTurnId = undefined;
   };
@@ -204,26 +215,26 @@ function renderWithGroups(
   entries: AppServerThreadEntry[],
   groups: RenderGroup[]
 ): TranscriptRenderItem[] {
-  const entryToGroup = new Map<string, RenderGroup>();
-  const groupedEntryIds = new Set<string>();
+  const entryToGroup = new Map<AppServerThreadEntry, RenderGroup>();
+  const groupedEntries = new Set<AppServerThreadEntry>();
 
   for (const group of groups) {
     for (const entry of group.entries) {
-      groupedEntryIds.add(entry.id);
+      groupedEntries.add(entry);
     }
     const firstEntry = group.entries[0];
     if (firstEntry) {
-      entryToGroup.set(firstEntry.id, group);
+      entryToGroup.set(firstEntry, group);
     }
   }
 
   const items: TranscriptRenderItem[] = [];
   for (const entry of entries) {
-    const group = entryToGroup.get(entry.id);
+    const group = entryToGroup.get(entry);
     if (group) {
       items.push({ type: "workPhaseGroup", ...group });
     }
-    if (groupedEntryIds.has(entry.id)) {
+    if (groupedEntries.has(entry)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

I fixed the transcript renderer so repeated completed work segments from the same turn do not show the same elapsed-time label multiple times.

This specifically covers Review turns that can render as review start, work, review result, then more work. The first completed work group keeps the elapsed label, while later groups for that same turn render as "More work".

I also made transcript grouping use entry object identity instead of entry ids, with a fallback group-id suffix when ids collide. That prevents live/persisted duplicate ids such as `live-warning-*` from corrupting the grouping map or producing duplicate React keys.

## Verification

I verified the focused renderer coverage passes:

```sh
pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
```

I also ran:

```sh
pnpm typecheck
pnpm --filter @pwragnt/desktop typecheck
```

Both typecheck commands are currently blocked in this worktree because `node_modules` is missing, so TypeScript cannot resolve workspace/dependency packages such as `@pwragnt/shared`, `react`, `electron`, and `@playwright/test`.
