### PR TITLE
fix(desktop): promote approval chip CTA

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -129,9 +129,6 @@ export function ThreadMetaChips({
           className="thread-row__chip thread-row__chip--approval"
           title="Waiting for approval"
         >
-          <span aria-hidden="true" className="thread-row__chip-icon">
-            !
-          </span>
           Waiting for approval
         </span>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -350,6 +350,7 @@ describe("Sidebar", () => {
 
     const approvalChip = within(threadButton).getByTitle("Waiting for approval");
     expect(approvalChip).toHaveTextContent("Waiting for approval");
+    expect(approvalChip).not.toHaveTextContent("!");
     expect(approvalChip).toHaveAttribute("title", "Waiting for approval");
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -708,10 +708,14 @@ textarea {
 }
 
 .thread-row__chip--approval {
-  border: 1px solid var(--accent-border);
-  background: var(--accent-soft);
-  color: var(--text-primary);
-  font-weight: 600;
+  border: 1px solid var(--accent-strong);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 700;
+}
+
+.thread-row__chip--approval:hover {
+  background: var(--accent-strong);
 }
 
 .path-copy-target {


### PR DESCRIPTION
## Summary
- Promote the sidebar `Waiting for approval` chip to the same tangerine CTA treatment as the approval action.
- Remove the leading `!` punctuation marker so the state reads as an action cue instead of a warning badge.
- Add sidebar coverage to ensure the approval chip text remains present without the punctuation marker.

## Verification
- `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/approval-pending.spec.ts`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/tangerine-terminal-theme.spec.ts -g "keeps workflow states and narrow desktop layout readable"`
