### PR TITLE
fix(desktop): Stop routing after access mode changes

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -112,3 +112,38 @@ test("dismisses the pending approval UI after approval", async () => {
     await app.close();
   }
 });
+
+test("stops the active turn on its original execution mode after access mode changes", async () => {
+  const app = await openApprovalPendingReplay();
+
+  try {
+    await expect
+      .poll(async () => await app.getLastStartTurn({ executionMode: "default" }))
+      .toMatchObject({
+        threadId: "thread-approval-pending",
+      });
+    expect(await app.getLastStartTurn({ executionMode: "full-access" })).toBeUndefined();
+
+    const accessMode = app.window.getByLabel("Access mode");
+    await expect(accessMode).toHaveAttribute("data-value", "default");
+    await accessMode.click();
+    await app.window.getByRole("option", { name: "Full Access" }).click();
+    await expect(accessMode).toHaveAttribute("data-value", "full-access");
+
+    await app.window.getByRole("button", { name: "Stop" }).click();
+
+    await expect
+      .poll(async () => await app.getInterruptTurnCalls({ executionMode: "default" }))
+      .toEqual([
+        {
+          threadId: "thread-approval-pending",
+          turnId: "turn-approval-2",
+        },
+      ]);
+    await expect
+      .poll(async () => await app.getInterruptTurnCalls({ executionMode: "full-access" }))
+      .toEqual([]);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -19,7 +19,8 @@
           "thread/list",
           "thread/read",
           "skills/list",
-          "turn/start"
+          "turn/start",
+          "turn/interrupt"
         ]
       }
     },
@@ -133,6 +134,15 @@
           "reason": "Do you want to allow network access so I can query npm metadata for the `dive` package?",
           "command": "/bin/zsh -lc 'npm view dive'"
         }
+      }
+    },
+    {
+      "id": "turn-interrupt-1",
+      "kind": "response",
+      "method": "turn/interrupt",
+      "result": {
+        "threadId": "thread-approval-pending",
+        "turnId": "turn-approval-2"
       }
     }
   ]

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -27,6 +27,9 @@ type LaunchResult = {
   getLastRenameThread: (params?: {
     executionMode?: ThreadExecutionMode;
   }) => Promise<unknown>;
+  getInterruptTurnCalls: (params?: {
+    executionMode?: ThreadExecutionMode;
+  }) => Promise<unknown>;
   respondToPendingRequest: (params: {
     executionMode?: ThreadExecutionMode;
     requestId: string;
@@ -135,6 +138,12 @@ export async function launchElectronApp(params: {
       await electronApp.evaluate(
         (_electron, value) =>
           globalThis.__PWRAGNT_REPLAY_DRIVER__?.getLastRenameThread(value),
+        requestParams
+      ),
+    getInterruptTurnCalls: async (requestParams) =>
+      await electronApp.evaluate(
+        (_electron, value) =>
+          globalThis.__PWRAGNT_REPLAY_DRIVER__?.getInterruptTurnCalls(value),
         requestParams
       ),
     respondToPendingRequest: async (requestParams) => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -424,6 +424,19 @@ function buildPendingRequestKey(params: {
   return `${params.backend}:${params.threadId}:${params.requestId}`;
 }
 
+function buildActiveTurnModeKey(threadId: string, turnId: string): string {
+  return `${threadId}:${turnId}`;
+}
+
+function readStatusType(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || !("type" in value)) {
+    return undefined;
+  }
+
+  const type = value.type;
+  return typeof type === "string" ? type : undefined;
+}
+
 function mergeMethods(results: InitializeResult[]): string[] {
   return [...new Set(results.flatMap((result) => result.methods ?? []))];
 }
@@ -777,6 +790,7 @@ export class DesktopBackendRegistry {
       token: number;
     }
   >();
+  private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly attemptedTitleGenerations = new Set<string>();
   private titleGenerationSequence = 0;
 
@@ -1247,14 +1261,17 @@ export class DesktopBackendRegistry {
       reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
       fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
     });
+    let activeTurnMode: ThreadExecutionMode | undefined;
     const result =
       params.backend === "codex"
-        ? await this.withCodexThreadClient(params.threadId, async (client) =>
-            await client.startTurn({
+        ? await this.withCodexThreadClient(params.threadId, async (client, mode) => {
+            const started = await client.startTurn({
               ...params,
               ...turnParams,
-            }),
-          )
+            });
+            activeTurnMode = mode;
+            return started;
+          })
         : await this.grokClient.startTurn({
             threadId: params.threadId,
             input: params.input,
@@ -1275,6 +1292,12 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         ...turnParams,
       });
+    }
+    if (params.backend === "codex" && activeTurnMode) {
+      this.activeCodexTurnModes.set(
+        buildActiveTurnModeKey(result.threadId, result.turnId),
+        activeTurnMode,
+      );
     }
 
     const response = {
@@ -1323,12 +1346,26 @@ export class DesktopBackendRegistry {
     threadId: string;
     turnId: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
-    const result =
+    const activeCodexTurnMode =
       params.backend === "codex"
-        ? await this.withCodexThreadClient(params.threadId, async (client) =>
-            await client.interruptTurn(params),
+        ? this.activeCodexTurnModes.get(
+            buildActiveTurnModeKey(params.threadId, params.turnId),
           )
+        : undefined;
+    const result =
+      params.backend === "codex" && activeCodexTurnMode
+        ? await this.getClient("codex", activeCodexTurnMode).interruptTurn(params)
+        : params.backend === "codex"
+          ? await this.withCodexThreadClient(params.threadId, async (client) =>
+              await client.interruptTurn(params),
+            )
         : await this.grokClient.interruptTurn(params);
+
+    if (params.backend === "codex") {
+      this.activeCodexTurnModes.delete(
+        buildActiveTurnModeKey(result.threadId, result.turnId),
+      );
+    }
 
     return {
       backend: params.backend,
@@ -2393,6 +2430,32 @@ export class DesktopBackendRegistry {
   }
 
   private async emit(event: AgentEvent): Promise<void> {
+    if (
+      event.backend === "codex" &&
+      event.notification.method === "turn/completed" &&
+      event.notification.params.turnId
+    ) {
+      this.activeCodexTurnModes.delete(
+        buildActiveTurnModeKey(
+          event.notification.params.threadId,
+          event.notification.params.turnId,
+        ),
+      );
+    }
+
+    if (
+      event.backend === "codex" &&
+      event.notification.method === "thread/status/changed" &&
+      readStatusType(event.notification.params.status) !== "active"
+    ) {
+      const keyPrefix = `${event.notification.params.threadId}:`;
+      for (const key of this.activeCodexTurnModes.keys()) {
+        if (key.startsWith(keyPrefix)) {
+          this.activeCodexTurnModes.delete(key);
+        }
+      }
+    }
+
     if (event.notification.method === "serverRequest/resolved") {
       const key = buildPendingRequestKey({
         backend: event.backend,

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -56,6 +56,10 @@ export class ReplayClient {
     threadId: string;
     name: string;
   };
+  private readonly interruptTurnCalls: Array<{
+    threadId: string;
+    turnId: string;
+  }> = [];
 
   constructor(private readonly controller: ReplayController) {}
 
@@ -165,15 +169,26 @@ export class ReplayClient {
     };
   }
 
-  async interruptTurn(_params?: {
+  async interruptTurn(params: {
     threadId: string;
     turnId: string;
   }): Promise<{ threadId: string; turnId: string }> {
     await this.ensureInitialized();
+    this.interruptTurnCalls.push({
+      threadId: params.threadId,
+      turnId: params.turnId,
+    });
     return this.controller.consumeResponse("turn/interrupt").result as {
       threadId: string;
       turnId: string;
     };
+  }
+
+  async setThreadPermissions(params: {
+    threadId: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+    return { threadId: params.threadId };
   }
 
   async renameThread(params: {
@@ -240,6 +255,13 @@ export class ReplayClient {
       }
     | undefined {
     return this.lastRenameThreadParams;
+  }
+
+  getInterruptTurnCalls(): Array<{
+    threadId: string;
+    turnId: string;
+  }> {
+    return [...this.interruptTurnCalls];
   }
 
   async respondToPendingRequest(requestId: string): Promise<void> {

--- a/apps/desktop/src/main/testing/replay-controller.ts
+++ b/apps/desktop/src/main/testing/replay-controller.ts
@@ -19,7 +19,7 @@ export class ReplayController {
 
   constructor(private readonly fixture: ReplayFixture) {
     validateReplayFixture(fixture);
-    this.steps = fixture.steps;
+    this.steps = [...fixture.steps];
   }
 
   consumeResponse(method: ReplayResponseMethod): ReplayResponseStep {

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -58,6 +58,13 @@ type ReplayDriver = {
         name: string;
       }
     | undefined;
+  getInterruptTurnCalls(params?: {
+    backend?: AppServerBackendKind;
+    executionMode?: ThreadExecutionMode;
+  }): Array<{
+    threadId: string;
+    turnId: string;
+  }>;
   getPendingRequest(params?: {
     backend?: AppServerBackendKind;
     executionMode?: ThreadExecutionMode;
@@ -100,6 +107,10 @@ type ReplayRuntimeClient = {
         name: string;
       }
     | undefined;
+  getInterruptTurnCalls?(): Array<{
+    threadId: string;
+    turnId: string;
+  }>;
   getInitializeResult(): Promise<{
     serverInfo?: {
       name?: string;
@@ -222,6 +233,13 @@ export function createReplayClientsFromEnv():
       });
       return client.getLastRenameThreadParams?.();
     },
+    getInterruptTurnCalls: (params) => {
+      const client = getReplayClient(clients, {
+        backend: params?.backend,
+        executionMode: params?.executionMode,
+      });
+      return client.getInterruptTurnCalls?.() ?? [];
+    },
     respondToPendingRequest: async (params) => {
       const client = getReplayClient(clients, {
         backend: params.backend,
@@ -303,6 +321,7 @@ function createUnavailableReplayClient(
     getLastStartTurnParams: () => undefined,
     getLastStartReviewParams: () => undefined,
     getLastRenameThreadParams: () => undefined,
+    getInterruptTurnCalls: () => [],
     getInitializeResult: async () => {
       throw new Error(message);
     },


### PR DESCRIPTION
## Summary

I fixed Stop routing for Codex turns when the access mode is changed while a turn is still active.

The desktop backend now remembers which Codex execution mode actually started a turn and routes `turn/interrupt` to that same client. This keeps Stop from following a newly selected Default/Full Access value that has not yet taken effect for the active turn.

I also extended the replay E2E harness so the approval-pending replay can verify interrupt routing separately for Default Access and Full Access.

## Verification

I verified:

- `pnpm typecheck`
- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/backend-registry.test.ts src/main/__tests__/replay-runtime.test.ts`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/approval-pending.spec.ts`
