### PR TITLE
fix(desktop): show sent steer messages in transcript

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -160,6 +160,137 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("materializes completed steer user messages in the transcript", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-message-1`,
+              role: "assistant" as const,
+              text: `Loaded ${threadId}`,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.addOptimisticUserMessage("Steer while thinking.");
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "userMessage",
+              id: "steer-message-1",
+              content: [
+                {
+                  type: "text",
+                  text: "Steer while thinking.",
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "assistant:Loaded thread-1",
+        "user:Steer while thinking.",
+      ]);
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              output: [{ type: "text", text: "Steer acknowledged." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "assistant:Loaded thread-1",
+        "user:Steer while thinking.",
+        "assistant:Steer acknowledged.",
+      ]);
+    });
+  });
+
   it("keeps live protocol activity before hydrated review output after completion", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1109,6 +1109,105 @@ function reviewEntryFromCompletedItem(params: {
   };
 }
 
+function messageContentFromUserItem(item: Record<string, unknown>): {
+  parts?: AppServerThreadMessageEntry["parts"];
+  text: string;
+} {
+  type MessagePart = NonNullable<AppServerThreadMessageEntry["parts"]>[number];
+  const content = Array.isArray(item.content) ? item.content : [];
+  const parts: MessagePart[] = content
+    .map((part): MessagePart | undefined => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) {
+        return undefined;
+      }
+
+      const record = part as Record<string, unknown>;
+      if (record.type === "text" && typeof record.text === "string") {
+        return { type: "text", text: record.text };
+      }
+
+      const imageUrl =
+        typeof record.url === "string"
+          ? record.url
+          : typeof record.image_url === "string"
+            ? record.image_url
+            : undefined;
+      if (
+        imageUrl &&
+        (record.type === "image" ||
+          record.type === "input_image" ||
+          record.type === "image_url")
+      ) {
+        const alt =
+          typeof record.alt === "string"
+            ? record.alt
+            : typeof record.name === "string"
+              ? record.name
+              : undefined;
+        return {
+          type: "image",
+          url: imageUrl,
+          ...(alt ? { alt } : {}),
+        };
+      }
+
+      return undefined;
+    })
+    .filter((part): part is MessagePart => Boolean(part));
+  const text =
+    parts
+      .filter((part): part is Extract<MessagePart, { type: "text" }> => part.type === "text")
+      .map((part) => part.text.trim())
+      .filter(Boolean)
+      .join("\n\n") ||
+    (typeof item.text === "string" ? item.text.trim() : "");
+
+  return {
+    ...(parts.length > 0 ? { parts } : {}),
+    text,
+  };
+}
+
+function userMessageEntryFromCompletedItem(params: {
+  turnId?: string;
+  item?: {
+    id?: string;
+    type?: string;
+    content?: unknown;
+    text?: unknown;
+  };
+}): AppServerThreadMessageEntry | undefined {
+  const item = params.item;
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+
+  const record = item as Record<string, unknown>;
+  if (record.type !== "userMessage") {
+    return undefined;
+  }
+
+  const content = messageContentFromUserItem(record);
+  if (!content.text && !content.parts?.length) {
+    return undefined;
+  }
+
+  const turn = buildTurnMetadata({
+    fallbackId: typeof params.turnId === "string" ? params.turnId : undefined,
+    fallbackStatus: "in_progress",
+  });
+
+  return {
+    type: "message",
+    id: typeof record.id === "string" ? record.id : `user-${Date.now()}`,
+    role: "user",
+    text: content.text,
+    ...(content.parts ? { parts: content.parts } : {}),
+    ...(turn ? { turn } : {}),
+    createdAt: Date.now(),
+  };
+}
+
 function hasReviewEntryForTurn(
   response: AppServerReadThreadResponse | undefined,
   turnId: string | undefined
@@ -1849,6 +1948,33 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "item/completed") {
+          const userMessageEntry = userMessageEntryFromCompletedItem(
+            event.notification.params
+          );
+          if (userMessageEntry) {
+            const nextResponse = appendMessageEntries(
+              current.response,
+              {
+                backend: event.backend,
+                threadId: notificationThreadId,
+              },
+              [userMessageEntry]
+            );
+
+            return {
+              ...current,
+              expectOwnUpdate: true,
+              interacted: true,
+              lastTouchedAt: nextLastTouchedAt,
+              optimisticEntries: current.optimisticEntries.filter(
+                (entry) =>
+                  entry.type !== "message" ||
+                  !messageMatchesOptimisticEntry(userMessageEntry, entry)
+              ),
+              response: nextResponse,
+            };
+          }
+
           if (isContextCompactionItemNotification(event.notification)) {
             return {
               ...current,


### PR DESCRIPTION
Fixes a steering regression where a pending Command+Enter steer chip cleared after injection but the sent steer never appeared in the transcript.

Codex emits injected steer text as a live `item/completed` event with `item.type: "userMessage"`. The renderer transcript state now materializes those completed user-message items into normal transcript entries and removes any matching optimistic duplicate, so the pending steer visibly becomes a sent user message and remains ordered with the rest of the turn.

Verification:
- `pnpm test -- apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (medium reasoning) via [Codex](https://openai.com/codex)
