### PR TITLE
fix(desktop): stop idle branch drift polling

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -848,15 +848,11 @@ export function ThreadView(props: ThreadViewProps) {
     }
 
     void checkSelectedThreadBranchDrift("focus");
-    const intervalId = window.setInterval(() => {
-      void checkSelectedThreadBranchDrift("focus");
-    }, 30_000);
     const unsubscribeFocus = props.desktopApi?.onWindowFocus?.(() => {
       void checkSelectedThreadBranchDrift("focus");
     });
 
     return () => {
-      window.clearInterval(intervalId);
       unsubscribeFocus?.();
     };
   }, [props.desktopApi, selectedLaunchpad, selectedThreadKey]);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2796,4 +2796,72 @@ describe("ThreadView", () => {
     });
     expect(refreshNavigation).toHaveBeenCalled();
   });
+
+  it("checks branch drift on selection and focus without background polling", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      checkedAt: Date.now(),
+      expectedBranch: "feature/old",
+      observedBranch: "feature/old",
+      drifted: false,
+    }));
+    let focusCallback: (() => void) | undefined;
+
+    try {
+      render(
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{
+            checkThreadBranchDrift,
+            onWindowFocus: (callback) => {
+              focusCallback = callback;
+              return () => {
+                focusCallback = undefined;
+              };
+            },
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={{
+            id: "thread-branch",
+            title: "Branch drift",
+            titleSource: "explicit",
+            source: "codex",
+            gitBranch: "feature/old",
+            observedGitBranch: "feature/old",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+          }}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(checkThreadBranchDrift).toHaveBeenCalledTimes(1);
+      });
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30_000);
+
+      await act(async () => {
+        focusCallback?.();
+      });
+
+      await waitFor(() => {
+        expect(checkThreadBranchDrift).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Stop the selected thread view from polling branch drift every 30 seconds while the window is idle.
- Keep branch drift checks when a thread is selected and when the desktop window receives focus.
- Add a renderer regression test covering the non-polling behavior.

## Why

An idle desktop window with a selected git-backed Codex thread was still calling `checkThreadBranchDrift()` every 30 seconds. That check currently resolves thread workspace state through a Codex `thread/list` call, so the app kept emitting protocol traffic even when the user was interacting with the same thread in a different instance.

This keeps the useful drift warning at user attention boundaries without creating background Codex protocol noise.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm typecheck`
