### PR TITLE
fix(desktop): trim protocol log noise

### DIFF
--- a/apps/desktop/src/main/__tests__/log.test.ts
+++ b/apps/desktop/src/main/__tests__/log.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { compactStructuredLogData } from "../log";
+
+describe("main logger compact formatting", () => {
+  it("omits undefined object fields from compact log output", () => {
+    expect(
+      compactStructuredLogData([
+        "message",
+        {
+          backend: "codex",
+          itemId: undefined,
+          method: "thread/list",
+          turnId: undefined,
+        },
+      ]),
+    ).toEqual(["message backend=codex method=thread/list"]);
+  });
+
+  it("drops empty structured payloads after undefined fields are omitted", () => {
+    expect(compactStructuredLogData(["message", { turnId: undefined }])).toEqual([
+      "message",
+    ]);
+  });
+
+  it("keeps non-object arguments as passthrough data", () => {
+    const error = new Error("boom");
+
+    expect(compactStructuredLogData(["message", { ok: true }, error])).toEqual([
+      "message ok=true",
+      error,
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
@@ -7,9 +7,10 @@ import {
 
 function createEvent(
   envelope: JsonRpcObserverEvent["envelope"],
+  direction: JsonRpcObserverEvent["direction"] = "inbound",
 ): JsonRpcObserverEvent {
   return {
-    direction: "inbound",
+    direction,
     envelope,
     raw: JSON.stringify(envelope),
   };
@@ -36,14 +37,59 @@ describe("protocol log observer", () => {
 
     expect(info).toHaveBeenCalledWith("message", {
       backend: "codex",
-      direction: "inbound",
-      id: undefined,
-      itemId: undefined,
+      direction: "in",
       kind: "notification",
       method: "turn/started",
       paramKeys: ["turnId", "threadId"],
       turnId: "turn-1",
       threadId: "thread-1",
+    });
+  });
+
+  it("omits absent ids and attributes responses to their request method", () => {
+    const info = vi.fn();
+    const observer = createProtocolLogObserver({
+      backend: "codex",
+      logger: { info },
+    });
+
+    observer.onMessage(
+      createEvent(
+        {
+          id: "rpc-1",
+          jsonrpc: "2.0",
+          method: "thread/list",
+          params: {
+            archived: false,
+            limit: 100,
+            sortKey: "recent",
+          },
+        },
+        "outbound",
+      ),
+    );
+    observer.onMessage(
+      createEvent({
+        id: "rpc-1",
+        jsonrpc: "2.0",
+        result: { threads: [] },
+      }),
+    );
+
+    expect(info).toHaveBeenNthCalledWith(1, "message", {
+      backend: "codex",
+      direction: "out",
+      id: "rpc-1",
+      kind: "request",
+      method: "thread/list",
+      paramKeys: ["archived", "limit", "sortKey"],
+    });
+    expect(info).toHaveBeenNthCalledWith(2, "message", {
+      backend: "codex",
+      direction: "in",
+      id: "rpc-1",
+      kind: "response",
+      method: "thread/list",
     });
   });
 

--- a/apps/desktop/src/main/app-server/protocol-log-observer.ts
+++ b/apps/desktop/src/main/app-server/protocol-log-observer.ts
@@ -74,6 +74,7 @@ export function createProtocolLogObserver(
   const streamLogIntervalMs =
     options.streamLogIntervalMs ?? STREAM_LOG_INTERVAL_MS;
   const deltaBuffers = new Map<string, DeltaBuffer>();
+  const requestMethodsById = new Map<string, string>();
 
   function logDeltaBuffer(
     key: string,
@@ -127,8 +128,10 @@ export function createProtocolLogObserver(
       const envelope = event.envelope;
       const params = asRecord(envelope.params);
       const item = asRecord(params?.item);
-      const method = envelope.method ?? "response";
       const id = envelope.id == null ? undefined : String(envelope.id);
+      const kind = classifyEnvelope(envelope);
+      const method =
+        envelope.method ?? (id ? requestMethodsById.get(id) : undefined) ?? "response";
       const delta = pickRawString(params, "delta");
       const deltaKey = delta
         ? buildDeltaKey({
@@ -165,17 +168,27 @@ export function createProtocolLogObserver(
       }
 
       flushDeltaBuffersFor(envelope);
-      logger.info("message", {
-        backend: options.backend,
-        direction: event.direction,
-        id,
-        itemId: pickString(params, "itemId") ?? pickString(item, "id"),
-        kind: classifyEnvelope(envelope),
-        method,
-        paramKeys: Object.keys(params ?? {}),
-        turnId: pickString(params, "turnId"),
-        threadId: pickString(params, "threadId"),
-      });
+      if (kind === "request" && id && envelope.method) {
+        requestMethodsById.set(id, envelope.method);
+      }
+      const paramKeys = Object.keys(params ?? {});
+      logger.info(
+        "message",
+        compactFields({
+          backend: options.backend,
+          direction: compactDirection(event.direction),
+          id,
+          itemId: pickString(params, "itemId") ?? pickString(item, "id"),
+          kind,
+          method,
+          paramKeys: paramKeys.length > 0 ? paramKeys : undefined,
+          turnId: pickString(params, "turnId"),
+          threadId: pickString(params, "threadId"),
+        }),
+      );
+      if (kind === "response" && id) {
+        requestMethodsById.delete(id);
+      }
     },
   };
 }
@@ -197,6 +210,16 @@ function classifyEnvelope(envelope: JsonRpcEnvelope): "notification" | "request"
     return "notification";
   }
   return "response";
+}
+
+function compactDirection(direction: JsonRpcObserverEvent["direction"]): "in" | "out" {
+  return direction === "inbound" ? "in" : "out";
+}
+
+function compactFields<T extends Record<string, unknown>>(fields: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -28,16 +28,21 @@ type CompactField = {
   value: string;
 };
 
-function compactStructuredLogData(data: unknown[]): unknown[] {
+export function compactStructuredLogData(data: unknown[]): unknown[] {
   if (data.length < 2 || typeof data[0] !== "string") {
     return data;
   }
 
   const compacted: string[] = [];
   const passthrough: unknown[] = [];
+  let hadStructuredPayload = false;
   for (const item of data.slice(1)) {
     if (isPlainObject(item)) {
-      compacted.push(compactObjectFields(item));
+      hadStructuredPayload = true;
+      const compactedFields = compactObjectFields(item);
+      if (compactedFields) {
+        compacted.push(compactedFields);
+      }
     } else {
       passthrough.push(item);
     }
@@ -45,6 +50,8 @@ function compactStructuredLogData(data: unknown[]): unknown[] {
 
   return compacted.length > 0
     ? [`${data[0]} ${compacted.filter(Boolean).join(" ")}`, ...passthrough]
+    : hadStructuredPayload
+      ? [data[0], ...passthrough]
     : data;
 }
 
@@ -68,6 +75,9 @@ function collectCompactFields(
   for (const [key, child] of Object.entries(value)) {
     if (fields.length >= MAX_COMPACT_FIELDS) {
       return;
+    }
+    if (child === undefined) {
+      continue;
     }
     const fieldKey = prefix ? `${prefix}.${key}` : key;
     if (

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -1,6 +1,9 @@
 import electronLog from "electron-log/main.js";
 
 let initialized = false;
+const MAX_COMPACT_STRING_LENGTH = 320;
+const MAX_COMPACT_FIELDS = 24;
+const MAX_COMPACT_DEPTH = 2;
 
 export function initializeMainLogger(): void {
   if (initialized) {
@@ -10,8 +13,116 @@ export function initializeMainLogger(): void {
   initialized = true;
   electronLog.initialize();
   electronLog.scope.labelPadding = false;
+  electronLog.hooks.push((message) => ({
+    ...message,
+    data: compactStructuredLogData(message.data),
+  }));
 }
 
 export function getMainLogger(scope: string) {
   return electronLog.scope(scope);
+}
+
+type CompactField = {
+  key: string;
+  value: string;
+};
+
+function compactStructuredLogData(data: unknown[]): unknown[] {
+  if (data.length < 2 || typeof data[0] !== "string") {
+    return data;
+  }
+
+  const compacted: string[] = [];
+  const passthrough: unknown[] = [];
+  for (const item of data.slice(1)) {
+    if (isPlainObject(item)) {
+      compacted.push(compactObjectFields(item));
+    } else {
+      passthrough.push(item);
+    }
+  }
+
+  return compacted.length > 0
+    ? [`${data[0]} ${compacted.filter(Boolean).join(" ")}`, ...passthrough]
+    : data;
+}
+
+function compactObjectFields(value: Record<string, unknown>): string {
+  const fields: CompactField[] = [];
+  collectCompactFields(value, "", fields, 0);
+  const suffix = fields.length >= MAX_COMPACT_FIELDS ? " ..." : "";
+  return `${fields.slice(0, MAX_COMPACT_FIELDS).map((field) => `${field.key}=${field.value}`).join(" ")}${suffix}`;
+}
+
+function collectCompactFields(
+  value: Record<string, unknown>,
+  prefix: string,
+  fields: CompactField[],
+  depth: number,
+): void {
+  if (fields.length >= MAX_COMPACT_FIELDS) {
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (fields.length >= MAX_COMPACT_FIELDS) {
+      return;
+    }
+    const fieldKey = prefix ? `${prefix}.${key}` : key;
+    if (
+      isPlainObject(child) &&
+      depth < MAX_COMPACT_DEPTH &&
+      Object.keys(child).length <= 8
+    ) {
+      collectCompactFields(child, fieldKey, fields, depth + 1);
+      continue;
+    }
+    fields.push({
+      key: fieldKey,
+      value: compactLogValue(child),
+    });
+  }
+}
+
+function compactLogValue(value: unknown): string {
+  if (typeof value === "string") {
+    return quoteIfNeeded(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return String(value);
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => compactLogValue(item)).join(",")}]`;
+  }
+  if (value instanceof Error) {
+    return quoteIfNeeded(value.stack ?? value.message);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return quoteIfNeeded(JSON.stringify(value) ?? String(value));
+}
+
+function quoteIfNeeded(value: string): string {
+  const compact = value.replace(/\s+/g, " ").trim();
+  const truncated =
+    compact.length > MAX_COMPACT_STRING_LENGTH
+      ? `${compact.slice(0, MAX_COMPACT_STRING_LENGTH - 3)}...`
+      : compact;
+  if (/^[A-Za-z0-9_./:@+-]+$/.test(truncated)) {
+    return truncated;
+  }
+  return JSON.stringify(truncated);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }


### PR DESCRIPTION
## Summary

I brought over the compact desktop structured log formatter from `feat/messaging-platform-integration`, then tightened the protocol log summaries so routine app-server traffic is easier to scan.

The protocol logger now omits absent optional IDs instead of printing `undefined`, drops empty `paramKeys`, abbreviates directions to `in`/`out`, and attributes JSON-RPC responses back to the request method when the request id is known. That makes thread listing logs read as `method=thread/list` on both request and response lines without adding thread/turn/item fields that do not exist for that operation.

## Verification

- `pnpm exec vitest run apps/desktop/src/main/__tests__/protocol-log-observer.test.ts apps/desktop/src/main/__tests__/log.test.ts --config vitest.workspace.ts`
- `pnpm typecheck`
