### PR TITLE
fix(desktop): stale Grok launchpad defaults

### DIFF
--- a/apps/desktop/e2e/provider-model-selectors.spec.ts
+++ b/apps/desktop/e2e/provider-model-selectors.spec.ts
@@ -127,6 +127,48 @@ test("OpenAI new-thread selector uses concrete model and reasoning defaults", as
   }
 });
 
+test("OpenAI new-thread launchpad wins when sticky Grok defaults are unavailable", async () => {
+  const fixture = await createProviderSelectorFixture({
+    backend: "codex",
+    launchpadDefaults: {
+      backend: "grok",
+      executionMode: "default",
+      model: "grok-4.20-reasoning",
+      reasoningEffort: "medium",
+      workMode: "local",
+    },
+  });
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: fixture.env,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "New thread" }).click();
+    await expect(app.window.getByRole("heading", { level: 2, name: "New thread" })).toBeVisible();
+
+    await expect(app.window.getByText("Grok", { exact: true })).toHaveCount(0);
+    await expect(app.window.getByText("OpenAI", { exact: true }).first()).toBeVisible();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const providerSelect = settings.getByLabel("Provider");
+    const modelSelect = settings.getByLabel("Model");
+    const prompt = app.window.locator("textarea.composer__input");
+
+    await expect(providerSelect).toHaveAttribute("data-value", "codex");
+    await expect(modelSelect).toHaveAttribute("data-value", "gpt-5.5");
+    await expect(
+      app.window.getByText(
+        "This backend is unavailable right now. Your draft stays here until send is available again."
+      )
+    ).toHaveCount(0);
+    await expect(prompt).toBeEnabled();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("Grok new-thread selector hides reasoning for Grok 4.20 models", async () => {
   const fixture = await createProviderSelectorFixture({
     backend: "grok",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -32,6 +32,7 @@ async function waitForCondition(predicate: () => boolean): Promise<void> {
 
 function createOverlayStoreMock(params?: {
   executionMode?: "default" | "full-access";
+  launchpadDefaults?: NavigationLaunchpadDefaults;
   overlays?: Record<string, ThreadOverlayState>;
 }) {
   const initialOverlay = params?.executionMode
@@ -49,6 +50,7 @@ function createOverlayStoreMock(params?: {
     backend: "codex",
     executionMode: "default",
     workMode: "local",
+    ...params?.launchpadDefaults,
   };
   const launchpads = new Map<string, NavigationLaunchpadDraft>();
   if (initialOverlay) {
@@ -933,6 +935,58 @@ describe("DesktopBackendRegistry", () => {
     expect(workspace.launchpad.directoryLabel).toBe("Workspaces");
     expect(workspace.launchpad.workMode).toBe("local");
     expect(workspace.launchpad.branchName).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("falls back to OpenAI launchpad state when sticky Grok defaults are unavailable", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.4",
+            label: "GPT-5.4",
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        launchpadDefaults: {
+          backend: "grok",
+          executionMode: "default",
+          model: "grok-4.20-reasoning",
+          reasoningEffort: "medium",
+          workMode: "local",
+        },
+      }),
+    });
+
+    const launchpad = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(launchpad.defaults).toMatchObject({
+      backend: "codex",
+      executionMode: "default",
+      model: "gpt-5.4",
+      reasoningEffort: "medium",
+    });
+    expect(launchpad.launchpad).toMatchObject({
+      backend: "codex",
+      executionMode: "default",
+      model: "gpt-5.4",
+      reasoningEffort: "medium",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -765,6 +765,33 @@ function resolveModelSettingsFromOptions(
   };
 }
 
+function getAvailableExecutionMode(
+  backend: BackendSummary,
+  preferred: ThreadExecutionMode,
+): ThreadExecutionMode {
+  return (
+    backend.executionModes.find((mode) => mode.available && mode.mode === preferred)?.mode ??
+    backend.executionModes.find((mode) => mode.available && mode.isDefault)?.mode ??
+    backend.executionModes.find((mode) => mode.available)?.mode ??
+    preferred
+  );
+}
+
+function launchpadDefaultsEqual(
+  left: NavigationLaunchpadDefaults,
+  right: NavigationLaunchpadDefaults,
+): boolean {
+  return (
+    left.backend === right.backend &&
+    left.executionMode === right.executionMode &&
+    left.workMode === right.workMode &&
+    left.model === right.model &&
+    left.reasoningEffort === right.reasoningEffort &&
+    left.serviceTier === right.serviceTier &&
+    left.fastMode === right.fastMode
+  );
+}
+
 export class DesktopBackendRegistry {
   private readonly codexDefaultClient: BackendClient;
   private readonly codexFullAccessClient: BackendClient;
@@ -1584,15 +1611,34 @@ export class DesktopBackendRegistry {
     const existing = await this.overlayStore.getDirectoryLaunchpad({
       directoryKey: request.directoryKey,
     });
-    const defaults = await this.overlayStore.getLaunchpadDefaults();
+    const defaults = await this.resolveLaunchpadDefaults(
+      await this.overlayStore.getLaunchpadDefaults(),
+      request.preferredBackend,
+    );
     if (existing) {
+      const backend = await this.resolveLaunchpadBackend(existing.backend);
+      const modelSettings = await this.resolveLaunchpadModelSettings(
+        backend,
+        existing,
+      );
+      const executionMode = getAvailableExecutionMode(
+        backend,
+        existing.executionMode,
+      );
+      const normalizedExisting: NavigationLaunchpadDraft = {
+        ...existing,
+        backend: backend.kind,
+        executionMode,
+        ...modelSettings,
+      };
+
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
         const refreshed: NavigationLaunchpadDraft = {
-          ...existing,
+          ...normalizedExisting,
           directoryKind: request.directoryKind,
           directoryLabel: request.directoryLabel,
           directoryPath: request.directoryPath,
-          backend: request.preferredBackend ?? defaults.backend,
+          backend: defaults.backend,
           executionMode: defaults.executionMode,
           model: defaults.model,
           reasoningEffort: defaults.reasoningEffort,
@@ -1609,6 +1655,23 @@ export class DesktopBackendRegistry {
         };
       }
 
+      if (
+        normalizedExisting.backend !== existing.backend ||
+        normalizedExisting.executionMode !== existing.executionMode ||
+        normalizedExisting.model !== existing.model ||
+        normalizedExisting.reasoningEffort !== existing.reasoningEffort ||
+        normalizedExisting.serviceTier !== existing.serviceTier ||
+        normalizedExisting.fastMode !== existing.fastMode
+      ) {
+        return {
+          launchpad: await this.overlayStore.upsertDirectoryLaunchpad({
+            ...normalizedExisting,
+            updatedAt: Date.now(),
+          }),
+          defaults,
+        };
+      }
+
       return {
         launchpad: existing,
         defaults,
@@ -1620,7 +1683,7 @@ export class DesktopBackendRegistry {
       directoryKind: request.directoryKind,
       directoryLabel: request.directoryLabel,
       directoryPath: request.directoryPath,
-      backend: request.preferredBackend ?? defaults.backend,
+      backend: defaults.backend,
       executionMode: defaults.executionMode,
       model: defaults.model,
       reasoningEffort: defaults.reasoningEffort,
@@ -1793,6 +1856,63 @@ export class DesktopBackendRegistry {
       await this.getBackendLaunchpadOptions(backend),
       settings,
     );
+  }
+
+  private async resolveLaunchpadBackend(
+    preferred: AppServerBackendKind,
+  ): Promise<BackendSummary> {
+    const { backends } = await this.listBackends({ includeUnavailable: true });
+    const availableBackends = backends.filter(
+      (backend) => backend.available && backend.capabilities.createThread,
+    );
+
+    return (
+      availableBackends.find((backend) => backend.kind === preferred) ??
+      availableBackends.find((backend) => backend.kind === "codex") ??
+      availableBackends[0] ??
+      backends.find((backend) => backend.kind === preferred) ??
+      backends.find((backend) => backend.kind === "codex") ??
+      backends[0]!
+    );
+  }
+
+  private async resolveLaunchpadModelSettings(
+    backend: BackendSummary,
+    settings: ModelSettings,
+  ): Promise<ModelSettings> {
+    return resolveModelSettingsFromOptions(
+      backend.kind,
+      backend.launchpadOptions,
+      settings,
+    );
+  }
+
+  private async resolveLaunchpadDefaults(
+    storedDefaults: NavigationLaunchpadDefaults,
+    preferredBackend?: AppServerBackendKind,
+  ): Promise<NavigationLaunchpadDefaults> {
+    const backend = await this.resolveLaunchpadBackend(
+      preferredBackend ?? storedDefaults.backend,
+    );
+    const modelSettings = await this.resolveLaunchpadModelSettings(
+      backend,
+      storedDefaults,
+    );
+    const resolvedDefaults: NavigationLaunchpadDefaults = {
+      ...storedDefaults,
+      backend: backend.kind,
+      executionMode: getAvailableExecutionMode(
+        backend,
+        storedDefaults.executionMode,
+      ),
+      ...modelSettings,
+    };
+
+    if (launchpadDefaultsEqual(storedDefaults, resolvedDefaults)) {
+      return storedDefaults;
+    }
+
+    return await this.overlayStore.setLaunchpadDefaults(resolvedDefaults);
   }
 
   private readCodexDefaultModelsOnce(): Promise<BackendModelOption[]> {


### PR DESCRIPTION
## Summary

I fixed new-thread launchpad provider selection so stale sticky Grok defaults no longer leave the UI split between Grok and OpenAI when Grok is unavailable.

The backend registry now resolves launchpad defaults and saved launchpad drafts against currently available create-capable backends. If the stored default says Grok but only OpenAI is available, the launchpad state, header chip, provider selector, model setting, and send availability all converge on OpenAI.

## Testing

I verified this with:

- `pnpm test -- apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop exec playwright test e2e/provider-model-selectors.spec.ts`

## Notes

The regression test reproduces the rescue case by seeding sticky Grok launchpad defaults while running with only the OpenAI replay backend available. It asserts that the launchpad renders OpenAI, uses the OpenAI model default, does not show the unavailable-backend warning, and leaves the composer enabled.
