### PR TITLE
feat(desktop): Improve branch chooser popover

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -430,6 +430,7 @@ function ComposerDropdown(props: {
   compact?: boolean;
   disabled?: boolean;
   id?: string;
+  kind?: "branch";
   onChange: (value: string) => void;
   options: ComposerDropdownOption[];
   value: string;
@@ -442,7 +443,13 @@ function ComposerDropdown(props: {
 
   return (
     <div
-      className={`composer-dropdown${props.compact ? " composer-dropdown--compact" : ""}`}
+      className={[
+        "composer-dropdown",
+        props.compact ? "composer-dropdown--compact" : "",
+        props.kind === "branch" ? "composer-dropdown--branch" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       ref={ref}
     >
       <button
@@ -489,7 +496,7 @@ function ComposerDropdown(props: {
               ) : (
                 <span aria-hidden="true" className="composer-dropdown__check" />
               )}
-              <span>{option.label}</span>
+              <span className="composer-dropdown__option-label">{option.label}</span>
             </button>
           ))}
         </div>
@@ -2214,6 +2221,7 @@ export function Composer(props: ComposerProps) {
               id="launchpad-branch"
               compact
               disabled={launchpadSubmitting}
+              kind="branch"
               value={
                 props.launchpad.branchName ??
                 props.directory?.gitStatus?.currentBranch ??

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1228,6 +1228,55 @@ describe("Composer", () => {
     });
   });
 
+  it("renders the worktree base branch menu as a branch chooser", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "develop",
+            branches: [
+              "feat/desktop-settings-config",
+              "codex/plan-github-actions-rollout",
+              "develop",
+              "main",
+            ],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "feat/desktop-settings-config",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(screen.getByRole("listbox").closest(".composer-dropdown")).toHaveClass(
+      "composer-dropdown--branch"
+    );
+    expect(
+      screen.getByRole("option", { name: "feat/desktop-settings-config" })
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
   it("shows handoff to local for existing worktree threads", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3753,8 +3753,12 @@ textarea {
   z-index: 30;
   bottom: calc(100% + 8px);
   left: 0;
-  min-width: max(100%, 220px);
+  min-width: max(100%, 260px);
+  max-width: min(420px, calc(100vw - 32px));
+  max-height: min(420px, calc(100dvh - 128px));
   padding: 6px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
@@ -3763,17 +3767,18 @@ textarea {
 
 .composer-dropdown__option {
   width: 100%;
-  min-height: 34px;
+  min-height: 40px;
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 10px;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 10px;
   border: 0;
   border-radius: 6px;
   background: transparent;
   color: var(--text-primary);
   font: inherit;
   font-size: 14px;
+  line-height: 1.35;
   text-align: left;
 }
 
@@ -3792,7 +3797,22 @@ textarea {
   width: 14px;
   flex: 0 0 14px;
   color: var(--accent-bright);
+  line-height: 1.35;
   text-align: center;
+}
+
+.composer-dropdown__option-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.composer-dropdown--branch .composer-dropdown__menu {
+  min-width: max(100%, 340px);
+}
+
+.composer-dropdown--branch .composer-dropdown__option-label,
+.composer-dropdown--branch .composer-dropdown__label {
+  font-family: var(--font-mono);
 }
 
 .composer-dropdown__separator {


### PR DESCRIPTION
## Summary

I tightened up the launchpad base branch chooser so long branch lists stay usable on screen and branch names are easier to scan.

## Changes

- Constrain the dropdown menu to the viewport and make long lists scroll.
- Give branch chooser rows more vertical rhythm so wrapped branch names do not visually run together.
- Use the mono branch-name treatment for branch chooser labels.
- Add a focused renderer regression test for the worktree base branch menu.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop build`
