### PR TITLE
fix(desktop): preserve launchpad sticky defaults

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -303,6 +303,74 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
 
     await expect(workspaceMode).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("opening a directory launchpad without edits does not persist a pending draft", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-state-"));
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      PWRAGNT_STATE_ROOT: stateRoot,
+    },
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+    const overlay = JSON.parse(
+      await readFile(path.join(stateRoot, "overlay-state.json"), "utf8"),
+    );
+    expect(overlay.directoryLaunchpads).toEqual({});
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("directory launchpad keeps full access as the sticky default after user changes access mode", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const accessMode = settings.getByLabel("Access mode");
+    await expect(accessMode).toHaveAttribute("data-value", "default");
+    await selectComposerOption({
+      select: accessMode,
+      window: app.window,
+      option: "Full Access",
+    });
+    await expect(accessMode).toHaveAttribute("data-value", "full-access");
+
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for OtherRepo" })
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "OtherRepo" }),
+    ).toBeVisible();
+    await expect(settings.getByLabel("Access mode")).toHaveAttribute(
+      "data-value",
+      "full-access",
+    );
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -311,12 +311,8 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
 
 test("opening a directory launchpad without edits does not persist a pending draft", async () => {
   const fixture = await createDirectoryLaunchpadFixture();
-  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-launchpad-state-"));
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
-    env: {
-      PWRAGNT_STATE_ROOT: stateRoot,
-    },
   });
 
   try {
@@ -329,13 +325,15 @@ test("opening a directory launchpad without edits does not persist a pending dra
       app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
     ).toBeVisible();
     const overlay = JSON.parse(
-      await readFile(path.join(stateRoot, "overlay-state.json"), "utf8"),
+      await readFile(
+        path.join(app.homeRoot, ".local", "state", "pwragnt", "overlay-state.json"),
+        "utf8",
+      ),
     );
     expect(overlay.directoryLaunchpads).toEqual({});
   } finally {
     await app.close();
     await fixture.cleanup();
-    await rm(stateRoot, { recursive: true, force: true });
   }
 });
 

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -9,6 +9,7 @@ const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 
 type LaunchResult = {
   electronApp: ElectronApplication;
+  homeRoot: string;
   window: Page;
   advance: (params?: {
     executionMode?: ThreadExecutionMode;
@@ -45,7 +46,7 @@ export async function launchElectronApp(params: {
     height: number;
   };
 }): Promise<LaunchResult> {
-  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-desktop-e2e-"));
+  const homeRoot = await mkdtemp(path.join(os.tmpdir(), "pwragnt-desktop-e2e-home-"));
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) {
@@ -53,9 +54,9 @@ export async function launchElectronApp(params: {
     }
   }
   Object.assign(env, {
+    HOME: homeRoot,
     NODE_ENV: "production",
     PWRAGNT_REPLAY_FIXTURE_PATH: params.fixturePath,
-    PWRAGNT_STATE_ROOT: stateRoot,
   });
   delete env.ELECTRON_RENDERER_URL;
   for (const [key, value] of Object.entries(params.env ?? {})) {
@@ -110,6 +111,7 @@ export async function launchElectronApp(params: {
 
   return {
     electronApp,
+    homeRoot,
     window,
     advance: async (advanceParams) => {
       await electronApp.evaluate(async (_electron, value) => {
@@ -153,7 +155,7 @@ export async function launchElectronApp(params: {
     },
     close: async () => {
       await electronApp.close();
-      await rm(stateRoot, { recursive: true, force: true });
+      await rm(homeRoot, { recursive: true, force: true });
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -849,6 +849,7 @@ describe("DesktopBackendRegistry", () => {
     const updated = await registry.updateDirectoryLaunchpad({
       directoryKey: "directory:/repo-a",
       patch: { workMode: "worktree" },
+      stickySettingsChanged: true,
     });
     const next = await registry.ensureDirectoryLaunchpad({
       directoryKey: "directory:/repo-b",
@@ -887,6 +888,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.updateDirectoryLaunchpad({
       directoryKey: "directory:/repo-b",
       patch: { workMode: "worktree" },
+      stickySettingsChanged: true,
     });
 
     const reopened = await registry.ensureDirectoryLaunchpad({
@@ -921,6 +923,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.updateDirectoryLaunchpad({
       directoryKey: "directory:/repo-a",
       patch: { workMode: "worktree" },
+      stickySettingsChanged: true,
     });
 
     const workspace = await registry.ensureDirectoryLaunchpad({
@@ -935,6 +938,70 @@ describe("DesktopBackendRegistry", () => {
     expect(workspace.launchpad.directoryLabel).toBe("Workspaces");
     expect(workspace.launchpad.workMode).toBe("local");
     expect(workspace.launchpad.branchName).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("does not persist a directory launchpad just from opening it", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const opened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(opened.launchpad.prompt).toBe("");
+    await expect(
+      overlayStore.getDirectoryLaunchpad({ directoryKey: "directory:/repo-a" }),
+    ).resolves.toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("does not rewrite sticky defaults when only pending prompt data is saved", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "full-access",
+          workMode: "local",
+        },
+      }),
+    });
+
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: {
+        prompt: "Draft work",
+        executionMode: "default",
+      },
+    });
+
+    expect(updated.launchpad.executionMode).toBe("default");
+    expect(updated.defaults.executionMode).toBe("full-access");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -600,7 +600,8 @@ type ModelSettings = {
 function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): boolean {
   return (
     launchpad.prompt.trim().length === 0 &&
-    (launchpad.imageAttachments?.length ?? 0) === 0
+    (launchpad.imageAttachments?.length ?? 0) === 0 &&
+    launchpad.settingsTouchedAt === undefined
   );
 }
 
@@ -1681,9 +1682,8 @@ export class DesktopBackendRegistry {
           branchName: existing.branchName ?? request.currentBranch,
           updatedAt: Date.now(),
         };
-        const persisted = await this.overlayStore.upsertDirectoryLaunchpad(refreshed);
         return {
-          launchpad: persisted,
+          launchpad: refreshed,
           defaults,
         };
       }
@@ -1728,9 +1728,8 @@ export class DesktopBackendRegistry {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    const persisted = await this.overlayStore.upsertDirectoryLaunchpad(launchpad);
     return {
-      launchpad: persisted,
+      launchpad,
       defaults,
     };
   }
@@ -1752,30 +1751,33 @@ export class DesktopBackendRegistry {
       ...current,
       ...request.patch,
       directoryKey: request.directoryKey,
+      settingsTouchedAt: request.stickySettingsChanged
+        ? Date.now()
+        : current.settingsTouchedAt,
       updatedAt: Date.now(),
     };
     const persisted = await this.overlayStore.upsertDirectoryLaunchpad(nextLaunchpad);
 
     const stickyPatch: Partial<NavigationLaunchpadDefaults> = {};
-    if (request.patch.backend) {
+    if (request.stickySettingsChanged && request.patch.backend) {
       stickyPatch.backend = request.patch.backend;
     }
-    if (request.patch.executionMode) {
+    if (request.stickySettingsChanged && request.patch.executionMode) {
       stickyPatch.executionMode = request.patch.executionMode;
     }
-    if ("model" in request.patch) {
+    if (request.stickySettingsChanged && "model" in request.patch) {
       stickyPatch.model = request.patch.model;
     }
-    if ("reasoningEffort" in request.patch) {
+    if (request.stickySettingsChanged && "reasoningEffort" in request.patch) {
       stickyPatch.reasoningEffort = request.patch.reasoningEffort;
     }
-    if ("serviceTier" in request.patch) {
+    if (request.stickySettingsChanged && "serviceTier" in request.patch) {
       stickyPatch.serviceTier = request.patch.serviceTier;
     }
-    if ("fastMode" in request.patch) {
+    if (request.stickySettingsChanged && "fastMode" in request.patch) {
       stickyPatch.fastMode = request.patch.fastMode;
     }
-    if (request.patch.workMode) {
+    if (request.stickySettingsChanged && request.patch.workMode) {
       stickyPatch.workMode = request.patch.workMode;
     }
 
@@ -1805,9 +1807,10 @@ export class DesktopBackendRegistry {
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
-    const launchpad = await this.overlayStore.getDirectoryLaunchpad({
-      directoryKey: request.directoryKey,
-    });
+    const launchpad =
+      (await this.overlayStore.getDirectoryLaunchpad({
+        directoryKey: request.directoryKey,
+      })) ?? request.launchpad;
     if (!launchpad) {
       throw new Error(`No launchpad found for ${request.directoryKey}`);
     }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -983,6 +983,9 @@ describe("App", () => {
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
         directoryKey: "workspace:new-thread",
+        launchpad: expect.objectContaining({
+          directoryKey: "workspace:new-thread",
+        }),
         input: [
           {
             type: "text",
@@ -1381,6 +1384,9 @@ describe("App", () => {
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
         directoryKey: "workspace:new-thread",
+        launchpad: expect.objectContaining({
+          directoryKey: "workspace:new-thread",
+        }),
         input: [{ type: "text", text: "hello new codex thread" }]
       });
     });
@@ -1665,6 +1671,9 @@ describe("App", () => {
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
         directoryKey: "workspace:new-thread",
+        launchpad: expect.objectContaining({
+          directoryKey: "workspace:new-thread",
+        }),
         input: [
           {
             type: "text",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -81,7 +81,8 @@ type ComposerProps = {
         | "directoryPath"
         | "imageAttachments"
       >
-    >
+    >,
+    options?: { stickySettingsChanged?: boolean }
   ) => Promise<void>;
   removeOptimisticMessage?: (id: string) => void;
   setExecutionModeError?: string;
@@ -1510,7 +1511,9 @@ export function Composer(props: ComposerProps) {
     }
 
     setSendError(undefined);
-    void props.onUpdateLaunchpad(props.launchpad.directoryKey, patch);
+    void props.onUpdateLaunchpad(props.launchpad.directoryKey, patch, {
+      stickySettingsChanged: true,
+    });
   };
 
   const handleThreadModelSettingsPatch = (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1223,7 +1223,8 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(onUpdateLaunchpad).toHaveBeenCalledWith(
         "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
-        { workMode: "worktree" }
+        { workMode: "worktree" },
+        { stickySettingsChanged: true }
       );
     });
   });

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -28,6 +28,19 @@ function buildLaunchpadSelectionKey(directoryKey: string): string {
   return `launchpad:${directoryKey}`;
 }
 
+function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolean {
+  const launchpad = directory.launchpad;
+  if (!launchpad) {
+    return false;
+  }
+
+  return (
+    launchpad.prompt.trim().length > 0 ||
+    (launchpad.imageAttachments?.length ?? 0) > 0 ||
+    launchpad.settingsTouchedAt !== undefined
+  );
+}
+
 export function DirectoriesList(props: DirectoriesListProps) {
   const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>({});
   const threadsByKey = useMemo(
@@ -128,7 +141,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               <button
                 aria-label={`Open new thread launchpad for ${directory.label}`}
                 className={`directory-row__launchpad-button${
-                  directory.launchpad ? " has-draft" : ""
+                  hasPendingLaunchpadState(directory) ? " has-draft" : ""
                 }`}
                 type="button"
                 onClick={() => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -293,6 +293,92 @@ describe("Sidebar", () => {
     expect(onOpenLaunchpad).toHaveBeenCalledWith(directories[0], undefined);
   });
 
+  it("does not highlight an opened-only launchpad as a pending draft", () => {
+    const openedOnlyDirectories: NavigationDirectorySummary[] = [
+      {
+        ...directories[0]!,
+        launchpad: {
+          directoryKey: directories[0]!.key,
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      },
+    ];
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={openedOnlyDirectories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open new thread launchpad for PwrAgnt" }),
+    ).not.toHaveClass("has-draft");
+  });
+
+  it("highlights launchpads with pending prompt data", () => {
+    const pendingDirectories: NavigationDirectorySummary[] = [
+      {
+        ...directories[0]!,
+        launchpad: {
+          directoryKey: directories[0]!.key,
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Pending work",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    ];
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={pendingDirectories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open new thread launchpad for PwrAgnt" }),
+    ).toHaveClass("has-draft");
+  });
+
   it("shows the thinking indicator instead of unread for an active initiated turn", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -671,7 +671,8 @@ type ThreadViewProps = {
         | "directoryPath"
         | "imageAttachments"
       >
-    >
+    >,
+    options?: { stickySettingsChanged?: boolean }
   ) => Promise<void>;
   removeOptimisticMessage: (id: string) => void;
   transcriptViewport?: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -651,8 +651,12 @@ describe("useThreadNavigation", () => {
 
     expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
       directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+      launchpad: expect.objectContaining({
+        directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+      }),
       input: undefined,
       collaborationMode: undefined,
+      reviewTarget: undefined,
     });
     expect(result.current.selectedThread?.id).toBe("thread-new");
     expect(result.current.selectedThread?.gitBranch).toBe("HEAD");

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -736,7 +736,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   updatingThreadExecutionMode?: ThreadExecutionMode;
   updateDirectoryLaunchpad: (
     directoryKey: string,
-    patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"]
+    patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"],
+    options?: { stickySettingsChanged?: boolean }
   ) => Promise<void>;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
@@ -1390,7 +1391,8 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const updateDirectoryLaunchpad = useCallback(
     async (
       directoryKey: string,
-      patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"]
+      patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"],
+      options?: { stickySettingsChanged?: boolean }
     ): Promise<void> => {
       if (!desktopApi?.updateDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing updateDirectoryLaunchpad().");
@@ -1403,6 +1405,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         const response = await desktopApi.updateDirectoryLaunchpad({
           directoryKey,
           patch,
+          stickySettingsChanged: options?.stickySettingsChanged,
         });
         setState((current) => ({
           ...current,
@@ -1489,6 +1492,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       try {
         const response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
+          launchpad,
           input,
           collaborationMode,
           reviewTarget,

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -94,6 +94,59 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("ignores opened-only launchpads with no pending data or touched settings", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/pwrdrvr/PwrAgnt": {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([]);
+  });
+
+  it("keeps launchpads with user-touched settings even when the prompt is empty", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/pwrdrvr/PwrAgnt": {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          backend: "codex",
+          executionMode: "full-access",
+          prompt: "",
+          settingsTouchedAt: 2_000,
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+          settingsTouchedAt: 2_000,
+        }),
+      }),
+    ]);
+  });
+
   it("keeps same-named Codex worktrees as separate directory rows", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -116,6 +116,16 @@ function ensureSummary(
   return created;
 }
 
+function hasPersistableLaunchpadState(
+  launchpad: DirectoryLaunchpadOverlayState,
+): boolean {
+  return (
+    launchpad.prompt.trim().length > 0 ||
+    (launchpad.imageAttachments?.length ?? 0) > 0 ||
+    launchpad.settingsTouchedAt !== undefined
+  );
+}
+
 export function buildDirectorySummaries(params: {
   threads: NavigationThreadSummary[];
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
@@ -174,7 +184,7 @@ export function buildDirectorySummaries(params: {
   }
 
   for (const [directoryKey, launchpad] of Object.entries(params.launchpadsByKey ?? {})) {
-    if (!launchpad) {
+    if (!launchpad || !hasPersistableLaunchpadState(launchpad)) {
       continue;
     }
     const summary = ensureSummary(summaries, {

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -191,8 +191,18 @@ export function buildNavigationSnapshotHash(params: {
             backend: directory.launchpad.backend,
             executionMode: directory.launchpad.executionMode,
             prompt: directory.launchpad.prompt,
+            imageAttachments: (directory.launchpad.imageAttachments ?? []).map((attachment) => ({
+              id: attachment.id,
+              height: attachment.height ?? null,
+              name: attachment.name,
+              size: attachment.size,
+              type: attachment.type,
+              url: attachment.url,
+              width: attachment.width ?? null,
+            })),
             workMode: directory.launchpad.workMode,
             branchName: directory.launchpad.branchName ?? null,
+            settingsTouchedAt: directory.launchpad.settingsTouchedAt ?? null,
             updatedAt: directory.launchpad.updatedAt,
           }
         : null,

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -248,6 +248,10 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
               typeof launchpadRecord.fastMode === "boolean"
                 ? launchpadRecord.fastMode
                 : undefined,
+            settingsTouchedAt:
+              typeof launchpadRecord.settingsTouchedAt === "number"
+                ? launchpadRecord.settingsTouchedAt
+                : undefined,
             createdAt:
               typeof launchpadRecord.createdAt === "number"
                 ? launchpadRecord.createdAt

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -197,6 +197,7 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "directoryPath"
     >
   >;
+  stickySettingsChanged?: boolean;
 };
 
 export type UpdateDirectoryLaunchpadResponse = {
@@ -215,6 +216,7 @@ export type ResetDirectoryLaunchpadResponse = {
 
 export type MaterializeDirectoryLaunchpadRequest = {
   directoryKey: string;
+  launchpad?: NavigationLaunchpadDraft;
   input?: AppServerTurnInputItem[];
   collaborationMode?: AppServerCollaborationModeRequest;
   reviewTarget?: AppServerReviewTarget;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -48,6 +48,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   directoryPath?: string;
   imageAttachments?: NavigationLaunchpadImageAttachment[];
   prompt: string;
+  settingsTouchedAt?: number;
   workMode: LaunchpadWorkMode;
   branchName?: string;
   createdAt: number;


### PR DESCRIPTION
## Summary

I fixed directory launchpad sticky-default persistence so setup defaults only change after an explicit setup-control user action, while prompt text and pasted images still autosave as pending launchpad data.

I also tightened the directory `+` pending-state signal so opened-only launchpads do not persist and do not show as orange pending drafts after restart.

## Details

- Opening a directory launchpad now returns an ephemeral empty draft instead of writing it to the overlay store.
- Launchpad prompt/image autosaves persist pending launchpad data but do not rewrite sticky defaults.
- Setup controls mark their updates as sticky-setting user actions, which updates sticky defaults and records that the launchpad has meaningful pending setup state.
- Directory summaries and sidebar rendering ignore opened-only empty launchpads and only show the orange `+` for real pending data or user-touched settings.
- Desktop E2E launches now isolate home-relative app state with a temporary `HOME`, without setting XDG overrides or `PWRAGNT_STATE_ROOT`.

## Verification

I verified this with:

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragnt/desktop test:e2e -- directory-launchpad-workspace.spec.ts`
