### PR TITLE
test(desktop): cover composer image bottom glue regression

### DIFF
--- a/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
+++ b/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
@@ -23,6 +23,13 @@ async function collectScrollSamples(locator: Locator) {
   return values;
 }
 
+async function distanceFromTranscriptBottom(locator: Locator) {
+  return await locator.evaluate((element) => {
+    const maxScrollTop = Math.max(element.scrollHeight - element.clientHeight, 0);
+    return Math.round(maxScrollTop - element.scrollTop);
+  });
+}
+
 function expectStableSeries(values: number[], label: string) {
   const min = Math.min(...values);
   const max = Math.max(...values);
@@ -41,7 +48,7 @@ test("opens a long transcript at the bottom without downward drift and restores 
     windowSize: {
       width: 1280,
       height: 720,
-    }
+    },
   });
 
   try {
@@ -161,6 +168,110 @@ test("opens a long transcript at the bottom without downward drift and restores 
     await expect(
       transcript.getByText("Short companion thread message 2.")
     ).toHaveCount(0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("keeps a bottom-pinned long transcript glued when a reply image preview resizes the composer", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/long-thread-scroll-stability/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1280,
+      height: 720,
+    }
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Long scroll stability thread/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Long scroll stability thread"
+      })
+    ).toBeVisible();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const list = app.window.locator(".transcript-list__items");
+    const jumpToLatest = app.window.getByRole("button", {
+      name: "Jump to latest message",
+    });
+
+    await expect(
+      transcript.getByText("Long thread message 180: final transcript marker.")
+    ).toBeVisible();
+
+    await expect
+      .poll(async () =>
+        await list.evaluate((element) =>
+          Math.round(Math.max(element.scrollHeight - element.clientHeight, 0))
+        )
+      )
+      .toBeGreaterThan(2000);
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list))
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+
+    await app.window
+      .getByLabel("Reply")
+      .fill("Here is the screenshot that explains it.");
+    await app.window.evaluate(async () => {
+      const textarea = document.querySelector<HTMLTextAreaElement>("#thread-composer");
+      if (!textarea) {
+        throw new Error("Reply textarea not found");
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = 900;
+      canvas.height = 500;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Canvas context not available");
+      }
+      context.fillStyle = "#1f6f78";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.fillStyle = "#ffffff";
+      context.font = "48px sans-serif";
+      context.fillText("composer resize regression", 64, 120);
+
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((value) => {
+          if (!value) {
+            reject(new Error("Could not create pasted image blob"));
+            return;
+          }
+          resolve(value);
+        }, "image/png");
+      });
+      const file = new File([blob], "bottom-glue-regression.png", {
+        type: "image/png",
+      });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      textarea.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dataTransfer,
+        })
+      );
+    });
+
+    await expect(app.window.getByAltText("bottom-glue-regression.png")).toBeVisible();
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list))
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -81,6 +81,10 @@ type ScrollSnapshot = {
   threadId?: string;
 };
 
+type SyncScrollStateOptions = {
+  preserveGlueOnResize?: boolean;
+};
+
 const BOTTOM_THRESHOLD_PX = 24;
 type ScrollBottomMode = "instant" | "smooth";
 
@@ -401,8 +405,31 @@ export function TranscriptList(props: TranscriptListProps) {
     props.threadId
   ]);
 
-  const syncScrollState = useCallback(() => {
-    const snapshot = captureSnapshot();
+  const syncScrollState = useCallback((options?: SyncScrollStateOptions) => {
+    let snapshot = captureSnapshot();
+    const previousSnapshot = snapshotRef.current;
+    const wasGluedToBottom =
+      isGluedToBottomRef.current ||
+      Boolean(previousSnapshot && previousSnapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX);
+    const resizedWhileBottomPinned = Boolean(
+      options?.preserveGlueOnResize &&
+        snapshot &&
+        previousSnapshot &&
+        wasGluedToBottom &&
+        snapshot.distanceFromBottom > BOTTOM_THRESHOLD_PX &&
+        snapshot.scrollTop === previousSnapshot.scrollTop &&
+        (snapshot.clientHeight !== previousSnapshot.clientHeight ||
+          snapshot.scrollHeight !== previousSnapshot.scrollHeight)
+    );
+
+    if (resizedWhileBottomPinned) {
+      const container = scrollContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+        snapshot = captureSnapshot();
+      }
+    }
+
     snapshotRef.current = snapshot;
     const isAtBottom = Boolean(snapshot && snapshot.distanceFromBottom <= BOTTOM_THRESHOLD_PX);
     if (isAtBottom) {
@@ -580,7 +607,8 @@ export function TranscriptList(props: TranscriptListProps) {
 
   useEffect(() => {
     const content = scrollContentRef.current;
-    if (!content || typeof ResizeObserver === "undefined") {
+    const container = scrollContainerRef.current;
+    if (!content || !container || typeof ResizeObserver === "undefined") {
       return undefined;
     }
 
@@ -588,10 +616,11 @@ export function TranscriptList(props: TranscriptListProps) {
       if (isGluedToBottomRef.current) {
         scrollToBottom("instant");
       } else {
-        syncScrollState();
+        syncScrollState({ preserveGlueOnResize: true });
       }
     });
     observer.observe(content);
+    observer.observe(container);
     return () => {
       observer.disconnect();
     };
@@ -634,7 +663,9 @@ export function TranscriptList(props: TranscriptListProps) {
             disableBottomGlue();
           }
         }}
-        onScroll={syncScrollState}
+        onScroll={() => {
+          syncScrollState({ preserveGlueOnResize: true });
+        }}
       >
         <div ref={scrollContentRef} className="transcript-list__content">
           {transcriptRenderItems.map((item) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1937,6 +1937,36 @@ describe("TranscriptList", () => {
     }
   });
 
+  it("keeps the bottom pinned when the transcript viewport shrinks without user scroll", () => {
+    const entries = Array.from({ length: 18 }, (_, index) => ({
+      type: "message" as const,
+      id: `viewport-resize-message-${index + 1}`,
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      text: `Viewport resize transcript message ${index + 1}`
+    }));
+    scrollHeight = 720;
+    clientHeight = 240;
+    render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 480;
+    fireEvent.scroll(list);
+
+    clientHeight = 154;
+    fireEvent.scroll(list);
+
+    expect(list.scrollTop).toBe(720);
+    expect(screen.queryByRole("button", { name: "Jump to latest message" })).not.toBeInTheDocument();
+  });
+
   it("does not move the reader when new messages arrive below an older viewport", () => {
     const entries = Array.from({ length: 16 }, (_, index) => ({
       type: "message" as const,


### PR DESCRIPTION
## Summary

This fixes the transcript bottom-glue regression when a user is replying in an existing long thread and pastes an image. The composer image preview can shrink the transcript viewport, but that layout resize is not a user scroll action, so the transcript now preserves bottom-following mode instead of showing the jump-to-latest control.

## Changes

- Adds an E2E regression that opens a long existing thread, types reply text, pastes an image into the composer, and verifies the transcript remains bottom-pinned.
- Preserves transcript glue when the scroll container or rendered transcript resizes while it was already pinned to the bottom.
- Adds a renderer unit test for viewport shrink without user scroll.

## Verification

I verified:

```sh
pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
pnpm --filter @pwragnt/desktop test:e2e -- thread-open-scroll-stability.spec.ts
pnpm --filter @pwragnt/desktop typecheck
```

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)
