### PR TITLE
fix(desktop): show queued image thumbnails

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,4 +1,5 @@
 import {
+  type ReactNode,
   type ClipboardEvent,
   type DragEvent,
   useEffect,
@@ -336,6 +337,38 @@ function formatDraftPreview(draft: QueuedTurnDraft): string {
   return `${draft.imageAttachments.length} image${
     draft.imageAttachments.length === 1 ? "" : "s"
   }`;
+}
+
+function QueuedImageAttachments(props: {
+  attachments: ComposerImageAttachment[];
+}): ReactNode {
+  if (props.attachments.length === 0) {
+    return null;
+  }
+
+  const visibleAttachments = props.attachments.slice(0, 3);
+  const overflowCount = props.attachments.length - visibleAttachments.length;
+
+  return (
+    <div
+      className="composer__queued-images"
+      aria-label={`Queued image attachments: ${props.attachments.length}`}
+    >
+      {visibleAttachments.map((attachment, index) => (
+        <img
+          className="composer__queued-image"
+          key={attachment.id}
+          src={attachment.url}
+          alt={formatPastedImageAlt(attachment, index)}
+        />
+      ))}
+      {overflowCount > 0 ? (
+        <span className="composer__queued-image-count">
+          +{overflowCount}
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 function collectTextFragments(value: unknown): string[] {
@@ -1656,6 +1689,7 @@ export function Composer(props: ComposerProps) {
               {formatDraftPreview(pendingSteer)}
             </span>
           </div>
+          <QueuedImageAttachments attachments={pendingSteer.imageAttachments} />
           <div className="composer__queued-actions">
             {pendingSteer.status === "pending" ? (
               <>
@@ -1694,6 +1728,7 @@ export function Composer(props: ComposerProps) {
               {formatDraftPreview(queuedTurn)}
             </span>
           </div>
+          <QueuedImageAttachments attachments={queuedTurn.imageAttachments} />
           <div className="composer__queued-actions">
             {supportsSteering ? (
               <button

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -376,6 +376,62 @@ describe("Composer", () => {
     });
   });
 
+  it("shows queued image thumbnails while a turn is active", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "queued.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Active image turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("queued.png")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+    expect(screen.getByText("1 image")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Queued image attachments: 1")
+    ).toBeInTheDocument();
+    expect(screen.getByAltText("queued.png")).toBeInTheDocument();
+  });
+
   it("steers Command Enter during an active turn when supported", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3533,7 +3533,7 @@ textarea {
 
 .composer__queued {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 10px;
   padding: 8px 10px;
@@ -3568,6 +3568,35 @@ textarea {
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.composer__queued-images {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.composer__queued-image,
+.composer__queued-image-count {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-hover);
+}
+
+.composer__queued-image {
+  object-fit: cover;
+}
+
+.composer__queued-image-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .composer__queued-actions {


### PR DESCRIPTION
## Summary

This fixes the queued-message preview so image attachments are visible before the message is sent.

I added compact thumbnails to queued and pending-steer rows, keeping them on the right side before the action buttons so normal queued text rows keep the same height. Image-only queued drafts still show the existing text fallback like `1 image`, but now also show a visible preview.

## Screenshots

### After

<img width="1392" height="956" alt="image" src="https://github.com/user-attachments/assets/f4907c3b-8d05-4ef3-a64a-0b59a8b644cd" />

### Before

<img width="950" height="380" alt="image" src="https://github.com/user-attachments/assets/28b21419-1d97-4240-8a29-069f97eca462" />

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
- `git diff --check`
