### PR TITLE
fix(desktop): Preserve composer drafts when opening settings

### DIFF
--- a/apps/desktop/e2e/composer-draft-settings.spec.ts
+++ b/apps/desktop/e2e/composer-draft-settings.spec.ts
@@ -1,0 +1,230 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createComposerDraftSettingsFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-composer-draft-settings-"));
+  const fixturePath = path.join(rootDir, "composer-draft-settings.fixture.json");
+  await mkdir(rootDir, { recursive: true });
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "composer-draft-settings",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-first",
+                title: "Draft survives settings thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-second",
+                title: "Second draft parking thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-first",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "first-message-1",
+                  role: "assistant",
+                  text: "First thread is ready.",
+                },
+              ],
+              messages: [
+                {
+                  id: "first-message-1",
+                  role: "assistant",
+                  text: "First thread is ready.",
+                },
+              ],
+              lastAssistantMessage: "First thread is ready.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-read-second",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "second-message-1",
+                  role: "assistant",
+                  text: "Second thread is ready.",
+                },
+              ],
+              messages: [
+                {
+                  id: "second-message-1",
+                  role: "assistant",
+                  text: "Second thread is ready.",
+                },
+              ],
+              lastAssistantMessage: "Second thread is ready.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-read-first-again",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "first-message-1",
+                  role: "assistant",
+                  text: "First thread is ready.",
+                },
+              ],
+              messages: [
+                {
+                  id: "first-message-1",
+                  role: "assistant",
+                  text: "First thread is ready.",
+                },
+              ],
+              lastAssistantMessage: "First thread is ready.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("keeps a thread reply draft after opening settings and returning to the thread", async () => {
+  const fixture = await createComposerDraftSettingsFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-chips",
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const draft = "$ce:plan keep this draft through settings";
+    const reply = app.window.getByRole("textbox", { name: "Reply" });
+
+    await app.window
+      .getByRole("button", { name: /Draft survives settings thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Draft survives settings thread",
+      }),
+    ).toBeVisible();
+
+    await reply.fill(draft);
+
+    await app.window
+      .getByRole("button", { name: /Second draft parking thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Second draft parking thread",
+      }),
+    ).toBeVisible();
+
+    await app.window
+      .getByRole("button", { name: /Draft survives settings thread/i })
+      .first()
+      .click();
+    await expect(reply).toHaveValue(draft);
+
+    await app.window.getByRole("button", { name: "Open settings" }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 1,
+        name: "Settings",
+      }),
+    ).toBeVisible();
+
+    const threadButtonCoveredBySettings = await app.window
+      .getByRole("button", { name: /Draft survives settings thread/i })
+      .first()
+      .evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        const topElement = document.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+        return Boolean(topElement?.closest(".app-shell__settings-layer"));
+      });
+    expect(threadButtonCoveredBySettings).toBe(true);
+
+    await app.window.getByRole("button", { name: "Back" }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Draft survives settings thread",
+      }),
+    ).toBeVisible();
+    await expect(reply).toHaveValue(draft);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -125,12 +125,6 @@ function DesktopAppShell(props: {
       />
 
       <main className="app-main">
-        {mainView === "settings" ? (
-          <SettingsScreen
-            settings={settings}
-            onClose={() => setMainView("thread")}
-          />
-        ) : (
         <ThreadView
           activeTurnId={session.activeTurnId}
           activeTurnStartedAt={session.activeTurnStartedAt}
@@ -217,8 +211,16 @@ function DesktopAppShell(props: {
           removeOptimisticMessage={session.removeOptimisticMessage}
           transcriptViewport={session.viewport}
         />
-        )}
       </main>
+
+      {mainView === "settings" ? (
+        <div className="app-shell__settings-layer">
+          <SettingsScreen
+            settings={settings}
+            onClose={() => setMainView("thread")}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -63,6 +63,7 @@ textarea {
 
 .app-shell {
   display: grid;
+  position: relative;
   grid-template-columns: var(--sidebar-width, 408px) minmax(0, 1fr);
   align-items: stretch;
   height: 100vh;
@@ -1151,6 +1152,17 @@ textarea {
   min-width: 0;
   padding: 24px 0 24px 28px;
   overflow: hidden;
+}
+
+.app-shell__settings-layer {
+  display: flex;
+  position: absolute;
+  z-index: 30;
+  inset: 0;
+  min-width: 0;
+  min-height: 0;
+  padding: 24px;
+  background: var(--bg-app);
 }
 
 .thread-view {
@@ -4597,6 +4609,12 @@ textarea {
   .app-main {
     display: block;
     overflow: visible;
+    padding: 20px 16px 24px;
+  }
+
+  .app-shell__settings-layer {
+    position: fixed;
+    overflow: auto;
     padding: 20px 16px 24px;
   }
 


### PR DESCRIPTION
## Summary

I fixed the composer draft loss when opening Settings by keeping the app shell mounted underneath a full-app settings layer. The Settings screen now covers the sidebar and conversation, and the existing Back button closes it, so thread-local composer state survives opening Settings and returning to the thread.

I also added a replay-backed desktop E2E regression that verifies a Tiptap-configured composer draft survives:

- switching to another thread and back
- opening Settings, covering the thread list, and returning with Back

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test`
- `pnpm --filter @pwragnt/desktop build && pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/composer-draft-settings.spec.ts`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/directory-launchpad-workspace.spec.ts:427`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/plan-autocomplete-order.spec.ts`
- `pnpm test:desktop-e2e` (one unrelated `plan-autocomplete-order` failure, passed on direct rerun)
