### PR TITLE
fix(desktop): stale steer recovery

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -283,6 +283,11 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
   };
+  lastSteerTurnParams?: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    expectedTurnId: string;
+  };
   lastStartReviewParams?: {
     threadId: string;
     target: AppServerReviewTarget;
@@ -318,6 +323,7 @@ class MockBackendClient {
   };
   listThreadsCallCount = 0;
   listModelsCallCount = 0;
+  steerTurnCallCount = 0;
   lastListThreadsParams?: {
     filter?: string;
   };
@@ -345,6 +351,7 @@ class MockBackendClient {
       modelListErrors?: Error[];
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
+      steerTurnError?: Error;
       setThreadPermissionsError?: Error;
     }
   ) {}
@@ -501,6 +508,20 @@ class MockBackendClient {
 
   async interruptTurn(): Promise<{ threadId: string; turnId: string }> {
     return { threadId: "thread-1", turnId: "turn-1" };
+  }
+
+  async steerTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    expectedTurnId: string;
+  }): Promise<{ threadId: string; turnId: string }> {
+    this.steerTurnCallCount += 1;
+    this.lastSteerTurnParams = params;
+    if (this.options.steerTurnError) {
+      throw this.options.steerTurnError;
+    }
+
+    return { threadId: params.threadId, turnId: params.expectedTurnId };
   }
 
   async emit(notification: AppServerNotification): Promise<void> {
@@ -1223,6 +1244,47 @@ describe("DesktopBackendRegistry", () => {
       threadId: "thread-title",
       name: "Leopard tea button",
     });
+
+    await registry.close();
+  });
+
+  it("steers Codex turns through the active execution mode for the thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/steer"] },
+      steerTurnError: new Error("json-rpc error (-32600): no active turn to steer"),
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/steer"] },
+      steerTurnError: new Error(
+        "json-rpc error (-32600): expected active turn id `turn-0` but found `turn-1`",
+      ),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock({ executionMode: "full-access" }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Start active work" }],
+    });
+
+    await expect(
+      registry.steerTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-0",
+        input: [{ type: "text", text: "Course correct" }],
+      }),
+    ).rejects.toThrow("expected active turn id `turn-0` but found `turn-1`");
+
+    expect(codexFullAccessClient.steerTurnCallCount).toBe(1);
+    expect(codexClient.steerTurnCallCount).toBe(0);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1451,7 +1451,7 @@ export class DesktopBackendRegistry {
 
     const result =
       params.backend === "codex"
-        ? await this.withCodexThreadClient(params.threadId, steerWithClient)
+        ? await this.withActiveCodexThreadClient(params.threadId, steerWithClient)
         : await steerWithClient(this.grokClient);
 
     return {
@@ -2189,6 +2189,30 @@ export class DesktopBackendRegistry {
     }
 
     throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  private async withActiveCodexThreadClient<T>(
+    threadId: string,
+    operation: (client: BackendClient, mode: ThreadExecutionMode) => Promise<T>,
+  ): Promise<T> {
+    const activeMode = this.findActiveCodexThreadMode(threadId);
+    if (activeMode) {
+      return await operation(this.getClient("codex", activeMode), activeMode);
+    }
+
+    return await this.withCodexThreadClient(threadId, operation);
+  }
+
+  private findActiveCodexThreadMode(threadId: string): ThreadExecutionMode | undefined {
+    const keyPrefix = `${threadId}:`;
+    const modes = new Set<ThreadExecutionMode>();
+    for (const [key, mode] of this.activeCodexTurnModes.entries()) {
+      if (key.startsWith(keyPrefix)) {
+        modes.add(mode);
+      }
+    }
+
+    return modes.size === 1 ? [...modes][0] : undefined;
   }
 
   private async archiveWithClient(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -411,6 +411,29 @@ function isSteerInjectionOpportunity(method: string): boolean {
   return method === "item/completed" || method === "exec_command/ended";
 }
 
+function parseStaleSteerError(
+  error: unknown
+): { activeTurnId?: string; active: boolean } | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  if (normalized.includes("no active turn to steer")) {
+    return { active: false };
+  }
+
+  const activeTurnMatch = message.match(/found `([^`]+)`/);
+  if (
+    normalized.includes("expected active turn id") &&
+    activeTurnMatch?.[1]
+  ) {
+    return {
+      active: true,
+      activeTurnId: activeTurnMatch[1],
+    };
+  }
+
+  return undefined;
+}
+
 function HighlightedAutocompleteLabel(props: {
   label: string;
   query: string;
@@ -1189,6 +1212,25 @@ export function Composer(props: ComposerProps) {
         input: payload.input,
       });
     } catch (error) {
+      const staleSteer = parseStaleSteerError(error);
+      if (staleSteer) {
+        if (queuedTurn) {
+          setDraft(pending.text);
+          setImageAttachments(pending.imageAttachments);
+        } else {
+          setQueuedTurn({
+            text: pending.text,
+            imageAttachments: pending.imageAttachments,
+          });
+        }
+        setPendingSteer(undefined);
+        setSendError(undefined);
+        const nextActiveTurnId = staleSteer.active ? staleSteer.activeTurnId : undefined;
+        updateActiveTurnId(nextActiveTurnId);
+        props.onActiveTurnIdChange?.(nextActiveTurnId);
+        props.onPendingStatusChange?.(staleSteer.active ? "Thinking" : undefined);
+        return;
+      }
       setPendingSteer((current) =>
         current?.text === pending.text &&
         current.imageAttachments === pending.imageAttachments

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -773,6 +773,230 @@ describe("Composer", () => {
     expect(screen.getByText("steer failed")).toBeInTheDocument();
   });
 
+  it("sends a pending steer as the next turn when Codex reports no active turn", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerTurn = vi.fn(async () => {
+      throw new Error("json-rpc error (-32600): no active turn to steer");
+    });
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const onActiveTurnIdChange = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn,
+          steerTurn,
+        }}
+        disabled={false}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Recovered stale steer",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Send after stale steer" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter", metaKey: true });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "ready",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledTimes(1);
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Send after stale steer" }],
+        }),
+      );
+    });
+    expect(onActiveTurnIdChange).toHaveBeenCalledWith(undefined);
+    expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
+    expect(screen.queryByText("no active turn to steer")).not.toBeInTheDocument();
+  });
+
+  it("queues a stale pending steer behind the active turn Codex reports", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerTurn = vi.fn(async () => {
+      throw new Error(
+        "json-rpc error (-32600): expected active turn id `turn-1` but found `turn-2`",
+      );
+    });
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-3",
+    }));
+    const onActiveTurnIdChange = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startTurn,
+          steerTurn,
+        }}
+        disabled={false}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Queued stale steer",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Queue after the real active turn" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter", metaKey: true });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "ready",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledTimes(1);
+      expect(onActiveTurnIdChange).toHaveBeenCalledWith("turn-2");
+    });
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            turn: {
+              id: "turn-2",
+              status: "completed",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Queue after the real active turn" }],
+        }),
+      );
+    });
+  });
+
   it("restores a pending steer to the draft when turn completion leaves an existing queue", async () => {
     let agentEventHandler:
       | ((event: {


### PR DESCRIPTION
## Summary

I fixed stale desktop steer recovery for Codex turns.

The captured protocol traffic for thread `019dde4b-4979-7220-938e-ca79eb4e34c4` showed a `turn/steer` request using stale expected turn `019de4a8-831e-7083-b3ae-b5e9fe3dd2b1`. The full-access Codex client reported the real active turn was `019de4a8-7e43-77c0-948b-821113067d1e`, then the desktop fallback tried the default client and surfaced the less useful `no active turn to steer` error.

## Changes

- Route Codex `steerTurn` through the known active execution mode for the thread when the registry has one.
- Recover stale composer steer failures by preserving the user input:
  - `no active turn to steer` becomes the next normal queued turn.
  - `expected active turn id ... but found ...` updates the active turn id and queues the draft behind that turn.
- Added unit coverage for the captured main-process mode-routing failure and the renderer stale-steer recovery paths.

## Verification

I verified this with:

- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragnt/desktop exec vitest run --environment jsdom src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test -- apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
