### PR TITLE
fix(desktop): preserve directory launchpad identity

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -275,6 +275,17 @@ async function createDirectoryLaunchpadFixture(): Promise<{
   };
 }
 
+async function readOverlayState(homeRoot: string): Promise<{
+  directoryLaunchpads?: Record<string, unknown>;
+}> {
+  return JSON.parse(
+    await readFile(
+      path.join(homeRoot, ".local", "state", "pwragnt", "overlay-state.json"),
+      "utf8",
+    ),
+  );
+}
+
 test("directory launchpad can switch from local checkout to a new worktree", async () => {
   const fixture = await createDirectoryLaunchpadFixture();
   const app = await launchElectronApp({
@@ -309,7 +320,7 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
   }
 });
 
-test("opening a directory launchpad without edits does not persist a pending draft", async () => {
+test("opening a directory launchpad persists directory identity for future draft saves", async () => {
   const fixture = await createDirectoryLaunchpadFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -324,13 +335,69 @@ test("opening a directory launchpad without edits does not persist a pending dra
     await expect(
       app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
     ).toBeVisible();
-    const overlay = JSON.parse(
-      await readFile(
-        path.join(app.homeRoot, ".local", "state", "pwragnt", "overlay-state.json"),
-        "utf8",
-      ),
-    );
-    expect(overlay.directoryLaunchpads).toEqual({});
+
+    const rootDir = path.dirname(fixture.fixturePath);
+    const repoDir = path.join(rootDir, "FixtureRepo");
+    const directoryKey = `directory:${repoDir}`;
+    await expect
+      .poll(async () => {
+        const overlay = await readOverlayState(app.homeRoot);
+        return overlay.directoryLaunchpads?.[directoryKey];
+      })
+      .toMatchObject({
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        prompt: "",
+      });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad draft save does not leak the directory key into project labels", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const rootDir = path.dirname(fixture.fixturePath);
+    const repoDir = path.join(rootDir, "FixtureRepo");
+    const directoryKey = `directory:${repoDir}`;
+
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("Keep the project identity stable");
+
+    await expect
+      .poll(async () => {
+        const overlay = await readOverlayState(app.homeRoot);
+        return overlay.directoryLaunchpads?.[directoryKey];
+      })
+      .toMatchObject({
+        directoryKey,
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        prompt: "Keep the project identity stable",
+      });
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+    await expect(app.window.getByText(/^directory:/)).toHaveCount(0);
+    await expect(app.window.getByText("FixtureRepo").first()).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -963,7 +963,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("does not persist a directory launchpad just from opening it", async () => {
+  it("persists directory launchpad identity when opening it", async () => {
     const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
@@ -988,7 +988,48 @@ describe("DesktopBackendRegistry", () => {
     expect(opened.launchpad.prompt).toBe("");
     await expect(
       overlayStore.getDirectoryLaunchpad({ directoryKey: "directory:/repo-a" }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      prompt: "",
+    });
+
+    await registry.close();
+  });
+
+  it("keeps launchpad directory metadata when the first draft update arrives", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      currentBranch: "main",
+    });
+
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { prompt: "Fix the app" },
+    });
+
+    expect(updated.launchpad.directoryLabel).toBe("Repo A");
+    expect(updated.launchpad.directoryPath).toBe("/repo-a");
+    expect(updated.launchpad.branchName).toBe("main");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1683,7 +1683,7 @@ export class DesktopBackendRegistry {
           updatedAt: Date.now(),
         };
         return {
-          launchpad: refreshed,
+          launchpad: await this.overlayStore.upsertDirectoryLaunchpad(refreshed),
           defaults,
         };
       }
@@ -1729,7 +1729,7 @@ export class DesktopBackendRegistry {
       updatedAt: Date.now(),
     };
     return {
-      launchpad,
+      launchpad: await this.overlayStore.upsertDirectoryLaunchpad(launchpad),
       defaults,
     };
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -139,6 +139,12 @@ function insertPendingEntry(
     return;
   }
 
+  const existingIndex = entries.findIndex((entry) => entry.id === pendingEntry.id);
+  if (existingIndex >= 0) {
+    entries[existingIndex] = pendingEntry;
+    return;
+  }
+
   const pendingTurnId = pendingEntry.turn?.id;
   if (!pendingTurnId || isAssistantFinalMessage(pendingEntry)) {
     entries.push(pendingEntry);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -879,6 +879,50 @@ describe("TranscriptList", () => {
     expect(workGroup).toHaveAttribute("aria-expanded", "false");
   });
 
+  it("replaces a persisted entry when pending protocol activity has the same id", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "activity",
+            id: "live-mcp-protocol-status",
+            summary: "MCP server starting",
+            status: "in_progress",
+            details: [
+              {
+                id: "mcp-status-context7",
+                kind: "command",
+                label: "MCP context7 starting",
+                status: "in_progress"
+              }
+            ]
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingProtocolActivityEntry={{
+          type: "activity",
+          id: "live-mcp-protocol-status",
+          summary: "MCP server ready",
+          status: "completed",
+          details: [
+            {
+              id: "mcp-status-context7",
+              kind: "command",
+              label: "MCP context7 ready",
+              status: "completed"
+            }
+          ]
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole("button", { name: /MCP server ready/i })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: /MCP server starting/i })).not.toBeInTheDocument();
+  });
+
   it("keeps a pending tool below the earlier pending assistant message that started first", () => {
     render(
       <TranscriptList


### PR DESCRIPTION
## Summary

I fixed the directory launchpad identity flow so opening a project launchpad persists its directory metadata immediately. That keeps later draft autosaves from reconstructing the launchpad with the internal `directory:/...` key as the user-facing label.

I also made transcript pending entries replace same-id persisted entries before rendering, which prevents the duplicate `live-mcp-protocol-status` React key warning from producing duplicate children.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @pwragnt/desktop build && pnpm --filter @pwragnt/desktop test:e2e -- directory-launchpad-workspace.spec.ts`

The E2E now opens a directory launchpad, triggers draft autosave, and verifies the persisted project label remains `FixtureRepo` instead of leaking `directory:/...`.
