### PR TITLE
fix(desktop): repair stale launchpad labels

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -404,6 +404,54 @@ test("directory launchpad draft save does not leak the directory key into projec
   }
 });
 
+test("directory launchpad repairs stale drafts that saved the internal directory key as the label", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const rootDir = path.dirname(fixture.fixturePath);
+    const repoDir = path.join(rootDir, "FixtureRepo");
+    const directoryKey = `directory:${repoDir}`;
+
+    await app.window.evaluate(async (key) => {
+      await (window as any).pwragnt.updateDirectoryLaunchpad({
+        directoryKey: key,
+        patch: {
+          prompt: "A stale draft that already has content",
+        },
+      });
+    }, directoryKey);
+
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+    await expect(app.window.getByText(/^directory:/)).toHaveCount(0);
+
+    await expect
+      .poll(async () => {
+        const overlay = await readOverlayState(app.homeRoot);
+        return overlay.directoryLaunchpads?.[directoryKey];
+      })
+      .toMatchObject({
+        directoryKey,
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        prompt: "A stale draft that already has content",
+      });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("directory launchpad keeps full access as the sticky default after user changes access mode", async () => {
   const fixture = await createDirectoryLaunchpadFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1034,6 +1034,51 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("repairs stale non-empty launchpad directory metadata when reopened", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { prompt: "Already drafted" },
+    });
+
+    const reopened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      currentBranch: "main",
+    });
+
+    expect(reopened.launchpad).toMatchObject({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      prompt: "Already drafted",
+    });
+    await expect(
+      overlayStore.getDirectoryLaunchpad({ directoryKey: "directory:/repo-a" }),
+    ).resolves.toMatchObject({
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    await registry.close();
+  });
+
   it("does not rewrite sticky defaults when only pending prompt data is saved", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1665,6 +1665,10 @@ export class DesktopBackendRegistry {
         executionMode,
         ...modelSettings,
       };
+      const identityChanged =
+        normalizedExisting.directoryKind !== request.directoryKind ||
+        normalizedExisting.directoryLabel !== request.directoryLabel ||
+        normalizedExisting.directoryPath !== request.directoryPath;
 
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
         const refreshed: NavigationLaunchpadDraft = {
@@ -1689,6 +1693,7 @@ export class DesktopBackendRegistry {
       }
 
       if (
+        identityChanged ||
         normalizedExisting.backend !== existing.backend ||
         normalizedExisting.executionMode !== existing.executionMode ||
         normalizedExisting.model !== existing.model ||
@@ -1699,6 +1704,9 @@ export class DesktopBackendRegistry {
         return {
           launchpad: await this.overlayStore.upsertDirectoryLaunchpad({
             ...normalizedExisting,
+            directoryKind: request.directoryKind,
+            directoryLabel: request.directoryLabel,
+            directoryPath: request.directoryPath,
             updatedAt: Date.now(),
           }),
           defaults,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -862,8 +862,10 @@ export function ThreadView(props: ThreadViewProps) {
     };
   }, [props.desktopApi, selectedLaunchpad, selectedThreadKey]);
 
-  const publishLiveTranscriptEntry = useCallback(<T extends AppServerThreadEntry,>(entry: T): T => {
-    props.onLiveTranscriptEntry?.(entry);
+  const deferLiveTranscriptEntry = useCallback(<T extends AppServerThreadEntry,>(entry: T): T => {
+    queueMicrotask(() => {
+      props.onLiveTranscriptEntry?.(entry);
+    });
     return entry;
   }, [props.onLiveTranscriptEntry]);
 
@@ -987,21 +989,21 @@ export function ThreadView(props: ThreadViewProps) {
           setPendingActivityEntry((current) => {
             const next = completeEntryTurn(current);
             if (next) {
-              publishLiveTranscriptEntry(next);
+              deferLiveTranscriptEntry(next);
             }
             return next;
           });
           setPendingProtocolActivityEntry((current) => {
             const next = completeEntryTurn(current);
             if (next) {
-              publishLiveTranscriptEntry(next);
+              deferLiveTranscriptEntry(next);
             }
             return next;
           });
           setPendingPlanEntry((current) => {
             const next = completeEntryTurn(current);
             if (next) {
-              publishLiveTranscriptEntry(next);
+              deferLiveTranscriptEntry(next);
             }
             return next;
           });
@@ -1178,8 +1180,8 @@ export function ThreadView(props: ThreadViewProps) {
     props.activeTurnId,
     props.activeTurnStartedAt,
     props.desktopApi,
+    deferLiveTranscriptEntry,
     liveNotificationTurnId,
-    publishLiveTranscriptEntry,
     selectedThread,
   ]);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerNotification, AppServerPendingRequestNotification } from "@pwragnt/shared";
 import type { PendingMcpInteractionState } from "../mcp-elicitation";
@@ -2862,6 +2863,119 @@ describe("ThreadView", () => {
       });
     } finally {
       setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("defers completed live transcript publishing outside the render phase", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onPublished = vi.fn();
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: AppServerNotification;
+        }) => void)
+      | undefined;
+
+    function Harness() {
+      const [entries, setEntries] = useState<any[]>([]);
+
+      return (
+        <ThreadView
+          activeTurnId="turn-1"
+          activeTurnStartedAt={1_000}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{
+            onAgentEvent: (callback) => {
+              agentEventHandler = callback as typeof agentEventHandler;
+              return () => undefined;
+            },
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          selectedThread={{
+            id: "thread-live",
+            title: "Live turn",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+          }}
+          skills={[]}
+          transcriptEntries={entries}
+          clearPendingRequest={() => undefined}
+          onLiveTranscriptEntry={(entry) => {
+            onPublished(entry);
+            setEntries((current) => [...current, entry]);
+          }}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    try {
+      render(<Harness />);
+
+      await act(async () => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "mcpServer/startupStatus/updated",
+            params: {
+              name: "context7",
+              status: "ready",
+            },
+          },
+        });
+      });
+
+      await act(async () => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-live",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                completedAt: 2_000,
+                output: [],
+              },
+            },
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(onPublished).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "live-mcp-protocol-status",
+            turn: expect.objectContaining({
+              id: "turn-1",
+              status: "completed",
+            }),
+          }),
+        );
+      });
+      expect(
+        consoleErrorSpy.mock.calls.some((call) =>
+          call.some(
+            (part) =>
+              typeof part === "string" &&
+              part.includes("Cannot update a component"),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleErrorSpy.mockRestore();
     }
   });
 });

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -94,6 +94,61 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("uses the directory basename when a linked thread label is an internal directory key", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "directory:/Users/huntharo/github/PwrAgnt",
+              path: "/Users/huntharo/github/PwrAgnt",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/github/PwrAgnt",
+        label: "PwrAgnt",
+      }),
+    ]);
+  });
+
+  it("normalizes stale launchpad labels that contain internal directory keys", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/github/PwrAgnt": {
+          directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "directory:/Users/huntharo/github/PwrAgnt",
+          directoryPath: "/Users/huntharo/github/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Existing draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/github/PwrAgnt",
+        label: "PwrAgnt",
+        launchpad: expect.objectContaining({
+          directoryLabel: "PwrAgnt",
+          prompt: "Existing draft",
+        }),
+      }),
+    ]);
+  });
+
   it("ignores opened-only launchpads with no pending data or touched settings", () => {
     const directories = buildDirectorySummaries({
       threads: [],

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -22,6 +22,27 @@ function pathBaseName(value?: string): string {
   return parts.at(-1) ?? normalized;
 }
 
+function isInternalDirectoryLabel(value?: string): boolean {
+  return Boolean(value?.startsWith("directory:") || value?.startsWith("workspace:"));
+}
+
+function displayDirectoryLabel(params: {
+  kind?: DirectoryDescriptor["kind"];
+  label?: string;
+  path?: string;
+}): string {
+  const label = params.label?.trim();
+  if (label && !isInternalDirectoryLabel(label)) {
+    return label;
+  }
+
+  if (params.kind === "workspace") {
+    return "Workspaces";
+  }
+
+  return pathBaseName(params.path) || label || "Directory";
+}
+
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
   const scratchWorkspaceMatch = directory.path.match(
     /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/,
@@ -64,7 +85,11 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
   return {
     key: `directory:${directory.path}`,
     kind: "directory",
-    label: directory.label,
+    label: displayDirectoryLabel({
+      kind: "directory",
+      label: directory.label,
+      path: directory.path,
+    }),
     path: directory.path,
   };
 }
@@ -190,10 +215,21 @@ export function buildDirectorySummaries(params: {
     const summary = ensureSummary(summaries, {
       key: directoryKey,
       kind: launchpad.directoryKind,
-      label: launchpad.directoryLabel,
+      label: displayDirectoryLabel({
+        kind: launchpad.directoryKind,
+        label: launchpad.directoryLabel,
+        path: launchpad.directoryPath,
+      }),
       path: launchpad.directoryPath,
     });
-    summary.launchpad = launchpad;
+    summary.launchpad = {
+      ...launchpad,
+      directoryLabel: displayDirectoryLabel({
+        kind: launchpad.directoryKind,
+        label: launchpad.directoryLabel,
+        path: launchpad.directoryPath,
+      }),
+    };
     summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, launchpad.updatedAt);
   }
 


### PR DESCRIPTION
## Summary

I fixed a stale launchpad state case where an existing non-empty directory draft could keep `directory:/...` as its saved label after the earlier launchpad identity fix. Reopening a directory launchpad now refreshes the directory identity fields while preserving the user's prompt, images, and settings.

I also added defensive directory label normalization so internal keys like `directory:/...` or `workspace:/...` cannot leak into directory rows or launchpad headers if stale data already exists.

Finally, I fixed the React render-phase warning from completed live transcript entries by deferring the parent `onLiveTranscriptEntry` callback until after the pending-entry state updater returns.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop build && pnpm --filter @pwragnt/desktop test:e2e -- directory-launchpad-workspace.spec.ts`
- `pnpm typecheck`

I also manually verified the stale `directory:/...` launchpad display repaired correctly in the running app.
