### PR TITLE
fix(agent-core): derive stale launchpad paths

### DIFF
--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -149,6 +149,37 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("derives stale launchpad display labels from the directory key when path is missing", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/github/PwrAgnt": {
+          directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+          directoryKind: "directory",
+          directoryLabel: "directory:/Users/huntharo/github/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Existing draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/github/PwrAgnt",
+        label: "PwrAgnt",
+        path: "/Users/huntharo/github/PwrAgnt",
+        launchpad: expect.objectContaining({
+          directoryLabel: "PwrAgnt",
+          directoryPath: "/Users/huntharo/github/PwrAgnt",
+        }),
+      }),
+    ]);
+  });
+
   it("ignores opened-only launchpads with no pending data or touched settings", () => {
     const directories = buildDirectorySummaries({
       threads: [],

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -43,6 +43,15 @@ function displayDirectoryLabel(params: {
   return pathBaseName(params.path) || label || "Directory";
 }
 
+function pathFromDirectoryKey(directoryKey: string): string | undefined {
+  const directoryPath = directoryKey.startsWith("directory:")
+    ? directoryKey.slice("directory:".length)
+    : directoryKey.startsWith("workspace:")
+      ? directoryKey.slice("workspace:".length)
+      : undefined;
+  return directoryPath?.trim() || undefined;
+}
+
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
   const scratchWorkspaceMatch = directory.path.match(
     /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/,
@@ -212,23 +221,22 @@ export function buildDirectorySummaries(params: {
     if (!launchpad || !hasPersistableLaunchpadState(launchpad)) {
       continue;
     }
+    const launchpadPath = launchpad.directoryPath ?? pathFromDirectoryKey(directoryKey);
+    const launchpadLabel = displayDirectoryLabel({
+      kind: launchpad.directoryKind,
+      label: launchpad.directoryLabel,
+      path: launchpadPath,
+    });
     const summary = ensureSummary(summaries, {
       key: directoryKey,
       kind: launchpad.directoryKind,
-      label: displayDirectoryLabel({
-        kind: launchpad.directoryKind,
-        label: launchpad.directoryLabel,
-        path: launchpad.directoryPath,
-      }),
-      path: launchpad.directoryPath,
+      label: launchpadLabel,
+      path: launchpadPath,
     });
     summary.launchpad = {
       ...launchpad,
-      directoryLabel: displayDirectoryLabel({
-        kind: launchpad.directoryKind,
-        label: launchpad.directoryLabel,
-        path: launchpad.directoryPath,
-      }),
+      directoryLabel: launchpadLabel,
+      directoryPath: launchpadPath,
     };
     summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, launchpad.updatedAt);
   }


### PR DESCRIPTION
## Summary

I fixed the stale launchpad normalization fallback so launchpad records with only a `directoryKey` like `directory:/repo` can still recover a real path and display label.

This makes the repaired launchpad path handling more robust for drafts created by the old autosave path where `directoryPath` was missing but the key still encoded the directory.

## Testing

- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm typecheck`
