### PR TITLE
feat(messaging): sync platform topic names

### DIFF
--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -969,6 +969,7 @@ function createApi(options: {
   deleteApplicationCommand: ReturnType<typeof vi.fn>;
   listApplicationCommands: ReturnType<typeof vi.fn>;
   sendTyping: ReturnType<typeof vi.fn>;
+  updateChannelName: ReturnType<typeof vi.fn>;
   updateApplicationCommand: ReturnType<typeof vi.fn>;
   updateInteractionOriginalResponse: ReturnType<typeof vi.fn>;
   updateMessage: ReturnType<typeof vi.fn>;
@@ -1013,6 +1014,9 @@ function createApi(options: {
       async (_applicationId: string) => applicationCommands,
     ),
     sendTyping: vi.fn(async (_channelId: string) => undefined),
+    updateChannelName: vi.fn(
+      async (_channelId: string, _request: { name: string }) => undefined,
+    ),
     updateApplicationCommand: vi.fn(
       async (
         applicationId: string,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1131,10 +1131,67 @@ describe("MessagingController", () => {
       text: expect.stringContaining("Turn: working"),
     });
   });
+
+  it("syncs the platform conversation name from the bound thread title", async () => {
+    const setConversationTitle = vi.fn(
+      async (
+        request: Parameters<NonNullable<MessagingAdapter["setConversationTitle"]>>[0],
+      ) => ({
+      channel: "telegram" as const,
+      conversation: {
+        ...request.channel.conversation,
+        title: request.title,
+      },
+      outcome: "updated" as const,
+      title: request.title,
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({ setConversationTitle });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:sync-name",
+        routingState: {
+          opaque: {
+            chatId: 777,
+            messageThreadId: 9,
+          },
+        },
+      }),
+    );
+
+    expect(setConversationTitle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "chat-1",
+          }),
+        }),
+        routingState: {
+          opaque: {
+            chatId: 777,
+            messageThreadId: 9,
+          },
+        },
+        title: "Thread one",
+      }),
+    );
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "confirmation",
+      title: "Name synced",
+      body: expect.stringContaining('Thread one'),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Binding: Thread one"),
+    });
+  });
 });
 
 async function createHarness(options?: {
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+  setConversationTitle?: MessagingAdapter["setConversationTitle"];
 }): Promise<{
   controller: MessagingController;
   compactThread: ReturnType<typeof vi.fn>;
@@ -1169,6 +1226,9 @@ async function createHarness(options?: {
           };
         }),
     ),
+    ...(options?.setConversationTitle
+      ? { setConversationTitle: options.setConversationTitle }
+      : {}),
   };
   const getNavigationSnapshot = vi.fn(async () => buildNavigationSnapshot());
   const startThread = vi.fn(async (request: StartThreadRequest) => ({
@@ -1382,6 +1442,7 @@ function buildTextEvent(text: string): MessagingInboundTextEvent {
 
 function buildCallbackEvent(params: {
   actionId: string;
+  routingState?: MessagingInboundCallbackEvent["routingState"];
   value?: MessagingInboundCallbackEvent["value"];
 }): MessagingInboundCallbackEvent {
   return {
@@ -1398,6 +1459,7 @@ function buildCallbackEvent(params: {
       },
     },
     receivedAt: 1000,
+    routingState: params.routingState,
     interaction: {
       channel: "telegram",
       id: params.actionId,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -126,10 +126,11 @@ describe("MessagingController", () => {
     ).resolves.toMatchObject({
       backend: "codex",
       threadId: "new-thread-1",
-      threadDisplay: {
-        projectLabel: "PwrAgnt",
-      },
     });
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(binding).not.toHaveProperty("threadDisplay");
   });
 
   it("binds a callback-selected thread to the channel", async () => {
@@ -586,13 +587,10 @@ describe("MessagingController", () => {
         }),
       ],
     });
-    await expect(
-      harness.store.findActiveBindingForChannel(buildTextEvent("who are you").channel),
-    ).resolves.toMatchObject({
-      activeTurn: {
-        status: "completed",
-      },
-    });
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildTextEvent("who are you").channel,
+    );
+    expect(binding).not.toHaveProperty("activeTurn");
   });
 
   it("ignores turn completion events that do not include output text", async () => {
@@ -1147,6 +1145,9 @@ describe("MessagingController", () => {
       updatedAt: 1000,
     }));
     const harness = await createHarness({ setConversationTitle });
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.title = "Renamed in Desktop";
+    harness.getNavigationSnapshot.mockResolvedValue(navigation);
     await bindThread(harness);
 
     await harness.controller.handleInboundEvent(
@@ -1174,17 +1175,17 @@ describe("MessagingController", () => {
             messageThreadId: 9,
           },
         },
-        title: "Thread one",
+        title: "Renamed in Desktop",
       }),
     );
     expect(harness.delivered.at(-2)).toMatchObject({
       kind: "confirmation",
       title: "Name synced",
-      body: expect.stringContaining('Thread one'),
+      body: expect.stringContaining('Renamed in Desktop'),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Binding: Thread one"),
+      text: expect.stringContaining("Binding: Renamed in Desktop"),
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -204,6 +204,49 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Thread state: unavailable");
     expect(intent.text).not.toContain("Old cached title");
   });
+
+  it("uses launchpad defaults after live state and binding preferences", () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      backend: "codex",
+      executionMode: "full-access",
+      fastMode: true,
+      model: "gpt-5.4",
+      reasoningEffort: "medium",
+    };
+    const thread = navigation.threads[0]!;
+    delete thread.executionMode;
+    delete thread.fastMode;
+    delete thread.model;
+    delete thread.reasoningEffort;
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+
+    const intent = buildBindingStatusIntent({
+      id: "status-6",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Model: gpt-5.4");
+    expect(intent.text).toContain("Reasoning: medium");
+    expect(intent.text).toContain("Fast mode: on");
+    expect(intent.text).toContain("Permissions: Full Access");
+  });
 });
 
 function buildNavigationSnapshot(): NavigationSnapshot {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -1,35 +1,38 @@
 import { describe, expect, it } from "vitest";
 import type { MessagingBindingRecord, NavigationSnapshot } from "@pwragnt/shared";
 import { buildBindingStatusIntent } from "../messaging/core/messaging-status-card";
+import { resolveMessagingThreadState } from "../messaging/core/messaging-thread-state";
 
 describe("buildBindingStatusIntent", () => {
   it("renders binding, preference, project, and unavailable status fields", () => {
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      preferences: {
+        fastMode: true,
+        model: "gpt-5.3-codex",
+        permissionsMode: "full-access",
+        reasoningEffort: "high",
+        updatedAt: 1000,
+      },
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
     const intent = buildBindingStatusIntent({
       id: "status-1",
       createdAt: 1000,
-      binding: {
-        id: "binding-1",
-        authorizedActorIds: ["user-1"],
-        backend: "codex",
-        channel: {
-          channel: "telegram",
-          conversation: {
-            id: "chat-1",
-            kind: "dm",
-          },
-        },
-        createdAt: 1000,
-        preferences: {
-          fastMode: true,
-          model: "gpt-5.3-codex",
-          permissionsMode: "full-access",
-          reasoningEffort: "high",
-          updatedAt: 1000,
-        },
-        threadId: "thread-1",
-        updatedAt: 1000,
-      } satisfies MessagingBindingRecord,
-      navigation: buildNavigationSnapshot(),
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
     expect(intent).toMatchObject({
@@ -47,6 +50,7 @@ describe("buildBindingStatusIntent", () => {
     });
     expect(intent.text).toContain("Binding: Thread one (codex)");
     expect(intent.text).toContain("Project: PwrAgnt");
+    expect(intent.text).toContain("Branch: unavailable");
     expect(intent.text).toContain("Model: gpt-5.3-codex");
     expect(intent.text).toContain("Reasoning: high");
     expect(intent.text).toContain("Fast mode: on");
@@ -55,29 +59,31 @@ describe("buildBindingStatusIntent", () => {
   });
 
   it("targets an existing status surface for updates", () => {
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      statusSurface: {
+        channel: "telegram",
+        id: "42",
+      },
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
     const intent = buildBindingStatusIntent({
       id: "status-2",
       createdAt: 1000,
-      binding: {
-        id: "binding-1",
-        authorizedActorIds: ["user-1"],
-        backend: "codex",
-        channel: {
-          channel: "telegram",
-          conversation: {
-            id: "chat-1",
-            kind: "dm",
-          },
-        },
-        createdAt: 1000,
-        statusSurface: {
-          channel: "telegram",
-          id: "42",
-        },
-        threadId: "thread-1",
-        updatedAt: 1000,
-      } satisfies MessagingBindingRecord,
-      navigation: buildNavigationSnapshot(),
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
     expect(intent.delivery?.mode).toBe("update");
@@ -90,30 +96,31 @@ describe("buildBindingStatusIntent", () => {
   it("renders live thread permissions ahead of stale binding preferences", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0]!.executionMode = "default";
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      preferences: {
+        executionMode: "full-access",
+        permissionsMode: "full-access",
+        updatedAt: 900,
+      },
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
     const intent = buildBindingStatusIntent({
       id: "status-3",
       createdAt: 1000,
-      binding: {
-        id: "binding-1",
-        authorizedActorIds: ["user-1"],
-        backend: "codex",
-        channel: {
-          channel: "telegram",
-          conversation: {
-            id: "chat-1",
-            kind: "dm",
-          },
-        },
-        createdAt: 1000,
-        preferences: {
-          executionMode: "full-access",
-          permissionsMode: "full-access",
-          updatedAt: 900,
-        },
-        threadId: "thread-1",
-        updatedAt: 1000,
-      } satisfies MessagingBindingRecord,
-      navigation,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
     expect(intent.text).toContain("Permissions: Default Access");
@@ -123,6 +130,79 @@ describe("buildBindingStatusIntent", () => {
         label: "Permissions: Default",
       }),
     );
+  });
+
+  it("renders live thread state ahead of stale binding display metadata", () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.title = "Renamed in Desktop";
+    navigation.threads[0]!.gitBranch = "main";
+    navigation.threads[0]!.observedGitBranch = "feature/work";
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      threadDisplay: {
+        directoryPath: "/old/path",
+        projectLabel: "Old Project",
+        threadTitle: "Old cached title",
+      },
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+
+    const intent = buildBindingStatusIntent({
+      id: "status-4",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Binding: Renamed in Desktop (codex)");
+    expect(intent.text).not.toContain("Old cached title");
+    expect(intent.text).not.toContain("Old Project");
+    expect(intent.text).toContain("Branch: main (now feature/work)");
+  });
+
+  it("renders a stale binding without falling back to old display metadata", () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads = [];
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      threadDisplay: {
+        threadTitle: "Old cached title",
+      },
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+
+    const intent = buildBindingStatusIntent({
+      id: "status-5",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Binding: thread-1 (codex)");
+    expect(intent.text).toContain("Thread state: unavailable");
+    expect(intent.text).not.toContain("Old cached title");
   });
 });
 

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -190,6 +190,64 @@ describe("MessagingStore", () => {
     });
   });
 
+  it("drops deprecated cached thread display and active turn data from bindings", async () => {
+    const { filePath, store } = await createStore();
+    await store.upsertBinding(
+      buildBinding({
+        activeTurn: {
+          status: "working",
+          turnId: "turn-1",
+          updatedAt: 1000,
+        },
+        threadDisplay: {
+          directoryPath: "/old/path",
+          projectLabel: "Old Project",
+          threadTitle: "Old cached title",
+          worktreePath: "/old/worktree",
+        },
+      }),
+    );
+
+    await expect(store.getBinding("binding-1")).resolves.toEqual(
+      expect.not.objectContaining({
+        activeTurn: expect.anything(),
+        threadDisplay: expect.anything(),
+      }),
+    );
+
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        version: 2,
+        browseSessions: {},
+        bindings: {
+          "binding-1": buildBinding({
+            activeTurn: {
+              status: "working",
+              turnId: "turn-1",
+              updatedAt: 1000,
+            },
+            threadDisplay: {
+              threadTitle: "Old cached title",
+            },
+          }),
+        },
+        callbackHandles: {},
+        pendingIntents: {},
+        deliveries: {},
+      }),
+      "utf8",
+    );
+
+    const reloaded = new MessagingStore(filePath);
+    await expect(reloaded.getBinding("binding-1")).resolves.toEqual(
+      expect.not.objectContaining({
+        activeTurn: expect.anything(),
+        threadDisplay: expect.anything(),
+      }),
+    );
+  });
+
   it("finds active bindings by stable channel conversation and ignores revoked records", async () => {
     const { store } = await createStore();
     await store.upsertBinding(buildBinding());

--- a/apps/desktop/src/main/__tests__/messaging-thread-state.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-thread-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type {
+  MessagingBindingRecord,
+  MessagingActiveTurnSummary,
+  NavigationSnapshot,
+} from "@pwragnt/shared";
+import { resolveMessagingThreadState } from "../messaging/core/messaging-thread-state";
+
+describe("resolveMessagingThreadState", () => {
+  it("resolves current desktop thread facts from navigation state", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    const activeTurn = {
+      turnId: "turn-1",
+      status: "working",
+      updatedAt: 1000,
+    } satisfies MessagingActiveTurnSummary;
+
+    const state = resolveMessagingThreadState({ activeTurn, binding, navigation });
+
+    expect(state).toMatchObject({
+      activeTurn,
+      directoryPath: "/repo/pwragnt",
+      executionMode: "full-access",
+      fastMode: false,
+      gitBranch: "main",
+      missing: false,
+      model: "gpt-5.5",
+      observedGitBranch: "feature/live",
+      projectLabel: "PwrAgnt",
+      reasoningEffort: "high",
+      threadKey: "codex:thread-1",
+      title: "Live desktop title",
+      workMode: "worktree",
+      worktreePath: "/repo/pwragnt/.worktrees/live",
+    });
+  });
+
+  it("returns a missing state without using stale binding display metadata", () => {
+    const binding = buildBinding({
+      threadDisplay: {
+        directoryPath: "/old/path",
+        projectLabel: "Old Project",
+        threadTitle: "Old cached title",
+        worktreePath: "/old/worktree",
+      },
+    });
+    const navigation = buildNavigationSnapshot();
+    navigation.threads = [];
+
+    const state = resolveMessagingThreadState({ binding, navigation });
+
+    expect(state).toEqual({
+      missing: true,
+      threadKey: "codex:thread-1",
+    });
+  });
+});
+
+function buildBinding(
+  overrides: Partial<MessagingBindingRecord> = {},
+): MessagingBindingRecord {
+  return {
+    id: "binding-1",
+    authorizedActorIds: ["user-1"],
+    backend: "codex",
+    channel: {
+      channel: "telegram",
+      conversation: {
+        id: "chat-1",
+        kind: "dm",
+      },
+    },
+    createdAt: 1000,
+    threadId: "thread-1",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildNavigationSnapshot(): NavigationSnapshot {
+  return {
+    backend: "all",
+    directories: [
+      {
+        key: "directory:pwragnt",
+        kind: "directory",
+        label: "PwrAgnt",
+        latestUpdatedAt: 1000,
+        needsAttentionCount: 0,
+        path: "/repo/pwragnt",
+        threadKeys: ["codex:thread-1"],
+      },
+    ],
+    fetchedAt: 1000,
+    inboxThreadKeys: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+    threads: [
+      {
+        executionMode: "full-access",
+        fastMode: false,
+        gitBranch: "main",
+        id: "thread-1",
+        inbox: {
+          inInbox: false,
+        },
+        linkedDirectories: [
+          {
+            id: "directory:pwragnt",
+            kind: "local",
+            label: "PwrAgnt",
+            path: "/repo/pwragnt",
+          },
+          {
+            id: "worktree:pwragnt-live",
+            kind: "worktree",
+            label: "PwrAgnt",
+            path: "/repo/pwragnt",
+            worktreePath: "/repo/pwragnt/.worktrees/live",
+          },
+        ],
+        model: "gpt-5.5",
+        observedGitBranch: "feature/live",
+        reasoningEffort: "high",
+        source: "codex",
+        title: "Live desktop title",
+        titleSource: "explicit",
+      },
+    ],
+    unchanged: false,
+  };
+}

--- a/apps/desktop/src/main/__tests__/messaging-thread-state.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-thread-state.test.ts
@@ -51,6 +51,10 @@ describe("resolveMessagingThreadState", () => {
     const state = resolveMessagingThreadState({ binding, navigation });
 
     expect(state).toEqual({
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
       missing: true,
       threadKey: "codex:thread-1",
     });

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -16,6 +16,7 @@ import type {
 import { TelegramAdapter } from "@pwragnt/messaging-provider-telegram";
 import type {
   TelegramBotApi,
+  TelegramEditForumTopicRequest,
   TelegramEditMessageTextRequest,
   TelegramPinChatMessageRequest,
   TelegramSendChatActionRequest,
@@ -171,6 +172,57 @@ describe("TelegramAdapter", () => {
       }),
     );
     expect(api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("renames Telegram forum topics without allowing plain chat renames", async () => {
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: ["42"],
+      },
+      now: () => 1000,
+    });
+
+    await expect(
+      adapter.setConversationTitle({
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "9",
+            kind: "topic",
+            parentId: "777",
+          },
+        },
+        title: "Thread one",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "updated",
+      title: "Thread one",
+    });
+    expect(api.editForumTopic).toHaveBeenCalledWith({
+      chat_id: 777,
+      message_thread_id: 9,
+      name: "Thread one",
+    });
+
+    await expect(
+      adapter.setConversationTitle({
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "channel",
+          },
+        },
+        title: "Thread one",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "unsupported",
+    });
+    expect(api.editForumTopic).toHaveBeenCalledTimes(1);
   });
 
   it("expires Telegram typing activity when no idle signal arrives", async () => {
@@ -1175,6 +1227,7 @@ async function createControllerHarness(): Promise<{
 function createApi(): {
   answerCallbackQuery: ReturnType<typeof vi.fn>;
   deleteWebhook: ReturnType<typeof vi.fn>;
+  editForumTopic: ReturnType<typeof vi.fn>;
   editMessageText: ReturnType<typeof vi.fn>;
   getWebhookInfo: ReturnType<typeof vi.fn>;
   pinChatMessage: ReturnType<typeof vi.fn>;
@@ -1187,6 +1240,7 @@ function createApi(): {
   return {
     answerCallbackQuery: vi.fn(async () => true),
     deleteWebhook: vi.fn(async () => true),
+    editForumTopic: vi.fn(async (_request: TelegramEditForumTopicRequest) => true),
     editMessageText: vi.fn(async (request: TelegramEditMessageTextRequest) => ({
       chat: {
         id: Number(request.chat_id),

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -9,6 +9,10 @@ import type {
   ListBackendsResponse,
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingActorIdentity,
+  MessagingAdapterState,
+  MessagingChannelRef,
+  MessagingChannelKind,
   NavigationSnapshot,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
@@ -23,8 +27,27 @@ import type {
   SubmitServerRequestResponse,
 } from "@pwragnt/shared";
 
+export type MessagingConversationTitleUpdateRequest = {
+  actor?: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+  title: string;
+};
+
+export type MessagingConversationTitleUpdateResult = {
+  channel: MessagingChannelKind;
+  conversation: MessagingChannelRef["conversation"];
+  errorMessage?: string;
+  outcome: "updated" | "unsupported" | "failed";
+  title: string;
+  updatedAt: number;
+};
+
 export type MessagingAdapter = {
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  setConversationTitle?(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult>;
 };
 
 export type MessagingBackendBridge = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1095,6 +1095,10 @@ export class MessagingController {
       await this.compactThread(binding, event);
       return;
     }
+    if (actionId === "status:sync-name") {
+      await this.syncConversationName(binding, event);
+      return;
+    }
 
     await this.deliver(
       buildConfirmationIntent({
@@ -1317,6 +1321,97 @@ export class MessagingController {
       force: true,
     });
     await this.renderBindingStatus(updatedBinding, event);
+  }
+
+  private async syncConversationName(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    if (!this.options.adapter.setConversationTitle) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("status-sync-name-unavailable"),
+          createdAt: this.now(),
+          title: "Name sync unavailable",
+          body: "This messaging provider does not support syncing the conversation name.",
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const threadTitle = normalizeConversationTitle(
+      findThreadForBinding(navigation, binding)?.title ?? binding.threadDisplay?.threadTitle,
+    );
+    if (!threadTitle) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("status-sync-name-missing-title"),
+          createdAt: this.now(),
+          title: "Name sync unavailable",
+          body: "This thread does not have a Codex thread name to sync yet.",
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+      return;
+    }
+
+    const result = await this.options.adapter.setConversationTitle({
+      actor: event.actor,
+      channel: binding.channel,
+      routingState: event.routingState ?? binding.routingState,
+      title: threadTitle,
+    });
+    if (result.outcome !== "updated") {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("status-sync-name-failed"),
+          createdAt: this.now(),
+          title: "Name sync unavailable",
+          body:
+            result.errorMessage ??
+            `This ${conversationKindLabel(binding.channel.conversation.kind)} cannot be renamed from messaging.`,
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+      return;
+    }
+
+    const updatedBinding = await this.options.store.upsertBinding({
+      ...binding,
+      channel: {
+        ...binding.channel,
+        conversation: {
+          ...binding.channel.conversation,
+          title: result.title,
+        },
+      },
+      threadDisplay: {
+        ...binding.threadDisplay,
+        threadTitle: result.title,
+      },
+      updatedAt: this.now(),
+    });
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("status-sync-name-confirmed"),
+        createdAt: this.now(),
+        title: "Name synced",
+        body: `Set this ${conversationKindLabel(binding.channel.conversation.kind)} name to "${result.title}".`,
+      }),
+      updatedBinding,
+      event,
+    );
+    await this.renderBindingStatus(updatedBinding, event, navigation);
   }
 
   private async updateBindingPreferences(
@@ -1785,6 +1880,24 @@ function readBrowseAction(event: MessagingInboundCallbackEvent): string | undefi
 function readStatusAction(event: MessagingInboundCallbackEvent): string | undefined {
   const actionId = event.actionId ?? event.interaction.id;
   return actionId.startsWith("status:") ? actionId : undefined;
+}
+
+function normalizeConversationTitle(title: string | undefined): string | undefined {
+  const normalized = title?.replace(/\s+/g, " ").trim();
+  return normalized || undefined;
+}
+
+function conversationKindLabel(kind: MessagingBindingRecord["channel"]["conversation"]["kind"]): string {
+  switch (kind) {
+    case "topic":
+      return "topic";
+    case "thread":
+      return "thread";
+    case "channel":
+      return "channel";
+    case "dm":
+      return "conversation";
+  }
 }
 
 function threadIdForBackendEvent(event: AgentEvent): ThreadIdentifier | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -22,6 +22,7 @@ import type {
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
 import { MessagingStore, buildMessagingConversationKey } from "./messaging-store.js";
 import type { MessagingAdapter, MessagingBackendBridge } from "./messaging-adapter.js";
 import {
@@ -50,6 +51,7 @@ import {
   buildStatusModelPickerIntent,
   buildStatusReasoningPickerIntent,
 } from "./messaging-status-card.js";
+import { resolveMessagingThreadState } from "./messaging-thread-state.js";
 
 const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
@@ -120,6 +122,7 @@ export class MessagingController {
   private readonly now: () => number;
   private readonly pendingIntentTtlMs: number;
   private readonly interactionMapper: MessagingInteractionMapper;
+  private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
 
@@ -196,60 +199,65 @@ export class MessagingController {
     );
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
     for (const binding of bindings) {
-      let currentBinding = binding;
+      let activeTurn = this.getActiveTurn(binding);
       if (lifecycle) {
-        currentBinding = await this.options.store.upsertBinding({
-          ...binding,
-          activeTurn: lifecycle,
+        const previousTurn = activeTurn;
+        activeTurn = lifecycle;
+        this.setActiveTurn(binding, activeTurn);
+        this.logBindingTurnStateChange(
+          binding,
+          previousTurn,
+          activeTurn,
+          event.notification.method,
+        );
+      } else if (isThreadStatusIdleEvent(event) && activeTurn) {
+        const previousTurn = activeTurn;
+        activeTurn = {
+          ...activeTurn,
+          status: "completed",
           updatedAt: this.now(),
-        });
-        this.logBindingTurnStateChange(binding, currentBinding, event.notification.method);
-      } else if (isThreadStatusIdleEvent(event) && binding.activeTurn) {
-        currentBinding = await this.options.store.upsertBinding({
-          ...binding,
-          activeTurn: {
-            ...binding.activeTurn,
-            status: "completed",
-            updatedAt: this.now(),
-          },
-          updatedAt: this.now(),
-        });
-        this.logBindingTurnStateChange(binding, currentBinding, event.notification.method);
+        };
+        this.setActiveTurn(binding, activeTurn);
+        this.logBindingTurnStateChange(
+          binding,
+          previousTurn,
+          activeTurn,
+          event.notification.method,
+        );
       }
 
       const assistantText = assistantTextForBackendEvent(event);
-      if (assistantText && !lifecycle && currentBinding.activeTurn?.status === "working") {
-        currentBinding = await this.options.store.upsertBinding({
-          ...currentBinding,
-          activeTurn: {
-            ...currentBinding.activeTurn,
-            status: "completed",
-            updatedAt: this.now(),
-          },
+      if (assistantText && !lifecycle && activeTurn?.status === "working") {
+        const previousTurn = activeTurn;
+        activeTurn = {
+          ...activeTurn,
+          status: "completed",
           updatedAt: this.now(),
-        });
+        };
+        this.setActiveTurn(binding, activeTurn);
         this.logBindingTurnStateChange(
           binding,
-          currentBinding,
+          previousTurn,
+          activeTurn,
           event.notification.method,
         );
-        await this.signalTurnActivity(currentBinding, currentBinding.activeTurn!, {
+        await this.signalTurnActivity(binding, activeTurn, {
           reason: "assistant_final",
           force: true,
         });
       }
       if (assistantText) {
-        await this.deliverAssistantMessage(assistantText, event, currentBinding);
+        await this.deliverAssistantMessage(assistantText, event, binding);
       }
 
-      if (lifecycle || (isThreadStatusIdleEvent(event) && binding.activeTurn)) {
-        await this.signalTurnActivity(currentBinding, currentBinding.activeTurn!, {
+      if (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn)) {
+        await this.signalTurnActivity(binding, activeTurn!, {
           reason: event.notification.method,
           force: true,
         });
-        await this.renderBindingStatus(currentBinding);
-      } else if (!assistantText && currentBinding.activeTurn?.status === "working") {
-        await this.signalTurnActivity(currentBinding, currentBinding.activeTurn, {
+        await this.renderBindingStatus(binding);
+      } else if (!assistantText && activeTurn?.status === "working") {
+        await this.signalTurnActivity(binding, activeTurn, {
           reason: event.notification.method,
         });
       }
@@ -300,19 +308,16 @@ export class MessagingController {
         });
       }
       if (request.params.turnId) {
-        const updatedBinding = await this.options.store.upsertBinding({
-          ...binding,
-          activeTurn: {
-            turnId: request.params.turnId,
-            status: "waiting",
-            updatedAt: this.now(),
-          },
+        const activeTurn: MessagingActiveTurnSummary = {
+          turnId: request.params.turnId,
+          status: "waiting",
           updatedAt: this.now(),
-        });
-        await this.signalTurnActivity(updatedBinding, updatedBinding.activeTurn!, {
+        };
+        this.setActiveTurn(binding, activeTurn);
+        await this.signalTurnActivity(binding, activeTurn, {
           force: true,
         });
-        await this.renderBindingStatus(updatedBinding);
+        await this.renderBindingStatus(binding);
       }
     }
   }
@@ -443,20 +448,17 @@ export class MessagingController {
       ],
       ...turnSettings,
     });
-    const updatedBinding = await this.options.store.upsertBinding({
-      ...binding,
-      activeTurn: {
-        turnId: started.turnId,
-        status: "working",
-        startedAt: this.now(),
-        updatedAt: this.now(),
-      },
+    const activeTurn: MessagingActiveTurnSummary = {
+      turnId: started.turnId,
+      status: "working",
+      startedAt: this.now(),
       updatedAt: this.now(),
-    });
-    await this.signalTurnActivity(updatedBinding, updatedBinding.activeTurn!, {
+    };
+    this.setActiveTurn(binding, activeTurn);
+    await this.signalTurnActivity(binding, activeTurn, {
       force: true,
     });
-    await this.renderBindingStatus(updatedBinding, undefined, navigation);
+    await this.renderBindingStatus(binding, undefined, navigation);
   }
 
   private async handleCallback(event: MessagingInboundCallbackEvent): Promise<void> {
@@ -863,12 +865,9 @@ export class MessagingController {
         return;
       }
       const binding = await this.bindChannelToThread(event, target);
-      const updatedBinding = await this.applyBrowseBindingMetadata(
-        binding,
-        session,
-        navigation,
-        target,
-      );
+      const updatedBinding = session.preferences
+        ? await this.updateBindingPreferences(binding, session.preferences)
+        : binding;
       await this.options.store.deleteBrowseSession(session.id);
       await this.deliver(
         buildConfirmationIntent({
@@ -958,15 +957,9 @@ export class MessagingController {
       backend: started.backend,
       threadId: started.threadId,
     });
-    const updatedBinding = await this.options.store.upsertBinding({
-      ...binding,
-      preferences,
-      threadDisplay: {
-        directoryPath: directory?.path ?? project.path,
-        projectLabel: directory?.label ?? project.label,
-      },
-      updatedAt: this.now(),
-    });
+    const updatedBinding = preferences
+      ? await this.updateBindingPreferences(binding, preferences)
+      : binding;
     await this.options.store.deleteBrowseSession(session.id);
     await this.deliver(
       buildConfirmationIntent({
@@ -979,32 +972,6 @@ export class MessagingController {
       updatedBinding,
     );
     await this.renderBindingStatus(updatedBinding, event);
-  }
-
-  private async applyBrowseBindingMetadata(
-    binding: MessagingBindingRecord,
-    session: MessagingBrowseSessionRecord,
-    navigation: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
-    target: { backend: AppServerBackendKind; threadId: ThreadIdentifier },
-  ): Promise<MessagingBindingRecord> {
-    const thread = navigation.threads.find(
-      (candidate) => candidate.source === target.backend && candidate.id === target.threadId,
-    );
-    const directory = session.selectedProject
-      ? directoryForProjectSelection(navigation, session.selectedProject)
-      : undefined;
-    return await this.options.store.upsertBinding({
-      ...binding,
-      preferences: session.preferences,
-      threadDisplay: {
-        directoryPath: directory?.path ?? thread?.linkedDirectories[0]?.path,
-        projectLabel: directory?.label ?? thread?.linkedDirectories[0]?.label,
-        threadTitle: thread?.title,
-        worktreePath: thread?.linkedDirectories.find((item) => item.kind === "worktree")
-          ?.worktreePath,
-      },
-      updatedAt: this.now(),
-    });
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -1259,7 +1226,7 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const activeTurn = binding.activeTurn;
+    const activeTurn = this.getActiveTurn(binding);
     if (!activeTurn || !["working", "waiting"].includes(activeTurn.status)) {
       await this.renderBindingStatus(binding, event);
       return;
@@ -1269,19 +1236,16 @@ export class MessagingController {
       threadId: binding.threadId,
       turnId: activeTurn.turnId,
     });
-    const updatedBinding = await this.options.store.upsertBinding({
-      ...binding,
-      activeTurn: {
-        ...activeTurn,
-        status: "interrupted",
-        updatedAt: this.now(),
-      },
+    const interruptedTurn: MessagingActiveTurnSummary = {
+      ...activeTurn,
+      status: "interrupted",
       updatedAt: this.now(),
-    });
-    await this.signalTurnActivity(updatedBinding, updatedBinding.activeTurn!, {
+    };
+    this.setActiveTurn(binding, interruptedTurn);
+    await this.signalTurnActivity(binding, interruptedTurn, {
       force: true,
     });
-    await this.renderBindingStatus(updatedBinding, event);
+    await this.renderBindingStatus(binding, event);
   }
 
   private async compactThread(
@@ -1307,20 +1271,17 @@ export class MessagingController {
       backend: binding.backend,
       threadId: binding.threadId,
     });
-    const updatedBinding = await this.options.store.upsertBinding({
-      ...binding,
-      activeTurn: {
-        turnId: compacted.turnId,
-        status: "working",
-        startedAt: this.now(),
-        updatedAt: this.now(),
-      },
+    const activeTurn: MessagingActiveTurnSummary = {
+      turnId: compacted.turnId,
+      status: "working",
+      startedAt: this.now(),
       updatedAt: this.now(),
-    });
-    await this.signalTurnActivity(updatedBinding, updatedBinding.activeTurn!, {
+    };
+    this.setActiveTurn(binding, activeTurn);
+    await this.signalTurnActivity(binding, activeTurn, {
       force: true,
     });
-    await this.renderBindingStatus(updatedBinding, event);
+    await this.renderBindingStatus(binding, event);
   }
 
   private async syncConversationName(
@@ -1345,9 +1306,12 @@ export class MessagingController {
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
-    const threadTitle = normalizeConversationTitle(
-      findThreadForBinding(navigation, binding)?.title ?? binding.threadDisplay?.threadTitle,
-    );
+    const threadState = resolveMessagingThreadState({
+      activeTurn: this.getActiveTurn(binding),
+      binding,
+      navigation,
+    });
+    const threadTitle = normalizeConversationTitle(threadState.title);
     if (!threadTitle) {
       await this.deliver(
         buildErrorIntent({
@@ -1394,10 +1358,6 @@ export class MessagingController {
           ...binding.channel.conversation,
           title: result.title,
         },
-      },
-      threadDisplay: {
-        ...binding.threadDisplay,
-        threadTitle: result.title,
       },
       updatedAt: this.now(),
     });
@@ -1469,11 +1429,12 @@ export class MessagingController {
     }
 
     const statusSurface = binding.pinnedStatusSurface ?? binding.statusSurface;
-    if (binding.activeTurn) {
+    const activeTurn = this.getActiveTurn(binding);
+    if (activeTurn) {
       await this.signalTurnActivity(
         binding,
         {
-          ...binding.activeTurn,
+          ...activeTurn,
           status: "interrupted",
           updatedAt: this.now(),
         },
@@ -1543,7 +1504,11 @@ export class MessagingController {
             id: this.newIntentId("status-retire"),
             binding,
             createdAt: this.now(),
-            navigation,
+            threadState: resolveMessagingThreadState({
+              activeTurn: this.getActiveTurn(binding),
+              binding,
+              navigation,
+            }),
           }),
           actions: [],
           delivery: {
@@ -1613,7 +1578,11 @@ export class MessagingController {
       id: this.newIntentId("status"),
       binding,
       createdAt: this.now(),
-      navigation: snapshot,
+      threadState: resolveMessagingThreadState({
+        activeTurn: this.getActiveTurn(binding),
+        binding,
+        navigation: snapshot,
+      }),
     });
     const result = await this.deliver(intent, binding, event);
     if (!result.surface) {
@@ -1629,6 +1598,23 @@ export class MessagingController {
       statusSurface: result.surface,
       updatedAt: this.now(),
     });
+  }
+
+  private getActiveTurn(
+    binding: MessagingBindingRecord,
+  ): MessagingActiveTurnSummary | undefined {
+    return this.activeTurnsByThreadKey.get(this.threadKeyForBinding(binding));
+  }
+
+  private setActiveTurn(
+    binding: MessagingBindingRecord,
+    activeTurn: MessagingActiveTurnSummary,
+  ): void {
+    this.activeTurnsByThreadKey.set(this.threadKeyForBinding(binding), activeTurn);
+  }
+
+  private threadKeyForBinding(binding: MessagingBindingRecord): string {
+    return buildThreadIdentityKey(binding.backend, binding.threadId);
   }
 
   private async signalTurnActivity(
@@ -1676,12 +1662,11 @@ export class MessagingController {
   }
 
   private logBindingTurnStateChange(
-    previous: MessagingBindingRecord,
-    next: MessagingBindingRecord,
+    binding: MessagingBindingRecord,
+    previousTurn: MessagingActiveTurnSummary | undefined,
+    nextTurn: MessagingActiveTurnSummary | undefined,
     reason: string,
   ): void {
-    const previousTurn = previous.activeTurn;
-    const nextTurn = next.activeTurn;
     if (
       previousTurn?.turnId === nextTurn?.turnId &&
       previousTurn?.status === nextTurn?.status
@@ -1690,7 +1675,7 @@ export class MessagingController {
     }
 
     this.logger.debug?.(
-      `messaging turn state changed reason=${reason} backend=${next.backend} thread=${next.threadId} binding=${next.id} previous=${previousTurn?.status ?? "none"}:${previousTurn?.turnId ?? "none"} next=${nextTurn?.status ?? "none"}:${nextTurn?.turnId ?? "none"}`,
+      `messaging turn state changed reason=${reason} backend=${binding.backend} thread=${binding.threadId} binding=${binding.id} previous=${previousTurn?.status ?? "none"}:${previousTurn?.turnId ?? "none"} next=${nextTurn?.status ?? "none"}:${nextTurn?.turnId ?? "none"}`,
     );
   }
 

--- a/apps/desktop/src/main/messaging/core/messaging-migrations.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-migrations.ts
@@ -41,11 +41,28 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
   return {
     version: CURRENT_MESSAGING_STORE_VERSION,
     browseSessions: migrateRecord(record.browseSessions, isMessagingBrowseSessionRecord),
-    bindings: migrateRecord(record.bindings, isMessagingBindingRecord),
+    bindings: migrateBindingRecords(record.bindings),
     callbackHandles: migrateRecord(record.callbackHandles, isMessagingCallbackHandleRecord),
     pendingIntents: migrateRecord(record.pendingIntents, isMessagingPendingIntentRecord),
     deliveries: migrateRecord(record.deliveries, isMessagingDeliveryRecord),
   };
+}
+
+function migrateBindingRecords(value: unknown): Record<string, MessagingBindingRecord> {
+  const bindings = migrateRecord(value, isMessagingBindingRecord);
+  return Object.fromEntries(
+    Object.entries(bindings).map(([id, binding]) => [
+      id,
+      stripCachedThreadState(binding),
+    ]),
+  );
+}
+
+function stripCachedThreadState(
+  binding: MessagingBindingRecord,
+): MessagingBindingRecord {
+  const { activeTurn: _activeTurn, threadDisplay: _threadDisplay, ...rest } = binding;
+  return rest;
 }
 
 function migrateRecord<T>(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -2,37 +2,31 @@ import type {
   MessagingBindingRecord,
   MessagingSingleSelectIntent,
   MessagingStatusIntent,
-  NavigationSnapshot,
-  NavigationThreadSummary,
 } from "@pwragnt/shared";
+import type { MessagingResolvedThreadState } from "./messaging-thread-state.js";
 
 export function buildBindingStatusIntent(params: {
   binding: MessagingBindingRecord;
   createdAt: number;
   id: string;
-  navigation?: NavigationSnapshot;
+  threadState: MessagingResolvedThreadState;
 }): MessagingStatusIntent {
-  const thread = findThread(params.navigation, params.binding);
-  const display = params.binding.threadDisplay;
   const preferences = params.binding.preferences;
-  const defaults = params.navigation?.launchpadDefaults;
-  const projectLabel =
-    display?.projectLabel ?? thread?.linkedDirectories[0]?.label ?? unavailable();
-  const directoryPath =
-    display?.directoryPath ?? thread?.linkedDirectories[0]?.path ?? unavailable();
-  const model = thread?.model ?? preferences?.model ?? defaults?.model ?? unavailable();
+  const projectLabel = params.threadState.projectLabel ?? unavailable();
+  const directoryPath = params.threadState.directoryPath ?? unavailable();
+  const model = params.threadState.model ?? preferences?.model ?? unavailable();
   const reasoning =
-    thread?.reasoningEffort ??
+    params.threadState.reasoningEffort ??
     preferences?.reasoningEffort ??
-    defaults?.reasoningEffort ??
     unavailable();
-  const fastMode = thread?.fastMode ?? preferences?.fastMode ?? defaults?.fastMode;
+  const fastMode = params.threadState.fastMode ?? preferences?.fastMode;
   const permissionsMode =
-    thread?.executionMode ??
+    params.threadState.executionMode ??
     preferences?.permissionsMode ??
     (preferences?.executionMode === "full-access" ? "full-access" : undefined) ??
-    (defaults?.executionMode === "full-access" ? "full-access" : "default");
-  const activeTurn = params.binding.activeTurn;
+    "default";
+  const activeTurn = params.threadState.activeTurn;
+  const branch = formatBranch(params.threadState);
 
   return {
     id: params.id,
@@ -45,12 +39,14 @@ export function buildBindingStatusIntent(params: {
       pin: true,
     },
     targetSurface: params.binding.statusSurface,
-    status: statusForBinding(params.binding),
+    status: statusForThreadState(params.threadState),
     text: [
-      `Binding: ${display?.threadTitle ?? thread?.title ?? params.binding.threadId} (${params.binding.backend})`,
+      `Binding: ${params.threadState.title ?? params.binding.threadId} (${params.binding.backend})`,
       `Project: ${projectLabel}`,
       `Directory: ${directoryPath}`,
-      display?.worktreePath ? `Worktree: ${display.worktreePath}` : undefined,
+      params.threadState.worktreePath ? `Worktree: ${params.threadState.worktreePath}` : undefined,
+      `Branch: ${branch ?? unavailable()}`,
+      params.threadState.missing ? "Thread state: unavailable" : undefined,
       `Model: ${model}`,
       `Reasoning: ${reasoning}`,
       `Fast mode: ${fastMode === undefined ? unavailable() : fastMode ? "on" : "off"}`,
@@ -202,19 +198,10 @@ export function buildStatusReasoningPickerIntent(params: {
   };
 }
 
-function findThread(
-  navigation: NavigationSnapshot | undefined,
-  binding: MessagingBindingRecord,
-): NavigationThreadSummary | undefined {
-  return navigation?.threads.find(
-    (thread) => thread.source === binding.backend && thread.id === binding.threadId,
-  );
-}
-
-function statusForBinding(
-  binding: MessagingBindingRecord,
+function statusForThreadState(
+  threadState: MessagingResolvedThreadState,
 ): MessagingStatusIntent["status"] {
-  switch (binding.activeTurn?.status) {
+  switch (threadState.activeTurn?.status) {
     case "working":
       return "working";
     case "waiting":
@@ -226,6 +213,20 @@ function statusForBinding(
     case undefined:
       return "idle";
   }
+}
+
+function formatBranch(threadState: MessagingResolvedThreadState): string | undefined {
+  if (!threadState.gitBranch && !threadState.observedGitBranch) {
+    return undefined;
+  }
+  if (
+    threadState.gitBranch &&
+    threadState.observedGitBranch &&
+    threadState.gitBranch !== threadState.observedGitBranch
+  ) {
+    return `${threadState.gitBranch} (now ${threadState.observedGitBranch})`;
+  }
+  return threadState.gitBranch ?? threadState.observedGitBranch;
 }
 
 function unavailable(): string {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -14,16 +14,24 @@ export function buildBindingStatusIntent(params: {
   const preferences = params.binding.preferences;
   const projectLabel = params.threadState.projectLabel ?? unavailable();
   const directoryPath = params.threadState.directoryPath ?? unavailable();
-  const model = params.threadState.model ?? preferences?.model ?? unavailable();
+  const defaults = params.threadState.launchpadDefaults;
+  const model =
+    params.threadState.model ??
+    preferences?.model ??
+    defaults?.model ??
+    unavailable();
   const reasoning =
     params.threadState.reasoningEffort ??
     preferences?.reasoningEffort ??
+    defaults?.reasoningEffort ??
     unavailable();
-  const fastMode = params.threadState.fastMode ?? preferences?.fastMode;
+  const fastMode =
+    params.threadState.fastMode ?? preferences?.fastMode ?? defaults?.fastMode;
   const permissionsMode =
     params.threadState.executionMode ??
     preferences?.permissionsMode ??
     (preferences?.executionMode === "full-access" ? "full-access" : undefined) ??
+    defaults?.executionMode ??
     "default";
   const activeTurn = params.threadState.activeTurn;
   const branch = formatBranch(params.threadState);

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -99,6 +99,12 @@ export function buildBindingStatusIntent(params: {
         fallbackText: "compact",
       },
       {
+        id: "status:sync-name",
+        label: "Sync name",
+        style: "secondary",
+        fallbackText: "sync name",
+      },
+      {
         id: "status:stop",
         label: "Stop",
         style: "danger",

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -422,8 +422,9 @@ export function buildMessagingConversationKey(channel: MessagingChannelRef): str
 }
 
 function sanitizeBinding(binding: MessagingBindingRecord): MessagingBindingRecord {
+  const { activeTurn: _activeTurn, threadDisplay: _threadDisplay, ...rest } = binding;
   return {
-    ...binding,
+    ...rest,
     authorizedActorIds: [...new Set(binding.authorizedActorIds)],
     pinnedStatusSurface: sanitizeSurfaceRef(binding.pinnedStatusSurface),
     routingState: sanitizeAdapterState(binding.routingState),

--- a/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
@@ -2,6 +2,7 @@ import type {
   MessagingActiveTurnSummary,
   MessagingBindingRecord,
   NavigationDirectorySummary,
+  NavigationLaunchpadDefaults,
   NavigationSnapshot,
   NavigationThreadSummary,
   ThreadExecutionMode,
@@ -14,6 +15,7 @@ export type MessagingResolvedThreadState = {
   executionMode?: ThreadExecutionMode;
   fastMode?: boolean;
   gitBranch?: string;
+  launchpadDefaults?: NavigationLaunchpadDefaults;
   missing: boolean;
   model?: string;
   observedGitBranch?: string;
@@ -43,6 +45,7 @@ export function resolveMessagingThreadState(params: {
   if (!thread) {
     return {
       activeTurn: params.activeTurn,
+      launchpadDefaults: params.navigation.launchpadDefaults,
       missing: true,
       threadKey,
     };
@@ -66,6 +69,7 @@ export function resolveMessagingThreadState(params: {
     executionMode: thread.executionMode,
     fastMode: thread.fastMode,
     gitBranch: thread.gitBranch,
+    launchpadDefaults: params.navigation.launchpadDefaults,
     missing: false,
     model: thread.model,
     observedGitBranch: thread.observedGitBranch,

--- a/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
@@ -1,0 +1,91 @@
+import type {
+  MessagingActiveTurnSummary,
+  MessagingBindingRecord,
+  NavigationDirectorySummary,
+  NavigationSnapshot,
+  NavigationThreadSummary,
+  ThreadExecutionMode,
+} from "@pwragnt/shared";
+import { buildThreadIdentityKey } from "@pwragnt/shared";
+
+export type MessagingResolvedThreadState = {
+  activeTurn?: MessagingActiveTurnSummary;
+  directoryPath?: string;
+  executionMode?: ThreadExecutionMode;
+  fastMode?: boolean;
+  gitBranch?: string;
+  missing: boolean;
+  model?: string;
+  observedGitBranch?: string;
+  projectLabel?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  thread?: NavigationThreadSummary;
+  threadKey: string;
+  title?: string;
+  titleSource?: NavigationThreadSummary["titleSource"];
+  workMode?: "local" | "worktree";
+  worktreePath?: string;
+};
+
+export function resolveMessagingThreadState(params: {
+  activeTurn?: MessagingActiveTurnSummary;
+  binding: MessagingBindingRecord;
+  navigation: NavigationSnapshot;
+}): MessagingResolvedThreadState {
+  const threadKey = buildThreadIdentityKey(params.binding.backend, params.binding.threadId);
+  const thread = params.navigation.threads.find(
+    (candidate) =>
+      candidate.source === params.binding.backend &&
+      candidate.id === params.binding.threadId,
+  );
+
+  if (!thread) {
+    return {
+      activeTurn: params.activeTurn,
+      missing: true,
+      threadKey,
+    };
+  }
+
+  const directory = primaryDirectoryForThread(params.navigation, threadKey);
+  const linkedDirectory =
+    thread.linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
+    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
+    thread.linkedDirectories[0];
+  const worktreeDirectory = thread.linkedDirectories.find(
+    (candidate) => candidate.kind === "worktree" || candidate.worktreePath,
+  );
+  const worktreePath =
+    worktreeDirectory?.worktreePath ??
+    (worktreeDirectory?.kind === "worktree" ? worktreeDirectory.path : undefined);
+
+  return {
+    activeTurn: params.activeTurn,
+    directoryPath: linkedDirectory?.path ?? directory?.path,
+    executionMode: thread.executionMode,
+    fastMode: thread.fastMode,
+    gitBranch: thread.gitBranch,
+    missing: false,
+    model: thread.model,
+    observedGitBranch: thread.observedGitBranch,
+    projectLabel: linkedDirectory?.label ?? directory?.label,
+    reasoningEffort: thread.reasoningEffort,
+    serviceTier: thread.serviceTier,
+    thread,
+    threadKey,
+    title: thread.title,
+    titleSource: thread.titleSource,
+    workMode: worktreePath ? "worktree" : linkedDirectory?.kind,
+    worktreePath,
+  };
+}
+
+function primaryDirectoryForThread(
+  navigation: NavigationSnapshot,
+  threadKey: string,
+): NavigationDirectorySummary | undefined {
+  return navigation.directories.find((directory) =>
+    directory.threadKeys.includes(threadKey),
+  );
+}

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1,6 +1,10 @@
 import { MessagingController } from "./core/messaging-controller";
 import type { MessagingStore } from "./core/messaging-store";
-import type { MessagingBackendBridge } from "./core/messaging-adapter";
+import type {
+  MessagingBackendBridge,
+  MessagingConversationTitleUpdateRequest,
+  MessagingConversationTitleUpdateResult,
+} from "./core/messaging-adapter";
 import type { AgentEvent, AppServerPendingRequestNotification } from "@pwragnt/shared";
 import type {
   MessagingChannelKind,
@@ -22,6 +26,9 @@ export type DesktopMessagingAdapter = {
   authorizedActorIds: readonly string[];
   channel: MessagingChannelKind;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  setConversationTitle?(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };

--- a/docs/plans/2026-05-02-001-refactor-messaging-live-thread-state-plan.md
+++ b/docs/plans/2026-05-02-001-refactor-messaging-live-thread-state-plan.md
@@ -1,0 +1,356 @@
+---
+title: refactor: Use live desktop thread state for messaging bindings
+type: refactor
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+---
+
+# refactor: Use live desktop thread state for messaging bindings
+
+## Overview
+
+Refactor the messaging binding cache so it stores only messaging-owned routing, authorization, delivery, callback, and preference data. Thread facts shown in messaging surfaces, including thread name, local/worktree identity, working directory, branch state, model, reasoning, permissions, and active turn details, should be read from a desktop-owned thread state projection at render/action time.
+
+The immediate bug is that `/status` can show a stale thread name because `MessagingBindingRecord.threadDisplay.threadTitle` overrides the current `NavigationThreadSummary.title`. The broader fix is to stop treating binding records as a second thread metadata store.
+
+## Problem Frame
+
+The desktop renderer shows renamed threads from the desktop navigation state. Messaging `/status` also fetches navigation state through `DesktopMessagingBackendBridge.getNavigationSnapshot()`, but the current status card prefers persisted binding metadata:
+
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` renders `threadDisplay.threadTitle` before `thread.title`.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` writes `threadDisplay` during browse binding, new-thread binding, and sync-name confirmation.
+- `apps/desktop/src/main/messaging/core/messaging-store.ts` persists those values in `messaging-state.json`.
+
+That makes the messaging store an accidental duplicate of desktop thread state. The binding store should identify which platform conversation is bound to which PwrAgnt thread, not remember what that PwrAgnt thread looked like when the binding was created.
+
+## Requirements Trace
+
+- R1-R6. Preserve channel-agnostic messaging contracts and opaque adapter state, while keeping workflow state distinct from platform payloads.
+- R7-R12. Keep binding, detach, restart recovery, and free-form routing working with a minimal binding record.
+- R13-R17. Keep `/status`, `/resume`, and rich controls accurate for Telegram and Discord by rendering from the same desktop state used by the app UI.
+- R23-R27. Keep provider packages isolated; provider adapters should not learn desktop thread semantics.
+- R31-R36. Preserve authorization, callback scoping, revocation, redaction, and audit behavior while reducing duplicated persistent state.
+
+## Scope Boundaries
+
+- In scope: binding-store field audit, live desktop thread state read model, `/status` rendering, sync-name title source, binding metadata writes, migrations, and regression tests.
+- In scope: deciding which state belongs in `messaging-state.json` versus desktop navigation/backend state.
+- In scope: preserving existing Telegram and Discord provider behavior behind the current adapter interface.
+- Out of scope: changing the renderer thread UI, renaming UX, provider SDK choices, hosted bot infrastructure, webhook transport, or a settings screen.
+- Out of scope: adding new status fields that desktop state cannot currently provide, except for a small desktop-owned active-turn projection if needed to remove duplicated turn state from bindings.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` already mirrors the renderer path by using `DesktopBackendRegistry.listThreads()`, `getDesktopOverlayStore().reconcileNavigationSnapshot()`, and `readDirectoryStatuses()`.
+- `apps/desktop/src/main/ipc/app-server.ts` exposes the same navigation snapshot shape to the renderer through `getNavigationSnapshot()`.
+- `packages/agent-core/src/domain/navigation-state.ts` materializes thread title, linked directories, execution mode, model, reasoning, fast mode, branch metadata, worktree snapshots, inbox state, and launchpad defaults.
+- `packages/shared/src/contracts/navigation.ts` defines `NavigationThreadSummary` and `NavigationDirectorySummary`, which are the desktop thread browsing source shared by renderer and messaging.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` reads navigation snapshots for the sidebar and applies optimistic rename state before refreshing through the desktop bridge.
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` currently renders from both `MessagingBindingRecord.threadDisplay` and `NavigationSnapshot`.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` currently persists display metadata in `threadDisplay` and stores `activeTurn` on the binding.
+- `apps/desktop/src/main/messaging/core/messaging-store.ts` is correctly shaped for messaging-owned state: bindings, browse sessions, callback handles, pending intents, deliveries, redaction, and restart-safe callback lookup.
+- `packages/messaging/AGENTS.md` requires provider packages to stay channel-focused and isolated from desktop, agent-core, and sibling providers.
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-30-003-refactor-desktop-hosted-messaging-plan.md` superseded the earlier agent-core ownership direction: desktop owns messaging orchestration and uses `DesktopBackendRegistry` as the state/operation boundary.
+- `docs/plans/2026-04-30-002-feat-messaging-command-surfaces-plan.md` introduced managed status surfaces and binding preferences, but its `last known thread display metadata` should now be narrowed to fallback-only migration data or removed.
+- No `docs/solutions/` directory exists in this worktree, so there are no durable solution notes for this specific state-duplication class.
+
+### External References
+
+- External research is not needed for this plan. The issue is internal state ownership and contract shape, and the repo already has strong local patterns for navigation state, overlay state, messaging store persistence, and provider boundaries.
+
+## Key Technical Decisions
+
+- **Messaging bindings are identity and routing records, not thread snapshots.** Keep channel ref, backend, thread id, actor authorization, provider routing state, surfaces, callbacks, pending intents, deliveries, and messaging preferences. Do not persist thread name, project label, directory path, worktree path, branch name, model, reasoning, permissions, or active turn as authoritative thread display data.
+- **Render messaging status from a desktop-owned read model.** The status card should receive a resolved thread state built from `NavigationSnapshot` and any desktop-owned active-turn projection. Binding metadata is fallback-only when the thread cannot be found.
+- **Use navigation state as the shared source for desktop facts already present there.** Thread name, linked directories, local/worktree mode, directory path, branch, execution mode, model, reasoning, fast mode, worktree snapshots, and launchpad defaults should come from the same navigation path the renderer uses.
+- **Treat active turn state as desktop runtime state, not binding display state.** If messaging still needs a cached active turn for typing/stop behavior, hide that behind a desktop-owned thread activity projection or a clearly named transient runtime cache, not `threadDisplay`.
+- **Keep preferences separate from current thread state.** `MessagingBindingPreferences` can remain the user's messaging-side requested defaults or pending settings, but live thread fields win whenever the desktop state has a value.
+- **Make sync-name use the resolved desktop title.** The sync action should read the current thread title from the desktop thread state projection and should not write that title back into `threadDisplay`.
+- **Provider packages stay unchanged unless the generic contract changes.** Telegram and Discord should continue receiving semantic intents; they should not import navigation, renderer, registry, or desktop state modules.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `/status` prefer persisted binding display metadata or live navigation state?** Live navigation state. Persisted display metadata caused the stale name bug and should be fallback-only during migration.
+- **Should providers fetch desktop state directly?** No. Providers render intents and own platform transport. Desktop messaging orchestration resolves thread state before creating intents.
+- **Should the messaging store keep provider routing and surface state?** Yes. That is messaging-owned restart state and remains necessary for updates, pins, callbacks, and delivery fallback.
+- **Should this change remove binding preferences?** No. Preferences are user-requested messaging settings and launch defaults. They must not override confirmed live thread state when a thread record is available.
+
+### Deferred to Implementation
+
+- Whether to remove `threadDisplay` entirely in one change or keep it as a deprecated migration fallback for one store version.
+- Whether active turn state can be read directly from an existing desktop runtime store or needs a small new desktop-owned activity snapshot in `DesktopMessagingBackendBridge`.
+- The exact label format for local/worktree and branch lines after the resolver exposes all current desktop fields.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Provider["Telegram / Discord provider"] --> Controller["Desktop messaging controller"]
+    Controller --> BindingStore["MessagingStore"]
+    Controller --> StateReader["Desktop thread state reader"]
+    StateReader --> Registry["DesktopBackendRegistry"]
+    StateReader --> Overlay["Desktop overlay store"]
+    Registry --> Navigation["NavigationSnapshot"]
+    Overlay --> Navigation
+    Registry --> Activity["Desktop active-turn/runtime events"]
+    Navigation --> Resolved["Resolved thread state"]
+    Activity --> Resolved
+    BindingStore --> Resolved
+    Resolved --> Status["Status / sync-name / turn actions"]
+    Status --> Provider
+```
+
+The binding store remains necessary, but its authority is limited:
+
+| State category | Source of truth | Messaging-store role |
+| --- | --- | --- |
+| Channel conversation, actor authorization, provider routing state | Messaging store/provider adapter | Authoritative |
+| Managed status surface, pinned surface, callback handles, deliveries | Messaging store/provider adapter | Authoritative |
+| Thread id and backend id for a binding | Messaging store | Authoritative binding identity |
+| Thread title, linked directories, worktree/local state, branch, model, reasoning, permissions | Desktop navigation/backend state | Read-only consumer |
+| Active turn id/status | Desktop runtime activity projection | Read-only consumer, with transient fallback only if required |
+| Messaging preferences | Messaging store | User-requested defaults; live desktop state wins |
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Classify binding-store ownership"] --> U2["Unit 2: Add resolved desktop thread state"]
+    U2 --> U3["Unit 3: Render status and sync from resolved state"]
+    U3 --> U4["Unit 4: Stop persisting duplicate display metadata"]
+    U4 --> U5["Unit 5: Migrate and harden tests"]
+```
+
+- [ ] **Unit 1: Classify binding-store ownership**
+
+**Goal:** Make the allowed contents of `MessagingBindingRecord` explicit so future changes do not reintroduce desktop thread metadata into the binding cache.
+
+**Requirements:** R1-R6, R7-R12, R31-R36
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Modify: `packages/messaging/interface/src/index.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- Test: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+
+**Approach:**
+- Document or encode the boundary between messaging-owned state and desktop-owned thread state.
+- Deprecate `MessagingThreadDisplaySummary` as authoritative state. If retained, name it as migration/fallback metadata and keep renderers from preferring it over live desktop state.
+- Keep `routingState`, `statusSurface`, `pinnedStatusSurface`, `preferences`, authorization, and callback-related data in the messaging store.
+- Keep provider-specific routing data opaque; do not move Telegram/Discord IDs into desktop thread state.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- `packages/messaging/AGENTS.md`
+
+**Test scenarios:**
+- Happy path: a binding record with only channel, backend, thread id, authorization, routing state, surfaces, and preferences remains valid after migration.
+- Edge case: an existing binding containing `threadDisplay.threadTitle` migrates without becoming the preferred source for status rendering.
+- Regression: provider-facing interface types still compile without importing desktop or agent-core modules.
+- Error path: secret-like keys in provider opaque state are still redacted during persistence.
+
+**Verification:**
+- A reviewer can tell from the contracts and tests which binding fields are authoritative and which desktop fields must be resolved elsewhere.
+
+- [ ] **Unit 2: Add a resolved desktop thread state reader**
+
+**Goal:** Provide a single desktop-owned read model for messaging workflows that need current thread facts.
+
+**Requirements:** R7-R17, R31-R36
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/messaging/core/messaging-thread-state.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-thread-state.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Resolve a binding into a current thread state object using `backend`, `threadId`, `NavigationSnapshot.threads`, and `NavigationSnapshot.directories`.
+- Include current title, title source, primary project label, primary directory path, local/worktree identity, worktree path, git branch, observed branch, model, reasoning, service tier, fast mode, execution mode, and launchpad defaults where available.
+- Include active turn state from a desktop-owned runtime source. Prefer an existing registry/event-derived source if present; otherwise add a narrow bridge-owned activity tracker fed by the same backend events messaging already receives.
+- Return explicit missing-thread state when the thread is not found so `/status` can say the binding is stale without inventing a title from the old cache.
+- Keep the reader inside desktop messaging/core or the desktop bridge; do not add provider dependencies.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- `apps/desktop/src/main/ipc/app-server.ts`
+- `packages/agent-core/src/domain/navigation-state.ts`
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+
+**Test scenarios:**
+- Happy path: resolving a binding returns the title and linked directory from a navigation snapshot.
+- Happy path: resolving a worktree thread returns worktree path and branch fields from `NavigationThreadSummary`.
+- Happy path: live execution mode/model/reasoning/fast mode from the navigation thread wins over stale binding preferences.
+- Edge case: a binding whose thread is absent returns a missing state with backend/thread id and no stale display title.
+- Integration: a backend turn lifecycle event updates the active-turn projection used by status rendering.
+
+**Verification:**
+- Messaging workflows have one helper to ask "what does the desktop currently know about this bound thread?" without reading display fields from the binding record.
+
+- [ ] **Unit 3: Render status and sync-name from resolved state**
+
+**Goal:** Make `/status`, status button updates, and "Sync name" use current desktop state rather than cached binding display metadata.
+
+**Requirements:** R13-R17, R23-R27, R31-R36
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Change status intent building to accept resolved thread state, not raw binding plus optional navigation.
+- Render title, project, directory, worktree, branch, model, reasoning, fast mode, permissions, and turn lines from resolved desktop state.
+- Use binding preferences only when live thread state is absent or when rendering a requested setting that has not yet been confirmed by desktop state.
+- Make `status:sync-name` read `resolvedThread.title` and never write the synced name into binding display metadata.
+- Preserve status surface update/pin behavior and the existing channel-neutral action list.
+- When the thread cannot be resolved, render a clear stale-binding status with backend/thread id and controls for refresh/detach; do not use an old title as if it were current.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+
+**Test scenarios:**
+- Happy path: `/status` displays a renamed thread title from the navigation snapshot even when the binding has an older fallback title.
+- Happy path: `/status` displays local/worktree directory and branch data from `NavigationThreadSummary`.
+- Happy path: `status:sync-name` sends the current desktop thread title to the provider.
+- Edge case: if navigation cannot find the bound thread, `/status` shows the thread id and stale-binding context without using `threadDisplay.threadTitle`.
+- Regression: pinned Telegram/Discord status surfaces still update existing managed messages when the adapter returns an updateable surface.
+- Regression: live permissions from the desktop thread continue to beat stale binding preferences.
+
+**Verification:**
+- Re-running `/status` after a desktop thread rename shows the new desktop title without rebinding or pressing Sync name.
+
+- [ ] **Unit 4: Stop persisting duplicate display metadata during binding flows**
+
+**Goal:** Remove writes that refresh or create duplicate thread display state in `messaging-state.json`.
+
+**Requirements:** R7-R12, R13-R17, R31-R36
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
+
+**Approach:**
+- Update thread binding and new-thread binding paths so they persist binding identity, route state, actor authorization, surfaces, and preferences only.
+- Remove or quarantine `applyBrowseBindingMetadata()` so it no longer writes thread title, project label, directory path, or worktree path into the binding as current state.
+- Keep `/resume` pickers using navigation snapshots directly; picker labels can still render thread/project names because picker intent data is ephemeral and regenerated from desktop state.
+- For newly started threads that are not immediately visible in navigation, render an explicit "starting" or id-based fallback from the start result rather than persisting a project/title snapshot.
+- Ensure callback handles and browse sessions continue to carry enough ephemeral picker state to resolve user actions without becoming long-lived thread metadata.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
+
+**Test scenarios:**
+- Happy path: selecting a thread from `/resume` creates a binding without `threadDisplay.threadTitle`.
+- Happy path: starting a new thread from `/resume --new` creates a binding with preferences but without persisted project/title display metadata.
+- Happy path: picker labels still show thread and project names because they are regenerated from the navigation snapshot.
+- Edge case: after a browse session expires, callbacks still fail closed without relying on binding display metadata.
+- Regression: free-form text still routes to the bound thread after restart using only binding identity and routing state.
+
+**Verification:**
+- New or refreshed bindings no longer add duplicate desktop thread display data to `messaging-state.json`.
+
+- [ ] **Unit 5: Migrate old state and harden cross-surface tests**
+
+**Goal:** Make existing user state safe and add regressions that prove messaging follows the desktop state source.
+
+**Requirements:** R7-R17, R31-R36
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Approach:**
+- Add a migration that either drops deprecated `threadDisplay` values or marks them fallback-only depending on the decision from Unit 1.
+- Add regression coverage using a binding with stale `threadDisplay` and a navigation snapshot with a newer title, directory/worktree, and branch.
+- Add controller-level coverage for `/status`, refresh, sync-name, and status action flows to ensure each fetches or receives resolved desktop thread state.
+- Add store snapshot coverage that verifies old binding records remain loadable and actionable after migration.
+- Keep provider tests focused on rendering/delivery; provider packages should not know the new desktop state reader exists.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- `packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts`
+- `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts`
+
+**Test scenarios:**
+- Happy path: a v2 store with stale `threadDisplay.threadTitle` loads, `/status` renders the live desktop title, and the binding still routes messages.
+- Happy path: `status:sync-name` with stale binding metadata renames the platform conversation to the live desktop title.
+- Edge case: a missing navigation thread renders stale-binding status and does not mutate platform names.
+- Error path: if desktop state lookup fails, the controller delivers a recoverable status error instead of falling back to stale duplicate display state.
+- Integration: Telegram and Discord status rendering tests continue to receive the same semantic intent shape, with only text content changing to current desktop data.
+
+**Verification:**
+- Existing users do not need to delete `messaging-state.json`, and stale display metadata cannot override the desktop state after migration.
+
+## System-Wide Impact
+
+- **Interaction graph:** `/resume`, `/status`, status callbacks, sync-name, start-turn routing, compact/stop actions, and provider deliveries all depend on the binding-to-thread resolver.
+- **Error propagation:** Missing desktop state should become a recoverable messaging error or stale-binding status, not silent fallback to old display metadata.
+- **State lifecycle risks:** Binding state must stay restart-safe for platform routing while no longer becoming a stale thread metadata cache.
+- **API surface parity:** Telegram and Discord should see the same semantic intents. Provider package APIs should not grow desktop-specific state concepts.
+- **Integration coverage:** Controller tests need cross-layer coverage because the bug appears only when store state and desktop navigation state disagree.
+- **Unchanged invariants:** Binding authorization, provider opaque routing state, managed surface update/pin behavior, callback expiration, and delivery redaction remain messaging-store responsibilities.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Removing `threadDisplay` too aggressively could break old bindings during migration. | Keep old records loadable and add migration tests before deleting or ignoring fields. |
+| Active turn id may not have a single existing desktop state source. | Add the smallest desktop-owned runtime activity projection needed, fed by backend events already flowing through `DesktopBackendRegistry`. |
+| Preferences could still mask live desktop state after model/reasoning/permissions updates. | Establish resolver precedence in tests: live thread state wins; preferences are fallback or pending-request defaults. |
+| Newly started threads may briefly be absent from navigation snapshots. | Render an explicit pending/id fallback for that transient case rather than persisting a fake display snapshot. |
+| Provider packages might be pulled across desktop boundaries accidentally. | Keep all resolution in desktop messaging/core and preserve provider tests that compile without desktop imports. |
+
+## Documentation / Operational Notes
+
+- No user-facing docs are required unless the migration changes troubleshooting advice for `messaging-state.json`.
+- Add a short code comment or contract note where binding fields are defined so future status fields are added to the desktop state reader, not to binding display metadata.
+- Manual validation should include renaming a thread in Desktop, re-running `/status` from Discord and Telegram, pressing Sync name, and confirming both platforms use the renamed desktop title.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md](../brainstorms/2026-04-30-messaging-platform-integration-requirements.md)
+- Related plan: [docs/plans/2026-04-30-003-refactor-desktop-hosted-messaging-plan.md](2026-04-30-003-refactor-desktop-hosted-messaging-plan.md)
+- Related plan: [docs/plans/2026-04-30-002-feat-messaging-command-surfaces-plan.md](2026-04-30-002-feat-messaging-command-surfaces-plan.md)
+- Related code: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- Related code: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Related code: `apps/desktop/src/main/ipc/app-server.ts`
+- Related code: `packages/agent-core/src/domain/navigation-state.ts`
+- Related code: `packages/shared/src/contracts/navigation.ts`

--- a/docs/plans/2026-05-02-001-refactor-messaging-live-thread-state-plan.md
+++ b/docs/plans/2026-05-02-001-refactor-messaging-live-thread-state-plan.md
@@ -1,7 +1,7 @@
 ---
 title: refactor: Use live desktop thread state for messaging bindings
 type: refactor
-status: active
+status: completed
 date: 2026-05-02
 origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
 ---
@@ -131,7 +131,7 @@ flowchart TB
     U4 --> U5["Unit 5: Migrate and harden tests"]
 ```
 
-- [ ] **Unit 1: Classify binding-store ownership**
+- [x] **Unit 1: Classify binding-store ownership**
 
 **Goal:** Make the allowed contents of `MessagingBindingRecord` explicit so future changes do not reintroduce desktop thread metadata into the binding cache.
 
@@ -166,7 +166,7 @@ flowchart TB
 **Verification:**
 - A reviewer can tell from the contracts and tests which binding fields are authoritative and which desktop fields must be resolved elsewhere.
 
-- [ ] **Unit 2: Add a resolved desktop thread state reader**
+- [x] **Unit 2: Add a resolved desktop thread state reader**
 
 **Goal:** Provide a single desktop-owned read model for messaging workflows that need current thread facts.
 
@@ -204,7 +204,7 @@ flowchart TB
 **Verification:**
 - Messaging workflows have one helper to ask "what does the desktop currently know about this bound thread?" without reading display fields from the binding record.
 
-- [ ] **Unit 3: Render status and sync-name from resolved state**
+- [x] **Unit 3: Render status and sync-name from resolved state**
 
 **Goal:** Make `/status`, status button updates, and "Sync name" use current desktop state rather than cached binding display metadata.
 
@@ -242,7 +242,7 @@ flowchart TB
 **Verification:**
 - Re-running `/status` after a desktop thread rename shows the new desktop title without rebinding or pressing Sync name.
 
-- [ ] **Unit 4: Stop persisting duplicate display metadata during binding flows**
+- [x] **Unit 4: Stop persisting duplicate display metadata during binding flows**
 
 **Goal:** Remove writes that refresh or create duplicate thread display state in `messaging-state.json`.
 
@@ -278,7 +278,7 @@ flowchart TB
 **Verification:**
 - New or refreshed bindings no longer add duplicate desktop thread display data to `messaging-state.json`.
 
-- [ ] **Unit 5: Migrate old state and harden cross-surface tests**
+- [x] **Unit 5: Migrate old state and harden cross-surface tests**
 
 **Goal:** Make existing user state safe and add regressions that prove messaging follows the desktop state source.
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -582,6 +582,10 @@ export type MessagingActiveTurnSummary = {
 };
 
 export type MessagingThreadDisplaySummary = {
+  /**
+   * Deprecated migration fallback only. Current thread display facts must be
+   * resolved from the desktop navigation/backend state before rendering.
+   */
   directoryPath?: string;
   projectLabel?: string;
   threadTitle?: string;
@@ -595,6 +599,10 @@ export type MessagingBindingRecord = {
   threadId: ThreadIdentifier;
   authorizedActorIds: string[];
   routingState?: MessagingAdapterState;
+  /**
+   * Deprecated migration fallback only. Current turn activity is desktop runtime
+   * state and must be resolved before rendering or acting.
+   */
   activeTurn?: MessagingActiveTurnSummary;
   createdAt: number;
   updatedAt: number;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -500,6 +500,22 @@ export type MessagingDeliveryResult = {
   deliveredAt: number;
 };
 
+export type MessagingConversationTitleUpdateRequest = {
+  actor?: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+  title: string;
+};
+
+export type MessagingConversationTitleUpdateResult = {
+  channel: MessagingChannelKind;
+  conversation: MessagingConversationRef;
+  errorMessage?: string;
+  outcome: "updated" | "unsupported" | "failed";
+  title: string;
+  updatedAt: number;
+};
+
 export type MessagingInboundBaseEvent = {
   id: string;
   kind: MessagingInboundEventKind;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -89,6 +89,62 @@ describe("discord adapter", () => {
       },
     });
   });
+
+  it("renames Discord threads without allowing plain channel renames", async () => {
+    const updateChannelName = vi.fn(async () => {});
+    const adapter = new DiscordAdapter({
+      api: createApi({ updateChannelName }),
+      config: {
+        authorizedActorIds: ["user-1"],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    await expect(
+      adapter.setConversationTitle({
+        channel: {
+          channel: "discord",
+          conversation: {
+            id: "thread-channel-1",
+            kind: "channel",
+            parentId: "guild-1",
+          },
+        },
+        routingState: {
+          opaque: {
+            channelType: 11,
+            isThread: true,
+          },
+        },
+        title: "Thread one",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "updated",
+      title: "Thread one",
+    });
+    expect(updateChannelName).toHaveBeenCalledWith("thread-channel-1", {
+      name: "Thread one",
+    });
+
+    await expect(
+      adapter.setConversationTitle({
+        channel: {
+          channel: "discord",
+          conversation: {
+            id: "plain-channel-1",
+            kind: "channel",
+            parentId: "guild-1",
+          },
+        },
+        title: "Thread one",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "unsupported",
+    });
+    expect(updateChannelName).toHaveBeenCalledTimes(1);
+  });
 });
 
 function discordAudit(): MessagingAuditContext {
@@ -122,6 +178,7 @@ function createApi(overrides: Partial<DiscordApi> = {}): DiscordApi {
     deleteApplicationCommand: async () => {},
     listApplicationCommands: async () => [],
     sendTyping: async () => {},
+    updateChannelName: async () => {},
     updateApplicationCommand: async () => applicationCommand(),
     updateInteractionOriginalResponse: async () => ({
       channel_id: "channel-1",

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -14,6 +14,8 @@ import {
 } from "discord.js";
 import type {
   MessagingAdapterState,
+  MessagingConversationTitleUpdateRequest,
+  MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
   MessagingInboundEvent,
   MessagingJsonValue,
@@ -108,13 +110,16 @@ export type DiscordMessageCreateDispatch = {
   }>;
   author: DiscordUser;
   channel_id: string;
+  channel_type?: number;
   content?: string;
   guild_id?: string;
   id: string;
+  is_thread?: boolean;
 };
 
 export type DiscordInteractionCreateDispatch = {
   channel_id: string;
+  channel_type?: number;
   data?: {
     custom_id?: string;
     name?: string;
@@ -122,6 +127,7 @@ export type DiscordInteractionCreateDispatch = {
   };
   guild_id?: string;
   id: string;
+  is_thread?: boolean;
   member?: {
     nick?: string | null;
     user?: DiscordUser;
@@ -157,6 +163,7 @@ export type DiscordGatewayConnection = {
 };
 
 export type DiscordApi = DiscordApplicationCommandApi & {
+  updateChannelName(channelId: string, request: { name: string }): Promise<void>;
   createInteractionResponse(
     interactionId: string,
     interactionToken: string,
@@ -191,6 +198,9 @@ export type DiscordProviderAdapter = {
   authorizedActorIds: readonly string[];
   channel: "discord";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  setConversationTitle(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };
@@ -362,6 +372,46 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
   }
 
+  async setConversationTitle(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult> {
+    const title = sanitizeDiscordThreadName(request.title);
+    const conversation = request.channel.conversation;
+    if (!isDiscordThreadConversation(request)) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: "Discord name sync is only available inside Discord threads.",
+        outcome: "unsupported",
+        title,
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      await this.api.updateChannelName(conversation.id, { name: title });
+      return {
+        channel: this.channel,
+        conversation: {
+          ...conversation,
+          title,
+        },
+        outcome: "updated",
+        title,
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: errorMessage(error),
+        outcome: "failed",
+        title,
+        updatedAt: this.now(),
+      };
+    }
+  }
+
   async handleGatewayEvent(event: DiscordGatewayEvent): Promise<void> {
     if (event.t === "MESSAGE_CREATE") {
       await this.handleMessageCreate(event.d);
@@ -381,7 +431,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
     const channel = this.channelFromDiscord(message.channel_id, message.guild_id);
     const receivedAt = this.now();
-    const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id);
+    const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
+      channelType: message.channel_type,
+      isThread: message.is_thread,
+    });
 
     if (message.attachments && message.attachments.length > 0) {
       const attachment = message.attachments[0]!;
@@ -488,6 +541,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       routingState: this.routingStateFromDiscord(
         interaction.channel_id,
         interaction.guild_id,
+        {
+          channelType: interaction.channel_type,
+          isThread: interaction.is_thread,
+        },
       ),
     });
   }
@@ -516,7 +573,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         interaction.channel_id,
         interaction.guild_id,
         {
+          channelType: interaction.channel_type,
           interactionToken: interaction.token,
+          isThread: interaction.is_thread,
         },
       ),
     });
@@ -818,16 +877,22 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private routingStateFromDiscord(
     channelId: string,
     guildId: string | undefined,
-    interaction?: {
-      interactionToken: string;
+    options?: {
+      channelType?: number;
+      interactionToken?: string;
+      isThread?: boolean;
     },
   ): MessagingAdapterState {
     return {
       opaque: {
-        applicationId: interaction ? (this.options.config.applicationId ?? null) : null,
+        applicationId: options?.interactionToken
+          ? (this.options.config.applicationId ?? null)
+          : null,
         channelId,
+        channelType: options?.channelType ?? null,
         guildId: guildId ?? null,
-        interactionToken: interaction?.interactionToken ?? null,
+        interactionToken: options?.interactionToken ?? null,
+        isThread: options?.isThread ?? null,
       },
     };
   }
@@ -880,6 +945,15 @@ class DiscordRestApi implements DiscordApi {
     return (await this.rest.post(Routes.channelMessages(channelId), {
       body: request,
     })) as DiscordMessage;
+  }
+
+  async updateChannelName(
+    channelId: string,
+    request: { name: string },
+  ): Promise<void> {
+    await this.rest.patch(Routes.channel(channelId), {
+      body: request,
+    });
   }
 
   async createInteractionResponse(
@@ -1031,9 +1105,11 @@ function messageToDispatch(message: Message): DiscordMessageCreateDispatch {
     })),
     author: userToDiscordUser(message.author),
     channel_id: message.channelId,
+    channel_type: message.channel.type,
     content: message.content,
     guild_id: message.guildId ?? undefined,
     id: message.id,
+    is_thread: discordChannelIsThread(message.channel),
   };
 }
 
@@ -1044,11 +1120,15 @@ function interactionToDispatch(
     const buttonInteraction = interaction as ButtonInteraction;
     return {
       channel_id: buttonInteraction.channelId,
+      channel_type: buttonInteraction.channel?.type,
       data: {
         custom_id: buttonInteraction.customId,
       },
       guild_id: buttonInteraction.guildId ?? undefined,
       id: buttonInteraction.id,
+      is_thread: buttonInteraction.channel
+        ? discordChannelIsThread(buttonInteraction.channel)
+        : undefined,
       member: buttonInteraction.inGuild()
         ? {
             nick:
@@ -1071,6 +1151,7 @@ function interactionToDispatch(
     const commandInteraction = interaction as ChatInputCommandInteraction;
     return {
       channel_id: commandInteraction.channelId,
+      channel_type: commandInteraction.channel?.type,
       data: {
         name: commandInteraction.commandName,
         options: commandInteraction.options.data.map((option) => ({
@@ -1085,6 +1166,9 @@ function interactionToDispatch(
       },
       guild_id: commandInteraction.guildId ?? undefined,
       id: commandInteraction.id,
+      is_thread: commandInteraction.channel
+        ? discordChannelIsThread(commandInteraction.channel)
+        : undefined,
       member: commandInteraction.inGuild()
         ? {
             nick:
@@ -1111,6 +1195,42 @@ function userToDiscordUser(user: User): DiscordUser {
     id: user.id,
     username: user.username,
   };
+}
+
+function isDiscordThreadConversation(
+  request: MessagingConversationTitleUpdateRequest,
+): boolean {
+  if (request.channel.conversation.kind === "thread") {
+    return true;
+  }
+
+  const opaque = request.routingState?.opaque;
+  if (!opaque || typeof opaque !== "object" || Array.isArray(opaque)) {
+    return false;
+  }
+
+  if (opaque.isThread === true) {
+    return true;
+  }
+
+  return (
+    opaque.channelType === 10 ||
+    opaque.channelType === 11 ||
+    opaque.channelType === 12
+  );
+}
+
+function sanitizeDiscordThreadName(title: string): string {
+  const normalized = title.replace(/\s+/g, " ").trim();
+  return Array.from(normalized || "PwrAgnt thread").slice(0, 100).join("");
+}
+
+function discordChannelIsThread(channel: unknown): boolean {
+  if (!channel || typeof channel !== "object" || !("isThread" in channel)) {
+    return false;
+  }
+  const isThread = (channel as { isThread?: unknown }).isThread;
+  return typeof isThread === "function" && Boolean(isThread.call(channel));
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -35,6 +35,11 @@ describe("adaptGrammyBot", () => {
       parse_mode: "HTML",
       text: "Binding active",
     });
+    await bot.api.editForumTopic({
+      chat_id: 42,
+      message_thread_id: 9,
+      name: "Thread one",
+    });
     await bot.api.sendPhoto({
       caption: "image",
       chat_id: 42,
@@ -81,6 +86,11 @@ describe("adaptGrammyBot", () => {
         parse_mode: "HTML",
       },
     );
+    expect(grammyBot.api.editForumTopic).toHaveBeenCalledWith(
+      42,
+      9,
+      "Thread one",
+    );
     expect(grammyBot.api.sendPhoto).toHaveBeenCalledWith(
       42,
       "https://example.com/image.png",
@@ -105,6 +115,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
   api: {
     answerCallbackQuery: ReturnType<typeof vi.fn>;
     deleteWebhook: ReturnType<typeof vi.fn>;
+    editForumTopic: ReturnType<typeof vi.fn>;
     editMessageText: ReturnType<typeof vi.fn>;
     getWebhookInfo: ReturnType<typeof vi.fn>;
     pinChatMessage: ReturnType<typeof vi.fn>;
@@ -119,6 +130,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
     api: {
       answerCallbackQuery: vi.fn(async () => true),
       deleteWebhook: vi.fn(async () => true),
+      editForumTopic: vi.fn(async () => true),
       editMessageText: vi.fn(
         async (
           chatId: number | string,

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -89,7 +89,9 @@ describe("adaptGrammyBot", () => {
     expect(grammyBot.api.editForumTopic).toHaveBeenCalledWith(
       42,
       9,
-      "Thread one",
+      {
+        name: "Thread one",
+      },
     );
     expect(grammyBot.api.sendPhoto).toHaveBeenCalledWith(
       42,

--- a/packages/messaging/providers/telegram/src/index.ts
+++ b/packages/messaging/providers/telegram/src/index.ts
@@ -4,6 +4,7 @@ export type {
   TelegramBotLike,
   TelegramCallbackQuery,
   TelegramChat,
+  TelegramEditForumTopicRequest,
   TelegramEditMessageTextRequest,
   TelegramMessage,
   TelegramPinChatMessageRequest,

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -3,6 +3,8 @@ import { Bot } from "grammy";
 import type {
   MessagingAdapterState,
   MessagingCallbackHandleStore,
+  MessagingConversationTitleUpdateRequest,
+  MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
   MessagingInboundEvent,
   MessagingJsonValue,
@@ -112,6 +114,12 @@ export type TelegramEditMessageTextRequest = TelegramSendMessageRequest & {
   message_id: number;
 };
 
+export type TelegramEditForumTopicRequest = {
+  chat_id: number | string;
+  message_thread_id: number;
+  name: string;
+};
+
 export type TelegramSendPhotoRequest = {
   caption?: string;
   chat_id: number | string;
@@ -149,6 +157,7 @@ export type TelegramBotApi = {
     text?: string;
   }): Promise<boolean>;
   deleteWebhook(params?: { drop_pending_updates?: boolean }): Promise<boolean>;
+  editForumTopic(request: TelegramEditForumTopicRequest): Promise<boolean>;
   editMessageText(request: TelegramEditMessageTextRequest): Promise<TelegramSentMessage>;
   getWebhookInfo(): Promise<{ url: string }>;
   pinChatMessage(request: TelegramPinChatMessageRequest): Promise<boolean>;
@@ -177,6 +186,11 @@ export type TelegramGrammyBotLike = {
       other?: { text?: string },
     ): Promise<boolean>;
     deleteWebhook(params?: { drop_pending_updates?: boolean }): Promise<boolean>;
+    editForumTopic(
+      chatId: number | string,
+      messageThreadId: number,
+      name: string,
+    ): Promise<boolean>;
     editMessageText(
       chatId: number | string,
       messageId: number,
@@ -223,6 +237,9 @@ export type TelegramProviderAdapter = {
   authorizedActorIds: readonly string[];
   channel: "telegram";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  setConversationTitle(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };
@@ -442,6 +459,54 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           }
         : undefined,
     };
+  }
+
+  async setConversationTitle(
+    request: MessagingConversationTitleUpdateRequest,
+  ): Promise<MessagingConversationTitleUpdateResult> {
+    const title = sanitizeTelegramTopicName(request.title);
+    const conversation = request.channel.conversation;
+    const target =
+      this.telegramStateFromChannel(conversation) ??
+      this.telegramStateFromSurface(request.routingState);
+
+    if (conversation.kind !== "topic" || !target?.messageThreadId) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: "Telegram name sync is only available inside forum topics.",
+        outcome: "unsupported",
+        title,
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      await this.bot.api.editForumTopic({
+        chat_id: target.chatId,
+        message_thread_id: target.messageThreadId,
+        name: title,
+      });
+      return {
+        channel: this.channel,
+        conversation: {
+          ...conversation,
+          title,
+        },
+        outcome: "updated",
+        title,
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: errorMessage(error),
+        outcome: "failed",
+        title,
+        updatedAt: this.now(),
+      };
+    }
   }
 
   async handleUpdate(update: TelegramUpdate): Promise<void> {
@@ -992,6 +1057,12 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
           text: params.text,
         }),
       deleteWebhook: async (params) => await bot.api.deleteWebhook(params),
+      editForumTopic: async (request) =>
+        await bot.api.editForumTopic(
+          request.chat_id,
+          request.message_thread_id,
+          request.name,
+        ),
       editMessageText: async (request) => {
         const { chat_id, message_id, text, ...other } = request;
         return coerceTelegramSentMessage(
@@ -1049,6 +1120,11 @@ function coerceTelegramSentMessage(
 function parseTelegramIdentifier(value: string): number | string {
   const numeric = Number(value);
   return Number.isSafeInteger(numeric) && String(numeric) === value ? numeric : value;
+}
+
+function sanitizeTelegramTopicName(title: string): string {
+  const normalized = title.replace(/\s+/g, " ").trim();
+  return Array.from(normalized || "PwrAgnt thread").slice(0, 128).join("");
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -189,7 +189,10 @@ export type TelegramGrammyBotLike = {
     editForumTopic(
       chatId: number | string,
       messageThreadId: number,
-      name: string,
+      other?: Omit<
+        TelegramEditForumTopicRequest,
+        "chat_id" | "message_thread_id"
+      >,
     ): Promise<boolean>;
     editMessageText(
       chatId: number | string,
@@ -1061,7 +1064,9 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         await bot.api.editForumTopic(
           request.chat_id,
           request.message_thread_id,
-          request.name,
+          {
+            name: request.name,
+          },
         ),
       editMessageText: async (request) => {
         const { chat_id, message_id, text, ...other } = request;

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -430,6 +430,10 @@ export type MessagingActiveTurnSummary = {
 };
 
 export type MessagingThreadDisplaySummary = {
+  /**
+   * Deprecated migration fallback only. Current thread display facts must be
+   * resolved from the desktop navigation/backend state before rendering.
+   */
   directoryPath?: string;
   projectLabel?: string;
   threadTitle?: string;
@@ -443,6 +447,10 @@ export type MessagingBindingRecord = {
   threadId: ThreadIdentifier;
   authorizedActorIds: string[];
   routingState?: MessagingAdapterState;
+  /**
+   * Deprecated migration fallback only. Current turn activity is desktop runtime
+   * state and must be resolved before rendering or acting.
+   */
   activeTurn?: MessagingActiveTurnSummary;
   createdAt: number;
   updatedAt: number;

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -348,6 +348,22 @@ export type MessagingDeliveryResult = {
   deliveredAt: number;
 };
 
+export type MessagingConversationTitleUpdateRequest = {
+  actor?: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+  title: string;
+};
+
+export type MessagingConversationTitleUpdateResult = {
+  channel: MessagingChannelKind;
+  conversation: MessagingConversationRef;
+  errorMessage?: string;
+  outcome: "updated" | "unsupported" | "failed";
+  title: string;
+  updatedAt: number;
+};
+
 export type MessagingInboundBaseEvent = {
   id: string;
   kind: MessagingInboundEventKind;


### PR DESCRIPTION
## Summary

I added a messaging status action to sync the platform conversation name to the current Codex thread title, and I refactored messaging status rendering so it reads live desktop thread state instead of stale binding-cache display metadata.

- Added a `Sync name` status button for bound messaging conversations.
- Added a generic optional adapter hook for conversation title updates.
- Implemented Telegram forum-topic renames with `editForumTopic`.
- Implemented Discord thread renames with `PATCH /channels/{id}` while avoiding ordinary channel renames unless routing metadata confirms the conversation is a thread.
- Added a desktop-owned messaging thread-state resolver for current title, project, directory, worktree, branch, model, reasoning, fast mode, permissions mode, and active turn state.
- Stopped persisting duplicate `threadDisplay` and `activeTurn` state into messaging bindings, and migrated old records so stale cached thread names cannot override the desktop app's current state.
- Updated `/status`, Refresh, status retirement, and Sync name flows to resolve thread facts from the live navigation snapshot before rendering or acting.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/messaging-thread-state.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project messaging packages/messaging/interface/src/__tests__/messaging-contract.test.ts packages/messaging/interface/src/__tests__/messaging-interface.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/messaging*.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project messaging packages/messaging/interface/src/__tests__/messaging-contract.test.ts packages/messaging/interface/src/__tests__/messaging-interface.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts`
- `pnpm lint`

## Post-Deploy Monitoring & Validation

After this lands, I would validate with an existing stale binding by renaming a thread in the Desktop app, running `/status` from Discord and Telegram, and confirming the rendered title and Sync name result match the Desktop title without rebinding or editing `messaging-state.json`.
