### PR TITLE
fix(telegram): ignore topic rename service messages

### DIFF
--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -987,6 +987,46 @@ describe("TelegramAdapter", () => {
     expect(events).toEqual([]);
   });
 
+  it("ignores Telegram forum topic rename service messages", async () => {
+    const events: MessagingInboundEvent[] = [];
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: ["42"],
+      },
+      pollOnStart: false,
+    });
+
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    await adapter.handleUpdate({
+      update_id: 7,
+      message: {
+        chat: {
+          id: -100777,
+          title: "PwrAgnt topics",
+          type: "supergroup",
+        },
+        forum_topic_edited: {
+          name: "Renamed topic",
+        },
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+        },
+        message_id: 106,
+        message_thread_id: 12,
+      },
+    });
+
+    expect(events).toEqual([]);
+  });
+
   it("ignores Telegram messages authored by the configured bot", async () => {
     const events: MessagingInboundEvent[] = [];
     const api = createApi();
@@ -1004,7 +1044,7 @@ describe("TelegramAdapter", () => {
       events.push(event);
     });
     await adapter.handleUpdate({
-      update_id: 7,
+      update_id: 8,
       message: {
         chat: {
           id: 777,
@@ -1016,7 +1056,7 @@ describe("TelegramAdapter", () => {
           is_bot: true,
           username: "huntharo_bot",
         },
-        message_id: 106,
+        message_id: 107,
         text: "Binding: Thread one",
       },
     });
@@ -1041,7 +1081,7 @@ describe("TelegramAdapter", () => {
       events.push(event);
     });
     await adapter.handleUpdate({
-      update_id: 8,
+      update_id: 9,
       message: {
         chat: {
           id: 777,
@@ -1053,7 +1093,7 @@ describe("TelegramAdapter", () => {
           is_bot: true,
           username: "other_bot",
         },
-        message_id: 107,
+        message_id: 108,
         text: "hello from another bot",
       },
     });

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -67,7 +67,20 @@ export type TelegramMessage = {
     file_name?: string;
     mime_type?: string;
   };
+  forum_topic_closed?: Record<string, never>;
+  forum_topic_created?: {
+    icon_color?: number;
+    icon_custom_emoji_id?: string;
+    name: string;
+  };
+  forum_topic_edited?: {
+    icon_custom_emoji_id?: string;
+    name?: string;
+  };
+  forum_topic_reopened?: Record<string, never>;
   from?: TelegramUser;
+  general_forum_topic_hidden?: Record<string, never>;
+  general_forum_topic_unhidden?: Record<string, never>;
   message_id: number;
   message_thread_id?: number;
   photo?: Array<{
@@ -464,9 +477,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       return;
     }
 
-    if (message.pinned_message || this.isOwnBotUser(message.from)) {
+    const serviceMessageReason = telegramServiceMessageReason(message);
+    if (serviceMessageReason || this.isOwnBotUser(message.from)) {
       this.options.logger?.debug(
-        `telegram inbound ignored update=${updateId} message=${message.message_id} reason=${message.pinned_message ? "pin" : "own_bot"} chat=${message.chat.id}`,
+        `telegram inbound ignored update=${updateId} message=${message.message_id} reason=${serviceMessageReason ?? "own_bot"} chat=${message.chat.id}`,
       );
       return;
     }
@@ -1059,4 +1073,29 @@ function compactPreview(text: string, limit = 96): string {
   const compact = text.replace(/\s+/g, " ").trim();
   const preview = compact.length > limit ? `${compact.slice(0, limit - 3)}...` : compact;
   return preview.replace(/["\\]/g, "\\$&");
+}
+
+function telegramServiceMessageReason(message: TelegramMessage): string | undefined {
+  if (message.pinned_message) {
+    return "pin";
+  }
+  if (message.forum_topic_created) {
+    return "forum_topic_created";
+  }
+  if (message.forum_topic_edited) {
+    return "forum_topic_edited";
+  }
+  if (message.forum_topic_closed) {
+    return "forum_topic_closed";
+  }
+  if (message.forum_topic_reopened) {
+    return "forum_topic_reopened";
+  }
+  if (message.general_forum_topic_hidden) {
+    return "general_forum_topic_hidden";
+  }
+  if (message.general_forum_topic_unhidden) {
+    return "general_forum_topic_unhidden";
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

This fixes Telegram forum topic rename handling so service messages from Telegram are ignored instead of being normalized as unsupported media.

## Changes

- Added Telegram forum topic service-message fields to the provider message shape.
- Treat topic create/edit/close/reopen and general-topic hide/unhide updates like pin service messages: log and ignore them before the unsupported-media path.
- Added a regression test for `forum_topic_edited` updates from Telegram supergroup topics.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`.
- I ran `pnpm --filter @pwragnt/messaging-provider-telegram typecheck`.
- I ran `pnpm lint`.
