### PR TITLE
feat(messaging): worktree handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5,7 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
   AppServerPendingRequestNotification,
+  HandoffThreadWorkspaceRequest,
   ListBackendsResponse,
+  MessagingSurfaceAction,
   MessagingDeliveryResult,
   MessagingInboundCallbackEvent,
   MessagingInboundEvent,
@@ -1740,6 +1742,205 @@ describe("MessagingController", () => {
     });
   });
 
+  it("runs a local-to-worktree handoff from the status menu", async () => {
+    const harness = await createHarness();
+    harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Workspace Handoff"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "handoff:local-to-worktree",
+          label: "Handoff to New Worktree",
+        }),
+      ]),
+    });
+
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: toWorktree.id,
+        value: toWorktree.value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Choose the branch"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "handoff:select-leave-branch",
+          label: "1. main",
+        }),
+      ]),
+    });
+
+    const leaveMain = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: leaveMain.id,
+        value: leaveMain.value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Leave Local on: main"),
+    });
+
+    const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
+    harness.getNavigationSnapshot.mockResolvedValue(buildWorktreeHandoffNavigationSnapshot());
+    harness.getNavigationSnapshot.mockResolvedValueOnce(
+      buildLocalHandoffNavigationSnapshot(),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: confirm.id,
+        value: confirm.value,
+      }),
+    );
+
+    expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      direction: "local-to-worktree",
+      leaveLocalBranch: "main",
+      repositoryPath: "/repo/pwragnt",
+      sourceBranch: "feature/handoff",
+      sourcePath: "/repo/pwragnt",
+      threadId: "thread-1",
+    });
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "status",
+      status: "completed",
+      text: expect.stringContaining("/repo/pwragnt/.worktrees/pwragnt-feature-handoff"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining(
+        "Worktree: /repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+      ),
+    });
+  });
+
+  it("runs a worktree-to-local handoff from the status menu", async () => {
+    const harness = await createHarness();
+    harness.getNavigationSnapshot.mockResolvedValue(buildWorktreeHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+
+    const toLocal = findChoice(harness.delivered.at(-1), "handoff:worktree-to-local");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: toLocal.id,
+        value: toLocal.value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Confirm Handoff",
+      body: expect.stringContaining("Confirm handoff to Local."),
+    });
+
+    const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
+    harness.getNavigationSnapshot.mockResolvedValue(buildNavigationSnapshot());
+    harness.getNavigationSnapshot.mockResolvedValueOnce(
+      buildWorktreeHandoffNavigationSnapshot(),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: confirm.id,
+        value: confirm.value,
+      }),
+    );
+
+    expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      direction: "worktree-to-local",
+      repositoryPath: "/repo/pwragnt",
+      sourceBranch: "feature/handoff",
+      sourcePath: "/repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+      threadId: "thread-1",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Directory: /repo/pwragnt"),
+    });
+    const finalStatus = harness.delivered.at(-1);
+    if (!finalStatus || finalStatus.kind !== "status") {
+      throw new Error("Expected final handoff delivery to be a status intent");
+    }
+    expect(finalStatus.text).not.toContain("Worktree:");
+  });
+
+  it("rejects stale handoff confirmations when workspace metadata changes", async () => {
+    const harness = await createHarness();
+    harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: toWorktree.id,
+        value: toWorktree.value,
+      }),
+    );
+    const leaveMain = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: leaveMain.id,
+        value: leaveMain.value,
+      }),
+    );
+    const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
+
+    harness.getNavigationSnapshot.mockResolvedValue(buildNavigationSnapshot());
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: confirm.id,
+        value: confirm.value,
+      }),
+    );
+
+    expect(harness.handoffThreadWorkspace).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Handoff unavailable",
+    });
+  });
+
+  it("reports handoff as unavailable when the backend bridge does not expose it", async () => {
+    const harness = await createHarness({ handoff: false });
+    harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Handoff unavailable",
+      body: expect.stringContaining("does not expose"),
+    });
+  });
+
   it("syncs the platform conversation name from the bound thread title", async () => {
     const setConversationTitle = vi.fn(
       async (
@@ -1803,6 +2004,7 @@ describe("MessagingController", () => {
 async function createHarness(options?: {
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
+  handoff?: false;
   logger?: MessagingControllerOptions["logger"];
   now?: () => number;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
@@ -1812,6 +2014,7 @@ async function createHarness(options?: {
   compactThread: ReturnType<typeof vi.fn>;
   delivered: MessagingSurfaceIntent[];
   getNavigationSnapshot: ReturnType<typeof vi.fn>;
+  handoffThreadWorkspace: ReturnType<typeof vi.fn> | undefined;
   interruptTurn: ReturnType<typeof vi.fn>;
   listBackends: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
@@ -1868,6 +2071,38 @@ async function createHarness(options?: {
   const interruptTurn = vi.fn(async (request) => request);
   const setThreadExecutionMode = vi.fn(async (request) => request);
   const setThreadModelSettings = vi.fn(async (request) => request);
+  const handoffThreadWorkspace =
+    options?.handoff === false
+      ? undefined
+      : vi.fn(async (request: HandoffThreadWorkspaceRequest) => ({
+          backend: request.backend,
+          threadId: request.threadId,
+          direction: request.direction,
+          workMode: request.direction === "local-to-worktree"
+            ? "worktree" as const
+            : "local" as const,
+          branch: request.sourceBranch,
+          repositoryPath: request.repositoryPath ?? "/repo/pwragnt",
+          targetPath: request.direction === "local-to-worktree"
+            ? "/repo/pwragnt/.worktrees/pwragnt-feature-handoff"
+            : "/repo/pwragnt",
+          linkedDirectory: request.direction === "local-to-worktree"
+            ? {
+                id: "pwragnt-handoff:codex:thread-1",
+                kind: "worktree" as const,
+                label: "PwrAgnt",
+                path: "/repo/pwragnt",
+                worktreePath: "/repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+              }
+            : {
+                id: "directory:pwragnt",
+                kind: "local" as const,
+                label: "PwrAgnt",
+                path: "/repo/pwragnt",
+              },
+          warnings: [],
+          completedAt: 1000,
+        }));
   const listBackends = vi.fn(async (): Promise<ListBackendsResponse> => ({
     fetchedAt: 1000,
     backends: [buildBackendSummary()],
@@ -1882,6 +2117,7 @@ async function createHarness(options?: {
   const backend: MessagingBackendBridge = {
     compactThread,
     getNavigationSnapshot,
+    ...(handoffThreadWorkspace ? { handoffThreadWorkspace } : {}),
     interruptTurn,
     listBackends,
     readThreadStatus,
@@ -1905,6 +2141,7 @@ async function createHarness(options?: {
     compactThread,
     delivered,
     getNavigationSnapshot,
+    handoffThreadWorkspace,
     interruptTurn,
     listBackends,
     readThreadStatus,
@@ -2019,6 +2256,68 @@ function buildNavigationSnapshot(): NavigationSnapshot {
       executionMode: "default",
     },
   };
+}
+
+function buildLocalHandoffNavigationSnapshot(): NavigationSnapshot {
+  const snapshot = buildNavigationSnapshot();
+  snapshot.threads[0] = {
+    ...snapshot.threads[0]!,
+    gitBranch: "feature/handoff",
+  };
+  snapshot.directories[0] = {
+    ...snapshot.directories[0]!,
+    gitStatus: {
+      currentBranch: "feature/handoff",
+      handoffBranches: ["main", "develop"],
+    },
+  };
+  return snapshot;
+}
+
+function buildWorktreeHandoffNavigationSnapshot(): NavigationSnapshot {
+  const snapshot = buildNavigationSnapshot();
+  snapshot.threads[0] = {
+    ...snapshot.threads[0]!,
+    gitBranch: "feature/handoff",
+    linkedDirectories: [
+      {
+        id: "pwragnt-handoff:codex:thread-1",
+        kind: "worktree",
+        label: "PwrAgnt",
+        path: "/repo/pwragnt",
+        worktreePath: "/repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+      },
+    ],
+  };
+  return snapshot;
+}
+
+function findChoice(
+  intent: MessagingSurfaceIntent | undefined,
+  actionId: string,
+): MessagingSurfaceAction {
+  if (!intent || !("choices" in intent)) {
+    throw new Error(`Intent does not contain choices for ${actionId}`);
+  }
+  const action = intent.choices.find((choice) => choice.id === actionId);
+  if (!action) {
+    throw new Error(`Choice ${actionId} not found`);
+  }
+  return action;
+}
+
+function findAction(
+  intent: MessagingSurfaceIntent | undefined,
+  actionId: string,
+): MessagingSurfaceAction {
+  if (!intent || !("actions" in intent) || !Array.isArray(intent.actions)) {
+    throw new Error(`Intent does not contain actions for ${actionId}`);
+  }
+  const action = intent.actions.find((candidate) => candidate.id === actionId);
+  if (!action) {
+    throw new Error(`Action ${actionId} not found`);
+  }
+  return action;
 }
 
 function buildCommandEvent(

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { MessagingBindingRecord, NavigationSnapshot } from "@pwragnt/shared";
-import { buildBindingStatusIntent } from "../messaging/core/messaging-status-card";
+import {
+  buildBindingStatusIntent,
+  buildHandoffBranchPickerIntent,
+  buildHandoffConfirmationIntent,
+  buildHandoffOverviewIntent,
+  handoffRequestFromValue,
+  type MessagingWorkspaceHandoffContext,
+} from "../messaging/core/messaging-status-card";
 import { resolveMessagingThreadState } from "../messaging/core/messaging-thread-state";
 
 describe("buildBindingStatusIntent", () => {
@@ -247,7 +254,144 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Fast mode: on");
     expect(intent.text).toContain("Permissions: Full Access");
   });
+
+  it("adds the status handoff action when a handoff context is available", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-7",
+      createdAt: 1000,
+      binding,
+      handoff: buildHandoffContext(),
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "status:handoff",
+        label: "Handoff",
+        value: expect.objectContaining({
+          backend: "codex",
+          direction: "local-to-worktree",
+          repositoryPath: "/repo/pwragnt",
+          sourceBranch: "feature/handoff",
+          sourcePath: "/repo/pwragnt",
+          threadId: "thread-1",
+        }),
+      }),
+    );
+  });
+
+  it("builds handoff overview, branch picker, and confirmation intents", () => {
+    const binding = buildBinding();
+    const context = buildHandoffContext();
+    const overview = buildHandoffOverviewIntent({
+      id: "handoff-overview-1",
+      binding,
+      context,
+      createdAt: 1000,
+    });
+
+    expect(overview).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Workspace Handoff"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "handoff:local-to-worktree",
+          label: "Handoff to New Worktree",
+        }),
+      ]),
+    });
+
+    const branchPicker = buildHandoffBranchPickerIntent({
+      id: "handoff-branch-1",
+      binding,
+      context,
+      createdAt: 1000,
+    });
+    expect(branchPicker.choices[0]).toMatchObject({
+      id: "handoff:select-leave-branch",
+      label: "1. main",
+      value: expect.objectContaining({
+        leaveLocalBranch: "main",
+      }),
+    });
+
+    const confirmation = buildHandoffConfirmationIntent({
+      id: "handoff-confirm-1",
+      binding,
+      context,
+      createdAt: 1000,
+      leaveLocalBranch: "main",
+    });
+    expect(confirmation).toMatchObject({
+      kind: "confirmation",
+      title: "Confirm Handoff",
+      body: expect.stringContaining("Leave Local on: main"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "handoff:confirm",
+          value: expect.objectContaining({
+            leaveLocalBranch: "main",
+          }),
+        }),
+      ]),
+    });
+  });
+
+  it("parses a handoff request only from complete action values", () => {
+    expect(
+      handoffRequestFromValue({
+        backend: "codex",
+        direction: "local-to-worktree",
+        repositoryPath: "/repo/pwragnt",
+        sourceBranch: "feature/handoff",
+        sourcePath: "/repo/pwragnt",
+        threadId: "thread-1",
+      }),
+    ).toEqual({
+      backend: "codex",
+      direction: "local-to-worktree",
+      repositoryPath: "/repo/pwragnt",
+      sourceBranch: "feature/handoff",
+      sourcePath: "/repo/pwragnt",
+      threadId: "thread-1",
+    });
+    expect(handoffRequestFromValue({ direction: "local-to-worktree" })).toBeUndefined();
+  });
 });
+
+function buildBinding(): MessagingBindingRecord {
+  return {
+    id: "binding-1",
+    authorizedActorIds: ["user-1"],
+    backend: "codex",
+    channel: {
+      channel: "telegram",
+      conversation: {
+        id: "chat-1",
+        kind: "dm",
+      },
+    },
+    createdAt: 1000,
+    threadId: "thread-1",
+    updatedAt: 1000,
+  };
+}
+
+function buildHandoffContext(): MessagingWorkspaceHandoffContext {
+  return {
+    backend: "codex",
+    branch: "feature/handoff",
+    leaveLocalBranches: ["main", "develop"],
+    projectLabel: "PwrAgnt",
+    repositoryPath: "/repo/pwragnt",
+    threadId: "thread-1",
+    threadTitle: "Thread one",
+    workingDirectoryPath: "/repo/pwragnt",
+    workspaceKind: "local",
+  };
+}
 
 function buildNavigationSnapshot(): NavigationSnapshot {
   return {

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -4,6 +4,8 @@ import type {
   AppServerThreadStatus,
   CompactThreadRequest,
   CompactThreadResponse,
+  HandoffThreadWorkspaceRequest,
+  HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
   GetNavigationSnapshotRequest,
@@ -67,6 +69,9 @@ export type MessagingBackendBridge = {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<AppServerThreadStatus | undefined>;
+  handoffThreadWorkspace?(
+    request: HandoffThreadWorkspaceRequest,
+  ): Promise<HandoffThreadWorkspaceResponse>;
   startThread?(request: StartThreadRequest): Promise<StartThreadResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
   compactThread?(request: CompactThreadRequest): Promise<CompactThreadResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4,6 +4,9 @@ import type {
   AppServerBackendKind,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
+  HandoffThreadWorkspaceRequest,
+  HandoffThreadWorkspaceResponse,
+  LinkedDirectorySummary,
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingActiveTurnSummary,
@@ -19,6 +22,7 @@ import type {
   MessagingPendingIntentRecord,
   MessagingSurfaceIntent,
   MessagingToolUpdateMode,
+  NavigationDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
   ThreadExecutionMode,
@@ -52,10 +56,15 @@ import {
 } from "./messaging-resume-browser.js";
 import {
   buildBindingStatusIntent,
+  buildHandoffBranchPickerIntent,
+  buildHandoffConfirmationIntent,
+  buildHandoffOverviewIntent,
   buildStatusModelPickerIntent,
   buildStatusReasoningPickerIntent,
+  handoffRequestFromValue,
   nextMessagingToolUpdateMode,
   resolveMessagingToolUpdateMode,
+  type MessagingWorkspaceHandoffContext,
 } from "./messaging-status-card.js";
 import { resolveMessagingThreadState } from "./messaging-thread-state.js";
 import { summarizeToolActivityFromBackendEvent } from "./messaging-tool-activity.js";
@@ -1233,6 +1242,31 @@ export class MessagingController {
       await this.renderBindingStatus(binding, event);
       return;
     }
+    if (actionId === "status:handoff") {
+      await this.presentHandoffOverview(binding, event);
+      return;
+    }
+    if (actionId === "handoff:cancel") {
+      await this.clearActiveHandoffIntent(event);
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+    if (actionId === "handoff:local-to-worktree") {
+      await this.presentHandoffBranchPicker(binding, event);
+      return;
+    }
+    if (actionId === "handoff:worktree-to-local") {
+      await this.presentHandoffConfirmation(binding, event);
+      return;
+    }
+    if (actionId === "handoff:select-leave-branch") {
+      await this.presentHandoffConfirmation(binding, event);
+      return;
+    }
+    if (actionId === "handoff:confirm") {
+      await this.executeHandoff(binding, event);
+      return;
+    }
     if (actionId === "status:model") {
       await this.presentModelPicker(binding, event);
       return;
@@ -1283,6 +1317,313 @@ export class MessagingController {
       }),
       binding,
     );
+  }
+
+  private async presentHandoffOverview(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    if (!this.options.backend.handoffThreadWorkspace) {
+      await this.deliverHandoffUnavailable(binding, event, "This runtime does not expose workspace handoff through messaging.");
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const context = handoffContextForBinding(binding, navigation);
+    if (!context) {
+      await this.deliverHandoffUnavailable(binding, event, "This thread does not have enough Git workspace metadata for handoff.");
+      return;
+    }
+
+    await this.deliverAndStoreStatusSubmode(
+      {
+        ...buildHandoffOverviewIntent({
+          id: this.newIntentId("handoff-overview"),
+          binding,
+          context,
+          createdAt: this.now(),
+        }),
+        audit: this.buildHandoffAudit("handoff.overview", binding, event),
+      },
+      binding,
+      event,
+    );
+  }
+
+  private async presentHandoffBranchPicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const context = handoffContextForBinding(binding, navigation);
+    if (!context || context.workspaceKind !== "local") {
+      await this.deliverHandoffUnavailable(binding, event, "This thread is not currently in a Local workspace that can move to a worktree.");
+      return;
+    }
+    if (context.leaveLocalBranches.length === 0) {
+      await this.deliverHandoffUnavailable(binding, event, "No safe branch choices are available to leave checked out in Local.");
+      return;
+    }
+
+    await this.deliverAndStoreStatusSubmode(
+      {
+        ...buildHandoffBranchPickerIntent({
+          id: this.newIntentId("handoff-branch"),
+          binding,
+          context,
+          createdAt: this.now(),
+        }),
+        audit: this.buildHandoffAudit("handoff.branch_picker", binding, event),
+      },
+      binding,
+      event,
+    );
+  }
+
+  private async presentHandoffConfirmation(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const context = handoffContextForBinding(binding, navigation);
+    const request = handoffRequestFromValue(event.value);
+    if (!context || !request) {
+      await this.deliverInvalidHandoffSelection(binding, event);
+      return;
+    }
+
+    const validation = validateHandoffRequest(request, context);
+    if (!validation.valid) {
+      await this.deliverHandoffUnavailable(binding, event, validation.reason);
+      return;
+    }
+
+    await this.deliverAndStoreStatusSubmode(
+      {
+        ...buildHandoffConfirmationIntent({
+          id: this.newIntentId("handoff-confirm"),
+          binding,
+          context,
+          createdAt: this.now(),
+          leaveLocalBranch: request.leaveLocalBranch,
+        }),
+        audit: this.buildHandoffAudit(
+          `handoff.confirmation.${request.direction}`,
+          binding,
+          event,
+        ),
+      },
+      binding,
+      event,
+    );
+  }
+
+  private async executeHandoff(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    if (!this.options.backend.handoffThreadWorkspace) {
+      await this.deliverHandoffUnavailable(binding, event, "This runtime does not expose workspace handoff through messaging.");
+      return;
+    }
+
+    const request = handoffRequestFromValue(event.value);
+    if (!request) {
+      await this.deliverInvalidHandoffSelection(binding, event);
+      return;
+    }
+
+    const currentBinding = await this.options.store.getBinding(binding.id);
+    if (
+      !currentBinding ||
+      currentBinding.revokedAt ||
+      currentBinding.backend !== binding.backend ||
+      currentBinding.threadId !== binding.threadId ||
+      !currentBinding.authorizedActorIds.includes(event.actor.platformUserId)
+    ) {
+      await this.deliverHandoffUnavailable(binding, event, "That handoff prompt is stale. Use /status to refresh.");
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const context = handoffContextForBinding(currentBinding, navigation);
+    if (!context) {
+      await this.deliverHandoffUnavailable(currentBinding, event, "This thread no longer has enough Git workspace metadata for handoff.");
+      return;
+    }
+    const validation = validateHandoffRequest(request, context);
+    if (!validation.valid) {
+      await this.deliverHandoffUnavailable(currentBinding, event, validation.reason);
+      return;
+    }
+
+    await this.deliver(
+      {
+        ...buildStatusIntent({
+          id: this.newIntentId("handoff-running"),
+          createdAt: this.now(),
+          status: "working",
+          text: `Running workspace handoff: ${formatHandoffDirection(request.direction)}.`,
+        }),
+        audit: this.buildHandoffAudit(
+          `handoff.running.${request.direction}`,
+          currentBinding,
+          event,
+        ),
+      },
+      currentBinding,
+      event,
+    );
+
+    try {
+      const result = await this.options.backend.handoffThreadWorkspace(request);
+      await this.clearActiveHandoffIntent(event);
+      const refreshedNavigation = await this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+      const updatedBinding = await this.updateBindingAfterHandoff(
+        currentBinding,
+        result,
+      );
+      await this.deliver(
+        {
+          ...buildStatusIntent({
+            id: this.newIntentId("handoff-completed"),
+            createdAt: this.now(),
+            status: "completed",
+            text: handoffSuccessText(result),
+          }),
+          audit: this.buildHandoffAudit(
+            `handoff.completed.${request.direction}`,
+            updatedBinding,
+            event,
+          ),
+        },
+        updatedBinding,
+        event,
+      );
+      await this.renderBindingStatus(updatedBinding, event, refreshedNavigation);
+    } catch (error) {
+      await this.deliver(
+        {
+          ...buildErrorIntent({
+            id: this.newIntentId("handoff-failed"),
+            createdAt: this.now(),
+            title: "Handoff failed",
+            body: error instanceof Error ? error.message : String(error),
+            recoverable: true,
+          }),
+          audit: this.buildHandoffAudit(
+            `handoff.failed.${request.direction}`,
+            currentBinding,
+            event,
+          ),
+        },
+        currentBinding,
+        event,
+      );
+    }
+  }
+
+  private async updateBindingAfterHandoff(
+    binding: MessagingBindingRecord,
+    _result: HandoffThreadWorkspaceResponse,
+  ): Promise<MessagingBindingRecord> {
+    // Live navigation now owns status display metadata; keep the binding current
+    // without restoring legacy threadDisplay cache fields that the store strips.
+    return await this.options.store.upsertBinding({
+      ...binding,
+      updatedAt: this.now(),
+    });
+  }
+
+  private async deliverAndStoreStatusSubmode(
+    intent: MessagingSurfaceIntent,
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const pendingIntent = await this.storePendingIntent(intent, binding, event);
+    const result = await this.deliver(intent, binding, event);
+    if (!result.surface) {
+      return;
+    }
+    await this.options.store.upsertPendingIntent({
+      ...pendingIntent,
+      surface: result.surface,
+    });
+    await this.options.store.upsertBinding({
+      ...binding,
+      statusSurface: result.surface,
+      updatedAt: this.now(),
+    });
+  }
+
+  private async clearActiveHandoffIntent(event: MessagingInboundEvent): Promise<void> {
+    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (pendingIntent && pendingIntent.intent.id.includes("handoff")) {
+      await this.options.store.deletePendingIntent(pendingIntent.id);
+    }
+  }
+
+  private async deliverHandoffUnavailable(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+    body: string,
+  ): Promise<void> {
+    await this.deliver(
+      {
+        ...buildErrorIntent({
+          id: this.newIntentId("handoff-unavailable"),
+          createdAt: this.now(),
+          title: "Handoff unavailable",
+          body,
+          recoverable: true,
+        }),
+        audit: this.buildHandoffAudit("handoff.unavailable", binding, event),
+      },
+      binding,
+      event,
+    );
+  }
+
+  private async deliverInvalidHandoffSelection(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      {
+        ...buildErrorIntent({
+          id: this.newIntentId("handoff-invalid"),
+          createdAt: this.now(),
+          title: "Invalid handoff selection",
+          body: "That handoff selection is no longer available. Use /status to refresh.",
+          recoverable: true,
+        }),
+        audit: this.buildHandoffAudit("handoff.invalid_selection", binding, event),
+      },
+      binding,
+      event,
+    );
+  }
+
+  private buildHandoffAudit(
+    action: string,
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): NonNullable<MessagingSurfaceIntent["audit"]> {
+    return buildMessagingAuditContext({
+      action,
+      actor: event.actor,
+      backend: binding.backend,
+      bindingId: binding.id,
+      channel: binding.channel,
+      now: this.now(),
+      threadId: binding.threadId,
+    });
   }
 
   private async presentModelPicker(
@@ -1821,6 +2162,9 @@ export class MessagingController {
       id: this.newIntentId("status"),
       binding,
       createdAt: this.now(),
+      handoff: this.options.backend.handoffThreadWorkspace
+        ? handoffContextForBinding(binding, snapshot)
+        : undefined,
       threadState: resolveMessagingThreadState({
         activeTurn,
         binding,
@@ -2219,7 +2563,153 @@ function readBrowseAction(event: MessagingInboundCallbackEvent): string | undefi
 
 function readStatusAction(event: MessagingInboundCallbackEvent): string | undefined {
   const actionId = event.actionId ?? event.interaction.id;
-  return actionId.startsWith("status:") ? actionId : undefined;
+  return actionId.startsWith("status:") || actionId.startsWith("handoff:")
+    ? actionId
+    : undefined;
+}
+
+function handoffContextForBinding(
+  binding: MessagingBindingRecord,
+  navigation: NavigationSnapshot,
+): MessagingWorkspaceHandoffContext | undefined {
+  const thread = findThreadForBinding(navigation, binding);
+  if (!thread) {
+    return undefined;
+  }
+
+  const worktreeDirectory = thread.linkedDirectories.find(
+    (directory) => directory.kind === "worktree" || Boolean(directory.worktreePath),
+  );
+  if (worktreeDirectory) {
+    const repositoryPath = worktreeDirectory.path;
+    const workingDirectoryPath = worktreeDirectory.worktreePath ?? worktreeDirectory.path;
+    const branch = thread.observedGitBranch ?? thread.gitBranch;
+    if (!repositoryPath || !workingDirectoryPath || !branch) {
+      return undefined;
+    }
+    return {
+      backend: binding.backend,
+      branch,
+      leaveLocalBranches: [],
+      projectLabel: worktreeDirectory.label,
+      repositoryPath,
+      threadId: binding.threadId,
+      threadTitle: thread.title,
+      workingDirectoryPath,
+      workspaceKind: "worktree",
+    };
+  }
+
+  const localDirectory =
+    thread.linkedDirectories.find((directory) => directory.kind === "local") ??
+    thread.linkedDirectories[0];
+  if (!localDirectory?.path) {
+    return undefined;
+  }
+  const directorySummary = findNavigationDirectory(navigation, localDirectory);
+  const branch =
+    thread.observedGitBranch ??
+    thread.gitBranch ??
+    directorySummary?.gitStatus?.currentBranch;
+  if (!branch) {
+    return undefined;
+  }
+  const leaveLocalBranches = (
+    directorySummary?.gitStatus?.handoffBranches ??
+    directorySummary?.gitStatus?.branches?.filter((candidate) => candidate !== branch) ??
+    []
+  ).filter(
+    (candidate, index, branches) =>
+      candidate !== branch && branches.indexOf(candidate) === index,
+  );
+  if (leaveLocalBranches.length === 0) {
+    return undefined;
+  }
+
+  return {
+    backend: binding.backend,
+    branch,
+    leaveLocalBranches,
+    projectLabel: localDirectory.label,
+    repositoryPath: localDirectory.path,
+    threadId: binding.threadId,
+    threadTitle: thread.title,
+    workingDirectoryPath: localDirectory.path,
+    workspaceKind: "local",
+  };
+}
+
+function findNavigationDirectory(
+  navigation: NavigationSnapshot,
+  linkedDirectory: LinkedDirectorySummary,
+): NavigationDirectorySummary | undefined {
+  return navigation.directories.find(
+    (directory) =>
+      directory.key === linkedDirectory.id ||
+      directory.path === linkedDirectory.path ||
+      (linkedDirectory.worktreePath && directory.path === linkedDirectory.worktreePath),
+  );
+}
+
+function validateHandoffRequest(
+  request: HandoffThreadWorkspaceRequest,
+  context: MessagingWorkspaceHandoffContext,
+): { valid: true } | { valid: false; reason: string } {
+  const expectedDirection =
+    context.workspaceKind === "local" ? "local-to-worktree" : "worktree-to-local";
+  if (
+    request.backend !== context.backend ||
+    request.threadId !== context.threadId ||
+    request.direction !== expectedDirection ||
+    request.repositoryPath !== context.repositoryPath ||
+    request.sourcePath !== context.workingDirectoryPath
+  ) {
+    return {
+      valid: false,
+      reason: "That handoff prompt is stale. Use /status to refresh.",
+    };
+  }
+  if (context.branch && request.sourceBranch !== context.branch) {
+    return {
+      valid: false,
+      reason: "The thread branch changed. Use /status to refresh before handoff.",
+    };
+  }
+  if (request.direction === "local-to-worktree") {
+    if (!request.leaveLocalBranch) {
+      return {
+        valid: false,
+        reason: "Choose the branch to leave checked out in Local before handoff.",
+      };
+    }
+    if (!context.leaveLocalBranches.includes(request.leaveLocalBranch)) {
+      return {
+        valid: false,
+        reason: "That Local branch choice is no longer available. Use /status to refresh.",
+      };
+    }
+  }
+  return { valid: true };
+}
+
+function formatHandoffDirection(
+  direction: HandoffThreadWorkspaceRequest["direction"],
+): string {
+  return direction === "local-to-worktree"
+    ? "Local to new worktree"
+    : "Worktree to Local";
+}
+
+function handoffSuccessText(result: HandoffThreadWorkspaceResponse): string {
+  return [
+    `Workspace handoff complete: ${formatHandoffDirection(result.direction)}.`,
+    `Workspace: ${result.workMode === "worktree" ? "Worktree" : "Local"}`,
+    `Target: ${result.targetPath}`,
+    result.branch ? `Branch: ${result.branch}` : undefined,
+    ...result.warnings.map((warning) => `Warning: ${warning}`),
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
 }
 
 function normalizeConversationTitle(title: string | undefined): string | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1,14 +1,32 @@
 import type {
+  AppServerBackendKind,
+  HandoffThreadWorkspaceRequest,
   MessagingBindingRecord,
+  MessagingConfirmationIntent,
+  MessagingJsonValue,
   MessagingToolUpdateMode,
   MessagingSingleSelectIntent,
   MessagingStatusIntent,
+  ThreadIdentifier,
 } from "@pwragnt/shared";
 import type { MessagingResolvedThreadState } from "./messaging-thread-state.js";
+
+export type MessagingWorkspaceHandoffContext = {
+  backend: AppServerBackendKind;
+  branch?: string;
+  leaveLocalBranches: string[];
+  projectLabel?: string;
+  repositoryPath: string;
+  threadId: ThreadIdentifier;
+  threadTitle?: string;
+  workingDirectoryPath: string;
+  workspaceKind: "local" | "worktree";
+};
 
 export function buildBindingStatusIntent(params: {
   binding: MessagingBindingRecord;
   createdAt: number;
+  handoff?: MessagingWorkspaceHandoffContext;
   id: string;
   threadState: MessagingResolvedThreadState;
   toolUpdateMode?: MessagingToolUpdateMode;
@@ -103,6 +121,17 @@ export function buildBindingStatusIntent(params: {
         style: "secondary",
         fallbackText: "permissions",
       },
+      ...(params.handoff
+        ? [
+            {
+              id: "status:handoff",
+              label: "Handoff",
+              style: "secondary" as const,
+              fallbackText: "handoff",
+              value: handoffValue(params.handoff),
+            },
+          ]
+        : []),
       {
         id: "status:tool-updates",
         label: `Tools: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
@@ -180,6 +209,234 @@ export function formatMessagingToolUpdateModeLabel(
     case "show_all":
       return "Show All";
   }
+}
+
+export function buildHandoffOverviewIntent(params: {
+  binding: MessagingBindingRecord;
+  context: MessagingWorkspaceHandoffContext;
+  createdAt: number;
+  id: string;
+}): MessagingSingleSelectIntent {
+  const action =
+    params.context.workspaceKind === "local"
+      ? {
+          id: "handoff:local-to-worktree",
+          label: "Handoff to New Worktree",
+          fallbackText: "1",
+          style: "primary" as const,
+          value: handoffValue(params.context),
+        }
+      : {
+          id: "handoff:worktree-to-local",
+          label: "Handoff to Local",
+          fallbackText: "1",
+          style: "primary" as const,
+          value: handoffValue(params.context),
+        };
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: [
+      handoffOverviewText(params.context),
+      `1. ${action.label}`,
+      "Reply with 1, Back, Refresh, or Cancel.",
+    ].join("\n"),
+    prompt: handoffOverviewText(params.context),
+    choices: [
+      action,
+      {
+        id: "status:refresh",
+        label: "Back",
+        fallbackText: "back",
+        style: "secondary",
+      },
+      {
+        id: "status:refresh",
+        label: "Refresh",
+        fallbackText: "refresh",
+        style: "secondary",
+      },
+      {
+        id: "handoff:cancel",
+        label: "Cancel",
+        fallbackText: "cancel",
+        style: "secondary",
+      },
+    ],
+  };
+}
+
+export function buildHandoffBranchPickerIntent(params: {
+  binding: MessagingBindingRecord;
+  context: MessagingWorkspaceHandoffContext;
+  createdAt: number;
+  id: string;
+}): MessagingSingleSelectIntent {
+  const choices = params.context.leaveLocalBranches.map((branch, index) => ({
+    id: "handoff:select-leave-branch",
+    label: `${index + 1}. ${branch}`,
+    fallbackText: String(index + 1),
+    style: "secondary" as const,
+    value: {
+      ...handoffValue(params.context),
+      leaveLocalBranch: branch,
+    },
+  }));
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: [
+      "Choose the branch that should remain checked out in Local.",
+      ...choices.map((choice) => choice.label),
+      "Reply with a number, Back, Refresh, or Cancel.",
+    ].join("\n"),
+    prompt: [
+      "Choose the branch that should remain checked out in Local.",
+      `Moving branch: ${params.context.branch ?? unavailable()}`,
+      `Local: ${params.context.repositoryPath}`,
+    ].join("\n"),
+    choices: [
+      ...choices,
+      {
+        id: "status:handoff",
+        label: "Back",
+        fallbackText: "back",
+        style: "secondary" as const,
+        value: handoffValue(params.context),
+      },
+      {
+        id: "status:refresh",
+        label: "Refresh",
+        fallbackText: "refresh",
+        style: "secondary" as const,
+      },
+      {
+        id: "handoff:cancel",
+        label: "Cancel",
+        fallbackText: "cancel",
+        style: "secondary" as const,
+      },
+    ],
+  };
+}
+
+export function buildHandoffConfirmationIntent(params: {
+  binding: MessagingBindingRecord;
+  context: MessagingWorkspaceHandoffContext;
+  createdAt: number;
+  id: string;
+  leaveLocalBranch?: string;
+}): MessagingConfirmationIntent {
+  const direction =
+    params.context.workspaceKind === "local" ? "local-to-worktree" : "worktree-to-local";
+  const body = [
+    direction === "local-to-worktree"
+      ? "Confirm handoff to a new worktree."
+      : "Confirm handoff to Local.",
+    `Thread: ${params.context.threadTitle ?? params.context.threadId} (${params.context.backend})`,
+    `Project: ${params.context.projectLabel ?? unavailable()}`,
+    `Repository: ${params.context.repositoryPath}`,
+    `Working directory: ${params.context.workingDirectoryPath}`,
+    `Branch: ${params.context.branch ?? unavailable()}`,
+    params.leaveLocalBranch
+      ? `Leave Local on: ${params.leaveLocalBranch}`
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+
+  return {
+    id: params.id,
+    kind: "confirmation",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    title: "Confirm Handoff",
+    body,
+    fallbackText: "Reply Confirm, Back, or Cancel.",
+    actions: [
+      {
+        id: "handoff:confirm",
+        label: "Confirm",
+        fallbackText: "confirm",
+        style: "primary",
+        value: {
+          ...handoffValue(params.context),
+          ...(params.leaveLocalBranch
+            ? { leaveLocalBranch: params.leaveLocalBranch }
+            : {}),
+        },
+      },
+      {
+        id: params.context.workspaceKind === "local"
+          ? "handoff:local-to-worktree"
+          : "status:handoff",
+        label: "Back",
+        fallbackText: "back",
+        style: "secondary",
+        value: handoffValue(params.context),
+      },
+      {
+        id: "handoff:cancel",
+        label: "Cancel",
+        fallbackText: "cancel",
+        style: "secondary",
+      },
+    ],
+  };
+}
+
+export function handoffRequestFromValue(
+  value: unknown,
+): HandoffThreadWorkspaceRequest | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (
+    value.direction !== "local-to-worktree" &&
+    value.direction !== "worktree-to-local"
+  ) {
+    return undefined;
+  }
+  if (
+    (value.backend !== "codex" && value.backend !== "grok") ||
+    typeof value.threadId !== "string" ||
+    typeof value.repositoryPath !== "string" ||
+    typeof value.sourcePath !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    backend: value.backend,
+    threadId: value.threadId,
+    direction: value.direction,
+    repositoryPath: value.repositoryPath,
+    sourcePath: value.sourcePath,
+    sourceBranch: typeof value.sourceBranch === "string" ? value.sourceBranch : undefined,
+    leaveLocalBranch:
+      typeof value.leaveLocalBranch === "string" ? value.leaveLocalBranch : undefined,
+  };
 }
 
 export function buildStatusModelPickerIntent(params: {
@@ -287,6 +544,35 @@ function formatBranch(threadState: MessagingResolvedThreadState): string | undef
     return `${threadState.gitBranch} (now ${threadState.observedGitBranch})`;
   }
   return threadState.gitBranch ?? threadState.observedGitBranch;
+}
+
+function handoffValue(
+  context: MessagingWorkspaceHandoffContext,
+): Record<string, MessagingJsonValue> {
+  return {
+    backend: context.backend,
+    threadId: context.threadId,
+    direction:
+      context.workspaceKind === "local" ? "local-to-worktree" : "worktree-to-local",
+    repositoryPath: context.repositoryPath,
+    sourcePath: context.workingDirectoryPath,
+    ...(context.branch ? { sourceBranch: context.branch } : {}),
+  };
+}
+
+function handoffOverviewText(context: MessagingWorkspaceHandoffContext): string {
+  return [
+    "Workspace Handoff",
+    `Project: ${context.projectLabel ?? unavailable()}`,
+    `Repository: ${context.repositoryPath}`,
+    `Working directory: ${context.workingDirectoryPath}`,
+    `Workspace: ${context.workspaceKind === "local" ? "Local" : "Worktree"}`,
+    `Branch: ${context.branch ?? unavailable()}`,
+  ].join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function unavailable(): string {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -5,6 +5,8 @@ import type {
   CompactThreadRequest,
   CompactThreadResponse,
   GetNavigationSnapshotRequest,
+  HandoffThreadWorkspaceRequest,
+  HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
   ListBackendsRequest,
@@ -68,6 +70,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       threadId: request.threadId,
     });
     return response.threadStatus ?? response.replay.threadStatus;
+  }
+
+  async handoffThreadWorkspace(
+    request: HandoffThreadWorkspaceRequest,
+  ): Promise<HandoffThreadWorkspaceResponse> {
+    return await this.registry.handoffThreadWorkspace(request);
   }
 
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -108,6 +108,14 @@ surfaces can happen while a turn is paused for the user. The controller owns
 those lifecycle decisions and translates them into active or idle activity
 intents.
 
+Workspace handoff is expressed with the same generic status, single-select,
+confirmation, and error intents as other messaging workflows. Adapters should
+render its `Handoff`, branch, confirm, back, refresh, and cancel actions like
+any other `MessagingSurfaceAction`; provider payloads must remain short opaque
+handles. If a platform cannot show every button, text fallback remains the
+required escape hatch until PwrAgnt has a generic low-button-count variation
+policy.
+
 ## Adding A New Adapter
 
 To add Mattermost, Feishu/Lark, Slack, Matrix, or another channel:

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -29,6 +29,26 @@ the closest native layout they support: Telegram inline keyboards can honor
 explicit row groupings, and Discord components use action rows with provider
 limits.
 
+## Workspace Handoff
+
+A bound conversation can move the current thread between Local and Worktree
+from `/status` when PwrAgnt has enough repository and Git branch metadata for a
+safe handoff. The status card shows a `Handoff` action only for eligible
+threads.
+
+The handoff mode shows the project repository path, the current working
+directory path, the workspace kind, and the current branch before asking for a
+choice. Local-to-worktree handoff asks which branch should remain checked out
+in Local, then asks for confirmation. Worktree-to-local handoff asks for
+confirmation directly. Both paths call the desktop workspace handoff operation,
+then refresh the binding display and status card after success.
+
+All handoff steps include text fallback, so replying with the shown number,
+label, `confirm`, `back`, `refresh`, or `cancel` follows the same controller
+path as pressing a button. `/resume` still starts or binds threads; the New
+Local / New Handoff split and any low-button-count variation policy are
+deferred.
+
 ## Typing Indicators
 
 Messaging adapters show platform typing indicators while a bound turn is
@@ -171,20 +191,29 @@ Telegram:
 4. Use Projects, select a project, then select a thread.
 5. Verify a pinned status card appears and updates in place.
 6. Use status buttons to change Model, Reasoning, Fast mode, and Permissions.
-7. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
-8. Verify typing continues through an intermediate assistant update and stops at turn completion.
-9. Run a quiet command sequence and verify `Show Some` sends individual tool updates.
-10. Run a noisy command or file-read sequence and verify remaining tool updates batch before the final assistant response.
-11. Cycle Tools through `Show All`, `Show Less`, and `Show None`; verify all, batched, and suppressed behavior respectively.
-12. Trigger a Plan questionnaire and answer with both a button and text fallback.
-13. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
-14. Verify markdown, inline code, fenced code, long responses, and image output render.
-15. Restart PwrAgnt and verify the same Telegram conversation still routes to the bound thread.
-16. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
-17. Send a small `.txt` attachment and verify a turn starts with the extracted text.
-18. Send an image attachment and verify a turn starts with normalized image input.
-19. Send an oversized file or voice message and verify it is rejected without model upload.
-20. Verify assistant image and file parts render as Telegram photo/document attachments.
+7. For a bound Local thread with handoff branch metadata, choose Handoff from
+   `/status`, hand off to a new worktree, and verify the refreshed status shows
+   the worktree path.
+8. For a bound worktree thread, choose Handoff from `/status`, hand off to
+   Local, and verify the refreshed status no longer shows a worktree path.
+9. Repeat at least one handoff step by text fallback, such as replying `1` or
+   `confirm`.
+10. Try a stale or ineligible handoff prompt and verify the bot reports a
+   recoverable error without detaching the conversation.
+11. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
+12. Verify typing continues through an intermediate assistant update and stops at turn completion.
+13. Run a quiet command sequence and verify `Show Some` sends individual tool updates.
+14. Run a noisy command or file-read sequence and verify remaining tool updates batch before the final assistant response.
+15. Cycle Tools through `Show All`, `Show Less`, and `Show None`; verify all, batched, and suppressed behavior respectively.
+16. Trigger a Plan questionnaire and answer with both a button and text fallback.
+17. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
+18. Verify markdown, inline code, fenced code, long responses, and image output render.
+19. Restart PwrAgnt and verify the same Telegram conversation still routes to the bound thread.
+20. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
+21. Send a small `.txt` attachment and verify a turn starts with the extracted text.
+22. Send an image attachment and verify a turn starts with normalized image input.
+23. Send an oversized file or voice message and verify it is rejected without model upload.
+24. Verify assistant image and file parts render as Telegram photo/document attachments.
 
 Discord:
 
@@ -192,17 +221,26 @@ Discord:
 2. Send `/resume` from an allowlisted Discord user.
 3. Verify a numbered thread picker appears with components.
 4. Choose a thread by component, then repeat by replying `1`.
-5. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
-6. Verify typing continues through an intermediate assistant update and stops at turn completion.
-7. Run quiet and noisy tool sequences and verify the selected Tools mode controls individual, batched, or suppressed generated updates.
-8. Trigger a Plan questionnaire and answer with both a component and text fallback.
-9. Trigger an approval request and test accept, session accept, decline, and cancel.
-10. Verify markdown, inline code, fenced code, long responses, and image output render.
-11. Restart PwrAgnt and verify the same Discord channel still routes to the bound thread.
-12. Send a small `.txt` attachment and verify a turn starts with the extracted text.
-13. Send an image attachment and verify a turn starts with normalized image input.
-14. Send an oversized attachment and verify it is rejected without model upload.
-15. Verify assistant image and file parts render as Discord embeds/uploads.
+5. For a bound Local thread with handoff branch metadata, choose Handoff from
+   `/status`, hand off to a new worktree, and verify the refreshed status shows
+   the worktree path.
+6. For a bound worktree thread, choose Handoff from `/status`, hand off to
+   Local, and verify the refreshed status no longer shows a worktree path.
+7. Repeat at least one handoff step by text fallback, such as replying `1` or
+   `confirm`.
+8. Try a stale or ineligible handoff prompt and verify the bot reports a
+   recoverable error without detaching the conversation.
+9. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
+10. Verify typing continues through an intermediate assistant update and stops at turn completion.
+11. Run quiet and noisy tool sequences and verify the selected Tools mode controls individual, batched, or suppressed generated updates.
+12. Trigger a Plan questionnaire and answer with both a component and text fallback.
+13. Trigger an approval request and test accept, session accept, decline, and cancel.
+14. Verify markdown, inline code, fenced code, long responses, and image output render.
+15. Restart PwrAgnt and verify the same Discord channel still routes to the bound thread.
+16. Send a small `.txt` attachment and verify a turn starts with the extracted text.
+17. Send an image attachment and verify a turn starts with normalized image input.
+18. Send an oversized attachment and verify it is rejected without model upload.
+19. Verify assistant image and file parts render as Discord embeds/uploads.
 
 Discord currently has parity for the shared workflow and button actions, but it
 does not pin or edit status cards yet; status updates degrade to normal

--- a/docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md
+++ b/docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md
@@ -1,0 +1,421 @@
+---
+title: feat: Add messaging workspace handoff surface
+type: feat
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+deepened: 2026-05-02
+---
+
+# feat: Add messaging workspace handoff surface
+
+## Overview
+
+Add a channel-neutral messaging handoff flow that lets a bound Telegram or Discord conversation move its current PwrAgnt thread between Local and Worktree from the `/status` surface.
+
+The first slice should add a `Handoff` action to the status card, then repaint the managed status surface into a handoff mode that explains the current project directory, current working directory, current branch, and valid handoff direction. It should call the existing desktop `handoffThreadWorkspace` operation rather than reimplementing Git movement in messaging code.
+
+The `/resume` New Local / New Handoff button split and broader low-button-count versus high-button-count rendering policy are intentionally deferred. The current plan keeps the feature useful through the status card and free-form fallback without forcing a premature platform capability model.
+
+## Problem Frame
+
+Messaging users can already resume threads, start threads, bind conversations, and use the status card for model, reasoning, fast mode, permissions, stop, compact, refresh, and detach. Separately, the desktop app already has thread workspace handoff contracts and a main-process Git handoff service. The missing behavior is the bridge between those systems: a remote user in Telegram or Discord cannot ask the bound thread to move from Local to a new worktree, or from a worktree back to Local.
+
+This matters most when the user is away from the desktop but still controlling real local development state from messaging. The flow must be explicit enough to avoid moving the wrong checkout and conservative enough to preserve the handoff safety rules from the desktop implementation.
+
+## Requirements Trace
+
+- R1. A bound messaging conversation can discover whether its current thread is eligible for workspace handoff from `/status`.
+- R2. The status card exposes a `Handoff` action only when the bound thread has enough navigation and Git metadata to present a safe handoff flow.
+- R3. Handoff mode states the project repository path, active working directory path, active workspace kind, and observed/current branch before asking for a decision.
+- R4. Local-to-worktree handoff asks which branch should remain checked out in Local before invoking the handoff.
+- R5. Worktree-to-local handoff presents a confirmation before invoking the handoff.
+- R6. Successful handoff updates the binding display metadata and repaints the status card with the new Local/Worktree state.
+- R7. Handoff failures surface recoverable error text, including warnings and stash recovery details when the backend returns them.
+- R8. The flow remains channel-neutral: controller, store, and renderer code must not branch on Telegram or Discord except through existing adapter delivery behavior.
+- R9. Text fallback can complete the same handoff steps by replying with visible option numbers or labels.
+- R10. `/resume` arguments and the New Local / New Handoff button split are not part of this implementation slice.
+- R11. Handoff confirmation preserves acting-user audit context because it mutates local Git state and thread workspace metadata.
+
+## Scope Boundaries
+
+- In scope: `/status` Handoff button, handoff overview mode, branch picker for local-to-worktree, confirmation for worktree-to-local, backend bridge invocation, binding display refresh, text fallback, and focused Telegram/Discord rendering coverage through the existing generic intent tests.
+- In scope: existing desktop handoff behavior, including dirty-workspace stash preservation, Git branch occupancy checks, archive-on-worktree-to-local, and overlay metadata updates.
+- Out of scope: new Git handoff transaction behavior; `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts` is the source of truth for Git movement.
+- Out of scope: splitting `/resume` New into New Local and New Handoff buttons.
+- Out of scope: `/resume` flags or slash-command args for handoff. Discord presents args poorly for this use case, so the first slice should avoid new command arguments.
+- Out of scope: a generic low-button-count/high-button-count variation system across all messaging surfaces. This plan should leave compatible hooks where natural, but not design that larger abstraction now.
+- Out of scope: provider-specific callback payload formats, Telegram chat IDs, Discord message IDs, or channel-specific permission logic in workflow code.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/messaging/AGENTS.md` requires workflow semantics to stay channel-neutral and platform limitations to be represented through generic interface extensions, provider capabilities, delivery results, or fallback behavior.
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` builds the current status card and already uses managed status surface updates for model and reasoning picker modes.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` routes `status:*` callbacks, updates binding preferences, repaints status surfaces, handles text fallback through pending intents, and persists browse/status session state.
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` shows the pattern for channel-neutral picker actions, fallback text, pagination, and action values.
+- `apps/desktop/src/main/messaging/core/messaging-adapter.ts` defines `MessagingBackendBridge`; it already exposes status-card backend operations but not `handoffThreadWorkspace`.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` is the desktop implementation of the bridge and delegates to `DesktopBackendRegistry`.
+- `apps/desktop/src/main/app-server/backend-registry.ts` already exposes `handoffThreadWorkspace`, resolves thread workspace metadata, invokes `GitWorkspaceHandoffService`, updates overlay linked-directory state, and records archived source worktree snapshots.
+- `packages/shared/src/contracts/normalized-app-server.ts` already defines `HandoffThreadWorkspaceRequest`, `HandoffThreadWorkspaceResponse`, `ThreadWorkspaceHandoffDirection`, and stash summary types.
+- `packages/shared/src/contracts/navigation.ts` exposes directory Git status including `currentBranch`, `branches`, and `handoffBranches`, which should drive branch choices for local-to-worktree.
+- `packages/shared/src/contracts/messaging.ts` is the desktop messaging controller's current type surface, while `packages/messaging/interface/src/index.ts` is the provider-facing generic interface. The two are intentionally similar today, so any messaging contract change must either keep them mirrored or deliberately converge one on the other in a separate refactor.
+- `packages/messaging/interface/src/index.ts` already supports `status`, `single_select`, `confirmation`, generic actions, action layout hints, managed delivery policies, and restart-safe callback handles for provider packages.
+- `packages/messaging/providers/telegram/src/telegram-formatting.ts` and `packages/messaging/providers/discord/src/discord-formatting.ts` render generic actions with `layoutMessagingActionRows`.
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`, `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`, `packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts`, and `packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts` are the primary tests to extend.
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md` established that handoff is a main-process transaction that preserves dirty non-ignored changes through named stashes and updates PwrAgnt overlay metadata after Git succeeds.
+- `docs/plans/2026-04-30-002-feat-messaging-command-surfaces-plan.md` established the current messaging status-card pattern: managed status surfaces should repaint in place when possible, keep text fallback, and keep Telegram/Discord differences behind adapters.
+- `docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md` requires anchored thread/worktree identity and forbids silently re-homing a thread just because the same branch exists elsewhere.
+- No `docs/solutions/` directory exists in this worktree yet.
+
+### External References
+
+- Telegram Bot API inline keyboard callback data is limited to 1-64 bytes, which confirms that callback indirection and store-backed action records must remain the workflow pattern: https://core.telegram.org/bots/api
+- Discord message components support button action rows with up to 5 buttons per row and 5 rows per message, which is enough for this first status-card Handoff action but still argues against overloading `/resume` before a generic variation policy exists: https://docs.discord.com/developers/docs/interactions/message-components
+
+## Key Technical Decisions
+
+- **Use `/status` as the entry point.** Status already represents the bound thread and has a managed surface that can repaint into sub-modes. This avoids new slash-command arguments and avoids deciding the `/resume` New Local / New Handoff split before the button variation policy is clear.
+- **Model handoff as a status sub-mode, not a separate command.** The user is acting on the currently bound thread, so the flow should inherit the binding, actor authorization, target surface, and callback lifecycle from the status card.
+- **Call the existing desktop handoff operation through `MessagingBackendBridge`.** Messaging owns user interaction and audit context; `DesktopBackendRegistry` and `GitWorkspaceHandoffService` own Git correctness, overlay mutation, stash details, archive behavior, and recovery data.
+- **Derive eligibility from navigation snapshots and linked directories.** A bound thread should offer Handoff only when the current navigation snapshot can identify an eligible local or worktree linked directory plus enough branch data to create a safe request.
+- **Keep provider limitations out of workflow branches for now.** Telegram and Discord both support enough buttons for this first slice. Low-button-count platforms should rely on fallback text until a broader capability policy is designed.
+- **Persist handoff choices as pending intents/callback handles, not adapter memory.** Branch choices and confirmation actions must survive process restart or fail closed with a refresh message.
+- **Make branch selection explicit for local-to-worktree.** The existing handoff request requires `leaveLocalBranch`; the messaging UI should present the `handoffBranches` list and not silently guess.
+- **Refresh binding display from the post-handoff navigation state.** The response contains the target linked directory, but the status card should also re-read navigation after success so binding metadata and status text reflect the same state the rest of desktop will show.
+- **Treat handoff as a sensitive state-changing action.** Confirmation must be scoped to the binding's authorized actor, carry an audit context with actor/channel/backend/thread/direction, and avoid logging or persisting raw provider payloads. Displaying local paths is acceptable in the authorized conversation because status already exposes directory context, but errors should not include secrets or raw adapter state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this start on `/resume`?** No. `/resume` may eventually split New into New Local and New Handoff on platforms with enough buttons, but the first implementation should use `/status` where the bound-thread context is already explicit.
+- **Should this be a slash-command argument?** No. Discord's slash-command argument presentation is a poor fit for this flow, and the user specifically dislikes that direction.
+- **Should messaging implement Git handoff logic?** No. It should call the existing desktop handoff operation and surface its success, warnings, and errors.
+- **Should platform button limits block this slice?** No. The first status-card flow is small enough for Telegram and Discord. The generic variation model is deferred.
+
+### Deferred to Implementation
+
+- Exact status-card copy for handoff warnings and stash recovery details should be finalized once the implementation sees the actual error shapes emitted through the bridge.
+- Exact branch ordering should follow `gitStatus.handoffBranches` when available, with implementation-time fallback to `branches` only if the status service does not provide handoff-specific choices for a valid local checkout.
+- Whether a channel with very few buttons should show `Handoff` on the primary status card or require a text-only command is deferred to a future provider capability plan.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+    [*] --> StatusCard
+    StatusCard --> HandoffOverview: Handoff
+    HandoffOverview --> LeaveLocalBranchPicker: Local to Worktree
+    LeaveLocalBranchPicker --> ConfirmLocalToWorktree: choose leave-local branch
+    HandoffOverview --> ConfirmWorktreeToLocal: Worktree to Local
+    ConfirmLocalToWorktree --> RunningHandoff: confirm
+    ConfirmWorktreeToLocal --> RunningHandoff: confirm
+    RunningHandoff --> StatusCard: success, refresh binding
+    RunningHandoff --> HandoffError: failure
+    HandoffError --> HandoffOverview: Back / Retry
+    HandoffOverview --> StatusCard: Back
+```
+
+The user-visible states are: normal status, unavailable, overview, leave-local branch picker, confirmation, running, success/status refresh, recoverable failure, stale-action refresh, and canceled/back. These states should be represented by existing generic `status`, `single_select`, `confirmation`, and `error` intents rather than new provider-specific surfaces.
+
+```mermaid
+sequenceDiagram
+    participant User as Messaging user
+    participant Controller as Messaging controller
+    participant Store as Messaging store
+    participant Bridge as MessagingBackendBridge
+    participant Registry as DesktopBackendRegistry
+    participant Git as GitWorkspaceHandoffService
+
+    User->>Controller: status:handoff callback or text fallback
+    Controller->>Bridge: getNavigationSnapshot
+    Controller->>Store: persist handoff pending intent
+    Controller-->>User: handoff overview / branch picker / confirmation
+    User->>Controller: confirm handoff choice
+    Controller->>Bridge: handoffThreadWorkspace(request)
+    Bridge->>Registry: handoffThreadWorkspace(request)
+    Registry->>Git: handoff transaction
+    Git-->>Registry: target linked directory + warnings
+    Registry-->>Bridge: handoff response
+    Bridge-->>Controller: handoff response
+    Controller->>Bridge: getNavigationSnapshot
+    Controller->>Store: update binding threadDisplay
+    Controller-->>User: refreshed status card
+```
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Shared bridge and metadata contracts"] --> U2["Unit 2: Handoff status renderer"]
+    U1 --> U3["Unit 3: Controller flow and backend invocation"]
+    U2 --> U3
+    U3 --> U4["Unit 4: Provider rendering and fallback coverage"]
+    U3 --> U5["Unit 5: Docs and manual validation"]
+```
+
+- [ ] **Unit 1: Expose handoff through the messaging backend bridge**
+
+**Goal:** Give messaging controller code a channel-neutral way to invoke the existing desktop handoff operation and to capture enough handoff metadata in binding display state.
+
+**Requirements:** R1, R3, R6, R7, R8, R11
+
+**Dependencies:** Existing desktop handoff contracts and `DesktopBackendRegistry.handoffThreadWorkspace`.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Modify: `packages/messaging/interface/src/index.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Approach:**
+- Add optional `handoffThreadWorkspace` support to `MessagingBackendBridge` using the existing `HandoffThreadWorkspaceRequest` and `HandoffThreadWorkspaceResponse` shared types.
+- Keep the bridge optional so non-desktop or future hosted runtimes can report Handoff unavailable without pretending to support local Git movement.
+- Extend `MessagingThreadDisplaySummary` only if the existing `directoryPath`, `projectLabel`, `threadTitle`, and `worktreePath` fields cannot describe the post-handoff state clearly enough. Prefer using existing fields plus branch/workspace text in the status renderer before adding new contract shape.
+- Keep `packages/shared/src/contracts/messaging.ts` and `packages/messaging/interface/src/index.ts` aligned for any messaging intent, binding, or display metadata changes. If implementation finds the duplication too risky, split that cleanup into a separate preparatory refactor instead of quietly changing only one side.
+- Do not import provider packages or provider SDKs from bridge or controller code.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `packages/messaging/AGENTS.md`
+
+**Test scenarios:**
+- Happy path: a messaging bridge backed by `DesktopBackendRegistry` forwards `handoffThreadWorkspace` with backend, thread id, direction, source path, repository path, source branch, and leave-local branch.
+- Edge case: a controller harness without `handoffThreadWorkspace` treats Handoff as unavailable rather than throwing.
+- Regression: `packages/messaging/interface` remains provider-neutral and does not import Telegram, Discord, desktop main-process modules, or sibling providers.
+- Regression: shared desktop messaging types and provider-facing interface types stay compatible for the handoff-related fields.
+
+**Verification:**
+- Messaging code can call desktop handoff through a typed bridge, and package boundary lint remains compatible with the messaging package guidance.
+
+- [ ] **Unit 2: Add channel-neutral handoff status intents**
+
+**Goal:** Build the status-card Handoff entry point and the handoff sub-mode intents that explain current workspace state, present valid choices, and provide text fallback.
+
+**Requirements:** R1, R2, R3, R4, R5, R8, R9, R10, R11
+
+**Dependencies:** Unit 1 bridge types.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+
+**Approach:**
+- Add a `status:handoff` action to `buildBindingStatusIntent` only when the caller provides an eligible handoff context. Keep the default status card unchanged for ineligible threads.
+- Add helper logic that derives a handoff context from the bound thread in a navigation snapshot:
+  - Current linked directory and workspace kind: local or worktree.
+  - Repository/project directory path.
+  - Active working directory path.
+  - Current or observed branch.
+  - Available leave-local branches from `gitStatus.handoffBranches`.
+- Create a handoff overview as a `single_select` or `confirmation` intent that reuses the managed status surface and includes fallback text listing numbered choices.
+- For local-to-worktree, present a branch picker before confirmation. The branch picker choices should be branch names that can remain in Local after the current branch moves to a worktree.
+- For worktree-to-local, present a direct confirmation that names the source worktree path and target local repository path.
+- The confirmation copy should identify the acting thread, backend, direction, repository path, working directory path, and branch before any Git mutation starts.
+- Include Back/Refresh/Cancel actions so the user can return to the normal status card without changing Git state.
+- Keep the status-card helper pure: it should receive a handoff context from the controller or a small selector helper, then produce intents without reading backend state itself.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- `apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts`
+
+**Test scenarios:**
+- Happy path: a bound local thread with repository path, current branch, and handoff branches renders status with a `Handoff` action.
+- Happy path: selecting Handoff for a local thread renders a handoff overview naming project directory, working directory, branch, and `Handoff to New Worktree`.
+- Happy path: selecting local-to-worktree renders branch choices from `handoffBranches` plus Back/Cancel.
+- Happy path: confirmation text includes backend/thread identity, direction, repository path, working directory path, branch, and selected leave-local branch when applicable.
+- Happy path: a bound worktree thread renders a handoff overview naming project directory, worktree path, branch, and `Handoff to Local`.
+- Edge case: a directory without Git metadata or without an eligible linked directory omits the Handoff action and keeps the rest of the status card intact.
+- Edge case: no `handoffBranches` for a local thread renders a recoverable unavailable explanation rather than guessing a branch.
+- Integration: fallback text includes numbers/labels that the deterministic mapper can resolve to the same action IDs as button callbacks.
+- Regression: existing status-card tests still prove model, reasoning, fast mode, permissions, compact, stop, refresh, and detach actions render when handoff is absent.
+
+**Verification:**
+- Handoff sub-mode can be rendered and navigated with generic messaging intents, without provider-specific branches and without changing `/resume` behavior.
+
+- [ ] **Unit 3: Execute handoff from messaging callbacks and refresh binding state**
+
+**Goal:** Wire `status:handoff` callbacks through branch selection, confirmation, backend invocation, success refresh, and failure reporting.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R11
+
+**Dependencies:** Units 1 and 2.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts`
+
+**Approach:**
+- Add status callback handling for `status:handoff`, `handoff:local-to-worktree`, `handoff:worktree-to-local`, `handoff:select-leave-branch`, `handoff:confirm`, and `handoff:cancel` style actions.
+- Store the in-progress handoff choice in existing pending intent or callback-handle records if the current shape can carry it. Add a small store field only if needed to survive restart across the multi-step branch picker.
+- Validate actor, channel, binding id, and current thread before invoking handoff. If the binding changed since the handoff prompt was rendered, fail closed and ask the user to refresh `/status`.
+- Validate the source path, repository path, source branch, and selected leave-local branch against the latest navigation snapshot immediately before invoking the bridge. Do not trust stale values stored in callback handles as authority.
+- Build `HandoffThreadWorkspaceRequest` from the latest navigation snapshot, selected direction, source directory/worktree, source branch, repository path, and selected leave-local branch.
+- Attach audit context to handoff prompts and result/error messages, including actor id, channel, backend, thread id, direction, and occurred-at timestamp. Do not store raw Telegram/Discord callback payloads or raw provider routing state in workflow-owned fields.
+- Deliver a short progress/status message before invoking the backend if the operation may take noticeable time.
+- On success, re-read navigation, update binding display metadata, delete stale handoff pending state, and repaint the status card.
+- On failure, keep the binding unchanged, preserve the status surface, and render a recoverable error that includes the backend message plus any returned warnings/stash refs when available.
+
+**Execution note:** Add controller tests before implementation for the local-to-worktree and worktree-to-local callback sequences; the Git transaction itself is already tested in the app-server service.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md`
+
+**Test scenarios:**
+- Happy path: local status Handoff -> choose local-to-worktree -> choose leave-local branch -> confirm invokes `handoffThreadWorkspace` with `direction: local-to-worktree` and repaints status with worktree display metadata.
+- Happy path: worktree status Handoff -> confirm invokes `handoffThreadWorkspace` with `direction: worktree-to-local` and repaints status without stale worktree path.
+- Happy path: after success, the binding keeps model/reasoning/fast/permissions preferences while updating thread display metadata.
+- Edge case: actor mismatch on a handoff callback fails closed and does not call backend handoff.
+- Edge case: binding changes between prompt and confirmation fails closed with a refresh message.
+- Error path: unauthorized or actor-mismatched text fallback cannot confirm handoff even if it matches the visible option label.
+- Error path: bridge lacks `handoffThreadWorkspace` and Handoff mode reports unavailable.
+- Error path: backend handoff rejects due to branch occupancy or stash conflict and messaging renders a recoverable error without deleting binding or stale status surface.
+- Integration: successful and failed handoff results preserve audit context without persisting raw provider payloads or secrets.
+- Integration: text fallback replies such as `1`, branch label, `confirm`, `back`, and `cancel` route to the same controller paths as callbacks.
+
+**Verification:**
+- A bound messaging conversation can complete both handoff directions through generic callbacks or text fallback, and status reflects the final desktop navigation state after success.
+
+- [ ] **Unit 4: Keep provider rendering and button limits honest**
+
+**Goal:** Ensure Telegram and Discord render the new Handoff flow cleanly with existing generic actions and do not regress current status-card layouts.
+
+**Requirements:** R2, R8, R9, R10
+
+**Dependencies:** Units 2 and 3.
+
+**Files:**
+- Modify: `packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts`
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts`
+- Modify: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Approach:**
+- Prefer existing `MessagingActionLayoutHint` and `actionLayout.columns` before adding any new layout contract.
+- Verify that the status card with Handoff still fits Discord's component limits and Telegram's inline keyboard model.
+- Avoid provider-specific workflow logic. If a provider cannot render the full action set later, the provider should omit/degrade actions through generic capability or delivery policy work in a separate plan.
+
+**Patterns to follow:**
+- `packages/messaging/interface/src/index.ts`
+- `packages/messaging/providers/telegram/src/telegram-formatting.ts`
+- `packages/messaging/providers/discord/src/discord-formatting.ts`
+
+**Test scenarios:**
+- Happy path: Telegram keyboard for handoff overview honors explicit rows and emits opaque callback handles, not semantic payloads.
+- Happy path: Discord components for status plus Handoff remain within 5 rows and 25 buttons.
+- Edge case: disabled or unavailable handoff actions are not rendered as active provider buttons.
+- Regression: current status-card model/reasoning/fast/permissions/compact/stop/refresh/detach actions still render after adding Handoff.
+- Integration: fallback text for handoff intents remains complete when rendered text-only.
+
+**Verification:**
+- Telegram and Discord provider tests prove the first handoff slice fits the current adapter rendering contract, with no new platform-specific branches in workflow code.
+
+- [ ] **Unit 5: Update docs and manual validation checklist**
+
+**Goal:** Document the new messaging handoff flow, its boundaries, and how to validate it end to end.
+
+**Requirements:** R1, R6, R7, R9, R10
+
+**Dependencies:** Units 1-4.
+
+**Files:**
+- Modify: `docs/messaging-platform-integration.md`
+- Modify: `docs/messaging-adapter-contract.md`
+- Test expectation: none -- documentation-only unit; behavior is covered by controller, store, and provider tests above.
+
+**Approach:**
+- Add a `/status` Handoff section explaining what the bot shows before handoff and which directions are supported.
+- State that `/resume` New Local/New Handoff split is deferred and that users should use `/status` on a bound thread for workspace movement.
+- State that low-button-count variation is deferred and that all handoff steps must remain operable through fallback text.
+- Add manual smoke steps for Telegram and Discord:
+  - Bind a local thread, use `/status`, hand off to a new worktree, verify status shows the new worktree.
+  - Bind a worktree thread, use `/status`, hand off to Local, verify status shows Local.
+  - Exercise a text fallback path for at least one handoff step.
+  - Confirm failures are recoverable by attempting handoff when required branch metadata is missing or stale.
+- Keep setup docs clear that no additional bot credentials or slash-command args are required.
+
+**Patterns to follow:**
+- `docs/messaging-platform-integration.md`
+- `docs/messaging-adapter-contract.md`
+
+**Test scenarios:**
+- Test expectation: none -- docs-only change.
+
+**Verification:**
+- A maintainer can follow the docs to validate the feature manually on Telegram and Discord without reading implementation code.
+
+## System-Wide Impact
+
+- **Interaction graph:** `/status` now branches into a managed Handoff sub-flow that touches messaging controller state, persistent callback handles, desktop backend bridge, backend registry, Git handoff service, overlay store, and status-card refresh.
+- **Error propagation:** Git and overlay errors must travel from `GitWorkspaceHandoffService` / `DesktopBackendRegistry` through `DesktopMessagingBackendBridge` into a recoverable messaging error. Messaging should not swallow stash refs or branch-conflict messages that help the user recover.
+- **State lifecycle risks:** Multi-step handoff prompts can go stale if the binding changes, the thread moves, or Git state changes before confirmation. Confirmation must re-read navigation and fail closed when state no longer matches.
+- **Security boundary:** A messaging handoff is a remote request to mutate local Git state. It must require the same authorized actor/binding checks as status actions, preserve audit context, and keep provider payloads, adapter state, and secrets out of workflow-owned logs and persisted fields.
+- **API surface parity:** Desktop IPC already exposes handoff; messaging should use the same shared request/response contracts through its backend bridge. No provider-specific API should be added for this workflow.
+- **Integration coverage:** Unit tests must cover controller-to-bridge request construction and post-success binding refresh; existing app-server handoff tests cover Git mechanics.
+- **Unchanged invariants:** Adapter state remains opaque, authorization remains based on stable actor IDs, `/resume` behavior remains unchanged, and Git branch/worktree mutation remains owned by the app-server handoff service.
+
+```mermaid
+flowchart TB
+    A["/status surface"] --> B["Handoff sub-mode"]
+    B --> C["Messaging pending intent / callback handle"]
+    C --> D["MessagingBackendBridge"]
+    D --> E["DesktopBackendRegistry.handoffThreadWorkspace"]
+    E --> F["GitWorkspaceHandoffService"]
+    E --> G["OverlayStore linked directory update"]
+    G --> H["Navigation snapshot refresh"]
+    H --> A
+```
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Handoff prompt uses stale thread or Git state | Re-read navigation at confirmation time and fail closed when binding/thread/source metadata no longer matches. |
+| Local-to-worktree branch choice is wrong or guessed | Require an explicit leave-local branch from `gitStatus.handoffBranches`; render unavailable when safe choices are absent. |
+| Messaging hides important Git recovery data | Include backend error text, warnings, and stash refs in recoverable error output where available. |
+| Messaging handoff becomes an unaudited remote Git mutation | Require binding-scoped actor authorization at confirmation and attach audit context to handoff prompts/results. |
+| Status card becomes too crowded | Add only one `Handoff` entry to the main card and keep branch/direction choices in sub-modes; defer broad button-variation work. |
+| Channel-specific button limits leak into controller code | Use generic intent actions, row hints, delivery results, and fallback text; provider-specific degradation belongs in adapter policy. |
+| Users confuse starting a new thread with handing off an existing thread | Keep this slice on `/status` for bound existing threads, and document that `/resume` New behavior is unchanged. |
+
+## Documentation / Operational Notes
+
+- Update messaging docs after implementation so users know Handoff lives under `/status`.
+- The manual validation checklist should use real local repositories/worktrees because the important behavior crosses messaging, desktop bridge, Git, and overlay state.
+- No new secrets, environment variables, bot commands, or Discord slash-command options are required for this slice.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md](../brainstorms/2026-04-30-messaging-platform-integration-requirements.md)
+- Related requirements: [docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md](../brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md)
+- Related requirements: [docs/brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md](../brainstorms/2026-04-19-codex-desktop-protocol-parity-requirements.md)
+- Related plan: [docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md](2026-04-29-001-feat-thread-workspace-handoff-plan.md)
+- Related plan: [docs/plans/2026-04-30-002-feat-messaging-command-surfaces-plan.md](2026-04-30-002-feat-messaging-command-surfaces-plan.md)
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Related code: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts`
+- External docs: https://core.telegram.org/bots/api
+- External docs: https://docs.discord.com/developers/docs/interactions/message-components

--- a/docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md
+++ b/docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md
@@ -161,7 +161,7 @@ flowchart TB
     U3 --> U5["Unit 5: Docs and manual validation"]
 ```
 
-- [ ] **Unit 1: Expose handoff through the messaging backend bridge**
+- [x] **Unit 1: Expose handoff through the messaging backend bridge**
 
 **Goal:** Give messaging controller code a channel-neutral way to invoke the existing desktop handoff operation and to capture enough handoff metadata in binding display state.
 
@@ -200,7 +200,7 @@ flowchart TB
 **Verification:**
 - Messaging code can call desktop handoff through a typed bridge, and package boundary lint remains compatible with the messaging package guidance.
 
-- [ ] **Unit 2: Add channel-neutral handoff status intents**
+- [x] **Unit 2: Add channel-neutral handoff status intents**
 
 **Goal:** Build the status-card Handoff entry point and the handoff sub-mode intents that explain current workspace state, present valid choices, and provide text fallback.
 
@@ -248,7 +248,7 @@ flowchart TB
 **Verification:**
 - Handoff sub-mode can be rendered and navigated with generic messaging intents, without provider-specific branches and without changing `/resume` behavior.
 
-- [ ] **Unit 3: Execute handoff from messaging callbacks and refresh binding state**
+- [x] **Unit 3: Execute handoff from messaging callbacks and refresh binding state**
 
 **Goal:** Wire `status:handoff` callbacks through branch selection, confirmation, backend invocation, success refresh, and failure reporting.
 
@@ -298,7 +298,7 @@ flowchart TB
 **Verification:**
 - A bound messaging conversation can complete both handoff directions through generic callbacks or text fallback, and status reflects the final desktop navigation state after success.
 
-- [ ] **Unit 4: Keep provider rendering and button limits honest**
+- [x] **Unit 4: Keep provider rendering and button limits honest**
 
 **Goal:** Ensure Telegram and Discord render the new Handoff flow cleanly with existing generic actions and do not regress current status-card layouts.
 
@@ -331,7 +331,7 @@ flowchart TB
 **Verification:**
 - Telegram and Discord provider tests prove the first handoff slice fits the current adapter rendering contract, with no new platform-specific branches in workflow code.
 
-- [ ] **Unit 5: Update docs and manual validation checklist**
+- [x] **Unit 5: Update docs and manual validation checklist**
 
 **Goal:** Document the new messaging handoff flow, its boundaries, and how to validate it end to end.
 

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -11,6 +11,7 @@ import {
   type MessagingCallbackHandleRecord,
   type MessagingInboundMediaEvent,
   type MessagingMessageIntent,
+  type MessagingSingleSelectIntent,
   type MessagingThreadPickerIntent,
 } from "../index";
 
@@ -206,6 +207,61 @@ describe("messaging surface contract", () => {
 
     expect(intent.audit?.actor.platformUserId).toBe("telegram-user-1");
     expect(JSON.stringify(intent.decisions)).not.toContain("telegram-user-1");
+  });
+
+  it("describes workspace handoff as generic single-select actions", () => {
+    const intent = {
+      id: "handoff-overview-1",
+      kind: "single_select",
+      createdAt: 1000,
+      bindingId: "binding-1",
+      prompt: "Workspace Handoff\nRepository: /repo/pwragnt\nBranch: feature/handoff",
+      fallbackText: "Reply with 1, Back, Refresh, or Cancel.",
+      audit: {
+        actor: {
+          platformUserId: "telegram-user-1",
+        },
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "chat-1",
+            kind: "dm",
+          },
+        },
+        backend: "codex",
+        threadId: "thread-1",
+        action: "handoff.overview",
+        occurredAt: 1000,
+      },
+      choices: [
+        {
+          id: "handoff:local-to-worktree",
+          label: "Handoff to New Worktree",
+          style: "primary",
+          fallbackText: "1",
+          value: {
+            backend: "codex",
+            threadId: "thread-1",
+            direction: "local-to-worktree",
+            repositoryPath: "/repo/pwragnt",
+            sourcePath: "/repo/pwragnt",
+            sourceBranch: "feature/handoff",
+          },
+        },
+        {
+          id: "handoff:cancel",
+          label: "Cancel",
+          style: "secondary",
+          fallbackText: "cancel",
+        },
+      ],
+    } satisfies MessagingSingleSelectIntent;
+
+    expect(intent.choices[0]?.value).toMatchObject({
+      direction: "local-to-worktree",
+      repositoryPath: "/repo/pwragnt",
+    });
+    expect(JSON.stringify(intent)).not.toMatch(/callback_data|custom_id/);
   });
 
   it("marks inbound media as unsupported by default", () => {

--- a/packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts
@@ -147,6 +147,70 @@ describe("discord formatting", () => {
     ]);
   });
 
+  it("renders workspace handoff choices inside component limits", () => {
+    const intent = {
+      id: "handoff-overview-1",
+      kind: "single_select",
+      createdAt: 1000,
+      prompt: [
+        "Workspace Handoff",
+        "Repository: /repo/pwragnt",
+        "Working directory: /repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+        "Branch: feature/handoff",
+      ].join("\n"),
+      fallbackText: "Reply with 1, Back, Refresh, or Cancel.",
+      choices: [
+        {
+          id: "handoff:worktree-to-local",
+          label: "Handoff to Local",
+          style: "primary",
+          fallbackText: "1",
+          value: {
+            backend: "codex",
+            threadId: "thread-1",
+            direction: "worktree-to-local",
+            repositoryPath: "/repo/pwragnt",
+            sourcePath: "/repo/pwragnt/.worktrees/pwragnt-feature-handoff",
+            sourceBranch: "feature/handoff",
+          },
+        },
+        {
+          id: "status:refresh",
+          label: "Back",
+          style: "secondary",
+          fallbackText: "back",
+        },
+        {
+          id: "status:refresh",
+          label: "Refresh",
+          style: "secondary",
+          fallbackText: "refresh",
+        },
+        {
+          id: "handoff:cancel",
+          label: "Cancel",
+          style: "secondary",
+          fallbackText: "cancel",
+        },
+      ],
+    } satisfies Parameters<typeof textForDiscordIntent>[0];
+
+    const components = buildDiscordComponents(
+      intent.choices,
+      (action) => `dc:${action.id}`,
+    );
+
+    expect(textForDiscordIntent(intent)).toContain("Workspace Handoff");
+    expect(components).toHaveLength(1);
+    expect(components?.[0]?.components.map((button) => button.label)).toEqual([
+      "Handoff to Local",
+      "Back",
+      "Refresh",
+      "Cancel",
+    ]);
+    expect(JSON.stringify(components)).not.toContain("/repo/pwragnt");
+  });
+
   it("preserves approval markdown code blocks", () => {
     const rendered = textForDiscordIntent({
       id: "approval-1",

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts
@@ -132,6 +132,55 @@ describe("telegram formatting", () => {
     ]);
   });
 
+  it("renders workspace handoff choices with opaque callback handles", () => {
+    const intent = {
+      id: "handoff-overview-1",
+      kind: "single_select",
+      createdAt: 1000,
+      prompt: [
+        "Workspace Handoff",
+        "Repository: /repo/pwragnt",
+        "Working directory: /repo/pwragnt",
+        "Branch: feature/handoff",
+      ].join("\n"),
+      fallbackText: "Reply with 1, Back, Refresh, or Cancel.",
+      choices: [
+        {
+          id: "handoff:local-to-worktree",
+          label: "Handoff to New Worktree",
+          style: "primary",
+          fallbackText: "1",
+          value: {
+            backend: "codex",
+            threadId: "thread-1",
+            direction: "local-to-worktree",
+            repositoryPath: "/repo/pwragnt",
+            sourcePath: "/repo/pwragnt",
+            sourceBranch: "feature/handoff",
+          },
+        },
+        {
+          id: "handoff:cancel",
+          label: "Cancel",
+          style: "secondary",
+          fallbackText: "cancel",
+        },
+      ],
+    } satisfies Parameters<typeof textForTelegramIntent>[0];
+
+    const keyboard = buildTelegramKeyboard(
+      intent.choices,
+      (action) => `tg:${action.id}`,
+    );
+
+    expect(textForTelegramIntent(intent)).toContain("Workspace Handoff");
+    expect(keyboard?.inline_keyboard.map((row) => row.map((button) => button.text))).toEqual([
+      ["Handoff to New Worktree"],
+      ["Cancel"],
+    ]);
+    expect(JSON.stringify(keyboard)).not.toContain("/repo/pwragnt");
+  });
+
   it("escapes plain text without introducing formatting", () => {
     expect(escapeTelegramHtml("a < b && b > c")).toBe(
       "a &lt; b &amp;&amp; b &gt; c",


### PR DESCRIPTION
## Summary

I added a channel-neutral workspace handoff flow under `/status` for bound messaging conversations.

The new flow:
- shows a `Handoff` status action only when the bound thread has safe Git workspace metadata
- presents an overview with repository path, working directory, workspace kind, and branch
- asks which branch should remain checked out in Local before local-to-worktree handoff
- confirms worktree-to-local handoff directly
- calls the existing desktop `handoffThreadWorkspace` bridge instead of duplicating Git movement in messaging
- refreshes binding display metadata and the status card after success
- fails closed on stale or ineligible handoff prompts

I also updated the messaging docs and marked the execution plan complete.

## Validation

I verified this with:

```shell
pnpm typecheck
pnpm test
pnpm lint:boundaries
git diff --check
```

`pnpm test` passed with 124 test files passing and 1 skipped.

## Notes

The `/resume` New Local / New Handoff split is intentionally not included here. This PR keeps handoff on the bound-thread `/status` surface and preserves text fallback for platforms with tighter button constraints.
