### PR TITLE
fix(messaging): keep typing active through working turns

### DIFF
--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -612,6 +612,63 @@ describe("DiscordAdapter", () => {
     }
   });
 
+  it("stops Discord typing renewal after an idle activity signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createApi();
+      const adapter = new DiscordAdapter({
+        api: api as unknown as DiscordApi,
+        config: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: ["42"],
+        },
+        gateway: createGateway(),
+        now: () => 1000,
+      });
+      const audit = {
+        actor: {
+          platformUserId: "42",
+        },
+        channel: {
+          channel: "discord" as const,
+          conversation: {
+            id: "channel-1",
+            kind: "channel" as const,
+            parentId: "guild-1",
+          },
+        },
+        occurredAt: 1000,
+      };
+
+      await adapter.deliver({
+        id: "activity-1",
+        kind: "activity",
+        activity: "typing",
+        createdAt: 1000,
+        state: "active",
+        audit,
+      });
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.sendTyping.mock.calls.length).toBeGreaterThan(1);
+
+      await adapter.deliver({
+        id: "activity-2",
+        kind: "activity",
+        activity: "typing",
+        createdAt: 1000,
+        state: "idle",
+        audit,
+      });
+      const callsAfterIdle = api.sendTyping.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(api.sendTyping).toHaveBeenCalledTimes(callsAfterIdle);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("resolves component custom IDs and acknowledges interactions", async () => {
     const harness = await createControllerHarness();
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -550,7 +550,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("routes completed assistant item text to active thread bindings", async () => {
+  it("routes assistant item text without completing the active turn", async () => {
     const harness = await createHarness();
     await bindThread(harness);
     await harness.controller.handleInboundEvent(buildTextEvent("who are you"));
@@ -572,11 +572,7 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered.at(-2)).toMatchObject({
-      kind: "activity",
-      activity: "typing",
-      state: "idle",
-    });
+    expect(harness.delivered).toHaveLength(1);
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "message",
       role: "assistant",
@@ -590,9 +586,99 @@ describe("MessagingController", () => {
       harness.store.findActiveBindingForChannel(buildTextEvent("who are you").channel),
     ).resolves.toMatchObject({
       activeTurn: {
+        status: "working",
+      },
+    });
+  });
+
+  it("keeps typing active after assistant item text until terminal completion", async () => {
+    let now = 1000;
+    const harness = await createHarness({
+      now: () => now,
+    });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start multi-step work"));
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "agentMessage",
+            text: "First update.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+      }),
+    ]);
+
+    now += 11_000;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-2",
+            type: "reasoning",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "active",
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "First update.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "idle",
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(buildTextEvent("").channel),
+    ).resolves.toMatchObject({
+      activeTurn: {
         status: "completed",
       },
     });
+    expect(harness.delivered.filter((intent) => intent.kind === "message")).toHaveLength(1);
   });
 
   it("ignores turn completion events that do not include output text", async () => {
@@ -773,6 +859,57 @@ describe("MessagingController", () => {
     });
   });
 
+  it("stops typing while presenting a Plan questionnaire for an active turn", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("plan this"));
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-1",
+        questions: [
+          {
+            id: "q1",
+            header: "Mode",
+            question: "How should I proceed?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: "Plan (Recommended)",
+                description: "Stay in planning mode.",
+              },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    expect(harness.delivered.at(-3)).toMatchObject({
+      kind: "questionnaire",
+    });
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "idle",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      status: "waiting",
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(buildTextEvent("").channel),
+    ).resolves.toMatchObject({
+      activeTurn: {
+        status: "waiting",
+      },
+    });
+  });
+
   it("submits approval callbacks through the backend bridge", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(
@@ -817,6 +954,54 @@ describe("MessagingController", () => {
     });
   });
 
+  it("resumes typing after submitting an approval response for the waiting turn", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run a command"));
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:accept" }),
+    );
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "approval",
+        decisions: [],
+      }),
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "active",
+      }),
+      expect.objectContaining({
+        kind: "status",
+        status: "working",
+      }),
+      expect.objectContaining({
+        kind: "status",
+        text: "Approval response sent.",
+      }),
+    ]);
+    await expect(
+      harness.store.findActiveBindingForChannel(buildTextEvent("").channel),
+    ).resolves.toMatchObject({
+      activeTurn: {
+        status: "working",
+      },
+    });
+  });
+
   it("clears approval buttons after approval button callbacks", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(
@@ -853,7 +1038,11 @@ describe("MessagingController", () => {
         decision: "accept",
       },
     });
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(
+      harness.delivered.find(
+        (intent) => intent.kind === "approval" && intent.decisions.length === 0,
+      ),
+    ).toMatchObject({
       kind: "approval",
       decisions: [],
       delivery: {
@@ -906,7 +1095,11 @@ describe("MessagingController", () => {
     });
 
     expect(harness.submitServerRequest).not.toHaveBeenCalled();
-    expect(harness.delivered.at(-1)).toMatchObject({
+    expect(
+      harness.delivered.find(
+        (intent) => intent.kind === "approval" && intent.decisions.length === 0,
+      ),
+    ).toMatchObject({
       kind: "approval",
       decisions: [],
       delivery: {
@@ -918,6 +1111,55 @@ describe("MessagingController", () => {
         id: `surface:${approvalIntent?.id}`,
       },
     });
+  });
+
+  it("resumes typing when the backend resolves an approval for the waiting turn", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run a command"));
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+    const approvalIntent = harness.delivered.find((intent) => intent.kind === "approval");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "approval-1",
+        },
+      },
+    });
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "approval",
+        decisions: [],
+        targetSurface: expect.objectContaining({
+          id: `surface:${approvalIntent?.id}`,
+        }),
+      }),
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "active",
+      }),
+      expect.objectContaining({
+        kind: "status",
+        status: "working",
+      }),
+    ]);
   });
 
   it("reports expired approval callbacks with retry guidance", async () => {
@@ -1135,6 +1377,7 @@ describe("MessagingController", () => {
 
 async function createHarness(options?: {
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+  now?: () => number;
 }): Promise<{
   controller: MessagingController;
   compactThread: ReturnType<typeof vi.fn>;
@@ -1216,7 +1459,7 @@ async function createHarness(options?: {
       adapter,
       authorizedActorIds: ["user-1"],
       backend,
-      now: () => 1000,
+      now: options?.now ?? (() => 1000),
       store,
     }),
     compactThread,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -731,6 +731,49 @@ describe("MessagingController", () => {
     expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("typing signaled"));
   });
 
+  it("clears typing when status refresh observes an idle backend thread", async () => {
+    let now = 1000;
+    const logger = {
+      debug: vi.fn<(message: string, data?: Record<string, unknown>) => void>(),
+    };
+    const harness = await createHarness({
+      logger,
+      now: () => now,
+    });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start work"));
+    harness.delivered.length = 0;
+    logger.debug.mockClear();
+
+    now += 1000;
+    harness.readThreadStatus.mockResolvedValue("idle");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:refresh" }),
+    );
+
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "idle",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      status: "idle",
+      text: expect.stringContaining("Turn: completed"),
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "messaging turn state changed reason=status_refresh:thread_status_idle",
+      ),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "messaging typing signaled state=idle reason=status_refresh:thread_status_idle",
+      ),
+    );
+  });
+
   it("ignores turn completion events that do not include output text", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -1482,6 +1525,7 @@ async function createHarness(options?: {
   getNavigationSnapshot: ReturnType<typeof vi.fn>;
   interruptTurn: ReturnType<typeof vi.fn>;
   listBackends: ReturnType<typeof vi.fn>;
+  readThreadStatus: ReturnType<typeof vi.fn>;
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
   setThreadModelSettings: ReturnType<typeof vi.fn>;
   startThread: ReturnType<typeof vi.fn>;
@@ -1536,6 +1580,7 @@ async function createHarness(options?: {
     fetchedAt: 1000,
     backends: [buildBackendSummary()],
   }));
+  const readThreadStatus = vi.fn(async () => undefined);
   const submitServerRequest = vi.fn(async (request: SubmitServerRequestRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -1547,6 +1592,7 @@ async function createHarness(options?: {
     getNavigationSnapshot,
     interruptTurn,
     listBackends,
+    readThreadStatus,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
@@ -1568,6 +1614,7 @@ async function createHarness(options?: {
     getNavigationSnapshot,
     interruptTurn,
     listBackends,
+    readThreadStatus,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -16,7 +16,10 @@ import type {
   StartTurnRequest,
   SubmitServerRequestRequest,
 } from "@pwragnt/shared";
-import { MessagingController } from "../messaging/core/messaging-controller";
+import {
+  MessagingController,
+  type MessagingControllerOptions,
+} from "../messaging/core/messaging-controller";
 import type { MessagingAdapter, MessagingBackendBridge } from "../messaging/core/messaging-adapter";
 import { MessagingStore } from "../messaging/core/messaging-store";
 
@@ -679,6 +682,62 @@ describe("MessagingController", () => {
       },
     });
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toHaveLength(1);
+  });
+
+  it("suppresses high-frequency typing refreshes without logging each skipped delta", async () => {
+    let now = 1000;
+    const logger = {
+      debug: vi.fn<(message: string, data?: Record<string, unknown>) => void>(),
+    };
+    const harness = await createHarness({
+      logger,
+      now: () => now,
+    });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run noisy command"));
+    harness.delivered.length = 0;
+    logger.debug.mockClear();
+
+    now += 500;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/commandExecution/outputDelta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          delta: "lots of output",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    now += 10_000;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/commandExecution/outputDelta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          delta: "still working",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "active",
+      }),
+    ]);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("typing signaled"));
   });
 
   it("ignores turn completion events that do not include output text", async () => {
@@ -1377,6 +1436,7 @@ describe("MessagingController", () => {
 
 async function createHarness(options?: {
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+  logger?: MessagingControllerOptions["logger"];
   now?: () => number;
 }): Promise<{
   controller: MessagingController;
@@ -1459,6 +1519,7 @@ async function createHarness(options?: {
       adapter,
       authorizedActorIds: ["user-1"],
       backend,
+      logger: options?.logger,
       now: options?.now ?? (() => 1000),
       store,
     }),

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -301,7 +301,11 @@ describe("DesktopMessagingRuntime", () => {
       },
     });
 
-    expect(telegramAdapter.delivered.at(-1)).toMatchObject({
+    expect(
+      telegramAdapter.delivered.find(
+        (intent) => intent.kind === "approval" && intent.decisions.length === 0,
+      ),
+    ).toMatchObject({
       kind: "approval",
       decisions: [],
       delivery: {

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -300,7 +300,7 @@ describe("TelegramAdapter", () => {
     }
   });
 
-  it("does not re-issue Telegram typing after final assistant text and backend noise", async () => {
+  it("continues Telegram typing after assistant text until terminal completion", async () => {
     vi.useFakeTimers();
     try {
       const harness = await createControllerHarness();
@@ -369,7 +369,27 @@ describe("TelegramAdapter", () => {
       } satisfies AgentEvent);
       await vi.advanceTimersByTimeAsync(10_000);
 
-      expect(harness.api.sendChatAction).toHaveBeenCalledTimes(1);
+      expect(harness.api.sendChatAction.mock.calls.length).toBeGreaterThan(1);
+
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      } satisfies AgentEvent);
+      const callsAfterCompletion = harness.api.sendChatAction.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(harness.api.sendChatAction).toHaveBeenCalledTimes(callsAfterCompletion);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -444,6 +444,53 @@ function readStatusType(value: unknown): string | undefined {
   return typeof type === "string" ? type : undefined;
 }
 
+function readTurnStatus(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || !("status" in value)) {
+    return undefined;
+  }
+
+  const status = value.status;
+  return typeof status === "string" ? status : undefined;
+}
+
+function logBackendLifecycleNotification(
+  backend: AppServerBackendKind,
+  notification: AppServerNotification,
+): void {
+  if (
+    notification.method !== "turn/completed" &&
+    notification.method !== "turn/failed" &&
+    notification.method !== "turn/cancelled" &&
+    notification.method !== "thread/status/changed"
+  ) {
+    return;
+  }
+
+  if (notification.method === "thread/status/changed") {
+    backendRegistryLog.info("backend lifecycle notification", {
+      backend,
+      method: notification.method,
+      status: readStatusType(notification.params.status),
+      threadId: notification.params.threadId,
+    });
+    return;
+  }
+
+  if (
+    notification.method === "turn/completed" ||
+    notification.method === "turn/failed" ||
+    notification.method === "turn/cancelled"
+  ) {
+    backendRegistryLog.info("backend lifecycle notification", {
+      backend,
+      method: notification.method,
+      status: readTurnStatus(notification.params.turn),
+      threadId: notification.params.threadId,
+      turnId: notification.params.turnId,
+    });
+  }
+}
+
 function mergeMethods(results: InitializeResult[]): string[] {
   return [...new Set(results.flatMap((result) => result.methods ?? []))];
 }
@@ -2059,6 +2106,7 @@ export class DesktopBackendRegistry {
   private subscribeClient(backend: AppServerBackendKind, client: BackendClient): void {
     this.unsubscribers.push(
       client.onNotification(async (notification) => {
+        logBackendLifecycleNotification(backend, notification);
         await this.emit({ backend, notification });
       }),
     );

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -1,5 +1,7 @@
 import type {
   AgentEvent,
+  AppServerBackendKind,
+  AppServerThreadStatus,
   CompactThreadRequest,
   CompactThreadResponse,
   InterruptTurnRequest,
@@ -54,6 +56,10 @@ export type MessagingBackendBridge = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  readThreadStatus?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadStatus | undefined>;
   startThread?(request: StartThreadRequest): Promise<StartThreadResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
   compactThread?(request: CompactThreadRequest): Promise<CompactThreadResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -218,26 +218,6 @@ export class MessagingController {
       }
 
       const assistantText = assistantTextForBackendEvent(event);
-      if (assistantText && !lifecycle && currentBinding.activeTurn?.status === "working") {
-        currentBinding = await this.options.store.upsertBinding({
-          ...currentBinding,
-          activeTurn: {
-            ...currentBinding.activeTurn,
-            status: "completed",
-            updatedAt: this.now(),
-          },
-          updatedAt: this.now(),
-        });
-        this.logBindingTurnStateChange(
-          binding,
-          currentBinding,
-          event.notification.method,
-        );
-        await this.signalTurnActivity(currentBinding, currentBinding.activeTurn!, {
-          reason: "assistant_final",
-          force: true,
-        });
-      }
       if (assistantText) {
         await this.deliverAssistantMessage(assistantText, event, currentBinding);
       }
@@ -248,7 +228,31 @@ export class MessagingController {
           force: true,
         });
         await this.renderBindingStatus(currentBinding);
-      } else if (!assistantText && currentBinding.activeTurn?.status === "working") {
+      } else if (
+        currentBinding.activeTurn?.status === "waiting" &&
+        isTurnWorkActivityEvent(event, currentBinding.activeTurn)
+      ) {
+        const previousBinding = currentBinding;
+        currentBinding = await this.options.store.upsertBinding({
+          ...currentBinding,
+          activeTurn: {
+            ...currentBinding.activeTurn,
+            status: "working",
+            updatedAt: this.now(),
+          },
+          updatedAt: this.now(),
+        });
+        this.logBindingTurnStateChange(
+          previousBinding,
+          currentBinding,
+          event.notification.method,
+        );
+        await this.signalTurnActivity(currentBinding, currentBinding.activeTurn!, {
+          reason: event.notification.method,
+          force: true,
+        });
+        await this.renderBindingStatus(currentBinding);
+      } else if (currentBinding.activeTurn?.status === "working") {
         await this.signalTurnActivity(currentBinding, currentBinding.activeTurn, {
           reason: event.notification.method,
         });
@@ -514,6 +518,13 @@ export class MessagingController {
         await this.submitApprovalAction(pendingIntent.intent, action.id);
         await this.retireApprovalIntent(pendingIntent, event);
         await this.options.store.deletePendingIntent(pendingIntent.id);
+        const resumedBinding = await this.resumeBindingForPendingIntent(
+          pendingIntent,
+          "pending_request.submitted",
+        );
+        if (resumedBinding) {
+          await this.renderBindingStatus(resumedBinding, event);
+        }
         await this.deliver(
           buildStatusIntent({
             id: this.newIntentId("approval-submitted"),
@@ -595,6 +606,13 @@ export class MessagingController {
     )) {
       await this.retireApprovalIntent(pendingIntent);
       await this.options.store.deletePendingIntent(pendingIntent.id);
+      const resumedBinding = await this.resumeBindingForPendingIntent(
+        pendingIntent,
+        event.notification.method,
+      );
+      if (resumedBinding) {
+        await this.renderBindingStatus(resumedBinding);
+      }
     }
   }
 
@@ -632,6 +650,45 @@ export class MessagingController {
         intentId: pendingIntent.intent.id,
       });
     }
+  }
+
+  private async resumeBindingForPendingIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+    reason: string,
+  ): Promise<MessagingBindingRecord | undefined> {
+    const bindingId = pendingIntent.bindingId;
+    const turnId = pendingIntent.intent.requestContext?.turnId;
+    if (!bindingId || !turnId) {
+      return undefined;
+    }
+
+    const binding = await this.options.store.getBinding(bindingId);
+    const activeTurn = binding?.activeTurn;
+    if (
+      !binding ||
+      binding.revokedAt ||
+      !activeTurn ||
+      activeTurn.turnId !== turnId ||
+      activeTurn.status !== "waiting"
+    ) {
+      return undefined;
+    }
+
+    const updatedBinding = await this.options.store.upsertBinding({
+      ...binding,
+      activeTurn: {
+        ...activeTurn,
+        status: "working",
+        updatedAt: this.now(),
+      },
+      updatedAt: this.now(),
+    });
+    this.logBindingTurnStateChange(binding, updatedBinding, reason);
+    await this.signalTurnActivity(updatedBinding, updatedBinding.activeTurn!, {
+      force: true,
+      reason,
+    });
+    return updatedBinding;
   }
 
   private async deliverAssistantMessage(
@@ -1874,6 +1931,33 @@ function isThreadStatusIdleEvent(event: AgentEvent): boolean {
     };
   };
   return params.status?.type === "idle";
+}
+
+function isTurnWorkActivityEvent(
+  event: AgentEvent,
+  activeTurn: MessagingActiveTurnSummary,
+): boolean {
+  const params = event.notification.params as {
+    turn?: {
+      id?: unknown;
+    };
+    turnId?: unknown;
+  };
+  const turnId =
+    typeof params.turnId === "string"
+      ? params.turnId
+      : typeof params.turn?.id === "string"
+        ? params.turn.id
+        : undefined;
+  if (turnId !== activeTurn.turnId) {
+    return false;
+  }
+
+  return (
+    event.notification.method.startsWith("item/") ||
+    event.notification.method.startsWith("turn/") ||
+    event.notification.method.startsWith("thread/")
+  );
 }
 
 function turnLifecycleForBackendEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1607,11 +1607,6 @@ export class MessagingController {
       lastSignaledAt !== undefined &&
       now - lastSignaledAt < TYPING_ACTIVITY_REFRESH_MS
     ) {
-      if (options?.reason !== "item/agentMessage/delta") {
-        this.logger.debug?.(
-          `messaging typing suppressed state=${state} reason=${options?.reason ?? "unknown"} elapsedMs=${now - lastSignaledAt} thread=${binding.threadId} turn=${activeTurn.turnId} binding=${binding.id}`,
-        );
-      }
       return;
     }
     if (state === "active") {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1624,12 +1624,16 @@ export class MessagingController {
       (await this.options.backend.getNavigationSnapshot({
         backend: "all",
       }));
+    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+      binding,
+      "status_refresh",
+    );
     const intent = buildBindingStatusIntent({
       id: this.newIntentId("status"),
       binding,
       createdAt: this.now(),
       threadState: resolveMessagingThreadState({
-        activeTurn: this.getActiveTurn(binding),
+        activeTurn,
         binding,
         navigation: snapshot,
       }),
@@ -1648,6 +1652,46 @@ export class MessagingController {
       statusSurface: result.surface,
       updatedAt: this.now(),
     });
+  }
+
+  private async reconcileActiveTurnFromBackendStatus(
+    binding: MessagingBindingRecord,
+    reason: string,
+  ): Promise<MessagingActiveTurnSummary | undefined> {
+    const activeTurn = this.getActiveTurn(binding);
+    if (
+      !activeTurn ||
+      activeTurn.status !== "working" ||
+      !this.options.backend.readThreadStatus
+    ) {
+      return activeTurn;
+    }
+
+    const threadStatus = await this.options.backend.readThreadStatus({
+      backend: binding.backend,
+      threadId: binding.threadId,
+    });
+    if (threadStatus !== "idle") {
+      return activeTurn;
+    }
+
+    const completedTurn: MessagingActiveTurnSummary = {
+      ...activeTurn,
+      status: "completed",
+      updatedAt: this.now(),
+    };
+    this.setActiveTurn(binding, completedTurn);
+    this.logBindingTurnStateChange(
+      binding,
+      activeTurn,
+      completedTurn,
+      `${reason}:thread_status_idle`,
+    );
+    await this.signalTurnActivity(binding, completedTurn, {
+      force: true,
+      reason: `${reason}:thread_status_idle`,
+    });
+    return completedTurn;
   }
 
   private getActiveTurn(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,5 +1,7 @@
 import type {
   AgentEvent,
+  AppServerBackendKind,
+  AppServerThreadStatus,
   CompactThreadRequest,
   CompactThreadResponse,
   GetNavigationSnapshotRequest,
@@ -53,6 +55,18 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         gitStatus: directoryStatuses[directory.key],
       })),
     };
+  }
+
+  async readThreadStatus(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadStatus | undefined> {
+    const response = await this.registry.readThread({
+      backend: request.backend,
+      limit: 0,
+      threadId: request.threadId,
+    });
+    return response.threadStatus ?? response.replay.threadStatus;
   }
 
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -64,6 +64,19 @@ Telegram currently uses Bot API long polling, HTML-safe text, inline keyboards,
 and `sendPhoto` for image URLs. Discord uses Gateway events, REST message
 delivery, defensive `allowed_mentions`, components, and image embeds.
 
+## Typing Activity
+
+`activity: "typing"` is a semantic lease signal from the messaging controller.
+Adapters should start or refresh the platform typing indicator when
+`state: "active"` arrives, stop the platform indicator when `state: "idle"`
+arrives, and let the lease expire as a fallback if no idle signal is delivered.
+
+Adapters must not infer agent lifecycle from message content. Assistant message
+delivery can happen while a turn is still working, and pending user-input
+surfaces can happen while a turn is paused for the user. The controller owns
+those lifecycle decisions and translates them into active or idle activity
+intents.
+
 ## Adding A New Adapter
 
 To add Mattermost, Feishu/Lark, Slack, Matrix, or another channel:

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -29,6 +29,15 @@ the closest native layout they support: Telegram inline keyboards can honor
 explicit row groupings, and Discord components use action rows with provider
 limits.
 
+## Typing Indicators
+
+Messaging adapters show platform typing indicators while a bound turn is
+actively waiting on the agent. Intermediate assistant messages or status updates
+do not stop typing by themselves; the indicator stops when the turn completes,
+fails, is interrupted, or enters a pending user-input break such as a Plan
+questionnaire or approval prompt. After the user answers that prompt, typing can
+resume for the same turn until terminal completion.
+
 ## Configuration
 
 Messaging is disabled unless a channel has both credentials and authorized actor
@@ -112,12 +121,13 @@ Telegram:
 5. Verify a pinned status card appears and updates in place.
 6. Use status buttons to change Model, Reasoning, Fast mode, and Permissions.
 7. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
-8. Trigger a Plan questionnaire and answer with both a button and text fallback.
-9. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
-10. Verify markdown, inline code, fenced code, long responses, and image output render.
-11. Restart PwrAgnt and verify the same Telegram conversation still routes to the bound thread.
-12. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
-13. Send a file or voice message and verify it is rejected without download.
+8. Verify typing continues through an intermediate assistant update and stops at turn completion.
+9. Trigger a Plan questionnaire and answer with both a button and text fallback.
+10. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
+11. Verify markdown, inline code, fenced code, long responses, and image output render.
+12. Restart PwrAgnt and verify the same Telegram conversation still routes to the bound thread.
+13. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
+14. Send a file or voice message and verify it is rejected without download.
 
 Discord:
 
@@ -126,11 +136,12 @@ Discord:
 3. Verify a numbered thread picker appears with components.
 4. Choose a thread by component, then repeat by replying `1`.
 5. Send free-form text and verify a PwrAgnt turn starts in the bound thread.
-6. Trigger a Plan questionnaire and answer with both a component and text fallback.
-7. Trigger an approval request and test accept, session accept, decline, and cancel.
-8. Verify markdown, inline code, fenced code, long responses, and image output render.
-9. Restart PwrAgnt and verify the same Discord channel still routes to the bound thread.
-10. Send an attachment and verify it is rejected without download.
+6. Verify typing continues through an intermediate assistant update and stops at turn completion.
+7. Trigger a Plan questionnaire and answer with both a component and text fallback.
+8. Trigger an approval request and test accept, session accept, decline, and cancel.
+9. Verify markdown, inline code, fenced code, long responses, and image output render.
+10. Restart PwrAgnt and verify the same Discord channel still routes to the bound thread.
+11. Send an attachment and verify it is rejected without download.
 
 Discord currently has parity for the shared workflow and button actions, but it
 does not pin or edit status cards yet; status updates degrade to normal

--- a/docs/plans/2026-05-02-001-fix-messaging-typing-indicator-plan.md
+++ b/docs/plans/2026-05-02-001-fix-messaging-typing-indicator-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Keep messaging typing indicators alive for active turns
 type: fix
-status: active
+status: completed
 date: 2026-05-02
 origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
 deepened: 2026-05-02
@@ -118,7 +118,7 @@ The important separation is that `message` delivery is orthogonal to `activity` 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Characterize current early-idle lifecycle behavior**
+- [x] **Unit 1: Characterize current early-idle lifecycle behavior**
 
 **Goal:** Add failing controller-level coverage that proves an assistant `item/completed` event should not stop typing before terminal turn completion.
 
@@ -155,7 +155,7 @@ The important separation is that `message` delivery is orthogonal to `activity` 
 **Verification:**
 - Tests fail on the current early-idle implementation and describe the desired lifecycle in channel-neutral terms.
 
-- [ ] **Unit 2: Separate assistant message delivery from turn terminal state**
+- [x] **Unit 2: Separate assistant message delivery from turn terminal state**
 
 **Goal:** Refactor controller backend-event handling so assistant text delivery does not complete the active turn unless terminal lifecycle evidence is present.
 
@@ -189,7 +189,7 @@ The important separation is that `message` delivery is orthogonal to `activity` 
 **Verification:**
 - Messaging controller behavior expresses turn activity from lifecycle state, and assistant output can be delivered mid-turn without stopping provider typing leases.
 
-- [ ] **Unit 3: Preserve user-input break semantics and resumed-work behavior**
+- [x] **Unit 3: Preserve user-input break semantics and resumed-work behavior**
 
 **Goal:** Keep typing off while the agent is waiting on user input, and make the lifecycle robust when the same turn resumes after a questionnaire, approval, or future MCP elicitation.
 
@@ -228,7 +228,7 @@ The important separation is that `message` delivery is orthogonal to `activity` 
 **Verification:**
 - The controller distinguishes working, waiting-for-user, and terminal states without treating visible prompts as completed turns.
 
-- [ ] **Unit 4: Lock provider lease behavior to generic activity intents**
+- [x] **Unit 4: Lock provider lease behavior to generic activity intents**
 
 **Goal:** Ensure Telegram and Discord providers keep renewing typing while active intents continue, stop only on idle intents or lease expiry, and remain unaware of turn protocol details.
 
@@ -262,7 +262,7 @@ The important separation is that `message` delivery is orthogonal to `activity` 
 **Verification:**
 - Provider tests prove the adapters obey the generic activity contract while lifecycle semantics remain in the controller.
 
-- [ ] **Unit 5: Document typing lifecycle semantics**
+- [x] **Unit 5: Document typing lifecycle semantics**
 
 **Goal:** Capture the controller/provider boundary so future adapter work does not reintroduce message-delivery-driven typing state.
 

--- a/docs/plans/2026-05-02-001-fix-messaging-typing-indicator-plan.md
+++ b/docs/plans/2026-05-02-001-fix-messaging-typing-indicator-plan.md
@@ -1,0 +1,327 @@
+---
+title: fix: Keep messaging typing indicators alive for active turns
+type: fix
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+deepened: 2026-05-02
+---
+
+# fix: Keep messaging typing indicators alive for active turns
+
+## Overview
+
+Fix the messaging-platform bug where Telegram and Discord typing indicators can stop immediately after the first assistant response or update in a turn, even though the agent is still connected and working.
+
+The messaging controller should treat typing/activity as a turn-lifecycle signal, not as a message-delivery side effect. Assistant message chunks or `item/completed` agent-message events may be visible user-facing output, but they do not prove the turn is terminal. The typing indicator should remain active through normal backend activity and stop only when the turn reaches a terminal state or when the agent is intentionally waiting on user input, such as a Plan questionnaire, approval prompt, or future MCP elicitation.
+
+## Problem Frame
+
+The current controller flow in `apps/desktop/src/main/messaging/core/messaging-controller.ts` sets `activeTurn.status = "completed"` when `assistantTextForBackendEvent()` finds text on a non-lifecycle backend event. In practice, an `item/completed` event for an assistant message can arrive before `turn/completed`. That path logs `assistant_final`, sends a `MessagingActivityIntent` with `state: "idle"`, and causes providers to stop the renewable typing lease while the backend turn can still continue with more work.
+
+Telegram and Discord providers already have the right adapter primitive: `activity: "typing"` with `state: "active"` starts or refreshes a renewable lease, and `state: "idle"` stops it. The bug is in when the desktop messaging workflow emits the idle signal.
+
+## Requirements Trace
+
+- R1. After free-form messaging text starts a bound agent turn, the channel typing indicator stays active while the turn is working.
+- R2. Delivering the first assistant message or assistant item completion does not mark the turn completed or stop typing unless a terminal turn event is also present.
+- R3. Backend activity during a working turn refreshes the typing lease at the existing bounded cadence.
+- R4. Terminal turn states stop typing: `turn/completed`, `turn/failed`, `turn/cancelled`, `turn/interrupted` where supported, and explicit idle thread status used as a fallback when no terminal turn event arrives.
+- R5. User-input breaks stop typing while the agent is waiting on the user: Plan questionnaires, approval prompts, and future MCP elicitation requests that carry the active `turnId`.
+- R6. When a waiting prompt is resolved and the same turn resumes work, typing can become active again without requiring a new user message.
+- R7. The behavior remains channel-neutral. Telegram and Discord adapter code should not learn agent lifecycle semantics beyond the generic `activity` intent.
+
+## Scope Boundaries
+
+- In scope: desktop messaging controller lifecycle logic, typing activity intent emission, controller tests, Telegram/Discord provider lease regression tests, and documentation of typing lifecycle semantics.
+- In scope: preserving current provider lease behavior and existing `TYPING_ACTIVITY_REFRESH_MS` / `TYPING_ACTIVITY_LEASE_MS` policy unless tests expose a direct mismatch.
+- Out of scope: changing Telegram Bot API or Discord REST/Gateway integration mechanics.
+- Out of scope: adding a new hosted webhook mode, public bot service, or messaging replay harness.
+- Out of scope: implementing full MCP elicitation support in messaging if it is not already surfaced through the messaging pending-request path. This plan only establishes the lifecycle rule it should follow when wired.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` owns inbound text routing, backend event handling, pending request handling, active turn state, and `signalTurnActivity()`.
+- `signalTurnActivity()` already maps `activeTurn.status === "working"` to `MessagingActivityIntent.state = "active"` and all other statuses to `idle`, with refresh suppression through `TYPING_ACTIVITY_REFRESH_MS`.
+- `assistantTextForBackendEvent()` extracts assistant text from both `item/completed` and `turn/completed`. The current non-lifecycle `item/completed` path is the likely early-idle source.
+- `handleBackendPendingRequest()` already sets `activeTurn.status = "waiting"` for pending requests with a `turnId`, which intentionally sends idle and updates status.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` currently classifies `item/tool/requestUserInput` and `*requestApproval*` notifications as messaging pending requests. MCP elicitation is not in this classifier today.
+- `packages/messaging/interface/src/index.ts` and `packages/shared/src/contracts/messaging.ts` define the generic `MessagingActivityIntent` contract with `activity: "typing"`, `state: "active" | "idle"`, and optional `leaseMs`.
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts` starts, refreshes, expires, and stops Telegram `sendChatAction` typing signals from generic activity intents.
+- `packages/messaging/providers/discord/src/discord-adapter.ts` starts, refreshes, expires, and stops Discord typing requests from generic activity intents.
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`, `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`, and `apps/desktop/src/main/__tests__/discord-adapter.test.ts` already cover the closest controller and provider typing paths.
+- `docs/messaging-adapter-contract.md` is the right place to document provider lifecycle expectations without leaking controller implementation details.
+
+### Institutional Learnings
+
+- No relevant `docs/solutions/` artifacts exist for messaging typing lifecycle bugs.
+- `docs/plans/2026-04-30-001-feat-messaging-platform-integration-plan.md` established the channel-neutral surface boundary and the rule that adapters own platform rendering while controller workflow owns thread, approval, questionnaire, and fallback semantics.
+- `docs/plans/2026-04-30-003-refactor-desktop-hosted-messaging-plan.md` superseded earlier package ownership and confirmed desktop main-process messaging is the integration host.
+- `docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md` established that Plan questionnaires are active-turn pending-input breaks, not terminal turn completion.
+- `docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md` established that MCP elicitation is also a request/response pause in an active turn, with separate response semantics from approvals and questionnaires.
+
+### External References
+
+- External research is not needed for this fix. The provider APIs already support renewable typing indicators in the current code; the issue is local turn-state classification.
+
+## Key Technical Decisions
+
+- **Typing follows turn lifecycle, not assistant message delivery.** Assistant text should be delivered as a `message` intent without changing `activeTurn.status` unless the same backend event is a terminal lifecycle event.
+- **Keep waiting states idle.** Presenting a questionnaire, approval prompt, or MCP elicitation is a user-input break. The indicator should stop while the agent is waiting for the user, even though the larger turn may continue afterward.
+- **Let resolved prompts resume typing for the same turn.** Once the user responds to a pending request or the backend reports `serverRequest/resolved` for the active waiting turn, the controller should treat the turn as waiting on the agent again and move it back to `working` unless a terminal event has already settled the turn. Subsequent backend activity can refresh the same lease, and provider lease expiry remains the fallback if no more activity arrives.
+- **Centralize event-to-turn-state classification.** Add or refactor toward a small helper that describes whether a backend or pending-request event starts work, refreshes work, pauses for user input, or terminates the turn. Tests should target the behavior rather than scattered incidental branches.
+- **Keep provider behavior generic.** Telegram and Discord should continue to respond only to `MessagingActivityIntent`; they should not parse `turn/completed`, `item/completed`, questionnaires, approvals, or MCP events.
+- **Preserve fallback idle behavior.** `thread/status/changed` idle can still stop typing when no terminal turn completion arrives, but it should be treated as lifecycle evidence, not as a consequence of a rendered assistant message.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Do Plan questionnaires end the turn?** No for messaging lifecycle purposes. They are a pending-input break inside an active turn and should stop typing until the user responds.
+- **Should assistant `item/completed` be treated as final output?** No. It is message output for delivery/deduplication, not terminal turn-state evidence.
+- **Should adapters own the decision about when typing stops?** No. Adapters own platform typing mechanics; the controller owns semantic activity state.
+- **Is external API research required?** No. Existing Telegram and Discord providers already implement start/refresh/stop leases from generic activity intents.
+
+### Deferred to Implementation
+
+- Whether MCP elicitation is currently exposed to messaging through `isMessagingPendingRequest()`. If not, this fix should document the rule and avoid sneaking MCP support into scope.
+- Whether `turn/interrupted` appears as `turn/cancelled`, `turn/failed`, or another concrete method in the current app-server event stream. Match existing normalized event names rather than inventing a new protocol string.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Working: outbound text / turn started
+    Working --> Working: backend activity, deltas, assistant items
+    Working --> WaitingForUser: questionnaire, approval, MCP elicitation
+    WaitingForUser --> Working: user response / request resolved
+    Working --> Idle: turn completed / failed / cancelled
+    Working --> Idle: explicit idle fallback without terminal event
+    WaitingForUser --> Idle: terminal turn event while prompt is pending
+```
+
+The important separation is that `message` delivery is orthogonal to `activity` state:
+
+| Event shape | Message delivery | Typing state |
+| --- | --- | --- |
+| User sends bound text | none | active |
+| `item/completed` agent message | deliver assistant message | keep or refresh active |
+| `turn/completed` with output | deliver deduped assistant message | idle |
+| Plan questionnaire / approval | deliver pending prompt | idle |
+| Future MCP elicitation | deliver pending prompt when supported | idle |
+| User response or request resolved for same active turn | optional status update | active |
+
+## Implementation Units
+
+- [ ] **Unit 1: Characterize current early-idle lifecycle behavior**
+
+**Goal:** Add failing controller-level coverage that proves an assistant `item/completed` event should not stop typing before terminal turn completion.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+
+**Approach:**
+- Update the existing controller test that currently expects `item/completed` assistant text to emit idle. It should instead expect message delivery while the binding remains `activeTurn.status = "working"` until a terminal turn event arrives.
+- Add a sequence that starts a turn, delivers an assistant `item/completed` message, emits follow-up backend activity, then emits `turn/completed`; typing should be active before completion and idle after completion.
+- Update provider-oriented tests that currently encode "do not re-issue typing after final assistant text" so "final" means a terminal turn event, not the first assistant item text.
+- Keep current tests that prove explicit terminal or idle fallback events stop typing.
+
+**Execution note:** Start with failing characterization tests before changing lifecycle code.
+
+**Patterns to follow:**
+- Existing typing lifecycle tests in `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Existing Telegram timer/lease tests in `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Existing Discord timer/lease tests in `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+
+**Test scenarios:**
+- Happy path: inbound text starts a turn and emits one active typing intent.
+- Regression: `item/completed` with `item.type = "agentMessage"` and text delivers a message but does not emit idle and does not mark the binding completed.
+- Happy path: a later backend activity event during the same turn refreshes or preserves typing according to `TYPING_ACTIVITY_REFRESH_MS`.
+- Happy path: `turn/completed` after earlier assistant item delivery emits idle and updates the binding status to completed.
+- Edge case: `turn/completed` with duplicate output text does not double-deliver the assistant message because delivery deduplication still keys by backend/thread/turn/text.
+- Error path: `thread/status/changed` idle without a terminal turn event still emits idle as the existing fallback.
+
+**Verification:**
+- Tests fail on the current early-idle implementation and describe the desired lifecycle in channel-neutral terms.
+
+- [ ] **Unit 2: Separate assistant message delivery from turn terminal state**
+
+**Goal:** Refactor controller backend-event handling so assistant text delivery does not complete the active turn unless terminal lifecycle evidence is present.
+
+**Requirements:** R1, R2, R3, R4, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Remove the non-lifecycle `assistant_final` transition that marks a working active turn as completed solely because `assistantTextForBackendEvent()` returned text.
+- Keep `deliverAssistantMessage()` and `assistantMessageDeliveryKey()` so assistant output still reaches the messaging channel and duplicate terminal output remains suppressed.
+- Ensure non-terminal backend activity while `activeTurn.status === "working"` can still call `signalTurnActivity()` at the existing refresh cadence.
+- Keep terminal lifecycle handling authoritative for completion, failure, cancellation, and fallback idle status.
+- Prefer a small event-classification helper if it makes the state transitions explicit enough to avoid future accidental coupling between message output and activity state.
+
+**Patterns to follow:**
+- `turnLifecycleForBackendEvent()` in `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `assistantTextForBackendEvent()` and `assistantMessageDeliveryKey()` in the same file
+- `buildActivityIntent()` in `apps/desktop/src/main/messaging/core/messaging-renderer.ts`
+
+**Test scenarios:**
+- Regression: first assistant item text during a working turn leaves `activeTurn.status = "working"`.
+- Happy path: terminal `turn/completed` changes the same binding to completed and emits exactly one idle activity intent.
+- Happy path: terminal `turn/failed` or cancellation changes typing to idle without requiring assistant text.
+- Edge case: an assistant text event for an unknown or unbound thread does not create a binding or typing signal.
+- Integration: status-card rendering after non-terminal assistant text still shows the turn as working; after terminal completion it shows completed/idle.
+
+**Verification:**
+- Messaging controller behavior expresses turn activity from lifecycle state, and assistant output can be delivered mid-turn without stopping provider typing leases.
+
+- [ ] **Unit 3: Preserve user-input break semantics and resumed-work behavior**
+
+**Goal:** Keep typing off while the agent is waiting on user input, and make the lifecycle robust when the same turn resumes after a questionnaire, approval, or future MCP elicitation.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts` only if current pending-request classification needs a narrow lifecycle hook
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts` only if runtime pending-request classification changes
+
+**Approach:**
+- Preserve `handleBackendPendingRequest()` behavior that sets `activeTurn.status = "waiting"` and emits idle for pending requests with a `turnId`.
+- Add or adjust tests proving Plan questionnaires and approval prompts stop typing while they are visible.
+- Move `waiting -> working` when a pending request response is submitted for the active turn or when `serverRequest/resolved` arrives for that same turn, unless a terminal event has already settled it.
+- Ensure subsequent backend activity for a waiting active turn can also resume the status to `working` instead of being ignored because only `working` currently refreshes typing.
+- Treat MCP elicitation as a documented pending-input lifecycle category, but do not broaden runtime classification unless current messaging code already has enough request shape to render it correctly.
+
+**Patterns to follow:**
+- `handleBackendPendingRequest()` and `handleBackendRequestResolved()` in `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Plan questionnaire separation from `docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md`
+- MCP request separation from `docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md`
+
+**Test scenarios:**
+- Happy path: `item/tool/requestUserInput` with `turnId` presents a questionnaire intent, sets active turn waiting, and emits idle.
+- Happy path: approval request with `turnId` presents an approval intent, sets active turn waiting, and emits idle.
+- Regression: while a waiting prompt is visible, periodic backend noise does not restart typing unless it is classified as resumed work.
+- Happy path: after a questionnaire or approval response is submitted for the same active turn, typing returns to active while preserving the same `turnId`.
+- Happy path: if `serverRequest/resolved` arrives for the same waiting turn without a local response path, typing returns to active while preserving the same `turnId`.
+- Happy path: subsequent explicit backend activity for a waiting turn can also return typing to active.
+- Edge case: a terminal turn event while waiting emits idle and clears/settles status without restarting typing.
+- Deferred integration: MCP elicitation follows the same waiting-state lifecycle when it is surfaced as a messaging pending request.
+
+**Verification:**
+- The controller distinguishes working, waiting-for-user, and terminal states without treating visible prompts as completed turns.
+
+- [ ] **Unit 4: Lock provider lease behavior to generic activity intents**
+
+**Goal:** Ensure Telegram and Discord providers keep renewing typing while active intents continue, stop only on idle intents or lease expiry, and remain unaware of turn protocol details.
+
+**Requirements:** R1, R3, R4, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+- Modify: `packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts` if provider-package coverage needs the same assertion
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts` if provider-package coverage needs the same assertion
+
+**Approach:**
+- Keep provider implementation unchanged unless tests reveal a lease-refresh bug. The expected fix is primarily controller-side.
+- Add provider assertions that repeated active typing activity refreshes the lease without rendering a visible message.
+- Add provider assertions that idle activity stops the lease, and no further `sendChatAction` / Discord typing request fires after stop.
+- Keep lease-expiry behavior as a fallback when no idle signal arrives.
+
+**Patterns to follow:**
+- `startTypingSignal()`, `refreshTypingSignalLease()`, and `stopTypingSignal()` in `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- `startTypingSignal()`, `refreshTypingSignalLease()`, and `stopTypingSignal()` in `packages/messaging/providers/discord/src/discord-adapter.ts`
+
+**Test scenarios:**
+- Happy path: an active intent starts Telegram/Discord typing without sending a visible message.
+- Happy path: a second active intent for the same target refreshes the lease instead of creating duplicate intervals.
+- Happy path: an idle intent stops the existing lease.
+- Edge case: if no idle arrives, the lease expires and no interval keeps running indefinitely.
+- Regression: provider tests do not mention `item/completed`, `turn/completed`, Plan questionnaires, approvals, or MCP events.
+
+**Verification:**
+- Provider tests prove the adapters obey the generic activity contract while lifecycle semantics remain in the controller.
+
+- [ ] **Unit 5: Document typing lifecycle semantics**
+
+**Goal:** Capture the controller/provider boundary so future adapter work does not reintroduce message-delivery-driven typing state.
+
+**Requirements:** R5, R7
+
+**Dependencies:** Units 2-4
+
+**Files:**
+- Modify: `docs/messaging-adapter-contract.md`
+- Modify: `docs/messaging-platform-integration.md`
+- Test: `apps/desktop/src/main/__tests__/messaging-docs-links.test.ts`
+
+**Approach:**
+- Add a short section to the adapter contract explaining that `activity: "typing"` is a semantic lease signal from the controller: providers start/refresh on active, stop on idle, and do not infer lifecycle from message content.
+- Add a short operational note to the messaging platform docs explaining user-visible behavior: typing stays on during active agent work, stops for pending user input, and stops on terminal turn completion/failure/cancellation.
+- Keep documentation channel-neutral and avoid platform-specific protocol claims beyond existing Telegram/Discord sections.
+
+**Patterns to follow:**
+- Existing boundary language in `docs/messaging-adapter-contract.md`
+- Existing manual smoke checklist in `docs/messaging-platform-integration.md`
+
+**Test scenarios:**
+- Test expectation: none for behavior -- docs-only. Existing docs link tests should still pass.
+
+**Verification:**
+- Messaging docs explain the lifecycle rule in terms that provider authors can follow without reading controller internals.
+
+## System-Wide Impact
+
+- **Interaction graph:** Bound messaging text flows through provider inbound normalization, `MessagingController.handleInboundEvent()`, `DesktopBackendBridge.startTurn()`, backend events, controller delivery, and provider activity leases. This plan changes only the controller's lifecycle classification and tests provider lease behavior at the generic intent boundary.
+- **Error propagation:** Provider delivery failures should continue to be isolated by `DesktopMessagingRuntime`; this fix should not make typing failures abort assistant message delivery or status-card updates.
+- **State lifecycle risks:** `MessagingBindingRecord.activeTurn` remains the source of messaging activity status. The key risk is stale `working` after a missed terminal event; preserving the explicit idle-status fallback mitigates that.
+- **API surface parity:** `MessagingActivityIntent` should remain channel-neutral. No Telegram/Discord-specific contract fields are needed.
+- **Integration coverage:** Unit coverage should exercise controller event ordering and provider timers. Manual smoke can verify Telegram/Discord client behavior, but deterministic tests should prove the lifecycle.
+- **Unchanged invariants:** Authorization, binding lookup, pending intent TTLs, callback handle opacity, message deduplication, and provider package boundaries do not change.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Typing remains active forever if a terminal event is missed | Preserve explicit idle thread-status fallback and provider lease expiry. |
+| Waiting prompts restart typing too early | Keep pending-request state as `waiting` and require explicit resolution or resumed-work evidence before returning to `working`. |
+| Assistant messages duplicate when both `item/completed` and `turn/completed` carry the same text | Keep `assistantMessageDeliveryKey()` deduplication and add a regression test. |
+| Provider tests accidentally encode controller lifecycle semantics | Assert only generic active/idle activity intents in provider tests. |
+| MCP elicitation scope expands the fix | Document MCP lifecycle expectations but defer full messaging MCP support unless current runtime classification already supports it cleanly. |
+
+## Documentation / Operational Notes
+
+- Update messaging docs after code behavior is locked so live smoke testers know typing should persist through intermediate assistant updates.
+- Manual Telegram/Discord smoke validation should include a prompt that produces an early assistant message or update followed by more work before completion.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md](../brainstorms/2026-04-30-messaging-platform-integration-requirements.md)
+- Related plan: [docs/plans/2026-04-30-001-feat-messaging-platform-integration-plan.md](2026-04-30-001-feat-messaging-platform-integration-plan.md)
+- Related plan: [docs/plans/2026-04-30-003-refactor-desktop-hosted-messaging-plan.md](2026-04-30-003-refactor-desktop-hosted-messaging-plan.md)
+- Related plan: [docs/plans/2026-04-20-001-feat-plan-questionnaire-navigation-plan.md](2026-04-20-001-feat-plan-questionnaire-navigation-plan.md)
+- Related plan: [docs/plans/2026-04-28-001-feat-desktop-mcp-request-support-plan.md](2026-04-28-001-feat-desktop-mcp-request-support-plan.md)
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Related code: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- Related docs: [docs/messaging-adapter-contract.md](../messaging-adapter-contract.md)


### PR DESCRIPTION
## Summary

- Planned and implemented the messaging typing-indicator lifecycle fix.
- Kept Telegram/Discord typing active through working turns instead of stopping on the first assistant item message.
- Preserved idle behavior for terminal turn states and pending user-input breaks, then resumed typing for the same turn after approval/request resolution.
- Documented the generic activity lease boundary for messaging adapters.

## Verification

- `pnpm vitest run apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/telegram-adapter.test.ts apps/desktop/src/main/__tests__/discord-adapter.test.ts apps/desktop/src/main/__tests__/messaging-docs-links.test.ts --config vitest.workspace.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
