### PR TITLE
fix(desktop): review composer autocomplete overlay

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1009,24 +1009,27 @@ export function Composer(props: ComposerProps) {
       ? undefined
       : availableAutocompleteKind;
   const autocompleteKind: AutocompleteKind | undefined =
-    displayedAutocompleteKind === "slash" &&
-    parseReviewCommand(draft) &&
-    draft.trim() === "/review"
+    reviewConfig ||
+    (displayedAutocompleteKind === "slash" &&
+      parseReviewCommand(draft) &&
+      draft.trim() === "/review")
       ? undefined
       : displayedAutocompleteKind;
   const hasAutocomplete = Boolean(autocompleteKind);
   const activeAutocompleteIndex =
-    displayedAutocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
+    autocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
   const autocompleteLength =
-    displayedAutocompleteKind === "skills" ? filteredSkills.length : filteredSlashCommands.length;
+    autocompleteKind === "skills"
+      ? filteredSkills.length
+      : filteredSlashCommands.length;
   const autocompleteListboxId =
-    displayedAutocompleteKind === "skills"
+    autocompleteKind === "skills"
       ? skillListboxId
-      : displayedAutocompleteKind === "slash"
+      : autocompleteKind === "slash"
         ? slashListboxId
         : undefined;
   const activeAutocompleteOptionId =
-    autocompleteListboxId && displayedAutocompleteKind
+    autocompleteListboxId && autocompleteKind
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
   const reviewBranchOptions = useMemo(
@@ -1037,6 +1040,7 @@ export function Composer(props: ComposerProps) {
     [props.directory, props.thread]
   );
   const isBareReviewCommand = draft.trim() === "/review";
+  const isReviewComposerOpen = Boolean(reviewConfig && isBareReviewCommand);
 
   useEffect(() => {
     const previousScopeKey = activeComposerScopeKeyRef.current;
@@ -1101,17 +1105,17 @@ export function Composer(props: ComposerProps) {
   }, [composerImplementation]);
 
   useEffect(() => {
-    if (!displayedAutocompleteKind) {
+    if (!autocompleteKind) {
       return;
     }
 
     autocompleteOptionRefs.current[activeAutocompleteIndex]?.scrollIntoView?.({
       block: "nearest",
     });
-  }, [activeAutocompleteIndex, displayedAutocompleteKind]);
+  }, [activeAutocompleteIndex, autocompleteKind]);
 
   useEffect(() => {
-    if (!displayedAutocompleteKind) {
+    if (!autocompleteKind) {
       return;
     }
 
@@ -1140,7 +1144,7 @@ export function Composer(props: ComposerProps) {
     return () => {
       window.removeEventListener("resize", updateAutocompleteLayout);
     };
-  }, [activeAutocompleteIndex, displayedAutocompleteKind]);
+  }, [activeAutocompleteIndex, autocompleteKind]);
 
   useEffect(() => {
     if (!trigger) {
@@ -1400,6 +1404,27 @@ export function Composer(props: ComposerProps) {
       props.onActiveTurnIdChange?.(undefined);
       setSendError(error instanceof Error ? error.message : String(error));
     }
+  };
+
+  const enterReviewComposer = (): void => {
+    setReviewConfig(
+      createReviewConfig({
+        directory: props.directory,
+        thread: props.thread,
+      })
+    );
+    updateVisibleDraft("/review");
+    setDismissedAutocompleteKey(autocompleteKey);
+    setActiveSkillIndex(0);
+    setActiveSlashIndex(0);
+    setSendError(undefined);
+  };
+
+  const exitReviewComposer = (): void => {
+    setReviewConfig(undefined);
+    clearComposerDraft();
+    setSendError(undefined);
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
 
   const buildTurnPayload = (
@@ -1836,6 +1861,11 @@ export function Composer(props: ComposerProps) {
 
   const applySlashCommand = (command: SlashCommandSuggestion): void => {
     if (!inputRef.current) {
+      return;
+    }
+
+    if (command.id === "review-current") {
+      enterReviewComposer();
       return;
     }
 
@@ -2628,6 +2658,11 @@ export function Composer(props: ComposerProps) {
   const composerPlaceholder = isLaunchpad
     ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
     : "Reply to this thread";
+  const composerLabel = isReviewComposerOpen
+    ? "Review"
+    : isLaunchpad
+      ? "New thread"
+      : "Reply";
   const handleComposerChange = (
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
@@ -2745,8 +2780,11 @@ export function Composer(props: ComposerProps) {
         void submitTurn();
       }}
     >
-      <label className="composer__label" htmlFor="thread-composer">
-        {isLaunchpad ? "New thread" : "Reply"}
+      <label
+        className="composer__label"
+        htmlFor={isReviewComposerOpen ? undefined : "thread-composer"}
+      >
+        {composerLabel}
       </label>
 
       {pendingSteer ? (
@@ -2841,7 +2879,134 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       <div className="composer__input-wrap" ref={inputWrapRef}>
-        {composerImplementation === "custom-widget-chips" ? (
+        {isReviewComposerOpen ? (
+          <fieldset className="composer__review-config" aria-label="Review target">
+            <legend>Review target</legend>
+            <div className="composer__review-options">
+              {REVIEW_TARGET_OPTIONS.map((option) => (
+                <button
+                  key={option.target}
+                  type="button"
+                  aria-pressed={reviewConfig?.target === option.target}
+                  className={`composer__review-option${reviewConfig?.target === option.target ? " is-active" : ""}`}
+                  onClick={() => {
+                    setReviewConfig((current) => ({
+                      ...(current ??
+                        createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                      target: option.target,
+                    }));
+                    setSendError(undefined);
+                  }}
+                >
+                  <span>{option.label}</span>
+                  <small>{option.description}</small>
+                </button>
+              ))}
+            </div>
+
+            {reviewConfig?.target === "baseBranch" ? (
+              <label className="composer__review-field">
+                <span>Base branch</span>
+                <input
+                  className="composer__review-input"
+                  list="composer-review-branches"
+                  value={reviewConfig.branch}
+                  onChange={(event) => {
+                    setReviewConfig((current) => ({
+                      ...(current ??
+                        createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                      branch: event.target.value,
+                      target: "baseBranch",
+                    }));
+                    setSendError(undefined);
+                  }}
+                />
+                {reviewBranchOptions.length > 0 ? (
+                  <datalist id="composer-review-branches">
+                    {reviewBranchOptions.map((branch) => (
+                      <option key={branch} value={branch} />
+                    ))}
+                  </datalist>
+                ) : null}
+              </label>
+            ) : null}
+
+            {reviewConfig?.target === "commit" ? (
+              <label className="composer__review-field">
+                <span>Commit SHA</span>
+                <input
+                  className="composer__review-input"
+                  value={reviewConfig.commit}
+                  onChange={(event) => {
+                    setReviewConfig((current) => ({
+                      ...(current ??
+                        createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                      commit: event.target.value,
+                      target: "commit",
+                    }));
+                    setSendError(undefined);
+                  }}
+                />
+              </label>
+            ) : null}
+
+            {reviewConfig?.target === "custom" ? (
+              <label className="composer__review-field">
+                <span>Instructions</span>
+                <textarea
+                  className="composer__review-input composer__review-input--textarea"
+                  value={reviewConfig.customInstructions}
+                  onChange={(event) => {
+                    setReviewConfig((current) => ({
+                      ...(current ??
+                        createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                      customInstructions: event.target.value,
+                      target: "custom",
+                    }));
+                    setSendError(undefined);
+                  }}
+                />
+              </label>
+            ) : null}
+
+            <div className="composer__review-actions">
+              <button
+                type="button"
+                className="composer__secondary-action"
+                onClick={exitReviewComposer}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="composer__primary-action"
+                disabled={!buildConfiguredReviewCommand(reviewConfig)}
+                onClick={() => {
+                  const configuredReviewCommand =
+                    buildConfiguredReviewCommand(reviewConfig);
+                  if (!configuredReviewCommand) {
+                    return;
+                  }
+                  void submitReviewCommand(configuredReviewCommand);
+                }}
+              >
+                Start review
+              </button>
+            </div>
+          </fieldset>
+        ) : composerImplementation === "custom-widget-chips" ? (
           <ComposerRichInput
             ref={inputRef}
             id="thread-composer"
@@ -2951,7 +3116,7 @@ export function Composer(props: ComposerProps) {
           />
         )}
 
-        {displayedAutocompleteKind === "skills" ? (
+        {autocompleteKind === "skills" ? (
           <div
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
             role="listbox"
@@ -2995,7 +3160,7 @@ export function Composer(props: ComposerProps) {
               </button>
             ))}
           </div>
-        ) : displayedAutocompleteKind === "slash" ? (
+        ) : autocompleteKind === "slash" ? (
           <div
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
             role="listbox"
@@ -3043,138 +3208,6 @@ export function Composer(props: ComposerProps) {
           </div>
         ) : null}
       </div>
-
-      {reviewConfig && isBareReviewCommand ? (
-        <fieldset className="composer__review-config" aria-label="Review target">
-          <legend>Review target</legend>
-          <div className="composer__review-options">
-            {REVIEW_TARGET_OPTIONS.map((option) => (
-              <button
-                key={option.target}
-                type="button"
-                aria-pressed={reviewConfig.target === option.target}
-                className={`composer__review-option${reviewConfig.target === option.target ? " is-active" : ""}`}
-                onClick={() => {
-                  setReviewConfig((current) => ({
-                    ...(current ??
-                      createReviewConfig({
-                        directory: props.directory,
-                        thread: props.thread,
-                      })),
-                    target: option.target,
-                  }));
-                  setSendError(undefined);
-                }}
-              >
-                <span>{option.label}</span>
-                <small>{option.description}</small>
-              </button>
-            ))}
-          </div>
-
-          {reviewConfig.target === "baseBranch" ? (
-            <label className="composer__review-field">
-              <span>Base branch</span>
-              <input
-                className="composer__review-input"
-                list="composer-review-branches"
-                value={reviewConfig.branch}
-                onChange={(event) => {
-                  setReviewConfig((current) => ({
-                    ...(current ??
-                      createReviewConfig({
-                        directory: props.directory,
-                        thread: props.thread,
-                      })),
-                    branch: event.target.value,
-                    target: "baseBranch",
-                  }));
-                  setSendError(undefined);
-                }}
-              />
-              {reviewBranchOptions.length > 0 ? (
-                <datalist id="composer-review-branches">
-                  {reviewBranchOptions.map((branch) => (
-                    <option key={branch} value={branch} />
-                  ))}
-                </datalist>
-              ) : null}
-            </label>
-          ) : null}
-
-          {reviewConfig.target === "commit" ? (
-            <label className="composer__review-field">
-              <span>Commit SHA</span>
-              <input
-                className="composer__review-input"
-                value={reviewConfig.commit}
-                onChange={(event) => {
-                  setReviewConfig((current) => ({
-                    ...(current ??
-                      createReviewConfig({
-                        directory: props.directory,
-                        thread: props.thread,
-                      })),
-                    commit: event.target.value,
-                    target: "commit",
-                  }));
-                  setSendError(undefined);
-                }}
-              />
-            </label>
-          ) : null}
-
-          {reviewConfig.target === "custom" ? (
-            <label className="composer__review-field">
-              <span>Instructions</span>
-              <textarea
-                className="composer__review-input composer__review-input--textarea"
-                value={reviewConfig.customInstructions}
-                onChange={(event) => {
-                  setReviewConfig((current) => ({
-                    ...(current ??
-                      createReviewConfig({
-                        directory: props.directory,
-                        thread: props.thread,
-                      })),
-                    customInstructions: event.target.value,
-                    target: "custom",
-                  }));
-                  setSendError(undefined);
-                }}
-              />
-            </label>
-          ) : null}
-
-          <div className="composer__review-actions">
-            <button
-              type="button"
-              className="composer__secondary-action"
-              onClick={() => {
-                setReviewConfig(undefined);
-                setSendError(undefined);
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="composer__primary-action"
-              disabled={!buildConfiguredReviewCommand(reviewConfig)}
-              onClick={() => {
-                const configuredReviewCommand =
-                  buildConfiguredReviewCommand(reviewConfig);
-                if (!configuredReviewCommand) {
-                  return;
-                }
-                void submitReviewCommand(configuredReviewCommand);
-              }}
-            >
-              Start review
-            </button>
-          </div>
-        </fieldset>
-      ) : null}
 
       {imageAttachments.length > 0 ? (
         <div className="composer__attachments" aria-label="Pasted images">

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1246,10 +1246,11 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "/review" } });
 
-    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
     expect(startReview).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
@@ -1313,7 +1314,7 @@ describe("Composer", () => {
     });
   });
 
-  it("inserts slash review commands from autocomplete", async () => {
+  it("opens review composer from slash review autocomplete", async () => {
     render(
       <Composer
         desktopApi={{
@@ -1346,10 +1347,12 @@ describe("Composer", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /\/review/i }));
 
-    expect(textarea).toHaveValue("/review ");
+    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
   });
 
-  it("applies the focused slash command option from the keyboard", async () => {
+  it("opens review composer from the focused slash command option", async () => {
     render(
       <Composer
         desktopApi={{
@@ -1380,7 +1383,39 @@ describe("Composer", () => {
     expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(textarea).toHaveValue("/review ");
+    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
+  });
+
+  it("returns to an empty text entry when review composer is cancelled", async () => {
+    render(
+      <Composer
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/r" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toHaveValue("");
+    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
   });
 
   it("shows thread access in the composer and opens workspace handoff", async () => {


### PR DESCRIPTION
## Summary

I fixed the `/review` composer flow so entering review mode replaces the normal reply input with the review composer instead of leaving slash autocomplete layered over the review controls.

## What changed

- Open the review composer directly when `/review` is selected from slash autocomplete by click or Enter.
- Suppress autocomplete while review mode is active.
- Render the review target picker in the composer input slot, with Cancel returning to an empty normal reply entry.
- Cover the click, keyboard, bare `/review`, and cancel flows in composer tests.

## Verification

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
