### PR TITLE
fix(desktop): branch drift expected branch preservation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
 - For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragnt/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.
+- When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- packages/...` makes Vitest run the full workspace suite.
 
 ## Runtime Config
 

--- a/apps/desktop/e2e/thread-branch-drift.spec.ts
+++ b/apps/desktop/e2e/thread-branch-drift.spec.ts
@@ -1,0 +1,196 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createBranchDriftFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  stateRoot: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-branch-drift-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const stateRoot = path.join(rootDir, "state");
+  await mkdir(repoDir, { recursive: true });
+  await mkdir(stateRoot, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "codex/expected-branch"], {
+    cwd: repoDir,
+    stdio: "ignore",
+  });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed expected branch",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+  execFileSync("git", ["checkout", "-B", "codex/current-branch"], {
+    cwd: repoDir,
+    stdio: "ignore",
+  });
+
+  await writeFile(
+    path.join(stateRoot, "overlay-state.json"),
+    JSON.stringify(
+      {
+        version: 5,
+        backends: {},
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "default",
+          workMode: "local",
+        },
+        directoryLaunchpads: {},
+        threads: {
+          "codex:thread-branch-drift": {
+            backend: "codex",
+            threadId: "thread-branch-drift",
+            executionMode: "default",
+            observedGitBranch: "codex/expected-branch",
+            extraLinkedDirectories: [
+              {
+                id: "pwragnt-handoff:codex:thread-branch-drift",
+                kind: "worktree",
+                label: "FixtureRepo",
+                path: repoDir,
+                worktreePath: repoDir,
+              },
+            ],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const fixturePath = path.join(rootDir, "thread-branch-drift.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-branch-drift",
+          threadId: "thread-branch-drift",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-branch-drift",
+                title: "Branch drift replay",
+                titleSource: "explicit",
+                summary: "A thread whose checkout changed branch.",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "codex/expected-branch",
+                linkedDirectories: [],
+                updatedAt: 1_760_000_000_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The branch drift replay is loaded.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The branch drift replay is loaded.",
+                },
+              ],
+              lastAssistantMessage: "The branch drift replay is loaded.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+    stateRoot,
+  };
+}
+
+test("keeps the branch drift warning open after refreshing observed checkout state", async () => {
+  const fixture = await createBranchDriftFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      PWRAGNT_STATE_ROOT: fixture.stateRoot,
+    },
+  });
+
+  try {
+    const dialog = app.window.getByRole("dialog", {
+      name: "Thread branch changed",
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("codex/expected-branch");
+    await expect(dialog).toContainText("codex/current-branch");
+
+    await app.window.waitForTimeout(7_000);
+
+    await expect(dialog).toBeVisible();
+
+    const overlay = JSON.parse(
+      await readFile(path.join(fixture.stateRoot, "overlay-state.json"), "utf8"),
+    ) as {
+      threads: Record<string, { gitBranch?: string; observedGitBranch?: string }>;
+    };
+    expect(overlay.threads["codex:thread-branch-drift"]).toMatchObject({
+      gitBranch: "codex/expected-branch",
+      observedGitBranch: "codex/current-branch",
+    });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -157,6 +157,47 @@ describe("OverlayStore", () => {
     });
   });
 
+  it("promotes legacy observed handoff branch metadata before recording checkout drift", async () => {
+    const store = await createStore();
+
+    await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "pwragnt-handoff:codex:thread-1",
+        kind: "worktree",
+        label: "repo",
+        path: "/repo",
+        worktreePath: "/repo/.worktrees/repo-feature",
+      },
+    });
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/expected",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: undefined,
+      observedGitBranch: "feature/expected",
+    });
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/current",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "feature/expected",
+      observedGitBranch: "feature/current",
+    });
+  });
+
   it("stores worktree snapshot metadata by backend-qualified thread", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -201,6 +201,48 @@ describe("refresh reconciliation", () => {
     );
   });
 
+  it("keeps legacy handoff expected branch stable after observing checkout drift", async () => {
+    const store = await createStore();
+
+    await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "pwragnt-handoff:codex:thread-1",
+        kind: "worktree",
+        label: "PwrAgnt",
+        path: "/repo",
+        worktreePath: "/repo/.worktrees/pwragnt-feature",
+      },
+    });
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/thread-workspace-handoff-plan",
+    });
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "fix/context-rail-slide-reflow",
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [
+        buildThread({
+          gitBranch: "feat/thread-workspace-handoff-plan",
+          observedGitBranch: "fix/context-rail-slide-reflow",
+        }),
+      ],
+    });
+
+    expect(snapshot.threads[0]?.gitBranch).toBe("feat/thread-workspace-handoff-plan");
+    expect(snapshot.threads[0]?.observedGitBranch).toBe(
+      "fix/context-rail-slide-reflow",
+    );
+  });
+
   it("tracks mixed-backend threads with duplicate ids independently in aggregate snapshots", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -365,8 +365,21 @@ export class OverlayStore {
         executionMode: "default",
         extraLinkedDirectories: [],
       };
+      const previousObservedBranch = current.observedGitBranch?.trim();
+      const nextObservedBranch = params.branch?.trim();
+      const legacyHandoffExpectedBranch =
+        !current.gitBranch?.trim() &&
+        previousObservedBranch &&
+        nextObservedBranch &&
+        previousObservedBranch !== nextObservedBranch &&
+        hasHandoffWorkspace(current.extraLinkedDirectories)
+          ? previousObservedBranch
+          : undefined;
       const nextState: ThreadOverlayState = {
         ...current,
+        gitBranch: current.gitBranch?.trim()
+          ? current.gitBranch
+          : legacyHandoffExpectedBranch,
         observedGitBranch: params.branch,
       };
       data.threads[threadKey] = nextState;
@@ -516,4 +529,10 @@ export class OverlayStore {
     await writeFile(tempPath, JSON.stringify(data, null, 2), "utf8");
     await rename(tempPath, this.filePath);
   }
+}
+
+function hasHandoffWorkspace(
+  directories: ThreadOverlayState["extraLinkedDirectories"] = [],
+): boolean {
+  return directories.some((directory) => directory.id.startsWith("pwragnt-handoff:"));
 }


### PR DESCRIPTION
## Summary

I fixed branch drift handling for legacy handoff overlays so refreshing the observed checkout branch no longer silently promotes the current checkout into the expected branch. The branch-change warning now stays visible until the user explicitly retains the expected branch or updates it.

I also documented the `pnpm test` focused-run convention in `AGENTS.md` after verifying that `pnpm test -- packages/...` runs the full Vitest workspace while `pnpm test packages/...` correctly focuses the file.

## Verification

- I confirmed the new branch drift E2E failed before the fix.
- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/overlay-store.test.ts packages/agent-core/src/__tests__/refresh-reconciliation.test.ts`
- `pnpm --filter @pwragnt/desktop test:e2e -- thread-branch-drift.spec.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts`

## Notes

- A broad `pnpm test -- packages/agent-core/src/__tests__/overlay-store.test.ts` run intentionally reproduced the unfocused behavior and hit an unrelated existing failure in `apps/desktop/src/main/__tests__/index.test.ts`.
