### PR TITLE
fix(desktop): repair skill autocomplete regressions

### DIFF
--- a/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/skill-autocomplete-interactions/replay.fixture.json
@@ -1,0 +1,198 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "skill-autocomplete-interactions",
+    "threadId": "thread-skill-autocomplete"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-skill-autocomplete",
+          "title": "Skill autocomplete replay",
+          "titleSource": "explicit",
+          "summary": "Thread reply composer autocomplete regression coverage",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [
+            {
+              "id": "pwragnt-fixture",
+              "label": "PwrAgnt",
+              "path": "/Users/huntharo/github/PwrAgnt",
+              "kind": "local"
+            }
+          ],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "user",
+            "text": "Check the desktop composer autocomplete behavior."
+          },
+          {
+            "type": "message",
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready to exercise the thread reply composer."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "user",
+            "text": "Check the desktop composer autocomplete behavior."
+          },
+          {
+            "id": "message-2",
+            "role": "assistant",
+            "text": "Ready to exercise the thread reply composer."
+          }
+        ],
+        "lastUserMessage": "Check the desktop composer autocomplete behavior.",
+        "lastAssistantMessage": "Ready to exercise the thread reply composer.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "skills-list-1",
+      "kind": "response",
+      "method": "skills/list",
+      "result": [
+        {
+          "cwd": "/Users/huntharo/github/PwrAgnt",
+          "skills": [
+            {
+              "name": "adversarial-document-reviewer",
+              "description": "Conditional document-review persona, selected when the document has >5 requirements or implementation units.",
+              "path": "/Users/huntharo/.codex/skills/adversarial-document-reviewer/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "ce:brainstorm",
+              "description": "Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation.",
+              "path": "/Users/huntharo/.codex/skills/ce-brainstorm/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "ce:compound",
+              "description": "Document a recently solved problem to compound your team's knowledge.",
+              "path": "/Users/huntharo/.codex/skills/ce-compound/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "ce:plan",
+              "description": "Transform feature descriptions or requirements into structured implementation plans.",
+              "path": "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-01",
+              "description": "Generated skill 01 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-01/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-02",
+              "description": "Generated skill 02 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-02/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-03",
+              "description": "Generated skill 03 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-03/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-04",
+              "description": "Generated skill 04 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-04/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-05",
+              "description": "Generated skill 05 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-05/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-06",
+              "description": "Generated skill 06 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-06/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-07",
+              "description": "Generated skill 07 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-07/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            },
+            {
+              "name": "zz-scroll-skill-08",
+              "description": "Generated skill 08 for autocomplete paging coverage.",
+              "path": "/Users/huntharo/.codex/skills/zz-scroll-skill-08/SKILL.md",
+              "enabled": true,
+              "scope": "user"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-skill-autocomplete",
+        "turnId": "turn-skill-autocomplete"
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -1,0 +1,160 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Locator } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+  specDir,
+  "fixtures/skill-autocomplete-interactions/replay.fixture.json",
+);
+const customWidgetComposerEnv = {
+  PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "custom-widget-chips",
+};
+const reportedDraftPrefix =
+  "Oh shoot... I was wrong about this I think. I thought the desktop app didn't show the tool use but I was looking at a version of the desktop app that didn't start the turn. I just now looked at the instance that started the turn and it does indeed have the tool use notifications.\n\n\n\nLet's use ";
+
+async function openSkillAutocompleteThread(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+) {
+  await app.window
+    .getByRole("button", { name: /Skill autocomplete replay/i })
+    .first()
+    .click();
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: "Skill autocomplete replay",
+    }),
+  ).toBeVisible();
+  await expect(
+    app.window.getByText("Ready to exercise the thread reply composer."),
+  ).toBeVisible();
+}
+
+async function getActiveOptionIndex(
+  listbox: Locator,
+): Promise<number> {
+  return await listbox.getByRole("button").evaluateAll((buttons) =>
+    buttons.findIndex((button) => button.getAttribute("aria-selected") === "true"),
+  );
+}
+
+async function seedComposerDraft(input: Locator, value: string): Promise<void> {
+  await input.evaluate((element, nextValue) => {
+    const editor = element as HTMLElement & {
+      setSelectionRange: (start: number, end: number) => void;
+      value: string;
+    };
+    editor.value = nextValue;
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+    editor.setSelectionRange(nextValue.length, nextValue.length);
+  }, value);
+  await input.focus();
+}
+
+test("thread reply skill autocomplete filters and commits the reported multi-line draft", async () => {
+  const app = await launchElectronApp({
+    env: customWidgetComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await seedComposerDraft(richInput, reportedDraftPrefix);
+    await app.window.keyboard.type("$ce");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();
+
+    await app.window.keyboard.type(":p");
+    let firstOption = app.window
+      .getByRole("listbox", { name: "Skills" })
+      .getByRole("button")
+      .first();
+    await expect(firstOption).toContainText("$ce:plan");
+
+    await app.window.keyboard.type("lan");
+    firstOption = app.window
+      .getByRole("listbox", { name: "Skills" })
+      .getByRole("button")
+      .first();
+    await expect(firstOption).toContainText("$ce:plan");
+
+    await app.window.keyboard.press("Enter");
+
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeHidden();
+    await expect(
+      richInput.locator(".skill-chip", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(richInput).toHaveAttribute("data-value", reportedDraftPrefix);
+    await expect(richInput).not.toContainText("$ce:plan plan");
+
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await expect
+      .poll(async () => await app.getLastStartTurn())
+      .toMatchObject({
+        threadId: "thread-skill-autocomplete",
+        input: [
+          {
+            type: "text",
+            text: `${reportedDraftPrefix}[$ce:plan](/Users/huntharo/.codex/skills/ce-plan/SKILL.md)`.trim(),
+          },
+        ],
+      });
+  } finally {
+    await app.close();
+  }
+});
+
+test("thread reply skill autocomplete has a visible overlay boundary and page navigation", async () => {
+  const app = await launchElectronApp({
+    env: customWidgetComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const richInput = app.window.getByTestId("composer-rich-input");
+    await richInput.fill("$");
+
+    const listbox = app.window.getByRole("listbox", { name: "Skills" });
+    await expect(listbox).toBeVisible();
+
+    const overlayStyles = await listbox.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        backgroundColor: styles.backgroundColor,
+        borderTopColor: styles.borderTopColor,
+        boxShadow: styles.boxShadow,
+      };
+    });
+    const inputStyles = await richInput.evaluate((element) => {
+      const styles = getComputedStyle(element);
+      return {
+        backgroundColor: styles.backgroundColor,
+        borderTopColor: styles.borderTopColor,
+      };
+    });
+    expect(overlayStyles.backgroundColor).not.toBe(inputStyles.backgroundColor);
+    expect(overlayStyles.borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(overlayStyles.boxShadow).toContain("inset");
+
+    expect(await getActiveOptionIndex(listbox)).toBe(0);
+    await app.window.keyboard.press("PageDown");
+    expect(await getActiveOptionIndex(listbox)).toBeGreaterThan(1);
+    await app.window.keyboard.press("PageUp");
+    expect(await getActiveOptionIndex(listbox)).toBe(0);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -120,6 +120,75 @@ test("thread reply Tiptap skill autocomplete filters and commits the reported mu
   }
 });
 
+test("thread reply Tiptap skill insertion preserves rich Markdown blocks", async () => {
+  const app = await launchElectronApp({
+    env: tiptapWysiwygComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await textbox.evaluate((element) => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData(
+        "text/html",
+        [
+          "<p>Here is the code:</p>",
+          '<pre><code class="language-ts">const value = 1;\nreturn value;</code></pre>',
+          "<p>Let's use </p>",
+        ].join(""),
+      );
+      dataTransfer.setData(
+        "text/plain",
+        "Here is the code:\n\n```ts\nconst value = 1;\nreturn value;\n```\n\nLet's use ",
+      );
+      element.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dataTransfer,
+        }),
+      );
+    });
+    const closingParagraph = tiptapInput.locator("p", { hasText: "Let's use" }).last();
+    await closingParagraph.click();
+    await app.window.keyboard.press("End");
+    await app.window.keyboard.type(" ");
+
+    const codeBlock = tiptapInput.locator("pre", {
+      hasText: "const value = 1;\nreturn value;",
+    });
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock).not.toContainText("```");
+    const seededDraft = await tiptapInput.getAttribute("data-value");
+    expect(seededDraft).toContain("```ts\nconst value = 1;\nreturn value;\n```");
+    expect(seededDraft).toMatch(/Let's use $/);
+
+    await app.window.keyboard.type("$ce:plan");
+    await expect(
+      app.window.getByRole("button", { name: /\$ce:plan/i }),
+    ).toBeVisible();
+    await app.window.keyboard.press("Enter");
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock).not.toContainText("```");
+    await expect(tiptapInput).toHaveAttribute("data-value", seededDraft ?? "");
+  } finally {
+    await app.close();
+  }
+});
+
 test("thread reply skill autocomplete filters and commits the reported multi-line draft", async () => {
   const app = await launchElectronApp({
     env: customWidgetComposerEnv,

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -189,6 +189,92 @@ test("thread reply Tiptap skill insertion preserves rich Markdown blocks", async
   }
 });
 
+test("thread reply Tiptap Tab insertion keeps caret after chip and copy-paste preserves skill metadata", async () => {
+  const app = await launchElectronApp({
+    env: tiptapWysiwygComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("Let's use $ce:plan");
+    await expect(
+      app.window.getByRole("button", { name: /\$ce:plan/i }),
+    ).toBeVisible();
+    await app.window.keyboard.press("Tab");
+
+    const caretIsAfterChip = await tiptapInput.evaluate((element) => {
+      const chip = element.querySelector(".composer-tiptap-input__mention");
+      const selection = window.getSelection();
+      if (!chip || !selection || selection.rangeCount === 0) {
+        return false;
+      }
+
+      const caretRange = selection.getRangeAt(0);
+      const afterChipRange = document.createRange();
+      afterChipRange.setStartAfter(chip);
+      afterChipRange.collapse(true);
+      return caretRange.compareBoundaryPoints(
+        Range.START_TO_START,
+        afterChipRange,
+      ) >= 0;
+    });
+    expect(caretIsAfterChip).toBe(true);
+
+    await app.window.keyboard.type(" after");
+
+    const textAfterTabInsertion = await tiptapInput.innerText();
+    expect(textAfterTabInsertion.indexOf("$ce:plan")).toBeGreaterThanOrEqual(0);
+    expect(textAfterTabInsertion.indexOf("$ce:plan")).toBeLessThan(
+      textAfterTabInsertion.indexOf(" after"),
+    );
+
+    const chip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:plan",
+    });
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute(
+      "data-skill-path",
+      "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+    );
+
+    await textbox.focus();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+C" : "Control+C",
+    );
+    await app.window.keyboard.press("Delete");
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+V" : "Control+V",
+    );
+
+    const pastedChip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:plan",
+    });
+    await expect(pastedChip).toBeVisible();
+    await expect(tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$skill",
+    })).toHaveCount(0);
+    await expect(pastedChip).toHaveAttribute(
+      "data-skill-path",
+      "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
 test("thread reply skill autocomplete filters and commits the reported multi-line draft", async () => {
   const app = await launchElectronApp({
     env: customWidgetComposerEnv,

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -125,7 +125,8 @@ test("thread reply skill autocomplete has a visible overlay boundary and page na
     await openSkillAutocompleteThread(app);
 
     const richInput = app.window.getByTestId("composer-rich-input");
-    await richInput.fill("$");
+    await richInput.focus();
+    await app.window.keyboard.type("$");
 
     const listbox = app.window.getByRole("listbox", { name: "Skills" });
     await expect(listbox).toBeVisible();

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -11,6 +11,9 @@ const fixturePath = path.resolve(
 const customWidgetComposerEnv = {
   PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "custom-widget-chips",
 };
+const tiptapWysiwygComposerEnv = {
+  PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-wysiwyg-markdown-chips",
+};
 const reportedDraftPrefix =
   "Oh shoot... I was wrong about this I think. I thought the desktop app didn't show the tool use but I was looking at a version of the desktop app that didn't start the turn. I just now looked at the instance that started the turn and it does indeed have the tool use notifications.\n\n\n\nLet's use ";
 
@@ -52,6 +55,70 @@ async function seedComposerDraft(input: Locator, value: string): Promise<void> {
   }, value);
   await input.focus();
 }
+
+test("thread reply Tiptap skill autocomplete filters and commits the reported multi-line draft", async () => {
+  const app = await launchElectronApp({
+    env: tiptapWysiwygComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.fill(reportedDraftPrefix);
+    await textbox.focus();
+    await app.window.keyboard.press("End");
+    const seededDraft = await tiptapInput.getAttribute("data-value");
+    expect(seededDraft).toMatch(/Let's use $/);
+
+    await app.window.keyboard.type("$ce");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();
+
+    await app.window.keyboard.type(":p");
+    let firstOption = app.window
+      .getByRole("listbox", { name: "Skills" })
+      .getByRole("button")
+      .first();
+    await expect(firstOption).toContainText("$ce:plan");
+
+    await app.window.keyboard.type("lan");
+    firstOption = app.window
+      .getByRole("listbox", { name: "Skills" })
+      .getByRole("button")
+      .first();
+    await expect(firstOption).toContainText("$ce:plan");
+
+    await app.window.keyboard.press("Enter");
+
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeHidden();
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
+    ).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute("data-value", seededDraft ?? "");
+    await expect(tiptapInput).not.toContainText("$ce:plan plan");
+
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await expect
+      .poll(async () => await app.getLastStartTurn())
+      .toMatchObject({
+        threadId: "thread-skill-autocomplete",
+        input: [
+          {
+            type: "text",
+            text: `${seededDraft ?? ""}[$ce:plan](/Users/huntharo/.codex/skills/ce-plan/SKILL.md)`.trim(),
+          },
+        ],
+      });
+  } finally {
+    await app.close();
+  }
+});
 
 test("thread reply skill autocomplete filters and commits the reported multi-line draft", async () => {
   const app = await launchElectronApp({

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1829,7 +1829,7 @@ export function Composer(props: ComposerProps) {
       inputRef.current?.setSelectionRange(tokenIndex, tokenIndex);
     };
     if (composerUsesTiptap) {
-      requestAnimationFrame(restoreSelection);
+      requestAnimationFrame(() => inputRef.current?.focus());
     } else {
       restoreSelection();
     }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -807,6 +807,7 @@ function ComposerApplicationButton(props: {
 export function Composer(props: ComposerProps) {
   const inputRef = useRef<ComposerRichInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
+  const autocompleteListRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const skillListboxId = useId();
@@ -2574,27 +2575,53 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    const updateActiveAutocompleteIndex = (
+      updater: (current: number) => number,
+    ): void => {
+      if (autocompleteKind === "skills") {
+        setActiveSkillIndex(updater);
+      } else {
+        setActiveSlashIndex(updater);
+      }
+    };
+
+    const getAutocompletePageStep = (): number => {
+      const list = autocompleteListRef.current;
+      const option = autocompleteOptionRefs.current.find(Boolean);
+      const optionHeight = option?.getBoundingClientRect().height ?? 0;
+      if (list && optionHeight > 0) {
+        return Math.max(1, Math.floor(list.clientHeight / optionHeight));
+      }
+      return Math.max(1, Math.min(6, autocompleteLength - 1));
+    };
+
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      if (autocompleteKind === "skills") {
-        setActiveSkillIndex((current) =>
-          Math.min(current + 1, autocompleteLength - 1)
-        );
-      } else {
-        setActiveSlashIndex((current) =>
-          Math.min(current + 1, autocompleteLength - 1)
-        );
-      }
+      updateActiveAutocompleteIndex((current) =>
+        Math.min(current + 1, autocompleteLength - 1)
+      );
       return;
     }
 
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      if (autocompleteKind === "skills") {
-        setActiveSkillIndex((current) => Math.max(current - 1, 0));
-      } else {
-        setActiveSlashIndex((current) => Math.max(current - 1, 0));
-      }
+      updateActiveAutocompleteIndex((current) => Math.max(current - 1, 0));
+      return;
+    }
+
+    if (event.key === "PageDown") {
+      event.preventDefault();
+      const pageStep = getAutocompletePageStep();
+      updateActiveAutocompleteIndex((current) =>
+        Math.min(current + pageStep, autocompleteLength - 1)
+      );
+      return;
+    }
+
+    if (event.key === "PageUp") {
+      event.preventDefault();
+      const pageStep = getAutocompletePageStep();
+      updateActiveAutocompleteIndex((current) => Math.max(current - pageStep, 0));
       return;
     }
 
@@ -2954,6 +2981,7 @@ export function Composer(props: ComposerProps) {
         {displayedAutocompleteKind === "skills" ? (
           <div
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            ref={autocompleteListRef}
             role="listbox"
             aria-label="Skills"
             id={skillListboxId}
@@ -2998,6 +3026,7 @@ export function Composer(props: ComposerProps) {
         ) : displayedAutocompleteKind === "slash" ? (
           <div
             className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            ref={autocompleteListRef}
             role="listbox"
             aria-label="Commands"
             id={slashListboxId}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -42,18 +42,30 @@ const SkillMention = Mention.extend({
     return {
       id: {
         default: null,
+        parseHTML: (element) =>
+          element.getAttribute("data-composer-skill-token-id") ??
+          element.getAttribute("data-id"),
       },
       name: {
         default: null,
+        parseHTML: (element) =>
+          element.getAttribute("data-skill-name") ??
+          element.getAttribute("data-label") ??
+          element.textContent?.replace(/^\$/, "") ??
+          null,
       },
       path: {
         default: null,
+        parseHTML: (element) => element.getAttribute("data-skill-path"),
       },
       description: {
         default: null,
+        parseHTML: (element) => element.getAttribute("data-skill-description"),
       },
       shortDescription: {
         default: null,
+        parseHTML: (element) =>
+          element.getAttribute("data-skill-short-description"),
       },
     };
   },
@@ -71,8 +83,16 @@ const SkillMention = Mention.extend({
         class: "thread-row__chip skill-chip composer-tiptap-input__mention",
         "data-type": "mention",
         "data-composer-skill-token-id": String(node.attrs.id ?? ""),
+        "data-id": String(node.attrs.id ?? ""),
+        "data-label": skill.name,
         "data-skill-name": skill.name,
         ...(skill.path ? { "data-skill-path": skill.path } : {}),
+        ...(skill.description
+          ? { "data-skill-description": skill.description }
+          : {}),
+        ...(skill.shortDescription
+          ? { "data-skill-short-description": skill.shortDescription }
+          : {}),
         ...(tooltip ? { "data-tooltip": tooltip } : {}),
       },
       `$${skill.name}`,
@@ -663,7 +683,7 @@ function applyExternalSkillInsertion(params: {
   return params.editor.commands.insertContentAt(
     { from, to },
     insertedContent,
-    { updateSelection: false },
+    { updateSelection: true },
   );
 }
 
@@ -833,6 +853,7 @@ export const ComposerTiptapInput = forwardRef<
         selectionIndex: selectionIndexRef.current,
       })
     ) {
+      pendingSelectionIndexRef.current = undefined;
       return;
     }
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -407,13 +407,29 @@ function insertWysiwygSoftBreak(editor: TiptapEditor): boolean {
 function getDraftIndexAtPosition(
   editor: NonNullable<ReturnType<typeof useEditor>>,
   position: number,
+  mode: TiptapReadMode,
 ): number {
   let index = 0;
   let found = false;
 
-  editor.state.doc.descendants((node, pos) => {
+  editor.state.doc.descendants((node, pos, parent, childIndex) => {
     if (found) {
       return false;
+    }
+
+    if (parent?.type.name === "doc") {
+      if (position <= pos) {
+        found = true;
+        return false;
+      }
+      if (childIndex > 0) {
+        index += mode === "markdown" ? 2 : 1;
+      }
+      if (position <= pos + 1) {
+        found = true;
+        return false;
+      }
+      return true;
     }
 
     if (node.isText) {
@@ -450,14 +466,28 @@ function getDraftIndexAtPosition(
 function getPositionAtDraftIndex(
   editor: NonNullable<ReturnType<typeof useEditor>>,
   draftIndex: number,
+  mode: TiptapReadMode,
 ): number {
   let index = 0;
   let position = editor.state.doc.content.size;
   let found = false;
 
-  editor.state.doc.descendants((node, pos) => {
+  editor.state.doc.descendants((node, pos, parent, childIndex) => {
     if (found) {
       return false;
+    }
+
+    if (parent?.type.name === "doc") {
+      if (childIndex > 0) {
+        const separatorLength = mode === "markdown" ? 2 : 1;
+        if (draftIndex < index + separatorLength) {
+          position = pos + 1;
+          found = true;
+          return false;
+        }
+        index += separatorLength;
+      }
+      return true;
     }
 
     if (node.isText) {
@@ -626,6 +656,7 @@ export const ComposerTiptapInput = forwardRef<
       selectionIndexRef.current = getDraftIndexAtPosition(
         nextEditor,
         nextEditor.state.selection.from,
+        readMode,
       );
       propsRef.current.onChange(next.value, next.skillTokens);
     },
@@ -633,6 +664,7 @@ export const ComposerTiptapInput = forwardRef<
       selectionIndexRef.current = getDraftIndexAtPosition(
         nextEditor,
         nextEditor.state.selection.from,
+        readMode,
       );
     },
   });
@@ -689,7 +721,7 @@ export const ComposerTiptapInput = forwardRef<
       pendingSelectionIndexRef.current = undefined;
       selectionIndexRef.current = nextSelectionIndex;
       editor.commands.setTextSelection(
-        getPositionAtDraftIndex(editor, nextSelectionIndex),
+        getPositionAtDraftIndex(editor, nextSelectionIndex, readMode),
       );
     }
   }, [editor, props.skillTokens, props.value, propsSignature, readMode]);
@@ -751,7 +783,7 @@ export const ComposerTiptapInput = forwardRef<
         return;
       }
       selectionIndexRef.current = start;
-      editor.commands.setTextSelection(getPositionAtDraftIndex(editor, start));
+      editor.commands.setTextSelection(getPositionAtDraftIndex(editor, start, readMode));
     },
   }));
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -14,7 +14,7 @@ import Mention from "@tiptap/extension-mention";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorContent, useEditor, type JSONContent } from "@tiptap/react";
 import type { AppServerSkillSummary } from "@pwragnt/shared";
-import { buildSkillTooltip } from "../../lib/skill-mentions";
+import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
 import type {
   ComposerRichInputHandle,
   ComposerRichInputProps,
@@ -404,6 +404,22 @@ function insertWysiwygSoftBreak(editor: TiptapEditor): boolean {
   return editor.commands.setHardBreak();
 }
 
+function getCodeBlockMarkdownParts(node: ProseMirrorNode): {
+  contentLength: number;
+  prefixLength: number;
+  totalLength: number;
+} {
+  const language = typeof node.attrs.language === "string" ? node.attrs.language : "";
+  const prefixLength = `\`\`\`${language}\n`.length;
+  const contentLength = node.textContent.length;
+  const suffixLength = "\n```".length;
+  return {
+    contentLength,
+    prefixLength,
+    totalLength: prefixLength + contentLength + suffixLength,
+  };
+}
+
 function getDraftIndexAtPosition(
   editor: NonNullable<ReturnType<typeof useEditor>>,
   position: number,
@@ -424,6 +440,16 @@ function getDraftIndexAtPosition(
       }
       if (childIndex > 0) {
         index += mode === "markdown" ? 2 : 1;
+      }
+      if (mode === "markdown" && node.type.name === "codeBlock") {
+        const codeBlock = getCodeBlockMarkdownParts(node);
+        const nodeEnd = pos + node.nodeSize;
+        if (position >= nodeEnd) {
+          index += codeBlock.totalLength;
+          return false;
+        }
+        index += codeBlock.prefixLength;
+        return true;
       }
       if (position <= pos + 1) {
         found = true;
@@ -487,12 +513,29 @@ function getPositionAtDraftIndex(
         }
         index += separatorLength;
       }
+      if (mode === "markdown" && node.type.name === "codeBlock") {
+        const codeBlock = getCodeBlockMarkdownParts(node);
+        if (draftIndex <= index + codeBlock.totalLength) {
+          const codeContentIndex = draftIndex - index - codeBlock.prefixLength;
+          if (codeContentIndex <= 0) {
+            position = pos + 1;
+          } else if (codeContentIndex <= codeBlock.contentLength) {
+            position = pos + 1 + codeContentIndex;
+          } else {
+            position = pos + node.nodeSize;
+          }
+          found = true;
+          return false;
+        }
+        index += codeBlock.totalLength;
+        return false;
+      }
       return true;
     }
 
     if (node.isText) {
       const textLength = node.text?.length ?? 0;
-      if (draftIndex < index + textLength) {
+      if (draftIndex <= index + textLength) {
         position = pos + Math.max(0, draftIndex - index);
         found = true;
         return false;
@@ -540,6 +583,16 @@ function getSkillSummary(attrs: Record<string, unknown>): AppServerSkillSummary 
   };
 }
 
+function getSkillMentionAttrs(skill: ComposerSkillToken): Record<string, unknown> {
+  return {
+    id: skill.id,
+    name: skill.name,
+    path: skill.path ?? null,
+    description: skill.description ?? null,
+    shortDescription: skill.shortDescription ?? null,
+  };
+}
+
 function getContentSignature(params: {
   skillTokens: ComposerSkillToken[];
   value: string;
@@ -552,6 +605,66 @@ function getContentSignature(params: {
       path: token.path,
     })),
   });
+}
+
+function applyExternalSkillInsertion(params: {
+  current: TiptapReadState;
+  editor: TiptapEditor;
+  nextSkillTokens: ComposerSkillToken[];
+  nextValue: string;
+  readMode: TiptapReadMode;
+  selectionIndex: number;
+}): boolean {
+  if (params.nextSkillTokens.length !== params.current.skillTokens.length + 1) {
+    return false;
+  }
+
+  const currentTokenIds = new Set(
+    params.current.skillTokens.map((token) => token.id),
+  );
+  const insertedSkill = params.nextSkillTokens.find(
+    (token) => !currentTokenIds.has(token.id),
+  );
+  if (!insertedSkill) {
+    return false;
+  }
+
+  const trigger =
+    findSkillTrigger(params.current.value, params.selectionIndex) ??
+    findSkillTrigger(params.current.value, params.current.value.length);
+  if (!trigger || trigger.start !== insertedSkill.index) {
+    return false;
+  }
+
+  const before = params.current.value.slice(0, trigger.start);
+  const after = params.current.value.slice(trigger.end);
+  const insertedSpace = after.length > 0 && !/^\s/.test(after);
+  const expectedValue = `${before}${insertedSpace ? " " : ""}${after}`;
+  if (params.nextValue !== expectedValue) {
+    return false;
+  }
+
+  const from = getPositionAtDraftIndex(
+    params.editor,
+    trigger.start,
+    params.readMode,
+  );
+  const to = getPositionAtDraftIndex(params.editor, trigger.end, params.readMode);
+  const insertedContent: JSONContent[] = [
+    {
+      type: "mention",
+      attrs: getSkillMentionAttrs(insertedSkill),
+    },
+  ];
+  if (insertedSpace) {
+    insertedContent.push({ type: "text", text: " " });
+  }
+
+  return params.editor.commands.insertContentAt(
+    { from, to },
+    insertedContent,
+    { updateSelection: false },
+  );
 }
 
 export const ComposerTiptapInput = forwardRef<
@@ -706,6 +819,20 @@ export const ComposerTiptapInput = forwardRef<
     const currentSignature = getContentSignature(current);
     if (currentSignature === propsSignature) {
       pendingExternalSignatureRef.current = undefined;
+      return;
+    }
+
+    pendingExternalSignatureRef.current = propsSignature;
+    if (
+      applyExternalSkillInsertion({
+        current,
+        editor,
+        nextSkillTokens: props.skillTokens,
+        nextValue: props.value,
+        readMode,
+        selectionIndex: selectionIndexRef.current,
+      })
+    ) {
       return;
     }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -80,6 +80,68 @@ function backendSummary(
   };
 }
 
+const reportedSkillAutocompleteDraftPrefix =
+  "Oh shoot... I was wrong about this I think. I thought the desktop app didn't show the tool use but I was looking at a version of the desktop app that didn't start the turn. I just now looked at the instance that started the turn and it does indeed have the tool use notifications.\n\n\n\nLet's use ";
+
+const autocompleteRegressionSkills = [
+  {
+    name: "adversarial-document-reviewer",
+    description:
+      "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions.",
+    path: "/Users/huntharo/.codex/skills/adversarial-document-reviewer/SKILL.md",
+    enabled: true,
+  },
+  {
+    name: "ce:brainstorm",
+    description:
+      "Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation.",
+    path: "/Users/huntharo/.codex/skills/ce-brainstorm/SKILL.md",
+    enabled: true,
+  },
+  {
+    name: "ce:compound",
+    description: "Document a recently solved problem to compound your team's knowledge.",
+    path: "/Users/huntharo/.codex/skills/ce-compound/SKILL.md",
+    enabled: true,
+  },
+  {
+    name: "ce:plan",
+    description: "Transform feature descriptions or requirements into structured implementation plans.",
+    path: "/Users/huntharo/.codex/skills/ce-plan/SKILL.md",
+    enabled: true,
+  },
+];
+
+function renderComposerWithRegressionSkills(
+  startTurn = vi.fn(async () => ({
+    backend: "codex" as const,
+    threadId: "thread-1",
+    turnId: "turn-1",
+  })),
+): { startTurn: typeof startTurn } {
+  render(
+    <Composer
+      composerImplementation="custom-widget-chips"
+      desktopApi={{
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      }}
+      disabled={false}
+      skills={autocompleteRegressionSkills}
+      thread={{
+        id: "thread-1",
+        title: "Build Codex client",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      }}
+    />
+  );
+
+  return { startTurn };
+}
+
 describe("Composer", () => {
   it("opens the current workspace in discovered applications", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
@@ -2261,6 +2323,75 @@ describe("Composer", () => {
     expect(options.slice(2).join(" ")).toContain("$adversarial-document-reviewer");
   });
 
+  it("filters skill autocomplete from the reported multi-line draft body", () => {
+    renderComposerWithRegressionSkills();
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}$ce` },
+    });
+
+    expect(screen.getByRole("listbox", { name: "Skills" })).toBeInTheDocument();
+
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}$ce:p` },
+    });
+
+    let options = within(screen.getByRole("listbox", { name: "Skills" }))
+      .getAllByRole("button")
+      .map((option) => option.textContent ?? "");
+
+    expect(options[0]).toContain("$ce:plan");
+    expect(options[0]).not.toContain("$ce:brainstorm");
+
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}$ce:plan` },
+    });
+
+    options = within(screen.getByRole("listbox", { name: "Skills" }))
+      .getAllByRole("button")
+      .map((option) => option.textContent ?? "");
+
+    expect(options[0]).toContain("$ce:plan");
+    expect(options[0]).not.toContain("$ce:brainstorm");
+  });
+
+  it("commits a skill in the reported multi-line draft without leftover text or extra blank lines", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    renderComposerWithRegressionSkills(startTurn);
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}$ce:plan` },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const richInput = screen.getByTestId("composer-rich-input");
+    expect(within(richInput).getByText("$ce:plan")).toBeInTheDocument();
+    expect(input).toHaveValue(reportedSkillAutocompleteDraftPrefix);
+    expect(richInput).toHaveTextContent("Let's use");
+    expect(richInput).not.toHaveTextContent("Let's use $ce:plan plan");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "text",
+            text: `${reportedSkillAutocompleteDraftPrefix}[$ce:plan](/Users/huntharo/.codex/skills/ce-plan/SKILL.md)`.trim(),
+          },
+        ],
+      });
+    });
+  });
+
   it("renders selected skill chips without leaving raw mention text", async () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -2725,6 +2856,65 @@ describe("Composer", () => {
     expect(within(screen.getByTestId("composer-rich-input")).getByText("$ce:plan")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toHaveValue("");
     expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
+  });
+
+  it("moves skill autocomplete by a page with PageDown and PageUp", () => {
+    render(
+      <Composer
+        composerImplementation="custom-widget-chips"
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={Array.from({ length: 12 }, (_, index) => {
+          const suffix = String(index + 1).padStart(2, "0");
+          return {
+            name: `ce:test-${suffix}`,
+            description: `Generated test skill ${suffix}`,
+            path: `/Users/huntharo/.codex/skills/ce-test-${suffix}/SKILL.md`,
+            enabled: true,
+          };
+        })}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, { target: { value: "$ce" } });
+
+    const listbox = screen.getByRole("listbox", { name: "Skills" });
+    const getActiveOptionIndex = (): number =>
+      within(listbox)
+        .getAllByRole("button")
+        .findIndex((option) => option.getAttribute("aria-selected") === "true");
+
+    expect(getActiveOptionIndex()).toBe(0);
+
+    fireEvent.keyDown(input, { key: "PageDown" });
+    expect(getActiveOptionIndex()).toBeGreaterThan(1);
+
+    fireEvent.keyDown(input, { key: "PageUp" });
+    expect(getActiveOptionIndex()).toBe(0);
+
+    fireEvent.keyDown(input, { key: "PageUp" });
+    expect(getActiveOptionIndex()).toBe(0);
+
+    for (let index = 0; index < 4; index += 1) {
+      fireEvent.keyDown(input, { key: "PageDown" });
+    }
+    expect(getActiveOptionIndex()).toBe(11);
   });
 
   it("dismisses skill autocomplete when Escape is pressed from a focused option", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -153,6 +153,15 @@ describe("Tangerine Terminal theme contract", () => {
     expect(compactTitleRule).not.toContain("line-height: 1;");
   });
 
+  it("keeps composer autocomplete visually separated from transcript surfaces", () => {
+    const autocompleteRule = extractRuleBody(css, ".composer__autocomplete");
+
+    expect(autocompleteRule).toContain("border: 1px solid var(--border-strong);");
+    expect(autocompleteRule).toContain("background: var(--bg-panel-elevated);");
+    expect(autocompleteRule).toContain("inset 0 0 0 1px rgba(247, 243, 235, 0.06)");
+    expect(autocompleteRule).not.toContain("background: rgba(10, 10, 10, 0.98);");
+  });
+
   it("keeps thinking scanner variants on one shared visible sweep", () => {
     expect(css).toContain("--thinking-scanner-progress: 0;");
     expect(css).toContain("--thinking-scanner-full-offset: 0px;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4377,8 +4377,10 @@ textarea {
   padding: 8px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: rgba(10, 10, 10, 0.98);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
+  background: var(--bg-panel-elevated);
+  box-shadow:
+    inset 0 0 0 1px rgba(247, 243, 235, 0.06),
+    0 18px 48px rgba(0, 0, 0, 0.52);
   scrollbar-color: var(--border-strong) transparent;
   scrollbar-width: thin;
 }

--- a/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
+++ b/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Repair skill autocomplete filtering and insertion regressions
 type: fix
-status: active
+status: completed
 date: 2026-05-02
 ---
 

--- a/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
+++ b/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
@@ -1,0 +1,307 @@
+---
+title: fix: Repair skill autocomplete filtering and insertion regressions
+type: fix
+status: active
+date: 2026-05-02
+---
+
+# fix: Repair skill autocomplete filtering and insertion regressions
+
+## Overview
+
+Fix the desktop composer skill autocomplete regressions seen when inserting a skill into the body of a multi-line reply. The implementation should add failing coverage first, then make `$ce`, `$ce:p`, and `$ce:plan` open and filter correctly, make keyboard insertion replace the full typed trigger without leaving suffix text or adding blank lines, improve popup contrast against the transcript, and add PageUp/PageDown navigation while autocomplete is open.
+
+## Problem Frame
+
+The current composer autocomplete can lose the real caret/query context in multi-line drafts. In the reported flow, typing `$ce` after a long paragraph did not open autocomplete, typing `$ce:p` opened a list that was effectively unfiltered, typing `$ce:plan` still highlighted `$ce:brainstorm`, and committing `$ce:plan` inserted a chip while leaving `plan` as raw text and adding one or two blank lines above the insertion line. The visual list also blends into the transcript behind it, making the overlay boundary hard to read.
+
+## Requirements Trace
+
+- R1. Typing `$ce` in the body of a multi-line composer draft opens skill autocomplete when matching skills exist.
+- R2. Typing namespace prefixes such as `$ce:p` filters by the complete typed prefix so `$ce:plan` ranks ahead of unrelated or description-only matches.
+- R3. Typing the full skill label `$ce:plan` keeps `$ce:plan` as the active/top match instead of selecting `$ce:brainstorm`.
+- R4. Keyboard selection with Arrow keys and Enter replaces the entire active trigger range and leaves no raw suffix text such as `plan`.
+- R5. Skill insertion into a multi-line draft preserves existing line breaks exactly and does not add blank lines above the insertion line.
+- R6. The autocomplete popup has a clearer visual boundary against transcript/content behind it while staying within the Tangerine Terminal theme.
+- R7. PageUp and PageDown move the active autocomplete selection by approximately one visible page while the popup is open, for both skill and slash autocomplete where the shared handler applies.
+- R8. Existing inline chip serialization remains intact: selected skills still send as markdown links with the skill path.
+
+## Scope Boundaries
+
+- This plan only covers desktop renderer composer autocomplete behavior and styling.
+- This plan does not change app-server skill discovery, lazy skill loading, skill metadata shape, or `skills/list` responses.
+- This plan does not redesign transcript rendering or thread message layout.
+- This plan does not refresh replay fixtures unless existing deterministic E2E fixture builders cannot express the reported flow.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` owns skill filtering, active autocomplete indexes, keyboard handling, `applySkill`, and popup rendering.
+- `apps/desktop/src/renderer/src/lib/skill-mentions.ts` owns `findSkillTrigger`, mention markdown construction, and trigger insertion helpers.
+- `apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx` maps contenteditable DOM selection and zero-width skill chips back to draft indexes.
+- `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx` maps TipTap selections and mention nodes back to draft indexes for the TipTap composer path.
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` already covers basic skill insertion, prefix ranking, inline chip rendering, and focused option activation.
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` already covers skill autocomplete in Electron, active keyboard selection, long-list scrolling, and both custom-widget and TipTap composer implementations.
+- `apps/desktop/src/renderer/src/styles/app.css` contains `.composer__autocomplete` and option styling. The theme source of truth is `docs/UI-THEME.md`; the desktop layout source is `docs/design/desktop-style-guide.md`.
+- `docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md` is the completed predecessor plan. This follow-up preserves its inline chip and path-bearing markdown decisions while fixing the newly reported regression.
+
+### Reported Draft Fixture
+
+Tests should use this exact multi-line draft body before the typed skill trigger:
+
+```text
+Oh shoot... I was wrong about this I think. I thought the desktop app didn't show the tool use but I was looking at a version of the desktop app that didn't start the turn. I just now looked at the instance that started the turn and it does indeed have the tool use notifications.
+
+
+
+Let's use $ce
+```
+
+The `$ce` suffix should be varied to `$ce:p` and `$ce:plan` in trigger/filtering tests. Commit tests should start from the `$ce:plan` variant and assert the selected chip replaces the whole trigger.
+
+### Institutional Learnings
+
+- No `docs/solutions/` entries were present in this worktree for this topic.
+
+### External References
+
+- External research is not needed. The issue is grounded in local React renderer state, contenteditable/TipTap selection mapping, CSS token usage, and existing Playwright coverage.
+
+## Key Technical Decisions
+
+- Treat trigger detection and trigger replacement as one shared contract: the same start/end/query range used to filter autocomplete must be the range used by `applySkill` when committing a skill. This prevents the UI from filtering on one query while insertion replaces a different range.
+- Prefer exact and prefix skill-name matches over description matches for namespaced skills. Description fallback remains useful for discovery, but it should never outrank a name that exactly equals or starts with the typed `$` query.
+- Add regression tests around the reported multi-line text before implementation. This is a user-visible editor regression with several interacting symptoms, so tests should lock the observed contract before changing helpers.
+- Improve the autocomplete boundary with theme-consistent contrast rather than a light-gray slab. Use `--bg-panel-elevated`, `--border-strong`, a subtle inner outline, and active-row tangerine cues so the popup reads as an overlay while preserving the black-first workstation feel.
+- Implement PageUp/PageDown through the existing active-index path, not through native page scrolling. When autocomplete is open, these keys should be captured like ArrowUp/ArrowDown and keep the active option visible with the existing `scrollIntoView` behavior.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this update the completed 2026-04-30 plan? No. That plan is marked `status: complete` and describes the previous implementation. This is a follow-up regression plan with new requirements and should remain separate.
+- Should the autocomplete list use a lighter gray background? Not as the primary design move. A lighter border/outline and slightly elevated near-black panel better match `docs/UI-THEME.md` while making the overlay boundary clearer.
+- Should PageUp/PageDown affect the page behind the composer while autocomplete is open? No. While the popup is open, autocomplete owns those keys, just like it already owns ArrowUp/ArrowDown.
+
+### Deferred to Implementation
+
+- Exact page-step size for PageUp/PageDown: implementation should derive this from visible options or popup height if straightforward; otherwise use a small constant that approximates one visible page and is covered by tests.
+- Exact root cause of the blank-line insertion: implementation should determine whether the issue comes from trigger fallback to draft end, stale selection index, TipTap paragraph conversion, contenteditable hard-break handling, or programmatic change reconciliation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Draft["Composer draft text"]
+    Caret["Current draft selection index"]
+    Trigger["findSkillTrigger result"]
+    Filter["Rank/filter skills from trigger.query"]
+    Popup["Autocomplete active option"]
+    Commit["applySkill uses same trigger range"]
+    Tokens["Draft plus inline skill token"]
+
+    Draft --> Trigger
+    Caret --> Trigger
+    Trigger --> Filter
+    Filter --> Popup
+    Popup --> Commit
+    Trigger --> Commit
+    Commit --> Tokens
+```
+
+The key invariant is that `Trigger` is computed from the current draft and current selection, then carried through filtering and commit. Falling back to a different trigger, or recomputing against stale selection, is where partial replacement and leftover suffix text can occur.
+
+## Implementation Units
+
+- [ ] **Unit 1: Lock down trigger detection and filtering regressions**
+
+**Goal:** Add failing coverage for `$ce`, `$ce:p`, and `$ce:plan` in the reported multi-line composer text, then make skill filtering use the full typed prefix consistently.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/skill-mentions.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Add component tests using the exact reported draft fixture before `Let's use $ce`, `Let's use $ce:p`, and `Let's use $ce:plan`.
+- Include skills in the same relative order as the screenshots and fixture data: `ce:brainstorm`, `ce:compound`, `ce:plan`, and at least one description-only adversarial match.
+- Verify `$ce` opens the Skills listbox from a multi-line draft.
+- Verify `$ce:p` and `$ce:plan` put `$ce:plan` before `$ce:brainstorm` and description-only matches.
+- Review `findSkillTrigger` and selection-index sources for both textarea/custom-widget and TipTap paths. The fix should preserve existing valid trigger boundaries while accepting the reported inline body case.
+- Keep description matching as fallback discovery only after exact, colon-prefix, and plain prefix name matches.
+
+**Execution note:** Add the failing tests before changing trigger or ranking behavior.
+
+**Patterns to follow:**
+- Existing "prioritizes skill name prefix matches over description-only matches" coverage in `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
+- Existing `rankSkillAutocompleteMatch` scoring in `apps/desktop/src/renderer/src/features/composer/Composer.tsx`.
+
+**Test scenarios:**
+- Happy path: with the reported multi-line draft ending in `Let's use $ce`, the Skills listbox opens and contains `ce:` skills.
+- Happy path: with the draft ending in `Let's use $ce:p`, `$ce:plan` is the first skill option.
+- Happy path: with the draft ending in `Let's use $ce:plan`, `$ce:plan` remains the first skill option.
+- Edge case: a description-only match containing `ce` does not rank above a skill whose name starts with `ce:`.
+- Regression: existing slash command autocomplete still filters and inserts independently of skill trigger changes.
+
+**Verification:**
+- The component tests fail on the current behavior and pass after the trigger/filtering fix.
+- No app-server or skill loading behavior changes are needed.
+
+- [ ] **Unit 2: Make skill commit replace the active trigger without text or line-break damage**
+
+**Goal:** Ensure keyboard commit replaces the full typed trigger range in a multi-line draft, inserts one inline skill chip, leaves no raw suffix text, and preserves existing newlines exactly.
+
+**Requirements:** R4, R5, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Test: `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`
+
+**Approach:**
+- Add tests that type or set the exact reported draft fixture with `Let's use $ce:plan`, commit with Enter, and assert the draft text around the chip is exactly the original text with the trigger removed.
+- Assert the rich input contains one `$ce:plan` chip and does not contain a raw trailing `plan` text node.
+- Assert the line count and blank-line structure before `Let's use` are unchanged after insertion.
+- Remove or constrain the current fallback in `applySkill` that can recompute `findSkillTrigger(draft, draft.length)` when the selection trigger is missing. That fallback is useful only if it cannot replace the wrong trigger in multi-line bodies.
+- If the root cause is stale selection reporting, align `selectionStart`/`selectionEnd` updates in `ComposerRichInput.tsx` and `ComposerTiptapInput.tsx` so `Composer.tsx` sees the caret location that produced the popup.
+- Keep token insertion zero-width in the canonical draft, preserving send-time markdown serialization from existing inline chip logic.
+- Add or extend a thread reply composer E2E spec for this regression. `directory-launchpad-skills.spec.ts` remains useful for long-list and implementation-mode coverage, but the user-reported failure happened in the thread reply composer under the transcript.
+
+**Execution note:** Add characterization coverage for the exact reported draft before changing `applySkill` or selection mapping.
+
+**Patterns to follow:**
+- Existing inline chip tests in `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
+- Existing `typeSkillChip` helper and TipTap/custom-widget coverage in `apps/desktop/e2e/directory-launchpad-skills.spec.ts`.
+
+**Test scenarios:**
+- Happy path: committing `$ce:plan` with Enter in the reported multi-line draft inserts exactly one `$ce:plan` chip.
+- Happy path: after commit, the serialized send payload contains the original prose plus one `[$ce:plan](...)` mention and no duplicate `plan` text.
+- Edge case: the text before `Let's use` has the same number of newline characters before and after commit.
+- Edge case: committing from a focused option and committing from input-owned focus behave the same.
+- Integration: the same flow passes in the Electron E2E composer path used by the desktop app, not only in jsdom component tests.
+- Integration: the thread reply composer E2E path reproduces the reported context with transcript content above the composer and verifies no extra blank lines appear after selecting `$ce:plan`.
+- Regression: inserting a skill at the end of a one-line draft still works.
+
+**Verification:**
+- The reported leftover `plan` suffix and added blank lines are covered by failing tests and fixed.
+- Existing chip deletion, draft persistence, and send payload tests remain green.
+
+- [ ] **Unit 3: Add PageUp/PageDown autocomplete navigation**
+
+**Goal:** Capture PageUp and PageDown while autocomplete is open and move the active option by a visible page, keeping the option in view.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Test: `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`
+
+**Approach:**
+- Extend `handleAutocompleteKeyDown` for `PageDown` and `PageUp`.
+- Share the index update helper between skill and slash autocomplete so the behavior is consistent and bounded to `0..autocompleteLength - 1`.
+- Derive a page step from visible option count when available, or choose a stable fallback step that matches the E2E long-list viewport.
+- Prevent default page scrolling while autocomplete is open and the key is handled.
+- Rely on the existing active option scroll effect to keep the selected item visible.
+
+**Patterns to follow:**
+- Existing ArrowUp/ArrowDown handling in `handleAutocompleteKeyDown`.
+- Existing long-list scrolling E2E coverage in `apps/desktop/e2e/directory-launchpad-skills.spec.ts`.
+
+**Test scenarios:**
+- Happy path: with a long skill list and the first option active, PageDown moves active selection past the next single ArrowDown position.
+- Happy path: PageUp after PageDown moves selection back toward the top without going negative.
+- Edge case: PageDown at the end clamps to the last option; PageUp at the beginning clamps to the first option.
+- Regression: ArrowUp/ArrowDown still move by one option.
+- Regression: slash command autocomplete also honors PageUp/PageDown through the shared handler when multiple slash options are available, or the test documents why slash paging is intentionally not applicable.
+- Regression: when autocomplete is closed, PageUp/PageDown are not captured by composer autocomplete logic.
+
+**Verification:**
+- Component tests prove active-index behavior.
+- E2E coverage proves the visible list scrolls to keep the paged option reachable.
+
+- [ ] **Unit 4: Strengthen autocomplete overlay visual contrast**
+
+**Goal:** Make the autocomplete list boundary legible against the transcript and composer area without drifting from the black-first Tangerine Terminal visual system.
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
+- Test: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Test: `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`
+
+**Approach:**
+- Change `.composer__autocomplete` from a near-identical panel surface to a clearly elevated overlay using theme tokens: `--bg-panel-elevated`, `--border-strong`, and a subtle inner outline or separator.
+- Keep the active row as the strongest tangerine cue and avoid large orange fills or a generic light-gray panel.
+- Keep radius at 8px or below and preserve stable dimensions for hover/focus states.
+- Add a small style contract assertion if current tests already cover shared theme classes; otherwise rely on E2E CSS assertions near the existing active-option visual checks.
+- In thread reply composer E2E, assert the popup border/background differ from the transcript/input background enough to make the overlay boundary measurable, without snapshotting exact pixels.
+
+**Patterns to follow:**
+- `docs/UI-THEME.md` token contract and anti-patterns.
+- Existing active option CSS checks in `apps/desktop/e2e/directory-launchpad-skills.spec.ts`.
+
+**Test scenarios:**
+- Happy path: the autocomplete listbox uses an elevated near-black background and non-transparent border.
+- Happy path: active option styling remains tangerine-led and visually distinct inside the improved container.
+- Edge case: long descriptions remain readable against the new surface.
+- Regression: popup dimensions and internal scrolling do not change when visual contrast changes.
+
+**Verification:**
+- Playwright assertions confirm the popup has a distinguishable background/border from the underlying transcript/composer surface.
+- The visual treatment still follows the theme guide: no light-gray slab, no gradient, no orange-dominant panel.
+
+## System-Wide Impact
+
+- **Interaction graph:** The affected flow is `ComposerRichInput` or `ComposerTiptapInput` selection state -> `findSkillTrigger` -> `filteredSkills` -> `handleAutocompleteKeyDown` -> `applySkill` -> inline token serialization -> `startTurn`.
+- **Error propagation:** No new error surface is expected. If a trigger cannot be found at commit time, the implementation should leave the draft unchanged and keep focus predictable rather than replacing an inferred range.
+- **State lifecycle risks:** Stale selection indexes and stale trigger ranges are the primary risk. Tests should cover both text entry and keyboard commit because state can shift between render, keydown, and programmatic insertion.
+- **API surface parity:** The composer has textarea, custom-widget, and TipTap modes. Fixes should cover the active shipped mode and preserve compatibility with the other tested modes where existing E2E coverage exercises them.
+- **Integration coverage:** Component tests are required for exact string and ranking assertions; thread reply composer E2E tests are required for the reported transcript-adjacent flow; launchpad E2E tests remain useful for long-list scrolling and alternate composer implementations.
+- **Unchanged invariants:** Skill discovery remains lazy/thread-scoped; selected skills still serialize to markdown links; slash command autocomplete remains independent; plain Enter without autocomplete still submits the reply.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Fixing selection in one composer implementation regresses another implementation path. | Add targeted coverage for the active rich input path and preserve existing custom-widget and TipTap tests in `directory-launchpad-skills.spec.ts`. |
+| A fallback trigger at draft end masks missing caret state and causes wrong-range replacement. | Treat missing active trigger as a no-op or explicitly carry the trigger range from filtering to commit instead of recomputing against draft end. |
+| PageUp/PageDown step size becomes brittle under different row heights. | Prefer visible-row calculation from DOM metrics; if using a fallback, test behavior semantically rather than exact index count. |
+| Visual contrast fix drifts into an off-theme light panel. | Use existing theme tokens and verify against `docs/UI-THEME.md`: elevated near-black surface, stronger border, restrained tangerine focus. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation is required.
+- The screenshots in the user report are the primary acceptance reference; the implementation should not add explanatory UI copy to describe autocomplete behavior.
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md`
+- Theme guide: `docs/UI-THEME.md`
+- Desktop style guide: `docs/design/desktop-style-guide.md`
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx`
+- Related helper: `apps/desktop/src/renderer/src/lib/skill-mentions.ts`
+- Related tests: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Related E2E tests: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Related E2E tests: `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`

--- a/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
+++ b/docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md
@@ -116,7 +116,7 @@ The key invariant is that `Trigger` is computed from the current draft and curre
 
 ## Implementation Units
 
-- [ ] **Unit 1: Lock down trigger detection and filtering regressions**
+- [x] **Unit 1: Lock down trigger detection and filtering regressions**
 
 **Goal:** Add failing coverage for `$ce`, `$ce:p`, and `$ce:plan` in the reported multi-line composer text, then make skill filtering use the full typed prefix consistently.
 
@@ -154,7 +154,7 @@ The key invariant is that `Trigger` is computed from the current draft and curre
 - The component tests fail on the current behavior and pass after the trigger/filtering fix.
 - No app-server or skill loading behavior changes are needed.
 
-- [ ] **Unit 2: Make skill commit replace the active trigger without text or line-break damage**
+- [x] **Unit 2: Make skill commit replace the active trigger without text or line-break damage**
 
 **Goal:** Ensure keyboard commit replaces the full typed trigger range in a multi-line draft, inserts one inline skill chip, leaves no raw suffix text, and preserves existing newlines exactly.
 
@@ -198,7 +198,7 @@ The key invariant is that `Trigger` is computed from the current draft and curre
 - The reported leftover `plan` suffix and added blank lines are covered by failing tests and fixed.
 - Existing chip deletion, draft persistence, and send payload tests remain green.
 
-- [ ] **Unit 3: Add PageUp/PageDown autocomplete navigation**
+- [x] **Unit 3: Add PageUp/PageDown autocomplete navigation**
 
 **Goal:** Capture PageUp and PageDown while autocomplete is open and move the active option by a visible page, keeping the option in view.
 
@@ -235,7 +235,7 @@ The key invariant is that `Trigger` is computed from the current draft and curre
 - Component tests prove active-index behavior.
 - E2E coverage proves the visible list scrolls to keep the paged option reachable.
 
-- [ ] **Unit 4: Strengthen autocomplete overlay visual contrast**
+- [x] **Unit 4: Strengthen autocomplete overlay visual contrast**
 
 **Goal:** Make the autocomplete list boundary legible against the transcript and composer area without drifting from the black-first Tangerine Terminal visual system.
 


### PR DESCRIPTION
## Summary

This fixes the desktop skill autocomplete regression in multi-line reply drafts for both the custom chip composer and the full TipTap WYSIWYG composer, with coverage around the exact reported `$ce`, `$ce:p`, `$ce:plan`, keyboard commit, and PageUp/PageDown flows.

The composer now captures PageUp/PageDown while autocomplete is open and moves the active option by the visible list height, reusing the same active-index and scroll path as arrow navigation. The regression coverage locks the reported multi-line body, verifies prefix ranking keeps `$ce:plan` ahead of unrelated matches, and checks that committing the skill sends the markdown-link skill mention without leftover raw text or added blank lines. The TipTap path now maps ProseMirror caret positions back to serialized draft indexes with the same paragraph and code-block Markdown wrappers that TipTap emits, which keeps filtering and replacement anchored to the actual caret in rich multi-block drafts. Skill insertion in TipTap now applies a local mention-node transaction when possible instead of rebuilding the whole editor document from serialized Markdown, preserving WYSIWYG blocks such as fenced code blocks. Tab selection leaves the caret after the inserted chip, and copied/pasted chips round-trip their skill title and `SKILL.md` path instead of falling back to `$skill`. The autocomplete overlay also uses the elevated panel token plus a stronger shadow/inner outline so it reads as an overlay instead of blending into the transcript.

## Testing

- `pnpm vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragnt/desktop build`
- `pnpm --filter @pwragnt/desktop exec playwright test -c playwright.config.ts e2e/skill-autocomplete-interactions.spec.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm lint`

I also ran `pnpm test` locally; the new autocomplete coverage passed, but that local run reported the desktop-main bootstrap test in `apps/desktop/src/main/__tests__/index.test.ts` for "awaits startup CPU profiling before creating the first window", where `messagingRuntimeStartMock` was not called. The PR's GitHub `Test` check passed.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5.5 via [Codex](https://openai.com/codex)
