### PR TITLE
fix(desktop): open transcript file links in editor

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -1,18 +1,33 @@
-import type { AppServerSkillSummary } from "@pwragnt/shared";
-import { memo, useMemo, type ReactNode } from "react";
+import type {
+  AppServerSkillSummary,
+  DesktopApplicationsSnapshot,
+} from "@pwragnt/shared";
+import { memo, useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
 import ReactMarkdown, { type Components, type UrlTransform } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { SkillChip } from "../composer/SkillChip";
 
 type ThreadMarkdownProps = {
+  applications?: DesktopApplicationsSnapshot;
   className?: string;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   skills?: AppServerSkillSummary[];
   text: string;
   variant?: "message" | "summary";
 };
 
 export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdownProps) {
+  const editorApplication = useMemo(
+    () =>
+      props.applications?.editors.find(
+        (application) =>
+          application.canOpenWorkspace &&
+          application.id === props.applications?.preferredEditorId.value
+      ) ?? props.applications?.editors.find((application) => application.canOpenWorkspace),
+    [props.applications]
+  );
   const skillsByPath = useMemo(
     () =>
       new Map(
@@ -24,6 +39,28 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       ),
     [props.skills]
   );
+
+  const openLocalFileLink = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, href: string): void => {
+      const targetPath = localFilePathFromHref(href);
+      if (!targetPath || !editorApplication || !props.desktopApi?.openApplication) {
+        return;
+      }
+
+      event.preventDefault();
+      void props.desktopApi
+        .openApplication({
+          applicationId: editorApplication.id,
+          kind: "editor",
+          targetPath,
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to open transcript file link", error);
+        });
+    },
+    [editorApplication, props.desktopApi]
+  );
+
   const components = useMemo<Components>(
     () => ({
       a(anchorProps) {
@@ -47,6 +84,9 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           <a
             className="transcript-message__link"
             href={href || undefined}
+            onClick={(event) => {
+              openLocalFileLink(event, href);
+            }}
             rel="noreferrer"
             target="_blank"
             title={href || undefined}
@@ -120,7 +160,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         return <ul className="transcript-message__list">{listProps.children}</ul>;
       },
     }),
-    [skillsByPath]
+    [openLocalFileLink, skillsByPath]
   );
 
   return (
@@ -166,11 +206,23 @@ const normalizeMarkdownUrl: UrlTransform = (url) => {
 
 function normalizeSkillPath(href: string): string | undefined {
   if (href.startsWith("file://")) {
-    return decodeURIComponent(href.replace(/^file:\/\//, ""));
+    return stripFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
   }
 
   if (href.startsWith("/")) {
-    return href;
+    return stripFileLineSuffix(href);
+  }
+
+  return undefined;
+}
+
+function localFilePathFromHref(href: string): string | undefined {
+  if (href.startsWith("file://")) {
+    return stripFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
+  }
+
+  if (href.startsWith("/")) {
+    return stripFileLineSuffix(href);
   }
 
   return undefined;
@@ -183,6 +235,11 @@ function denormalizeMarkdownUrl(url: string): string {
 
   return url;
 }
+
+function stripFileLineSuffix(filePath: string): string {
+  return filePath.replace(/:(\d+)(?::\d+)?$/, "");
+}
+
 function extractTextContent(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") {
     return String(node);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1456,6 +1456,8 @@ export function ThreadView(props: ThreadViewProps) {
               entries={props.transcriptEntries}
               activeTurnId={props.activeTurnId}
               activeTurnStartedAt={props.activeTurnStartedAt}
+              applications={props.applications}
+              desktopApi={props.desktopApi}
               error={props.transcriptError}
               loading={props.loading}
               loadingMore={props.loadingMore}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -14,8 +14,10 @@ import type {
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
   AppServerSkillSummary,
-  AppServerThreadReplayPagination
+  AppServerThreadReplayPagination,
+  DesktopApplicationsSnapshot
 } from "@pwragnt/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { PendingQuestionnaire } from "./PendingQuestionnaire";
 import { PendingMcpInteraction } from "./PendingMcpInteraction";
@@ -38,6 +40,8 @@ type TranscriptViewport = {
 type TranscriptListProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   entries: AppServerThreadEntry[];
   error?: string;
   loading: boolean;
@@ -679,7 +683,9 @@ export function TranscriptList(props: TranscriptListProps) {
               return (
                 <TranscriptWorkPhaseGroup
                   key={item.id}
+                  applications={props.applications}
                   collapsible={item.collapsible}
+                  desktopApi={props.desktopApi}
                   entries={item.entries}
                   expanded={expandedCommentaryGroupIds.has(item.id)}
                   label={item.label}
@@ -696,12 +702,24 @@ export function TranscriptList(props: TranscriptListProps) {
             return entry.type === "activity" ? (
               <TranscriptActivity key={entry.id} entry={entry} />
             ) : entry.type === "plan" ? (
-              <TranscriptPlan key={entry.id} entry={entry} />
+              <TranscriptPlan
+                key={entry.id}
+                applications={props.applications}
+                desktopApi={props.desktopApi}
+                entry={entry}
+              />
             ) : entry.type === "review" ? (
-              <TranscriptReview key={entry.id} entry={entry} />
+              <TranscriptReview
+                key={entry.id}
+                applications={props.applications}
+                desktopApi={props.desktopApi}
+                entry={entry}
+              />
             ) : (
               <TranscriptMessage
                 key={entry.id}
+                applications={props.applications}
+                desktopApi={props.desktopApi}
                 message={entry}
                 skills={skills}
                 onOpenImage={props.onOpenImage}
@@ -749,7 +767,9 @@ export function TranscriptList(props: TranscriptListProps) {
                 </span>
               </div>
               <ThreadMarkdown
+                applications={props.applications}
                 className="transcript-request__prompt"
+                desktopApi={props.desktopApi}
                 text={pendingRequestPrompt(props.pendingRequest)}
               />
               <div className="transcript-request__actions">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,14 +1,18 @@
 import { memo, type ReactNode } from "react";
 import type {
+  DesktopApplicationsSnapshot,
   AppServerSkillSummary,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadMessagePart,
 } from "@pwragnt/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptImage } from "./TranscriptImage";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptMessageProps = {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   message: AppServerThreadMessageEntry;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -44,6 +48,8 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
             renderMessageSegment({
               segment,
               index,
+              applications: props.applications,
+              desktopApi: props.desktopApi,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
             })
@@ -90,6 +96,8 @@ function groupMessageParts(parts: AppServerThreadMessagePart[]): MessagePartSegm
 }
 
 function renderMessageSegment(params: {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   segment: MessagePartSegment;
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -125,7 +133,9 @@ function renderMessageSegment(params: {
   return (
     <ThreadMarkdown
       key={`text:${params.index}`}
+      applications={params.applications}
       className="transcript-message__text-block"
+      desktopApi={params.desktopApi}
       skills={params.skills}
       text={params.segment.part.text}
     />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
@@ -1,7 +1,13 @@
-import type { AppServerThreadPlanEntry } from "@pwragnt/shared";
+import type {
+  AppServerThreadPlanEntry,
+  DesktopApplicationsSnapshot,
+} from "@pwragnt/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptPlanProps = {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   entry: AppServerThreadPlanEntry;
 };
 
@@ -67,7 +73,9 @@ export function TranscriptPlan(props: TranscriptPlanProps) {
 
       {props.entry.markdown ? (
         <ThreadMarkdown
+          applications={props.applications}
           className="transcript-plan__markdown"
+          desktopApi={props.desktopApi}
           text={props.entry.markdown}
         />
       ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -1,11 +1,15 @@
 import type {
   AppServerReviewFinding,
   AppServerThreadReviewEntry,
+  DesktopApplicationsSnapshot,
 } from "@pwragnt/shared";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptReviewProps = {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   entry: AppServerThreadReviewEntry;
 };
 
@@ -124,7 +128,12 @@ export function TranscriptReview(props: TranscriptReviewProps) {
           <p className="transcript-review__eyebrow">Review</p>
           <p className="transcript-review__summary">{summary}</p>
           {body ? (
-            <ThreadMarkdown className="transcript-review__body" text={body} />
+            <ThreadMarkdown
+              applications={props.applications}
+              className="transcript-review__body"
+              desktopApi={props.desktopApi}
+              text={body}
+            />
           ) : null}
         </div>
         {props.entry.createdAt ? (
@@ -177,7 +186,9 @@ export function TranscriptReview(props: TranscriptReviewProps) {
                   </span>
                 </div>
                 <ThreadMarkdown
+                  applications={props.applications}
                   className="transcript-review__finding-body"
+                  desktopApi={props.desktopApi}
                   text={finding.body}
                 />
                 <div className="transcript-review__location">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -3,14 +3,18 @@ import type {
   AppServerSkillSummary,
   AppServerThreadEntry,
   AppServerThreadImagePart,
+  DesktopApplicationsSnapshot,
 } from "@pwragnt/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
 import { TranscriptReview } from "./TranscriptReview";
 
 type TranscriptWorkPhaseGroupProps = {
+  applications?: DesktopApplicationsSnapshot;
   collapsible: boolean;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
   entries: AppServerThreadEntry[];
   expanded: boolean;
   label: string;
@@ -29,7 +33,15 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
       className="transcript-work-phase-group__content"
       hidden={props.collapsible && !props.expanded}
     >
-      {props.entries.map((entry) => renderEntry(entry, props.skills, props.onOpenImage))}
+      {props.entries.map((entry) =>
+        renderEntry({
+          applications: props.applications,
+          desktopApi: props.desktopApi,
+          entry,
+          onOpenImage: props.onOpenImage,
+          skills: props.skills,
+        })
+      )}
     </div>
   );
 
@@ -58,23 +70,38 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
 
 TranscriptWorkPhaseGroup.displayName = "TranscriptWorkPhaseGroup";
 
-function renderEntry(
-  entry: AppServerThreadEntry,
-  skills: AppServerSkillSummary[],
-  onOpenImage?: (image: AppServerThreadImagePart) => void
-) {
+function renderEntry(params: {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "openApplication">;
+  entry: AppServerThreadEntry;
+  skills: AppServerSkillSummary[];
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
+}) {
+  const entry = params.entry;
   return entry.type === "activity" ? (
     <TranscriptActivity key={entry.id} entry={entry} />
   ) : entry.type === "plan" ? (
-    <TranscriptPlan key={entry.id} entry={entry} />
+    <TranscriptPlan
+      key={entry.id}
+      applications={params.applications}
+      desktopApi={params.desktopApi}
+      entry={entry}
+    />
   ) : entry.type === "review" ? (
-    <TranscriptReview key={entry.id} entry={entry} />
+    <TranscriptReview
+      key={entry.id}
+      applications={params.applications}
+      desktopApi={params.desktopApi}
+      entry={entry}
+    />
   ) : (
     <TranscriptMessage
       key={entry.id}
+      applications={params.applications}
+      desktopApi={params.desktopApi}
       message={entry}
-      skills={skills}
-      onOpenImage={onOpenImage}
+      skills={params.skills}
+      onOpenImage={params.onOpenImage}
     />
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { ThreadMarkdown } from "../ThreadMarkdown";
 
 describe("ThreadMarkdown", () => {
@@ -16,6 +16,50 @@ describe("ThreadMarkdown", () => {
       "href",
       "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
     );
+  });
+
+  it("opens local file links in the configured editor", async () => {
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+
+    render(
+      <ThreadMarkdown
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+            {
+              id: "zed",
+              kind: "editor",
+              name: "Zed",
+              source: "application",
+              appPath: "/Applications/Zed.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "zed", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+        }}
+        desktopApi={{ openApplication }}
+        text={"I updated [AGENTS.md](/repo/PwrAgnt/AGENTS.md:17)."}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "AGENTS.md" }));
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "zed",
+        kind: "editor",
+        targetPath: "/repo/PwrAgnt/AGENTS.md",
+      });
+    });
   });
 
   it("renders skill links as chips", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -239,6 +239,61 @@ describe("TranscriptList", () => {
     ).toHaveClass("transcript-message--user");
   });
 
+  it("opens transcript file links in the configured editor", async () => {
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+
+    render(
+      <TranscriptList
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+            {
+              id: "zed",
+              kind: "editor",
+              name: "Zed",
+              source: "application",
+              appPath: "/Applications/Zed.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "zed", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+        }}
+        desktopApi={{ openApplication }}
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "assistant",
+            text: "I updated [AGENTS.md](/repo/PwrAgnt/AGENTS.md:17).",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "AGENTS.md" }));
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "zed",
+        kind: "editor",
+        targetPath: "/repo/PwrAgnt/AGENTS.md",
+      });
+    });
+  });
+
   it("renders inline image previews and opens them on demand", () => {
     const onOpenImage = vi.fn();
     const dataUrl = "data:image/png;base64,aGVsbG8=";


### PR DESCRIPTION
## Summary

- Route local transcript file-link clicks through the desktop application bridge instead of leaving them as plain `file://` anchors.
- Use the configured preferred editor when available, falling back to the first workspace-capable editor.
- Strip transcript line suffixes like `:17` before opening the file, while preserving the rendered link href/title.
- Thread the desktop API and application snapshot through transcript messages, plans, reviews, grouped phases, and pending approval markdown.

## Testing

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`
