### PR TITLE
fix(desktop): reduce Grok startup protocol chatter

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "analyze:codex-thread-protocol": "tsx ./scripts/analyze-codex-thread-protocol.ts",
+    "analyze:protocol-capture": "tsx ./scripts/analyze-protocol-capture.ts",
     "analyze:startup-cpu-profile": "tsx ./scripts/analyze-startup-cpu-profile.ts",
     "build": "electron-vite build",
     "codex:generate-protocol": "pnpm --filter @pwragnt/shared codex:generate-app-server-protocol",

--- a/apps/desktop/scripts/analyze-protocol-capture.ts
+++ b/apps/desktop/scripts/analyze-protocol-capture.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { analyzeProtocolCaptureTraffic } from "../src/main/testing/protocol-capture-analysis";
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const inputPath = requireString(args, "input");
+  const outputPath = optionalString(args.output);
+  const analysis = await analyzeProtocolCaptureTraffic({
+    capturePath: path.resolve(inputPath),
+  });
+  const serialized = `${JSON.stringify(analysis, null, 2)}\n`;
+
+  if (outputPath) {
+    const resolvedOutputPath = path.resolve(outputPath);
+    await import("node:fs/promises").then((fs) =>
+      fs.writeFile(resolvedOutputPath, serialized, "utf8"),
+    );
+    console.log(`Wrote ${resolvedOutputPath}`);
+    return;
+  }
+
+  process.stdout.write(serialized);
+}
+
+type ParsedArgs = Record<string, string[]>;
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = ["true"];
+      continue;
+    }
+
+    parsed[key] ??= [];
+    parsed[key].push(next);
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function requireString(args: ParsedArgs, key: string): string {
+  const value = optionalString(args[key]);
+  if (!value) {
+    throw new Error(`Missing required --${key}`);
+  }
+  return value;
+}
+
+function optionalString(values: string[] | undefined): string | undefined {
+  const value = values?.at(-1)?.trim();
+  return value ? value : undefined;
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  pnpm --filter @pwragnt/desktop analyze:protocol-capture -- \\
+    --input .local/protocol-captures/2026-05-02T14-34-22-432Z-grok-default.jsonl
+
+Optional:
+  --output .local/protocol-capture-analysis.json`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -227,7 +227,11 @@ describe("app server ipc", () => {
       {} satisfies GetNavigationSnapshotRequest,
     );
 
-    expect(listThreads).toHaveBeenCalledWith({ backend: undefined, filter: undefined });
+    expect(listThreads).toHaveBeenCalledWith({
+      backend: undefined,
+      callerReason: "navigation-snapshot",
+      filter: undefined,
+    });
     expect(reconcileNavigationSnapshot).toHaveBeenCalledWith({
       backend: "all",
       fetchedAt: expect.any(Number),

--- a/apps/desktop/src/main/__tests__/backend-model-catalog.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-model-catalog.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { BackendModelOption } from "@pwragnt/shared";
+import { BackendModelCatalog } from "../app-server/backend-model-catalog";
+
+function createClient(params?: {
+  models?: BackendModelOption[];
+  errors?: Error[];
+}) {
+  const diagnostics: Array<{ callerReason?: string; ownerId?: string } | undefined> = [];
+  let callCount = 0;
+
+  return {
+    get callCount() {
+      return callCount;
+    },
+    diagnostics,
+    async listModels(requestDiagnostics?: {
+      callerReason?: string;
+      ownerId?: string;
+    }): Promise<BackendModelOption[]> {
+      callCount += 1;
+      diagnostics.push(requestDiagnostics);
+      const error = params?.errors?.shift();
+      if (error) {
+        throw error;
+      }
+      return params?.models ?? [];
+    },
+  };
+}
+
+describe("BackendModelCatalog", () => {
+  it("coalesces concurrent model reads for one backend", async () => {
+    let resolveModels:
+      | ((models: BackendModelOption[]) => void)
+      | undefined;
+    const diagnostics: Array<{ callerReason?: string; ownerId?: string } | undefined> = [];
+    let callCount = 0;
+    const grokClient = {
+      get callCount() {
+        return callCount;
+      },
+      diagnostics,
+      async listModels(requestDiagnostics?: {
+        callerReason?: string;
+        ownerId?: string;
+      }): Promise<BackendModelOption[]> {
+        callCount += 1;
+        diagnostics.push(requestDiagnostics);
+        return await new Promise<BackendModelOption[]>((resolve) => {
+          resolveModels = resolve;
+        });
+      },
+    };
+    const catalog = new BackendModelCatalog({
+      codex: createClient(),
+      grok: grokClient,
+    });
+
+    const first = catalog.readModels("grok", "backend-summary");
+    const second = catalog.readModels("grok", "thread-start-defaults");
+    resolveModels?.([{ id: "grok-4", label: "Grok 4" }]);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [{ id: "grok-4", label: "Grok 4" }],
+      [{ id: "grok-4", label: "Grok 4" }],
+    ]);
+    expect(grokClient.callCount).toBe(1);
+    expect(grokClient.diagnostics[0]).toMatchObject({
+      callerReason: "backend-summary",
+    });
+    expect(grokClient.diagnostics[0]?.ownerId).toMatch(
+      /^backend-model-catalog-/,
+    );
+  });
+
+  it("caches successful empty model lists", async () => {
+    const grokClient = createClient({ models: [] });
+    const catalog = new BackendModelCatalog({
+      codex: createClient(),
+      grok: grokClient,
+    });
+
+    await expect(catalog.readModels("grok", "backend-summary")).resolves.toEqual([]);
+    await expect(catalog.readModels("grok", "thread-start-defaults")).resolves.toEqual([]);
+
+    expect(grokClient.callCount).toBe(1);
+  });
+
+  it("clears failed in-flight reads so later consumers can retry", async () => {
+    const grokClient = createClient({
+      errors: [new Error("Grok is still starting")],
+      models: [{ id: "grok-4", label: "Grok 4" }],
+    });
+    const catalog = new BackendModelCatalog({
+      codex: createClient(),
+      grok: grokClient,
+    });
+
+    await expect(catalog.readModels("grok", "backend-summary")).rejects.toThrow(
+      "Grok is still starting",
+    );
+    await expect(catalog.readModels("grok", "thread-start-defaults")).resolves.toEqual([
+      { id: "grok-4", label: "Grok 4" },
+    ]);
+
+    expect(grokClient.callCount).toBe(2);
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -344,6 +344,10 @@ class MockBackendClient {
     callerReason?: string;
     ownerId?: string;
   };
+  lastListThreadsDiagnostics?: {
+    callerReason?: string;
+    ownerId?: string;
+  };
   lastListThreadsParams?: {
     filter?: string;
   };
@@ -391,8 +395,9 @@ class MockBackendClient {
   async listThreads(params?: {
     archived?: boolean;
     filter?: string;
-  }): Promise<AppServerThreadSummary[]> {
+  }, diagnostics?: { callerReason?: string; ownerId?: string }): Promise<AppServerThreadSummary[]> {
     this.listThreadsCallCount += 1;
+    this.lastListThreadsDiagnostics = diagnostics;
     this.lastListThreadsParams = params;
     return this.options.threads ?? [];
   }
@@ -936,6 +941,73 @@ describe("DesktopBackendRegistry", () => {
     expect(grokClient.lastListModelsDiagnostics).toMatchObject({
       callerReason: "thread-start-defaults",
     });
+
+    await registry.close();
+  });
+
+  it("coalesces repeated Grok thread list requests in the startup refresh window", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Grok App Server", version: "1.0.0" },
+        methods: ["thread/list"],
+      },
+      threads: [
+        {
+          id: "thread-grok",
+          title: "Grok thread",
+          titleSource: "explicit",
+          source: "grok",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const codexClient = new MockBackendClient({});
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({}),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      callerReason: "navigation-snapshot",
+    });
+    await registry.listThreads({
+      backend: "grok",
+      callerReason: "branch-drift",
+    });
+
+    expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(grokClient.listThreadsCallCount).toBe(1);
+    expect(grokClient.lastListThreadsDiagnostics).toMatchObject({
+      callerReason: "navigation-snapshot",
+    });
+    expect(grokClient.lastListThreadsDiagnostics?.ownerId).toMatch(
+      /^backend-thread-list-cache-/,
+    );
+
+    await registry.close();
+  });
+
+  it("invalidates cached backend thread lists after starting a thread", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Grok App Server", version: "1.0.0" },
+        methods: ["thread/list", "thread/start"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      codexFullAccessClient: new MockBackendClient({}),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({ backend: "grok" });
+    await registry.startThread({ backend: "grok" });
+    await registry.listThreads({ backend: "grok" });
+
+    expect(grokClient.listThreadsCallCount).toBe(2);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -340,6 +340,10 @@ class MockBackendClient {
   listThreadsCallCount = 0;
   listModelsCallCount = 0;
   steerTurnCallCount = 0;
+  lastListModelsDiagnostics?: {
+    callerReason?: string;
+    ownerId?: string;
+  };
   lastListThreadsParams?: {
     filter?: string;
   };
@@ -424,8 +428,9 @@ class MockBackendClient {
     return this.options.skills ?? [];
   }
 
-  async listModels() {
+  async listModels(diagnostics?: { callerReason?: string; ownerId?: string }) {
     this.listModelsCallCount += 1;
+    this.lastListModelsDiagnostics = diagnostics;
     const error = this.options.modelListErrors?.shift();
     if (error) {
       throw error;
@@ -795,6 +800,12 @@ describe("DesktopBackendRegistry", () => {
 
     expect(codexClient.listModelsCallCount).toBe(1);
     expect(codexFullAccessClient.listModelsCallCount).toBe(0);
+    expect(codexClient.lastListModelsDiagnostics).toMatchObject({
+      callerReason: "backend-summary",
+    });
+    expect(codexClient.lastListModelsDiagnostics?.ownerId).toMatch(
+      /^backend-model-catalog-/,
+    );
     expect(firstResponse.backends[0]?.launchpadOptions?.models).toMatchObject([
       {
         id: "gpt-5.4",
@@ -863,6 +874,12 @@ describe("DesktopBackendRegistry", () => {
     await registry.startThread({ backend: "grok" });
 
     expect(grokClient.listModelsCallCount).toBe(1);
+    expect(grokClient.lastListModelsDiagnostics).toMatchObject({
+      callerReason: "backend-summary",
+    });
+    expect(grokClient.lastListModelsDiagnostics?.ownerId).toMatch(
+      /^backend-model-catalog-/,
+    );
     expect(firstResponse.backends[1]?.launchpadOptions?.models).toMatchObject([
       {
         id: "grok-custom-reasoning",
@@ -880,7 +897,50 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("retries Codex model discovery after a transient startup failure", async () => {
+  it("does not warm model lists during registry construction", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+    const codexFullAccessClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+    const grokClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Grok App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient,
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    expect(codexClient.listModelsCallCount).toBe(0);
+    expect(codexFullAccessClient.listModelsCallCount).toBe(0);
+    expect(grokClient.listModelsCallCount).toBe(0);
+
+    await registry.startThread({ backend: "grok" });
+
+    expect(codexClient.listModelsCallCount).toBe(0);
+    expect(codexFullAccessClient.listModelsCallCount).toBe(0);
+    expect(grokClient.listModelsCallCount).toBe(1);
+    expect(grokClient.lastListModelsDiagnostics).toMatchObject({
+      callerReason: "thread-start-defaults",
+    });
+
+    await registry.close();
+  });
+
+  it("retries Codex model discovery after a transient model-list failure", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
@@ -911,18 +971,15 @@ describe("DesktopBackendRegistry", () => {
       createScratchProjectDirectory: async () => "/tmp/pwragnt-scratch",
     });
 
-    await flushAsync();
     const response = await registry.listBackends({ includeUnavailable: true });
     await registry.startThread({ backend: "codex" });
 
     expect(codexClient.listModelsCallCount).toBe(2);
     expect(codexFullAccessClient.listModelsCallCount).toBe(0);
-    expect(response.backends[0]?.launchpadOptions?.models).toMatchObject([
-      {
-        id: "gpt-5.4",
-        label: "GPT-5.4",
-      },
-    ]);
+    expect(response.backends[0]?.launchpadOptions?.models?.[0]).toMatchObject({
+      id: "gpt-5.5",
+      label: "GPT-5.5",
+    });
     expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -812,6 +812,74 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("reads Grok models once from the default client and reuses them", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+    const grokClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Grok App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+      models: [
+        {
+          id: "grok-custom-reasoning",
+          label: "Grok Custom Reasoning",
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: {
+          serverInfo: { name: "Codex App Server", version: "1.0.0" },
+          methods: ["thread/start", "turn/start"],
+        },
+      }),
+      grokClient,
+      overlayStore: createOverlayStoreMock({
+        launchpadDefaults: {
+          backend: "grok",
+          executionMode: "default",
+          workMode: "local",
+        },
+      }),
+      createScratchProjectDirectory: async () => "/tmp/pwragnt-scratch",
+    });
+
+    const firstResponse = await registry.listBackends({ includeUnavailable: true });
+    const secondResponse = await registry.listBackends({ includeUnavailable: true });
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      preferredBackend: "grok",
+    });
+    await registry.startThread({ backend: "grok" });
+
+    expect(grokClient.listModelsCallCount).toBe(1);
+    expect(firstResponse.backends[1]?.launchpadOptions?.models).toMatchObject([
+      {
+        id: "grok-custom-reasoning",
+        label: "Grok Custom Reasoning",
+      },
+    ]);
+    expect(secondResponse.backends[1]?.launchpadOptions?.models).toMatchObject([
+      {
+        id: "grok-custom-reasoning",
+        label: "Grok Custom Reasoning",
+      },
+    ]);
+    expect(grokClient.lastStartThreadParams?.model).toBe("grok-custom-reasoning");
+
+    await registry.close();
+  });
+
   it("retries Codex model discovery after a transient startup failure", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -144,6 +144,50 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("retries initialization when the initialized notification fails", async () => {
+    let initializeRequestCount = 0;
+    let initializedNotificationCount = 0;
+    let threadListRequestCount = 0;
+    const server = {
+      request: async (method: string): Promise<unknown> => {
+        if (method === "initialize") {
+          initializeRequestCount += 1;
+          return {
+            serverInfo: { name: "@pwragnt/grok-app-server", version: "1.0.0" },
+            methods: ["thread/list"],
+          };
+        }
+        if (method === "thread/list") {
+          threadListRequestCount += 1;
+          return { threads: [] };
+        }
+        throw new Error(`Unexpected request ${method}`);
+      },
+      notify: async (method: string): Promise<void> => {
+        if (method !== "initialized") {
+          return;
+        }
+        initializedNotificationCount += 1;
+        if (initializedNotificationCount === 1) {
+          throw new Error("initialized notification failed");
+        }
+      },
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await expect(client.getInitializeResult()).rejects.toThrow(
+      "initialized notification failed",
+    );
+    await expect(client.listThreads()).resolves.toEqual([]);
+
+    expect(initializeRequestCount).toBe(2);
+    expect(initializedNotificationCount).toBe(2);
+    expect(threadListRequestCount).toBe(1);
+
+    await client.close();
+  });
+
   it("lists threads, reads replay, and forwards turn notifications", async () => {
     const provider = new FakeProvider();
     const server = new CodexAppServer({

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -97,6 +97,53 @@ describe("GrokAppServerClient", () => {
     }
   });
 
+  it("coalesces concurrent initialize requests", async () => {
+    let initializeRequestCount = 0;
+    const server = {
+      request: async (method: string): Promise<unknown> => {
+        if (method === "initialize") {
+          initializeRequestCount += 1;
+          await Promise.resolve();
+          return {
+            serverInfo: { name: "@pwragnt/grok-app-server", version: "1.0.0" },
+            methods: ["model/list"],
+          };
+        }
+        if (method === "model/list") {
+          return {
+            data: [
+              {
+                id: "grok-custom-reasoning",
+                label: "Grok Custom Reasoning",
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected request ${method}`);
+      },
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    const [initialize, models, initializeAgain] = await Promise.all([
+      client.getInitializeResult(),
+      client.listModels(),
+      client.getInitializeResult(),
+    ]);
+
+    expect(initializeRequestCount).toBe(1);
+    expect(initialize.serverInfo?.name).toBe("@pwragnt/grok-app-server");
+    expect(initializeAgain.serverInfo?.name).toBe("@pwragnt/grok-app-server");
+    expect(models).toMatchObject([
+      {
+        id: "grok-custom-reasoning",
+        label: "Grok Custom Reasoning",
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("lists threads, reads replay, and forwards turn notifications", async () => {
     const provider = new FakeProvider();
     const server = new CodexAppServer({

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ProtocolCaptureStore, readProtocolCaptureFile } from "../testing/capture-store";
+import { analyzeProtocolCaptureTraffic } from "../testing/protocol-capture-analysis";
 import { createProtocolCaptureObserver, createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 
 async function createTempDir(): Promise<string> {
@@ -94,6 +95,49 @@ describe("ProtocolCaptureStore", () => {
       await fs.readFile(path.join(rootDir, "index.json"), "utf8")
     ) as Record<string, { threadIds: string[] }>;
     expect(index["capture-1"]?.threadIds).toEqual(["thread-1"]);
+  });
+
+  it("captures optional diagnostics without changing the raw JSON-RPC envelope", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    const store = new ProtocolCaptureStore({
+      backend: "grok",
+      captureId: "diagnostic-capture",
+      rootDir
+    });
+    const observer = createProtocolCaptureObserver({
+      backend: "grok",
+      store
+    });
+
+    await observer.onMessage({
+      direction: "outbound",
+      diagnostics: {
+        callerReason: "backend-summary",
+        ownerId: "model-catalog-1",
+      },
+      raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"model/list","params":{}}',
+      envelope: {
+        jsonrpc: "2.0",
+        id: "rpc-1",
+        method: "model/list",
+        params: {},
+      }
+    });
+    await store.close();
+
+    const [line] = (await fs.readFile(
+      path.join(rootDir, "diagnostic-capture.jsonl"),
+      "utf8",
+    )).trim().split("\n").map((entry) => JSON.parse(entry) as Record<string, unknown>);
+
+    expect(line).toMatchObject({
+      diagnostics: {
+        callerReason: "backend-summary",
+        ownerId: "model-catalog-1",
+      },
+      raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"model/list","params":{}}',
+    });
   });
 
   it("creates an env-backed capture session only when recording is enabled", async () => {
@@ -270,5 +314,96 @@ describe("ProtocolCaptureStore", () => {
         }),
       }),
     ]);
+  });
+
+  it("analyzes method counts separately and skips malformed capture rows", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    const capturePath = path.join(rootDir, "startup.jsonl");
+
+    await fs.writeFile(
+      capturePath,
+      [
+        JSON.stringify({
+          backend: "grok",
+          backendInstance: "default",
+          captureId: "startup-grok",
+          diagnostics: {
+            callerReason: "backend-summary",
+            ownerId: "model-catalog-1",
+          },
+          direction: "outbound",
+          kind: "request",
+          method: "initialize",
+          id: "rpc-1",
+          sequence: 1,
+          timestamp: 100,
+          threadIds: [],
+          raw: '{"jsonrpc":"2.0","id":"rpc-1","method":"initialize","params":{}}',
+        }),
+        JSON.stringify({
+          backend: "grok",
+          backendInstance: "default",
+          captureId: "startup-grok",
+          diagnostics: {
+            callerReason: "backend-summary",
+            ownerId: "model-catalog-1",
+          },
+          direction: "outbound",
+          kind: "request",
+          method: "model/list",
+          id: "rpc-2",
+          sequence: 2,
+          timestamp: 120,
+          threadIds: [],
+          raw: '{"jsonrpc":"2.0","id":"rpc-2","method":"model/list","params":{}}',
+        }),
+        JSON.stringify({
+          backend: "grok",
+          backendInstance: "default",
+          captureId: "startup-grok",
+          direction: "outbound",
+          kind: "request",
+          method: "thread/list",
+          id: "rpc-3",
+          sequence: 3,
+          timestamp: 140,
+          threadIds: [],
+          raw: '{"jsonrpc":"2.0","id":"rpc-3","method":"thread/list","params":{}}',
+        }),
+        "{malformed",
+        JSON.stringify({
+          backend: "grok",
+          backendInstance: "default",
+          captureId: "startup-grok",
+          direction: "outbound",
+          kind: "request",
+          method: "thread/list",
+          id: "rpc-4",
+          sequence: 4,
+          timestamp: 150,
+          threadIds: [],
+          raw: '{"jsonrpc":"2.0","id":"rpc-4","method":"thread/list","params":{}}',
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const analysis = await analyzeProtocolCaptureTraffic({ capturePath });
+
+    expect(analysis.malformedRecordCount).toBe(1);
+    expect(analysis.backendInstances).toEqual(["grok:default"]);
+    expect(analysis.summaries.grok?.requestCounts).toMatchObject({
+      initialize: 1,
+      "model/list": 1,
+      "thread/list": 2,
+    });
+    expect(analysis.summaries.grok?.requests["model/list"]).toMatchObject({
+      count: 1,
+      callerReasons: ["backend-summary"],
+      ownerIds: ["model-catalog-1"],
+      firstAt: 120,
+      lastAt: 120,
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
@@ -8,10 +8,12 @@ import {
 function createEvent(
   envelope: JsonRpcObserverEvent["envelope"],
   direction: JsonRpcObserverEvent["direction"] = "inbound",
+  diagnostics?: JsonRpcObserverEvent["diagnostics"],
 ): JsonRpcObserverEvent {
   return {
     direction,
     envelope,
+    diagnostics,
     raw: JSON.stringify(envelope),
   };
 }
@@ -43,6 +45,56 @@ describe("protocol log observer", () => {
       paramKeys: ["turnId", "threadId"],
       turnId: "turn-1",
       threadId: "thread-1",
+    });
+  });
+
+  it("includes caller diagnostics on requests and attributed responses", () => {
+    const info = vi.fn();
+    const observer = createProtocolLogObserver({
+      backend: "grok",
+      logger: { info },
+    });
+
+    observer.onMessage(
+      createEvent(
+        {
+          id: "rpc-1",
+          jsonrpc: "2.0",
+          method: "model/list",
+          params: {},
+        },
+        "outbound",
+        {
+          callerReason: "backend-summary",
+          ownerId: "model-catalog-1",
+        },
+      ),
+    );
+    observer.onMessage(
+      createEvent({
+        id: "rpc-1",
+        jsonrpc: "2.0",
+        result: { data: [] },
+      }),
+    );
+
+    expect(info).toHaveBeenNthCalledWith(1, "message", {
+      backend: "grok",
+      callerReason: "backend-summary",
+      direction: "out",
+      id: "rpc-1",
+      kind: "request",
+      method: "model/list",
+      ownerId: "model-catalog-1",
+    });
+    expect(info).toHaveBeenNthCalledWith(2, "message", {
+      backend: "grok",
+      callerReason: "backend-summary",
+      direction: "in",
+      id: "rpc-1",
+      kind: "response",
+      method: "model/list",
+      ownerId: "model-catalog-1",
     });
   });
 

--- a/apps/desktop/src/main/app-server/backend-model-catalog.ts
+++ b/apps/desktop/src/main/app-server/backend-model-catalog.ts
@@ -1,0 +1,82 @@
+import type { BackendModelOption } from "@pwragnt/shared";
+
+export type BackendModelCatalogBackend = "codex" | "grok";
+
+export type BackendModelCatalogCallerReason =
+  | "backend-summary"
+  | "launchpad-defaults"
+  | "thread-start-defaults"
+  | "settings-refresh"
+  | (string & {});
+
+export type BackendModelCatalogClient = {
+  listModels?(diagnostics?: {
+    callerReason?: string;
+    ownerId?: string;
+  }): Promise<BackendModelOption[]>;
+};
+
+type ModelState = {
+  models?: BackendModelOption[];
+  promise?: Promise<BackendModelOption[]>;
+};
+
+let catalogSequence = 0;
+
+export class BackendModelCatalog {
+  private readonly ownerId = `backend-model-catalog-${++catalogSequence}`;
+  private readonly states: Record<BackendModelCatalogBackend, ModelState> = {
+    codex: {},
+    grok: {},
+  };
+
+  constructor(
+    private readonly clients: Record<BackendModelCatalogBackend, BackendModelCatalogClient>,
+  ) {}
+
+  readModels(
+    backend: BackendModelCatalogBackend,
+    callerReason: BackendModelCatalogCallerReason,
+  ): Promise<BackendModelOption[]> {
+    const state = this.states[backend];
+    if (state.models) {
+      return Promise.resolve(state.models);
+    }
+    if (state.promise) {
+      return state.promise;
+    }
+
+    const client = this.clients[backend];
+    if (!client.listModels) {
+      state.models = [];
+      return Promise.resolve(state.models);
+    }
+
+    state.promise = client
+      .listModels({
+        callerReason,
+        ownerId: this.ownerId,
+      })
+      .then((models) => {
+        state.models = models;
+        state.promise = undefined;
+        return models;
+      })
+      .catch((error) => {
+        state.promise = undefined;
+        throw error;
+      });
+
+    return state.promise;
+  }
+
+  invalidate(backend?: BackendModelCatalogBackend): void {
+    if (backend) {
+      this.states[backend] = {};
+      return;
+    }
+
+    this.states.codex = {};
+    this.states.grok = {};
+  }
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -870,6 +870,8 @@ export class DesktopBackendRegistry {
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private codexDefaultModels?: BackendModelOption[];
   private codexDefaultModelsPromise?: Promise<BackendModelOption[]>;
+  private grokDefaultModels?: BackendModelOption[];
+  private grokDefaultModelsPromise?: Promise<BackendModelOption[]>;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -1019,6 +1021,7 @@ export class DesktopBackendRegistry {
               }));
 
     void this.readCodexDefaultModelsOnce().catch(() => undefined);
+    void this.readGrokDefaultModelsOnce().catch(() => undefined);
 
     this.subscribeClient("codex", this.codexDefaultClient);
     this.subscribeClient("codex", this.codexFullAccessClient);
@@ -2089,6 +2092,24 @@ export class DesktopBackendRegistry {
     return this.codexDefaultModelsPromise;
   }
 
+  private readGrokDefaultModelsOnce(): Promise<BackendModelOption[]> {
+    if (this.grokDefaultModels) {
+      return Promise.resolve(this.grokDefaultModels);
+    }
+
+    this.grokDefaultModelsPromise ??= readClientModels(this.grokClient)
+      .then((models) => {
+        this.grokDefaultModels = models;
+        return models;
+      })
+      .catch((error) => {
+        this.grokDefaultModelsPromise = undefined;
+        throw error;
+      });
+
+    return this.grokDefaultModelsPromise;
+  }
+
   private async getBackendLaunchpadOptions(
     backend: AppServerBackendKind,
   ): Promise<BackendLaunchpadOptions | undefined> {
@@ -2097,10 +2118,8 @@ export class DesktopBackendRegistry {
       return buildLaunchpadOptions(backend, models);
     }
 
-    return buildLaunchpadOptions(
-      backend,
-      await readClientModels(this.grokClient).catch(() => []),
-    );
+    const models = await this.readGrokDefaultModelsOnce().catch(() => []);
+    return buildLaunchpadOptions(backend, models);
   }
 
   private subscribeClient(backend: AppServerBackendKind, client: BackendClient): void {
@@ -2243,7 +2262,10 @@ export class DesktopBackendRegistry {
   ): Promise<BackendSummary> {
     try {
       const initialize = await client.getInitializeResult();
-      const models = await readClientModels(client).catch(() => []);
+      const models =
+        kind === "grok"
+          ? await this.readGrokDefaultModelsOnce().catch(() => [])
+          : await readClientModels(client).catch(() => []);
       const methods = Array.isArray(initialize.methods)
         ? initialize.methods.filter((method): method is string => typeof method === "string")
         : [];

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -104,6 +104,7 @@ type InitializeResult = {
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const REPLAY_THREAD_TITLE_ENV = "PWRAGNT_REPLAY_THREAD_TITLE";
+const THREAD_LIST_REUSE_WINDOW_MS = 750;
 const backendRegistryLog = getMainLogger("pwragnt:backend-registry");
 const execFile = promisify(execFileCallback);
 
@@ -118,7 +119,10 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
 type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
-  listThreads(params?: { archived?: boolean; filter?: string }): Promise<AppServerThreadSummary[]>;
+  listThreads(
+    params?: { archived?: boolean; filter?: string },
+    diagnostics?: { callerReason?: string; ownerId?: string },
+  ): Promise<AppServerThreadSummary[]>;
   archiveThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   restoreThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   renameThread?(params: { threadId: string; name: string }): Promise<{ threadId: string }>;
@@ -656,6 +660,24 @@ type ModelSettings = {
   fastMode?: boolean;
 };
 
+type ThreadListCallerReason =
+  | "archive-cleanup"
+  | "branch-drift"
+  | "ipc-list-threads"
+  | "messaging-navigation-snapshot"
+  | "navigation-snapshot"
+  | "title-generation"
+  | "workspace-handoff"
+  | (string & {});
+
+type ThreadListCacheState = {
+  expiresAt?: number;
+  promise?: Promise<AppServerThreadSummary[]>;
+  threads?: AppServerThreadSummary[];
+};
+
+let threadListCacheSequence = 0;
+
 function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): boolean {
   return (
     launchpad.prompt.trim().length === 0 &&
@@ -876,6 +898,8 @@ export class DesktopBackendRegistry {
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
+  private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
+  private readonly threadListCache = new Map<string, ThreadListCacheState>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -1059,29 +1083,80 @@ export class DesktopBackendRegistry {
   async listThreads(params: {
     archived?: boolean;
     backend?: AppServerBackendKind;
+    callerReason?: ThreadListCallerReason;
     filter?: string;
   } = {}): Promise<AppServerThreadSummary[]> {
+    const cacheKey = this.buildThreadListCacheKey(params);
+    const cached = this.threadListCache.get(cacheKey);
+    const now = Date.now();
+    if (cached?.threads && (cached.expiresAt ?? 0) > now) {
+      logDebug("threadListCache:hit", {
+        backend: params.backend ?? "all",
+        callerReason: params.callerReason ?? null,
+        ownerId: this.threadListCacheOwnerId,
+      });
+      return cached.threads;
+    }
+    if (cached?.promise) {
+      logDebug("threadListCache:coalesced", {
+        backend: params.backend ?? "all",
+        callerReason: params.callerReason ?? null,
+        ownerId: this.threadListCacheOwnerId,
+      });
+      return await cached.promise;
+    }
+
+    const promise = this.readThreadList(params)
+      .then((threads) => {
+        this.threadListCache.set(cacheKey, {
+          expiresAt: Date.now() + THREAD_LIST_REUSE_WINDOW_MS,
+          threads,
+        });
+        return threads;
+      })
+      .catch((error) => {
+        this.threadListCache.delete(cacheKey);
+        throw error;
+      });
+    this.threadListCache.set(cacheKey, { promise });
+    return await promise;
+  }
+
+  private async readThreadList(params: {
+    archived?: boolean;
+    backend?: AppServerBackendKind;
+    callerReason?: ThreadListCallerReason;
+    filter?: string;
+  }): Promise<AppServerThreadSummary[]> {
+    const diagnostics = {
+      callerReason: params.callerReason ?? "thread-list",
+      ownerId: this.threadListCacheOwnerId,
+    };
     if (params.backend === "codex") {
       return await this.listCodexThreads({
         archived: params.archived,
         filter: params.filter,
-      });
+      }, diagnostics);
     }
 
     if (params.backend === "grok") {
       return await this.grokClient.listThreads({
         archived: params.archived,
         filter: params.filter,
-      });
+      }, diagnostics);
     }
 
     const threadLists = await Promise.all([
-      this.listCodexThreads({
+      this.listThreads({
+        backend: "codex",
         archived: params.archived,
+        callerReason: params.callerReason,
         filter: params.filter,
       }),
-      this.grokClient.listThreads({
+      this.listThreads({
+        backend: "grok",
         archived: params.archived,
+        callerReason: params.callerReason,
         filter: params.filter,
       }).catch(() => []),
     ]);
@@ -1119,6 +1194,7 @@ export class DesktopBackendRegistry {
             await this.archiveWithClient(client, request.threadId),
           )
         : await this.archiveWithClient(this.grokClient, request.threadId);
+    this.invalidateThreadListCache(backend);
     const cleanup = thread
       ? await this.archiveThreadWorktrees({
           backend,
@@ -1144,6 +1220,7 @@ export class DesktopBackendRegistry {
             await this.restoreWithClient(client, request.threadId),
           )
         : await this.restoreWithClient(this.grokClient, request.threadId);
+    this.invalidateThreadListCache(backend);
 
     return {
       backend,
@@ -1265,6 +1342,7 @@ export class DesktopBackendRegistry {
             await this.renameWithClient(client, request.threadId, request.name),
           )
         : await this.renameWithClient(this.grokClient, request.threadId, request.name);
+    this.invalidateThreadListCache(backend);
 
     return {
       backend,
@@ -1333,6 +1411,7 @@ export class DesktopBackendRegistry {
       approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
       sandbox: request.sandbox ?? modeSettings.sandbox,
     });
+    this.invalidateThreadListCache(backend);
 
     if (backend === "codex") {
       await this.overlayStore.setThreadExecutionMode({
@@ -1633,6 +1712,7 @@ export class DesktopBackendRegistry {
     });
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
+      callerReason: "branch-drift",
       threadId: params.threadId,
     });
     const expectedBranch = resolveExpectedThreadBranch({
@@ -2117,6 +2197,9 @@ export class DesktopBackendRegistry {
     this.unsubscribers.push(
       client.onNotification(async (notification) => {
         logBackendLifecycleNotification(backend, notification);
+        if (this.shouldInvalidateThreadListCacheForNotification(notification.method)) {
+          this.invalidateThreadListCache(backend);
+        }
         await this.emit({ backend, notification });
       }),
     );
@@ -2141,11 +2224,52 @@ export class DesktopBackendRegistry {
       : this.codexDefaultClient;
   }
 
+  private buildThreadListCacheKey(params: {
+    archived?: boolean;
+    backend?: AppServerBackendKind;
+    filter?: string;
+  }): string {
+    return JSON.stringify({
+      archived: params.archived === true,
+      backend: params.backend ?? "all",
+      filter: params.filter?.trim() ?? "",
+    });
+  }
+
+  private invalidateThreadListCache(backend?: AppServerBackendKind): void {
+    if (!backend) {
+      this.threadListCache.clear();
+      return;
+    }
+
+    for (const key of this.threadListCache.keys()) {
+      if (key.includes(`"backend":"${backend}"`) || key.includes('"backend":"all"')) {
+        this.threadListCache.delete(key);
+      }
+    }
+  }
+
+  private shouldInvalidateThreadListCacheForNotification(method: string): boolean {
+    return (
+      method === "thread/archived" ||
+      method === "thread/name/updated" ||
+      method === "thread/started" ||
+      method === "thread/unarchived" ||
+      method === "turn/completed" ||
+      method === "turn/failed"
+    );
+  }
+
   private async listCodexThreads(params: {
     archived?: boolean;
     filter?: string;
-  } = {}): Promise<AppServerThreadSummary[]> {
-    const defaultThreads = await this.codexDefaultClient.listThreads(params).catch(() => []);
+  } = {}, diagnostics?: {
+    callerReason?: string;
+    ownerId?: string;
+  }): Promise<AppServerThreadSummary[]> {
+    const defaultThreads = await this.codexDefaultClient
+      .listThreads(params, diagnostics)
+      .catch(() => []);
     const allThreads = defaultThreads.map((thread) => ({
       ...thread,
       executionMode: "default" as const,
@@ -2368,12 +2492,14 @@ export class DesktopBackendRegistry {
     const activeThreads = await this.listThreads({
       backend: params.backend,
       archived: false,
+      callerReason: "archive-cleanup",
     }).catch(() => []);
     const archivedThreads = activeThreads.some((thread) => thread.id === params.threadId)
       ? []
       : await this.listThreads({
           backend: params.backend,
           archived: true,
+          callerReason: "archive-cleanup",
         }).catch(() => []);
 
     return [...activeThreads, ...archivedThreads].find(
@@ -2383,11 +2509,13 @@ export class DesktopBackendRegistry {
 
   private async findThreadForWorkspaceHandoff(params: {
     backend: AppServerBackendKind;
+    callerReason?: ThreadListCallerReason;
     threadId: string;
   }): Promise<AppServerThreadSummary | undefined> {
     return await this.listThreads({
       backend: params.backend,
       archived: false,
+      callerReason: params.callerReason ?? "workspace-handoff",
     })
       .then((threads) => threads.find((thread) => thread.id === params.threadId))
       .catch(() => undefined);
@@ -2614,6 +2742,7 @@ export class DesktopBackendRegistry {
     try {
       const currentThread = await this.findThreadForTitleGeneration({
         backend: params.backend,
+        callerReason: "title-generation",
         threadId: params.threadId,
       });
       if (!isEligibleForGeneratedTitle(currentThread, params.prompt)) {
@@ -2656,6 +2785,7 @@ export class DesktopBackendRegistry {
 
       const latestThread = await this.findThreadForTitleGeneration({
         backend: params.backend,
+        callerReason: "title-generation",
         threadId: params.threadId,
       });
       if (latestThread && !isEligibleForGeneratedTitle(latestThread, params.prompt)) {
@@ -2694,11 +2824,13 @@ export class DesktopBackendRegistry {
 
   private async findThreadForTitleGeneration(params: {
     backend: AppServerBackendKind;
+    callerReason?: ThreadListCallerReason;
     threadId: string;
   }): Promise<AppServerThreadSummary | undefined> {
     const activeThreads = await this.listThreads({
       backend: params.backend,
       archived: false,
+      callerReason: params.callerReason ?? "title-generation",
     }).catch(() => []);
     return activeThreads.find((thread) => thread.id === params.threadId);
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -89,6 +89,10 @@ import {
 } from "./thread-title-generation-service";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import {
+  BackendModelCatalog,
+  type BackendModelCatalogCallerReason,
+} from "./backend-model-catalog";
 
 type InitializeResult = {
   serverInfo?: {
@@ -169,7 +173,10 @@ type BackendClient = {
     target: StartReviewRequest["target"];
     delivery?: StartReviewRequest["delivery"];
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
-  listModels?(): Promise<BackendModelOption[]>;
+  listModels?(diagnostics?: {
+    callerReason?: string;
+    ownerId?: string;
+  }): Promise<BackendModelOption[]>;
   readAccount?(): Promise<BackendAccountSummary>;
   readRateLimits?(): Promise<BackendRateLimitSummary[]>;
   interruptTurn(params: {
@@ -868,10 +875,7 @@ export class DesktopBackendRegistry {
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
-  private codexDefaultModels?: BackendModelOption[];
-  private codexDefaultModelsPromise?: Promise<BackendModelOption[]>;
-  private grokDefaultModels?: BackendModelOption[];
-  private grokDefaultModelsPromise?: Promise<BackendModelOption[]>;
+  private readonly modelCatalog: BackendModelCatalog;
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -1019,9 +1023,10 @@ export class DesktopBackendRegistry {
                     : undefined,
                 },
               }));
-
-    void this.readCodexDefaultModelsOnce().catch(() => undefined);
-    void this.readGrokDefaultModelsOnce().catch(() => undefined);
+    this.modelCatalog = new BackendModelCatalog({
+      codex: this.codexDefaultClient,
+      grok: this.grokClient,
+    });
 
     this.subscribeClient("codex", this.codexDefaultClient);
     this.subscribeClient("codex", this.codexFullAccessClient);
@@ -1601,7 +1606,11 @@ export class DesktopBackendRegistry {
   async setThreadModelSettings(
     params: SetThreadModelSettingsRequest
   ): Promise<SetThreadModelSettingsResponse> {
-    const modelSettings = await this.resolveModelSettings(params.backend, params);
+    const modelSettings = await this.resolveModelSettings(
+      params.backend,
+      params,
+      "settings-refresh",
+    );
     await this.overlayStore.setThreadModelSettings({
       backend: params.backend,
       threadId: params.threadId,
@@ -2009,10 +2018,11 @@ export class DesktopBackendRegistry {
   private async resolveModelSettings(
     backend: AppServerBackendKind,
     settings: ModelSettings,
+    callerReason: BackendModelCatalogCallerReason = "thread-start-defaults",
   ): Promise<ModelSettings> {
     return resolveModelSettingsFromOptions(
       backend,
-      await this.getBackendLaunchpadOptions(backend),
+      await this.getBackendLaunchpadOptions(backend, callerReason),
       settings,
     );
   }
@@ -2039,9 +2049,13 @@ export class DesktopBackendRegistry {
     backend: BackendSummary,
     settings: ModelSettings,
   ): Promise<ModelSettings> {
+    const launchpadOptions =
+      backend.launchpadOptions ??
+      (await this.getBackendLaunchpadOptions(backend.kind, "launchpad-defaults"));
+
     return resolveModelSettingsFromOptions(
       backend.kind,
-      backend.launchpadOptions,
+      launchpadOptions,
       settings,
     );
   }
@@ -2074,51 +2088,28 @@ export class DesktopBackendRegistry {
     return await this.overlayStore.setLaunchpadDefaults(resolvedDefaults);
   }
 
-  private readCodexDefaultModelsOnce(): Promise<BackendModelOption[]> {
-    if (this.codexDefaultModels) {
-      return Promise.resolve(this.codexDefaultModels);
-    }
-
-    this.codexDefaultModelsPromise ??= readClientModels(this.codexDefaultClient)
-      .then((models) => {
-        this.codexDefaultModels = models;
-        return models;
-      })
-      .catch((error) => {
-        this.codexDefaultModelsPromise = undefined;
-        throw error;
-      });
-
-    return this.codexDefaultModelsPromise;
+  private readCodexDefaultModelsOnce(
+    callerReason: BackendModelCatalogCallerReason,
+  ): Promise<BackendModelOption[]> {
+    return this.modelCatalog.readModels("codex", callerReason);
   }
 
-  private readGrokDefaultModelsOnce(): Promise<BackendModelOption[]> {
-    if (this.grokDefaultModels) {
-      return Promise.resolve(this.grokDefaultModels);
-    }
-
-    this.grokDefaultModelsPromise ??= readClientModels(this.grokClient)
-      .then((models) => {
-        this.grokDefaultModels = models;
-        return models;
-      })
-      .catch((error) => {
-        this.grokDefaultModelsPromise = undefined;
-        throw error;
-      });
-
-    return this.grokDefaultModelsPromise;
+  private readGrokDefaultModelsOnce(
+    callerReason: BackendModelCatalogCallerReason,
+  ): Promise<BackendModelOption[]> {
+    return this.modelCatalog.readModels("grok", callerReason);
   }
 
   private async getBackendLaunchpadOptions(
     backend: AppServerBackendKind,
+    callerReason: BackendModelCatalogCallerReason,
   ): Promise<BackendLaunchpadOptions | undefined> {
     if (backend === "codex") {
-      const models = await this.readCodexDefaultModelsOnce().catch(() => []);
+      const models = await this.readCodexDefaultModelsOnce(callerReason).catch(() => []);
       return buildLaunchpadOptions(backend, models);
     }
 
-    const models = await this.readGrokDefaultModelsOnce().catch(() => []);
+    const models = await this.readGrokDefaultModelsOnce(callerReason).catch(() => []);
     return buildLaunchpadOptions(backend, models);
   }
 
@@ -2186,7 +2177,7 @@ export class DesktopBackendRegistry {
     ] = await Promise.allSettled([
       this.codexDefaultClient.getInitializeResult(),
       this.codexFullAccessClient.getInitializeResult(),
-      this.readCodexDefaultModelsOnce(),
+      this.readCodexDefaultModelsOnce("backend-summary"),
       readClientAccount(this.codexDefaultClient),
       readClientRateLimits(this.codexDefaultClient),
     ]);
@@ -2264,7 +2255,7 @@ export class DesktopBackendRegistry {
       const initialize = await client.getInitializeResult();
       const models =
         kind === "grok"
-          ? await this.readGrokDefaultModelsOnce().catch(() => [])
+          ? await this.readGrokDefaultModelsOnce("backend-summary").catch(() => [])
           : await readClientModels(client).catch(() => []);
       const methods = Array.isArray(initialize.methods)
         ? initialize.methods.filter((method): method is string => typeof method === "string")

--- a/apps/desktop/src/main/app-server/protocol-log-observer.ts
+++ b/apps/desktop/src/main/app-server/protocol-log-observer.ts
@@ -75,6 +75,10 @@ export function createProtocolLogObserver(
     options.streamLogIntervalMs ?? STREAM_LOG_INTERVAL_MS;
   const deltaBuffers = new Map<string, DeltaBuffer>();
   const requestMethodsById = new Map<string, string>();
+  const requestDiagnosticsById = new Map<
+    string,
+    NonNullable<JsonRpcObserverEvent["diagnostics"]>
+  >();
 
   function logDeltaBuffer(
     key: string,
@@ -132,6 +136,8 @@ export function createProtocolLogObserver(
       const kind = classifyEnvelope(envelope);
       const method =
         envelope.method ?? (id ? requestMethodsById.get(id) : undefined) ?? "response";
+      const diagnostics =
+        event.diagnostics ?? (id ? requestDiagnosticsById.get(id) : undefined);
       const delta = pickRawString(params, "delta");
       const deltaKey = delta
         ? buildDeltaKey({
@@ -170,17 +176,22 @@ export function createProtocolLogObserver(
       flushDeltaBuffersFor(envelope);
       if (kind === "request" && id && envelope.method) {
         requestMethodsById.set(id, envelope.method);
+        if (event.diagnostics) {
+          requestDiagnosticsById.set(id, event.diagnostics);
+        }
       }
       const paramKeys = Object.keys(params ?? {});
       logger.info(
         "message",
         compactFields({
           backend: options.backend,
+          callerReason: diagnostics?.callerReason,
           direction: compactDirection(event.direction),
           id,
           itemId: pickString(params, "itemId") ?? pickString(item, "id"),
           kind,
           method,
+          ownerId: diagnostics?.ownerId,
           paramKeys: paramKeys.length > 0 ? paramKeys : undefined,
           turnId: pickString(params, "turnId"),
           threadId: pickString(params, "threadId"),
@@ -188,6 +199,7 @@ export function createProtocolLogObserver(
       );
       if (kind === "response" && id) {
         requestMethodsById.delete(id);
+        requestDiagnosticsById.delete(id);
       }
     },
   };

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -64,6 +64,7 @@ import {
   JsonRpcConnection,
   type JsonRpcId,
   type JsonRpcObserver,
+  type JsonRpcObserverDiagnostics,
 } from "./json-rpc";
 import {
   createThreadDirectoryEnricher,
@@ -3204,6 +3205,7 @@ function buildThreadReadPayload(params: {
 
 async function requestWithFallbacks(params: {
   client: JsonRpcConnection;
+  diagnostics?: JsonRpcObserverDiagnostics;
   methods: Array<CodexClientRequestMethod | (string & {})>;
   payloads: unknown[];
   timeoutMs: number;
@@ -3213,7 +3215,12 @@ async function requestWithFallbacks(params: {
   for (const method of params.methods) {
     for (const payload of params.payloads) {
       try {
-        return await params.client.request(method, payload, params.timeoutMs);
+        return await params.client.request(
+          method,
+          payload,
+          params.timeoutMs,
+          params.diagnostics,
+        );
       } catch (error) {
         lastError = error;
         if (!isMethodUnavailableError(error, method)) {
@@ -3688,12 +3695,15 @@ export class CodexAppServerClient {
     return extractSkillCatalog(result);
   }
 
-  async listModels(): Promise<BackendModelOption[]> {
+  async listModels(
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): Promise<BackendModelOption[]> {
     await this.ensureInitialized();
 
     const payload: CodexModelListParams = {};
     const result = await requestWithFallbacks({
       client: this.connection,
+      diagnostics,
       methods: ["model/list"],
       payloads: [payload],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -78,6 +78,7 @@ import type {
 } from "../app-server/thread-title-generation-service";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+const ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
@@ -3256,6 +3257,7 @@ export class CodexAppServerClient {
     string,
     Promise<RawCodexThreadSummary[]>
   >();
+  private readonly archivedThreadMetadataLastRefreshByFilter = new Map<string, number>();
   private initialized = false;
   private initializationPromise: Promise<void> | null = null;
   private initializeResult: InitializeResult | null = null;
@@ -3575,11 +3577,12 @@ export class CodexAppServerClient {
   async listThreads(params?: {
     archived?: boolean;
     filter?: string;
-  }): Promise<AppServerThreadSummary[]> {
+  }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
     const requestParams = {
       client: this.connection,
+      diagnostics,
       methods: ["thread/list"] as CodexClientRequestMethod[],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     };
@@ -3599,7 +3602,7 @@ export class CodexAppServerClient {
       activeThreads: extractThreadsFromValue(activeResult),
       archivedThreads: this.getCachedArchivedThreadMetadata(params?.filter),
     });
-    this.scheduleArchivedThreadMetadataRefresh(params?.filter);
+    this.scheduleArchivedThreadMetadataRefresh(params?.filter, diagnostics);
 
     return await this.enrichThreads(threads);
   }
@@ -3608,9 +3611,23 @@ export class CodexAppServerClient {
     return this.archivedThreadMetadataByFilter.get(buildThreadMetadataCacheKey(filter)) ?? [];
   }
 
-  private scheduleArchivedThreadMetadataRefresh(filter?: string): void {
+  private scheduleArchivedThreadMetadataRefresh(
+    filter?: string,
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): void {
+    const cacheKey = buildThreadMetadataCacheKey(filter);
+    const lastRefreshAt = this.archivedThreadMetadataLastRefreshByFilter.get(cacheKey) ?? 0;
+    const hasCachedMetadata = this.archivedThreadMetadataByFilter.has(cacheKey);
+    if (
+      this.archivedThreadMetadataInFlightByFilter.has(cacheKey) ||
+      (hasCachedMetadata &&
+        Date.now() - lastRefreshAt < ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS)
+    ) {
+      return;
+    }
+
     setTimeout(() => {
-      void this.refreshArchivedThreadMetadata(filter).catch((error) => {
+      void this.refreshArchivedThreadMetadata(filter, diagnostics).catch((error) => {
         codexClientLog.warn("archived thread metadata refresh failed", {
           error: error instanceof Error ? error.message : String(error),
           filter: filter?.trim() || null,
@@ -3621,6 +3638,7 @@ export class CodexAppServerClient {
 
   private async refreshArchivedThreadMetadata(
     filter?: string,
+    diagnostics?: JsonRpcObserverDiagnostics,
   ): Promise<RawCodexThreadSummary[]> {
     const cacheKey = buildThreadMetadataCacheKey(filter);
     const inFlight = this.archivedThreadMetadataInFlightByFilter.get(cacheKey);
@@ -3630,6 +3648,12 @@ export class CodexAppServerClient {
 
     const requestPromise = requestWithFallbacks({
       client: this.connection,
+      diagnostics: diagnostics
+        ? {
+            ...diagnostics,
+            callerReason: `${diagnostics.callerReason ?? "thread-list"}:archived-metadata`,
+          }
+        : undefined,
       methods: ["thread/list"] as CodexClientRequestMethod[],
       payloads: buildThreadDiscoveryPayloads(filter, true),
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -3637,6 +3661,7 @@ export class CodexAppServerClient {
       .then((result) => {
         const threads = extractThreadsFromValue(result);
         this.archivedThreadMetadataByFilter.set(cacheKey, threads);
+        this.archivedThreadMetadataLastRefreshByFilter.set(cacheKey, Date.now());
         return threads;
       })
       .finally(() => {

--- a/apps/desktop/src/main/codex-app-server/json-rpc.ts
+++ b/apps/desktop/src/main/codex-app-server/json-rpc.ts
@@ -46,6 +46,12 @@ export type JsonRpcObserverEvent = {
   direction: "inbound" | "outbound";
   raw: string;
   envelope: JsonRpcEnvelope;
+  diagnostics?: JsonRpcObserverDiagnostics;
+};
+
+export type JsonRpcObserverDiagnostics = {
+  callerReason?: string;
+  ownerId?: string;
 };
 
 export interface JsonRpcObserver {
@@ -123,7 +129,8 @@ export class JsonRpcConnection {
   async request(
     method: string,
     params?: unknown,
-    timeoutMs?: number
+    timeoutMs?: number,
+    diagnostics?: JsonRpcObserverDiagnostics,
   ): Promise<unknown> {
     const id = `rpc-${++this.requestCounter}`;
     const requestPromise = new Promise<unknown>((resolve, reject) => {
@@ -139,7 +146,7 @@ export class JsonRpcConnection {
       id,
       method,
       params: params ?? {}
-    });
+    }, diagnostics);
 
     return await requestPromise;
   }
@@ -212,12 +219,16 @@ export class JsonRpcConnection {
     }
   }
 
-  private async sendEnvelope(envelope: JsonRpcEnvelope): Promise<void> {
+  private async sendEnvelope(
+    envelope: JsonRpcEnvelope,
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): Promise<void> {
     const raw = JSON.stringify(envelope);
     await this.notifyObserver({
       direction: "outbound",
       raw,
-      envelope
+      envelope,
+      diagnostics,
     });
     this.transport.send(raw);
   }

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -27,7 +27,10 @@ import type {
   BackendModelOption,
   LinkedDirectorySummary,
 } from "@pwragnt/shared";
-import type { JsonRpcObserver } from "../codex-app-server/json-rpc";
+import type {
+  JsonRpcObserver,
+  JsonRpcObserverDiagnostics,
+} from "../codex-app-server/json-rpc";
 import { summarizeToolActivityItems } from "../app-server/thread-activity";
 import { getMainLogger } from "../log";
 import {
@@ -853,10 +856,12 @@ export class GrokAppServerClient {
     return extractSkillsList(result);
   }
 
-  async listModels(): Promise<BackendModelOption[]> {
+  async listModels(
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): Promise<BackendModelOption[]> {
     await this.ensureInitialized();
 
-    const result = await this.request("model/list", {});
+    const result = await this.request("model/list", {}, diagnostics);
     return extractModelOptions(result);
   }
 
@@ -1160,12 +1165,17 @@ export class GrokAppServerClient {
     });
   }
 
-  private async request(method: string, params?: unknown): Promise<unknown> {
+  private async request(
+    method: string,
+    params?: unknown,
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): Promise<unknown> {
     const id = `rpc-${++this.requestCounter}`;
     const server = this.getServer();
 
     await this.observe({
       direction: "outbound",
+      diagnostics,
       envelope: {
         jsonrpc: "2.0",
         id,
@@ -1178,6 +1188,7 @@ export class GrokAppServerClient {
       const result = await server.request(method, params);
       await this.observe({
         direction: "inbound",
+        diagnostics,
         envelope: {
           jsonrpc: "2.0",
           id,
@@ -1188,6 +1199,7 @@ export class GrokAppServerClient {
     } catch (error) {
       await this.observe({
         direction: "inbound",
+        diagnostics,
         envelope: {
           jsonrpc: "2.0",
           id,
@@ -1217,6 +1229,7 @@ export class GrokAppServerClient {
 
   private async observe(params: {
     direction: "inbound" | "outbound";
+    diagnostics?: JsonRpcObserverDiagnostics;
     envelope: {
       jsonrpc: "2.0";
       id?: string;
@@ -1238,6 +1251,7 @@ export class GrokAppServerClient {
         direction: params.direction,
         raw: JSON.stringify(params.envelope),
         envelope: params.envelope,
+        diagnostics: params.diagnostics,
       });
     } catch (error) {
       grokClientLog.error("observer failed", {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1048,10 +1048,12 @@ export class GrokAppServerClient {
         capabilities: { experimentalApi: true },
       });
 
+      await this.notify("initialized", {});
       this.initializeResult = (result ?? {}) as InitializeResult;
       this.initialized = true;
-      await this.notify("initialized", {});
     })().catch((error) => {
+      this.initialized = false;
+      this.initializeResult = null;
       this.initializePromise = undefined;
       throw error;
     });

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -744,6 +744,7 @@ export class GrokAppServerClient {
   private requestCounter = 0;
   private server: GrokServerLike | null;
   private initialized = false;
+  private initializePromise?: Promise<void>;
   private initializeResult: InitializeResult | null = null;
   private readonly notificationListeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
@@ -776,6 +777,7 @@ export class GrokAppServerClient {
     this.unsubscribeRequest?.();
     this.unsubscribeRequest = undefined;
     this.initialized = false;
+    this.initializePromise = undefined;
     this.initializeResult = null;
   }
 
@@ -1034,15 +1036,22 @@ export class GrokAppServerClient {
       return;
     }
 
-    const result = await this.request("initialize", {
-      protocolVersion: DEFAULT_PROTOCOL_VERSION,
-      clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
-      capabilities: { experimentalApi: true },
+    this.initializePromise ??= (async () => {
+      const result = await this.request("initialize", {
+        protocolVersion: DEFAULT_PROTOCOL_VERSION,
+        clientInfo: { name: "pwragnt-desktop", version: "0.1.0" },
+        capabilities: { experimentalApi: true },
+      });
+
+      this.initializeResult = (result ?? {}) as InitializeResult;
+      this.initialized = true;
+      await this.notify("initialized", {});
+    })().catch((error) => {
+      this.initializePromise = undefined;
+      throw error;
     });
 
-    this.initializeResult = (result ?? {}) as InitializeResult;
-    await this.notify("initialized", {});
-    this.initialized = true;
+    await this.initializePromise;
   }
 
   private getServer(): GrokServerLike {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -812,13 +812,13 @@ export class GrokAppServerClient {
   async listThreads(params?: {
     archived?: boolean;
     filter?: string;
-  }): Promise<AppServerThreadSummary[]> {
+  }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
     const result = await this.request("thread/list", {
       archived: params?.archived === true,
       filter: params?.filter,
-    });
+    }, diagnostics);
     return await Promise.all(
       extractThreadSummaryList(result).map(async (thread) => {
         const normalized = normalizeThreadSummary(thread);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -90,9 +90,22 @@ function directoryStatusesEqual(
   });
 }
 
+function getNavigationSnapshotRequestKey(
+  request: GetNavigationSnapshotRequest,
+): string {
+  return JSON.stringify({
+    backend: request.backend ?? "all",
+    filter: request.filter ?? "",
+  });
+}
+
 class DesktopAppServerService {
   private focusedDiffService: FocusedDiffService | null = null;
   private focusedDiffServiceApiKey: string | undefined;
+  private readonly pendingNavigationSnapshots = new Map<
+    string,
+    Promise<NavigationSnapshot>
+  >();
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
     NavigationSnapshot["directories"]
@@ -105,6 +118,7 @@ class DesktopAppServerService {
     const threads = await getDesktopBackendRegistry().listThreads({
       backend,
       archived: request.archived,
+      callerReason: "ipc-list-threads",
       filter: request.filter,
     });
 
@@ -271,9 +285,33 @@ class DesktopAppServerService {
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
   ): Promise<NavigationSnapshot> {
+    const requestKey = getNavigationSnapshotRequestKey(request);
+    const pending = this.pendingNavigationSnapshots.get(requestKey);
+    if (pending) {
+      logDebug("getNavigationSnapshot:coalesced", {
+        backend: request.backend ?? "all",
+        filter: request.filter ?? null,
+      });
+      return await pending;
+    }
+
+    const promise = this.readNavigationSnapshot(request).finally(() => {
+      if (this.pendingNavigationSnapshots.get(requestKey) === promise) {
+        this.pendingNavigationSnapshots.delete(requestKey);
+      }
+    });
+    this.pendingNavigationSnapshots.set(requestKey, promise);
+
+    return await promise;
+  }
+
+  private async readNavigationSnapshot(
+    request: GetNavigationSnapshotRequest,
+  ): Promise<NavigationSnapshot> {
     const backend: AppServerBackendScope = request.backend ?? "all";
     const threads = await getDesktopBackendRegistry().listThreads({
       backend: backend === "all" ? undefined : backend,
+      callerReason: "navigation-snapshot",
       filter: request.filter,
     });
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -37,6 +37,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     const backend = request.backend ?? "all";
     const threads = await this.registry.listThreads({
       backend: backend === "all" ? undefined : backend,
+      callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
     });
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({

--- a/apps/desktop/src/main/testing/capture-store.ts
+++ b/apps/desktop/src/main/testing/capture-store.ts
@@ -7,6 +7,7 @@ export type ProtocolCaptureEventRecord = {
   backend: "codex" | "grok";
   backendInstance?: string;
   captureId: string;
+  diagnostics?: ProtocolCaptureDiagnostics;
   direction: "inbound" | "outbound";
   kind: "request" | "response" | "notification";
   method?: string;
@@ -15,6 +16,11 @@ export type ProtocolCaptureEventRecord = {
   timestamp: number;
   threadIds: string[];
   raw: string;
+};
+
+export type ProtocolCaptureDiagnostics = {
+  callerReason?: string;
+  ownerId?: string;
 };
 
 export type ProtocolCaptureStringReplacement = {
@@ -116,6 +122,7 @@ export class ProtocolCaptureStore {
 
   async append(params: {
     direction: "inbound" | "outbound";
+    diagnostics?: ProtocolCaptureDiagnostics;
     raw: string;
     envelope: {
       id?: string | number | null;
@@ -129,6 +136,7 @@ export class ProtocolCaptureStore {
       backend: this.params.backend,
       backendInstance: this.params.backendInstance,
       captureId: this.params.captureId,
+      diagnostics: normalizeDiagnostics(params.diagnostics),
       direction: params.direction,
       kind: getEnvelopeKind(params.envelope),
       method: params.envelope.method?.trim() || undefined,
@@ -341,6 +349,21 @@ function parseProtocolCaptureEnvelope(
   }
 
   return parsed as ProtocolCaptureEnvelope;
+}
+
+function normalizeDiagnostics(
+  diagnostics: ProtocolCaptureDiagnostics | undefined,
+): ProtocolCaptureDiagnostics | undefined {
+  const callerReason = diagnostics?.callerReason?.trim();
+  const ownerId = diagnostics?.ownerId?.trim();
+  if (!callerReason && !ownerId) {
+    return undefined;
+  }
+
+  return {
+    ...(callerReason ? { callerReason } : {}),
+    ...(ownerId ? { ownerId } : {}),
+  };
 }
 
 function extractThreadIds(envelope: {

--- a/apps/desktop/src/main/testing/protocol-capture-analysis.ts
+++ b/apps/desktop/src/main/testing/protocol-capture-analysis.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ProtocolCaptureEventRecord } from "./capture-store";
+
+export type ProtocolCaptureMethodSummary = {
+  count: number;
+  callerReasons: string[];
+  firstAt?: number;
+  lastAt?: number;
+  ownerIds: string[];
+};
+
+export type ProtocolCaptureBackendSummary = {
+  requestCounts: Record<string, number>;
+  notificationCounts: Record<string, number>;
+  responseCounts: Record<string, number>;
+  requests: Record<string, ProtocolCaptureMethodSummary>;
+};
+
+export type ProtocolCaptureTrafficAnalysis = {
+  backendInstances: string[];
+  captureIds: string[];
+  capturePath: string;
+  malformedRecordCount: number;
+  summaries: Record<string, ProtocolCaptureBackendSummary>;
+};
+
+export async function analyzeProtocolCaptureTraffic(params: {
+  capturePath: string;
+}): Promise<ProtocolCaptureTrafficAnalysis> {
+  const capturePath = path.resolve(params.capturePath);
+  const contents = await fs.readFile(capturePath, "utf8");
+  const captureIds = new Set<string>();
+  const backendInstances = new Set<string>();
+  const summaries = new Map<string, MutableBackendSummary>();
+  let malformedRecordCount = 0;
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    const record = parseCaptureRecord(line);
+    if (!record) {
+      malformedRecordCount += 1;
+      continue;
+    }
+
+    captureIds.add(record.captureId);
+    if (record.backendInstance) {
+      backendInstances.add(`${record.backend}:${record.backendInstance}`);
+    } else {
+      backendInstances.add(record.backend);
+    }
+
+    const summary = getMutableSummary(summaries, record.backend);
+    const method = record.method?.trim() || inferResponseMethod(record) || "unknown";
+    if (record.kind === "request" && record.direction === "outbound") {
+      increment(summary.requestCounts, method);
+      const methodSummary = getMutableMethodSummary(summary.requests, method);
+      methodSummary.count += 1;
+      methodSummary.firstAt =
+        methodSummary.firstAt === undefined
+          ? record.timestamp
+          : Math.min(methodSummary.firstAt, record.timestamp);
+      methodSummary.lastAt =
+        methodSummary.lastAt === undefined
+          ? record.timestamp
+          : Math.max(methodSummary.lastAt, record.timestamp);
+      const callerReason = record.diagnostics?.callerReason?.trim();
+      if (callerReason) {
+        methodSummary.callerReasons.add(callerReason);
+      }
+      const ownerId = record.diagnostics?.ownerId?.trim();
+      if (ownerId) {
+        methodSummary.ownerIds.add(ownerId);
+      }
+      continue;
+    }
+
+    if (record.kind === "notification") {
+      increment(summary.notificationCounts, method);
+      continue;
+    }
+
+    if (record.kind === "response") {
+      increment(summary.responseCounts, method);
+    }
+  }
+
+  return {
+    backendInstances: [...backendInstances].sort(),
+    captureIds: [...captureIds].sort(),
+    capturePath,
+    malformedRecordCount,
+    summaries: Object.fromEntries(
+      [...summaries.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([backend, summary]) => [backend, finalizeSummary(summary)]),
+    ),
+  };
+}
+
+type MutableMethodSummary = {
+  count: number;
+  callerReasons: Set<string>;
+  firstAt?: number;
+  lastAt?: number;
+  ownerIds: Set<string>;
+};
+
+type MutableBackendSummary = {
+  requestCounts: Record<string, number>;
+  notificationCounts: Record<string, number>;
+  responseCounts: Record<string, number>;
+  requests: Map<string, MutableMethodSummary>;
+};
+
+function parseCaptureRecord(line: string): ProtocolCaptureEventRecord | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const record = parsed as ProtocolCaptureEventRecord;
+    if (
+      (record.backend !== "codex" && record.backend !== "grok") ||
+      !record.captureId?.trim() ||
+      (record.direction !== "inbound" && record.direction !== "outbound") ||
+      (record.kind !== "request" &&
+        record.kind !== "response" &&
+        record.kind !== "notification") ||
+      typeof record.timestamp !== "number"
+    ) {
+      return null;
+    }
+
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+function inferResponseMethod(record: ProtocolCaptureEventRecord): string | undefined {
+  if (record.kind !== "response") {
+    return undefined;
+  }
+  return record.method?.trim() || undefined;
+}
+
+function getMutableSummary(
+  summaries: Map<string, MutableBackendSummary>,
+  backend: string,
+): MutableBackendSummary {
+  const existing = summaries.get(backend);
+  if (existing) {
+    return existing;
+  }
+
+  const created: MutableBackendSummary = {
+    requestCounts: {},
+    notificationCounts: {},
+    responseCounts: {},
+    requests: new Map(),
+  };
+  summaries.set(backend, created);
+  return created;
+}
+
+function getMutableMethodSummary(
+  summaries: Map<string, MutableMethodSummary>,
+  method: string,
+): MutableMethodSummary {
+  const existing = summaries.get(method);
+  if (existing) {
+    return existing;
+  }
+
+  const created: MutableMethodSummary = {
+    count: 0,
+    callerReasons: new Set(),
+    ownerIds: new Set(),
+  };
+  summaries.set(method, created);
+  return created;
+}
+
+function increment(record: Record<string, number>, key: string): void {
+  record[key] = (record[key] ?? 0) + 1;
+}
+
+function finalizeSummary(summary: MutableBackendSummary): ProtocolCaptureBackendSummary {
+  return {
+    requestCounts: sortCounts(summary.requestCounts),
+    notificationCounts: sortCounts(summary.notificationCounts),
+    responseCounts: sortCounts(summary.responseCounts),
+    requests: Object.fromEntries(
+      [...summary.requests.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([method, methodSummary]) => [
+          method,
+          {
+            count: methodSummary.count,
+            callerReasons: [...methodSummary.callerReasons].sort(),
+            firstAt: methodSummary.firstAt,
+            lastAt: methodSummary.lastAt,
+            ownerIds: [...methodSummary.ownerIds].sort(),
+          },
+        ]),
+    ),
+  };
+}
+
+function sortCounts(input: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(input).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}

--- a/apps/desktop/src/main/testing/protocol-capture.ts
+++ b/apps/desktop/src/main/testing/protocol-capture.ts
@@ -15,6 +15,7 @@ export function createProtocolCaptureObserver(params: {
     onMessage: async (event) => {
       await params.store.append({
         direction: event.direction,
+        diagnostics: event.diagnostics,
         raw: event.raw,
         envelope: event.envelope
       });

--- a/docs/plans/2026-05-02-002-fix-grok-startup-model-chatter-plan.md
+++ b/docs/plans/2026-05-02-002-fix-grok-startup-model-chatter-plan.md
@@ -13,6 +13,15 @@ deepened: 2026-05-02
 
 Make backend model discovery observable, explicit, and single-flight across startup consumers. Grok should not issue repeated `model/list` requests because messaging startup, renderer backend summaries, launchpad normalization, or thread-start defaults each asks for model options through a different path. For this pass, model discovery should be first-consumer driven rather than constructor-driven: messaging startup may construct backend bridges, but the first real model consumer, such as renderer backend summaries or launchpad model resolution, owns the initial fetch through the shared catalog.
 
+## Implementation Progress
+
+- Implemented protocol diagnostics and capture analysis so backend requests can be counted by method and attributed by caller reason/cache owner when available.
+- Implemented `BackendModelCatalog` as the shared Codex/Grok single-flight model cache with cached successes and retry after failed discovery.
+- Removed constructor-side model warmup from `DesktopBackendRegistry`; constructing the registry no longer calls Codex or Grok `listModels()`.
+- Routed backend summaries, launchpad/default model resolution, thread-start defaults, and settings refresh through the shared catalog with caller reasons.
+- Added focused unit coverage for catalog coalescing/retry, registry lazy model discovery, protocol capture analysis, and protocol log diagnostics.
+- Deferred the heavier startup E2E capture fixture; the new analyzer provides the manual acceptance workflow for live startup captures.
+
 ## Problem Frame
 
 The latest startup log shows Grok being initialized and asked for `model/list` before the renderer window exists. That happens because `bootstrapApp()` starts messaging before `createMainWindow()`, and `DesktopMessagingRuntime` constructs `DesktopMessagingBackendBridge`, whose default constructor calls `getDesktopBackendRegistry()`. The registry constructor currently creates the Grok client and starts model discovery as a constructor side effect.
@@ -128,7 +137,7 @@ flowchart TB
     U4 --> U5
 ```
 
-- [ ] **Unit 1: Add startup protocol evidence and counters**
+- [x] **Unit 1: Add startup protocol evidence and counters**
 
 **Goal:** Make every startup model-list request attributable before changing cache behavior, so the implementation can prove what remains.
 
@@ -165,7 +174,7 @@ flowchart TB
 **Verification:**
 - Developers can point the analyzer at a protocol capture and determine whether Grok made duplicate `model/list` calls or only duplicate `thread/list` calls.
 
-- [ ] **Unit 2: Extract a shared backend model catalog**
+- [x] **Unit 2: Extract a shared backend model catalog**
 
 **Goal:** Centralize Codex and Grok model discovery behind one single-flight cache that all registry paths share.
 
@@ -201,7 +210,7 @@ flowchart TB
 **Verification:**
 - Model discovery count is bounded by catalog state rather than by how many registry methods request model options.
 
-- [ ] **Unit 3: Remove constructor-side model warmup**
+- [x] **Unit 3: Remove constructor-side model warmup**
 
 **Goal:** Stop backend registry construction from issuing Grok or Codex model-list requests implicitly.
 
@@ -237,7 +246,7 @@ flowchart TB
 **Verification:**
 - Pre-renderer startup no longer emits Grok `model/list` solely because messaging created a backend bridge.
 
-- [ ] **Unit 4: Route all real model consumers through the catalog**
+- [x] **Unit 4: Route all real model consumers through the catalog**
 
 **Goal:** Make every legitimate model option consumer use the shared catalog and propagate caller reason.
 

--- a/docs/plans/2026-05-02-002-fix-grok-startup-model-chatter-plan.md
+++ b/docs/plans/2026-05-02-002-fix-grok-startup-model-chatter-plan.md
@@ -1,0 +1,356 @@
+---
+title: fix: Stop duplicate Grok startup model chatter
+type: fix
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md
+deepened: 2026-05-02
+---
+
+# fix: Stop duplicate Grok startup model chatter
+
+## Overview
+
+Make backend model discovery observable, explicit, and single-flight across startup consumers. Grok should not issue repeated `model/list` requests because messaging startup, renderer backend summaries, launchpad normalization, or thread-start defaults each asks for model options through a different path. For this pass, model discovery should be first-consumer driven rather than constructor-driven: messaging startup may construct backend bridges, but the first real model consumer, such as renderer backend summaries or launchpad model resolution, owns the initial fetch through the shared catalog.
+
+## Problem Frame
+
+The latest startup log shows Grok being initialized and asked for `model/list` before the renderer window exists. That happens because `bootstrapApp()` starts messaging before `createMainWindow()`, and `DesktopMessagingRuntime` constructs `DesktopMessagingBackendBridge`, whose default constructor calls `getDesktopBackendRegistry()`. The registry constructor currently creates the Grok client and starts model discovery as a constructor side effect.
+
+The pasted log contains one visible Grok `model/list` and multiple Grok `thread/list` calls, while the user report says they are seeing many Grok model-list calls within seconds. This mismatch is itself part of the bug: current protocol logs show backend, method, direction, and rpc id, but not the higher-level registry instance or caller reason that caused a request. The implementation needs to prove whether remaining chatter is duplicate model discovery, duplicate backend registry construction, dev-process restart behavior, or navigation/thread-list fan-out being misread as model-list chatter.
+
+This plan builds on the thread-refresh direction that broad startup work should be scoped, cache-first, and stable rather than eager and repeated (see origin: `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`).
+
+## Requirements Trace
+
+- R1. A single desktop app process must not issue more than one successful Grok `model/list` request during startup unless an explicit invalidation event occurs.
+- R2. Messaging startup must not independently trigger Grok model discovery just because it constructs a backend bridge.
+- R3. Renderer backend summaries, directory launchpad defaults, and Grok thread creation must share one Grok model catalog cache.
+- R4. Every backend model-list request logged or captured in development must be attributable to a caller reason and registry/cache instance.
+- R5. When Grok model discovery fails during early startup, later model consumers may retry once the relevant consumer asks again, but failures must not produce tight retry loops.
+- R6. Grok thread listing and navigation snapshot refreshes are separate from model discovery; the implementation must classify and verify them separately so `thread/list` fan-out is not mistaken for `model/list`.
+- R7. Existing Codex behavior must remain intact: default Codex models are discovered once and full-access Codex does not issue its own model-list request unless explicitly required.
+
+## Scope Boundaries
+
+- This plan does not remove Grok as a configured backend or hide it from provider selectors.
+- This plan does not change the Grok app-server protocol contract or the shape of `model/list` responses.
+- This plan does not solve all startup `thread/list` or Codex full-access initialization chatter, except where instrumentation needs to distinguish those methods from Grok model discovery.
+- This plan does not change messaging provider behavior or channel workflows beyond avoiding accidental backend model discovery from messaging bridge construction.
+- This plan does not add user-facing settings for model discovery policy.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/index.ts` starts `DesktopMessagingRuntime` before creating the renderer window. Any backend work reachable from messaging startup happens before the user can interact with the UI.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` constructs controllers and subscribes to backend events during `start()`.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` defaults its `registry` constructor argument to `getDesktopBackendRegistry()`, which can instantiate the backend registry even when messaging has not handled an inbound user action.
+- `apps/desktop/src/main/app-server/backend-registry.ts` owns Codex/Grok clients, backend summaries, launchpad model option resolution, and thread start defaults. It already has Codex and Grok model memoization, but model warmup still starts from the constructor.
+- `apps/desktop/src/main/grok-app-server/client.ts` now coalesces concurrent initialization inside one client, but that does not protect against multiple registry instances, constructor-side warmups, or independent cache objects.
+- `apps/desktop/src/renderer/src/lib/useBackendSummaries.ts` calls `listBackends()` on renderer mount, which is a legitimate model-summary consumer if backend summaries include live model options.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` calls `getNavigationSnapshot()` on renderer mount, which explains startup `thread/list` calls and should be analyzed separately from `model/list`.
+- `apps/desktop/src/main/testing/protocol-capture.ts` and `apps/desktop/src/main/app-server/protocol-log-observer.ts` already capture protocol traffic, but they do not attach registry/cache instance ids or caller reasons.
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts` already contains focused model-list count coverage for Codex and Grok reuse. That is the primary unit-test pattern to extend.
+- `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts` already covers client-level concurrent initialization coalescing. Registry/cache-level duplication needs separate tests.
+- `apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx`, `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`, and `apps/desktop/src/main/__tests__/app-server-ipc.test.ts` cover the startup-adjacent consumers that can accidentally trigger backend work.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this worktree, so there are no durable solution learnings to carry forward.
+- `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md` established that summary refresh and selected-thread runtime state should be separated. This plan applies the same separation to model metadata: model catalog discovery should not be coupled to generic registry construction or thread-list refresh.
+- `docs/plans/2026-04-19-001-fix-desktop-startup-thread-stability-plan.md` identified startup churn caused by broad navigation refresh and expensive main-process fan-out. This plan narrows one remaining startup surface: backend model metadata discovery.
+
+### External References
+
+- None. The problem is local Electron main-process lifecycle, registry caching, and protocol instrumentation. Existing repo patterns are sufficient.
+
+## Key Technical Decisions
+
+- **Move model discovery out of `DesktopBackendRegistry` construction.** Registry construction should wire clients and stores, not issue protocol requests. This keeps messaging bridge creation from causing hidden Grok traffic before the renderer exists.
+- **Introduce one process-wide backend model catalog owner.** Codex and Grok model caches should live behind one explicit model catalog service or registry-owned collaborator with single-flight behavior, cached successes, controlled retry after failures, and caller-reason telemetry.
+- **Keep live model data available to real model consumers.** `listBackends()`, launchpad model normalization, and Grok `startThread()` may still need model options, but they must ask through the shared catalog and reuse the same result.
+- **Use first-consumer discovery, not startup warmup, in this iteration.** Renderer backend summaries are a legitimate model consumer on app mount; messaging bridge construction is not. This makes a no-interaction startup easier to reason about because any Grok `model/list` after the renderer mounts can be attributed to `backend-summary`, not hidden main-process warmup.
+- **Tag model discovery by reason, not just backend.** Development protocol logs and capture metadata should identify whether a model fetch came from startup warmup, backend summary rendering, launchpad normalization, thread start defaulting, settings refresh, or explicit invalidation.
+- **Separate model-list verification from thread-list verification.** The user-facing complaint is about model chatter, while the pasted trace also shows navigation `thread/list` fan-out. The implementation should report counts by method so the next diagnosis does not collapse them together.
+- **Preserve retry semantics for real failures.** A transient failed `model/list` should clear the in-flight promise so a later model consumer can retry, but startup should not immediately re-trigger the same failed request from multiple consumers.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should Grok model discovery remain hidden in registry construction?** No. Constructor-side protocol traffic makes it hard to reason about startup and lets messaging trigger model discovery without a user-facing model need.
+- **Should the fix focus only on Grok client initialization coalescing?** No. Client-level initialize coalescing is necessary but insufficient; the remaining risk is registry/cache-level fan-out and hidden startup callers.
+- **Should `thread/list` be treated as proof that model-list caching failed?** No. The implementation must count `model/list` separately from `thread/list` and explain each request class.
+
+### Deferred to Implementation
+
+- The exact shape of caller-reason propagation through the registry and protocol observer. The implementation should choose the smallest local API that keeps tests readable.
+- Whether protocol capture files should store caller reason directly on each JSONL row or whether the reason should be logged through a parallel diagnostic event. The testable requirement is attributable evidence, not a specific storage shape.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    A["bootstrapApp"] --> B["DesktopMessagingRuntime"]
+    A --> C["Renderer window"]
+    B --> D["DesktopMessagingBackendBridge"]
+    C --> E["useBackendSummaries"]
+    C --> F["useThreadNavigation"]
+    D --> G["DesktopBackendRegistry"]
+    E --> G
+    F --> G
+    G --> H["BackendModelCatalog"]
+    H --> I["Codex default model cache"]
+    H --> J["Grok model cache"]
+    G --> K["Thread list / navigation"]
+```
+
+| Consumer | Should it trigger Grok `model/list`? | Expected behavior |
+|---|---:|---|
+| Messaging bridge construction | No | Construct registry/bridge without protocol model traffic |
+| Renderer `listBackends()` | Yes, if backend summaries include live model options | First real startup consumer; fetch through shared catalog and label reason as `backend-summary` |
+| Navigation snapshot / `thread/list` | No | List threads without touching model catalog |
+| Directory launchpad normalization | Yes, if resolving Grok model settings | Reuse shared catalog and fallback models if unavailable |
+| Grok `startThread()` without explicit model | Yes, if no cached/default model exists | Reuse shared catalog, with controlled retry after prior failure |
+| Settings/discovery refresh | Yes, explicitly | Invalidate or refresh through one named path |
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Add startup protocol evidence and counters"] --> U2["Unit 2: Extract shared model catalog"]
+    U2 --> U3["Unit 3: Remove constructor-side model warmup"]
+    U2 --> U4["Unit 4: Route all model consumers through catalog"]
+    U3 --> U5["Unit 5: Add startup integration coverage"]
+    U4 --> U5
+```
+
+- [ ] **Unit 1: Add startup protocol evidence and counters**
+
+**Goal:** Make every startup model-list request attributable before changing cache behavior, so the implementation can prove what remains.
+
+**Requirements:** R1, R4, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/protocol-log-observer.ts`
+- Modify: `apps/desktop/src/main/testing/protocol-capture.ts`
+- Modify: `apps/desktop/src/main/testing/capture-store.ts`
+- Create: `apps/desktop/scripts/analyze-protocol-capture.ts`
+- Test: `apps/desktop/src/main/__tests__/protocol-capture.test.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-thread-protocol-analysis.test.ts`
+
+**Approach:**
+- Extend development-only protocol diagnostics so captured/logged request rows can be grouped by backend, backend instance, method, registry/cache instance, and caller reason when that metadata is available.
+- Add a small capture analysis path that reports method counts and first/last timestamps by backend. This should make `model/list`, `thread/list`, `initialize`, account reads, and rate-limit reads visibly distinct.
+- Keep raw JSON-RPC envelopes unchanged; attach diagnostics as capture metadata or sidecar fields that do not alter protocol behavior.
+
+**Execution note:** Characterization-first. Capture the current startup method-count behavior before using the analyzer to validate the later units.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/testing/protocol-capture.ts`
+- `apps/desktop/src/main/app-server/protocol-log-observer.ts`
+- `apps/desktop/scripts/analyze-codex-thread-protocol.ts`
+
+**Test scenarios:**
+- Happy path: a capture containing one Grok `initialize`, one Grok `model/list`, and two Grok `thread/list` rows reports those as separate method counts.
+- Happy path: protocol log output for a model-list request includes backend, method, request id, and caller reason when supplied.
+- Edge case: existing capture files without caller metadata still analyze successfully and report method counts.
+- Error path: malformed JSONL rows are skipped with a diagnostic count rather than failing the entire analysis.
+
+**Verification:**
+- Developers can point the analyzer at a protocol capture and determine whether Grok made duplicate `model/list` calls or only duplicate `thread/list` calls.
+
+- [ ] **Unit 2: Extract a shared backend model catalog**
+
+**Goal:** Centralize Codex and Grok model discovery behind one single-flight cache that all registry paths share.
+
+**Requirements:** R1, R3, R5, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/backend-model-catalog.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-model-catalog.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Move model caching and in-flight promise ownership out of ad hoc registry fields into a focused catalog object.
+- Preserve the current successful-cache behavior: once Grok model discovery succeeds, subsequent backend summaries, launchpad normalization, and thread starts reuse the same result.
+- Preserve controlled retry after failure: a failed fetch clears only the failed in-flight promise for that backend so a later real consumer can retry.
+- Include caller reason in catalog calls so diagnostics can distinguish startup warmup from renderer summaries and thread creation defaults.
+- Keep fallback model behavior in `buildLaunchpadOptions()` and model-setting resolution; the catalog should own discovery state, not product fallback rules.
+
+**Patterns to follow:**
+- Existing `readCodexDefaultModelsOnce()` and `readGrokDefaultModelsOnce()` behavior in `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Test scenarios:**
+- Happy path: two concurrent Grok model consumers share one in-flight `model/list` request and both receive the same model set.
+- Happy path: sequential Grok consumers after a successful discovery do not issue another `model/list`.
+- Happy path: Codex default model discovery still hits only the default client and not the full-access client.
+- Edge case: Grok discovery returning an empty list caches the successful empty result and lets fallback options be built by existing fallback logic.
+- Error path: the first Grok discovery failure does not poison the cache forever; a later consumer can retry and then cache success.
+- Integration: `listBackends()`, `ensureDirectoryLaunchpad()`, and Grok `startThread()` share the same catalog result.
+
+**Verification:**
+- Model discovery count is bounded by catalog state rather than by how many registry methods request model options.
+
+- [ ] **Unit 3: Remove constructor-side model warmup**
+
+**Goal:** Stop backend registry construction from issuing Grok or Codex model-list requests implicitly.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Approach:**
+- Remove eager model-list calls from `DesktopBackendRegistry` construction.
+- Do not add a replacement startup warmup path in this pass. Defer model discovery until the first real model consumer asks for it, with renderer backend summaries expected to be the first normal startup consumer.
+- Ensure `DesktopMessagingBackendBridge` can be constructed and subscribed to backend events without causing model catalog warmup.
+- Keep client construction itself lightweight; constructing a Grok client should not imply `initialize` or `model/list`.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Test scenarios:**
+- Happy path: constructing `DesktopBackendRegistry` with mock clients does not call `listModels()` before a model-consuming method is invoked.
+- Happy path: constructing `DesktopMessagingBackendBridge` does not call Grok `listModels()`.
+- Happy path: starting `DesktopMessagingRuntime` with configured adapters does not call Grok `listModels()` unless an inbound workflow explicitly asks for backend model options.
+- Edge case: backend event subscription still works after removing constructor warmup.
+- Integration: app startup can create messaging runtime and renderer IPC handlers without hidden model-list side effects before the renderer asks for backend summaries.
+
+**Verification:**
+- Pre-renderer startup no longer emits Grok `model/list` solely because messaging created a backend bridge.
+
+- [ ] **Unit 4: Route all real model consumers through the catalog**
+
+**Goal:** Make every legitimate model option consumer use the shared catalog and propagate caller reason.
+
+**Requirements:** R1, R3, R4, R5, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/ipc/agent-ipc.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useBackendSummaries.ts`
+- Modify: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx`
+
+**Approach:**
+- Route `describeCodexBackend()`, `describeSingleBackend("grok")`, `getBackendLaunchpadOptions()`, `resolveModelSettings()`, and Grok `startThread()` defaulting through the same catalog.
+- Keep `listBackends()` as a real model consumer for now so existing provider selectors keep receiving live options on renderer mount, but route it through the catalog and label the caller reason as `backend-summary`.
+- Propagate caller reasons such as `backend-summary`, `launchpad-defaults`, `thread-start-defaults`, and `settings-refresh`.
+- Ensure settings/discovery refresh events invalidate or refresh the catalog through one path rather than constructing a new registry or bypassing the catalog.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/renderer/src/lib/useBackendSummaries.ts`
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+
+**Test scenarios:**
+- Happy path: renderer backend summaries mounting twice still produces at most one Grok `model/list` after successful discovery.
+- Happy path: a Grok launchpad opened after backend summaries reuses the backend-summary catalog result.
+- Happy path: a Grok thread start without explicit model reuses the existing catalog result and sends the expected default model.
+- Edge case: if the user supplies an explicit Grok model, thread start does not need to fetch model options only to echo that explicit model.
+- Error path: if backend-summary model discovery fails, the backend remains visible with fallback options and a later Grok thread-start default may retry through the catalog.
+- Integration: Codex model-list count remains one on the default client across backend summaries and thread starts, with full-access unchanged.
+
+**Verification:**
+- There is exactly one code path that can call Grok `listModels()` for model metadata, and tests cover every current consumer.
+
+- [ ] **Unit 5: Add startup integration coverage and acceptance capture workflow**
+
+**Goal:** Prove the startup contract from the user’s repro shape and make future regressions easy to diagnose.
+
+**Requirements:** R1, R2, R4, R6, R7
+
+**Dependencies:** Units 1 through 4
+
+**Files:**
+- Modify: `apps/desktop/src/main/__tests__/index.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Modify: `apps/desktop/e2e/provider-model-selectors.spec.ts`
+- Create: `apps/desktop/e2e/fixtures/grok-startup-model-chatter/`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+
+**Approach:**
+- Add a main-process startup test that mirrors the important ordering: app ready, IPC handlers registered, messaging runtime starts, window creation follows. Assert that model discovery happens only from the intended owner and not from bridge construction.
+- Add a protocol-replay or E2E fixture that captures startup through first renderer mount and asserts Grok request counts by method. The acceptance should explicitly separate `model/list` from `thread/list`.
+- Keep provider selector behavior covered so deferring or centralizing model discovery does not leave the composer without model options when the user actually opens a Grok-backed launchpad or thread.
+- Document the expected dev repro interpretation in a short test or fixture comment: one intentional model-list is acceptable only after the first real model consumer asks for backend summaries or model defaults; repeated model-list calls without invalidation are not acceptable.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/__tests__/index.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- `apps/desktop/e2e/provider-model-selectors.spec.ts`
+- `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`
+
+**Test scenarios:**
+- Happy path: startup with messaging enabled constructs messaging runtime and renderer bridge without Grok `model/list` before the renderer backend-summary request.
+- Happy path: startup with messaging disabled follows the same first-consumer model-list policy and does not hide a second code path.
+- Happy path: first renderer `listBackends()` receives model options from the shared catalog or fallback policy without causing duplicate Grok discovery.
+- Edge case: repeated renderer remount or dev refresh does not reuse stale process-local state across a genuinely new Electron main process; counts are scoped per process/capture.
+- Error path: Grok unavailable at startup does not produce repeated failed model-list attempts from messaging plus renderer consumers.
+- Integration: protocol capture analysis for a startup run reports Grok `model/list` count within the accepted policy and reports Grok `thread/list` separately.
+
+**Verification:**
+- A developer can rerun the original startup repro with protocol logging/capture and see either zero or one intentional Grok `model/list` per process, with all later Grok chatter classified by method and reason.
+
+## System-Wide Impact
+
+- **Interaction graph:** `bootstrapApp()` -> messaging runtime -> backend bridge -> backend registry, plus renderer `useBackendSummaries()` and `useThreadNavigation()` all share the registry. Model discovery must be owned by the catalog, while navigation/thread listing stays in the registry.
+- **Error propagation:** model-list failures should degrade model options to fallbacks where possible and clear failed in-flight state for later retry. They should not fail messaging startup or renderer navigation.
+- **State lifecycle risks:** caches must be process-scoped and invalidated on explicit settings/discovery refresh. They should not survive a new Electron main process, and tests must not assume cross-process reuse.
+- **API surface parity:** Codex and Grok should use the same catalog abstraction, with Codex retaining its default/full-access distinction and Grok retaining one default client.
+- **Integration coverage:** unit tests must cover catalog behavior; startup-adjacent integration tests must cover messaging and renderer consumers together; protocol capture analysis must validate real method counts.
+- **Unchanged invariants:** Grok `model/list` response normalization, thread listing, thread read/start, and messaging command semantics remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The implementation fixes model-list count but leaves confusing thread-list chatter. | Add capture analysis that reports method counts separately and include acceptance criteria for both `model/list` and `thread/list` classification. |
+| Moving warmup out of the constructor causes model selectors to render fallback options longer than before. | Keep `listBackends()` as a legitimate catalog consumer or provide cached/fallback options with a follow-up refresh event when live models arrive. |
+| Multiple registry instances still exist in tests or dev-only paths. | Add registry/cache instance ids in diagnostics and tests that construct messaging plus renderer-adjacent consumers through the same singleton. |
+| Transient Grok failures trigger repeated retries from multiple startup consumers. | Use single-flight failure clearing with retry only on later explicit consumer calls, not immediate multi-consumer loops. |
+| Codex full-access starts fetching model lists accidentally while refactoring shared catalog code. | Preserve and extend tests asserting only the Codex default client performs model discovery. |
+
+## Documentation / Operational Notes
+
+- Update any startup troubleshooting notes only if the implementation adds a developer-facing capture analyzer or changes expected protocol log interpretation.
+- No user-facing documentation is required unless model selector loading behavior visibly changes.
+- The final implementation handoff should include a sample startup capture summary showing Grok `initialize`, `model/list`, and `thread/list` counts separately.
+
+## Sources & References
+
+- Origin document: `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`
+- Related plan: `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md`
+- Related plan: `docs/plans/2026-04-19-001-fix-desktop-startup-thread-stability-plan.md`
+- Related code: `apps/desktop/src/main/index.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/main/grok-app-server/client.ts`
+- Related code: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Related code: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useBackendSummaries.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Related tests: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Related tests: `apps/desktop/src/main/__tests__/grok-app-server-client.test.ts`
+- Related tests: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Related tests: `apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx`


### PR DESCRIPTION
## Summary

I fixed the startup protocol chatter around Grok and Codex by making model discovery and thread-list refreshes explicit, attributable, and coalesced.

This PR:
- adds protocol diagnostics and a capture analyzer so `model/list` and `thread/list` traffic can be counted separately with caller reasons
- moves Codex/Grok model discovery behind a shared single-flight `BackendModelCatalog`
- removes constructor-side Grok/Codex model warmup from the desktop backend registry
- coalesces short-window startup/thread selection `thread/list` refreshes across navigation, branch drift, and title-generation callers
- throttles Codex archived-thread metadata refreshes so active thread listing does not immediately trigger repeated hidden archived-list refreshes
- updates the implementation plan with progress and adds focused regression coverage

## Verification

I verified this with:
- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/backend-model-catalog.test.ts src/main/__tests__/backend-registry.test.ts src/main/__tests__/protocol-capture.test.ts src/main/__tests__/protocol-log-observer.test.ts src/main/__tests__/grok-app-server-client.test.ts`
- `pnpm --filter @pwragnt/desktop exec vitest run src/main/__tests__/backend-registry.test.ts src/main/__tests__/app-server-ipc.test.ts src/main/__tests__/codex-client.test.ts src/main/__tests__/grok-app-server-client.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`