### PR TITLE
fix(desktop): enforce transcript temporal ordering

### DIFF
--- a/apps/desktop/e2e/fixtures/transcript-temporal-order/README.md
+++ b/apps/desktop/e2e/fixtures/transcript-temporal-order/README.md
@@ -1,0 +1,13 @@
+# Transcript Temporal Order Fixture
+
+This fixture is a minimized replay derived from the May 2, 2026 failure shape for thread `019de585-735e-7aa0-82d7-469a6a32eb80`.
+
+It intentionally checks the chronology that failed in the live app:
+
+1. assistant message
+2. tool activity
+3. assistant message
+4. tool activity
+5. assistant message
+
+The live notifications establish precise observed order. The completion step then forces a `thread/read` hydration response where all same-turn entries share one coarse timestamp, matching the class of persisted data that previously allowed tool groups to move above earlier assistant text.

--- a/apps/desktop/e2e/fixtures/transcript-temporal-order/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/transcript-temporal-order/replay.fixture.json
@@ -1,0 +1,321 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "transcript-temporal-order",
+    "sourceCaptureId": "synthetic-from-019de585-735e-7aa0-82d7-469a6a32eb80",
+    "threadId": "thread-transcript-temporal-order"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-transcript-temporal-order",
+          "title": "Transcript temporal ordering",
+          "titleSource": "explicit",
+          "summary": "Verify live and hydrated transcript items never render out of time order",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "user-message-1",
+            "role": "user",
+            "text": "Show the temporal transcript order."
+          }
+        ],
+        "messages": [
+          {
+            "id": "user-message-1",
+            "role": "user",
+            "text": "Show the temporal transcript order."
+          }
+        ],
+        "lastUserMessage": "Show the temporal transcript order.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "turn": {
+            "id": "turn-temporal-order",
+            "status": "inProgress",
+            "startedAt": 1777730000
+          }
+        }
+      }
+    },
+    {
+      "id": "assistant-message-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/agentMessage/delta",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "itemId": "assistant-message-1",
+          "phase": "final",
+          "delta": "The code already logs explicit turn completion."
+        }
+      }
+    },
+    {
+      "id": "tool-read-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/started",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "item": {
+            "id": "tool-read-1",
+            "type": "commandExecution",
+            "status": "in_progress",
+            "command": "sed -n '1,120p' apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+            "commandActions": [
+              {
+                "type": "read",
+                "path": "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "assistant-message-2",
+      "kind": "notification",
+      "notification": {
+        "method": "item/agentMessage/delta",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "itemId": "assistant-message-2",
+          "phase": "final",
+          "delta": "I am going to close that gap in renderBindingStatus."
+        }
+      }
+    },
+    {
+      "id": "tool-search-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "item/started",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "item": {
+            "id": "tool-search-1",
+            "type": "commandExecution",
+            "status": "in_progress",
+            "command": "rg -n transcript apps/desktop/src/renderer/src/features/thread-detail",
+            "commandActions": [
+              {
+                "type": "search",
+                "path": "apps/desktop/src/renderer/src/features/thread-detail"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "assistant-message-3",
+      "kind": "notification",
+      "notification": {
+        "method": "item/agentMessage/delta",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "itemId": "assistant-message-3",
+          "delta": "I added the controller hook that reconciles navigation state."
+        }
+      }
+    },
+    {
+      "id": "turn-completed-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/completed",
+        "params": {
+          "threadId": "thread-transcript-temporal-order",
+          "turnId": "turn-temporal-order",
+          "turn": {
+            "id": "turn-temporal-order",
+            "status": "completed",
+            "durationMs": 70000,
+            "output": []
+          }
+        }
+      }
+    },
+    {
+      "id": "thread-read-2",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "user-message-1",
+            "role": "user",
+            "text": "Show the temporal transcript order.",
+            "createdAt": 1777730000000
+          },
+          {
+            "type": "message",
+            "id": "assistant-message-1",
+            "role": "assistant",
+            "phase": "final",
+            "text": "The code already logs explicit turn completion.",
+            "createdAt": 1777730000000,
+            "turn": {
+              "id": "turn-temporal-order",
+              "status": "completed",
+              "durationMs": 70000
+            }
+          },
+          {
+            "type": "activity",
+            "id": "activity-tool-read-1",
+            "summary": "Explored 1 item",
+            "createdAt": 1777730000000,
+            "details": [
+              {
+                "id": "tool-read-1",
+                "kind": "read",
+                "label": "Read useThreadSessionState.ts",
+                "path": "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+                "status": "completed"
+              }
+            ],
+            "turn": {
+              "id": "turn-temporal-order",
+              "status": "completed",
+              "durationMs": 70000
+            }
+          },
+          {
+            "type": "message",
+            "id": "assistant-message-2",
+            "role": "assistant",
+            "phase": "final",
+            "text": "I am going to close that gap in renderBindingStatus.",
+            "createdAt": 1777730000000,
+            "turn": {
+              "id": "turn-temporal-order",
+              "status": "completed",
+              "durationMs": 70000
+            }
+          },
+          {
+            "type": "activity",
+            "id": "activity-tool-search-1",
+            "summary": "Explored 1 item",
+            "createdAt": 1777730000000,
+            "details": [
+              {
+                "id": "tool-search-1",
+                "kind": "search",
+                "label": "Searched thread-detail",
+                "path": "apps/desktop/src/renderer/src/features/thread-detail",
+                "status": "completed"
+              }
+            ],
+            "turn": {
+              "id": "turn-temporal-order",
+              "status": "completed",
+              "durationMs": 70000
+            }
+          },
+          {
+            "type": "message",
+            "id": "assistant-message-3",
+            "role": "assistant",
+            "phase": "final",
+            "text": "I added the controller hook that reconciles navigation state.",
+            "createdAt": 1777730000000,
+            "turn": {
+              "id": "turn-temporal-order",
+              "status": "completed",
+              "durationMs": 70000
+            }
+          }
+        ],
+        "messages": [
+          {
+            "id": "user-message-1",
+            "role": "user",
+            "text": "Show the temporal transcript order.",
+            "createdAt": 1777730000000
+          },
+          {
+            "id": "assistant-message-1",
+            "role": "assistant",
+            "text": "The code already logs explicit turn completion.",
+            "createdAt": 1777730000000
+          },
+          {
+            "id": "assistant-message-2",
+            "role": "assistant",
+            "text": "I am going to close that gap in renderBindingStatus.",
+            "createdAt": 1777730000000
+          },
+          {
+            "id": "assistant-message-3",
+            "role": "assistant",
+            "text": "I added the controller hook that reconciles navigation state.",
+            "createdAt": 1777730000000
+          }
+        ],
+        "lastUserMessage": "Show the temporal transcript order.",
+        "lastAssistantMessage": "I added the controller hook that reconciles navigation state.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/transcript-temporal-order.spec.ts
+++ b/apps/desktop/e2e/transcript-temporal-order.spec.ts
@@ -44,11 +44,10 @@ test("transcript preserves temporal order across live activity and hydration", a
     assertOrdered(transcriptText, [
       "Show the temporal transcript order.",
       "The code already logs explicit turn completion.",
-      "Working for",
       "I am going to close that gap in renderBindingStatus.",
-      "Working for",
       "I added the controller hook that reconciles navigation state.",
     ]);
+    expect(countOccurrences(transcriptText, "Working for")).toBeLessThanOrEqual(1);
 
     await app.advance({ stepId: "turn-completed-1" });
 
@@ -92,4 +91,8 @@ function assertOrdered(text: string, labels: string[]): void {
     );
     previousIndex = nextIndex;
   }
+}
+
+function countOccurrences(text: string, label: string): number {
+  return text.split(label).length - 1;
 }

--- a/apps/desktop/e2e/transcript-temporal-order.spec.ts
+++ b/apps/desktop/e2e/transcript-temporal-order.spec.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("transcript preserves temporal order across live activity and hydration", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/transcript-temporal-order/replay.fixture.json"
+    )
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Transcript temporal ordering/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Transcript temporal ordering"
+      })
+    ).toBeVisible();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    await expect(transcript).toContainText("Show the temporal transcript order.");
+
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "assistant-message-1" });
+    await app.advance({ stepId: "tool-read-started-1" });
+    await app.advance({ stepId: "assistant-message-2" });
+    await app.advance({ stepId: "tool-search-started-1" });
+    await app.advance({ stepId: "assistant-message-3" });
+
+    await expect(transcript).toContainText("The code already logs explicit turn completion.");
+    await expect(transcript).toContainText("I am going to close that gap in renderBindingStatus.");
+    await expect(transcript).toContainText("I added the controller hook that reconciles navigation state.");
+
+    let transcriptText = await transcript.innerText();
+    assertOrdered(transcriptText, [
+      "Show the temporal transcript order.",
+      "The code already logs explicit turn completion.",
+      "Working for",
+      "I am going to close that gap in renderBindingStatus.",
+      "Working for",
+      "I added the controller hook that reconciles navigation state.",
+    ]);
+
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect(transcript.getByText("I added the controller hook")).toBeVisible();
+    transcriptText = await transcript.innerText();
+    assertOrdered(transcriptText, [
+      "Show the temporal transcript order.",
+      "The code already logs explicit turn completion.",
+      "Worked for 1m 10s",
+      "I am going to close that gap in renderBindingStatus.",
+      "More work",
+      "I added the controller hook that reconciles navigation state.",
+    ]);
+
+    await transcript.getByRole("button", { name: /Worked for 1m 10s/ }).click();
+    await transcript.getByRole("button", { name: /More work/ }).click();
+    await transcript.getByRole("button", { name: /Explored 1 item/ }).first().click();
+    await transcript.getByRole("button", { name: /Explored 1 item/ }).last().click();
+
+    await expect(transcript.getByText("Read useThreadSessionState.ts")).toBeVisible();
+    await expect(transcript.getByText("Searched thread-detail")).toBeVisible();
+    transcriptText = await transcript.innerText();
+    assertOrdered(transcriptText, [
+      "The code already logs explicit turn completion.",
+      "Read useThreadSessionState.ts",
+      "I am going to close that gap in renderBindingStatus.",
+      "Searched thread-detail",
+      "I added the controller hook that reconciles navigation state.",
+    ]);
+  } finally {
+    await app.close();
+  }
+});
+
+function assertOrdered(text: string, labels: string[]): void {
+  let previousIndex = -1;
+  for (const label of labels) {
+    const nextIndex = text.indexOf(label, previousIndex + 1);
+    expect(nextIndex, `Expected "${label}" after index ${previousIndex}`).toBeGreaterThan(
+      previousIndex
+    );
+    previousIndex = nextIndex;
+  }
+}

--- a/apps/desktop/src/main/__tests__/codex-thread-protocol-analysis.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-thread-protocol-analysis.test.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { analyzeCodexThreadProtocolCapture } from "../testing/codex-thread-protocol-analysis";
 
@@ -45,4 +47,184 @@ describe("analyzeCodexThreadProtocolCapture", () => {
       ]),
     );
   });
+
+  it("reports chronological thread message and tool order from thread/read and notifications", async () => {
+    const captureDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragnt-protocol-"));
+    const capturePath = path.join(captureDir, "temporal-order.jsonl");
+    try {
+      await fs.writeFile(
+        capturePath,
+        [
+          captureRecord({
+            direction: "outbound",
+            id: "rpc-1",
+            kind: "request",
+            method: "thread/read",
+            raw: {
+              jsonrpc: "2.0",
+              id: "rpc-1",
+              method: "thread/read",
+              params: {
+                threadId: "thread-1",
+                includeTurns: true,
+              },
+            },
+            sequence: 1,
+            threadIds: ["thread-1"],
+          }),
+          captureRecord({
+            direction: "inbound",
+            id: "rpc-1",
+            kind: "response",
+            raw: {
+              id: "rpc-1",
+              result: {
+                thread: {
+                  turns: [
+                    {
+                      id: "turn-1",
+                      items: [
+                        {
+                          type: "agentMessage",
+                          id: "message-1",
+                          text: "First commentary.",
+                        },
+                        {
+                          type: "commandExecution",
+                          id: "read-1",
+                          command: "sed -n '1,40p' src/one.ts",
+                        },
+                        {
+                          type: "agentMessage",
+                          id: "message-2",
+                          text: "Second commentary.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+            sequence: 2,
+            threadIds: ["thread-1"],
+          }),
+          captureRecord({
+            direction: "inbound",
+            kind: "notification",
+            method: "item/started",
+            raw: {
+              jsonrpc: "2.0",
+              method: "item/started",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: {
+                  type: "commandExecution",
+                  id: "read-2",
+                  command: "rg -n transcript src",
+                },
+              },
+            },
+            sequence: 3,
+            threadIds: ["thread-1"],
+          }),
+          captureRecord({
+            direction: "inbound",
+            kind: "notification",
+            method: "item/agentMessage/delta",
+            raw: {
+              jsonrpc: "2.0",
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                itemId: "message-3",
+                delta: "Final observed update.",
+              },
+            },
+            sequence: 4,
+            threadIds: ["thread-1"],
+          }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+
+      const analysis = await analyzeCodexThreadProtocolCapture({ capturePath });
+
+      expect(
+        analysis.threadOrder.events.map((event) => ({
+          itemId: event.itemId,
+          itemIndex: event.itemIndex,
+          kind: event.kind,
+          label: event.label,
+          sequence: event.sequence,
+          source: event.source,
+        })),
+      ).toEqual([
+        {
+          itemId: "message-1",
+          itemIndex: 0,
+          kind: "assistant-message",
+          label: "First commentary.",
+          sequence: 2,
+          source: "threadRead",
+        },
+        {
+          itemId: "read-1",
+          itemIndex: 1,
+          kind: "tool-activity",
+          label: "sed -n '1,40p' src/one.ts",
+          sequence: 2,
+          source: "threadRead",
+        },
+        {
+          itemId: "message-2",
+          itemIndex: 2,
+          kind: "assistant-message",
+          label: "Second commentary.",
+          sequence: 2,
+          source: "threadRead",
+        },
+        {
+          itemId: "read-2",
+          kind: "tool-activity",
+          label: "rg -n transcript src",
+          sequence: 3,
+          source: "notification",
+        },
+        {
+          itemId: "message-3",
+          kind: "assistant-message",
+          label: "Final observed update.",
+          sequence: 4,
+          source: "notification",
+        },
+      ]);
+    } finally {
+      await fs.rm(captureDir, { force: true, recursive: true });
+    }
+  });
 });
+
+function captureRecord(params: {
+  direction: "inbound" | "outbound";
+  id?: string;
+  kind: "request" | "response" | "notification";
+  method?: string;
+  raw: unknown;
+  sequence: number;
+  threadIds: string[];
+}): string {
+  return JSON.stringify({
+    backend: "codex",
+    captureId: "temporal-order-test",
+    direction: params.direction,
+    kind: params.kind,
+    ...(params.method ? { method: params.method } : {}),
+    ...(params.id ? { id: params.id } : {}),
+    sequence: params.sequence,
+    timestamp: 1_777_000_000_000 + params.sequence,
+    threadIds: params.threadIds,
+    raw: JSON.stringify(params.raw),
+  });
+}

--- a/apps/desktop/src/main/testing/codex-thread-protocol-analysis.ts
+++ b/apps/desktop/src/main/testing/codex-thread-protocol-analysis.ts
@@ -22,6 +22,19 @@ type ThreadListSample = {
   statusType?: string;
 };
 
+export type ThreadOrderEvent = {
+  itemId?: string;
+  itemIndex?: number;
+  kind: "assistant-message" | "tool-activity" | "turn" | "other";
+  label: string;
+  method?: string;
+  sequence: number;
+  source: "notification" | "threadRead";
+  threadId?: string;
+  timestamp: number;
+  turnId?: string;
+};
+
 type ThreadIdentityFieldCounts = {
   cwd: number;
   sessionCwd: number;
@@ -50,6 +63,9 @@ export type CodexThreadProtocolAnalysis = {
     requestCount: number;
     includeTurnsVariants: boolean[];
   };
+  threadOrder: {
+    events: ThreadOrderEvent[];
+  };
 };
 
 export async function analyzeCodexThreadProtocolCapture(params: {
@@ -58,6 +74,7 @@ export async function analyzeCodexThreadProtocolCapture(params: {
   const capturePath = path.resolve(params.capturePath);
   const records = await readProtocolCaptureFile(capturePath);
   const requestsById = buildRequestIndex(records);
+  const requestEnvelopesById = buildRequestEnvelopeIndex(records);
 
   const requestCounts: Record<string, number> = {};
   const notificationCounts: Record<string, number> = {};
@@ -78,6 +95,7 @@ export async function analyzeCodexThreadProtocolCapture(params: {
   let archivedRequestCount = 0;
   let threadReadRequestCount = 0;
   const includeTurnsVariants = new Set<boolean>();
+  const threadOrderEvents: ThreadOrderEvent[] = [];
 
   for (const entry of records) {
     const method = entry.envelope.method?.trim();
@@ -117,6 +135,10 @@ export async function analyzeCodexThreadProtocolCapture(params: {
 
     if (entry.record.direction === "inbound" && entry.record.kind === "notification" && method) {
       notificationCounts[method] = (notificationCounts[method] ?? 0) + 1;
+      const orderEvent = extractNotificationOrderEvent(entry);
+      if (orderEvent) {
+        threadOrderEvents.push(orderEvent);
+      }
       continue;
     }
 
@@ -125,6 +147,11 @@ export async function analyzeCodexThreadProtocolCapture(params: {
     }
 
     const responseMethod = lookupMethodForResponse(requestsById, entry.envelope);
+    if (responseMethod === "thread/read") {
+      threadOrderEvents.push(
+        ...extractThreadReadOrderEvents(entry, requestEnvelopesById),
+      );
+    }
     if (responseMethod !== "thread/list" && responseMethod !== "thread/loaded/list") {
       continue;
     }
@@ -186,6 +213,9 @@ export async function analyzeCodexThreadProtocolCapture(params: {
       requestCount: threadReadRequestCount,
       includeTurnsVariants: [...includeTurnsVariants].sort(),
     },
+    threadOrder: {
+      events: threadOrderEvents.sort(compareThreadOrderEvents),
+    },
   };
 }
 
@@ -208,6 +238,25 @@ function buildRequestIndex(
   return requestsById;
 }
 
+function buildRequestEnvelopeIndex(
+  records: CapturedProtocolEnvelopeRecord[],
+): Map<string, ProtocolCaptureEnvelope> {
+  const requestsById = new Map<string, ProtocolCaptureEnvelope>();
+  for (const entry of records) {
+    const method = entry.envelope.method?.trim();
+    if (
+      entry.record.direction === "outbound" &&
+      entry.record.kind === "request" &&
+      method &&
+      entry.envelope.id !== null &&
+      entry.envelope.id !== undefined
+    ) {
+      requestsById.set(String(entry.envelope.id), entry.envelope);
+    }
+  }
+  return requestsById;
+}
+
 function lookupMethodForResponse(
   requestsById: Map<string, string>,
   envelope: ProtocolCaptureEnvelope,
@@ -216,6 +265,177 @@ function lookupMethodForResponse(
     return undefined;
   }
   return requestsById.get(String(envelope.id));
+}
+
+function compareThreadOrderEvents(
+  left: ThreadOrderEvent,
+  right: ThreadOrderEvent,
+): number {
+  return (
+    left.sequence - right.sequence ||
+    (left.itemIndex ?? -1) - (right.itemIndex ?? -1) ||
+    left.label.localeCompare(right.label)
+  );
+}
+
+function extractNotificationOrderEvent(
+  entry: CapturedProtocolEnvelopeRecord,
+): ThreadOrderEvent | undefined {
+  const method = entry.envelope.method?.trim();
+  const params = asRecord(entry.envelope.params);
+  if (!method || !params) {
+    return undefined;
+  }
+
+  const threadId = pickString(params, ["threadId", "thread_id"]);
+  if (!threadId) {
+    return undefined;
+  }
+
+  const item = asRecord(params.item);
+  const itemId =
+    pickString(params, ["itemId", "item_id"]) ??
+    pickString(item ?? {}, ["id", "itemId", "item_id"]);
+  const turnId =
+    pickString(params, ["turnId", "turn_id"]) ??
+    pickString(item ?? {}, ["turnId", "turn_id"]);
+  const itemType = pickString(item ?? {}, ["type"]);
+  const delta = pickString(params, ["delta"]);
+
+  return {
+    ...(itemId ? { itemId } : {}),
+    kind: classifyOrderEventKind(method, itemType),
+    label: describeOrderEvent({
+      method,
+      item,
+      itemType,
+      delta,
+      params,
+    }),
+    method,
+    sequence: entry.record.sequence,
+    source: "notification",
+    threadId,
+    timestamp: entry.record.timestamp,
+    ...(turnId ? { turnId } : {}),
+  };
+}
+
+function extractThreadReadOrderEvents(
+  entry: CapturedProtocolEnvelopeRecord,
+  requestEnvelopesById: Map<string, ProtocolCaptureEnvelope>,
+): ThreadOrderEvent[] {
+  const requestId =
+    entry.envelope.id === null || entry.envelope.id === undefined
+      ? undefined
+      : String(entry.envelope.id);
+  const request = requestId ? requestEnvelopesById.get(requestId) : undefined;
+  if (request?.method !== "thread/read") {
+    return [];
+  }
+
+  const requestParams = asRecord(request.params);
+  const threadId = pickString(requestParams ?? {}, ["threadId", "thread_id"]);
+  const result = asRecord(entry.envelope.result);
+  const thread = asRecord(result?.thread);
+  const turns = Array.isArray(thread?.turns)
+    ? thread.turns
+        .map((turn) => asRecord(turn))
+        .filter((turn): turn is Record<string, unknown> => turn !== null)
+    : [];
+  const events: ThreadOrderEvent[] = [];
+
+  for (const turn of turns) {
+    const turnId = pickString(turn, ["id", "turnId", "turn_id"]);
+    const items = Array.isArray(turn.items)
+      ? turn.items
+          .map((item) => asRecord(item))
+          .filter((item): item is Record<string, unknown> => item !== null)
+      : [];
+
+    for (const [itemIndex, item] of items.entries()) {
+      const itemType = pickString(item, ["type"]);
+      const itemId = pickString(item, ["id", "itemId", "item_id", "call_id"]);
+      events.push({
+        ...(itemId ? { itemId } : {}),
+        itemIndex,
+        kind: classifyOrderEventKind("thread/read", itemType),
+        label: describeOrderEvent({
+          method: "thread/read",
+          item,
+          itemType,
+          params: item,
+        }),
+        method: "thread/read",
+        sequence: entry.record.sequence,
+        source: "threadRead",
+        ...(threadId ? { threadId } : {}),
+        timestamp: entry.record.timestamp,
+        ...(turnId ? { turnId } : {}),
+      });
+    }
+  }
+
+  return events;
+}
+
+function classifyOrderEventKind(
+  method: string,
+  itemType: string | undefined,
+): ThreadOrderEvent["kind"] {
+  if (method === "turn/completed" || method === "turn/started" || method === "turn/failed") {
+    return "turn";
+  }
+
+  if (method === "item/agentMessage/delta" || itemType === "agentMessage") {
+    return "assistant-message";
+  }
+
+  if (
+    itemType === "commandExecution" ||
+    itemType === "functionCall" ||
+    itemType === "mcpToolCall" ||
+    method.includes("commandExecution") ||
+    method.includes("mcpToolCall")
+  ) {
+    return "tool-activity";
+  }
+
+  return "other";
+}
+
+function describeOrderEvent(params: {
+  delta?: string;
+  item: Record<string, unknown> | null;
+  itemType?: string;
+  method: string;
+  params: Record<string, unknown>;
+}): string {
+  if (params.method === "item/agentMessage/delta") {
+    return compactLabel(params.delta ?? "assistant message delta");
+  }
+
+  if (params.method === "turn/completed") {
+    return "turn completed";
+  }
+
+  if (params.itemType === "agentMessage") {
+    return compactLabel(pickString(params.item ?? {}, ["text"]) ?? "assistant message");
+  }
+
+  if (params.itemType === "commandExecution") {
+    return compactLabel(
+      pickString(params.item ?? {}, ["command", "displayCommand"]) ??
+        "command execution",
+    );
+  }
+
+  return compactLabel(params.itemType ?? params.method);
+}
+
+function compactLabel(value: string): string {
+  const normalized = value.trim().replace(/\s+/g, " ");
+  return normalized.length > 120 ? `${normalized.slice(0, 117)}...` : normalized;
 }
 
 function compareRequestVariants(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -172,9 +172,17 @@ function insertPendingEntry(
     return;
   }
 
-  const finalMessageIndex = entries.findLastIndex(
-    (entry) => entry.turn?.id === pendingTurnId && isAssistantFinalMessage(entry)
-  );
+  const finalMessageIndex = entries.findLastIndex((entry) => {
+    if (entry.turn?.id !== pendingTurnId || !isAssistantFinalMessage(entry)) {
+      return false;
+    }
+
+    const finalCreatedAt = entryCreatedAt(entry);
+    return (
+      typeof pendingCreatedAt !== "number" ||
+      typeof finalCreatedAt !== "number"
+    );
+  });
   if (finalMessageIndex === -1) {
     entries.push(pendingEntry);
     return;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1061,6 +1061,51 @@ describe("TranscriptList", () => {
     ).toBeTruthy();
   });
 
+  it("keeps later pending assistant text below an earlier final same-turn message", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "user-1",
+            role: "user",
+            text: "Keep the visible transcript chronological.",
+            createdAt: 1_777_480_900_000,
+            turn: { id: "turn-1", status: "completed" }
+          },
+          {
+            type: "message",
+            id: "assistant-final-1",
+            role: "assistant",
+            phase: "final",
+            text: "First visible assistant update.",
+            createdAt: 1_777_480_902_000,
+            turn: { id: "turn-1", status: "completed" }
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingAssistantMessage={{
+          type: "message",
+          id: "assistant-pending-2",
+          role: "assistant",
+          text: "Second visible assistant update.",
+          createdAt: 1_777_480_903_000,
+          turn: { id: "turn-1", status: "completed" }
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const first = screen.getByText("First visible assistant update.");
+    const second = screen.getByText("Second visible assistant update.");
+
+    expect(
+      first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("collapses completed work groups when a final message arrives while live work is still pending", async () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -145,11 +145,12 @@ describe("buildTranscriptRenderItems", () => {
     });
 
     expect(items).toEqual([
+      { type: "entry", entry: first },
       {
         type: "workPhaseGroup",
         id: "work:turn-1:active",
         collapsible: false,
-        entries: [first, activity],
+        entries: [activity],
         label: "Working for 1m 01s",
       },
     ]);
@@ -286,6 +287,53 @@ describe("buildTranscriptRenderItems", () => {
         collapsible: true,
         entries: [secondActivity],
         label: "More work",
+      },
+    ]);
+  });
+
+  it("does not move later active work above intervening transcript entries", () => {
+    const turn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 1_000,
+    };
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Read one file",
+      details: [],
+      turn,
+    };
+    const answer = commentary("c1", "Interim update.", turn);
+    const secondActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-2",
+      summary: "Read another file",
+      details: [],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [firstActivity, answer, secondActivity],
+      activeTurnId: "turn-1",
+      now: 62_000,
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:tool-1:active",
+        collapsible: false,
+        entries: [firstActivity],
+        label: "Working for 1m 01s",
+      },
+      { type: "entry", entry: answer },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:tool-2:active",
+        collapsible: false,
+        entries: [secondActivity],
+        label: "Working for 1m 01s",
       },
     ]);
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -291,7 +291,7 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
-  it("does not move later active work above intervening transcript entries", () => {
+  it("only shows the active elapsed label for bottom-contiguous work", () => {
     const turn = {
       id: "turn-1",
       status: "in_progress" as const,
@@ -320,21 +320,42 @@ describe("buildTranscriptRenderItems", () => {
     });
 
     expect(items).toEqual([
-      {
-        type: "workPhaseGroup",
-        id: "work:turn-1:tool-1:active",
-        collapsible: false,
-        entries: [firstActivity],
-        label: "Working for 1m 01s",
-      },
+      { type: "entry", entry: firstActivity },
       { type: "entry", entry: answer },
       {
         type: "workPhaseGroup",
-        id: "work:turn-1:tool-2:active",
+        id: "work:turn-1:active",
         collapsible: false,
         entries: [secondActivity],
         label: "Working for 1m 01s",
       },
+    ]);
+  });
+
+  it("does not show an active elapsed label when active work is no longer at the bottom", () => {
+    const turn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 1_000,
+    };
+    const activity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Read one file",
+      details: [],
+      turn,
+    };
+    const answer = commentary("c1", "Interim update.", turn);
+
+    const items = buildTranscriptRenderItems({
+      entries: [activity, answer],
+      activeTurnId: "turn-1",
+      now: 62_000,
+    });
+
+    expect(items).toEqual([
+      { type: "entry", entry: activity },
+      { type: "entry", entry: answer },
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -451,6 +451,53 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("renders edited-file diffs as top-level activity instead of nested work", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Used 2 tools",
+      details: [],
+      turn,
+    };
+    const answer = final("f1", "Final answer.", turn);
+    const diffActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "diff-1",
+      summary: "Edited 2 files, +12, -3",
+      details: [
+        {
+          id: "diff-detail-1",
+          kind: "write",
+          label: "Update TranscriptList.tsx",
+          fileDiff: {
+            kind: "update",
+            additions: 12,
+            removals: 3,
+            diff: "diff --git a/TranscriptList.tsx b/TranscriptList.tsx",
+          },
+        },
+      ],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [firstActivity, answer, diffActivity],
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:tool-1:complete",
+        collapsible: true,
+        entries: [firstActivity],
+        label: "Worked for 1m 10s",
+      },
+      { type: "entry", entry: answer },
+      { type: "entry", entry: diffActivity },
+    ]);
+  });
+
   it("only collapses consecutive commentary in the fallback path", () => {
     const first = commentary("c1", "First scan.");
     const answer = final("f1", "Interim answer.");

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -36,15 +36,13 @@ export function buildTranscriptRenderItems(params: {
 
   if (activeTurnId) {
     const groups = buildCompletedGroups(params.entries, activeTurnId);
-    const activeGroup = buildActiveWorkGroup(
+    const activeGroups = buildActiveWorkGroups(
       params.entries,
       activeTurnId,
       params.now,
       params.activeTurnStartedAt
     );
-    if (activeGroup) {
-      groups.push(activeGroup);
-    }
+    groups.push(...activeGroups);
     if (groups.length > 0) {
       return renderWithGroups(params.entries, groups);
     }
@@ -72,20 +70,13 @@ type RenderGroup = {
   label: string;
 };
 
-function buildActiveWorkGroup(
+function buildActiveWorkGroups(
   entries: AppServerThreadEntry[],
   activeTurnId: string,
   now = Date.now(),
   activeTurnStartedAt?: number
-): RenderGroup | undefined {
-  const turnEntries = entries.filter(
-    (entry) => entry.turn?.id === activeTurnId && isWorkPhaseEntry(entry)
-  );
-  if (!hasConcreteWork(turnEntries)) {
-    return undefined;
-  }
-
-  const turn = turnEntries.find((entry) => entry.turn)?.turn;
+): RenderGroup[] {
+  const turn = entries.find((entry) => entry.turn?.id === activeTurnId)?.turn;
   const startedAtCandidates = [activeTurnStartedAt, turn?.startedAt].filter(
     (value): value is number => typeof value === "number"
   );
@@ -94,15 +85,49 @@ function buildActiveWorkGroup(
   const elapsedMs =
     typeof startedAt === "number" ? Math.max(now - startedAt, 0) : undefined;
   if (typeof elapsedMs !== "number" || elapsedMs <= 60_000) {
-    return undefined;
+    return [];
   }
 
-  return {
-    collapsible: false,
-    entries: turnEntries,
-    id: `work:${activeTurnId}:active`,
-    label: `Working for ${formatElapsedMs(elapsedMs)}`,
+  const groups: RenderGroup[] = [];
+  let currentEntries: AppServerThreadEntry[] = [];
+
+  const flushCurrent = (): void => {
+    if (!hasConcreteWork(currentEntries)) {
+      currentEntries = [];
+      return;
+    }
+
+    groups.push({
+      collapsible: false,
+      entries: currentEntries,
+      id: `work:${activeTurnId}:${currentEntries[0]?.id ?? groups.length}:active`,
+      label: `Working for ${formatElapsedMs(elapsedMs)}`,
+    });
+    currentEntries = [];
   };
+
+  for (const entry of entries) {
+    const canJoinGroup = entry.turn?.id === activeTurnId && isConcreteWorkEntry(entry);
+    if (!canJoinGroup) {
+      flushCurrent();
+      continue;
+    }
+
+    currentEntries.push(entry);
+  }
+
+  flushCurrent();
+
+  if (groups.length === 1) {
+    return [
+      {
+        ...groups[0],
+        id: `work:${activeTurnId}:active`,
+      },
+    ];
+  }
+
+  return groups;
 }
 
 function buildCompletedGroups(
@@ -268,7 +293,13 @@ function isWorkPhaseEntry(
 }
 
 function hasConcreteWork(entries: AppServerThreadEntry[]): boolean {
-  return entries.some((entry) => entry.type === "activity" || entry.type === "plan");
+  return entries.some(isConcreteWorkEntry);
+}
+
+function isConcreteWorkEntry(
+  entry: AppServerThreadEntry
+): entry is AppServerThreadActivityEntry | AppServerThreadPlanEntry {
+  return entry.type === "activity" || entry.type === "plan";
 }
 
 function readCompletedTurn(

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -266,7 +266,11 @@ function isWorkPhaseEntry(
   | AppServerThreadMessageEntry
   | AppServerThreadActivityEntry
   | AppServerThreadPlanEntry {
-  if (entry.type === "activity" || entry.type === "plan") {
+  if (entry.type === "activity") {
+    return !isFileDiffActivity(entry);
+  }
+
+  if (entry.type === "plan") {
     return true;
   }
 
@@ -280,7 +284,14 @@ function hasConcreteWork(entries: AppServerThreadEntry[]): boolean {
 function isConcreteWorkEntry(
   entry: AppServerThreadEntry
 ): entry is AppServerThreadActivityEntry | AppServerThreadPlanEntry {
-  return entry.type === "activity" || entry.type === "plan";
+  return (
+    entry.type === "plan" ||
+    (entry.type === "activity" && !isFileDiffActivity(entry))
+  );
+}
+
+function isFileDiffActivity(entry: AppServerThreadActivityEntry): boolean {
+  return entry.details.some((detail) => Boolean(detail.fileDiff?.diff));
 }
 
 function readCompletedTurn(

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -88,46 +88,27 @@ function buildActiveWorkGroups(
     return [];
   }
 
-  const groups: RenderGroup[] = [];
-  let currentEntries: AppServerThreadEntry[] = [];
-
-  const flushCurrent = (): void => {
-    if (!hasConcreteWork(currentEntries)) {
-      currentEntries = [];
-      return;
+  const activeEntries: AppServerThreadEntry[] = [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.turn?.id !== activeTurnId || !isConcreteWorkEntry(entry)) {
+      break;
     }
+    activeEntries.unshift(entry);
+  }
 
-    groups.push({
+  if (!hasConcreteWork(activeEntries)) {
+    return [];
+  }
+
+  return [
+    {
       collapsible: false,
-      entries: currentEntries,
-      id: `work:${activeTurnId}:${currentEntries[0]?.id ?? groups.length}:active`,
+      entries: activeEntries,
+      id: `work:${activeTurnId}:active`,
       label: `Working for ${formatElapsedMs(elapsedMs)}`,
-    });
-    currentEntries = [];
-  };
-
-  for (const entry of entries) {
-    const canJoinGroup = entry.turn?.id === activeTurnId && isConcreteWorkEntry(entry);
-    if (!canJoinGroup) {
-      flushCurrent();
-      continue;
-    }
-
-    currentEntries.push(entry);
-  }
-
-  flushCurrent();
-
-  if (groups.length === 1) {
-    return [
-      {
-        ...groups[0],
-        id: `work:${activeTurnId}:active`,
-      },
-    ];
-  }
-
-  return groups;
+    },
+  ];
 }
 
 function buildCompletedGroups(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -39,6 +39,34 @@ function transcriptLabels(entries: AppServerThreadEntry[]): string[] {
   );
 }
 
+function diffActivity(params: {
+  diff: string;
+  id: string;
+  summary: string;
+  turn: AppServerThreadActivityEntry["turn"];
+}): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: params.id,
+    summary: params.summary,
+    createdAt: Date.now(),
+    details: [
+      {
+        id: `${params.id}-detail`,
+        kind: "write",
+        label: "Update current.ts",
+        fileDiff: {
+          kind: "update",
+          diff: params.diff,
+          additions: 1,
+          removals: 1,
+        },
+      },
+    ],
+    turn: params.turn,
+  };
+}
+
 describe("useThreadSessionState", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -1271,6 +1299,126 @@ describe("useThreadSessionState", () => {
         entry.type === "activity" && entry.summary === "Edited 1 file, +1, -2"
     );
     expect(editedActivity?.details[0]?.fileDiff?.diff).toBe(liveDiff);
+  });
+
+  it("only carries forward edited file diffs for the current turn", async () => {
+    let now = 50_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    const previousTurn = {
+      id: "turn-previous",
+      status: "completed" as const,
+      durationMs: 70_000,
+    };
+    const currentTurn = {
+      id: "turn-current",
+      status: "completed" as const,
+      durationMs: 80_000,
+    };
+    const previousDiff = "diff --git a/old.ts b/old.ts\n--- a/old.ts\n+++ b/old.ts";
+    const currentDiff = "diff --git a/current.ts b/current.ts\n--- a/current.ts\n+++ b/current.ts";
+    const previousDiffActivity = diffActivity({
+      id: "previous-diff",
+      summary: "Edited 5 files, +204, -2",
+      diff: previousDiff,
+      turn: previousTurn,
+    });
+    const currentDiffActivity = diffActivity({
+      id: "current-diff",
+      summary: "Edited 6 files, +58, -46",
+      diff: currentDiff,
+      turn: currentTurn,
+    });
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [previousDiffActivity],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }))
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "assistant-final-current",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Current turn is complete.",
+              createdAt: 2_000,
+              turn: currentTurn,
+            },
+          ],
+          messages: [
+            {
+              id: "assistant-final-current",
+              role: "assistant" as const,
+              text: "Current turn is complete.",
+              createdAt: 2_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }));
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Edited 5 files, +204, -2",
+    ]);
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(currentDiffActivity);
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Edited 5 files, +204, -2",
+      "activity:Edited 6 files, +58, -46",
+    ]);
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 2_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Current turn is complete.",
+        "activity:Edited 6 files, +58, -46",
+      ]);
+    });
   });
 
   it("preserves session-owned live activity across thread switches and hydration", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1395,9 +1395,11 @@ describe("useThreadSessionState", () => {
     await waitFor(() => {
       expect(readThread).toHaveBeenCalledTimes(1);
     });
-    expect(transcriptLabels(result.current.entries)).toEqual([
-      "activity:Edited 5 files, +204, -2",
-    ]);
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "activity:Edited 5 files, +204, -2",
+      ]);
+    });
 
     act(() => {
       result.current.upsertLiveTranscriptEntry(currentDiffActivity);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1314,6 +1314,11 @@ describe("useThreadSessionState", () => {
       status: "completed" as const,
       durationMs: 80_000,
     };
+    const nextTurn = {
+      id: "turn-next",
+      status: "completed" as const,
+      durationMs: 90_000,
+    };
     const previousDiff = "diff --git a/old.ts b/old.ts\n--- a/old.ts\n+++ b/old.ts";
     const currentDiff = "diff --git a/current.ts b/current.ts\n--- a/current.ts\n+++ b/current.ts";
     const previousDiffActivity = diffActivity({
@@ -1372,6 +1377,36 @@ describe("useThreadSessionState", () => {
             hasPreviousPage: false,
           },
         },
+      }))
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "assistant-final-next",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Next turn is complete.",
+              createdAt: 3_000,
+              turn: nextTurn,
+            },
+          ],
+          messages: [
+            {
+              id: "assistant-final-next",
+              role: "assistant" as const,
+              text: "Next turn is complete.",
+              createdAt: 3_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
       }));
 
     const desktopApi: DesktopApi = {
@@ -1419,6 +1454,17 @@ describe("useThreadSessionState", () => {
       expect(transcriptLabels(result.current.entries)).toEqual([
         "message:Current turn is complete.",
         "activity:Edited 6 files, +58, -46",
+      ]);
+    });
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 3_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Next turn is complete.",
       ]);
     });
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1,6 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import type { AppServerThreadActivityEntry } from "@pwragnt/shared";
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "@pwragnt/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -24,6 +27,16 @@ function buildThread(params: {
     },
     updatedAt: params.updatedAt,
   };
+}
+
+function transcriptLabels(entries: AppServerThreadEntry[]): string[] {
+  return entries.map((entry) =>
+    entry.type === "message" && "text" in entry
+      ? `message:${entry.text}`
+      : entry.type === "activity" && "summary" in entry
+        ? `activity:${entry.summary}`
+        : entry.type
+  );
 }
 
 describe("useThreadSessionState", () => {
@@ -848,6 +861,255 @@ describe("useThreadSessionState", () => {
         .filter((entry) => entry.type === "message")
         .map((entry) => entry.phase)
     ).toEqual(["commentary", "commentary", "final"]);
+  });
+
+  it("keeps live activity between assistant messages after coarse hydration", async () => {
+    let now = 30_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const completedTurn = {
+      id: "turn-1",
+      status: "completed" as const,
+      durationMs: 70_000,
+    };
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      )
+      .mockImplementationOnce(
+        async ({
+          backend,
+          threadId,
+        }: {
+          backend?: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: "message-1",
+                role: "assistant" as const,
+                phase: "commentary" as const,
+                text: "First commentary.",
+                createdAt: 1_000,
+                turn: completedTurn,
+              },
+              {
+                type: "message" as const,
+                id: "message-2",
+                role: "assistant" as const,
+                phase: "commentary" as const,
+                text: "Second commentary.",
+                createdAt: 1_000,
+                turn: completedTurn,
+              },
+              {
+                type: "message" as const,
+                id: "turn-1:assistant",
+                role: "assistant" as const,
+                phase: "final" as const,
+                text: "Final answer.",
+                createdAt: 1_000,
+                turn: completedTurn,
+              },
+            ],
+            messages: [
+              {
+                id: "message-1",
+                role: "assistant" as const,
+                text: "First commentary.",
+                createdAt: 1_000,
+              },
+              {
+                id: "message-2",
+                role: "assistant" as const,
+                text: "Second commentary.",
+                createdAt: 1_000,
+              },
+              {
+                id: "turn-1:assistant",
+                role: "assistant" as const,
+                text: "Final answer.",
+                createdAt: 1_000,
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        })
+      );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "turn-1",
+              status: "inProgress",
+              startedAt: 1_000,
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-1",
+            delta: "First commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-1",
+              type: "commandExecution",
+              command: "sed -n '1,40p' src/one.ts",
+              commandActions: [{ type: "read", path: "src/one.ts" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-2",
+            delta: "Second commentary.",
+            phase: "commentary",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-2",
+              type: "commandExecution",
+              command: "rg -n transcript src",
+              commandActions: [{ type: "search", path: "src" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              durationMs: 70_000,
+              output: [{ type: "text", text: "Final answer." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:First commentary.",
+      "activity:Explored 1 item",
+      "message:Second commentary.",
+      "activity:Explored 1 item",
+      "message:Final answer.",
+    ]);
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 2_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:First commentary.",
+        "activity:Explored 1 item",
+        "message:Second commentary.",
+        "activity:Explored 1 item",
+        "message:Final answer.",
+      ]);
+    });
   });
 
   it("preserves session-owned live activity across thread switches and hydration", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1112,6 +1112,167 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("does not delete edited file diffs when a later hydration omits them", async () => {
+    let now = 40_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    const turn = {
+      id: "turn-1",
+      status: "completed" as const,
+      durationMs: 70_000,
+    };
+    const liveDiff = [
+      "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "@@ -113,2 +113,1 @@",
+      "-<<<<<<< HEAD",
+      "-function appendMessageEntries(",
+      "+function messageMatchesOptimisticEntry(",
+    ].join("\n");
+    const hydratedDiffActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "persisted-diff-1",
+      summary: "Edited 1 file, +1, -2",
+      createdAt: 1_000,
+      details: [
+        {
+          id: "persisted-diff-detail-1",
+          kind: "write",
+          label: "Update useThreadSessionState.ts",
+          path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+          fileDiff: {
+            kind: "update",
+            diff: liveDiff,
+            additions: 1,
+            removals: 2,
+          },
+        },
+      ],
+      turn,
+    };
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }))
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [hydratedDiffActivity],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }))
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "assistant-final-1",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Rebase completed and checks are green.",
+              createdAt: 2_000,
+              turn,
+            },
+          ],
+          messages: [
+            {
+              id: "assistant-final-1",
+              role: "assistant" as const,
+              text: "Rebase completed and checks are green.",
+              createdAt: 2_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }));
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry({
+        ...hydratedDiffActivity,
+        id: "live-diff-turn-1",
+        createdAt: 1_500,
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Edited 1 file, +1, -2",
+    ]);
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 2_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "activity:Edited 1 file, +1, -2",
+      ]);
+    });
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 3_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "activity:Edited 1 file, +1, -2",
+        "message:Rebase completed and checks are green.",
+      ]);
+    });
+
+    const editedActivity = result.current.entries.find(
+      (entry): entry is AppServerThreadActivityEntry =>
+        entry.type === "activity" && entry.summary === "Edited 1 file, +1, -2"
+    );
+    expect(editedActivity?.details[0]?.fileDiff?.diff).toBe(liveDiff);
+  });
+
   it("preserves session-owned live activity across thread switches and hydration", async () => {
     let now = 20_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -388,7 +388,8 @@ function findUniqueTranscriptOrderSource(
 
 function carryForwardTranscriptEntryOrder(
   response: AppServerReadThreadResponse,
-  sources: AppServerThreadEntry[]
+  sources: AppServerThreadEntry[],
+  liveSources: AppServerThreadEntry[] = []
 ): AppServerReadThreadResponse {
   if (sources.length === 0) {
     return response;
@@ -408,7 +409,14 @@ function carryForwardTranscriptEntryOrder(
     };
   });
 
-  const durableDiffSources = sources.filter(isDurableDiffActivity);
+  const freshCurrentTurnId = latestTranscriptTurnId(response.replay.entries);
+  const durableDiffSources = (
+    freshCurrentTurnId ? sources : liveSources
+  ).filter(
+    (source): source is AppServerThreadActivityEntry =>
+      isDurableDiffActivity(source) &&
+      (!freshCurrentTurnId || source.turn?.id === freshCurrentTurnId)
+  );
   const currentDurableDiffTurnId = durableDiffSources
     .map((source) => source.turn?.id)
     .findLast((turnId): turnId is string => Boolean(turnId));
@@ -446,6 +454,17 @@ function carryForwardTranscriptEntryOrder(
       entries,
     },
   };
+}
+
+function latestTranscriptTurnId(entries: AppServerThreadEntry[]): string | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const turnId = entries[index]?.turn?.id;
+    if (turnId) {
+      return turnId;
+    }
+  }
+
+  return undefined;
 }
 
 function isDurableDiffActivity(
@@ -1642,11 +1661,15 @@ export function useThreadSessionState(params: {
         }
 
         updateSession(targetThreadKey, (current) => {
-          const orderedResponse = carryForwardTranscriptEntryOrder(response, [
-            ...(current.response?.replay.entries ?? []),
+          const liveTranscriptSources = [
             ...current.optimisticEntries,
             ...(current.pendingAssistantMessage ? [current.pendingAssistantMessage] : []),
-          ]);
+          ];
+          const orderedResponse = carryForwardTranscriptEntryOrder(
+            response,
+            [...(current.response?.replay.entries ?? []), ...liveTranscriptSources],
+            liveTranscriptSources
+          );
           const hydratedCompletedTurn = didHydrateCompletedTurn(
             current.response,
             orderedResponse

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -215,8 +215,18 @@ function mergeTranscriptEntries(
     const terminalIndex =
       optimisticTurnId && !isTerminalTurnEntry(optimisticEntry)
         ? merged.findIndex(
-            (entry) =>
-              entry.turn?.id === optimisticTurnId && isTerminalTurnEntry(entry)
+            (entry) => {
+              if (entry.turn?.id !== optimisticTurnId || !isTerminalTurnEntry(entry)) {
+                return false;
+              }
+
+              const entryCreatedAt =
+                typeof entry.createdAt === "number" ? entry.createdAt : undefined;
+              return (
+                typeof optimisticCreatedAt !== "number" ||
+                typeof entryCreatedAt !== "number"
+              );
+            }
           )
         : -1;
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -395,7 +395,7 @@ function carryForwardTranscriptEntryOrder(
   }
 
   let changed = false;
-  const entries = response.replay.entries.map((entry) => {
+  let entries = response.replay.entries.map((entry) => {
     const source = findUniqueTranscriptOrderSource(entry, sources);
     if (!source || source.createdAt === entry.createdAt) {
       return entry;
@@ -408,6 +408,23 @@ function carryForwardTranscriptEntryOrder(
     };
   });
 
+  for (const source of sources) {
+    if (!isDurableDiffActivity(source)) {
+      continue;
+    }
+
+    const alreadyHydrated = entries.some(
+      (entry): entry is AppServerThreadActivityEntry =>
+        entry.type === "activity" && activityEntriesMatch(entry, source)
+    );
+    if (alreadyHydrated) {
+      continue;
+    }
+
+    changed = true;
+    entries = mergeTranscriptEntries(entries, [source]);
+  }
+
   if (!changed) {
     return response;
   }
@@ -419,6 +436,15 @@ function carryForwardTranscriptEntryOrder(
       entries,
     },
   };
+}
+
+function isDurableDiffActivity(
+  entry: AppServerThreadEntry
+): entry is AppServerThreadActivityEntry {
+  return (
+    entry.type === "activity" &&
+    entry.details.some((detail) => Boolean(detail.fileDiff?.diff))
+  );
 }
 
 function reviewEntriesMatch(

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -319,6 +319,98 @@ function activityEntriesMatch(
   );
 }
 
+function transcriptEntriesMatch(
+  candidate: AppServerThreadEntry,
+  existingEntry: AppServerThreadEntry
+): boolean {
+  if (candidate.id === existingEntry.id) {
+    return true;
+  }
+
+  if (candidate.type !== existingEntry.type) {
+    return false;
+  }
+
+  if (candidate.type === "message" && existingEntry.type === "message") {
+    return messageMatchesOptimisticEntry(
+      {
+        id: candidate.id,
+        role: candidate.role,
+        text: candidate.text,
+        parts: candidate.parts,
+        createdAt: candidate.createdAt,
+      },
+      existingEntry
+    );
+  }
+
+  if (candidate.type === "activity" && existingEntry.type === "activity") {
+    return activityEntriesMatch(candidate, existingEntry);
+  }
+
+  if (candidate.type === "review" && existingEntry.type === "review") {
+    return reviewEntriesMatch(candidate, existingEntry);
+  }
+
+  return false;
+}
+
+function findUniqueTranscriptOrderSource(
+  entry: AppServerThreadEntry,
+  sources: AppServerThreadEntry[]
+): AppServerThreadEntry | undefined {
+  const exactMatches = sources.filter(
+    (source) => source.id === entry.id && typeof source.createdAt === "number"
+  );
+  if (exactMatches.length > 0) {
+    return exactMatches[0];
+  }
+
+  const logicalMatches = sources.filter(
+    (source) =>
+      typeof source.createdAt === "number" &&
+      source.id !== entry.id &&
+      transcriptEntriesMatch(entry, source)
+  );
+
+  return logicalMatches.length === 1 ? logicalMatches[0] : undefined;
+}
+
+function carryForwardTranscriptEntryOrder(
+  response: AppServerReadThreadResponse,
+  sources: AppServerThreadEntry[]
+): AppServerReadThreadResponse {
+  if (sources.length === 0) {
+    return response;
+  }
+
+  let changed = false;
+  const entries = response.replay.entries.map((entry) => {
+    const source = findUniqueTranscriptOrderSource(entry, sources);
+    if (!source || source.createdAt === entry.createdAt) {
+      return entry;
+    }
+
+    changed = true;
+    return {
+      ...entry,
+      createdAt: source.createdAt,
+    };
+  });
+
+  if (!changed) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries,
+    },
+  };
+}
+
 function reviewEntriesMatch(
   candidate: AppServerThreadReviewEntry,
   optimisticEntry: AppServerThreadReviewEntry
@@ -1504,7 +1596,15 @@ export function useThreadSessionState(params: {
         }
 
         updateSession(targetThreadKey, (current) => {
-          const hydratedCompletedTurn = didHydrateCompletedTurn(current.response, response);
+          const orderedResponse = carryForwardTranscriptEntryOrder(response, [
+            ...(current.response?.replay.entries ?? []),
+            ...current.optimisticEntries,
+            ...(current.pendingAssistantMessage ? [current.pendingAssistantMessage] : []),
+          ]);
+          const hydratedCompletedTurn = didHydrateCompletedTurn(
+            current.response,
+            orderedResponse
+          );
           const needsHydrationAfterCompletion =
             current.needsHydrationAfterCompletion && !hydratedCompletedTurn;
           const completionHydrationRetries = needsHydrationAfterCompletion
@@ -1520,7 +1620,7 @@ export function useThreadSessionState(params: {
             logStaleThinkingState({
               current,
               reasons: thinkingReasons,
-              response,
+              response: orderedResponse,
               targetThreadKey,
             });
           }
@@ -1544,14 +1644,17 @@ export function useThreadSessionState(params: {
             loading: false,
             completionHydrationRetries,
             needsHydrationAfterCompletion,
-            optimisticEntries: pruneOptimisticEntries(current.optimisticEntries, response),
+            optimisticEntries: pruneOptimisticEntries(
+              current.optimisticEntries,
+              orderedResponse
+            ),
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
               : current.pendingAssistantMessage,
             pendingStatusText: shouldClearStaleThinking
               ? undefined
               : current.pendingStatusText,
-            response,
+            response: orderedResponse,
           };
         });
       } catch (error) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -408,8 +408,18 @@ function carryForwardTranscriptEntryOrder(
     };
   });
 
-  for (const source of sources) {
-    if (!isDurableDiffActivity(source)) {
+  const durableDiffSources = sources.filter(isDurableDiffActivity);
+  const currentDurableDiffTurnId = durableDiffSources
+    .map((source) => source.turn?.id)
+    .findLast((turnId): turnId is string => Boolean(turnId));
+  const latestDurableDiffSource = durableDiffSources.at(-1);
+
+  for (const source of durableDiffSources) {
+    if (currentDurableDiffTurnId) {
+      if (source.turn?.id !== currentDurableDiffTurnId) {
+        continue;
+      }
+    } else if (source !== latestDurableDiffSource) {
       continue;
     }
 

--- a/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
+++ b/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
@@ -91,6 +91,12 @@ except for explicitly older history loaded above the viewport.
 - R24. An active turn may render at most one live elapsed-time indicator such as
   `Working for ...` in the transcript; older active work groups must not each
   keep their own updating timer.
+- R25. Durable edited-file diff carry-forward is scoped to the current/latest
+  turn only; preserving current turn diffs must not resurrect edited-file
+  summaries from older turns at the bottom of the chat.
+- R26. Edited-file and changed-file diff activities should render as top-level
+  transcript items with file counts and line-change summaries visible without
+  first expanding a generic work group such as `More work`.
 
 **Testing Gates**
 - R13. Unit tests must fail when any visible transcript item has an ordering key
@@ -134,6 +140,8 @@ except for explicitly older history loaded above the viewport.
   response.
 - Active turns do not leak multiple simultaneous `Working for ...` indicators
   when assistant text and tool activity are interleaved.
+- The bottom of the transcript shows only the current turn's edited-file diff
+  summary, and that summary is directly visible at the top level.
 
 ## Why We Got This Wrong
 

--- a/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
+++ b/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
@@ -88,6 +88,9 @@ except for explicitly older history loaded above the viewport.
 - R23. End-of-turn transcript state should expose a durable modified/added/
   deleted file summary with inline diff access, so the user can inspect the
   final changes without relying on transient live protocol updates.
+- R24. An active turn may render at most one live elapsed-time indicator such as
+  `Working for ...` in the transcript; older active work groups must not each
+  keep their own updating timer.
 
 **Testing Gates**
 - R13. Unit tests must fail when any visible transcript item has an ordering key
@@ -129,6 +132,8 @@ except for explicitly older history loaded above the viewport.
 - Edited-file and changed-file diff entries remain visible after live updates,
   hydration catch-up, and later refreshes that omit the diff from the backend
   response.
+- Active turns do not leak multiple simultaneous `Working for ...` indicators
+  when assistant text and tool activity are interleaved.
 
 ## Why We Got This Wrong
 

--- a/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
+++ b/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
@@ -79,6 +79,15 @@ except for explicitly older history loaded above the viewport.
   turn-derived position.
 - R12. Turn completion must preserve the relative order of all retained
   optimistic activity and all materialized assistant messages.
+- R21. Once an edited-file or changed-file transcript entry with inline diff
+  content has been shown, later hydration, duplicate suppression, or refresh
+  churn must not remove that file list or diff from the chat.
+- R22. If a hydrated `thread/read` response temporarily includes an edited-file
+  diff and a later response omits it, the renderer must retain the previously
+  visible diff activity unless a newer equivalent diff activity replaces it.
+- R23. End-of-turn transcript state should expose a durable modified/added/
+  deleted file summary with inline diff access, so the user can inspect the
+  final changes without relying on transient live protocol updates.
 
 **Testing Gates**
 - R13. Unit tests must fail when any visible transcript item has an ordering key
@@ -117,6 +126,9 @@ except for explicitly older history loaded above the viewport.
   relative position of any group or transcript message.
 - Hydrating from `thread/read` during or after an active turn does not reshuffle
   already-observed live transcript items.
+- Edited-file and changed-file diff entries remain visible after live updates,
+  hydration catch-up, and later refreshes that omit the diff from the backend
+  response.
 
 ## Why We Got This Wrong
 

--- a/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
+++ b/docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
@@ -1,0 +1,178 @@
+---
+date: 2026-05-02
+topic: transcript-temporal-order-invariant
+---
+
+# Transcript Temporal Order Invariant
+
+## Problem Frame
+
+The desktop transcript is still able to display later tool/activity groups above
+earlier assistant text. In thread `019de585-735e-7aa0-82d7-469a6a32eb80`,
+protocol logging for the 9:04-9:06 AM EDT window shows agent messages and tool
+activity interleaved in real event order, but the UI screenshot shows later
+activity groups rendered above earlier assistant messages. This violates the
+basic chat contract: the transcript is a temporal record first, and grouping is
+only a presentation detail.
+
+The failure matters more than normal visual polish because it destroys trust in
+the transcript. A user watching a live demo must be able to assume that if an
+item is visually above another item, it happened no later than the item below it,
+except for explicitly older history loaded above the viewport.
+
+## Evidence
+
+- The protocol capture
+  `apps/desktop/.local/protocol-captures/2026-05-02T02-31-52-380Z-codex-full-access.jsonl`
+  records turn `019de8c9-b96b-7340-b78e-39bf6fe4ecf8` in temporal sequence:
+  an agent message begins around 9:04:12 AM EDT, followed by later command
+  activity around 9:04:19 AM EDT, more agent messages around 9:04:43 and
+  9:05:09 AM EDT, and additional tool activity around 9:05-9:06 AM EDT.
+- The external Codex rollout for the same thread preserves those event
+  timestamps in order; planning can use the protocol capture above as the
+  repo-local evidence source.
+- The renderer grouping helper currently groups active work by filtering all
+  work entries for a turn, not by checking bottom-contiguous adjacency first
+  (`apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`).
+- Live session state merges hydrated response entries and optimistic live
+  entries in several places, including agent-message deltas, tool starts, item
+  completions, and turn completion (`apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`).
+- `thread/read` hydration maps all items in a turn to the turn-level timestamp,
+  so it cannot by itself recover per-item temporal order after live optimistic
+  entries have separate event times
+  (`apps/desktop/src/main/codex-app-server/client.ts`).
+
+## Requirements
+
+**Hard Ordering Invariant**
+- R1. The transcript render order must be globally nondecreasing by the canonical
+  event order for all visible entries in a thread.
+- R2. A later tool/activity group must never render above an earlier user or
+  assistant message solely because the entries share a turn id.
+- R3. Grouping, collapsing, summarizing, and "same turn" affinity must not move
+  any entry across text, plan, review, approval, or command-output entries.
+- R4. If event timestamps are incomplete or equal, the app must use a stable
+  append sequence captured when the event was observed, not re-sort by type,
+  turn, role, or grouping convenience.
+
+**Grouping Semantics**
+- R5. Work grouping may only combine entries that are already adjacent in the
+  canonical transcript order.
+- R6. Completed work groups may remain collapsed, but the group placeholder must
+  occupy the position of the first grouped entry and may only contain entries up
+  to the last contiguous grouped entry before the next non-grouped transcript
+  item.
+- R7. Active work grouping may only append to the most recent bottom-contiguous
+  active work group when no text or other transcript item has appeared after
+  that group.
+- R8. Once assistant text appears after a tool group, later tool activity must
+  form a new group below that assistant text, even if it belongs to the same
+  turn.
+
+**Hydration And Live Merge**
+- R9. Live optimistic entries and hydrated `thread/read` entries must merge into
+  a single ordered ledger before rendering.
+- R10. Hydration must not replace precise live event order with coarser
+  turn-level timestamps when live per-item ordering is already known.
+- R11. Duplicate suppression must preserve the surviving entry's earliest known
+  event position and must not reinsert the survivor at the bottom or at a
+  turn-derived position.
+- R12. Turn completion must preserve the relative order of all retained
+  optimistic activity and all materialized assistant messages.
+
+**Testing Gates**
+- R13. Unit tests must fail when any visible transcript item has an ordering key
+  earlier than the item above it, after render-item construction.
+- R14. Renderer tests must include the real failure shape: assistant commentary,
+  later tool group, assistant commentary, later tool group, all in one turn.
+- R15. E2E/replay tests must assert DOM order for both collapsed and expanded
+  activity groups.
+- R16. E2E/replay tests must include hydration churn: live optimistic entries are
+  present, `thread/read` returns coarser persisted entries, and the rendered DOM
+  still preserves the original event order.
+- R17. Any test helper that builds transcript fixtures must make event order
+  explicit, preferably with a monotonic `sequence` or `observedAt` field, so
+  tests cannot accidentally pass by array order alone.
+
+**Diagnostics**
+- R18. Development builds should log or fail fast when the renderer receives
+  entries whose canonical order would place a later visible item above an
+  earlier visible item.
+- R19. When duplicate React keys are detected in transcript render items, the log
+  must include the entry ids, turn ids, render-item ids, and canonical order keys
+  involved.
+- R20. Protocol-capture analysis should be able to produce a compact transcript
+  order report for one thread id and turn id, so future reports can be compared
+  against DOM order without manual log spelunking.
+
+## Success Criteria
+
+- The 9:04-9:06 AM EDT sequence from thread
+  `019de585-735e-7aa0-82d7-469a6a32eb80` renders in the same order as the
+  protocol events: assistant text, later tools, assistant text, later tools,
+  assistant text.
+- No unit or E2E test can pass if a visible entry appears above an earlier
+  visible event.
+- Collapsing or expanding work groups changes detail visibility only, not the
+  relative position of any group or transcript message.
+- Hydrating from `thread/read` during or after an active turn does not reshuffle
+  already-observed live transcript items.
+
+## Why We Got This Wrong
+
+- We treated "same turn" as a stronger organizing principle than temporal
+  transcript order. That makes the UI feel tidy in simple cases but fails as
+  soon as one turn alternates text, tools, and more text.
+- We have multiple ordering sources: protocol notification order, optimistic
+  renderer insertion order, `createdAt`, turn-level `startedAt`, persisted
+  `thread/read` item order, and grouping order. No single canonical ledger owns
+  the final transcript order.
+- Hydration loses precision because some persisted entries only carry turn-level
+  time. When those entries are merged with live optimistic entries that have
+  later observed times, the merge logic can make plausible but wrong choices.
+- Existing tests cover several local cases, including collapsed tool activity,
+  but they do not assert the universal invariant across the complete live plus
+  hydration pipeline.
+- Grouping logic has been allowed to be clever. The durable rule needs to be
+  dumb: grouping can summarize adjacent entries, but it cannot move entries.
+
+## Scope Boundaries
+
+- This work does not redesign transcript styling.
+- This work does not require transcript virtualization.
+- This work does not require changing backend protocol semantics if the desktop
+  layer can maintain a canonical observed order.
+- This work should not depend on a human visually noticing order drift; failing
+  tests and development diagnostics are in scope.
+
+## Key Decisions
+
+- Time order is the primary product contract: it overrides role grouping,
+  turn grouping, work grouping, collapse state, and hydration convenience.
+- The transcript needs a canonical ordered-entry ledger before render grouping.
+  Grouping should consume that ledger and produce placeholders without changing
+  order.
+- Tests should enforce the invariant at multiple levels: merge unit, render-item
+  unit, and replay/E2E DOM order.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R4, R9-R12][Technical] Where should the canonical order key live:
+  shared app-server entry contract, renderer-only session state, or a small
+  transcript ledger adapter between hydration and rendering?
+- [Affects R16][Technical] Should the regression replay be derived from the
+  captured protocol file for thread `019de585-735e-7aa0-82d7-469a6a32eb80`, or
+  should it be a smaller synthetic fixture that preserves the same failure
+  shape?
+- [Affects R18-R20][Technical] Should out-of-order detection throw in tests only
+  and warn in development, or should it hard-fail in development builds too?
+
+## Next Steps
+
+-> /prompts:ce-plan for structured implementation planning.

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -43,6 +43,7 @@ That split means no layer could guarantee the visible transcript stayed in canon
 | R9-R12 live and hydrated merge semantics | Units 2, 4 |
 | R13-R17 unit, integration, E2E, and fixture coverage | Units 1, 3, 4, 5 |
 | R18-R20 diagnostics and protocol order reporting | Unit 6 |
+| R21-R23 durable edited-file diff retention and final change summary | Unit 2, Unit 4, follow-up test |
 
 ## Scope Boundaries
 

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -44,6 +44,7 @@ That split means no layer could guarantee the visible transcript stayed in canon
 | R13-R17 unit, integration, E2E, and fixture coverage | Units 1, 3, 4, 5 |
 | R18-R20 diagnostics and protocol order reporting | Unit 6 |
 | R21-R23 durable edited-file diff retention and final change summary | Unit 2, Unit 4, follow-up test |
+| R24 single active elapsed indicator | Unit 3, follow-up test |
 
 ## Scope Boundaries
 

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -1,0 +1,557 @@
+---
+date: 2026-05-02
+status: active
+type: fix
+title: Enforce transcript temporal order invariant
+origin: docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
+deepened: 2026-05-02
+---
+
+# Fix: Enforce Transcript Temporal Order Invariant
+
+## Overview
+
+The transcript must render in canonical temporal order at all times. Tool activity grouping, turn affinity, hydration, duplicate suppression, collapse state, and role styling are all subordinate to that invariant.
+
+The failure captured for thread `019de585-735e-7aa0-82d7-469a6a32eb80` showed later tool groups rendered above earlier assistant messages. That means the renderer did not have one authoritative order for visible transcript entries. It allowed grouping and merge convenience to reassemble the transcript after the fact.
+
+This plan makes transcript order explicit before rendering:
+
+1. Normalize live and hydrated transcript entries into one ordered ledger.
+2. Preserve precise observed live order when hydration provides only coarse turn timestamps.
+3. Make work grouping adjacency-only, including active turn grouping.
+4. Add unit and E2E invariants that fail on any visible out-of-order transcript item.
+5. Add diagnostics that explain the exact item, order key, and grouping decision when the invariant breaks.
+
+## Problem Frame
+
+The transcript is the user-facing record of agent work. When a later tool group renders above an earlier assistant message, the app tells a false story even if every individual message is present. The May 2 failure happened because multiple subsystems had partial ordering authority:
+
+- live session state tracked optimistic messages and activity entries
+- hydrated `thread/read` entries carried coarse turn-level timestamps
+- merge logic tried to reconcile entries after the fact
+- render grouping collected work entries by turn affinity
+
+That split means no layer could guarantee the visible transcript stayed in canonical event order. The fix is to make ordering a first-class invariant before grouping or rendering.
+
+## Requirements Trace
+
+| Requirement | Covered By |
+| --- | --- |
+| R1-R4 hard temporal ordering | Units 1, 2, 4, 6 |
+| R5-R8 grouping only adjacent/bottom-contiguous work | Units 1, 3, 5, 6 |
+| R9-R12 live and hydrated merge semantics | Units 2, 4 |
+| R13-R17 unit, integration, E2E, and fixture coverage | Units 1, 3, 4, 5 |
+| R18-R20 diagnostics and protocol order reporting | Unit 6 |
+
+## Scope Boundaries
+
+In scope:
+
+- Renderer transcript ordering for live optimistic entries, hydrated `thread/read` entries, and merged sessions.
+- Work group construction for active and completed turns.
+- Replay-backed E2E coverage for the May 2 failure shape.
+- Test/dev diagnostics that make ordering failures actionable.
+- Extending existing protocol analysis utilities where useful.
+
+Out of scope:
+
+- Visual redesign of the transcript.
+- Backend protocol changes unless implementation discovers an existing per-item sequence field that should be consumed.
+- Broad transcript storage rewrites.
+- Checking in raw `.local` protocol captures.
+- Changing unrelated typing indicator, review card, or navigation behavior beyond what is necessary to preserve transcript order.
+
+## Context And Research
+
+### Origin Requirements
+
+The requirements document is `docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md`.
+
+Important evidence from the origin:
+
+- Protocol capture `apps/desktop/.local/protocol-captures/2026-05-02T02-31-52-380Z-codex-full-access.jsonl` showed the protocol stream in the expected chronological order.
+- The in-app transcript rendered later "Explored 4 items" and "Explored 8 items" tool groups above earlier assistant messages.
+- The failure is unacceptable for demos because the transcript is the user's source of truth for what happened.
+
+### Existing Plans And Patterns
+
+- `docs/plans/2026-04-30-001-fix-live-transcript-ordering-plan.md` already moved toward session-owned live transcript state and fixed narrower live grouping issues. This plan builds on that work but tightens the invariant across live, hydrated, merged, and rendered states.
+- `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md` established `useThreadSessionState.ts` as the right owner for append-driven active thread state.
+- `docs/plans/2026-04-18-001-feat-desktop-replay-harness-plan.md` established replay-backed desktop E2E fixtures as the right way to make protocol-driven UI regressions reproducible.
+
+No durable `docs/solutions/` writeup exists yet for this class of failure.
+
+### Relevant Code
+
+- `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+  - Owns session state, live optimistic entries, pending assistant messages, turn completion, hydration merge, and duplicate suppression.
+  - `mergeTranscriptEntries(responseEntries, optimisticEntries)` currently merges hydrated response entries and live optimistic entries using timestamps, terminal same-turn entries, and append fallback. It does not use one canonical order ledger.
+  - `upsertLiveActivityEntry` assigns live activity timestamps and sequences, but that precision is not carried through a durable visible-order contract.
+  - `turn/completed` moves optimistic messages into response entries while retaining some non-message optimistic entries, which is a high-risk point for reshuffling.
+
+- `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`
+  - Builds render items and work groups.
+  - Completed groups are mostly adjacency-aware because they scan contiguous entries.
+  - Active work grouping currently selects all work-phase entries for the active turn, which can group non-contiguous activity above intervening text.
+
+- `apps/desktop/src/main/codex-app-server/client.ts`
+  - `extractThreadEntries` preserves `thread/read` item order, but assigns a turn-level timestamp to each extracted entry when item-level timing is absent.
+  - That timestamp is useful as a fallback but must not be treated as precise enough to reorder live-observed entries.
+
+- `apps/desktop/e2e/transcript-activity-order.spec.ts`
+  - Covers persisted activity order for a narrow fixture.
+  - Does not cover the May 2 live-plus-hydration failure shape or collapsed/expanded DOM order after refresh churn.
+
+### External Research
+
+Skipped. This is a local transcript state and rendering invariant with sufficient project-specific evidence, existing plans, and code patterns. External UI ordering guidance would not change the implementation shape.
+
+## Key Decisions
+
+### 1. Canonical order belongs in the renderer session ledger first
+
+Start with a renderer-owned order ledger in or near `useThreadSessionState.ts`, because this bug is caused by visible live/hydrated merge behavior. Do not promote a new shared API contract until implementation proves it is necessary.
+
+The ledger should assign or derive an order key for every visible transcript entry and keep that key stable across hydration, duplicate suppression, and turn completion.
+
+### 2. Observed live order outranks coarse hydrated timestamps
+
+Hydrated `thread/read` entries often have only turn-level timestamps. Those timestamps must not override live-observed order. If a live entry has an observed sequence, hydration can update content for the same logical entry but cannot move it ahead of an earlier observed visible item.
+
+### 3. Persisted array order remains meaningful
+
+For hydrated entries without item-level time or sequence, preserve the order returned by `thread/read`. If the app-server later exposes per-item protocol order, consume it as a stronger order source. Until then, array position is safer than pretending every same-turn item happened at the same turn timestamp.
+
+### 4. Grouping is a rendering transform, not an ordering authority
+
+Grouping code may collapse adjacent work entries into one render item. It may not search backward, collect same-turn entries across intervening text, or update an older group because a new tool event belongs to the same turn.
+
+### 5. Tests fail hard; production diagnostics stay non-fatal initially
+
+Unit tests and E2Es should fail on the first out-of-order visible item. Development diagnostics should log structured order violations. Production should not crash the transcript during a demo because the diagnostic itself should not become a user-visible outage.
+
+### 6. Entry identity matching must be conservative
+
+Hydration may not always provide a stable one-to-one identity for a live optimistic entry. If the implementation cannot prove two entries are the same logical transcript item, it should not merge them in a way that moves either entry. Keep both entries in canonical order and let duplicate diagnostics expose the ambiguity rather than silently rewriting history.
+
+## High-Level Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```mermaid
+flowchart TD
+  A[Live protocol notifications] --> C[Transcript order ledger]
+  B[Hydrated thread/read entries] --> C
+  C --> D[Ordered transcript entries]
+  D --> E[Adjacency-only render grouping]
+  E --> F[Transcript DOM]
+  E --> G[Test/dev order invariant checker]
+```
+
+Every visible entry should carry enough internal metadata to answer:
+
+- What logical entry is this?
+- What source produced or refreshed it?
+- What was the strongest known order signal?
+- Did this entry replace or suppress another entry?
+- What render group, if any, contains it?
+
+Suggested order signal precedence:
+
+| Signal | Meaning | Strength |
+| --- | --- | --- |
+| Live observed sequence | Monotonic order assigned when protocol activity/message is observed by the active session | Strongest |
+| Existing ledger key for same logical entry | Hydration or duplicate merge refreshes content without moving the entry | Strong |
+| Persisted per-item sequence or timestamp | Protocol-provided item order, if available in `thread/read` | Strong |
+| Hydrated array index within turn/session | Stable order from persisted transcript extraction | Medium |
+| Turn-level timestamp plus source index | Coarse fallback only | Weak |
+| Final append index | Last-resort deterministic fallback | Weakest |
+
+Grouping consumes already ordered entries. It never creates a new order. A group render item takes the order key of its first contained entry and may only contain entries that are contiguous in the ordered list.
+
+When identity is ambiguous, order preservation wins over deduplication. It is better to briefly show two adjacent representations of the same work than to move one representation above text that was already visible to the user.
+
+## Implementation Units
+
+### Unit Dependencies
+
+```mermaid
+flowchart TB
+  U1[Unit 1: Characterize order contract]
+  U2[Unit 2: Canonical order ledger]
+  U3[Unit 3: Adjacency grouping]
+  U4[Unit 4: Hydration precision]
+  U5[Unit 5: Replay E2E]
+  U6[Unit 6: Diagnostics]
+  U1 --> U2
+  U1 --> U3
+  U2 --> U4
+  U2 --> U5
+  U3 --> U5
+  U4 --> U5
+  U2 --> U6
+  U3 --> U6
+```
+
+- [ ] **Unit 1: Characterize the failure and order contract**
+
+**Goal:** Add focused tests that describe the invariant before changing core behavior.
+
+**Requirements:** R1-R8, R13-R14.
+
+**Dependencies:** None.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`
+
+**Approach:**
+
+- Write characterization tests before changing ordering logic.
+- Test the exact risk shape: interleaved assistant text and tool activity in one turn, then a later hydration update with weaker timestamp precision.
+- Add small assertion helpers that report visible labels and order keys when an ordering assertion fails.
+
+**Execution note:** Characterization-first. The first tests should fail against the current implementation for the active grouping and mixed live/hydration failure class.
+
+**Patterns to follow:**
+
+- Existing focused renderer tests in `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`.
+- Existing session hook tests in `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`.
+
+**Test scenarios:**
+
+- Happy path: live entries arrive as assistant message A, tool activity B, assistant message C, tool activity D; rendered labels stay A, B, C, D.
+- Edge case: entries have equal or missing timestamps; stable observed sequence still determines visible order.
+- Integration: hydration refresh returns same-turn entries with coarse timestamps after live observations; visible order does not change.
+- Error path: a deliberately out-of-order rendered list fails with a message naming the first offending item.
+
+**Verification:**
+
+- The tests describe the May 2 failure class without relying on brittle full snapshots.
+- The tests prove timestamp equality is not enough to reorder visible transcript entries.
+
+- [ ] **Unit 2: Introduce a canonical transcript order ledger**
+
+**Goal:** Make `useThreadSessionState.ts` produce one ordered transcript entry list for both live and hydrated data.
+
+**Requirements:** R1-R4, R9-R12, R16-R17.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+- Create, if it keeps the hook readable: `apps/desktop/src/renderer/src/lib/transcript-order.ts`
+
+**Approach:**
+
+- Add renderer-local order metadata for visible transcript entries.
+- Assign monotonic observed order when live protocol messages, activity, plans, and review entries are created.
+- Preserve an existing ledger order when hydration updates the same logical entry.
+- Treat hydrated response order as a stable fallback order, not as permission to reorder live-observed entries.
+- Make duplicate suppression preserve the survivor's canonical order.
+- Keep ambiguous live/hydrated identity matches as separate ordered entries until a stable identity proves they are the same logical item.
+- Make turn completion retain relative order for promoted assistant messages and retained activity entries.
+
+**Patterns to follow:**
+
+- Existing session-owned state pattern in `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`.
+- Prior live transcript direction in `docs/plans/2026-04-30-001-fix-live-transcript-ordering-plan.md`.
+
+**Test scenarios:**
+
+- Happy path: live-only assistant and activity entries sort by observed ledger order.
+- Happy path: hydrated-only entries sort by persisted extraction order.
+- Integration: mixed live and hydrated entries keep live-observed order while accepting refreshed content.
+- Edge case: duplicate message IDs or duplicate message content suppress to one visible item without changing that survivor's order.
+- Edge case: ambiguous live and hydrated entries remain in canonical order instead of merging backward across visible text.
+- Edge case: `turn/completed` promotes pending assistant messages and retains activity entries without changing their relative order.
+- Error path: a hydration refresh with a weaker order signal attempts to move an entry above an earlier observed item; the merge keeps the original order and diagnostics can report the conflict.
+
+**Verification:**
+
+- `mergeTranscriptEntries` or its replacement sorts by canonical order, not by incidental branch order.
+- Hydration can update content and completion metadata without moving an entry above an earlier visible item.
+
+- [ ] **Unit 3: Make work grouping strictly adjacency-preserving**
+
+**Goal:** Ensure render grouping cannot violate transcript order.
+
+**Requirements:** R5-R8, R13-R15.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`
+
+**Approach:**
+
+- Replace active-turn work grouping that filters all same-turn work entries with an ordered scan that only groups contiguous work entries.
+- Keep completed-group scanning adjacency-based and add tests that lock this behavior down.
+- Ensure a later same-turn tool activity after assistant text becomes a new work group at that later position.
+- Ensure a group render item inherits the order key or order position of its first member.
+
+**Patterns to follow:**
+
+- Existing completed-group scan behavior in `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`.
+- Existing duplicate/group regression tests in `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`.
+
+**Test scenarios:**
+
+- Happy path: adjacent activity entries for the same turn collapse into one work group at the first activity's position.
+- Edge case: activity, assistant text, later activity for the same active turn renders as group, text, later group.
+- Edge case: completed turn grouping follows the same contiguity rule as active turn grouping.
+- Integration: collapsed and expanded group representations expose the same chronological member order.
+
+**Verification:**
+
+- No render path collects non-contiguous entries into a group.
+- Collapsing and expanding a group does not change visible order.
+
+- [ ] **Unit 4: Preserve hydration precision and persisted item order**
+
+**Goal:** Stop persisted refreshes from erasing stronger ordering information.
+
+**Requirements:** R9-R12, R16-R17.
+
+**Dependencies:** Unit 2.
+
+**Files:**
+
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Approach:**
+
+- Audit `extractThreadEntries` for any available item-level timestamp, sequence, or array position that should be exposed or consumed.
+- Preserve `thread/read` item order explicitly when all same-turn entries share one turn timestamp.
+- If adding metadata to normalized entries is necessary, keep it optional and backend-agnostic.
+- Keep turn-level timestamps as weak fallback order signals.
+- Add mixed tests where live sequence has higher precision than refreshed `thread/read` entries.
+
+**Patterns to follow:**
+
+- Existing `extractThreadEntries` item-order preservation in `apps/desktop/src/main/codex-app-server/client.ts`.
+- Existing `codex-client` tests that verify protocol `thread/read` activity groups remain at captured item positions.
+
+**Test scenarios:**
+
+- Happy path: `thread/read` returns interleaved activity and assistant messages with identical turn timestamps; extracted order matches item order.
+- Edge case: item-level sequence or timestamp exists for some entries but not all; stronger item-level signals are used only where available and fallback order remains deterministic.
+- Integration: renderer receives a refreshed `thread/read` response after live observations; refreshed content is accepted without reshuffling visible entries.
+- Error path: duplicate persisted keys or ambiguous same-turn entries produce diagnostics with enough context to debug the ordering source.
+
+**Verification:**
+
+- App-server extraction preserves same-turn item order even when timestamps are identical.
+- Renderer hydration does not regress from live-observed order to coarser persisted timestamp order.
+- Grok and Codex transcript providers can continue using the same normalized transcript shape.
+
+- [ ] **Unit 5: Add replay E2E for the May 2 failure shape**
+
+**Goal:** Make the actual failure shape impossible to reintroduce unnoticed.
+
+**Requirements:** R15-R17.
+
+**Dependencies:** Units 2, 3, and 4.
+
+**Files:**
+
+- Create: `apps/desktop/e2e/transcript-temporal-order.spec.ts`
+- Create: `apps/desktop/e2e/fixtures/transcript-temporal-order/replay.fixture.json`
+- Create, if fixture explanation is useful: `apps/desktop/e2e/fixtures/transcript-temporal-order/README.md`
+
+**Approach:**
+
+- Derive a small replay fixture from the May 2 capture shape rather than checking in the raw `.local` capture.
+- Include interleaved assistant text and tool activity matching the observed class of failure:
+  - assistant message
+  - later tool activity group
+  - assistant message
+  - later tool activity group
+  - assistant message
+- Include a refresh or hydration step with coarser persisted ordering data.
+- Assert visible DOM order before and after group collapse/expand.
+- Assert that refreshing or reselecting the thread does not move tool groups above earlier assistant messages.
+
+**Patterns to follow:**
+
+- Existing replay fixture structure in `apps/desktop/e2e/fixtures/transcript-activity-order/replay.fixture.json`.
+- Existing replay-backed assertions in `apps/desktop/e2e/transcript-activity-order.spec.ts`.
+- Fixture seeding guidance in `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md` if a refreshed fixture is generated from local capture data.
+
+**Test scenarios:**
+
+- Happy path: visible transcript order is assistant message, tool group, assistant message, tool group, assistant message.
+- Edge case: collapsed work groups retain their chronological position relative to surrounding assistant messages.
+- Edge case: expanded work groups reveal member rows in the same canonical order as the group summary.
+- Integration: thread refresh or reselect after the replayed live events does not move either tool group upward.
+
+**Verification:**
+
+- The E2E fails if any visible transcript item appears above an earlier canonical item.
+- The fixture is minimal, sanitized, and documents which capture/thread inspired it.
+
+- [ ] **Unit 6: Add diagnostics and protocol order reporting**
+
+**Goal:** Make future ordering regressions easy to diagnose from tests, local demos, and protocol captures.
+
+**Requirements:** R18-R20.
+
+**Dependencies:** Units 2 and 3.
+
+**Files:**
+
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`
+- Create, if a helper boundary is cleaner: `apps/desktop/src/renderer/src/features/thread-detail/transcript-order-diagnostics.ts`
+- Modify: `apps/desktop/scripts/analyze-codex-thread-protocol.ts`
+- Modify: `apps/desktop/src/main/testing/codex-thread-protocol-analysis.ts`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-thread-protocol-analysis.test.ts`
+
+**Approach:**
+
+- Add a test/dev invariant checker for render items that reports render item id, entry ids, turn ids, order keys, source order signal, group id, and member order.
+- Fail tests on the first violation.
+- Log non-fatal structured diagnostics in development builds.
+- Extend the existing protocol analysis utility to print a chronological outline for a thread/turn, including message and tool activity order.
+- Include duplicate key diagnostics because duplicate suppression can mask ordering bugs.
+
+**Patterns to follow:**
+
+- Existing protocol analyzer boundaries in `apps/desktop/scripts/analyze-codex-thread-protocol.ts` and `apps/desktop/src/main/testing/codex-thread-protocol-analysis.ts`.
+- Existing render-item construction in `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`.
+
+**Test scenarios:**
+
+- Happy path: a correctly ordered render list passes the invariant checker without logging an error.
+- Error path: a synthetic out-of-order render list fails with the first offending item and the previous item it moved above.
+- Error path: a non-contiguous group fails with member order details.
+- Integration: protocol analysis summarizes the ordering evidence for thread `019de585-735e-7aa0-82d7-469a6a32eb80` from a repo-local capture when available.
+
+**Verification:**
+
+- Diagnostics identify the exact item and order key that violated the invariant.
+- Diagnostics are gated so normal production rendering does not crash.
+- Protocol order reports provide enough evidence to compare source order with rendered order.
+
+## Test Strategy
+
+Unit tests:
+
+- `useThreadSessionState` live sequence tests for interleaved messages and tool activity.
+- `useThreadSessionState` hydration tests for same-turn coarse timestamps.
+- `useThreadSessionState` duplicate suppression and turn completion order tests.
+- `transcript-render-items` grouping tests for active and completed turns.
+- `codex-client` extraction tests for same-turn persisted item order.
+
+E2E tests:
+
+- Replay fixture for the May 2 failure shape.
+- DOM order assertion over visible transcript items.
+- Collapsed and expanded group assertion.
+- Refresh/reselect assertion that hydration does not reshuffle visible items.
+
+Manual verification:
+
+- Run the desktop app against the relevant captured thread when local data is available.
+- Use protocol analysis output to compare source event order with rendered order.
+
+Implementation verification should include the desktop unit suite for the touched renderer/main code and the replay-backed desktop E2Es covering transcript temporal order and existing transcript activity order.
+
+## System Impact
+
+### State Lifecycle
+
+The highest-risk lifecycle events are:
+
+- first live assistant message for a turn
+- first live tool activity for a turn
+- additional tool activity after assistant text
+- `thread/read` refresh while a turn is active
+- `turn/completed`
+- duplicate suppression after hydration
+- thread reselect or navigation refresh
+
+Each event must update content without changing the canonical order of existing visible entries unless the existing entry had only weaker fallback order and no user-visible position has been established.
+
+### UI And Interaction
+
+The transcript should look the same except that ordering is correct. Collapsed groups still collapse, expanded groups still reveal members, and scroll behavior should not jump because a historical group was rewritten.
+
+### Provider Compatibility
+
+The order helper should operate on normalized transcript entries and not Codex-only protocol assumptions. Codex-specific analysis belongs in the Codex protocol analyzer, not in the renderer invariant.
+
+### Performance
+
+The ledger and invariant checks should be linear in visible transcript entries. Avoid repeated full scans inside per-entry render loops. Development diagnostics can be more verbose than production.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Order metadata spreads through shared types unnecessarily | Keep metadata renderer-local first; add optional normalized fields only if app-server extraction needs them. |
+| Hydrated timestamps still look authoritative | Treat turn-level timestamps as weak fallback and test identical timestamp cases. |
+| Active grouping keeps collecting non-contiguous entries | Replace filter-based active grouping with scan-based grouping and add regression tests. |
+| Duplicate suppression hides the wrong entry | Preserve survivor order explicitly and log duplicate diagnostics in tests/dev. |
+| Replay fixture is too large or sensitive | Check in a minimized synthetic fixture derived from the observed shape, not the raw capture. |
+| Diagnostics become noisy in production | Hard-fail tests, log in development, keep production non-fatal. |
+| Pagination or older history prepend interacts with order keys | Include deterministic fallback order and add tests if implementation touches pagination/prepending. |
+
+## Alternative Approaches Considered
+
+- **Fix only active grouping:** Rejected because it would address one visible symptom but not hydration, duplicate suppression, or turn completion reshuffling.
+- **Trust timestamps globally:** Rejected because hydrated entries can share one turn-level timestamp, which is the root of the precision gap.
+- **Push a backend protocol change first:** Deferred because the renderer can enforce a visible invariant now using observed sequence and persisted array order. Backend per-item sequence can be adopted later if available.
+- **Crash production on invariant violation:** Rejected for initial rollout because the diagnostic should not create a demo outage. Tests and E2Es still fail hard.
+
+## Documentation / Operational Notes
+
+- If the implementation introduces a reusable transcript ordering helper, document the invariant in a nearby module comment or test helper name rather than a user-facing UI string.
+- If the replay fixture is derived from a live capture, document the source thread id and sanitized event shape in the fixture README, not in checked-in raw logs.
+- A follow-up `docs/solutions/` writeup is warranted after implementation if this becomes the durable pattern for transcript ordering.
+
+## Open Questions
+
+Resolved during planning:
+
+- **Where should canonical order live first?** In the renderer session ledger, because the bug is in visible live/hydrated merging and grouping.
+- **Should the May 2 capture be checked in?** No. Use it as local evidence and check in a minimized replay fixture.
+- **Should diagnostics hard-crash production?** No. Tests and E2Es fail hard; production diagnostics stay non-fatal initially.
+
+Deferred to implementation:
+
+- The exact internal field names for order metadata.
+- Whether `thread/read` exposes a useful per-item sequence that `extractThreadEntries` can consume.
+- Whether order diagnostics should live beside session state or render item construction after the helper boundary is clearer.
+
+## Definition Of Done
+
+- All transcript render paths consume entries sorted by canonical order.
+- Active and completed work grouping is adjacency-only.
+- Hydration cannot move a live-observed entry above an earlier visible entry.
+- Duplicate suppression and turn completion preserve relative visible order.
+- Unit tests fail on out-of-order entries, non-contiguous grouping, and coarse hydration timestamp regressions.
+- A replay-backed E2E covers the May 2 failure shape and collapsed/expanded group DOM order.
+- Diagnostics identify the exact item and order key that violated the invariant.
+- Existing transcript activity order E2E remains passing.
+
+## Sources & References
+
+- Origin document: `docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md`
+- Prior related plan: `docs/plans/2026-04-30-001-fix-live-transcript-ordering-plan.md`
+- Thread refresh plan: `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md`
+- Replay harness plan: `docs/plans/2026-04-18-001-feat-desktop-replay-harness-plan.md`
+- Desktop app guidance: `apps/desktop/AGENTS.md`
+- Session state owner: `apps/desktop/src/renderer/src/lib/useThreadSessionState.ts`
+- Render grouping: `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`
+- Codex transcript extraction: `apps/desktop/src/main/codex-app-server/client.ts`
+- Existing replay E2E: `apps/desktop/e2e/transcript-activity-order.spec.ts`

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-05-02
-status: active
+status: completed
 type: fix
 title: Enforce transcript temporal order invariant
 origin: docs/brainstorms/2026-05-02-transcript-temporal-order-invariant-requirements.md
@@ -313,7 +313,7 @@ flowchart TB
 - No render path collects non-contiguous entries into a group.
 - Collapsing and expanding a group does not change visible order.
 
-- [ ] **Unit 4: Preserve hydration precision and persisted item order**
+- [x] **Unit 4: Preserve hydration precision and persisted item order**
 
 **Goal:** Stop persisted refreshes from erasing stronger ordering information.
 
@@ -354,7 +354,7 @@ flowchart TB
 - Renderer hydration does not regress from live-observed order to coarser persisted timestamp order.
 - Grok and Codex transcript providers can continue using the same normalized transcript shape.
 
-- [ ] **Unit 5: Add replay E2E for the May 2 failure shape**
+- [x] **Unit 5: Add replay E2E for the May 2 failure shape**
 
 **Goal:** Make the actual failure shape impossible to reintroduce unnoticed.
 
@@ -399,7 +399,7 @@ flowchart TB
 - The E2E fails if any visible transcript item appears above an earlier canonical item.
 - The fixture is minimal, sanitized, and documents which capture/thread inspired it.
 
-- [ ] **Unit 6: Add diagnostics and protocol order reporting**
+- [x] **Unit 6: Add diagnostics and protocol order reporting**
 
 **Goal:** Make future ordering regressions easy to diagnose from tests, local demos, and protocol captures.
 

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -194,7 +194,7 @@ flowchart TB
   U3 --> U6
 ```
 
-- [ ] **Unit 1: Characterize the failure and order contract**
+- [x] **Unit 1: Characterize the failure and order contract**
 
 **Goal:** Add focused tests that describe the invariant before changing core behavior.
 
@@ -232,7 +232,7 @@ flowchart TB
 - The tests describe the May 2 failure class without relying on brittle full snapshots.
 - The tests prove timestamp equality is not enough to reorder visible transcript entries.
 
-- [ ] **Unit 2: Introduce a canonical transcript order ledger**
+- [x] **Unit 2: Introduce a canonical transcript order ledger**
 
 **Goal:** Make `useThreadSessionState.ts` produce one ordered transcript entry list for both live and hydrated data.
 
@@ -276,7 +276,7 @@ flowchart TB
 - `mergeTranscriptEntries` or its replacement sorts by canonical order, not by incidental branch order.
 - Hydration can update content and completion metadata without moving an entry above an earlier visible item.
 
-- [ ] **Unit 3: Make work grouping strictly adjacency-preserving**
+- [x] **Unit 3: Make work grouping strictly adjacency-preserving**
 
 **Goal:** Ensure render grouping cannot violate transcript order.
 

--- a/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
+++ b/docs/plans/2026-05-02-001-fix-transcript-temporal-order-invariant-plan.md
@@ -45,6 +45,7 @@ That split means no layer could guarantee the visible transcript stayed in canon
 | R18-R20 diagnostics and protocol order reporting | Unit 6 |
 | R21-R23 durable edited-file diff retention and final change summary | Unit 2, Unit 4, follow-up test |
 | R24 single active elapsed indicator | Unit 3, follow-up test |
+| R25-R26 current-turn top-level edited-file summaries | Unit 3, Unit 4, follow-up test |
 
 ## Scope Boundaries
 


### PR DESCRIPTION
## Summary

This PR makes transcript temporal order a hard renderer invariant so live tool activity cannot be grouped or reinserted above earlier assistant text. It captures the May 2 failure shapes in docs and replay coverage, then fixes the renderer paths that were treating turn affinity or hydration churn as stronger than visible chronology.

## Changes

- Preserve stronger live-observed ordering across `thread/read` hydration when persisted entries only have coarse same-turn timestamps.
- Retain previously visible edited-file diff activities if a later hydration response omits them, so inline file lists and diffs do not disappear from the chat.
- Scope edited-file diff retention to the current/latest turn, preventing older turn summaries from being carried to the bottom with the current turn.
- Render edited-file diff activity at the transcript top level instead of nesting it under generic completed work groups, so file counts and line-change summaries are immediately visible.
- Limit active `Working for ...` elapsed indicators to the trailing active work block, so interleaved tool groups do not each keep a live timer.
- Make active and completed work grouping adjacency-only, so a group can only represent contiguous transcript entries at its current position.
- Tighten pending activity and pending assistant insertion so timestamped entries are not moved ahead of earlier same-turn final text.
- Add a replay-backed desktop E2E fixture for the May 2 transcript ordering failure, covering live order, hydrated order, collapsed groups, and expanded tool details.
- Extend Codex protocol capture analysis with a chronological thread-order outline for assistant messages, tools, and turn events.
- Document the requirements and implementation plan for the invariant.

## Verification

- `pnpm test:desktop-e2e -- transcript-temporal-order.spec.ts`
- `pnpm test:desktop-e2e -- transcript-activity-order.spec.ts`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/codex-thread-protocol-analysis.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts -- -t "preserves protocol thread/read activity groups"`
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)
