### PR TITLE
feat(desktop): show cached token percentages

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3809,7 +3809,7 @@ function buildContextWindowTooltip(
 
   const breakdown = [
     formatOptionalTokenDetail("input", contextWindow.inputTokens),
-    formatOptionalTokenDetail("cached", contextWindow.cachedInputTokens),
+    formatCachedTokenDetail(contextWindow.cachedInputTokens, contextWindow.inputTokens),
     formatOptionalTokenDetail("output", contextWindow.outputTokens),
     formatOptionalTokenDetail("reasoning", contextWindow.reasoningOutputTokens),
   ].filter((detail): detail is string => Boolean(detail));
@@ -3824,6 +3824,13 @@ function buildContextWindowTooltip(
         contextWindow.cumulativeTotalTokens
       )} tokens`
     );
+    const cumulativeCachedInput = formatCachedInputSummary(
+      contextWindow.cumulativeCachedInputTokens,
+      contextWindow.cumulativeInputTokens
+    );
+    if (cumulativeCachedInput) {
+      lines.push(`Cumulative cached input: ${cumulativeCachedInput}`);
+    }
   }
 
   return lines.join("\n");
@@ -3831,6 +3838,47 @@ function buildContextWindowTooltip(
 
 function formatOptionalTokenDetail(label: string, value: number | undefined): string | undefined {
   return typeof value === "number" ? `${formatCompactNumber(value)} ${label}` : undefined;
+}
+
+function formatCachedTokenDetail(
+  cachedInputTokens: number | undefined,
+  inputTokens: number | undefined
+): string | undefined {
+  if (typeof cachedInputTokens !== "number") {
+    return undefined;
+  }
+
+  const percent = formatCachedInputPercent(cachedInputTokens, inputTokens);
+  return `${formatCompactNumber(cachedInputTokens)} cached${percent ? ` (${percent})` : ""}`;
+}
+
+function formatCachedInputSummary(
+  cachedInputTokens: number | undefined,
+  inputTokens: number | undefined
+): string | undefined {
+  if (typeof cachedInputTokens !== "number") {
+    return undefined;
+  }
+
+  const percent = formatCachedInputPercent(cachedInputTokens, inputTokens);
+  return `${formatCompactNumber(cachedInputTokens)}${percent ? ` (${percent})` : ""}`;
+}
+
+function formatCachedInputPercent(
+  cachedInputTokens: number,
+  inputTokens: number | undefined
+): string | undefined {
+  if (typeof inputTokens !== "number" || inputTokens <= 0) {
+    return undefined;
+  }
+
+  const percent = Math.max(0, Math.min(100, (cachedInputTokens / inputTokens) * 100));
+  return formatPercent(percent);
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
 }
 
 function formatCompactNumber(value: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -228,6 +228,8 @@ describe("Composer", () => {
         backends={[backendSummary("codex")]}
         contextWindow={{
           cachedInputTokens: 32_000,
+          cumulativeCachedInputTokens: 48_000,
+          cumulativeInputTokens: 72_000,
           cumulativeTotalTokens: 80_000,
           inputTokens: 63_000,
           modelContextWindow: 128_000,
@@ -263,8 +265,9 @@ describe("Composer", () => {
         "Context window: 50% full (full moon)",
         "Current snapshot: 64k / 128k tokens",
         "Remaining: 64k tokens, 50% remaining",
-        "Current breakdown: 63k input, 32k cached, 1k output",
+        "Current breakdown: 63k input, 32k cached (50.8%), 1k output",
         "Cumulative usage reported: 80k tokens",
+        "Cumulative cached input: 48k (66.7%)",
       ].join("\n")
     );
     expect(screen.getByRole("img")).not.toHaveAttribute("title");

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3178,6 +3178,8 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.contextWindow).toEqual({
       cachedInputTokens: undefined,
+      cumulativeCachedInputTokens: undefined,
+      cumulativeInputTokens: undefined,
       cumulativeTotalTokens: undefined,
       inputTokens: undefined,
       modelContextWindow: 128_000,
@@ -3245,6 +3247,8 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.contextWindow).toEqual({
       cachedInputTokens: undefined,
+      cumulativeCachedInputTokens: undefined,
+      cumulativeInputTokens: undefined,
       cumulativeTotalTokens: undefined,
       inputTokens: 1_200,
       modelContextWindow: 258_400,
@@ -3320,6 +3324,8 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.contextWindow).toMatchObject({
       cachedInputTokens: 20_352,
+      cumulativeCachedInputTokens: 23_808,
+      cumulativeInputTokens: 41_267,
       cumulativeTotalTokens: 41_342,
       inputTokens: 20_663,
       modelContextWindow: 258_400,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -82,6 +82,8 @@ export type ThreadViewportState = {
 
 export type ThreadContextWindowState = {
   cachedInputTokens?: number;
+  cumulativeCachedInputTokens?: number;
+  cumulativeInputTokens?: number;
   cumulativeTotalTokens?: number;
   inputTokens?: number;
   modelContextWindow: number;
@@ -654,13 +656,16 @@ function normalizeThreadContextWindowState(
     0,
     Math.min(100, (remainingTokens / modelContextWindow) * 100)
   );
+  const hasDistinctCumulativeUsage =
+    totalUsage?.totalTokens !== undefined && totalUsage.totalTokens !== totalTokens;
 
   return {
     cachedInputTokens: currentUsage.cachedInputTokens,
-    cumulativeTotalTokens:
-      totalUsage?.totalTokens !== undefined && totalUsage.totalTokens !== totalTokens
-        ? totalUsage.totalTokens
-        : undefined,
+    cumulativeCachedInputTokens: hasDistinctCumulativeUsage
+      ? totalUsage.cachedInputTokens
+      : undefined,
+    cumulativeInputTokens: hasDistinctCumulativeUsage ? totalUsage.inputTokens : undefined,
+    cumulativeTotalTokens: hasDistinctCumulativeUsage ? totalUsage.totalTokens : undefined,
     inputTokens: currentUsage.inputTokens,
     modelContextWindow,
     outputTokens: currentUsage.outputTokens,


### PR DESCRIPTION
## Summary

I added cached-input percentages to the Codex context-window tooltip so high cumulative token counts are easier to interpret as mostly cached input instead of fresh inference input.

The tooltip now shows the current cached input as a percentage of current input, and it adds a cumulative cached input line using cumulative input as the denominator. The renderer session state now carries the cumulative cached/input counts needed for that display.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragnt/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.5 (258K context, high reasoning) via [Codex](https://openai.com/codex)
