### PR TITLE
feat(messaging): support messaging attachments

### DIFF
--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -853,8 +853,15 @@ describe("DiscordAdapter", () => {
     });
 
     expect(events.at(-1)).toMatchObject({
-      disposition: "unsupported",
+      disposition: "available",
       kind: "media",
+      attachments: [
+        expect.objectContaining({
+          disposition: "available",
+          kind: "file",
+          name: "secret.txt",
+        }),
+      ],
       media: {
         name: "secret.txt",
       },

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -117,9 +117,9 @@ vi.mock("../diagnostics/startup-cpu-profiler", () => ({
 }));
 
 async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 describe("bootstrapApp", () => {
@@ -157,6 +157,7 @@ describe("bootstrapApp", () => {
     startupProfilerInstance.attachWindow.mockReset();
     StartupCpuProfilerMock.mockClear();
     vi.resetModules();
+    vi.stubEnv("PWRAGNT_DISABLE_MESSAGING", undefined);
   });
 
   afterEach(() => {

--- a/apps/desktop/src/main/__tests__/messaging-attachment-image-normalization.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-attachment-image-normalization.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  nativeImage: {
+    createFromBuffer: vi.fn(),
+  },
+}));
+
+import {
+  calculateBoundedDimensions,
+  normalizeMessagingImageAttachment,
+} from "../messaging/attachment-image-normalization";
+
+describe("messaging attachment image normalization", () => {
+  it("keeps the medium profile aligned with current paste bounds", async () => {
+    const resize = vi.fn(() => fakeNativeImage(1536, 1024, 10));
+    const image = fakeNativeImage(3000, 2000, 12, { resize });
+
+    const result = await normalizeMessagingImageAttachment({
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: "image/jpeg",
+      profile: "medium",
+      dependencies: {
+        createImageFromBuffer: () => image,
+      },
+    });
+
+    expect(resize).toHaveBeenCalledWith({
+      height: 1024,
+      quality: "best",
+      width: 1536,
+    });
+    expect(result).toMatchObject({
+      height: 1024,
+      mimeType: "image/jpeg",
+      width: 1536,
+    });
+  });
+
+  it("preserves actual dimensions when the actual profile is selected", () => {
+    expect(
+      calculateBoundedDimensions({
+        height: 2000,
+        maxLongEdge: 8192,
+        maxShortEdge: 8192,
+        preserveActual: true,
+        width: 3000,
+      }),
+    ).toEqual({ height: 2000, width: 3000 });
+  });
+
+  it("normalizes GIF input to PNG", async () => {
+    const result = await normalizeMessagingImageAttachment({
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: "image/gif",
+      profile: "medium",
+      dependencies: {
+        createImageFromBuffer: () => fakeNativeImage(320, 240, 5),
+      },
+    });
+
+    expect(result.mimeType).toBe("image/png");
+    expect(result.dataUrl).toMatch(/^data:image\/png;base64,/);
+  });
+});
+
+function fakeNativeImage(
+  width: number,
+  height: number,
+  outputBytes: number,
+  overrides: Partial<Electron.NativeImage> = {},
+): Electron.NativeImage {
+  return {
+    getSize: () => ({ height, width }),
+    isEmpty: () => false,
+    resize: () => fakeNativeImage(width, height, outputBytes),
+    toJPEG: () => Buffer.alloc(outputBytes),
+    toPNG: () => Buffer.alloc(outputBytes),
+    ...overrides,
+  } as Electron.NativeImage;
+}

--- a/apps/desktop/src/main/__tests__/messaging-attachment-mime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-attachment-mime.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyMessagingAttachment,
+  decodeMessagingTextAttachment,
+} from "../messaging/core/messaging-attachment-mime";
+
+const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+describe("messaging attachment MIME classification", () => {
+  it("classifies text-like file types by extension and content", () => {
+    for (const fileName of [
+      "streaming-logs.txt",
+      "data.csv",
+      "payload.json",
+      "events.jsonl",
+      "config.toml",
+      "workflow.yaml",
+      "workflow.yml",
+      "notes.md",
+      "app.log",
+    ]) {
+      expect(
+        classifyMessagingAttachment({
+          data: bytes("hello\nworld\n"),
+          fileName,
+        }),
+      ).toMatchObject({ kind: "text" });
+    }
+  });
+
+  it("does not trust a text extension when bytes look binary", () => {
+    expect(
+      classifyMessagingAttachment({
+        data: new Uint8Array([0, 1, 2, 3]),
+        fileName: "secret.txt",
+        mimeType: "text/plain",
+      }),
+    ).toMatchObject({ kind: "binary" });
+  });
+
+  it("prefers magic bytes for images and PDFs", () => {
+    expect(
+      classifyMessagingAttachment({
+        data: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1]),
+        fileName: "image.bin",
+      }),
+    ).toMatchObject({ kind: "image", mimeType: "image/png" });
+    expect(
+      classifyMessagingAttachment({
+        data: bytes("%PDF-1.7\n"),
+        fileName: "file.bin",
+      }),
+    ).toMatchObject({ kind: "pdf" });
+  });
+
+  it("decodes plain text attachments", () => {
+    expect(decodeMessagingTextAttachment(bytes("alpha\nbeta"))).toBe("alpha\nbeta");
+    expect(decodeMessagingTextAttachment(new Uint8Array([1, 0, 2]))).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts
@@ -48,15 +48,11 @@ describe("processMessagingAttachments", () => {
     expect(result.input).toEqual([
       {
         type: "text",
-        text: "Please inspect this log",
-      },
-      {
-        type: "text",
-        text: expect.stringContaining("Attachment: streaming-logs.txt"),
+        text: expect.stringContaining("Please inspect this log\n\nAttached file: `streaming-logs.txt`"),
       },
     ]);
-    expect(result.input[1]).toMatchObject({
-      text: expect.stringContaining("line two"),
+    expect(result.input[0]).toMatchObject({
+      text: expect.stringContaining("```text\nline one\nline two\n```"),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  MessagingAdapter,
+} from "../messaging/core/messaging-adapter";
+import {
+  processMessagingAttachments,
+} from "../messaging/core/messaging-attachment-processor";
+
+const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+function createAdapter(dataByName: Record<string, Uint8Array>): MessagingAdapter {
+  return {
+    deliver: vi.fn(),
+    downloadAttachment: vi.fn(async ({ attachment }) => {
+      const data = dataByName[attachment.name] ?? new Uint8Array();
+      return {
+        data,
+        fileName: attachment.name,
+        mimeType: attachment.mimeType,
+        sizeBytes: data.byteLength,
+      };
+    }),
+  };
+}
+
+describe("processMessagingAttachments", () => {
+  it("turns text attachments into bounded text input", async () => {
+    const adapter = createAdapter({
+      "streaming-logs.txt": bytes("line one\nline two"),
+    });
+
+    const result = await processMessagingAttachments({
+      adapter,
+      attachments: [
+        {
+          id: "file-1",
+          kind: "file",
+          name: "streaming-logs.txt",
+          disposition: "available",
+          mimeType: "text/plain",
+          sizeBytes: 18,
+        },
+      ],
+      text: "Please inspect this log",
+    });
+
+    expect(result.rejections).toEqual([]);
+    expect(result.input).toEqual([
+      {
+        type: "text",
+        text: "Please inspect this log",
+      },
+      {
+        type: "text",
+        text: expect.stringContaining("Attachment: streaming-logs.txt"),
+      },
+    ]);
+    expect(result.input[1]).toMatchObject({
+      text: expect.stringContaining("line two"),
+    });
+  });
+
+  it("rejects binary bytes disguised as text", async () => {
+    const result = await processMessagingAttachments({
+      adapter: createAdapter({
+        "secret.txt": new Uint8Array([0, 1, 2, 3]),
+      }),
+      attachments: [
+        {
+          id: "file-1",
+          kind: "file",
+          name: "secret.txt",
+          disposition: "available",
+          mimeType: "text/plain",
+          sizeBytes: 4,
+        },
+      ],
+    });
+
+    expect(result.input).toEqual([]);
+    expect(result.rejections).toEqual([
+      {
+        name: "secret.txt",
+        reason: "Attachment type is not supported.",
+      },
+    ]);
+  });
+
+  it("rejects oversize attachments before downloading", async () => {
+    const adapter = createAdapter({});
+
+    const result = await processMessagingAttachments({
+      adapter,
+      attachments: [
+        {
+          id: "file-1",
+          kind: "file",
+          name: "huge.log",
+          disposition: "available",
+          mimeType: "text/plain",
+          sizeBytes: 99,
+        },
+      ],
+      policy: {
+        maxAttachmentBytes: 10,
+      },
+    });
+
+    expect(adapter.downloadAttachment).not.toHaveBeenCalled();
+    expect(result.rejections[0]).toMatchObject({
+      name: "huge.log",
+      reason: "Attachment is larger than the configured limit.",
+    });
+  });
+
+  it("extracts simple text-bearing PDFs and rejects PDFs without text", async () => {
+    const adapter = createAdapter({
+      "readable.pdf": bytes("%PDF-1.7\n(hello pdf) Tj\n"),
+      "scan.pdf": bytes("%PDF-1.7\n/image data\n"),
+    });
+
+    const readable = await processMessagingAttachments({
+      adapter,
+      attachments: [
+        {
+          id: "pdf-1",
+          kind: "file",
+          name: "readable.pdf",
+          disposition: "available",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+    const scanned = await processMessagingAttachments({
+      adapter,
+      attachments: [
+        {
+          id: "pdf-2",
+          kind: "file",
+          name: "scan.pdf",
+          disposition: "available",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+
+    expect(readable.input[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("hello pdf"),
+    });
+    expect(scanned.rejections[0]).toMatchObject({
+      name: "scan.pdf",
+      reason: "PDF text could not be extracted.",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -8,6 +8,8 @@ import {
   DISCORD_BOT_TOKEN_ENV,
   loadDesktopMessagingConfig,
   loadDesktopMessagingConfigFromSettings,
+  MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+  MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
   redactDesktopMessagingConfig,
   TELEGRAM_AUTHORIZED_USER_IDS_ENV,
   TELEGRAM_BOT_TOKEN_ENV,
@@ -131,6 +133,15 @@ describe("desktop messaging config", () => {
       botToken: "env-telegram-token",
       authorizedActorIds: ["42"],
     });
+  });
+
+  it("treats blank attachment integer env vars as unset", () => {
+    const config = loadDesktopMessagingConfig({
+      [MESSAGING_ATTACHMENT_MAX_BYTES_ENV]: "  ",
+      [MESSAGING_ATTACHMENT_MAX_COUNT_ENV]: "",
+    });
+
+    expect(config.attachmentPolicy).toBeUndefined();
   });
 
   it("redacts bot tokens while preserving useful diagnostics", () => {

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -94,6 +94,11 @@ describe("desktop messaging config", () => {
 
     expect(config).toEqual({
       toolUpdateDefaultMode: "show_some",
+      attachmentPolicy: {
+        imageProfile: "medium",
+        maxAttachmentBytes: 10485760,
+        maxAttachmentCount: 4,
+      },
       telegram: {
         channel: "telegram",
         enabled: true,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -570,11 +570,7 @@ describe("MessagingController", () => {
         input: [
           {
             type: "text",
-            text: "Please inspect this",
-          },
-          {
-            type: "text",
-            text: expect.stringContaining("Attachment: streaming-logs.txt"),
+            text: expect.stringContaining("Please inspect this\n\nAttached file: `streaming-logs.txt`"),
           },
         ],
       }),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -502,6 +502,15 @@ describe("MessagingController", () => {
         type: "file",
         name: "voice.m4a",
       },
+      attachments: [
+        {
+          id: "voice-1",
+          kind: "audio",
+          name: "voice.m4a",
+          disposition: "unsupported",
+          reason: "audio attachments are not supported",
+        },
+      ],
       disposition: "unsupported",
     });
 
@@ -512,8 +521,64 @@ describe("MessagingController", () => {
     );
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "error",
-      title: "Media is not supported yet",
+      title: "Attachment not supported",
     });
+  });
+
+  it("routes supported inbound text attachments into bound thread turns", async () => {
+    const harness = await createHarness({
+      downloadAttachment: vi.fn(async ({ attachment }) => {
+        const data = new TextEncoder().encode("first line\nsecond line");
+        return {
+          data,
+          fileName: attachment.name,
+          mimeType: attachment.mimeType,
+          sizeBytes: data.byteLength,
+        };
+      }),
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("Please inspect this"),
+      id: "event-media",
+      kind: "media",
+      text: "Please inspect this",
+      attachments: [
+        {
+          id: "file-1",
+          kind: "file",
+          name: "streaming-logs.txt",
+          disposition: "available",
+          mimeType: "text/plain",
+          sizeBytes: 22,
+        },
+      ],
+      disposition: "available",
+    });
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Please inspect this",
+          },
+          {
+            type: "text",
+            text: expect.stringContaining("Attachment: streaming-logs.txt"),
+          },
+        ],
+      }),
+    );
   });
 
   it("routes completed assistant output to active thread bindings", async () => {
@@ -1741,6 +1806,7 @@ describe("MessagingController", () => {
 
 async function createHarness(options?: {
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+  downloadAttachment?: MessagingAdapter["downloadAttachment"];
   logger?: MessagingControllerOptions["logger"];
   now?: () => number;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
@@ -1763,6 +1829,9 @@ async function createHarness(options?: {
   const store = await createStore();
   const delivered: MessagingSurfaceIntent[] = [];
   const adapter: MessagingAdapter = {
+    ...(options?.downloadAttachment
+      ? { downloadAttachment: options.downloadAttachment }
+      : {}),
     deliver: vi.fn(
       options?.deliver ??
         (async (intent) => {

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -20,6 +20,7 @@ import type {
   TelegramEditMessageTextRequest,
   TelegramPinChatMessageRequest,
   TelegramSendChatActionRequest,
+  TelegramSendDocumentRequest,
   TelegramSendMessageRequest,
   TelegramSendPhotoRequest,
   TelegramUnpinChatMessageRequest,
@@ -1002,13 +1003,20 @@ describe("TelegramAdapter", () => {
     });
 
     expect(events.at(-1)).toMatchObject({
-      disposition: "unsupported",
+      disposition: "available",
       kind: "media",
+      attachments: [
+        expect.objectContaining({
+          disposition: "available",
+          kind: "file",
+          name: "secret.txt",
+        }),
+      ],
       media: {
         name: "secret.txt",
       },
     });
-    expect("getFile" in api).toBe(false);
+    expect(api.getFile).not.toHaveBeenCalled();
   });
 
   it("ignores Telegram pin service messages", async () => {
@@ -1232,6 +1240,117 @@ describe("TelegramAdapter", () => {
       }),
     );
   });
+
+  it("uploads data URL image message intents through sendPhoto", async () => {
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: ["42"],
+      },
+      now: () => 1000,
+      pollOnStart: false,
+    });
+
+    await adapter.deliver({
+      audit: {
+        actor: {
+          platformUserId: "42",
+        },
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+        occurredAt: 1000,
+      },
+      createdAt: 1000,
+      id: "intent-data-image",
+      kind: "message",
+      parts: [
+        {
+          type: "image",
+          url: "data:image/png;base64,AQID",
+        },
+        {
+          markdown: "plain",
+          text: "Rendered image",
+          type: "text",
+        },
+      ],
+    });
+
+    expect(api.sendPhoto).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caption: "Rendered image",
+        chat_id: 777,
+        filename: "assistant-image.png",
+        photo: new Uint8Array([1, 2, 3]),
+      }),
+    );
+  });
+
+  it("sends file message intents through sendDocument", async () => {
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: ["42"],
+      },
+      now: () => 1000,
+      pollOnStart: false,
+    });
+    const data = new Uint8Array([1, 2, 3]);
+
+    await adapter.deliver({
+      audit: {
+        actor: {
+          platformUserId: "42",
+        },
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+        occurredAt: 1000,
+      },
+      createdAt: 1000,
+      id: "intent-file",
+      kind: "message",
+      parts: [
+        {
+          markdown: "plain",
+          text: "Generated log",
+          type: "text",
+        },
+        {
+          data,
+          mimeType: "text/plain",
+          name: "streaming-logs.txt",
+          sizeBytes: data.byteLength,
+          type: "file",
+        },
+      ],
+    });
+
+    expect(api.sendDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caption: "Generated log",
+        chat_id: 777,
+        document: data,
+        filename: "streaming-logs.txt",
+      }),
+    );
+    expect(api.sendMessage).not.toHaveBeenCalled();
+  });
 });
 
 async function createControllerHarness(): Promise<{
@@ -1290,8 +1409,10 @@ function createApi(): {
   editForumTopic: ReturnType<typeof vi.fn>;
   editMessageText: ReturnType<typeof vi.fn>;
   getWebhookInfo: ReturnType<typeof vi.fn>;
+  getFile: ReturnType<typeof vi.fn>;
   pinChatMessage: ReturnType<typeof vi.fn>;
   sendChatAction: ReturnType<typeof vi.fn>;
+  sendDocument: ReturnType<typeof vi.fn>;
   sendMessage: ReturnType<typeof vi.fn>;
   sendPhoto: ReturnType<typeof vi.fn>;
   setMyCommands: ReturnType<typeof vi.fn>;
@@ -1309,8 +1430,16 @@ function createApi(): {
       message_id: request.message_id,
     })),
     getWebhookInfo: vi.fn(async () => ({ url: "" })),
+    getFile: vi.fn(async () => ({ file_path: "documents/streaming-logs.txt" })),
     pinChatMessage: vi.fn(async (_request: TelegramPinChatMessageRequest) => true),
     sendChatAction: vi.fn(async (_request: TelegramSendChatActionRequest) => true),
+    sendDocument: vi.fn(async (request: TelegramSendDocumentRequest) => ({
+      chat: {
+        id: Number(request.chat_id),
+        type: "private",
+      },
+      message_id: 202,
+    })),
     sendMessage: vi.fn(async (request: TelegramSendMessageRequest) => ({
       chat: {
         id: Number(request.chat_id),

--- a/apps/desktop/src/main/messaging/attachment-image-normalization.ts
+++ b/apps/desktop/src/main/messaging/attachment-image-normalization.ts
@@ -1,0 +1,125 @@
+import { nativeImage } from "electron";
+import {
+  DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE,
+  IMAGE_UPLOAD_QUALITY_PROFILES,
+  type ImageUploadQualityProfile,
+} from "../../shared/image-normalization";
+
+export type MessagingNormalizedImage = {
+  dataUrl: string;
+  height: number;
+  mimeType: "image/jpeg" | "image/png";
+  original: {
+    height: number;
+    mimeType?: string;
+    size: number;
+    width: number;
+  };
+  size: number;
+  width: number;
+};
+
+export type MessagingImageNormalizationDependencies = {
+  createImageFromBuffer: (buffer: Buffer) => Electron.NativeImage;
+};
+
+const DEFAULT_DEPENDENCIES: MessagingImageNormalizationDependencies = {
+  createImageFromBuffer: (buffer) => nativeImage.createFromBuffer(buffer),
+};
+
+export async function normalizeMessagingImageAttachment(params: {
+  data: Uint8Array;
+  mimeType?: string;
+  profile?: ImageUploadQualityProfile;
+  dependencies?: Partial<MessagingImageNormalizationDependencies>;
+}): Promise<MessagingNormalizedImage> {
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...params.dependencies,
+  };
+  const source = dependencies.createImageFromBuffer(Buffer.from(params.data));
+  if (source.isEmpty()) {
+    throw new Error("Attachment image could not be decoded.");
+  }
+
+  const original = source.getSize();
+  if (original.width <= 0 || original.height <= 0) {
+    throw new Error("Attachment image has invalid dimensions.");
+  }
+
+  const profile =
+    IMAGE_UPLOAD_QUALITY_PROFILES[
+      params.profile ?? DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE
+    ];
+  const dimensions = calculateBoundedDimensions({
+    height: original.height,
+    maxLongEdge: profile.maxLongEdge,
+    maxShortEdge: profile.maxShortEdge,
+    preserveActual: profile.preserveActual,
+    width: original.width,
+  });
+  const image =
+    dimensions.width === original.width && dimensions.height === original.height
+      ? source
+      : source.resize({
+          height: dimensions.height,
+          quality: "best",
+          width: dimensions.width,
+        });
+
+  const outputMimeType = chooseOutputMimeType(params.mimeType);
+  const output =
+    outputMimeType === "image/png"
+      ? image.toPNG()
+      : image.toJPEG(Math.round(profile.jpegQuality * 100));
+
+  return {
+    dataUrl: `data:${outputMimeType};base64,${output.toString("base64")}`,
+    height: dimensions.height,
+    mimeType: outputMimeType,
+    original: {
+      height: original.height,
+      mimeType: params.mimeType,
+      size: params.data.byteLength,
+      width: original.width,
+    },
+    size: output.byteLength,
+    width: dimensions.width,
+  };
+}
+
+export function calculateBoundedDimensions(params: {
+  height: number;
+  maxLongEdge: number;
+  maxShortEdge: number;
+  preserveActual?: boolean;
+  width: number;
+}): { height: number; width: number } {
+  const width = Math.max(1, Math.round(params.width));
+  const height = Math.max(1, Math.round(params.height));
+  if (params.preserveActual) {
+    return { height, width };
+  }
+
+  const longEdge = Math.max(width, height);
+  const shortEdge = Math.min(width, height);
+  const scale = Math.min(
+    1,
+    params.maxLongEdge / longEdge,
+    params.maxShortEdge / shortEdge,
+  );
+
+  return {
+    height: Math.max(1, Math.round(height * scale)),
+    width: Math.max(1, Math.round(width * scale)),
+  };
+}
+
+function chooseOutputMimeType(mimeType: string | undefined): "image/jpeg" | "image/png" {
+  const normalized = mimeType?.trim().toLowerCase();
+  return normalized === "image/png" ||
+    normalized === "image/gif" ||
+    normalized === "image/svg+xml"
+    ? "image/png"
+    : "image/jpeg";
+}

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -10,6 +10,9 @@ import type {
   ListBackendsRequest,
   ListBackendsResponse,
   MessagingDeliveryResult,
+  MessagingAttachmentDownloadRequest,
+  MessagingAttachmentDownloadResult,
+  MessagingAdapterCapabilities,
   MessagingInboundEvent,
   MessagingActorIdentity,
   MessagingAdapterState,
@@ -46,7 +49,11 @@ export type MessagingConversationTitleUpdateResult = {
 };
 
 export type MessagingAdapter = {
+  capabilities?: MessagingAdapterCapabilities;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  downloadAttachment?(
+    request: MessagingAttachmentDownloadRequest,
+  ): Promise<MessagingAttachmentDownloadResult>;
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;

--- a/apps/desktop/src/main/messaging/core/messaging-attachment-mime.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-attachment-mime.ts
@@ -1,0 +1,189 @@
+import path from "node:path";
+
+export type MessagingAttachmentClassification =
+  | {
+      kind: "image";
+      mimeType: string;
+    }
+  | {
+      kind: "gif";
+      mimeType: "image/gif";
+    }
+  | {
+      kind: "pdf";
+      mimeType: "application/pdf";
+    }
+  | {
+      kind: "text";
+      mimeType: string;
+    }
+  | {
+      kind: "binary";
+      mimeType?: string;
+    };
+
+const TEXT_EXTENSIONS = new Set([
+  ".csv",
+  ".json",
+  ".jsonl",
+  ".log",
+  ".md",
+  ".markdown",
+  ".toml",
+  ".txt",
+  ".yaml",
+  ".yml",
+]);
+
+export function classifyMessagingAttachment(params: {
+  data: Uint8Array;
+  fileName: string;
+  mimeType?: string;
+}): MessagingAttachmentClassification {
+  const magic = classifyMagicBytes(params.data);
+  if (magic) {
+    return magic;
+  }
+
+  const mimeType = normalizeMimeType(params.mimeType);
+  if (mimeType) {
+    if (mimeType === "image/gif") {
+      return { kind: "gif", mimeType };
+    }
+    if (mimeType.startsWith("image/")) {
+      return { kind: "image", mimeType };
+    }
+    if (mimeType === "application/pdf") {
+      return { kind: "pdf", mimeType };
+    }
+    if (isTextLikeMimeType(mimeType)) {
+      return isProbablyUtf8Text(params.data)
+        ? { kind: "text", mimeType }
+        : { kind: "binary", mimeType };
+    }
+  }
+
+  const extension = path.extname(params.fileName).toLowerCase();
+  if (extension === ".pdf") {
+    return { kind: "pdf", mimeType: "application/pdf" };
+  }
+  if (extension === ".gif") {
+    return { kind: "gif", mimeType: "image/gif" };
+  }
+  if ([".jpg", ".jpeg"].includes(extension)) {
+    return { kind: "image", mimeType: "image/jpeg" };
+  }
+  if (extension === ".png") {
+    return { kind: "image", mimeType: "image/png" };
+  }
+  if (TEXT_EXTENSIONS.has(extension)) {
+    return isProbablyUtf8Text(params.data)
+      ? { kind: "text", mimeType: mimeType ?? mimeTypeForTextExtension(extension) }
+      : { kind: "binary", mimeType };
+  }
+
+  return isProbablyUtf8Text(params.data)
+    ? { kind: "text", mimeType: mimeType ?? "text/plain" }
+    : { kind: "binary", mimeType };
+}
+
+export function decodeMessagingTextAttachment(data: Uint8Array): string | undefined {
+  if (!isProbablyUtf8Text(data)) {
+    return undefined;
+  }
+  return new TextDecoder("utf-8", { fatal: false }).decode(data);
+}
+
+function classifyMagicBytes(
+  data: Uint8Array,
+): MessagingAttachmentClassification | undefined {
+  if (data.length >= 4) {
+    if (
+      data[0] === 0x89 &&
+      data[1] === 0x50 &&
+      data[2] === 0x4e &&
+      data[3] === 0x47
+    ) {
+      return { kind: "image", mimeType: "image/png" };
+    }
+    if (data[0] === 0xff && data[1] === 0xd8) {
+      return { kind: "image", mimeType: "image/jpeg" };
+    }
+    if (
+      data[0] === 0x47 &&
+      data[1] === 0x49 &&
+      data[2] === 0x46 &&
+      data[3] === 0x38
+    ) {
+      return { kind: "gif", mimeType: "image/gif" };
+    }
+    if (
+      data[0] === 0x25 &&
+      data[1] === 0x50 &&
+      data[2] === 0x44 &&
+      data[3] === 0x46
+    ) {
+      return { kind: "pdf", mimeType: "application/pdf" };
+    }
+  }
+  return undefined;
+}
+
+function isTextLikeMimeType(mimeType: string): boolean {
+  return (
+    mimeType.startsWith("text/") ||
+    [
+      "application/json",
+      "application/jsonl",
+      "application/toml",
+      "application/x-jsonlines",
+      "application/x-ndjson",
+      "application/x-yaml",
+      "application/yaml",
+      "application/yml",
+    ].includes(mimeType)
+  );
+}
+
+function isProbablyUtf8Text(data: Uint8Array): boolean {
+  if (data.length === 0) {
+    return true;
+  }
+  const sample = data.slice(0, Math.min(data.length, 4096));
+  let controlBytes = 0;
+  for (const byte of sample) {
+    if (byte === 0) {
+      return false;
+    }
+    if (byte < 0x09 || (byte > 0x0d && byte < 0x20)) {
+      controlBytes += 1;
+    }
+  }
+  return controlBytes / sample.length < 0.02;
+}
+
+function normalizeMimeType(mimeType: string | undefined): string | undefined {
+  const normalized = mimeType?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function mimeTypeForTextExtension(extension: string): string {
+  switch (extension) {
+    case ".csv":
+      return "text/csv";
+    case ".json":
+      return "application/json";
+    case ".jsonl":
+      return "application/x-ndjson";
+    case ".toml":
+      return "application/toml";
+    case ".yaml":
+    case ".yml":
+      return "application/x-yaml";
+    case ".md":
+    case ".markdown":
+      return "text/markdown";
+    default:
+      return "text/plain";
+  }
+}

--- a/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
@@ -44,12 +44,13 @@ export async function processMessagingAttachments(params: {
     ...DEFAULT_MESSAGING_ATTACHMENT_POLICY,
     ...params.policy,
   };
-  const input: AppServerTurnInputItem[] = [];
+  const textInput: string[] = [];
+  const mediaInput: AppServerTurnInputItem[] = [];
   const rejections: MessagingAttachmentRejection[] = [];
 
   const text = params.text?.trim();
   if (text) {
-    input.push({ type: "text", text });
+    textInput.push(text);
   }
 
   const attachments = params.attachments.slice(0, policy.maxAttachmentCount);
@@ -111,16 +112,15 @@ export async function processMessagingAttachments(params: {
           });
           continue;
         }
-        input.push({
-          type: "text",
-          text: formatAttachmentText({
+        textInput.push(
+          formatAttachmentText({
             content: truncateText(extracted, policy.maxExtractedTextCharacters),
             fileName: downloaded.fileName,
             mimeType: classification.mimeType,
             sizeBytes: downloaded.sizeBytes,
             truncated: extracted.length > policy.maxExtractedTextCharacters,
           }),
-        });
+        );
         continue;
       }
 
@@ -133,16 +133,15 @@ export async function processMessagingAttachments(params: {
           });
           continue;
         }
-        input.push({
-          type: "text",
-          text: formatAttachmentText({
+        textInput.push(
+          formatAttachmentText({
             content: truncateText(extracted, policy.maxExtractedTextCharacters),
             fileName: downloaded.fileName,
             mimeType: classification.mimeType,
             sizeBytes: downloaded.sizeBytes,
             truncated: extracted.length > policy.maxExtractedTextCharacters,
           }),
-        });
+        );
         continue;
       }
 
@@ -153,12 +152,11 @@ export async function processMessagingAttachments(params: {
           profile: policy.imageProfile,
         });
         if (classification.kind === "gif") {
-          input.push({
-            type: "text",
-            text: `Attachment ${downloaded.fileName} was an animated GIF. I converted the first frame to a still image for model input.`,
-          });
+          textInput.push(
+            `Attachment ${downloaded.fileName} was an animated GIF. I converted the first frame to a still image for model input.`,
+          );
         }
-        input.push({
+        mediaInput.push({
           type: "image",
           url: normalized.dataUrl,
         });
@@ -177,6 +175,18 @@ export async function processMessagingAttachments(params: {
     }
   }
 
+  const input: AppServerTurnInputItem[] = [
+    ...(textInput.length > 0
+      ? [
+          {
+            type: "text" as const,
+            text: textInput.join("\n\n"),
+          },
+        ]
+      : []),
+    ...mediaInput,
+  ];
+
   return { input, rejections };
 }
 
@@ -187,16 +197,66 @@ function formatAttachmentText(params: {
   sizeBytes: number;
   truncated: boolean;
 }): string {
+  const fence = markdownFenceFor(params.content);
   return [
-    `Attachment: ${params.fileName}`,
-    `MIME type: ${params.mimeType}`,
-    `Size: ${params.sizeBytes} bytes`,
+    `Attached file: \`${params.fileName}\``,
+    `Type: ${params.mimeType} | Size: ${formatByteSize(params.sizeBytes)}`,
     params.truncated ? "Content was truncated to the configured limit." : undefined,
     "",
+    `${fence}${markdownLanguageFor(params.fileName, params.mimeType)}`,
     params.content,
+    fence,
   ]
     .filter((line) => line !== undefined)
     .join("\n");
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} bytes`;
+  }
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(kib >= 10 ? 0 : 1)} KB`;
+  }
+  const mib = kib / 1024;
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
+}
+
+function markdownLanguageFor(fileName: string, mimeType: string): string {
+  const lowerName = fileName.toLowerCase();
+  const lowerMime = mimeType.toLowerCase();
+  if (lowerName.endsWith(".json") || lowerMime.includes("json")) {
+    return "json";
+  }
+  if (lowerName.endsWith(".jsonl") || lowerMime.includes("ndjson")) {
+    return "jsonl";
+  }
+  if (lowerName.endsWith(".csv")) {
+    return "csv";
+  }
+  if (lowerName.endsWith(".toml") || lowerMime.includes("toml")) {
+    return "toml";
+  }
+  if (
+    lowerName.endsWith(".yaml") ||
+    lowerName.endsWith(".yml") ||
+    lowerMime.includes("yaml")
+  ) {
+    return "yaml";
+  }
+  if (lowerName.endsWith(".md") || lowerName.endsWith(".markdown")) {
+    return "markdown";
+  }
+  return "text";
+}
+
+function markdownFenceFor(content: string): string {
+  const longestFence = Math.max(
+    2,
+    ...[...content.matchAll(/`+/g)].map((match) => match[0]?.length ?? 0),
+  );
+  return "`".repeat(longestFence + 1);
 }
 
 function truncateText(text: string, maxCharacters: number): string {

--- a/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
@@ -1,0 +1,215 @@
+import type {
+  AppServerTurnInputItem,
+  MessagingAttachmentDescriptor,
+} from "@pwragnt/shared";
+import type { ImageUploadQualityProfile } from "../../../shared/image-normalization";
+import { normalizeMessagingImageAttachment } from "../attachment-image-normalization";
+import type { MessagingAdapter } from "./messaging-adapter";
+import {
+  classifyMessagingAttachment,
+  decodeMessagingTextAttachment,
+} from "./messaging-attachment-mime";
+
+export type MessagingAttachmentPolicy = {
+  imageProfile: ImageUploadQualityProfile;
+  maxAttachmentBytes: number;
+  maxAttachmentCount: number;
+  maxExtractedTextCharacters: number;
+};
+
+export type MessagingAttachmentRejection = {
+  name: string;
+  reason: string;
+};
+
+export type MessagingAttachmentProcessingResult = {
+  input: AppServerTurnInputItem[];
+  rejections: MessagingAttachmentRejection[];
+};
+
+export const DEFAULT_MESSAGING_ATTACHMENT_POLICY: MessagingAttachmentPolicy = {
+  imageProfile: "medium",
+  maxAttachmentBytes: 10 * 1024 * 1024,
+  maxAttachmentCount: 4,
+  maxExtractedTextCharacters: 80_000,
+};
+
+export async function processMessagingAttachments(params: {
+  adapter: MessagingAdapter;
+  attachments: MessagingAttachmentDescriptor[];
+  policy?: Partial<MessagingAttachmentPolicy>;
+  text?: string;
+}): Promise<MessagingAttachmentProcessingResult> {
+  const policy = {
+    ...DEFAULT_MESSAGING_ATTACHMENT_POLICY,
+    ...params.policy,
+  };
+  const input: AppServerTurnInputItem[] = [];
+  const rejections: MessagingAttachmentRejection[] = [];
+
+  const text = params.text?.trim();
+  if (text) {
+    input.push({ type: "text", text });
+  }
+
+  const attachments = params.attachments.slice(0, policy.maxAttachmentCount);
+  if (params.attachments.length > policy.maxAttachmentCount) {
+    rejections.push({
+      name: "additional attachments",
+      reason: `Only ${policy.maxAttachmentCount} attachments can be processed at once.`,
+    });
+  }
+
+  for (const attachment of attachments) {
+    if (attachment.disposition !== "available") {
+      rejections.push({
+        name: attachment.name,
+        reason: attachment.reason ?? "Attachment type is not supported.",
+      });
+      continue;
+    }
+    if (attachment.sizeBytes && attachment.sizeBytes > policy.maxAttachmentBytes) {
+      rejections.push({
+        name: attachment.name,
+        reason: "Attachment is larger than the configured limit.",
+      });
+      continue;
+    }
+    if (!params.adapter.downloadAttachment) {
+      rejections.push({
+        name: attachment.name,
+        reason: "This messaging adapter cannot download attachments.",
+      });
+      continue;
+    }
+
+    try {
+      const downloaded = await params.adapter.downloadAttachment({
+        attachment,
+        maxBytes: policy.maxAttachmentBytes,
+      });
+      if (downloaded.sizeBytes > policy.maxAttachmentBytes) {
+        rejections.push({
+          name: attachment.name,
+          reason: "Attachment is larger than the configured limit.",
+        });
+        continue;
+      }
+
+      const classification = classifyMessagingAttachment({
+        data: downloaded.data,
+        fileName: downloaded.fileName,
+        mimeType: downloaded.mimeType ?? attachment.mimeType,
+      });
+
+      if (classification.kind === "text") {
+        const extracted = decodeMessagingTextAttachment(downloaded.data);
+        if (extracted === undefined) {
+          rejections.push({
+            name: attachment.name,
+            reason: "Attachment is not readable text.",
+          });
+          continue;
+        }
+        input.push({
+          type: "text",
+          text: formatAttachmentText({
+            content: truncateText(extracted, policy.maxExtractedTextCharacters),
+            fileName: downloaded.fileName,
+            mimeType: classification.mimeType,
+            sizeBytes: downloaded.sizeBytes,
+            truncated: extracted.length > policy.maxExtractedTextCharacters,
+          }),
+        });
+        continue;
+      }
+
+      if (classification.kind === "pdf") {
+        const extracted = extractBasicPdfText(downloaded.data);
+        if (!extracted) {
+          rejections.push({
+            name: attachment.name,
+            reason: "PDF text could not be extracted.",
+          });
+          continue;
+        }
+        input.push({
+          type: "text",
+          text: formatAttachmentText({
+            content: truncateText(extracted, policy.maxExtractedTextCharacters),
+            fileName: downloaded.fileName,
+            mimeType: classification.mimeType,
+            sizeBytes: downloaded.sizeBytes,
+            truncated: extracted.length > policy.maxExtractedTextCharacters,
+          }),
+        });
+        continue;
+      }
+
+      if (classification.kind === "image" || classification.kind === "gif") {
+        const normalized = await normalizeMessagingImageAttachment({
+          data: downloaded.data,
+          mimeType: classification.mimeType,
+          profile: policy.imageProfile,
+        });
+        if (classification.kind === "gif") {
+          input.push({
+            type: "text",
+            text: `Attachment ${downloaded.fileName} was an animated GIF. I converted the first frame to a still image for model input.`,
+          });
+        }
+        input.push({
+          type: "image",
+          url: normalized.dataUrl,
+        });
+        continue;
+      }
+
+      rejections.push({
+        name: attachment.name,
+        reason: "Attachment type is not supported.",
+      });
+    } catch (error) {
+      rejections.push({
+        name: attachment.name,
+        reason: error instanceof Error ? error.message : "Attachment could not be read.",
+      });
+    }
+  }
+
+  return { input, rejections };
+}
+
+function formatAttachmentText(params: {
+  content: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  truncated: boolean;
+}): string {
+  return [
+    `Attachment: ${params.fileName}`,
+    `MIME type: ${params.mimeType}`,
+    `Size: ${params.sizeBytes} bytes`,
+    params.truncated ? "Content was truncated to the configured limit." : undefined,
+    "",
+    params.content,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}
+
+function truncateText(text: string, maxCharacters: number): string {
+  if (text.length <= maxCharacters) {
+    return text;
+  }
+  return `${text.slice(0, maxCharacters)}\n[attachment truncated]`;
+}
+
+function extractBasicPdfText(data: Uint8Array): string | undefined {
+  const decoded = new TextDecoder("latin1", { fatal: false }).decode(data);
+  const matches = [...decoded.matchAll(/\(([^()]*)\)\s*Tj/g)]
+    .map((match) => match[1]?.replace(/\\([()\\])/g, "$1").trim())
+    .filter((value): value is string => Boolean(value));
+  return matches.length > 0 ? matches.join("\n") : undefined;
+}

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -12,6 +12,7 @@ import type {
   MessagingInboundCallbackEvent,
   MessagingInboundCommandEvent,
   MessagingInboundEvent,
+  MessagingInboundMediaEvent,
   MessagingInboundTextEvent,
   MessagingJsonValue,
   MessagingMessageIntent,
@@ -62,7 +63,12 @@ import {
   MessagingToolUpdatePolicy,
   type MessagingToolUpdatePolicyDelivery,
 } from "./messaging-tool-update-policy.js";
-
+import {
+  DEFAULT_MESSAGING_ATTACHMENT_POLICY,
+  processMessagingAttachments,
+  type MessagingAttachmentPolicy,
+  type MessagingAttachmentRejection,
+} from "./messaging-attachment-processor.js";
 const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
 const TYPING_ACTIVITY_REFRESH_MS = 10_000;
@@ -110,6 +116,14 @@ function findThreadForBinding(
   );
 }
 
+function formatAttachmentRejections(
+  rejections: MessagingAttachmentRejection[],
+): string {
+  return rejections
+    .map((rejection) => `${rejection.name}: ${rejection.reason}`)
+    .join("\n");
+}
+
 type MessagingControllerLogger = {
   debug?(message: string, data?: Record<string, unknown>): void;
 };
@@ -127,6 +141,7 @@ export type MessagingControllerOptions = {
   logger?: MessagingControllerLogger;
   now?: () => number;
   pendingIntentTtlMs?: number;
+  attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStore;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
 };
@@ -184,17 +199,7 @@ export class MessagingController {
     }
 
     if (event.kind === "media") {
-      await this.deliver(
-        buildErrorIntent({
-          id: this.newIntentId("unsupported-media"),
-          createdAt: this.now(),
-          title: "Media is not supported yet",
-          body: "This messaging integration accepts text and buttons for now.",
-          recoverable: true,
-        }),
-        undefined,
-        event,
-      );
+      await this.handleMedia(event);
       return;
     }
 
@@ -500,6 +505,108 @@ export class MessagingController {
     await this.signalTurnActivity(binding, activeTurn, {
       force: true,
     });
+    await this.renderBindingStatus(binding, undefined, navigation);
+  }
+
+  private async handleMedia(event: MessagingInboundMediaEvent): Promise<void> {
+    const command = event.text ? parseTextCommand(event.text) : undefined;
+    if (command) {
+      await this.handleCommand({
+        ...event,
+        kind: "command",
+        command,
+        args: parseTextCommandArgs(event.text ?? ""),
+        rawText: event.text ?? "",
+      });
+      return;
+    }
+
+    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    if (!binding) {
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("needs-binding-media"),
+          createdAt: this.now(),
+          title: "Choose a thread",
+          body: "Bind this conversation to a PwrAgnt thread before sending attachments.",
+          fallbackText: "Reply /resume to choose a thread.",
+          actions: [
+            {
+              id: "command:resume",
+              label: "Resume",
+              style: "primary",
+              fallbackText: "/resume",
+            },
+          ],
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const processed = await processMessagingAttachments({
+      adapter: this.options.adapter,
+      attachments: event.attachments,
+      policy: {
+        ...DEFAULT_MESSAGING_ATTACHMENT_POLICY,
+        ...this.options.attachmentPolicy,
+      },
+      text: event.text,
+    });
+
+    if (processed.input.length === 0) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("unsupported-media"),
+          createdAt: this.now(),
+          title: "Attachment not supported",
+          body:
+            processed.rejections.length > 0
+              ? formatAttachmentRejections(processed.rejections)
+              : "This attachment could not be prepared for the model.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const turnSettings = turnSettingsForBinding(binding, navigation);
+    const started = await this.options.backend.startTurn({
+      backend: binding.backend,
+      threadId: binding.threadId,
+      input: processed.input,
+      ...turnSettings,
+    });
+    const activeTurn: MessagingActiveTurnSummary = {
+      turnId: started.turnId,
+      status: "working",
+      startedAt: this.now(),
+      updatedAt: this.now(),
+    };
+    this.setActiveTurn(binding, activeTurn);
+    await this.signalTurnActivity(binding, activeTurn, {
+      force: true,
+    });
+
+    if (processed.rejections.length > 0) {
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("attachment-partial"),
+          createdAt: this.now(),
+          title: "Some attachments were skipped",
+          body: formatAttachmentRejections(processed.rejections),
+        }),
+        binding,
+        event,
+      );
+    }
+
     await this.renderBindingStatus(binding, undefined, navigation);
   }
 

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -1,16 +1,22 @@
 import type { DiscordMessagingConfig } from "@pwragnt/messaging-provider-discord";
 import type { TelegramMessagingConfig } from "@pwragnt/messaging-provider-telegram";
 import type { MessagingToolUpdateMode } from "@pwragnt/shared";
+import type { MessagingAttachmentPolicy } from "./core/messaging-attachment-processor";
 import type { DesktopSettingsService } from "../settings/desktop-settings-service";
 import {
   DISCORD_APPLICATION_ID_ENV,
   DISCORD_AUTHORIZED_USER_IDS_ENV,
   DISCORD_BOT_TOKEN_ENV,
   DISCORD_ENABLED_ENV,
+  MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV,
+  MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+  MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
   TELEGRAM_AUTHORIZED_USER_IDS_ENV,
   TELEGRAM_BOT_TOKEN_ENV,
   TELEGRAM_ENABLED_ENV,
   readEnvBoolean,
+  readEnvInteger,
+  readEnvMessagingImageProfile,
 } from "../settings/desktop-settings-env";
 
 export {
@@ -18,12 +24,16 @@ export {
   DISCORD_AUTHORIZED_USER_IDS_ENV,
   DISCORD_BOT_TOKEN_ENV,
   DISCORD_ENABLED_ENV,
+  MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV,
+  MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+  MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
   TELEGRAM_AUTHORIZED_USER_IDS_ENV,
   TELEGRAM_BOT_TOKEN_ENV,
   TELEGRAM_ENABLED_ENV,
 };
 
 export type DesktopMessagingConfig = {
+  attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   discord?: DiscordMessagingConfig;
   telegram?: TelegramMessagingConfig;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
@@ -41,9 +51,11 @@ export function loadDesktopMessagingConfig(
   const telegramAuthorizedActorIds = parseList(env[TELEGRAM_AUTHORIZED_USER_IDS_ENV]);
   const discordBotToken = readEnv(env, DISCORD_BOT_TOKEN_ENV, "DISCORD_BOT_TOKEN");
   const discordAuthorizedActorIds = parseList(env[DISCORD_AUTHORIZED_USER_IDS_ENV]);
+  const attachmentPolicy = readAttachmentPolicyFromEnv(env);
 
   return {
     toolUpdateDefaultMode: "show_some",
+    ...(attachmentPolicy ? { attachmentPolicy } : {}),
     ...(telegramBotToken && telegramAuthorizedActorIds.length > 0
       ? {
           telegram: {
@@ -84,9 +96,15 @@ export async function loadDesktopMessagingConfigFromSettings(
   const discordAuthorizedActorIds =
     envConfig.discord?.authorizedActorIds
     ?? snapshot.messaging.discord.authorizedUserIds.value;
+  const attachmentPolicy: Partial<MessagingAttachmentPolicy> = {
+    imageProfile: snapshot.messaging.attachments.imageProfile.value,
+    maxAttachmentBytes: snapshot.messaging.attachments.maxAttachmentBytes.value,
+    maxAttachmentCount: snapshot.messaging.attachments.maxAttachmentCount.value,
+  };
 
   return {
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
+    attachmentPolicy,
     ...(shouldEnableSettingsChannel(
       snapshot.messaging.telegram.enabled.value,
       envConfig.telegram,
@@ -150,6 +168,7 @@ export function redactDesktopMessagingConfig(
           authorizedActorCount: config.discord.authorizedActorIds.length,
         }
       : undefined,
+    attachmentPolicy: config.attachmentPolicy,
   };
 }
 
@@ -170,6 +189,26 @@ function parseList(value: string | undefined): string[] {
         .filter(Boolean),
     ),
   ];
+}
+
+function readAttachmentPolicyFromEnv(
+  env: NodeJS.ProcessEnv,
+): Partial<MessagingAttachmentPolicy> | undefined {
+  const imageProfile = readEnvMessagingImageProfile(env).value;
+  const maxAttachmentBytes = readEnvInteger(
+    env,
+    MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+  ).value;
+  const maxAttachmentCount = readEnvInteger(
+    env,
+    MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
+  ).value;
+  const policy: Partial<MessagingAttachmentPolicy> = {
+    ...(imageProfile ? { imageProfile } : {}),
+    ...(maxAttachmentBytes !== undefined ? { maxAttachmentBytes } : {}),
+    ...(maxAttachmentCount !== undefined ? { maxAttachmentCount } : {}),
+  };
+  return Object.keys(policy).length > 0 ? policy : undefined;
 }
 
 function shouldEnableSettingsChannel<TConfig>(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1,6 +1,7 @@
 import { MessagingController } from "./core/messaging-controller";
 import type { MessagingStore } from "./core/messaging-store";
 import type {
+  MessagingAdapter,
   MessagingBackendBridge,
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
@@ -26,6 +27,7 @@ export type DesktopMessagingAdapter = {
   authorizedActorIds: readonly string[];
   channel: MessagingChannelKind;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  downloadAttachment?: MessagingAdapter["downloadAttachment"];
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -78,6 +80,7 @@ export class DesktopMessagingRuntime {
       const authorizedActorIdSet = new Set(authorizedActorIds);
       const controller = new MessagingController({
         adapter,
+        attachmentPolicy: config.attachmentPolicy,
         authorizedActorIds,
         backend: this.options.backendBridge,
         channel: adapter.channel,

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type {
   DesktopChatReplyComposer,
+  DesktopMessagingImageProfile,
   MessagingToolUpdateMode,
 } from "@pwragnt/shared";
 import { DESKTOP_CONFIG_PATH_ENV } from "./desktop-settings-env";
@@ -19,6 +20,11 @@ export type DesktopSettingsConfig = {
   };
   messaging?: {
     toolUpdateMode?: MessagingToolUpdateMode;
+    attachments?: {
+      imageProfile?: DesktopMessagingImageProfile;
+      maxAttachmentBytes?: number;
+      maxAttachmentCount?: number;
+    };
     telegram?: {
       enabled?: boolean;
       authorizedUserIds?: string[];
@@ -46,7 +52,7 @@ export type DesktopSettingsConfig = {
   };
 };
 
-type TomlScalar = string | boolean | string[];
+type TomlScalar = string | number | boolean | string[];
 
 export function defaultDesktopConfigDir(
   options?: DesktopConfigPathOptions,
@@ -101,6 +107,10 @@ export function mergeDesktopSettingsConfig(
     messaging: {
       toolUpdateMode:
         patch.messaging?.toolUpdateMode ?? current.messaging?.toolUpdateMode,
+      attachments: {
+        ...current.messaging?.attachments,
+        ...patch.messaging?.attachments,
+      },
       telegram: {
         ...current.messaging?.telegram,
         ...patch.messaging?.telegram,
@@ -194,6 +204,20 @@ export function stringifyDesktopSettingsToml(
     );
   }
 
+  const attachments = config.messaging?.attachments;
+  if (attachments && hasDefinedValue(attachments)) {
+    sections.push(
+      [
+        "[messaging.attachments]",
+        formatOptionalTomlEntry("image_profile", attachments.imageProfile),
+        formatOptionalTomlEntry("max_attachment_bytes", attachments.maxAttachmentBytes),
+        formatOptionalTomlEntry("max_attachment_count", attachments.maxAttachmentCount),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
   const telegram = config.messaging?.telegram;
   if (telegram && hasDefinedValue(telegram)) {
     sections.push(
@@ -267,6 +291,7 @@ function normalizeDesktopConfig(
 ): DesktopSettingsConfig {
   const experimental = tables["experimental"];
   const messaging = tables["messaging"];
+  const attachments = tables["messaging.attachments"];
   const telegram = tables["messaging.telegram"];
   const discord = tables["messaging.discord"];
   const codex = tables["models.codex"];
@@ -279,6 +304,11 @@ function normalizeDesktopConfig(
     },
     messaging: {
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
+      attachments: {
+        imageProfile: readImageProfile(attachments?.image_profile),
+        maxAttachmentBytes: readNumber(attachments?.max_attachment_bytes),
+        maxAttachmentCount: readNumber(attachments?.max_attachment_count),
+      },
       telegram: {
         enabled: readBoolean(telegram?.enabled),
         authorizedUserIds: readStringArray(telegram?.authorized_user_ids),
@@ -314,17 +344,22 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.experimental = config.experimental;
   }
 
+  const attachments = config.messaging?.attachments;
   const telegram = config.messaging?.telegram;
   const discord = config.messaging?.discord;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
   if (
     toolUpdateMode !== undefined ||
-    (telegram && hasDefinedValue(telegram))
+    (attachments && hasDefinedValue(attachments))
+    || (telegram && hasDefinedValue(telegram))
     || (discord && hasDefinedValue(discord))
   ) {
     pruned.messaging = {};
     if (toolUpdateMode !== undefined) {
       pruned.messaging.toolUpdateMode = toolUpdateMode;
+    }
+    if (attachments && hasDefinedValue(attachments)) {
+      pruned.messaging.attachments = attachments;
     }
     if (telegram && hasDefinedValue(telegram)) {
       pruned.messaging.telegram = telegram;
@@ -410,6 +445,24 @@ function readStringArray(value: TomlScalar | undefined): string[] | undefined {
   return Array.isArray(value) ? value.map((item) => item.trim()).filter(Boolean) : undefined;
 }
 
+function readNumber(value: TomlScalar | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readImageProfile(
+  value: TomlScalar | undefined,
+): DesktopMessagingImageProfile | undefined {
+  return typeof value === "string" && isDesktopMessagingImageProfile(value)
+    ? value
+    : undefined;
+}
+
+function isDesktopMessagingImageProfile(
+  value: string,
+): value is DesktopMessagingImageProfile {
+  return value === "low" || value === "medium" || value === "high" || value === "actual";
+}
+
 function parseTomlValue(
   value: string,
   filePath: string,
@@ -426,6 +479,9 @@ function parseTomlValue(
   }
   if (value.startsWith("\"") && value.endsWith("\"")) {
     return unescapeQuotedString(value.slice(1, -1), filePath, lineNumber);
+  }
+  if (/^-?\d+$/.test(value)) {
+    return Number(value);
   }
   throw new Error(`Unsupported TOML value on line ${lineNumber} in ${filePath}`);
 }
@@ -557,13 +613,16 @@ function unescapeQuotedString(
 
 function formatOptionalTomlEntry(
   key: string,
-  value: string | boolean | string[] | undefined,
+  value: string | number | boolean | string[] | undefined,
 ): string | undefined {
   return value === undefined ? undefined : `${key} = ${formatTomlValue(value)}`;
 }
 
-function formatTomlValue(value: string | boolean | string[]): string {
+function formatTomlValue(value: string | number | boolean | string[]): string {
   if (typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "number") {
     return String(value);
   }
   if (Array.isArray(value)) {

--- a/apps/desktop/src/main/settings/desktop-settings-env.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-env.ts
@@ -84,7 +84,11 @@ export function readEnvInteger(
   if (rawValue === undefined) {
     return {};
   }
-  const value = Number(rawValue.trim());
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return {};
+  }
+  const value = Number(trimmed);
   return Number.isInteger(value) && value >= 0
     ? { value }
     : { error: `Invalid integer value for ${key}` };

--- a/apps/desktop/src/main/settings/desktop-settings-env.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-env.ts
@@ -1,4 +1,7 @@
-import type { DesktopChatReplyComposer } from "@pwragnt/shared";
+import type {
+  DesktopChatReplyComposer,
+  DesktopMessagingImageProfile,
+} from "@pwragnt/shared";
 
 export const DESKTOP_CONFIG_PATH_ENV = "PWRAGNT_CONFIG_PATH";
 export const CHAT_REPLY_COMPOSER_ENV =
@@ -18,6 +21,12 @@ export const DISCORD_AUTHORIZED_USER_IDS_ENV =
   "PWRAGNT_MESSAGING_DISCORD_AUTHORIZED_USER_IDS";
 export const DISCORD_AUTHORIZED_GUILDS_ENV =
   "PWRAGNT_MESSAGING_DISCORD_AUTHORIZED_GUILDS";
+export const MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV =
+  "PWRAGNT_MESSAGING_ATTACHMENT_IMAGE_PROFILE";
+export const MESSAGING_ATTACHMENT_MAX_BYTES_ENV =
+  "PWRAGNT_MESSAGING_ATTACHMENT_MAX_BYTES";
+export const MESSAGING_ATTACHMENT_MAX_COUNT_ENV =
+  "PWRAGNT_MESSAGING_ATTACHMENT_MAX_COUNT";
 export const CODEX_COMMAND_ENV = "PWRAGNT_CODEX_COMMAND";
 
 export type ParsedEnvValue<T> = {
@@ -67,6 +76,35 @@ export function readEnvList(
     .filter(Boolean);
 }
 
+export function readEnvInteger(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): ParsedEnvValue<number> {
+  const rawValue = env[key];
+  if (rawValue === undefined) {
+    return {};
+  }
+  const value = Number(rawValue.trim());
+  return Number.isInteger(value) && value >= 0
+    ? { value }
+    : { error: `Invalid integer value for ${key}` };
+}
+
+export function readEnvMessagingImageProfile(
+  env: NodeJS.ProcessEnv,
+): ParsedEnvValue<DesktopMessagingImageProfile> {
+  const value = readEnvString(env, MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV);
+  if (!value) {
+    return {};
+  }
+  if (!isDesktopMessagingImageProfile(value)) {
+    return {
+      error: `Invalid image profile for ${MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV}`,
+    };
+  }
+  return { value };
+}
+
 export function readEnvComposer(
   env: NodeJS.ProcessEnv,
 ): ParsedEnvValue<DesktopChatReplyComposer> {
@@ -89,4 +127,10 @@ function isDesktopChatReplyComposer(
     || value === "tiptap-wysiwyg-markdown-chips"
     || value === "custom-widget-chips"
   );
+}
+
+function isDesktopMessagingImageProfile(
+  value: string,
+): value is DesktopMessagingImageProfile {
+  return value === "low" || value === "medium" || value === "high" || value === "actual";
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,5 +1,6 @@
 import type {
   DesktopChatReplyComposer,
+  DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
   DesktopSettingsSecretName,
   DesktopSettingsSecretState,
@@ -24,13 +25,18 @@ import {
   DISCORD_AUTHORIZED_USER_IDS_ENV,
   DISCORD_BOT_TOKEN_ENV,
   DISCORD_ENABLED_ENV,
+  MESSAGING_ATTACHMENT_IMAGE_PROFILE_ENV,
+  MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+  MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
   TELEGRAM_AUTHORIZED_SUPERGROUPS_ENV,
   TELEGRAM_AUTHORIZED_USER_IDS_ENV,
   TELEGRAM_BOT_TOKEN_ENV,
   TELEGRAM_ENABLED_ENV,
   readEnvBoolean,
   readEnvComposer,
+  readEnvInteger,
   readEnvList,
+  readEnvMessagingImageProfile,
   readEnvString,
 } from "./desktop-settings-env";
 import { discoverCodexCommands } from "./codex-discovery";
@@ -120,6 +126,21 @@ export class DesktopSettingsService {
         toolUpdateMode: this.resolveToolUpdateMode(
           config.messaging?.toolUpdateMode,
         ),
+        attachments: {
+          imageProfile: this.resolveMessagingImageProfile(
+            config.messaging?.attachments?.imageProfile,
+          ),
+          maxAttachmentBytes: this.resolveNumber(
+            config.messaging?.attachments?.maxAttachmentBytes,
+            10 * 1024 * 1024,
+            MESSAGING_ATTACHMENT_MAX_BYTES_ENV,
+          ),
+          maxAttachmentCount: this.resolveNumber(
+            config.messaging?.attachments?.maxAttachmentCount,
+            4,
+            MESSAGING_ATTACHMENT_MAX_COUNT_ENV,
+          ),
+        },
         telegram: {
           enabled: this.resolveBoolean(
             config.messaging?.telegram?.enabled,
@@ -267,6 +288,46 @@ export class DesktopSettingsService {
     envKey: string,
   ): DesktopSettingsValue<boolean> {
     const envValue = readEnvBoolean(this.env, envKey);
+    if (envValue.value !== undefined) {
+      return {
+        value: envValue.value,
+        source: "env",
+        overriddenByEnv: configValue !== undefined,
+      };
+    }
+
+    return {
+      value: configValue ?? defaultValue,
+      source: configValue === undefined ? "default" : "config",
+      error: envValue.error,
+    };
+  }
+
+  private resolveMessagingImageProfile(
+    configValue: DesktopMessagingImageProfile | undefined,
+  ): DesktopSettingsValue<DesktopMessagingImageProfile> {
+    const envValue = readEnvMessagingImageProfile(this.env);
+    if (envValue.value) {
+      return {
+        value: envValue.value,
+        source: "env",
+        overriddenByEnv: configValue !== undefined,
+      };
+    }
+
+    return {
+      value: configValue ?? "medium",
+      source: configValue === undefined ? "default" : "config",
+      error: envValue.error,
+    };
+  }
+
+  private resolveNumber(
+    configValue: number | undefined,
+    defaultValue: number,
+    envKey: string,
+  ): DesktopSettingsValue<number> {
+    const envValue = readEnvInteger(this.env, envKey);
     if (envValue.value !== undefined) {
       return {
         value: envValue.value,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -73,6 +73,11 @@ describe("App", () => {
           authorizedUserIds: { value: [], source: "default" },
           authorizedGuilds: { value: [], source: "default" },
         },
+        attachments: {
+          imageProfile: { value: "medium", source: "default" },
+          maxAttachmentBytes: { value: 10485760, source: "default" },
+          maxAttachmentCount: { value: 4, source: "default" },
+        },
       },
       models: {
         codex: {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -984,15 +984,20 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "New thread" }));
     const newThreadComposer = await screen.findByRole("textbox", { name: "New thread" });
-    fireEvent.change(newThreadComposer, {
-      target: {
-        value: "Start a Grok-backed thread from the sidebar.",
-      },
+    await act(async () => {
+      fireEvent.change(newThreadComposer, {
+        target: {
+          value: "Start a Grok-backed thread from the sidebar.",
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(newThreadComposer).toHaveValue("Start a Grok-backed thread from the sidebar.");
     });
     const startThreadButton = screen.getByRole("button", { name: "Start thread" });
     await waitFor(() => {
       expect(startThreadButton).toBeEnabled();
-    });
+    }, { timeout: 5000 });
     fireEvent.click(startThreadButton);
 
     expect(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -46,6 +46,11 @@ function createSnapshot(
         authorizedUserIds: { value: [], source: "default" },
         authorizedGuilds: { value: [], source: "default" },
       },
+      attachments: {
+        imageProfile: { value: "medium", source: "default" },
+        maxAttachmentBytes: { value: 10485760, source: "default" },
+        maxAttachmentCount: { value: 4, source: "default" },
+      },
     },
     models: {
       codex: {

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -1,6 +1,15 @@
-export const NORMALIZED_IMAGE_MAX_LONG_EDGE = 2048;
-export const NORMALIZED_IMAGE_MAX_SHORT_EDGE = 1024;
-export const NORMALIZED_IMAGE_JPEG_QUALITY = 0.85;
+import {
+  DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE,
+  IMAGE_UPLOAD_QUALITY_PROFILES,
+  type ImageUploadQualityProfile,
+} from "../../../shared/image-normalization";
+
+export const NORMALIZED_IMAGE_MAX_LONG_EDGE =
+  IMAGE_UPLOAD_QUALITY_PROFILES.medium.maxLongEdge;
+export const NORMALIZED_IMAGE_MAX_SHORT_EDGE =
+  IMAGE_UPLOAD_QUALITY_PROFILES.medium.maxShortEdge;
+export const NORMALIZED_IMAGE_JPEG_QUALITY =
+  IMAGE_UPLOAD_QUALITY_PROFILES.medium.jpegQuality;
 
 export type NormalizedImageMimeType = "image/jpeg" | "image/png";
 
@@ -53,6 +62,7 @@ type NormalizeImageFileOptions = {
   jpegQuality?: number;
   maxLongEdge?: number;
   maxShortEdge?: number;
+  qualityProfile?: ImageUploadQualityProfile;
   dependencies?: Partial<ImageNormalizationDependencies>;
 };
 
@@ -114,13 +124,17 @@ export async function normalizeImageFile(
   file: File,
   options: NormalizeImageFileOptions = {},
 ): Promise<NormalizedImage> {
+  const profile =
+    IMAGE_UPLOAD_QUALITY_PROFILES[
+      options.qualityProfile ?? DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE
+    ];
   return await normalizeBlob({
     blob: file,
     fallback: options.fallback,
     fileName: file.name || "pasted-image",
-    jpegQuality: options.jpegQuality ?? NORMALIZED_IMAGE_JPEG_QUALITY,
-    maxLongEdge: options.maxLongEdge ?? NORMALIZED_IMAGE_MAX_LONG_EDGE,
-    maxShortEdge: options.maxShortEdge ?? NORMALIZED_IMAGE_MAX_SHORT_EDGE,
+    jpegQuality: options.jpegQuality ?? profile.jpegQuality,
+    maxLongEdge: options.maxLongEdge ?? profile.maxLongEdge,
+    maxShortEdge: options.maxShortEdge ?? profile.maxShortEdge,
     originalMimeType: inferImageMimeType(file),
     originalSize: file.size,
     dependencies: {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -136,6 +136,12 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("lets transcript scroll restoration own scroll anchoring", () => {
+    expect(css).toMatch(
+      /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/
+    );
+  });
+
   it("keeps thread header titles tall enough for descenders", () => {
     const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
     const threadRowTitleRule = extractRuleBody(css, ".thread-row__title");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1799,6 +1799,7 @@ textarea {
   flex-direction: column;
   gap: 12px;
   min-height: 0;
+  overflow-anchor: none;
   overflow-y: auto;
   padding-right: 4px;
   padding-bottom: 24px;

--- a/apps/desktop/src/shared/image-normalization.ts
+++ b/apps/desktop/src/shared/image-normalization.ts
@@ -1,3 +1,56 @@
+export type ImageUploadQualityProfile = "low" | "medium" | "high" | "actual";
+
+export type ImageUploadQualityProfileSettings = {
+  jpegQuality: number;
+  maxLongEdge: number;
+  maxShortEdge: number;
+  preserveActual?: boolean;
+};
+
+export const DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE: ImageUploadQualityProfile =
+  "medium";
+
+export const IMAGE_UPLOAD_QUALITY_PROFILES: Record<
+  ImageUploadQualityProfile,
+  ImageUploadQualityProfileSettings
+> = {
+  low: {
+    jpegQuality: 0.72,
+    maxLongEdge: 1280,
+    maxShortEdge: 720,
+  },
+  medium: {
+    jpegQuality: 0.85,
+    maxLongEdge: 2048,
+    maxShortEdge: 1024,
+  },
+  high: {
+    jpegQuality: 0.92,
+    maxLongEdge: 3072,
+    maxShortEdge: 2048,
+  },
+  actual: {
+    jpegQuality: 0.95,
+    maxLongEdge: 8192,
+    maxShortEdge: 8192,
+    preserveActual: true,
+  },
+};
+
+export function readImageUploadQualityProfile(
+  value: string | undefined,
+): ImageUploadQualityProfile | undefined {
+  switch (value?.trim().toLowerCase()) {
+    case "low":
+    case "medium":
+    case "high":
+    case "actual":
+      return value.trim().toLowerCase() as ImageUploadQualityProfile;
+    default:
+      return undefined;
+  }
+}
+
 export type ImageUploadFallbackRequest = {
   data: ArrayBuffer;
   fileName?: string;

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -18,6 +18,7 @@ Adapters should support:
 - error surfaces
 - image and file parts when the platform can render them safely
 - best-effort dismiss or update when the platform supports it
+- attachment capability metadata for provider-owned download and upload limits
 
 ## Outputs
 
@@ -26,9 +27,14 @@ Adapters emit `MessagingInboundEvent` values:
 - `command` for explicit commands such as `/threads`
 - `text` for ordinary user text
 - `callback` for button/component/select interactions
-- `media` with `disposition: "unsupported"` for inbound media until a separate
-  ingestion policy exists
+- `media` with generic attachment descriptors for provider media/files
 - `lifecycle` for adapter start/stop/bind events when useful
+
+Media events may include message text plus one or more attachments. Adapter
+fields such as Telegram file IDs or Discord CDN URLs must stay inside opaque
+attachment state; the controller decides whether to download, classify,
+normalize, extract, or reject the attachment after authorization and binding
+checks pass.
 
 The `actor.platformUserId` must be the stable platform ID used for
 authorization. Mutable usernames and display names may be included for audit or
@@ -68,8 +74,26 @@ native autolinking to plain text; neutralize that only with a provider-specific
 policy and tests for the concrete platform behavior.
 
 Telegram currently uses Bot API long polling, HTML-safe text, inline keyboards,
-and `sendPhoto` for image URLs. Discord uses Gateway events, REST message
-delivery, defensive `allowed_mentions`, components, and image embeds.
+`sendPhoto` for image URLs/data images, and `sendDocument` for generic file
+parts. Discord uses Gateway events, REST message delivery, defensive
+`allowed_mentions`, components, image embeds for remote URLs, and multipart
+uploads for byte-backed file/image parts.
+
+## Attachment Policy
+
+Providers expose metadata and transport:
+
+- inbound attachment descriptors with name, MIME hint, size hint, dimensions
+  where available, disposition, and opaque download state
+- a download method that resolves opaque state into bounded bytes
+- capability hints for inbound download and outbound file/image upload limits
+
+Desktop messaging core owns ingestion policy. It enforces attachment count and
+byte caps, sniffs content instead of trusting MIME alone, converts supported
+text-like files into bounded text input, normalizes images/GIF stills into
+model-safe JPEG/PNG data URLs, and returns user-visible rejection reasons for
+unsupported or oversized files. Downloaded bytes and extracted file contents are
+not persisted in messaging state.
 
 ## Typing Activity
 

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -69,6 +69,19 @@ default, then `Show Some` for old state. Pending batches flush before assistant
 messages, approval or questionnaire prompts, status replies, and terminal turn
 status so tool progress does not arrive after the response it explains.
 
+## Attachments
+
+Bound, authorized conversations can send supported attachments into the active
+thread. PwrAgnt accepts bounded text-like files (`.txt`, `.md`, `.csv`, `.json`,
+`.jsonl`, `.toml`, `.yaml`, `.yml`, logs, and similar UTF-8 text), images, GIFs
+as still images for model input, and PDFs when bounded text can be extracted.
+Unsupported binaries, audio/video, archives, OCR-only PDFs, and oversized files
+are rejected with a short provider message instead of being forwarded to a model.
+
+Images use the shared upload profile setting. The default `medium` profile
+matches desktop paste behavior; `low`, `high`, and `actual` can be set through
+TOML or environment variables while still respecting hard safety caps.
+
 ## Configuration
 
 Messaging is disabled unless a channel has both credentials and authorized actor
@@ -112,6 +125,12 @@ Discord:
 - `PWRAGNT_MESSAGING_DISCORD_APPLICATION_ID`
 - `PWRAGNT_MESSAGING_DISCORD_AUTHORIZED_USER_IDS`
 
+Attachment policy:
+
+- `PWRAGNT_MESSAGING_ATTACHMENT_IMAGE_PROFILE` (`low`, `medium`, `high`, or `actual`)
+- `PWRAGNT_MESSAGING_ATTACHMENT_MAX_BYTES`
+- `PWRAGNT_MESSAGING_ATTACHMENT_MAX_COUNT`
+
 The authorized ID variables are comma-separated lists. Bot tokens are redacted
 from runtime logs. Telegram also accepts `TELEGRAM_BOT_TOKEN` and Discord also
 accepts `DISCORD_BOT_TOKEN` as local migration fallbacks.
@@ -128,7 +147,8 @@ commands on every startup.
 - A conversation must be bound to a thread before ordinary text is routed.
 - Bindings, pending intents, and delivery records live in
   `messaging-state.json` under the desktop state root.
-- Inbound media is not downloaded or forwarded into agent turns in this MVP.
+- Inbound attachments are downloaded only after authorization and active binding
+  checks, then capped, sniffed, normalized, or rejected before model upload.
 - Telegram callback data and Discord component IDs contain short opaque handles,
   not thread IDs, request payloads, tokens, or callback secrets.
 - Discord deliveries use defensive `allowed_mentions` so agent output does not
@@ -161,7 +181,10 @@ Telegram:
 14. Verify markdown, inline code, fenced code, long responses, and image output render.
 15. Restart PwrAgnt and verify the same Telegram conversation still routes to the bound thread.
 16. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
-17. Send a file or voice message and verify it is rejected without download.
+17. Send a small `.txt` attachment and verify a turn starts with the extracted text.
+18. Send an image attachment and verify a turn starts with normalized image input.
+19. Send an oversized file or voice message and verify it is rejected without model upload.
+20. Verify assistant image and file parts render as Telegram photo/document attachments.
 
 Discord:
 
@@ -176,7 +199,10 @@ Discord:
 9. Trigger an approval request and test accept, session accept, decline, and cancel.
 10. Verify markdown, inline code, fenced code, long responses, and image output render.
 11. Restart PwrAgnt and verify the same Discord channel still routes to the bound thread.
-12. Send an attachment and verify it is rejected without download.
+12. Send a small `.txt` attachment and verify a turn starts with the extracted text.
+13. Send an image attachment and verify a turn starts with normalized image input.
+14. Send an oversized attachment and verify it is rejected without model upload.
+15. Verify assistant image and file parts render as Discord embeds/uploads.
 
 Discord currently has parity for the shared workflow and button actions, but it
 does not pin or edit status cards yet; status updates degrade to normal

--- a/docs/plans/2026-05-02-002-feat-messaging-attachments-plan.md
+++ b/docs/plans/2026-05-02-002-feat-messaging-attachments-plan.md
@@ -1,0 +1,509 @@
+---
+title: feat: Add messaging attachment ingestion and response delivery
+type: feat
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+deepened: 2026-05-02
+---
+
+# feat: Add messaging attachment ingestion and response delivery
+
+## Overview
+
+Add first-class attachment handling to the generic messaging interface so Telegram and Discord can accept user-sent files, normalize supported attachments into safe model inputs, and deliver assistant response attachments without leaking provider-specific media rules into workflow code.
+
+This extends the existing text/button messaging MVP. Today inbound media is intentionally rejected, and pasted desktop images are normalized only in the renderer composer path. The target behavior is that messaging attachments go through the same effective model-upload policy as pasted chat images, while response images/files use a single image profile setting that controls resolution and quality.
+
+## Problem Frame
+
+Remote agent control from Telegram and Discord needs attachments to behave like normal chat input. A user should be able to attach a small text file, CSV, JSON, YAML, TOML, image, or GIF from a messaging app and have PwrAgnt route it into the bound thread without shipping raw unbounded media to a model.
+
+The trust boundary is different from desktop paste. Messaging attachments arrive from external services, can be large, can have misleading MIME types, can be short-lived CDN URLs, and can include content types the model cannot consume. The generic controller should therefore own validation, caps, normalization, text extraction, audit logging, and user-visible rejection. Provider adapters should only expose platform metadata, opaque download handles, and provider upload/rendering capabilities.
+
+## Requirements Trace
+
+- R1. Extend `MessagingInboundMediaEvent` so inbound attachments can be represented as available, accepted, or rejected work, not only `disposition: "unsupported"` (see origin R1-R6, R26).
+- R2. Keep workflow semantics channel-neutral: Telegram and Discord adapters expose attachment metadata and opaque download handles, while controller/core logic decides whether an attachment can enter an agent turn (see origin R2, R5, R26).
+- R3. Normalize inbound images through the same policy as desktop-pasted images before model upload, including format conversion, dimensions, JPEG quality, and HEIC fallback where available.
+- R4. Add one image profile setting with `low`, `medium`, `high`, and `actual` profiles that applies to messaging image responses and model-upload normalization unless a narrower call site has a hard cap.
+- R5. Support bounded text-like attachments by MIME type, extension, and content sniffing: plain text, CSV, JSON, JSONL, TOML, YAML/YML, Markdown, logs, and similar source/code text.
+- R6. Support GIFs explicitly: preserve animated GIFs for outbound channel delivery when within provider limits, but convert inbound GIFs to a normalized still image for model upload unless future model capability says animation is supported.
+- R7. Treat PDF as a supported attachment category only for bounded text extraction; scanned/OCR-only PDF handling is out of scope for this pass.
+- R8. Enforce size, byte, pixel, attachment-count, and extracted-text caps before downloading fully, before decoding, and before sending to model providers.
+- R9. Deliver assistant response attachments as provider-native files/images where safe, with channel-specific degradation reported through generic delivery outcomes.
+- R10. Preserve authorization, audit, redaction, and restart-safe behavior for external attachment handling.
+
+## Scope Boundaries
+
+- In scope: generic attachment contracts, adapter download capability, desktop/core attachment processor, image profiles, inbound Telegram and Discord attachment ingestion, outbound response image/file delivery, config/docs, and deterministic tests.
+- In scope: image normalization for model input using existing Chromium/Electron/macOS `sips` behavior where it already exists or can be shared safely.
+- In scope: text extraction for bounded text-like files and non-OCR PDF text when an implementation-time library choice is made.
+- Out of scope: accepting arbitrary binary files into agent turns as raw files; the current app-server turn contract only supports text and image inputs.
+- Out of scope: malware scanning, OCR, audio/video transcription, ZIP/archive expansion, and persistent cloud object storage.
+- Out of scope: making Telegram or Discord provider code decide model-input semantics.
+- Out of scope: exact future support for Slack, Mattermost, Feishu/Lark, or iOS. The contract should be reusable, but only Telegram and Discord need implementation now.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/messaging/AGENTS.md` states that attachments and routing should be expressed generically, providers must stay isolated, and provider limitations should be encoded as capabilities or delivery results.
+- `packages/messaging/interface/src/index.ts` currently defines `MessagingFilePart`, `MessagingImagePart`, and `MessagingInboundMediaEvent`, but inbound media is only `disposition: "unsupported"`.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` currently rejects `event.kind === "media"` with "Media is not supported yet" and routes bound text into `StartTurnRequest.input`.
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts` already detects Telegram documents/photos/video/voice enough to emit an unsupported media event, but it intentionally does not expose `getFile` download behavior.
+- `packages/messaging/providers/discord/src/discord-adapter.ts` already receives attachment metadata and CDN URLs, but emits only the first attachment as unsupported media.
+- `apps/desktop/src/renderer/src/lib/image-normalization.ts` contains the current pasted-image policy: normalize to JPEG/PNG, cap dimensions at `2048` long edge and `1024` short edge, and use JPEG quality `0.85`.
+- `apps/desktop/src/main/ipc/image-normalization.ts` provides a narrow HEIC/HEIF fallback through Electron `nativeImage` and the macOS `sips` platform tool.
+- `packages/agent-core/src/providers/ai-sdk-message-builder.ts` enforces that data URL images must already be normalized to JPEG or PNG before provider submission.
+- `apps/desktop/src/main/settings/desktop-config.ts` and `docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md` define the TOML settings pattern for messaging config.
+- `docs/messaging-adapter-contract.md` documents the current rejection policy and is the right place to update generic adapter expectations.
+
+### Institutional Learnings
+
+- No `docs/solutions/` artifact exists yet for messaging media ingestion.
+- `docs/plans/2026-04-21-001-feat-electron-image-normalization-plan.md` established the existing local image-normalization decisions: avoid `sharp`, prefer Electron/Chromium primitives, use `sips` only as a narrow macOS HEIC/HEIF fallback, and keep provider layers strict.
+- `docs/plans/2026-04-30-001-feat-messaging-platform-integration-plan.md` established the channel-neutral surface boundary and explicitly deferred safe inbound media ingestion to a later plan.
+
+### External References
+
+- Telegram Bot API `sendPhoto` documents a 10 MB photo cap plus width/height constraints, and the generic "Sending Files" rules distinguish photo and other file upload caps: https://core.telegram.org/bots/api
+- Discord Create Message documents multipart file delivery and a 25 MiB maximum request size when sending messages: https://docs.discord.com/developers/resources/message#create-message
+
+## Key Technical Decisions
+
+- **Add attachment capability to the generic interface first.** The generic event should describe attachment metadata, source trust, size hints, MIME hints, and opaque download handles. Provider adapters should not convert these into model input.
+- **Centralize ingestion in desktop main messaging code.** The desktop main process already owns provider adapters, backend bridge, settings, logging, and filesystem access. It can safely download, sniff, normalize, and route attachments without pulling provider SDKs into controller workflow code.
+- **Extract a reusable image normalization service from the renderer-only path.** Keep the renderer paste flow working, but move profile definitions, resize math, MIME decisions, and HEIC fallback contracts into shared or main-process modules that messaging can call without DOM assumptions.
+- **Default to `medium` image profile.** Preserve the current paste behavior as the default profile: bounded dimensions and lossy JPEG for opaque raster images. `actual` is opt-in and still subject to model and provider hard limits.
+- **Use layered MIME detection.** Trust platform MIME only as a hint. Classify by declared MIME, filename extension, magic bytes where available, and text-decoding heuristics. Use the OS `file` command only as an optional best-effort fallback, not a required dependency.
+- **Convert text-like attachments into explicit text input blocks.** Since `StartTurnRequest.input` has only text and image items, accepted text files should be converted into bounded text items with filename/type/size headers rather than adding raw file inputs.
+- **Preserve outbound file delivery as a messaging concern.** `MessagingFilePart` already exists for assistant response attachments. Providers should upload/render it when within channel limits and return a generic failed/unsupported result when they cannot.
+- **Keep rejection user-visible but non-leaky.** Rejections should name the attachment and reason class, such as too large, unsupported type, unreadable, or extracted text too long, without echoing secrets or raw file content into logs.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should inbound messaging media continue to be rejected by default?** No. The new default should accept only supported attachment categories after validation and normalization, and reject the rest with clear messages.
+- **Should providers own model-upload resizing?** No. Providers expose platform metadata and download/render capabilities; the controller/attachment processor owns model-input policy.
+- **Should there be separate resolution and quality settings?** No for the first pass. Use one profile setting that chooses both dimensions and JPEG quality.
+- **Should `actual` bypass all limits?** No. `actual` bypasses soft downscaling/compression only where possible. It still respects channel, model, memory, and configured hard caps.
+- **Should GIFs be sent to models as animated files?** No for this pass. Inbound GIFs should normalize to a still image for model input; outbound GIF delivery can preserve animation when the channel accepts it and size caps allow.
+
+### Deferred to Implementation
+
+- Exact parser/library choice for PDF text extraction after checking current bundle cost, ESM compatibility, and Electron packaging behavior.
+- Whether to add a direct dependency such as `file-type` or reuse a currently transitive magic-byte helper. The plan requires an explicit dependency if the package is imported directly.
+- Exact profile numeric values after comparing current paste defaults, provider caps, and model limits. The default must remain no larger than current paste behavior.
+- Whether Telegram inbound photo download should prefer the largest platform photo size below the active profile cap or always download the largest then resize locally.
+- Final wording for attachment rejection messages after seeing real Telegram and Discord payloads.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant User as Messaging user
+    participant Provider as Telegram/Discord adapter
+    participant Controller as MessagingController
+    participant Processor as Attachment processor
+    participant Image as Image normalizer
+    participant Backend as Backend bridge
+    participant Agent as App-server backend
+
+    User->>Provider: message with text and attachments
+    Provider->>Controller: media/text event with opaque attachment handles
+    Controller->>Processor: validate actor, binding, caps, metadata
+    Processor->>Provider: download attachment stream or bytes by opaque handle
+    Processor->>Processor: sniff type, enforce caps, extract text if needed
+    Processor->>Image: normalize image/GIF still frame by active profile
+    Processor-->>Controller: accepted input items plus rejection summaries
+    Controller->>Backend: startTurn text/image input
+    Backend->>Agent: model-ready turn input
+    Controller->>Provider: user-visible rejection/accepted status if needed
+```
+
+Image profile behavior should be data-driven:
+
+| Profile | Intended use | Behavior |
+| --- | --- | --- |
+| `low` | bandwidth-sensitive mobile messaging | smaller dimensions, lower JPEG quality, never upscale |
+| `medium` | default and current paste parity | current `2048` long edge, `1024` short edge, JPEG quality near `0.85` |
+| `high` | detailed screenshots and diagrams | larger dimensions and higher JPEG quality within hard caps |
+| `actual` | opt-in original fidelity | preserve source dimensions/quality where compatible, but still transcode unsupported formats and reject over hard caps |
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Generic attachment contracts"] --> U2["Unit 2: Shared image profiles"]
+    U1 --> U3["Unit 3: Provider attachment handles"]
+    U2 --> U4["Unit 4: Attachment processor"]
+    U3 --> U4
+    U4 --> U5["Unit 5: Controller routing"]
+    U5 --> U6["Unit 6: Outbound delivery"]
+    U2 --> U7["Unit 7: Settings"]
+    U6 --> U8["Unit 8: Docs and smoke tests"]
+    U7 --> U8
+```
+
+- [ ] **Unit 1: Extend Generic Messaging Attachment Contracts**
+
+**Goal:** Represent inbound and outbound attachments in the generic messaging contract without platform-specific fields or SDK types.
+
+**Requirements:** R1, R2, R5, R6, R7, R9, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/messaging/interface/src/index.ts`
+- Modify: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts` if shared contract duplication is still required by desktop imports
+
+**Approach:**
+- Replace the single unsupported `MessagingInboundMediaEvent` shape with a media event that can carry one or more attachment descriptors.
+- Add a generic attachment descriptor with name, declared MIME type, size hint, source kind, optional dimensions/duration where provider metadata exists, and opaque adapter state for download.
+- Preserve a rejected/unsupported disposition for adapters that cannot expose usable media metadata.
+- Add generic provider capability hints for inbound download, outbound image upload, outbound file upload, max attachment count, max upload bytes, and whether remote URLs or byte uploads are supported.
+- Keep all provider-specific file IDs, CDN URLs that need auth, Telegram photo size arrays, and Discord attachment IDs inside adapter-owned opaque state.
+
+**Patterns to follow:**
+- Existing `MessagingAdapterState`, `MessagingFilePart`, and `MessagingImagePart` in `packages/messaging/interface/src/index.ts`
+- Boundary rules in `packages/messaging/AGENTS.md`
+- Existing contract tests in `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Test scenarios:**
+- Happy path: a media event carries text plus two attachments without any Telegram or Discord fields at the top level.
+- Happy path: an attachment descriptor can include filename, declared MIME, size, dimensions, and opaque state.
+- Edge case: an adapter can still emit a media event with rejected/unsupported disposition when it lacks download support.
+- Regression: provider packages continue importing only `@pwragnt/messaging-interface`, not desktop or agent-core modules.
+
+**Verification:**
+- Generic contracts can describe Telegram and Discord attachment payloads without platform-specific branches in controller code.
+
+- [ ] **Unit 2: Factor Image Normalization Profiles**
+
+**Goal:** Make the existing pasted-image normalization policy reusable by messaging ingestion and outbound response delivery.
+
+**Requirements:** R3, R4, R6, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/image-normalization.ts`
+- Modify: `apps/desktop/src/shared/image-normalization.ts`
+- Modify: `apps/desktop/src/main/ipc/image-normalization.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/image-normalization-ipc.test.ts`
+- Create: `apps/desktop/src/main/messaging/attachment-image-normalization.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-attachment-image-normalization.test.ts`
+
+**Approach:**
+- Define named image profiles in shared desktop code so renderer paste, messaging inbound upload, and messaging response delivery use the same profile table.
+- Preserve the current paste constants as the `medium` profile.
+- Keep profile selection data-only: max long edge, max short edge, JPEG quality, whether to preserve source dimensions, and hard safety caps.
+- Add a main-process callable normalization path for files/bytes downloaded by messaging providers. Do not require DOM APIs in the messaging path.
+- Treat GIF inbound as image-like but normalize to a still PNG/JPEG for model input. Preserve animated GIF only for outbound delivery when channel upload policy allows.
+- Keep HEIC/HEIF fallback narrow and do not turn `sips` into a general-purpose converter.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/lib/image-normalization.ts`
+- `apps/desktop/src/main/ipc/image-normalization.ts`
+- `docs/plans/2026-04-21-001-feat-electron-image-normalization-plan.md`
+
+**Test scenarios:**
+- Happy path: `medium` profile exactly matches the current paste bounds and JPEG quality.
+- Happy path: `low`, `high`, and `actual` resolve to deterministic profile records.
+- Happy path: an opaque PNG source with alpha remains PNG after normalization.
+- Happy path: an opaque large JPEG is resized and encoded according to the selected profile.
+- Edge case: `actual` preserves dimensions below hard caps and rejects dimensions or byte size above hard caps.
+- Edge case: GIF input produces a model-upload-safe still image and records that animation was not preserved.
+- Error path: unsupported image bytes fail with a concise, user-safe error.
+
+**Verification:**
+- Renderer paste tests still pass conceptually with the `medium` profile, and messaging tests can normalize image bytes without using provider code.
+
+- [ ] **Unit 3: Add Telegram and Discord Attachment Handles**
+
+**Goal:** Teach providers to expose download-capable attachment metadata and outbound upload capabilities through the generic adapter surface.
+
+**Requirements:** R1, R2, R5, R6, R8, R9, R10
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Modify: `packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Modify: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+- Modify: `apps/desktop/src/main/messaging/provider-loader.ts` if adapter capability wiring needs loader support
+
+**Approach:**
+- Telegram should map documents, photos, animations/GIFs, and possibly videos/voice into generic attachment descriptors, but only mark supported categories as available for this plan.
+- Telegram download should stay provider-owned because Bot API file IDs and `getFile` paths are platform details.
+- Discord should emit all message attachments, not only the first, with CDN URL details hidden behind generic opaque state when appropriate.
+- Providers should expose a download method or capability on the adapter object that accepts opaque attachment state and returns bounded bytes/stream plus resolved metadata.
+- Providers should expose outbound delivery capabilities for image/file parts, including byte caps and whether they need byte upload or can use remote URLs.
+- Do not download media inside provider event normalization unless the controller explicitly accepts the actor/binding and asks for the attachment.
+
+**Patterns to follow:**
+- Current unsupported-media tests in `apps/desktop/src/main/__tests__/telegram-adapter.test.ts` and `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+- Typing and delivery capability patterns in `packages/messaging/providers/telegram/src/telegram-adapter.ts` and `packages/messaging/providers/discord/src/discord-adapter.ts`
+
+**Test scenarios:**
+- Happy path: Telegram document `streaming-logs.txt` emits an available attachment descriptor with name, MIME hint, size if present, and opaque download state.
+- Happy path: Telegram photo emits image attachment metadata with width/height when available and an opaque provider handle.
+- Happy path: Discord message with multiple attachments emits all descriptors in one media event.
+- Edge case: message with both text and attachments preserves text rather than treating the whole event as media-only.
+- Error path: unsupported voice/video attachment emits a rejected descriptor without download.
+- Security regression: generic event snapshots do not expose Telegram file IDs or Discord signed CDN URLs outside opaque adapter state.
+
+**Verification:**
+- Provider tests prove metadata normalization and download handles without starting agent turns or importing desktop messaging code.
+
+- [ ] **Unit 4: Build Main-Process Attachment Processor**
+
+**Goal:** Download, classify, cap, normalize, and convert accepted messaging attachments into `StartTurnRequest.input` items.
+
+**Requirements:** R3, R5, R6, R7, R8, R10
+
+**Dependencies:** Units 1, 2, and 3
+
+**Files:**
+- Create: `apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts`
+- Create: `apps/desktop/src/main/messaging/core/messaging-attachment-mime.ts`
+- Create: `apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts`
+- Create: `apps/desktop/src/main/__tests__/messaging-attachment-mime.test.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+
+**Approach:**
+- Accept attachment descriptors only after the controller has authorized the actor and found an active binding.
+- Enforce metadata-level caps before download: max attachment count, max declared bytes, and unsupported declared type rejection.
+- Download through the adapter capability with a maximum byte budget so large files can fail before memory grows without bound.
+- Classify type by layered evidence: provider MIME hint, extension, magic bytes where available, text-decoding heuristics, and optional OS `file` fallback when available.
+- Treat text-like files as UTF-8 or safely decoded text after enforcing byte and extracted-character caps. Include filename, MIME, byte size, and truncation marker in the generated text item.
+- Treat CSV, JSON, JSONL, TOML, YAML/YML, Markdown, logs, and common source-code text as text-like, with validation light enough to avoid rejecting useful malformed logs.
+- Treat PDF as text-extraction only. If extraction is unavailable, encrypted, scanned-only, or over cap, reject with a PDF-specific reason.
+- Treat images and GIFs through Unit 2 normalization and emit `type: "image"` data URLs plus optional explanatory text when animation or fidelity was reduced.
+- Return accepted input items and rejection summaries separately so a mixed message can still start a turn when at least one attachment or text item is valid.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` for controller-facing pure helpers
+- `packages/agent-core/src/providers/ai-sdk-message-builder.ts` for strict provider image expectations
+- `apps/desktop/src/main/log.ts` for safe logging
+
+**Test scenarios:**
+- Happy path: `streaming-logs.txt` with `text/plain` becomes a bounded text input item with a filename header.
+- Happy path: JSON, JSONL, CSV, TOML, YAML, YML, Markdown, and `.log` files are classified as text-like by MIME or extension.
+- Happy path: an image attachment becomes a normalized JPEG/PNG data URL acceptable to `buildAiSdkMessages()`.
+- Happy path: a GIF attachment becomes a normalized still image plus a user-safe note that animation was not sent to the model.
+- Happy path: text plus two supported attachments produces ordered text/input items for one turn.
+- Edge case: no MIME type and misleading extension still classifies plain UTF-8 text by content heuristics.
+- Edge case: binary bytes with `.txt` extension are rejected as non-text.
+- Error path: declared size over policy cap is rejected before download.
+- Error path: downloaded bytes exceed cap and the adapter download is aborted or discarded without starting a turn.
+- Error path: malformed or encrypted PDF is rejected with a reason and no raw content logged.
+- Integration: every emitted image input is JPEG/PNG and passes `packages/agent-core/src/providers/ai-sdk-message-builder.ts`.
+
+**Verification:**
+- Processor tests prove supported attachments become model-ready text/image items and unsupported attachments produce deterministic rejection summaries.
+
+- [ ] **Unit 5: Route Accepted Media Through MessagingController**
+
+**Goal:** Replace the current blanket media rejection with authorized, bound attachment ingestion and mixed text-plus-attachment turn starts.
+
+**Requirements:** R1, R2, R3, R5, R6, R8, R10
+
+**Dependencies:** Units 1 through 4
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-renderer.ts`
+- Modify: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts` if runtime construction needs to inject the attachment processor
+- Modify: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Approach:**
+- Add a controller media path that mirrors the text path: authorize actor, handle pending intent if text exists, require active binding, resolve turn settings, process attachments, and start a turn when there is valid input.
+- Preserve `/resume` and command behavior for text-only messages. If a platform sends text plus attachments, command handling should win only when the text is clearly a command and attachments should be rejected or ignored with a clear note.
+- Send a concise confirmation/error intent when some attachments are rejected. If at least one input item is accepted, still start the turn and include rejection context as user-visible messaging feedback.
+- Maintain typing/status lifecycle behavior after a media-driven turn starts.
+- Do not store downloaded bytes in `MessagingStore`; persist only audit metadata and delivery status.
+
+**Patterns to follow:**
+- Existing `handleText()` flow in `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Existing unsupported media regression test in `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Test scenarios:**
+- Happy path: bound conversation sends text plus `streaming-logs.txt`; controller starts a turn with original text and extracted file text.
+- Happy path: bound conversation sends image-only attachment; controller starts an image-only turn.
+- Happy path: mixed valid image and invalid binary file starts a turn with the image and sends a rejection note for the invalid file.
+- Edge case: unbound conversation with attachment receives the same bind-first guidance as text.
+- Edge case: unauthorized actor attachment is rejected before adapter download is requested.
+- Error path: all attachments rejected results in no `startTurn()` call and a recoverable error intent.
+- Security regression: logs and store records contain metadata/reason codes, not attachment contents or secret URLs.
+
+**Verification:**
+- Controller tests prove media events now route through the same binding and activity lifecycle as text without forwarding raw file parts to the backend.
+
+- [ ] **Unit 6: Deliver Response Images and Files Through Providers**
+
+**Goal:** Make assistant response attachments render as platform-native images/files when safe and degrade predictably when provider limits prevent delivery.
+
+**Requirements:** R4, R6, R8, R9, R10
+
+**Dependencies:** Units 1, 2, and 3
+
+**Files:**
+- Modify: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Modify: `packages/messaging/providers/telegram/src/telegram-formatting.ts`
+- Modify: `packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts`
+- Modify: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- Modify: `packages/messaging/providers/discord/src/discord-formatting.ts`
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+
+**Approach:**
+- Use the image profile setting for assistant `MessagingImagePart` delivery when the part is a data URL or local/generated byte source that can be normalized before upload.
+- Telegram should use photo upload for normal images within photo constraints and document upload for non-photo files or degraded cases when supported by the generic file part.
+- Discord should send files through multipart upload when bytes are available and continue using embeds for remote image URLs when that is the better fit.
+- Preserve animated GIFs outbound when provider caps allow; otherwise degrade to still image or file rejection based on capability.
+- Keep long response text chunking separate from file upload. A file part should not cause text content to exceed provider message limits.
+- Return generic delivery results that distinguish presented, unsupported, and failed attachment delivery.
+
+**Patterns to follow:**
+- Current Telegram `sendPhoto` behavior in `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Current Discord image embed behavior in `packages/messaging/providers/discord/src/discord-adapter.ts`
+- `docs/messaging-adapter-contract.md` rendering policy
+
+**Test scenarios:**
+- Happy path: assistant image data URL is normalized by profile and uploaded/sent through Telegram.
+- Happy path: assistant image URL still uses Telegram photo or Discord embed path when no byte upload is needed.
+- Happy path: assistant file part `streaming-logs.txt` is uploaded as a provider file with caption/text kept within limits.
+- Happy path: outbound GIF within cap is preserved as animated delivery where provider supports it.
+- Edge case: file over provider cap returns `unsupported` or `failed` with a useful error message but does not crash delivery of adjacent text chunks.
+- Error path: provider upload failure reports a failed delivery result and logs only metadata.
+
+**Verification:**
+- Provider adapter tests prove response image/file delivery paths and degradation behavior from generic `MessagingMessageIntent` parts.
+
+- [ ] **Unit 7: Add Attachment Settings and Effective Policy Resolution**
+
+**Goal:** Expose durable settings for image profile and attachment caps with environment override behavior consistent with existing desktop settings.
+
+**Requirements:** R4, R8, R10
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/settings/desktop-config.ts`
+- Modify: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-config.ts`
+- Modify: `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/messaging-config.test.ts`
+- Modify: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx` if the current settings UI should expose attachment controls
+- Modify: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` if settings UI coverage is extended
+
+**Approach:**
+- Add a TOML shape under messaging settings for attachment policy, such as image profile and max attachment counts/bytes.
+- Add environment overrides for the same settings so automated or bandwidth-sensitive runs can force low-quality behavior.
+- Default the image profile to `medium`.
+- Keep settings app-level. Per-thread attachment policy is out of scope unless later product work needs it.
+- If the settings UI has not yet exposed attachment controls, at minimum support TOML/env configuration and document it. Add UI controls only if the existing settings page has a clear messaging section to extend.
+
+**Patterns to follow:**
+- Existing `[messaging.telegram]` and `[messaging.discord]` TOML parsing in `apps/desktop/src/main/settings/desktop-config.ts`
+- Existing effective-value tests in `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+- `docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md`
+
+**Test scenarios:**
+- Happy path: absent config resolves to `medium` image profile and conservative attachment caps.
+- Happy path: TOML image profile `low`, `medium`, `high`, and `actual` parse and round-trip.
+- Happy path: environment override wins over TOML and is reflected in effective settings metadata.
+- Error path: invalid image profile reports a config error and falls back safely.
+- Error path: invalid cap values are rejected or ignored with a clear config error.
+
+**Verification:**
+- Messaging runtime can resolve one effective attachment policy and pass it to the attachment processor and outbound delivery code.
+
+- [ ] **Unit 8: Update Documentation and Smoke Coverage**
+
+**Goal:** Document supported attachment types, limits, settings, provider behavior, and manual smoke flows.
+
+**Requirements:** R1-R10
+
+**Dependencies:** Units 1 through 7
+
+**Files:**
+- Modify: `docs/messaging-adapter-contract.md`
+- Modify: `docs/messaging-platform-integration.md`
+- Modify: `apps/desktop/src/main/__tests__/messaging-docs-links.test.ts`
+- Modify: `packages/messaging/AGENTS.md` only if the package boundary text needs an attachment-specific clarification
+
+**Approach:**
+- Update adapter contract docs to describe attachment descriptors, opaque download handles, provider-owned download/upload mechanics, and controller-owned ingestion semantics.
+- Update integration docs to list supported incoming types: text-like files, images, GIFs as stills for model input, and PDF text extraction when available.
+- Document unsupported categories: oversized files, arbitrary binaries, audio/video, archives, OCR-only PDFs, and files with unsafe/misleading content.
+- Document image profile behavior and the default `medium` policy.
+- Add manual Telegram and Discord smoke steps for incoming text file, incoming image, oversized rejection, response image delivery, and response file delivery.
+
+**Patterns to follow:**
+- Existing docs in `docs/messaging-adapter-contract.md`
+- Existing smoke checklist in `docs/messaging-platform-integration.md`
+
+**Test scenarios:**
+- Happy path: docs link test covers the updated docs.
+- Manual smoke: Telegram text file attachment starts a bound turn with extracted text.
+- Manual smoke: Discord image attachment starts a bound turn with normalized image input.
+- Manual smoke: oversized image/file is rejected before model upload.
+- Manual smoke: assistant response file renders as a channel attachment or reports provider degradation.
+
+**Verification:**
+- A developer adding a new provider can understand whether attachment handling belongs in the adapter, controller, or processor.
+
+## System-Wide Impact
+
+- **Interaction graph:** Provider inbound events feed `MessagingController`, which calls a new attachment processor, downloads through adapter capabilities, normalizes into `StartTurnRequest.input`, and then uses the existing backend bridge. Outbound assistant `MessagingMessageIntent` parts flow back through provider delivery policy.
+- **Error propagation:** Attachment validation errors should become recoverable messaging error/confirmation intents. Provider download/upload failures should become delivery failure results with safe logs.
+- **State lifecycle risks:** Downloaded bytes and extracted contents should not persist in `MessagingStore`. Pending events should be processed synchronously enough to avoid stale provider URLs, with clear failures when URLs expire.
+- **API surface parity:** Telegram and Discord should expose the same generic attachment descriptors and capability model even though Telegram uses file IDs and Discord uses attachment URLs.
+- **Integration coverage:** Unit tests should cover contracts, provider event normalization, processor classification, controller routing, provider outbound delivery, and config resolution. Manual smoke is still needed for real platform download/upload behavior.
+- **Unchanged invariants:** Provider packages remain isolated, desktop messaging core does not import provider SDKs, and agent-core/model providers still receive only text and JPEG/PNG image inputs.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Large external files exhaust memory or bandwidth | Enforce metadata caps before download, byte caps during download, profile caps during normalization, and hard model/provider caps before delivery. |
+| MIME type spoofing causes unsafe or unreadable content to enter model input | Use layered classification and reject conflicting binary/text evidence rather than trusting platform MIME alone. |
+| Provider-specific download state leaks into logs or contracts | Keep file IDs, signed URLs, and tokens inside `MessagingAdapterState`; log only safe metadata and reason codes. |
+| PDF support grows into OCR/document processing scope | Limit this pass to bounded text extraction and reject encrypted, scanned-only, or oversized PDFs. |
+| `actual` profile surprises users with large uploads | Keep default `medium`, document `actual` as opt-in, and preserve hard caps even for `actual`. |
+| GIF behavior differs between model input and response delivery | Document the split: inbound model input uses a still image, outbound channel delivery preserves animation when safe. |
+| New dependency for MIME/PDF detection affects Electron packaging | Make dependency choice explicit during implementation and cover it in desktop build/typecheck before merging. |
+
+## Documentation / Operational Notes
+
+- The default policy should be conservative enough for mobile messaging and should not send original-resolution images unless the user opts into `actual`.
+- Attachment rejection messages should be concise because mobile clients make long diagnostics noisy.
+- Manual validation should include the concrete case from the user screenshot: a `.txt` attachment in Telegram should no longer receive "Media is not supported yet" when the conversation is bound and authorized.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md](../brainstorms/2026-04-30-messaging-platform-integration-requirements.md)
+- Related plan: [docs/plans/2026-04-30-001-feat-messaging-platform-integration-plan.md](2026-04-30-001-feat-messaging-platform-integration-plan.md)
+- Related plan: [docs/plans/2026-04-21-001-feat-electron-image-normalization-plan.md](2026-04-21-001-feat-electron-image-normalization-plan.md)
+- Related docs: [docs/messaging-adapter-contract.md](../messaging-adapter-contract.md)
+- Related docs: [docs/messaging-platform-integration.md](../messaging-platform-integration.md)
+- Related code: `packages/messaging/interface/src/index.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/renderer/src/lib/image-normalization.ts`
+- Related code: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Related code: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- External docs: Telegram Bot API, https://core.telegram.org/bots/api
+- External docs: Discord Message Resource, https://docs.discord.com/developers/resources/message

--- a/docs/plans/2026-05-02-002-feat-messaging-attachments-plan.md
+++ b/docs/plans/2026-05-02-002-feat-messaging-attachments-plan.md
@@ -149,7 +149,7 @@ flowchart TB
     U7 --> U8
 ```
 
-- [ ] **Unit 1: Extend Generic Messaging Attachment Contracts**
+- [x] **Unit 1: Extend Generic Messaging Attachment Contracts**
 
 **Goal:** Represent inbound and outbound attachments in the generic messaging contract without platform-specific fields or SDK types.
 
@@ -183,7 +183,7 @@ flowchart TB
 **Verification:**
 - Generic contracts can describe Telegram and Discord attachment payloads without platform-specific branches in controller code.
 
-- [ ] **Unit 2: Factor Image Normalization Profiles**
+- [x] **Unit 2: Factor Image Normalization Profiles**
 
 **Goal:** Make the existing pasted-image normalization policy reusable by messaging ingestion and outbound response delivery.
 
@@ -225,7 +225,7 @@ flowchart TB
 **Verification:**
 - Renderer paste tests still pass conceptually with the `medium` profile, and messaging tests can normalize image bytes without using provider code.
 
-- [ ] **Unit 3: Add Telegram and Discord Attachment Handles**
+- [x] **Unit 3: Add Telegram and Discord Attachment Handles**
 
 **Goal:** Teach providers to expose download-capable attachment metadata and outbound upload capabilities through the generic adapter surface.
 
@@ -265,7 +265,7 @@ flowchart TB
 **Verification:**
 - Provider tests prove metadata normalization and download handles without starting agent turns or importing desktop messaging code.
 
-- [ ] **Unit 4: Build Main-Process Attachment Processor**
+- [x] **Unit 4: Build Main-Process Attachment Processor**
 
 **Goal:** Download, classify, cap, normalize, and convert accepted messaging attachments into `StartTurnRequest.input` items.
 
@@ -312,7 +312,7 @@ flowchart TB
 **Verification:**
 - Processor tests prove supported attachments become model-ready text/image items and unsupported attachments produce deterministic rejection summaries.
 
-- [ ] **Unit 5: Route Accepted Media Through MessagingController**
+- [x] **Unit 5: Route Accepted Media Through MessagingController**
 
 **Goal:** Replace the current blanket media rejection with authorized, bound attachment ingestion and mixed text-plus-attachment turn starts.
 
@@ -350,7 +350,7 @@ flowchart TB
 **Verification:**
 - Controller tests prove media events now route through the same binding and activity lifecycle as text without forwarding raw file parts to the backend.
 
-- [ ] **Unit 6: Deliver Response Images and Files Through Providers**
+- [x] **Unit 6: Deliver Response Images and Files Through Providers**
 
 **Goal:** Make assistant response attachments render as platform-native images/files when safe and degrade predictably when provider limits prevent delivery.
 
@@ -392,7 +392,7 @@ flowchart TB
 **Verification:**
 - Provider adapter tests prove response image/file delivery paths and degradation behavior from generic `MessagingMessageIntent` parts.
 
-- [ ] **Unit 7: Add Attachment Settings and Effective Policy Resolution**
+- [x] **Unit 7: Add Attachment Settings and Effective Policy Resolution**
 
 **Goal:** Expose durable settings for image profile and attachment caps with environment override behavior consistent with existing desktop settings.
 
@@ -431,7 +431,7 @@ flowchart TB
 **Verification:**
 - Messaging runtime can resolve one effective attachment policy and pass it to the attachment processor and outbound delivery code.
 
-- [ ] **Unit 8: Update Documentation and Smoke Coverage**
+- [x] **Unit 8: Update Documentation and Smoke Coverage**
 
 **Goal:** Document supported attachment types, limits, settings, provider behavior, and manual smoke flows.
 

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -228,10 +228,65 @@ describe("messaging surface contract", () => {
         name: "voice.m4a",
         mimeType: "audio/mp4",
       },
+      attachments: [
+        {
+          id: "attachment-1",
+          kind: "audio",
+          name: "voice.m4a",
+          mimeType: "audio/mp4",
+          disposition: "unsupported",
+          reason: "audio attachments are not supported",
+        },
+      ],
       disposition: "unsupported",
     } satisfies MessagingInboundMediaEvent;
 
     expect(event.disposition).toBe("unsupported");
+    expect(event.attachments[0]).toMatchObject({
+      kind: "audio",
+      name: "voice.m4a",
+    });
+  });
+
+  it("describes available inbound attachments with opaque download state", () => {
+    const event = {
+      id: "media-2",
+      kind: "media",
+      actor: {
+        platformUserId: "user-1",
+      },
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      receivedAt: 1000,
+      text: "Please inspect this log",
+      disposition: "available",
+      attachments: [
+        {
+          id: "telegram-file-1",
+          kind: "file",
+          name: "streaming-logs.txt",
+          mimeType: "text/plain",
+          sizeBytes: 2560,
+          disposition: "available",
+          state: {
+            opaque: {
+              provider: "telegram",
+              fileId: "opaque-to-core",
+            },
+          },
+        },
+      ],
+    } satisfies MessagingInboundMediaEvent;
+
+    expect(event.attachments).toHaveLength(1);
+    expect(event.attachments[0]?.state?.opaque).toMatchObject({
+      provider: "telegram",
+    });
   });
 
   it("describes restart-safe bindings, browse sessions, and callback handles", () => {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -161,6 +161,7 @@ export type MessagingImagePart = AppServerThreadImagePart & {
 export type MessagingFilePart = {
   type: "file";
   name: string;
+  data?: Uint8Array;
   url?: string;
   mimeType?: string;
   sizeBytes?: number;
@@ -554,10 +555,40 @@ export type MessagingInboundCallbackEvent = MessagingInboundBaseEvent & {
   value?: MessagingJsonValue;
 };
 
+export type MessagingAttachmentDisposition =
+  | "available"
+  | "rejected"
+  | "unsupported";
+
+export type MessagingAttachmentKind =
+  | "file"
+  | "image"
+  | "gif"
+  | "audio"
+  | "video"
+  | "unknown";
+
+export type MessagingAttachmentDescriptor = {
+  id: string;
+  kind: MessagingAttachmentKind;
+  name: string;
+  disposition: MessagingAttachmentDisposition;
+  description?: string;
+  height?: number;
+  mimeType?: string;
+  reason?: string;
+  sizeBytes?: number;
+  state?: MessagingAdapterState;
+  url?: string;
+  width?: number;
+};
+
 export type MessagingInboundMediaEvent = MessagingInboundBaseEvent & {
   kind: "media";
-  media: MessagingFilePart | AppServerThreadMessagePart;
-  disposition: "unsupported";
+  attachments: MessagingAttachmentDescriptor[];
+  disposition: MessagingAttachmentDisposition;
+  media?: MessagingFilePart | AppServerThreadMessagePart;
+  text?: string;
 };
 
 export type MessagingInboundLifecycleEvent = MessagingInboundBaseEvent & {
@@ -683,6 +714,32 @@ export type MessagingCallbackHandleRecord = {
   surface?: MessagingSurfaceRef;
   updatedAt: number;
   value?: MessagingJsonValue;
+};
+
+export type MessagingAttachmentDownloadRequest = {
+  attachment: MessagingAttachmentDescriptor;
+  maxBytes: number;
+};
+
+export type MessagingAttachmentDownloadResult = {
+  data: Uint8Array;
+  fileName: string;
+  mimeType?: string;
+  sizeBytes: number;
+};
+
+export type MessagingAdapterCapabilities = {
+  inboundAttachments?: {
+    maxAttachmentCount?: number;
+    maxDownloadBytes?: number;
+    supportsDownload: boolean;
+  };
+  outboundAttachments?: {
+    maxUploadBytes?: number;
+    supportsFileUpload: boolean;
+    supportsImageUpload: boolean;
+    supportsRemoteImageUrl: boolean;
+  };
 };
 
 export type MessagingCallbackHandleStore = {

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -145,6 +145,111 @@ describe("discord adapter", () => {
     });
     expect(updateChannelName).toHaveBeenCalledTimes(1);
   });
+
+  it("sends file message intents as Discord upload files", async () => {
+    const createMessage = vi.fn(async (channelId: string) => ({
+      channel_id: channelId,
+      id: "message-2",
+    }));
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: ["user-1"],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+    const data = new Uint8Array([1, 2, 3]);
+
+    await expect(
+      adapter.deliver({
+        audit: discordAudit(),
+        createdAt: 1234,
+        id: "message-file-1",
+        kind: "message",
+        parts: [
+          {
+            text: "Generated log",
+            type: "text",
+          },
+          {
+            data,
+            mimeType: "text/plain",
+            name: "streaming-logs.txt",
+            sizeBytes: data.byteLength,
+            type: "file",
+          },
+        ],
+        role: "assistant",
+      }),
+    ).resolves.toMatchObject({
+      channel: "discord",
+      deliveredAt: 1234,
+      outcome: "presented",
+    });
+
+    expect(createMessage).toHaveBeenCalledWith(
+      "channel-1",
+      expect.objectContaining({
+        content: "Generated log",
+        files: [
+          {
+            data,
+            name: "streaming-logs.txt",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("uploads data URL image message intents instead of embedding them", async () => {
+    const createMessage = vi.fn(async (channelId: string) => ({
+      channel_id: channelId,
+      id: "message-2",
+    }));
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: ["user-1"],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    await adapter.deliver({
+      audit: discordAudit(),
+      createdAt: 1234,
+      id: "message-image-data-url",
+      kind: "message",
+      parts: [
+        {
+          text: "Rendered image",
+          type: "text",
+        },
+        {
+          type: "image",
+          url: "data:image/png;base64,AQID",
+        },
+      ],
+      role: "assistant",
+    });
+
+    expect(createMessage).toHaveBeenCalledWith(
+      "channel-1",
+      expect.objectContaining({
+        content: "Rendered image",
+        embeds: undefined,
+        files: [
+          {
+            data: new Uint8Array([1, 2, 3]),
+            name: "assistant-image.png",
+          },
+        ],
+      }),
+    );
+  });
 });
 
 function discordAudit(): MessagingAuditContext {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -13,10 +13,15 @@ import {
   type User,
 } from "discord.js";
 import type {
+  MessagingAdapterCapabilities,
   MessagingAdapterState,
+  MessagingAttachmentDescriptor,
+  MessagingAttachmentDownloadRequest,
+  MessagingAttachmentDownloadResult,
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
+  MessagingFilePart,
   MessagingInboundEvent,
   MessagingJsonValue,
   MessagingSurfaceAction,
@@ -45,6 +50,13 @@ type DiscordComponentBinding = {
   actionId: string;
   value?: MessagingJsonValue;
 };
+
+type FetchLike = (url: string) => Promise<{
+  arrayBuffer(): Promise<ArrayBuffer>;
+  ok: boolean;
+  status: number;
+  statusText: string;
+}>;
 
 type DiscordTypingSignal = {
   interval: ReturnType<typeof setInterval>;
@@ -77,6 +89,10 @@ export type DiscordCreateMessageRequest = {
     image?: {
       url: string;
     };
+  }>;
+  files?: Array<{
+    data: Uint8Array;
+    name: string;
   }>;
 };
 
@@ -189,6 +205,7 @@ export type DiscordApi = DiscordApplicationCommandApi & {
 type DiscordAdapterOptions = {
   api?: DiscordApi;
   config: DiscordMessagingConfig;
+  fetch?: FetchLike;
   gateway?: DiscordGatewayConnection;
   logger?: DiscordProviderLogger;
   now?: () => number;
@@ -196,8 +213,12 @@ type DiscordAdapterOptions = {
 
 export type DiscordProviderAdapter = {
   authorizedActorIds: readonly string[];
+  capabilities?: MessagingAdapterCapabilities;
   channel: "discord";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  downloadAttachment?(
+    request: MessagingAttachmentDownloadRequest,
+  ): Promise<MessagingAttachmentDownloadResult>;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -207,6 +228,19 @@ export type DiscordProviderAdapter = {
 
 export class DiscordAdapter implements DiscordProviderAdapter {
   readonly channel = "discord" as const;
+  readonly capabilities: MessagingAdapterCapabilities = {
+    inboundAttachments: {
+      maxAttachmentCount: 10,
+      maxDownloadBytes: 25 * 1024 * 1024,
+      supportsDownload: true,
+    },
+    outboundAttachments: {
+      maxUploadBytes: 25 * 1024 * 1024,
+      supportsFileUpload: true,
+      supportsImageUpload: true,
+      supportsRemoteImageUrl: true,
+    },
+  };
 
   private componentBindings = new Map<string, DiscordComponentBinding>();
   private defaultApi?: DiscordApi;
@@ -242,6 +276,35 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     await this.gateway.close();
   }
 
+  async downloadAttachment(
+    request: MessagingAttachmentDownloadRequest,
+  ): Promise<MessagingAttachmentDownloadResult> {
+    const opaque = request.attachment.state?.opaque;
+    if (!opaque || typeof opaque !== "object" || Array.isArray(opaque)) {
+      throw new Error("Discord attachment download state is missing.");
+    }
+    const url = opaque.url;
+    if (typeof url !== "string" || !url) {
+      throw new Error("Discord attachment URL is missing.");
+    }
+    const response = await this.fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Discord attachment download failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data = new Uint8Array(await response.arrayBuffer());
+    if (data.byteLength > request.maxBytes) {
+      throw new Error("Discord attachment exceeds the configured download limit.");
+    }
+    return {
+      data,
+      fileName: request.attachment.name,
+      mimeType: request.attachment.mimeType,
+      sizeBytes: data.byteLength,
+    };
+  }
+
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
     if (intent.kind === "dismiss") {
       return {
@@ -271,8 +334,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         (action) => this.createCustomId(intent, action),
         intent.actionLayout,
       );
-      const imageUrl = this.firstImageUrl(intent);
-      const chunks = splitDiscordContent(textForDiscordIntent(intent) || " ");
+      const imageUpload = uploadableImagePart(intent);
+      const imageUrl = imageUpload ? undefined : this.firstImageUrl(intent);
+      const files = [...uploadableFileParts(intent), ...(imageUpload ? [imageUpload] : [])];
+      const chunks = splitDiscordContent(
+        (files.length > 0
+          ? textForDiscordIntentWithoutUploads(intent)
+          : textForDiscordIntent(intent)) || " ",
+      );
       const componentPayload =
         components ?? (intent.delivery?.replaceMarkup ? [] : undefined);
 
@@ -280,7 +349,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         target.applicationId &&
         target.interactionToken &&
         chunks.length === 1 &&
-        !imageUrl
+        !imageUrl &&
+        files.length === 0
       ) {
         const message = await this.api.updateInteractionOriginalResponse(
           target.applicationId,
@@ -313,6 +383,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
               allowed_mentions: defensiveAllowedMentions(),
               components: componentPayload,
               content: chunks[0] ?? " ",
+              files: filesForDiscordRequest(files),
             },
           );
           return {
@@ -345,6 +416,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
                   },
                 ]
               : undefined,
+          files: index === chunks.length - 1 ? filesForDiscordRequest(files) : undefined,
         };
         messages.push(await this.api.createMessage(target.channelId, request));
       }
@@ -437,21 +509,27 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     });
 
     if (message.attachments && message.attachments.length > 0) {
-      const attachment = message.attachments[0]!;
+      const attachments = message.attachments.map((attachment) =>
+        this.attachmentFromDiscord(attachment),
+      );
       await listener({
         id: `discord:message:${message.id}`,
         kind: "media",
+        attachments,
         actor: this.actorFromUser(message.author),
         channel,
-        disposition: "unsupported",
+        disposition: attachments.some((attachment) => attachment.disposition === "available")
+          ? "available"
+          : "unsupported",
         media: {
           type: "file",
-          name: attachment.filename,
-          mimeType: attachment.content_type,
-          sizeBytes: attachment.size,
+          name: attachments[0]?.name ?? "discord-attachment",
+          mimeType: attachments[0]?.mimeType,
+          sizeBytes: attachments[0]?.sizeBytes,
         },
         receivedAt,
         routingState,
+        text: message.content,
       });
       return;
     }
@@ -897,6 +975,35 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     };
   }
 
+  private attachmentFromDiscord(attachment: {
+    content_type?: string;
+    filename: string;
+    id: string;
+    size?: number;
+    url: string;
+  }): MessagingAttachmentDescriptor {
+    const mimeType = attachment.content_type;
+    const kind = attachmentKindFromDiscordMimeType(mimeType, attachment.filename);
+    const available =
+      kind === "file" || kind === "image" || kind === "gif";
+    return {
+      id: `discord:attachment:${attachment.id}`,
+      kind,
+      name: attachment.filename,
+      disposition: available ? "available" : "unsupported",
+      mimeType,
+      reason: available ? undefined : "unsupported attachment type",
+      sizeBytes: attachment.size,
+      state: {
+        opaque: {
+          attachmentId: attachment.id,
+          provider: "discord",
+          url: attachment.url,
+        },
+      },
+    };
+  }
+
   private get api(): DiscordApi {
     this.defaultApi ??= new DiscordRestApi(this.options.config.botToken);
     return this.options.api ?? this.defaultApi;
@@ -910,6 +1017,117 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private now(): number {
     return this.options.now?.() ?? Date.now();
   }
+
+  private get fetch(): FetchLike {
+    return this.options.fetch ?? fetch;
+  }
+}
+
+function uploadableFileParts(intent: MessagingSurfaceIntent): MessagingFilePart[] {
+  if (intent.kind !== "message") {
+    return [];
+  }
+
+  return intent.parts.filter(
+    (part): part is MessagingFilePart =>
+      part.type === "file" && part.data !== undefined,
+  );
+}
+
+function uploadableImagePart(intent: MessagingSurfaceIntent): MessagingFilePart | undefined {
+  if (intent.kind !== "message") {
+    return undefined;
+  }
+
+  const url = intent.parts.find((part) => part.type === "image")?.url;
+  if (!url) {
+    return undefined;
+  }
+
+  const dataImage = parseDataImageUrl(url);
+  if (!dataImage) {
+    return undefined;
+  }
+
+  return {
+    data: dataImage.data,
+    mimeType: dataImage.mimeType,
+    name: dataImage.name,
+    sizeBytes: dataImage.data.byteLength,
+    type: "file",
+  };
+}
+
+function textForDiscordIntentWithoutUploads(intent: MessagingSurfaceIntent): string {
+  if (intent.kind !== "message") {
+    return textForDiscordIntent(intent);
+  }
+
+  return textForDiscordIntent({
+    ...intent,
+    parts: intent.parts.filter(
+      (part) =>
+        !(part.type === "file" && part.data !== undefined) &&
+        !(part.type === "image" && part.url.startsWith("data:image/")),
+    ),
+  });
+}
+
+function filesForDiscordRequest(
+  files: MessagingFilePart[],
+): DiscordCreateMessageRequest["files"] | undefined {
+  if (files.length === 0) {
+    return undefined;
+  }
+
+  return files.map((file) => ({
+    data: file.data!,
+    name: file.name,
+  }));
+}
+
+function parseDataImageUrl(
+  url: string,
+): { data: Uint8Array; mimeType: string; name: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=]+)$/i.exec(url);
+  if (!match) {
+    return undefined;
+  }
+
+  const mimeType = match[1]?.toLowerCase() ?? "image/png";
+  const extension =
+    mimeType === "image/jpeg"
+      ? "jpg"
+      : mimeType === "image/png"
+        ? "png"
+        : mimeType === "image/gif"
+          ? "gif"
+          : "img";
+  return {
+    data: new Uint8Array(Buffer.from(match[2] ?? "", "base64")),
+    mimeType,
+    name: `assistant-image.${extension}`,
+  };
+}
+
+function attachmentKindFromDiscordMimeType(
+  mimeType: string | undefined,
+  filename: string,
+): MessagingAttachmentDescriptor["kind"] {
+  const lowerName = filename.toLowerCase();
+  if (mimeType?.startsWith("image/gif") || lowerName.endsWith(".gif")) {
+    return "gif";
+  }
+  if (mimeType?.startsWith("image/")) {
+    return "image";
+  }
+  if (mimeType?.startsWith("audio/")) {
+    return "audio";
+  }
+  if (mimeType?.startsWith("video/")) {
+    return "video";
+  }
+  return "file";
 }
 
 export function createDiscordAdapter(
@@ -942,8 +1160,13 @@ class DiscordRestApi implements DiscordApi {
     channelId: string,
     request: DiscordCreateMessageRequest,
   ): Promise<DiscordMessage> {
+    const { files, ...body } = request;
     return (await this.rest.post(Routes.channelMessages(channelId), {
-      body: request,
+      body,
+      files: files?.map((file) => ({
+        data: Buffer.from(file.data),
+        name: file.name,
+      })),
     })) as DiscordMessage;
   }
 
@@ -971,10 +1194,15 @@ class DiscordRestApi implements DiscordApi {
     interactionToken: string,
     request: DiscordCreateMessageRequest,
   ): Promise<DiscordMessage> {
+    const { files, ...body } = request;
     return (await this.rest.patch(
       `/webhooks/${applicationId}/${interactionToken}/messages/@original`,
       {
-        body: request,
+        body,
+        files: files?.map((file) => ({
+          data: Buffer.from(file.data),
+          name: file.name,
+        })),
       },
     )) as DiscordMessage;
   }
@@ -1018,8 +1246,13 @@ class DiscordRestApi implements DiscordApi {
     messageId: string,
     request: DiscordCreateMessageRequest,
   ): Promise<DiscordMessage> {
+    const { files, ...body } = request;
     return (await this.rest.patch(Routes.channelMessage(channelId, messageId), {
-      body: request,
+      body,
+      files: files?.map((file) => ({
+        data: Buffer.from(file.data),
+        name: file.name,
+      })),
     })) as DiscordMessage;
   }
 }

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   type TelegramGrammyBotLike,
   type TelegramPinChatMessageRequest,
   type TelegramSendChatActionRequest,
+  type TelegramSendDocumentRequest,
   type TelegramSendMessageRequest,
   type TelegramSendPhotoRequest,
   type TelegramUnpinChatMessageRequest,
@@ -44,6 +45,12 @@ describe("adaptGrammyBot", () => {
       caption: "image",
       chat_id: 42,
       photo: "https://example.com/image.png",
+    });
+    await bot.api.sendDocument({
+      caption: "file",
+      chat_id: 42,
+      document: new Uint8Array([1, 2, 3]),
+      filename: "streaming-logs.txt",
     });
     await bot.api.answerCallbackQuery({
       callback_query_id: "callback-1",
@@ -100,6 +107,15 @@ describe("adaptGrammyBot", () => {
         caption: "image",
       },
     );
+    expect(grammyBot.api.sendDocument).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        filename: "streaming-logs.txt",
+      }),
+      {
+        caption: "file",
+      },
+    );
     expect(grammyBot.api.answerCallbackQuery).toHaveBeenCalledWith("callback-1", {
       text: "Done",
     });
@@ -119,9 +135,11 @@ function createGrammyBot(): TelegramGrammyBotLike & {
     deleteWebhook: ReturnType<typeof vi.fn>;
     editForumTopic: ReturnType<typeof vi.fn>;
     editMessageText: ReturnType<typeof vi.fn>;
+    getFile: ReturnType<typeof vi.fn>;
     getWebhookInfo: ReturnType<typeof vi.fn>;
     pinChatMessage: ReturnType<typeof vi.fn>;
     sendChatAction: ReturnType<typeof vi.fn>;
+    sendDocument: ReturnType<typeof vi.fn>;
     sendMessage: ReturnType<typeof vi.fn>;
     sendPhoto: ReturnType<typeof vi.fn>;
     setMyCommands: ReturnType<typeof vi.fn>;
@@ -150,6 +168,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
           message_id: messageId,
         }),
       ),
+      getFile: vi.fn(async () => ({ file_path: "documents/file.txt" })),
       getWebhookInfo: vi.fn(async () => ({ url: "" })),
       pinChatMessage: vi.fn(
         async (
@@ -164,6 +183,22 @@ function createGrammyBot(): TelegramGrammyBotLike & {
           _action: TelegramSendChatActionRequest["action"],
           _other?: Omit<TelegramSendChatActionRequest, "chat_id" | "action">,
         ) => true,
+      ),
+      sendDocument: vi.fn(
+        async (
+          chatId: number | string,
+          _document: unknown,
+          _other?: Omit<
+            TelegramSendDocumentRequest,
+            "chat_id" | "document" | "filename"
+          >,
+        ) => ({
+          chat: {
+            id: Number(chatId),
+            type: "private" as const,
+          },
+          message_id: 202,
+        }),
       ),
       sendMessage: vi.fn(
         async (
@@ -182,7 +217,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
         async (
           chatId: number | string,
           _photo: string,
-          _other?: Omit<TelegramSendPhotoRequest, "chat_id" | "photo">,
+          _other?: Omit<TelegramSendPhotoRequest, "chat_id" | "photo" | "filename">,
         ) => ({
           chat: {
             id: Number(chatId),

--- a/packages/messaging/providers/telegram/src/index.ts
+++ b/packages/messaging/providers/telegram/src/index.ts
@@ -10,6 +10,7 @@ export type {
   TelegramPinChatMessageRequest,
   TelegramProviderLogger,
   TelegramSendChatActionRequest,
+  TelegramSendDocumentRequest,
   TelegramSendMessageRequest,
   TelegramSendPhotoRequest,
   TelegramSentMessage,

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1,11 +1,16 @@
 import { createHash } from "node:crypto";
-import { Bot } from "grammy";
+import { Bot, InputFile } from "grammy";
 import type {
   MessagingAdapterState,
+  MessagingAdapterCapabilities,
+  MessagingAttachmentDescriptor,
+  MessagingAttachmentDownloadRequest,
+  MessagingAttachmentDownloadResult,
   MessagingCallbackHandleStore,
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
+  MessagingFilePart,
   MessagingInboundEvent,
   MessagingJsonValue,
   MessagingSurfaceAction,
@@ -36,6 +41,13 @@ type TelegramDeliveryTarget = {
   messageThreadId?: number;
 };
 
+type FetchLike = (url: string) => Promise<{
+  arrayBuffer(): Promise<ArrayBuffer>;
+  ok: boolean;
+  status: number;
+  statusText: string;
+}>;
+
 type TelegramTypingSignal = {
   interval: ReturnType<typeof setInterval>;
   signalId: number;
@@ -62,12 +74,24 @@ export type TelegramChat = {
 };
 
 export type TelegramMessage = {
+  animation?: {
+    file_id: string;
+    file_name?: string;
+    file_size?: number;
+    height?: number;
+    mime_type?: string;
+    width?: number;
+  };
+  caption?: string;
   chat: TelegramChat;
   date?: number;
   document?: {
     file_id: string;
     file_name?: string;
+    file_size?: number;
+    height?: number;
     mime_type?: string;
+    width?: number;
   };
   forum_topic_closed?: Record<string, never>;
   forum_topic_created?: {
@@ -88,6 +112,8 @@ export type TelegramMessage = {
   photo?: Array<{
     file_id: string;
     file_size?: number;
+    height?: number;
+    width?: number;
   }>;
   pinned_message?: TelegramMessage;
   text?: string;
@@ -138,7 +164,18 @@ export type TelegramSendPhotoRequest = {
   chat_id: number | string;
   message_thread_id?: number;
   parse_mode?: "HTML";
-  photo: string;
+  filename?: string;
+  photo: string | Uint8Array;
+  reply_markup?: TelegramInlineKeyboardMarkup;
+};
+
+export type TelegramSendDocumentRequest = {
+  caption?: string;
+  chat_id: number | string;
+  document: string | Uint8Array;
+  filename?: string;
+  message_thread_id?: number;
+  parse_mode?: "HTML";
   reply_markup?: TelegramInlineKeyboardMarkup;
 };
 
@@ -173,8 +210,10 @@ export type TelegramBotApi = {
   editForumTopic(request: TelegramEditForumTopicRequest): Promise<boolean>;
   editMessageText(request: TelegramEditMessageTextRequest): Promise<TelegramSentMessage>;
   getWebhookInfo(): Promise<{ url: string }>;
+  getFile(fileId: string): Promise<{ file_path?: string }>;
   pinChatMessage(request: TelegramPinChatMessageRequest): Promise<boolean>;
   sendChatAction(request: TelegramSendChatActionRequest): Promise<boolean>;
+  sendDocument(request: TelegramSendDocumentRequest): Promise<TelegramSentMessage>;
   sendMessage(request: TelegramSendMessageRequest): Promise<TelegramSentMessage>;
   sendPhoto(request: TelegramSendPhotoRequest): Promise<TelegramSentMessage>;
   setMyCommands(params: {
@@ -214,6 +253,7 @@ export type TelegramGrammyBotLike = {
       other?: Omit<TelegramEditMessageTextRequest, "chat_id" | "message_id" | "text">,
     ): Promise<TelegramSentMessage | boolean>;
     getWebhookInfo(): Promise<{ url: string }>;
+    getFile(fileId: string): Promise<{ file_path?: string }>;
     pinChatMessage(
       chatId: number | string,
       messageId: number,
@@ -229,10 +269,15 @@ export type TelegramGrammyBotLike = {
       text: string,
       other?: Omit<TelegramSendMessageRequest, "chat_id" | "text">,
     ): Promise<TelegramSentMessage>;
+    sendDocument(
+      chatId: number | string,
+      document: InputFile | string,
+      other?: Omit<TelegramSendDocumentRequest, "chat_id" | "document" | "filename">,
+    ): Promise<TelegramSentMessage>;
     sendPhoto(
       chatId: number | string,
-      photo: string,
-      other?: Omit<TelegramSendPhotoRequest, "chat_id" | "photo">,
+      photo: InputFile | string,
+      other?: Omit<TelegramSendPhotoRequest, "chat_id" | "photo" | "filename">,
     ): Promise<TelegramSentMessage>;
     setMyCommands(
       commands: Array<{ command: string; description: string }>,
@@ -251,8 +296,12 @@ export type TelegramGrammyBotLike = {
 
 export type TelegramProviderAdapter = {
   authorizedActorIds: readonly string[];
+  capabilities?: MessagingAdapterCapabilities;
   channel: "telegram";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  downloadAttachment?(
+    request: MessagingAttachmentDownloadRequest,
+  ): Promise<MessagingAttachmentDownloadResult>;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -262,6 +311,19 @@ export type TelegramProviderAdapter = {
 
 export class TelegramAdapter implements TelegramProviderAdapter {
   readonly channel = "telegram" as const;
+  readonly capabilities: MessagingAdapterCapabilities = {
+    inboundAttachments: {
+      maxAttachmentCount: 10,
+      maxDownloadBytes: 20 * 1024 * 1024,
+      supportsDownload: true,
+    },
+    outboundAttachments: {
+      maxUploadBytes: 50 * 1024 * 1024,
+      supportsFileUpload: false,
+      supportsImageUpload: true,
+      supportsRemoteImageUrl: true,
+    },
+  };
 
   private callbackBindings = new Map<string, TelegramCallbackBinding>();
   private defaultBot?: TelegramBotLike;
@@ -270,6 +332,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     api?: TelegramBotApi;
     bot?: TelegramBotLike;
     config: TelegramMessagingConfig;
+    fetch?: FetchLike;
     logger?: TelegramProviderLogger;
     now?: () => number;
     pollOnStart?: boolean;
@@ -330,6 +393,41 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     this.listener = undefined;
   }
 
+  async downloadAttachment(
+    request: MessagingAttachmentDownloadRequest,
+  ): Promise<MessagingAttachmentDownloadResult> {
+    const opaque = request.attachment.state?.opaque;
+    if (!opaque || typeof opaque !== "object" || Array.isArray(opaque)) {
+      throw new Error("Telegram attachment download state is missing.");
+    }
+    const fileId = opaque.fileId;
+    if (typeof fileId !== "string" || !fileId) {
+      throw new Error("Telegram attachment file id is missing.");
+    }
+    const file = await this.bot.api.getFile(fileId);
+    if (!file.file_path) {
+      throw new Error("Telegram did not return a downloadable file path.");
+    }
+    const response = await this.fetch(
+      `https://api.telegram.org/file/bot${this.options.config.botToken}/${file.file_path}`,
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Telegram attachment download failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data = new Uint8Array(await response.arrayBuffer());
+    if (data.byteLength > request.maxBytes) {
+      throw new Error("Telegram attachment exceeds the configured download limit.");
+    }
+    return {
+      data,
+      fileName: request.attachment.name,
+      mimeType: request.attachment.mimeType,
+      sizeBytes: data.byteLength,
+    };
+  }
+
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
     const target = this.resolveTarget(intent);
     if (!target) {
@@ -368,18 +466,20 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     const actions = actionsForTelegramIntent(intent);
     const replyMarkup = await this.buildReplyMarkup(intent, actions);
-    const text = textForTelegramIntent(intent);
-    const image = this.firstImageUrl(intent);
+    const files = uploadableFileParts(intent);
+    const text = files.length > 0 ? textForTelegramIntentWithoutFiles(intent) : textForTelegramIntent(intent);
+    const image = this.firstImagePayload(intent);
     const sentMessages: TelegramSentMessage[] = [];
     let outcome: MessagingDeliveryResult["outcome"] = "presented";
     this.options.logger?.debug(
-      `telegram deliver begin kind=${intent.kind} mode=${intent.delivery?.mode ?? "new"} target=${this.compactTypingTarget(target)} chars=${text.length} actions=${actions.length} image=${Boolean(image)} preview="${compactPreview(text)}"`,
+      `telegram deliver begin kind=${intent.kind} mode=${intent.delivery?.mode ?? "new"} target=${this.compactTypingTarget(target)} chars=${text.length} actions=${actions.length} image=${Boolean(image)} files=${files.length} preview="${compactPreview(text)}"`,
     );
 
     if (
       intent.delivery?.mode === "update" &&
       target.messageId &&
       !image &&
+      files.length === 0 &&
       Buffer.byteLength(text || " ", "utf8") <= 4096
     ) {
       try {
@@ -411,6 +511,37 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         );
         outcome = "presented_new";
       }
+    } else if (files.length > 0) {
+      const caption = text && Buffer.byteLength(text, "utf8") <= 1024 ? text : undefined;
+      if (text && !caption) {
+        const chunks = splitTelegramHtml(text);
+        for (const chunk of chunks) {
+          sentMessages.push(
+            await this.bot.api.sendMessage({
+              chat_id: target.chatId,
+              disable_web_page_preview: true,
+              message_thread_id: target.messageThreadId,
+              parse_mode: "HTML",
+              text: chunk,
+            }),
+          );
+        }
+      }
+
+      const lastFileIndex = files.length - 1;
+      for (const [index, file] of files.entries()) {
+        sentMessages.push(
+          await this.bot.api.sendDocument({
+            caption: index === 0 ? caption : undefined,
+            chat_id: target.chatId,
+            document: file.url ?? file.data!,
+            filename: file.name,
+            message_thread_id: target.messageThreadId,
+            parse_mode: caption && index === 0 ? "HTML" : undefined,
+            reply_markup: index === lastFileIndex ? replyMarkup : undefined,
+          }),
+        );
+      }
     } else if (image) {
       sentMessages.push(
         await this.bot.api.sendPhoto({
@@ -418,7 +549,8 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           chat_id: target.chatId,
           message_thread_id: target.messageThreadId,
           parse_mode: text ? "HTML" : undefined,
-          photo: image,
+          filename: image.filename,
+          photo: image.source,
           reply_markup: replyMarkup,
         }),
       );
@@ -553,28 +685,35 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       return;
     }
 
-    if (!message.text) {
+    const attachments = this.attachmentsFromMessage(message);
+    if (attachments.length > 0) {
       await listener({
         id: `telegram:update:${updateId}:message:${message.message_id}`,
         kind: "media",
         actor: this.actorFromUser(message.from),
+        attachments,
         channel: this.channelFromMessage(message),
-        disposition: "unsupported",
+        disposition: attachments.some((attachment) => attachment.disposition === "available")
+          ? "available"
+          : "unsupported",
         media: {
           type: "file",
-          name:
-            message.document?.file_name ??
-            message.voice?.mime_type ??
-            message.video?.mime_type ??
-            "telegram-media",
+          name: attachments[0]?.name ?? "telegram-media",
           mimeType:
             message.document?.mime_type ??
+            message.animation?.mime_type ??
             message.voice?.mime_type ??
             message.video?.mime_type,
+          sizeBytes: attachments[0]?.sizeBytes,
         },
         receivedAt: this.messageReceivedAt(message),
         routingState: this.routingStateFromMessage(message),
+        text: message.caption,
       });
+      return;
+    }
+
+    if (!message.text) {
       return;
     }
 
@@ -650,6 +789,128 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       receivedAt: this.now(),
       routingState: this.routingStateFromMessage(message),
     });
+  }
+
+  private attachmentsFromMessage(message: TelegramMessage): MessagingAttachmentDescriptor[] {
+    const attachments: MessagingAttachmentDescriptor[] = [];
+    if (message.document) {
+      const mimeType = message.document.mime_type;
+      const image = mimeType?.startsWith("image/");
+      attachments.push({
+        id: `telegram:file:${message.document.file_id}`,
+        kind: image ? "image" : "file",
+        name: message.document.file_name ?? "telegram-document",
+        disposition: this.isDownloadableTelegramMimeType(mimeType) ? "available" : "rejected",
+        height: message.document.height,
+        mimeType,
+        reason: this.isDownloadableTelegramMimeType(mimeType)
+          ? undefined
+          : "unsupported attachment type",
+        sizeBytes: message.document.file_size,
+        state: {
+          opaque: {
+            fileId: message.document.file_id,
+            provider: "telegram",
+          },
+        },
+        width: message.document.width,
+      });
+    }
+
+    if (message.photo && message.photo.length > 0) {
+      const photo = [...message.photo].sort(
+        (left, right) => (right.file_size ?? 0) - (left.file_size ?? 0),
+      )[0]!;
+      attachments.push({
+        id: `telegram:photo:${photo.file_id}`,
+        kind: "image",
+        name: "telegram-photo.jpg",
+        disposition: "available",
+        height: photo.height,
+        mimeType: "image/jpeg",
+        sizeBytes: photo.file_size,
+        state: {
+          opaque: {
+            fileId: photo.file_id,
+            provider: "telegram",
+          },
+        },
+        width: photo.width,
+      });
+    }
+
+    if (message.animation) {
+      attachments.push({
+        id: `telegram:animation:${message.animation.file_id}`,
+        kind: "gif",
+        name: message.animation.file_name ?? "telegram-animation.gif",
+        disposition: "available",
+        height: message.animation.height,
+        mimeType: message.animation.mime_type ?? "image/gif",
+        sizeBytes: message.animation.file_size,
+        state: {
+          opaque: {
+            fileId: message.animation.file_id,
+            provider: "telegram",
+          },
+        },
+        width: message.animation.width,
+      });
+    }
+
+    if (message.voice) {
+      attachments.push({
+        id: `telegram:voice:${message.voice.file_id}`,
+        kind: "audio",
+        name: message.voice.mime_type ?? "telegram-voice",
+        disposition: "unsupported",
+        mimeType: message.voice.mime_type,
+        reason: "audio attachments are not supported",
+        state: {
+          opaque: {
+            fileId: message.voice.file_id,
+            provider: "telegram",
+          },
+        },
+      });
+    }
+
+    if (message.video) {
+      attachments.push({
+        id: `telegram:video:${message.video.file_id}`,
+        kind: "video",
+        name: message.video.mime_type ?? "telegram-video",
+        disposition: "unsupported",
+        mimeType: message.video.mime_type,
+        reason: "video attachments are not supported",
+        state: {
+          opaque: {
+            fileId: message.video.file_id,
+            provider: "telegram",
+          },
+        },
+      });
+    }
+
+    return attachments;
+  }
+
+  private isDownloadableTelegramMimeType(mimeType: string | undefined): boolean {
+    if (!mimeType) {
+      return true;
+    }
+    return (
+      mimeType.startsWith("text/") ||
+      mimeType.startsWith("image/") ||
+      [
+        "application/json",
+        "application/pdf",
+        "application/toml",
+        "application/x-yaml",
+        "application/yaml",
+        "text/csv",
+      ].includes(mimeType)
+    );
   }
 
   private async buildReplyMarkup(
@@ -769,12 +1030,24 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     };
   }
 
-  private firstImageUrl(intent: MessagingSurfaceIntent): string | undefined {
+  private firstImagePayload(
+    intent: MessagingSurfaceIntent,
+  ): { filename?: string; source: string | Uint8Array } | undefined {
     if (intent.kind !== "message") {
       return undefined;
     }
 
-    return intent.parts.find((part) => part.type === "image" && "url" in part)?.url;
+    const url = intent.parts.find((part) => part.type === "image" && "url" in part)?.url;
+    if (!url) {
+      return undefined;
+    }
+
+    const dataImage = parseDataImageUrl(url);
+    if (dataImage) {
+      return dataImage;
+    }
+
+    return { source: url };
   }
 
   private async deliverActivity(
@@ -1052,6 +1325,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return this.options.now?.() ?? Date.now();
   }
 
+  private get fetch(): FetchLike {
+    return this.options.fetch ?? fetch;
+  }
+
 }
 
 export function createTelegramAdapter(
@@ -1064,6 +1341,51 @@ export function createTelegramAdapter(
     logger,
     store,
   });
+}
+
+function uploadableFileParts(intent: MessagingSurfaceIntent): MessagingFilePart[] {
+  if (intent.kind !== "message") {
+    return [];
+  }
+
+  return intent.parts.filter(
+    (part): part is MessagingFilePart =>
+      part.type === "file" && (part.data !== undefined || Boolean(part.url)),
+  );
+}
+
+function textForTelegramIntentWithoutFiles(intent: MessagingSurfaceIntent): string {
+  if (intent.kind !== "message") {
+    return textForTelegramIntent(intent);
+  }
+
+  return textForTelegramIntent({
+    ...intent,
+    parts: intent.parts.filter((part) => part.type !== "file"),
+  });
+}
+
+function parseDataImageUrl(
+  url: string,
+): { filename: string; source: Uint8Array } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=]+)$/i.exec(url);
+  if (!match) {
+    return undefined;
+  }
+
+  const mimeType = match[1]?.toLowerCase();
+  const extension =
+    mimeType === "image/jpeg"
+      ? "jpg"
+      : mimeType === "image/png"
+        ? "png"
+        : mimeType === "image/gif"
+          ? "gif"
+          : "img";
+  return {
+    filename: `assistant-image.${extension}`,
+    source: new Uint8Array(Buffer.from(match[2] ?? "", "base64")),
+  };
 }
 
 export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
@@ -1090,6 +1412,7 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         );
       },
       getWebhookInfo: async () => await bot.api.getWebhookInfo(),
+      getFile: async (fileId) => await bot.api.getFile(fileId),
       pinChatMessage: async (request) => {
         const { chat_id, message_id, ...other } = request;
         return await bot.api.pinChatMessage(chat_id, message_id, other);
@@ -1102,9 +1425,19 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         const { chat_id, text, ...other } = request;
         return await bot.api.sendMessage(chat_id, text, other);
       },
+      sendDocument: async (request) => {
+        const { chat_id, document, filename, ...other } = request;
+        const upload =
+          typeof document === "string"
+            ? document
+            : new InputFile(Buffer.from(document), filename);
+        return await bot.api.sendDocument(chat_id, upload, other);
+      },
       sendPhoto: async (request) => {
-        const { chat_id, photo, ...other } = request;
-        return await bot.api.sendPhoto(chat_id, photo, other);
+        const { chat_id, filename, photo, ...other } = request;
+        const upload =
+          typeof photo === "string" ? photo : new InputFile(Buffer.from(photo), filename);
+        return await bot.api.sendPhoto(chat_id, upload, other);
       },
       setMyCommands: async (params) =>
         await bot.api.setMyCommands(params.commands),

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -29,6 +29,11 @@ describe("desktop settings contracts", () => {
           value: "show_some",
           source: "default",
         },
+        attachments: {
+          imageProfile: { value: "medium", source: "default" },
+          maxAttachmentBytes: { value: 10485760, source: "default" },
+          maxAttachmentCount: { value: 4, source: "default" },
+        },
         telegram: {
           enabled: { value: true, source: "config" },
           botToken: {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -163,6 +163,7 @@ export type MessagingImagePart = AppServerThreadImagePart & {
 export type MessagingFilePart = {
   type: "file";
   name: string;
+  data?: Uint8Array;
   url?: string;
   mimeType?: string;
   sizeBytes?: number;
@@ -402,10 +403,40 @@ export type MessagingInboundCallbackEvent = MessagingInboundBaseEvent & {
   value?: MessagingJsonValue;
 };
 
+export type MessagingAttachmentDisposition =
+  | "available"
+  | "rejected"
+  | "unsupported";
+
+export type MessagingAttachmentKind =
+  | "file"
+  | "image"
+  | "gif"
+  | "audio"
+  | "video"
+  | "unknown";
+
+export type MessagingAttachmentDescriptor = {
+  id: string;
+  kind: MessagingAttachmentKind;
+  name: string;
+  disposition: MessagingAttachmentDisposition;
+  description?: string;
+  height?: number;
+  mimeType?: string;
+  reason?: string;
+  sizeBytes?: number;
+  state?: MessagingAdapterState;
+  url?: string;
+  width?: number;
+};
+
 export type MessagingInboundMediaEvent = MessagingInboundBaseEvent & {
   kind: "media";
-  media: MessagingFilePart | AppServerThreadMessagePart;
-  disposition: "unsupported";
+  attachments: MessagingAttachmentDescriptor[];
+  disposition: MessagingAttachmentDisposition;
+  media?: MessagingFilePart | AppServerThreadMessagePart;
+  text?: string;
 };
 
 export type MessagingInboundLifecycleEvent = MessagingInboundBaseEvent & {
@@ -531,4 +562,30 @@ export type MessagingCallbackHandleRecord = {
   surface?: MessagingSurfaceRef;
   updatedAt: number;
   value?: MessagingJsonValue;
+};
+
+export type MessagingAttachmentDownloadRequest = {
+  attachment: MessagingAttachmentDescriptor;
+  maxBytes: number;
+};
+
+export type MessagingAttachmentDownloadResult = {
+  data: Uint8Array;
+  fileName: string;
+  mimeType?: string;
+  sizeBytes: number;
+};
+
+export type MessagingAdapterCapabilities = {
+  inboundAttachments?: {
+    maxAttachmentCount?: number;
+    maxDownloadBytes?: number;
+    supportsDownload: boolean;
+  };
+  outboundAttachments?: {
+    maxUploadBytes?: number;
+    supportsFileUpload: boolean;
+    supportsImageUpload: boolean;
+    supportsRemoteImageUrl: boolean;
+  };
 };

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -44,6 +44,14 @@ export type DesktopSettingsSecretStorageState = {
   unavailableReason?: string;
 };
 
+export type DesktopMessagingImageProfile = "low" | "medium" | "high" | "actual";
+
+export type DesktopMessagingAttachmentSettingsSnapshot = {
+  imageProfile: DesktopSettingsValue<DesktopMessagingImageProfile>;
+  maxAttachmentBytes: DesktopSettingsValue<number>;
+  maxAttachmentCount: DesktopSettingsValue<number>;
+};
+
 export type DesktopCodexCandidateSource =
   | "env"
   | "config"
@@ -105,6 +113,7 @@ export type DesktopSettingsSnapshot = {
   };
   messaging: {
     toolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
+    attachments: DesktopMessagingAttachmentSettingsSnapshot;
     telegram: {
       enabled: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
@@ -137,6 +146,11 @@ export type DesktopSettingsConfigPatch = {
   };
   messaging?: {
     toolUpdateMode?: MessagingToolUpdateMode;
+    attachments?: {
+      imageProfile?: DesktopMessagingImageProfile;
+      maxAttachmentBytes?: number;
+      maxAttachmentCount?: number;
+    };
     telegram?: {
       enabled?: boolean;
       authorizedUserIds?: string[];


### PR DESCRIPTION
## Summary

I added first-class attachment handling to the generic messaging surface so Telegram and Discord can accept supported incoming attachments and deliver assistant response files/images through provider-native paths.

## What changed

- Added generic attachment descriptors, provider capability hints, and bounded adapter download support.
- Added shared image quality profiles (`low`, `medium`, `high`, `actual`) and messaging attachment policy settings/env overrides.
- Added main-process attachment classification, text extraction, image/GIF still normalization, caps, and rejection summaries.
- Routed accepted media events through `MessagingController` so bound conversations can start turns from text files, images, GIF stills, and mixed text-plus-attachment messages.
- Added Telegram and Discord provider support for inbound attachment metadata/downloads and outbound file/image delivery.
- Updated messaging docs and marked the attachment implementation plan complete.

## Verification

I verified this with:

- `pnpm test -- apps/desktop/src/main/__tests__/messaging-attachment-mime.test.ts apps/desktop/src/main/__tests__/messaging-attachment-processor.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`

The targeted test command ran the workspace and passed with `128 passed | 1 skipped` test files.
