### PR TITLE
fix(desktop): workspace launchpad directory grouping

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1291,6 +1291,46 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("materializes Grok workspace launchpads into a scratch directory", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      createScratchProjectDirectory: async () => "/Users/test/.pwragnt/projects/2026-05-02-d4e5f6",
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "workspace:/Users/test/.pwragnt/projects",
+      launchpad: {
+        directoryKey: "workspace:/Users/test/.pwragnt/projects",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        directoryPath: "/Users/test/.pwragnt/projects",
+        backend: "grok",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        model: "grok-4.20-reasoning",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(grokClient.lastStartThreadParams?.cwd).toBe(
+      "/Users/test/.pwragnt/projects/2026-05-02-d4e5f6",
+    );
+
+    await registry.close();
+  });
+
   it("applies model settings from the selected thread overlay when starting turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1250,6 +1250,47 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("materializes workspace launchpads into a scratch directory instead of the workspace root", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      createScratchProjectDirectory: async () => "/Users/test/.pwragnt/projects/2026-05-02-a1b2c3",
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "workspace:/Users/test/.pwragnt/projects",
+      launchpad: {
+        directoryKey: "workspace:/Users/test/.pwragnt/projects",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        directoryPath: "/Users/test/.pwragnt/projects",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(codexClient.lastStartThreadParams?.cwd).toBe(
+      "/Users/test/.pwragnt/projects/2026-05-02-a1b2c3",
+    );
+
+    await registry.close();
+  });
+
   it("applies model settings from the selected thread overlay when starting turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -40,6 +40,7 @@ describe("GitDirectoryService", () => {
 
     await expect(
       service.prepareLaunchpadWorkspace({
+        directoryKind: "directory",
         directoryLabel: "FixtureRepo",
         directoryPath: repoDir,
         workMode: "local",
@@ -91,6 +92,7 @@ describe("GitDirectoryService", () => {
     const releaseRevision = runGit(repoDir, ["rev-parse", "release"]);
 
     const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
       directoryLabel: "FixtureRepo",
       directoryPath: repoDir,
       workMode: "worktree",
@@ -107,5 +109,21 @@ describe("GitDirectoryService", () => {
       .split("\n")
       .filter(Boolean);
     expect(branchesAfter).toEqual(branchesBefore);
+  });
+
+  it("does not use the workspace root as the cwd for workspace launchpads", async () => {
+    const service = new GitDirectoryService();
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+        directoryPath: "/Users/test/.pwragnt/projects",
+        workMode: "local",
+      }),
+    ).resolves.toEqual({
+      cwd: undefined,
+      workMode: "local",
+    });
   });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1935,7 +1935,15 @@ export class DesktopBackendRegistry {
       throw new Error(`No launchpad found for ${request.directoryKey}`);
     }
 
-    const workspace = await this.gitDirectoryService.prepareLaunchpadWorkspace(launchpad);
+    const preparedWorkspace =
+      await this.gitDirectoryService.prepareLaunchpadWorkspace(launchpad);
+    const workspace =
+      launchpad.directoryKind === "workspace" && !preparedWorkspace.cwd
+        ? {
+            ...preparedWorkspace,
+            cwd: await this.createScratchProjectDirectory(),
+          }
+        : preparedWorkspace;
     const startThreadResponse = await this.startThread({
       backend: launchpad.backend,
       executionMode: launchpad.executionMode,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -290,9 +290,16 @@ export class GitDirectoryService {
   async prepareLaunchpadWorkspace(
     launchpad: Pick<
       NavigationLaunchpadDraft,
-      "branchName" | "directoryLabel" | "directoryPath" | "workMode"
+      "branchName" | "directoryKind" | "directoryLabel" | "directoryPath" | "workMode"
     >,
   ): Promise<{ cwd?: string; workMode: LaunchpadWorkMode }> {
+    if (launchpad.directoryKind === "workspace") {
+      return {
+        cwd: undefined,
+        workMode: "local",
+      };
+    }
+
     const directoryPath = launchpad.directoryPath?.trim();
     if (!directoryPath) {
       return {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -233,6 +233,45 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("groups the scratch workspace root under Workspaces instead of a projects directory", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragnt/projects",
+              label: "projects",
+              path: "/Users/huntharo/.pwragnt/projects",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-2",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragnt/projects/2026-05-02-a1b2c3",
+              label: "2026-05-02-a1b2c3",
+              path: "/Users/huntharo/.pwragnt/projects/2026-05-02-a1b2c3",
+              kind: "local",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "workspace:/Users/huntharo/.pwragnt/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/huntharo/.pwragnt/projects",
+        threadKeys: ["codex:thread-1", "codex:thread-2"],
+      }),
+    ]);
+  });
+
   it("keeps same-named Codex worktrees as separate directory rows", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -53,6 +53,18 @@ function pathFromDirectoryKey(directoryKey: string): string | undefined {
 }
 
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
+  const scratchWorkspaceRootMatch = directory.path.match(
+    /^(.*[\\/]\.pwragnt[\\/]projects)$/,
+  );
+  if (scratchWorkspaceRootMatch) {
+    return {
+      key: `workspace:${scratchWorkspaceRootMatch[1]}`,
+      kind: "workspace",
+      label: "Workspaces",
+      path: scratchWorkspaceRootMatch[1],
+    };
+  }
+
   const scratchWorkspaceMatch = directory.path.match(
     /^(.*[\\/]\.pwragnt[\\/]projects)[\\/][^\\/]+$/,
   );


### PR DESCRIPTION
## Summary

I fixed workspace launchpad threads so they no longer get grouped under a separate `projects` directory when the thread is started from Workspaces.

The bug was that a workspace launchpad could materialize with `cwd` set to the scratch workspace parent, `~/.pwragnt/projects`. That made Codex persist the thread against the parent folder, and the directory classifier treated that parent as an ordinary directory named `projects`. I changed workspace launchpad materialization to omit the parent `cwd`, allowing the normal scratch-project creation path to supply a per-thread child directory. I also taught directory grouping to classify the scratch workspace root itself as `Workspaces`, so already-created records with that parent path render in the right bucket.

## Verification

I verified this with:

- `pnpm exec vitest run --config vitest.workspace.ts --project agent-core packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
