### PR TITLE
chore(tests): add nice test runner scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "pnpm typecheck && pnpm lint:boundaries",
     "lint:boundaries": "depcruise --config .dependency-cruiser.cjs apps/desktop/src/main/messaging packages/messaging",
     "test:desktop-e2e": "pnpm --filter @pwragnt/desktop build && pnpm --filter @pwragnt/desktop test:e2e",
+    "test:desktop-e2e:nice": "node ./scripts/nice-run.mjs pnpm test:desktop-e2e",
     "test": "vitest run --config vitest.workspace.ts",
+    "test:nice": "node ./scripts/nice-run.mjs pnpm test",
     "test:watch": "vitest --config vitest.workspace.ts",
     "typecheck": "pnpm -r --if-present typecheck"
   },

--- a/scripts/nice-run.mjs
+++ b/scripts/nice-run.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { setPriority } from "node:os";
+
+const NICE_LEVEL = 19;
+const POSIX_PLATFORMS = new Set(["darwin", "linux"]);
+
+function usage() {
+  process.stderr.write(
+    [
+      "Usage:",
+      "  node scripts/nice-run.mjs <command> [args...]",
+      "",
+      "Runs the command at niceness 19 on macOS/Linux and as-is on other platforms.",
+      "",
+    ].join("\n"),
+  );
+}
+
+function applyNiceness(platform) {
+  if (!POSIX_PLATFORMS.has(platform)) {
+    return;
+  }
+
+  try {
+    setPriority(NICE_LEVEL);
+  } catch (error) {
+    process.stderr.write(
+      `Unable to set process niceness to ${NICE_LEVEL}; running without priority adjustment. ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+  }
+}
+
+function run(argv = process.argv.slice(2), platform = process.platform) {
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    usage();
+    return argv.length === 0 ? 2 : 0;
+  }
+
+  applyNiceness(platform);
+
+  const [command, ...args] = argv;
+
+  const child = spawn(command, args, {
+    shell: platform === "win32",
+    stdio: "inherit",
+    windowsHide: false,
+  });
+
+  child.on("error", (error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 1);
+  });
+
+  return undefined;
+}
+
+const result = run();
+if (typeof result === "number") {
+  process.exit(result);
+}


### PR DESCRIPTION
## Summary

Adds a small test command wrapper that tries to lower process scheduling priority before launching expensive test runs.

## What changed

- Added `scripts/nice-run.mjs`, which applies niceness `19` on macOS/Linux before spawning the requested command.
- Kept Windows behavior as a passthrough so the scripts remain portable.
- Added `pnpm test:nice` and `pnpm test:desktop-e2e:nice` without changing test worker counts or lane concurrency.

## Validation

- `node --check scripts/nice-run.mjs`
- `node scripts/nice-run.mjs node -e 'process.exit(7)'`
- `pnpm test:nice`

After installing dependencies with `pnpm install --frozen-lockfile`, `pnpm test:nice` ran the full Vitest workspace: 130 test files, 926 tests. It finished with one existing failing test in `apps/desktop/src/main/__tests__/index.test.ts` (`bootstrapApp > awaits startup CPU profiling before creating the first window`), with 128 files passing and 1 skipped.
