### PR TITLE
fix(desktop): keep review autocomplete open on exact match

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1009,13 +1009,9 @@ export function Composer(props: ComposerProps) {
     autocompleteKey && autocompleteKey === dismissedAutocompleteKey
       ? undefined
       : availableAutocompleteKind;
-  const autocompleteKind: AutocompleteKind | undefined =
-    reviewConfig ||
-    (displayedAutocompleteKind === "slash" &&
-      parseReviewCommand(draft) &&
-      draft.trim() === "/review")
-      ? undefined
-      : displayedAutocompleteKind;
+  const autocompleteKind: AutocompleteKind | undefined = reviewConfig
+    ? undefined
+    : displayedAutocompleteKind;
   const hasAutocomplete = Boolean(autocompleteKind);
   const activeAutocompleteIndex =
     autocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1311,7 +1311,7 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "/review" } });
 
-    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
@@ -1415,6 +1415,42 @@ describe("Composer", () => {
     expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
+  });
+
+  it("keeps slash review autocomplete open for the exact command text", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/revie" } });
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: "/review" } });
+
+    const commands = screen.getByRole("listbox", { name: "Commands" });
+    expect(commands).toBeInTheDocument();
+    expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
   });
 
   it("opens review composer from the focused slash command option", async () => {


### PR DESCRIPTION
## Summary

This fixes the desktop slash-command autocomplete regression where typing the final `w` in `/review` closed the command picker before the user could commit the command.

The composer now keeps exact slash-command matches visible unless the review target composer is already open. Pressing Enter on `/review`, clicking the command suggestion, or using the Send button still enters the existing review target flow, while the autocomplete stays stable during normal typing.

## Testing

- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-renderer apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
