### PR TITLE
fix(desktop): preserve composer drafts across navigation

### DIFF
--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -1,0 +1,299 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createComposerDraftPersistenceFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-composer-drafts-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const fixturePath = path.join(rootDir, "composer-draft-persistence.fixture.json");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgnt Tests",
+      "-c",
+      "user.email=pwragnt-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const existingThread = {
+    id: "thread-existing",
+    title: "Existing draft parking thread",
+    titleSource: "explicit",
+    summary: "Existing thread for draft preservation",
+    source: "codex",
+    executionMode: "default",
+    linkedDirectories: [
+      {
+        id: "fixture-repo",
+        label: "FixtureRepo",
+        path: repoDir,
+        kind: "local",
+      },
+    ],
+    updatedAt: 2_000,
+  };
+  const threadReadResult = {
+    entries: [
+      {
+        type: "message",
+        id: "existing-message-1",
+        role: "assistant",
+        text: "Existing thread is ready.",
+      },
+    ],
+    messages: [
+      {
+        id: "existing-message-1",
+        role: "assistant",
+        text: "Existing thread is ready.",
+      },
+    ],
+    lastAssistantMessage: "Existing thread is ready.",
+    pagination: {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    },
+  };
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "composer-draft-persistence-regression",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: ["thread/list", "thread/read", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [existingThread],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: threadReadResult,
+          },
+          {
+            id: "turn-completed-refresh",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-existing",
+                turnId: "turn-refresh",
+                turn: {
+                  id: "turn-refresh",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-list-refresh",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                ...existingThread,
+                updatedAt: 3_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: threadReadResult,
+          },
+          {
+            id: "thread-read-3",
+            kind: "response",
+            method: "thread/read",
+            result: threadReadResult,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    repoDir,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElectronApp>>) {
+  await app.window.getByRole("button", { name: "directories" }).click();
+  await app.window
+    .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+    .click();
+
+  await expect(
+    app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+  ).toBeVisible();
+}
+
+async function openExistingThread(app: Awaited<ReturnType<typeof launchElectronApp>>) {
+  await app.window
+    .getByRole("button", { name: /Existing draft parking thread/i })
+    .first()
+    .click();
+  await expect(
+    app.window.getByRole("heading", {
+      level: 2,
+      name: "Existing draft parking thread",
+    }),
+  ).toBeVisible();
+}
+
+async function pasteDelayedImage(page: Page, params: {
+  accessibleName: "New thread" | "Reply";
+  filename: string;
+  label: string;
+}): Promise<void> {
+  await page.evaluate(async ({ accessibleName, filename, label }) => {
+    const textbox = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="textbox"]'),
+    ).find((element) => element.getAttribute("aria-label") === accessibleName);
+    if (!textbox) {
+      throw new Error(`${accessibleName} Tiptap textbox not found`);
+    }
+
+    const originalToBlob = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.toBlob = function delayedToBlob(callback, type, quality) {
+      window.setTimeout(() => {
+        originalToBlob.call(this, callback, type, quality);
+      }, 500);
+    };
+
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1600;
+      canvas.height = 900;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Canvas context not available");
+      }
+      context.fillStyle = "#245b55";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.fillStyle = "#f8fafc";
+      context.font = "96px sans-serif";
+      context.fillText(label, 96, 180);
+
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        originalToBlob.call(
+          canvas,
+          (value) => {
+            if (!value) {
+              reject(new Error("Could not create PNG blob"));
+              return;
+            }
+            resolve(value);
+          },
+          "image/png",
+        );
+      });
+      const file = new File([blob], filename, { type: "image/png" });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      textbox.dispatchEvent(
+        new ClipboardEvent("paste", {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dataTransfer,
+        }),
+      );
+    } finally {
+      HTMLCanvasElement.prototype.toBlob = originalToBlob;
+    }
+  }, params);
+}
+
+test("keeps Tiptap launchpad and reply drafts with pasted images across switching and refresh", async () => {
+  const fixture = await createComposerDraftPersistenceFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-chips",
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const launchpadDraft = "Launchpad draft text before refresh";
+    const replyDraft = "Reply draft text before refresh";
+
+    await openDirectoryLaunchpad(app);
+    let tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "New thread" }).fill(launchpadDraft);
+    await expect(tiptapInput).toHaveAttribute("data-value", launchpadDraft);
+    await pasteDelayedImage(app.window, {
+      accessibleName: "New thread",
+      filename: "launchpad-draft.png",
+      label: "launchpad draft",
+    });
+
+    await openExistingThread(app);
+    tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).fill(replyDraft);
+    await expect(tiptapInput).toHaveAttribute("data-value", replyDraft);
+    await pasteDelayedImage(app.window, {
+      accessibleName: "Reply",
+      filename: "reply-draft.png",
+      label: "reply draft",
+    });
+
+    await app.advance({ stepId: "turn-completed-refresh" });
+    await app.window.waitForTimeout(700);
+
+    await openDirectoryLaunchpad(app);
+    tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await expect(tiptapInput).toHaveAttribute("data-value", launchpadDraft);
+    await expect(app.window.getByLabel("Pasted images")).toHaveCount(1);
+    await expect(app.window.getByAltText("launchpad-draft.png")).toBeVisible();
+
+    await openExistingThread(app);
+    tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await expect(tiptapInput).toHaveAttribute("data-value", replyDraft);
+    await expect(app.window.getByLabel("Pasted images")).toHaveCount(1);
+    await expect(app.window.getByAltText("reply-draft.png")).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import {
   type DesktopSettingsState,
 } from "./features/settings/useDesktopSettings";
 import { ThreadView } from "./features/thread-detail/ThreadView";
+import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
@@ -51,6 +52,7 @@ function DesktopAppShell(props: {
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
+  const composerDraftStore = useComposerDraftStore();
   const session = useThreadSessionState({
     desktopApi,
     thread: navigation.selectedThread,
@@ -143,6 +145,7 @@ function DesktopAppShell(props: {
             )
           }
           composerImplementation={settings.composerImplementation}
+          composerDraftStore={composerDraftStore}
           desktopApi={desktopApi}
           launchpadError={navigation.launchpadError}
           loading={session.loading}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2492,14 +2492,22 @@ export function Composer(props: ComposerProps) {
     token: ComposerSkillToken,
     selectionStart: number,
   ): void => {
+    const nextSkillTokens = skillTokens.filter(
+      (candidate) => candidate.id !== token.id
+    );
     deletedSkillTokenHistoryRef.current.push({
       draft,
       selectionStart,
       skillTokens,
     });
-    setSkillTokens((current) =>
-      current.filter((candidate) => candidate.id !== token.id)
-    );
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+    });
+    saveComposerDraftSnapshot(composerScopeKey, {
+      draft,
+      imageAttachments,
+      skillTokens: nextSkillTokens,
+    });
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(selectionStart, selectionStart);
@@ -2886,6 +2894,17 @@ export function Composer(props: ComposerProps) {
     }
 
     if (restoreDeletedSkillToken(event)) {
+      return;
+    }
+
+    if (
+      event.key === "Backspace" &&
+      deleteEditorContent(event, "backward")
+    ) {
+      return;
+    }
+
+    if (event.key === "Delete" && deleteEditorContent(event, "forward")) {
       return;
     }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -48,6 +48,11 @@ import {
 } from "./ComposerRichInput";
 import { ComposerTextareaInput } from "./ComposerTextareaInput";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
+import {
+  useComposerDraftStore,
+  type ComposerDraftSnapshot,
+  type ComposerDraftStore,
+} from "./useComposerDraftStore";
 
 type ComposerProps = {
   activeTurnId?: string;
@@ -63,6 +68,7 @@ type ComposerProps = {
   disabled?: boolean;
   contextWindow?: ThreadContextWindowState;
   composerImplementation?: DesktopChatReplyComposer;
+  draftStore?: ComposerDraftStore;
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
   onActiveTurnIdChange?: (turnId?: string) => void;
@@ -198,12 +204,6 @@ type ReviewConfigState = {
   target?: ReviewTargetChoice;
 };
 
-type ComposerDraftState = {
-  draft: string;
-  imageAttachments: ComposerImageAttachment[];
-  skillTokens: ComposerSkillToken[];
-};
-
 const DEFAULT_REASONING_EFFORT = "medium";
 
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
@@ -288,6 +288,12 @@ function buildReviewBranchOptions(params: {
     }
   }
   return [...options];
+}
+
+function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined {
+  return scopeKey.startsWith("launchpad:")
+    ? scopeKey.slice("launchpad:".length)
+    : undefined;
 }
 
 function createReviewConfig(params: {
@@ -820,11 +826,40 @@ export function Composer(props: ComposerProps) {
     : props.thread
       ? `thread:${props.thread.source}:${props.thread.id}`
       : "empty";
+  const localDraftStore = useComposerDraftStore();
+  const draftStore = props.draftStore ?? localDraftStore;
+  const composerImplementation = props.composerImplementation ?? "textarea";
+  const composerSupportsSkillTokens = composerImplementation !== "textarea";
+  const composerUsesTiptap = composerImplementation.startsWith("tiptap-");
+  const savedInitialDraft = draftStore.get(composerScopeKey);
+  const hydratedInitialLaunchpad =
+    savedInitialDraft || !props.launchpad
+      ? undefined
+      : hydrateComposerDraft(props.launchpad.prompt ?? "", props.skills);
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
-  const scopedThreadDraftsRef = useRef(new Map<string, ComposerDraftState>());
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
-  const [draft, setDraft] = useState("");
+  const latestDraftSnapshotRef = useRef<{
+    scopeKey: string;
+    snapshot: ComposerDraftSnapshot;
+  }>({
+    scopeKey: composerScopeKey,
+    snapshot: {
+      draft: savedInitialDraft?.draft ?? hydratedInitialLaunchpad?.draft ?? "",
+      imageAttachments:
+        savedInitialDraft?.imageAttachments ??
+        props.launchpad?.imageAttachments ??
+        [],
+      skillTokens:
+        composerSupportsSkillTokens
+          ? savedInitialDraft?.skillTokens ?? hydratedInitialLaunchpad?.skillTokens ?? []
+          : [],
+    },
+  });
+  const launchpadUpdateRef = useRef(props.onUpdateLaunchpad);
+  const [draft, setDraft] = useState(
+    latestDraftSnapshotRef.current.snapshot.draft
+  );
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const workspaceMenuRef = useDismissableMenu<HTMLDivElement>(
     workspaceMenuOpen,
@@ -844,9 +879,13 @@ export function Composer(props: ComposerProps) {
   const [activeTurnId, setActiveTurnId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
-  const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>([]);
+  const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
+    latestDraftSnapshotRef.current.snapshot.imageAttachments
+  );
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
-  const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>([]);
+  const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>(
+    latestDraftSnapshotRef.current.snapshot.skillTokens
+  );
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
@@ -858,9 +897,6 @@ export function Composer(props: ComposerProps) {
   const [reviewConfig, setReviewConfig] = useState<ReviewConfigState>();
   const isLaunchpad = Boolean(props.launchpad && props.directory);
   const launchpad = props.launchpad;
-  const composerImplementation = props.composerImplementation ?? "textarea";
-  const composerSupportsSkillTokens = composerImplementation !== "textarea";
-  const composerUsesTiptap = composerImplementation.startsWith("tiptap-");
   const backend = useMemo(
     () =>
       props.backends?.find((candidate) =>
@@ -873,8 +909,8 @@ export function Composer(props: ComposerProps) {
     inputRef.current?.selectionStart ?? draft.length,
     draft.length,
   );
-  const isThreadComposerScope = (scopeKey: string): boolean =>
-    scopeKey.startsWith("thread:");
+  const isDraftStoreScope = (scopeKey: string): boolean =>
+    scopeKey.startsWith("thread:") || scopeKey.startsWith("launchpad:");
   const canonicalDraft = useMemo(
     () =>
       serializeDraftWithSkillTokens(
@@ -886,6 +922,15 @@ export function Composer(props: ComposerProps) {
   const hasComposerContent =
     draft.trim().length > 0 ||
     (composerSupportsSkillTokens && skillTokens.length > 0);
+  launchpadUpdateRef.current = props.onUpdateLaunchpad;
+  latestDraftSnapshotRef.current = {
+    scopeKey: composerScopeKey,
+    snapshot: {
+      draft,
+      imageAttachments,
+      skillTokens: composerSupportsSkillTokens ? skillTokens : [],
+    },
+  };
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
     deletedSkillTokenHistoryRef.current = [];
     if (!composerSupportsSkillTokens) {
@@ -923,11 +968,11 @@ export function Composer(props: ComposerProps) {
     }
     setDraft(nextDraft);
   };
-  const saveThreadComposerDraft = (
+  const saveComposerDraftSnapshot = (
     scopeKey: string,
-    state: ComposerDraftState,
+    state: ComposerDraftSnapshot,
   ): void => {
-    if (!isThreadComposerScope(scopeKey)) {
+    if (!isDraftStoreScope(scopeKey)) {
       return;
     }
 
@@ -936,16 +981,35 @@ export function Composer(props: ComposerProps) {
       state.skillTokens.length === 0 &&
       state.imageAttachments.length === 0
     ) {
-      scopedThreadDraftsRef.current.delete(scopeKey);
+      draftStore.delete(scopeKey);
       return;
     }
 
-    scopedThreadDraftsRef.current.set(scopeKey, state);
+    draftStore.set(scopeKey, state);
   };
-  const clearThreadComposerDraft = (scopeKey: string): void => {
-    if (isThreadComposerScope(scopeKey)) {
-      scopedThreadDraftsRef.current.delete(scopeKey);
+  const clearComposerDraftSnapshot = (scopeKey: string): void => {
+    if (isDraftStoreScope(scopeKey)) {
+      draftStore.delete(scopeKey);
     }
+  };
+  const persistLaunchpadDraftSnapshot = (
+    scopeKey: string,
+    snapshot: ComposerDraftSnapshot,
+  ): void => {
+    const directoryKey = getLaunchpadDirectoryKeyFromScope(scopeKey);
+    const updateLaunchpad = launchpadUpdateRef.current;
+    if (!directoryKey || !updateLaunchpad) {
+      return;
+    }
+
+    void updateLaunchpad(directoryKey, {
+      imageAttachments:
+        snapshot.imageAttachments.length > 0 ? snapshot.imageAttachments : undefined,
+      prompt: serializeDraftWithSkillTokens(
+        snapshot.draft,
+        composerSupportsSkillTokens ? snapshot.skillTokens : [],
+      ),
+    });
   };
   const updateActiveTurnId = (nextTurnId?: string): void => {
     activeTurnIdRef.current = nextTurnId;
@@ -1040,16 +1104,26 @@ export function Composer(props: ComposerProps) {
   const isReviewComposerOpen = Boolean(reviewConfig && isBareReviewCommand);
 
   useEffect(() => {
+    return () => {
+      const latest = latestDraftSnapshotRef.current;
+      saveComposerDraftSnapshot(latest.scopeKey, latest.snapshot);
+      persistLaunchpadDraftSnapshot(latest.scopeKey, latest.snapshot);
+    };
+  }, []);
+
+  useEffect(() => {
     const previousScopeKey = activeComposerScopeKeyRef.current;
     if (previousScopeKey === composerScopeKey) {
       return;
     }
 
-    saveThreadComposerDraft(previousScopeKey, {
+    const previousSnapshot = {
       draft,
       imageAttachments,
       skillTokens,
-    });
+    };
+    saveComposerDraftSnapshot(previousScopeKey, previousSnapshot);
+    persistLaunchpadDraftSnapshot(previousScopeKey, previousSnapshot);
 
     activeComposerScopeKeyRef.current = composerScopeKey;
     const current = pasteScopeRef.current;
@@ -1059,7 +1133,7 @@ export function Composer(props: ComposerProps) {
     };
 
     if (props.thread) {
-      const saved = scopedThreadDraftsRef.current.get(composerScopeKey);
+      const saved = draftStore.get(composerScopeKey);
       setDraft(saved?.draft ?? "");
       setImageAttachments(saved?.imageAttachments ?? []);
       setSkillTokens(saved?.skillTokens ?? []);
@@ -1162,8 +1236,15 @@ export function Composer(props: ComposerProps) {
     }
 
     hydratedLaunchpadKeyRef.current = props.launchpad?.directoryKey;
-    setComposerDraftFromCanonical(props.launchpad?.prompt ?? "");
-    setImageAttachments(props.launchpad?.imageAttachments ?? []);
+    const saved = draftStore.get(composerScopeKey);
+    if (saved) {
+      setDraft(saved.draft);
+      setImageAttachments(saved.imageAttachments);
+      setSkillTokens(composerSupportsSkillTokens ? saved.skillTokens : []);
+    } else {
+      setComposerDraftFromCanonical(props.launchpad?.prompt ?? "");
+      setImageAttachments(props.launchpad?.imageAttachments ?? []);
+    }
     setSending(false);
     setInterrupting(false);
     setSteering(false);
@@ -1172,7 +1253,15 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
     setPendingSteer(undefined);
-  }, [isLaunchpad, props.launchpad?.directoryKey, props.launchpad?.prompt, props.skills]);
+  }, [
+    composerScopeKey,
+    composerSupportsSkillTokens,
+    draftStore,
+    isLaunchpad,
+    props.launchpad?.directoryKey,
+    props.launchpad?.prompt,
+    props.skills,
+  ]);
 
   useEffect(() => {
     if (!props.thread) {
@@ -1387,7 +1476,7 @@ export function Composer(props: ComposerProps) {
       });
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
-      clearThreadComposerDraft(composerScopeKey);
+      clearComposerDraftSnapshot(composerScopeKey);
       clearComposerDraft();
       setReviewConfig(undefined);
     } catch (error) {
@@ -1500,7 +1589,7 @@ export function Composer(props: ComposerProps) {
       if (queued) {
         setQueuedTurn(undefined);
       } else {
-        clearThreadComposerDraft(composerScopeKey);
+        clearComposerDraftSnapshot(composerScopeKey);
         clearComposerDraft();
         setImageAttachments([]);
         if (collaborationMode) {
@@ -1546,7 +1635,7 @@ export function Composer(props: ComposerProps) {
       text: canonicalDraft,
       imageAttachments,
     });
-    clearThreadComposerDraft(composerScopeKey);
+    clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
     setReviewConfig(undefined);
@@ -1636,7 +1725,7 @@ export function Composer(props: ComposerProps) {
       imageAttachments: pending.imageAttachments,
       status: "pending",
     });
-    clearThreadComposerDraft(composerScopeKey);
+    clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
     setReviewConfig(undefined);
@@ -1896,7 +1985,7 @@ export function Composer(props: ComposerProps) {
   const removeImageAttachment = (id: string): void => {
     setImageAttachments((current) => {
       const nextAttachments = current.filter((attachment) => attachment.id !== id);
-      saveThreadComposerDraft(composerScopeKey, {
+      saveComposerDraftSnapshot(composerScopeKey, {
         draft,
         imageAttachments: nextAttachments,
         skillTokens,
@@ -1952,10 +2041,8 @@ export function Composer(props: ComposerProps) {
 
   const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
-    const pasteDraft = canonicalDraft;
+    const pasteDraft = draft;
     const pasteImageAttachments = imageAttachments;
-    const pasteLaunchpad = props.launchpad;
-    const updateLaunchpad = props.onUpdateLaunchpad;
 
     try {
       const nextAttachments = await Promise.all(
@@ -2006,35 +2093,29 @@ export function Composer(props: ComposerProps) {
       );
 
       if (activeComposerScopeKeyRef.current !== pasteScope.key) {
-        if (pasteLaunchpad && updateLaunchpad) {
-          const mergedAttachments = [...pasteImageAttachments, ...nextAttachments];
-          void updateLaunchpad(pasteLaunchpad.directoryKey, {
-            imageAttachments: mergedAttachments.length > 0 ? mergedAttachments : undefined,
-            prompt: pasteDraft,
-          });
-          return;
-        }
-
-        const saved = scopedThreadDraftsRef.current.get(pasteScope.key) ?? {
-          draft: "",
-          imageAttachments: [],
-          skillTokens: [],
+        const saved = draftStore.get(pasteScope.key) ?? {
+          draft: pasteDraft,
+          imageAttachments: pasteImageAttachments,
+          skillTokens,
         };
-        saveThreadComposerDraft(pasteScope.key, {
+        const nextSnapshot = {
           draft: saved.draft,
           imageAttachments: [...saved.imageAttachments, ...nextAttachments],
           skillTokens: saved.skillTokens,
-        });
+        };
+        saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
+        persistLaunchpadDraftSnapshot(pasteScope.key, nextSnapshot);
         return;
       }
 
       setImageAttachments((current) => {
         const mergedAttachments = [...current, ...nextAttachments];
-        saveThreadComposerDraft(pasteScope.key, {
+        const nextSnapshot = {
           draft,
           imageAttachments: mergedAttachments,
           skillTokens,
-        });
+        };
+        saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
         persistLaunchpadImageAttachments(mergedAttachments);
         return mergedAttachments;
       });
@@ -2069,9 +2150,18 @@ export function Composer(props: ComposerProps) {
     }
 
     setSendError(undefined);
-    void props.onUpdateLaunchpad(props.launchpad.directoryKey, patch, {
-      stickySettingsChanged: true,
-    });
+    void props.onUpdateLaunchpad(
+      props.launchpad.directoryKey,
+      {
+        imageAttachments:
+          imageAttachments.length > 0 ? imageAttachments : props.launchpad.imageAttachments,
+        prompt: canonicalDraft,
+        ...patch,
+      },
+      {
+        stickySettingsChanged: true,
+      },
+    );
   };
 
   const handleThreadModelSettingsPatch = (
@@ -2725,8 +2815,16 @@ export function Composer(props: ComposerProps) {
               : undefined;
           })()
         : undefined;
+    const storedSkillTokens = composerSupportsSkillTokens
+      ? nextSkillTokens ?? skillTokens
+      : [];
 
     updateVisibleDraft(nextDraft, nextSkillTokens);
+    saveComposerDraftSnapshot(composerScopeKey, {
+      draft: nextDraft,
+      imageAttachments,
+      skillTokens: storedSkillTokens,
+    });
     if (deletedSkillTokenHistoryEntry) {
       deletedSkillTokenHistoryRef.current.push(deletedSkillTokenHistoryEntry);
     }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2154,7 +2154,7 @@ export function Composer(props: ComposerProps) {
       props.launchpad.directoryKey,
       {
         imageAttachments:
-          imageAttachments.length > 0 ? imageAttachments : props.launchpad.imageAttachments,
+          imageAttachments.length > 0 ? imageAttachments : undefined,
         prompt: canonicalDraft,
         ...patch,
       },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -838,6 +838,7 @@ export function Composer(props: ComposerProps) {
       : hydrateComposerDraft(props.launchpad.prompt ?? "", props.skills);
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
+  const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
   const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
   const latestDraftSnapshotRef = useRef<{
     scopeKey: string;
@@ -992,6 +993,32 @@ export function Composer(props: ComposerProps) {
       draftStore.delete(scopeKey);
     }
   };
+  const markComposerDraftSubmitted = (scopeKey: string): void => {
+    if (!isDraftStoreScope(scopeKey)) {
+      return;
+    }
+
+    submittedDraftScopeKeysRef.current.add(scopeKey);
+    clearComposerDraftSnapshot(scopeKey);
+  };
+  const unmarkComposerDraftSubmitted = (scopeKey: string): void => {
+    submittedDraftScopeKeysRef.current.delete(scopeKey);
+  };
+  const clearSubmittedComposerDraft = (scopeKey: string): void => {
+    const emptySnapshot: ComposerDraftSnapshot = {
+      draft: "",
+      imageAttachments: [],
+      skillTokens: [],
+    };
+
+    clearComposerDraftSnapshot(scopeKey);
+    latestDraftSnapshotRef.current = {
+      scopeKey,
+      snapshot: emptySnapshot,
+    };
+    clearComposerDraft();
+    setImageAttachments([]);
+  };
   const persistLaunchpadDraftSnapshot = (
     scopeKey: string,
     snapshot: ComposerDraftSnapshot,
@@ -1010,6 +1037,18 @@ export function Composer(props: ComposerProps) {
         composerSupportsSkillTokens ? snapshot.skillTokens : [],
       ),
     });
+  };
+  const flushComposerDraftSnapshot = (
+    scopeKey: string,
+    snapshot: ComposerDraftSnapshot,
+  ): void => {
+    if (submittedDraftScopeKeysRef.current.has(scopeKey)) {
+      clearComposerDraftSnapshot(scopeKey);
+      return;
+    }
+
+    saveComposerDraftSnapshot(scopeKey, snapshot);
+    persistLaunchpadDraftSnapshot(scopeKey, snapshot);
   };
   const updateActiveTurnId = (nextTurnId?: string): void => {
     activeTurnIdRef.current = nextTurnId;
@@ -1106,8 +1145,7 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     return () => {
       const latest = latestDraftSnapshotRef.current;
-      saveComposerDraftSnapshot(latest.scopeKey, latest.snapshot);
-      persistLaunchpadDraftSnapshot(latest.scopeKey, latest.snapshot);
+      flushComposerDraftSnapshot(latest.scopeKey, latest.snapshot);
     };
   }, []);
 
@@ -1122,8 +1160,7 @@ export function Composer(props: ComposerProps) {
       imageAttachments,
       skillTokens,
     };
-    saveComposerDraftSnapshot(previousScopeKey, previousSnapshot);
-    persistLaunchpadDraftSnapshot(previousScopeKey, previousSnapshot);
+    flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
 
     activeComposerScopeKeyRef.current = composerScopeKey;
     const current = pasteScopeRef.current;
@@ -1410,6 +1447,10 @@ export function Composer(props: ComposerProps) {
     }
 
     const timeout = window.setTimeout(() => {
+      if (submittedDraftScopeKeysRef.current.has(composerScopeKey)) {
+        return;
+      }
+
       void props.onUpdateLaunchpad?.(launchpad.directoryKey, {
         imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
         prompt: canonicalDraft,
@@ -1419,7 +1460,7 @@ export function Composer(props: ComposerProps) {
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [canonicalDraft, imageAttachments, launchpad, props.onUpdateLaunchpad]);
+  }, [canonicalDraft, composerScopeKey, imageAttachments, launchpad, props.onUpdateLaunchpad]);
 
   const submitReviewCommand = async (reviewCommand: {
     displayText: string;
@@ -1438,6 +1479,8 @@ export function Composer(props: ComposerProps) {
     props.onPendingStatusChange?.("Reviewing");
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
+      const submittedScopeKey = composerScopeKey;
+      markComposerDraftSubmitted(submittedScopeKey);
       try {
         await props.onMaterializeLaunchpad(
           props.launchpad.directoryKey,
@@ -1445,10 +1488,10 @@ export function Composer(props: ComposerProps) {
           undefined,
           reviewCommand.target
         );
-        clearComposerDraft();
+        clearSubmittedComposerDraft(submittedScopeKey);
         setReviewConfig(undefined);
-        setImageAttachments([]);
       } catch (error) {
+        unmarkComposerDraftSubmitted(submittedScopeKey);
         props.onPendingStatusChange?.(undefined);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
@@ -1811,18 +1854,20 @@ export function Composer(props: ComposerProps) {
     setSending(true);
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
+      const submittedScopeKey = composerScopeKey;
+      markComposerDraftSubmitted(submittedScopeKey);
       try {
         await props.onMaterializeLaunchpad(
           props.launchpad.directoryKey,
           payload.input,
           collaborationMode
         );
-        clearComposerDraft();
-        setImageAttachments([]);
+        clearSubmittedComposerDraft(submittedScopeKey);
         if (collaborationMode) {
           setPlanModeEnabled(false);
         }
       } catch (error) {
+        unmarkComposerDraftSubmitted(submittedScopeKey);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
         setSending(false);
@@ -2788,6 +2833,7 @@ export function Composer(props: ComposerProps) {
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
   ): void => {
+    unmarkComposerDraftSubmitted(composerScopeKey);
     const pendingProgrammaticChange =
       pendingProgrammaticComposerChangeRef.current;
     if (pendingProgrammaticChange && nextSkillTokens) {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -754,7 +754,22 @@ export const ComposerTiptapInput = forwardRef<
           propsRef.current.onDrop?.(event as unknown as DragEvent<HTMLDivElement>);
           return event.defaultPrevented;
         },
-        keydown: (view, event) => {
+        keydown: (_view, event) => {
+          const currentProps = propsRef.current;
+          if (
+            (event.key === "Backspace" || event.key === "Delete") &&
+            currentProps.value.trim().length === 0 &&
+            currentProps.skillTokens.length === 1
+          ) {
+            event.preventDefault();
+            const currentEditor = editorRef.current;
+            currentEditor?.commands.setContent(buildTiptapContent("", []), {
+              emitUpdate: false,
+            });
+            propsRef.current.onChange("", []);
+            return true;
+          }
+
           if (
             propsRef.current.markdownConversion &&
             event.key === "Enter" &&

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2412,6 +2412,155 @@ describe("Composer", () => {
     });
   });
 
+  it("does not restore a submitted launchpad draft when materialization unmounts before local clear", async () => {
+    const draftStore = createComposerDraftStore();
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    let unmountComposer: () => void = () => undefined;
+    const onMaterializeLaunchpad = vi.fn(async () => {
+      unmountComposer();
+    });
+
+    const { unmount } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+    unmountComposer = unmount;
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Submitted launchpad should not come back" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+
+    await waitFor(() => {
+      expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        [{ type: "text", text: "Submitted launchpad should not come back" }],
+        undefined
+      );
+    });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("New thread")).toHaveValue("");
+  });
+
+  it("does not restore a submitted launchpad review draft when materialization unmounts before local clear", async () => {
+    const draftStore = createComposerDraftStore();
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    let unmountComposer: () => void = () => undefined;
+    const onMaterializeLaunchpad = vi.fn(async () => {
+      unmountComposer();
+    });
+
+    const { unmount } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+    unmountComposer = unmount;
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "/review main" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+
+    await waitFor(() => {
+      expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        undefined,
+        undefined,
+        { type: "baseBranch", branch: "main" }
+      );
+    });
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("New thread")).toHaveValue("");
+  });
+
   it("preserves launchpad prompt and pasted images when sticky settings change", async () => {
     const onUpdateLaunchpad = vi.fn(async () => undefined);
     const imageFile = new File([new Uint8Array([1, 2, 3])], "sticky-mockup.png", {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -10,6 +10,10 @@ import type {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeImageFile } from "../../../lib/image-normalization";
 import { Composer } from "../Composer";
+import type {
+  ComposerDraftSnapshot,
+  ComposerDraftStore,
+} from "../useComposerDraftStore";
 
 vi.mock("../../../lib/image-normalization", () => ({
   normalizeImageFile: vi.fn(async (file: File) => ({
@@ -43,6 +47,19 @@ function openDropdown(label: string): HTMLElement {
 function chooseDropdownOption(label: string, optionName: string): void {
   openDropdown(label);
   fireEvent.click(screen.getByRole("option", { name: optionName }));
+}
+
+function createComposerDraftStore(): ComposerDraftStore {
+  const drafts = new Map<string, ComposerDraftSnapshot>();
+  return {
+    delete: (scopeKey) => {
+      drafts.delete(scopeKey);
+    },
+    get: (scopeKey) => drafts.get(scopeKey),
+    set: (scopeKey, snapshot) => {
+      drafts.set(scopeKey, snapshot);
+    },
+  };
 }
 
 function backendSummary(
@@ -1719,7 +1736,7 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(onUpdateLaunchpad).toHaveBeenCalledWith(
         "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
-        { workMode: "worktree" },
+        expect.objectContaining({ workMode: "worktree" }),
         { stickySettingsChanged: true }
       );
     });
@@ -2273,6 +2290,203 @@ describe("Composer", () => {
 
     expect(textarea).toHaveValue("Line one edited\nLine two");
     expect(textarea.selectionStart).toBe(8);
+  });
+
+  it("restores a thread reply draft with pasted images after the composer remounts", async () => {
+    const draftStore = createComposerDraftStore();
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "reply-mockup.png", {
+      type: "image/png",
+    });
+    const thread = {
+      id: "thread-1",
+      title: "Build Codex client",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    const { unmount } = render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        draftStore={draftStore}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Keep this reply draft" },
+    });
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+    expect(await screen.findByAltText("reply-mockup.png")).toBeInTheDocument();
+
+    unmount();
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        draftStore={draftStore}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    expect(screen.getByLabelText("Reply")).toHaveValue("Keep this reply draft");
+    expect(screen.getByAltText("reply-mockup.png")).toBeInTheDocument();
+  });
+
+  it("flushes a launchpad draft on unmount before the debounce window expires", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const draftStore = createComposerDraftStore();
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const { unmount } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Persist this launchpad before navigation" },
+    });
+    unmount();
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          prompt: "Persist this launchpad before navigation",
+        })
+      );
+    });
+  });
+
+  it("preserves launchpad prompt and pasted images when sticky settings change", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "sticky-mockup.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        backends={[
+          backendSummary("codex", {
+            models: [
+              { id: "gpt-5.4", label: "GPT 5.4" },
+              { id: "gpt-5.5", label: "GPT 5.5" },
+            ],
+          }),
+        ]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          model: "gpt-5.4",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Keep this launchpad while changing settings" },
+    });
+    fireEvent.paste(screen.getByLabelText("New thread"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+    expect(await screen.findByAltText("sticky-mockup.png")).toBeInTheDocument();
+
+    chooseDropdownOption("Model", "GPT 5.5");
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          imageAttachments: expect.arrayContaining([
+            expect.objectContaining({ name: "sticky-mockup.png" }),
+          ]),
+          model: "gpt-5.5",
+          prompt: "Keep this launchpad while changing settings",
+        }),
+        { stickySettingsChanged: true },
+      );
+    });
   });
 
   it("inserts skill markdown from autocomplete and sends it through startTurn", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -1,0 +1,32 @@
+import { useMemo, useRef } from "react";
+import type { NavigationLaunchpadImageAttachment } from "@pwragnt/shared";
+import type { ComposerSkillToken } from "./ComposerRichInput";
+
+export type ComposerDraftSnapshot = {
+  draft: string;
+  imageAttachments: NavigationLaunchpadImageAttachment[];
+  skillTokens: ComposerSkillToken[];
+};
+
+export type ComposerDraftStore = {
+  delete(scopeKey: string): void;
+  get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  set(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
+};
+
+export function useComposerDraftStore(): ComposerDraftStore {
+  const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
+
+  return useMemo(
+    () => ({
+      delete: (scopeKey) => {
+        storeRef.current.delete(scopeKey);
+      },
+      get: (scopeKey) => storeRef.current.get(scopeKey),
+      set: (scopeKey, snapshot) => {
+        storeRef.current.set(scopeKey, snapshot);
+      },
+    }),
+    [],
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -28,6 +28,7 @@ import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { Composer } from "../composer/Composer";
+import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
@@ -583,6 +584,7 @@ type ThreadViewProps = {
   applications?: DesktopApplicationsSnapshot;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   composerDisabled: boolean;
+  composerDraftStore?: ComposerDraftStore;
   composerImplementation?: DesktopChatReplyComposer;
   desktopApi?: DesktopApi;
   launchpadError?: string;
@@ -1419,6 +1421,7 @@ export function ThreadView(props: ThreadViewProps) {
               applications={props.applications}
               desktopApi={props.desktopApi}
               composerImplementation={props.composerImplementation}
+              draftStore={props.composerDraftStore}
               directory={props.selectedDirectory}
               disabled={!launchpadBackend?.available}
               launchpad={selectedLaunchpad}
@@ -1501,6 +1504,7 @@ export function ThreadView(props: ThreadViewProps) {
             applications={props.applications}
             desktopApi={props.desktopApi}
             composerImplementation={props.composerImplementation}
+            draftStore={props.composerDraftStore}
             directory={props.selectedDirectory}
             disabled={props.composerDisabled}
             contextWindow={props.contextWindow}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -896,6 +896,114 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad).toBeUndefined();
   });
 
+  it("keeps newer launchpad edits when an older update response resolves later", async () => {
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const launchpad = {
+      directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+      directoryKind: "directory" as const,
+      directoryLabel: "PwrAgnt",
+      directoryPath: "/Users/huntharo/github/PwrAgnt",
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      workMode: "local" as const,
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const olderUpdate = createDeferred<{
+      defaults: typeof defaults;
+      launchpad: typeof launchpad;
+    }>();
+    const newerUpdate = createDeferred<{
+      defaults: typeof defaults;
+      launchpad: typeof launchpad;
+    }>();
+    const updateDirectoryLaunchpad = vi
+      .fn()
+      .mockReturnValueOnce(olderUpdate.promise)
+      .mockReturnValueOnce(newerUpdate.promise);
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "directory:/Users/huntharo/github/PwrAgnt",
+          kind: "directory" as const,
+          label: "PwrAgnt",
+          path: "/Users/huntharo/github/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+        "directory:/Users/huntharo/github/PwrAgnt"
+      );
+    });
+
+    let firstUpdate: Promise<void> | undefined;
+    let secondUpdate: Promise<void> | undefined;
+    act(() => {
+      firstUpdate = result.current.updateDirectoryLaunchpad(
+        "directory:/Users/huntharo/github/PwrAgnt",
+        { prompt: "older prompt" },
+      );
+      secondUpdate = result.current.updateDirectoryLaunchpad(
+        "directory:/Users/huntharo/github/PwrAgnt",
+        { prompt: "newer prompt" },
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
+    });
+
+    await act(async () => {
+      newerUpdate.resolve({
+        defaults,
+        launchpad: {
+          ...launchpad,
+          prompt: "newer prompt",
+          updatedAt: 3,
+        },
+      });
+      await secondUpdate!;
+    });
+    expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
+
+    await act(async () => {
+      olderUpdate.resolve({
+        defaults,
+        launchpad: {
+          ...launchpad,
+          prompt: "older prompt",
+          updatedAt: 2,
+        },
+      });
+      await firstUpdate!;
+    });
+
+    expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
+  });
+
   it("opens masthead new-thread drafts inside the Workspaces directory", async () => {
     const ensureDirectoryLaunchpad = vi.fn(async () => ({
       launchpad: {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1406,24 +1406,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       launchpadUpdateRevisionRef.current.set(directoryKey, revision);
 
       setState((current) => {
-        const currentLaunchpad = current.response?.directories.find(
+        const currentResponse = current.response;
+        const currentLaunchpad = currentResponse?.directories.find(
           (directory) => directory.key === directoryKey
         )?.launchpad;
-        if (!currentLaunchpad) {
+        if (!currentResponse || !currentLaunchpad) {
           return current;
         }
 
         return {
           ...current,
           response: applyLaunchpadUpdate(
-            current.response,
+            currentResponse,
             {
               ...currentLaunchpad,
               ...patch,
               directoryKey,
               updatedAt: Date.now(),
             },
-            current.response.launchpadDefaults
+            currentResponse.launchpadDefaults
           ),
         };
       });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -808,6 +808,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const scheduledRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
+  const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
@@ -1400,6 +1401,32 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       }
 
       setLaunchpadError(undefined);
+      const revision =
+        (launchpadUpdateRevisionRef.current.get(directoryKey) ?? 0) + 1;
+      launchpadUpdateRevisionRef.current.set(directoryKey, revision);
+
+      setState((current) => {
+        const currentLaunchpad = current.response?.directories.find(
+          (directory) => directory.key === directoryKey
+        )?.launchpad;
+        if (!currentLaunchpad) {
+          return current;
+        }
+
+        return {
+          ...current,
+          response: applyLaunchpadUpdate(
+            current.response,
+            {
+              ...currentLaunchpad,
+              ...patch,
+              directoryKey,
+              updatedAt: Date.now(),
+            },
+            current.response.launchpadDefaults
+          ),
+        };
+      });
 
       try {
         const response = await desktopApi.updateDirectoryLaunchpad({
@@ -1407,6 +1434,9 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           patch,
           stickySettingsChanged: options?.stickySettingsChanged,
         });
+        if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
+          return;
+        }
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
@@ -1416,6 +1446,9 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           ),
         }));
       } catch (error) {
+        if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
+          return;
+        }
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },

--- a/docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md
+++ b/docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md
@@ -1,0 +1,93 @@
+---
+date: 2026-05-02
+topic: desktop-composer-draft-persistence-regression
+---
+
+# Desktop Composer Draft Persistence Regression
+
+## Problem Frame
+
+Unsent composer content in the desktop app is user data. A user can start a Directories launchpad draft with screenshots and text, switch to an existing thread, add text and screenshots there, and then return to find the draft partially or entirely gone. This is unacceptable because the app is losing work before the user has sent it.
+
+The regression appears concentrated around the current Tiptap composer path and around refresh/navigation boundaries. Existing coverage verifies some adjacent behavior, but it does not exercise the full end-to-end workflow that failed: Directories `+` launchpad plus pasted images plus text, switching to a real thread with its own unsent text and images, and returning after refresh-capable navigation events.
+
+```mermaid
+flowchart TB
+    A["Open Directories"] --> B["Click + for a directory"]
+    B --> C["Compose launchpad text and paste screenshots"]
+    C --> D["Switch to existing thread"]
+    D --> E["Compose reply text and paste screenshots"]
+    E --> F["Refresh or navigation update occurs"]
+    F --> G["Return to directory + launchpad"]
+    G --> H["Launchpad text and screenshots are still present"]
+    H --> I["Return to existing thread"]
+    I --> J["Thread reply text and screenshots are still present"]
+```
+
+## Requirements
+
+**Draft Persistence Contract**
+- R1. Unsent Directories launchpad prompt text must survive switching away from the launchpad and reopening the same directory `+` entrypoint.
+- R2. Unsent Directories launchpad pasted image attachments must survive switching away from the launchpad and reopening the same directory `+` entrypoint.
+- R3. Launchpad text and image attachments must be persisted as one coherent draft state; navigation must not preserve one while losing the other.
+- R4. Unsent existing-thread reply text must survive switching to another thread, opening settings, returning from settings, and navigation refreshes.
+- R5. Unsent existing-thread reply image attachments must survive switching to another thread, opening settings, returning from settings, and navigation refreshes.
+- R6. Existing-thread reply text and image attachments must be retained together; refresh or rerender paths must not clear both, clear only text, or clear only images.
+
+**Tiptap Primary Path**
+- R7. The Tiptap composer variants currently used by the desktop app must be first-class in persistence behavior, not treated as secondary alternatives to the textarea implementation.
+- R8. Draft persistence tests must assert the canonical draft value exposed by the Tiptap editor as well as visible attachment chips/previews.
+- R9. Persistence behavior must be equivalent across plain text, skill-token text, and multiline Tiptap content unless a specific composer mode documents an intentional limitation.
+
+**Refresh and Race Resistance**
+- R10. A sidebar/navigation refresh must not overwrite newer local unsent composer state with older launchpad or thread state.
+- R11. Debounced launchpad autosave must not create a window where a fast navigation preserves pasted images but loses the prompt text.
+- R12. Image normalization that completes after the user switches away must attach the image to the original composer scope without overwriting newer text for that scope.
+- R13. Sticky launchpad settings updates must not reset prompt text or image attachments for the active launchpad.
+
+**Regression Coverage**
+- R14. Add a desktop E2E that reproduces the reported workflow using the Tiptap composer: open Directories, click `+`, enter text, paste at least one image, switch to an existing thread, enter text, paste at least one image, return to the launchpad, and assert both text and images remain.
+- R15. The same E2E must return to the existing thread and assert its unsent text and pasted image attachments remain.
+- R16. The E2E must include a refresh-capable boundary, such as a replayed thread lifecycle/navigation update or an explicit navigation snapshot refresh, before the final assertions.
+- R17. Unit or component coverage may remain, but it is not sufficient by itself; this regression requires an app-level test because the failure crosses composer, navigation, persistence, and refresh behavior.
+
+## Success Criteria
+
+- The reported workflow no longer loses text or screenshots in either the Directories launchpad or existing-thread reply composer.
+- Tiptap is covered directly in the regression tests.
+- A navigation refresh cannot wipe unsent composer state.
+- Launchpad sticky settings can change without resetting unsent launchpad text or images.
+- The E2E suite fails if launchpad text is dropped while screenshots survive, or if existing-thread text and screenshots are dropped after switching away and back.
+
+## Scope Boundaries
+
+- This work does not redesign the composer UI.
+- This work does not add multiple launchpad drafts per directory.
+- This work does not change the send semantics for turning a launchpad into a real thread.
+- This work does not require cross-app restart persistence for existing-thread reply drafts unless planning determines that is already intended behavior.
+- This work does not broaden image support beyond the existing pasted-image attachment behavior.
+
+## Key Decisions
+
+- Treat unsent composer content as user data: Draft text and images must be protected with the same seriousness as sent transcript content until the user sends or explicitly clears them.
+- Test Tiptap first: The app is now primarily using Tiptap, so regression protection must exercise Tiptap rather than relying on textarea-only coverage.
+- Require app-level coverage: Component tests are useful, but they did not catch this regression because refresh and navigation participate in the failure.
+- Preserve coherent draft state: The system must avoid partial persistence where screenshots survive but text does not, or where text survives but images do not.
+
+## Dependencies / Assumptions
+
+- The desktop app can already run replay-backed Electron E2Es for navigation and composer workflows.
+- Existing Tiptap E2Es cover skill and formatting behavior, but current coverage does not appear to cover the reported combined Tiptap text-plus-image persistence workflow.
+- Existing launchpad component tests cover image persistence on the default composer path, but those tests do not substitute for a Tiptap app-level regression.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R3, R10-R12][Technical] Should launchpad text autosave become immediate on scope switch, should autosave state be flushed before navigation selection changes, or should navigation merge newer local draft state after refresh?
+- [Affects R4-R6][Technical] Should existing-thread reply drafts remain renderer-session state, move into the same overlay persistence layer as launchpads, or use a separate scoped draft store?
+- [Affects R16][Technical] What is the most deterministic replay event for proving that navigation refresh cannot wipe the active and inactive composer drafts?
+- [Affects R13][Technical] Which sticky setting updates currently cause launchpad rerenders, and which ones can reset Tiptap editor state?
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md
+++ b/docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md
@@ -1,0 +1,351 @@
+---
+title: fix: Preserve composer drafts across navigation
+type: fix
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md
+---
+
+# fix: Preserve composer drafts across navigation
+
+## Overview
+
+Stabilize desktop composer draft ownership so unsent Tiptap text and pasted images survive Directories launchpad navigation, existing-thread switching, settings overlays, and navigation refreshes. The fix should treat draft text, skill tokens, and image attachments as one coherent scoped draft instead of allowing separate save paths to race.
+
+## Problem Frame
+
+The origin report describes user work being lost before send: a Directories `+` launchpad kept a pasted screenshot but dropped text, and an existing thread reply later lost both text and screenshots. Existing tests cover adjacent behaviors, but the full app-level Tiptap flow is not covered. The implementation needs to protect unsent composer content as user data while preserving the current launchpad and thread send semantics. (see origin: `docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md`)
+
+## Requirements Trace
+
+- R1, R2, R3. Directories launchpad prompt text and pasted images survive switching away and back as one coherent draft.
+- R4, R5, R6. Existing-thread reply text and pasted images survive thread switching, settings overlays, and navigation refreshes as one coherent draft.
+- R7, R8, R9. Tiptap composer variants are first-class in tests and behavior, including canonical `data-value`, skill-token text, and multiline content.
+- R10, R11, R12. Refresh, debounced autosave, and delayed image normalization cannot overwrite newer local unsent state or split text from images.
+- R13. Sticky launchpad setting changes preserve prompt text and image attachments.
+- R14, R15, R16, R17. Add app-level replay-backed E2E coverage for the reported Tiptap launchpad and existing-thread workflow, including a refresh-capable boundary.
+
+## Scope Boundaries
+
+- This plan does not redesign the composer UI.
+- This plan does not add multiple launchpad drafts per directory.
+- This plan does not change how a launchpad becomes a real thread on first send.
+- This plan keeps existing-thread reply drafts renderer-session scoped; it does not add cross-app restart persistence for existing-thread reply drafts.
+- This plan does not broaden image format support beyond existing pasted-image attachment behavior.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` owns the draft string, Tiptap/custom/textarea selection, skill tokens, image attachments, launchpad autosave, paste/drop handling, and thread-scoped in-memory draft map.
+- `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx` exposes the Tiptap canonical draft through `data-value` and handles text/html paste behavior for Tiptap variants.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` owns Directories launchpad selection, navigation refresh, `ensureDirectoryLaunchpad`, `updateDirectoryLaunchpad`, and local navigation snapshot application through `applyLaunchpadUpdate`.
+- `apps/desktop/src/main/app-server/backend-registry.ts` persists launchpad updates through `updateDirectoryLaunchpad` and merges sticky settings defaults into `NavigationLaunchpadDraft`.
+- `packages/agent-core/src/persistence/overlay-store.ts` stores `directoryLaunchpads` and `launchpadDefaults`; `packages/shared/src/contracts/navigation.ts` defines `NavigationLaunchpadDraft` and launchpad image attachment shape.
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` is the strongest existing Tiptap launchpad E2E pattern and already uses `PWRAGNT_EXPERIMENTAL_CHAT_REPLY_COMPOSER` variants plus `composer-tiptap-input` assertions.
+- `apps/desktop/e2e/composer-image-thread-switch.spec.ts` covers delayed image normalization after switching away from a newly created thread, but it uses the textarea-oriented paste helper and does not cover launchpad text-plus-image persistence.
+- `apps/desktop/e2e/composer-draft-settings.spec.ts` covers Tiptap text draft persistence through settings for an existing thread, but not pasted images or Directories launchpads.
+- `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` has launchpad pasted-image tests, including delayed normalization, but those tests currently exercise the default composer path rather than the Tiptap path.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this worktree, so there are no indexed institutional learnings to apply.
+- `docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md` established the composer invariant that the canonical draft string remains the source of truth for send behavior, draft persistence, launchpad hydration, and thread-scoped draft storage.
+- `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md` established that sidebar/navigation refreshes must not destabilize the selected thread surface.
+
+### External References
+
+- External research is not needed. The work is bounded to existing React renderer state, existing Tiptap integration, replay-backed Electron E2E patterns, and existing launchpad overlay persistence.
+
+## Key Technical Decisions
+
+- **Add the failing app-level Tiptap E2E first.** The reported loss crosses composer, navigation, overlay persistence, image normalization, and refresh, so unit tests alone cannot prove the regression is fixed.
+- **Make scoped draft state coherent.** Treat `draft`, `skillTokens`, and `imageAttachments` as one snapshot for a composer scope. Any save, restore, paste completion, launchpad update, settings change, or scope switch should operate on that snapshot rather than separate text and image paths.
+- **Keep existing-thread drafts renderer-session scoped.** The origin explicitly excludes cross-app restart persistence for existing-thread drafts. The practical fix is to ensure renderer-session thread drafts survive component rerenders, settings overlays, selection changes, and navigation refreshes.
+- **Make launchpad local state immediate and persistence merge-safe.** The active UI should not wait on a 250ms debounced IPC write before navigation can preserve prompt text. Persistence can remain asynchronous, but scope changes and refresh merges must not overwrite newer local draft state with stale launchpad data.
+- **Use Tiptap canonical values in assertions.** E2Es and component tests should assert `composer-tiptap-input` `data-value` plus visible `Pasted images` attachment previews because that is the editor path currently used in the app.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should launchpad autosave become immediate, flush before navigation, or merge after refresh?** Use a combined approach: keep local launchpad draft state immediate, flush the current scope before selection changes or unmounts, and guard async navigation/persistence responses from replacing newer local state.
+- **Should existing-thread reply drafts move to persistent overlay storage?** No for this fix. Keep them renderer-session scoped, but hoist or stabilize their storage so refresh and remount boundaries cannot drop them.
+- **What refresh-capable E2E boundary should prove the regression?** Use a replayed thread lifecycle or navigation snapshot refresh that exercises the real `useThreadNavigation` refresh path before final draft assertions.
+- **Which sticky settings are risky?** Provider, execution mode, model, reasoning, service tier, fast mode, work mode, and branch updates all patch launchpad state; each patch must preserve prompt and image attachments.
+
+### Deferred to Implementation
+
+- Exact helper internals for the scoped draft store.
+- Exact stale-response guard shape for launchpad updates, as long as it rejects older async responses in favor of newer local draft state.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Scope["Composer scope key"]
+    LocalDraft["Coherent local draft snapshot"]
+    Tiptap["Tiptap input data-value"]
+    Images["Pasted image attachments"]
+    LaunchpadOverlay["Launchpad overlay persistence"]
+    ThreadDrafts["Session thread draft store"]
+    Navigation["Navigation refresh"]
+    E2E["Replay-backed Tiptap E2E"]
+
+    Scope --> LocalDraft
+    Tiptap --> LocalDraft
+    Images --> LocalDraft
+    LocalDraft --> Tiptap
+    LocalDraft --> Images
+    LocalDraft --> LaunchpadOverlay
+    LocalDraft --> ThreadDrafts
+    Navigation --> LocalDraft
+    LocalDraft --> E2E
+```
+
+The important behavior is that every composer scope has a single local draft snapshot. Launchpad scopes additionally persist that snapshot to the overlay store; thread scopes retain it in renderer session memory. Navigation refresh may update sidebar metadata, but it must not replace a newer local draft snapshot with stale persisted state.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Add failing Tiptap E2E"] --> U2["Unit 2: Stabilize scoped draft snapshots"]
+    U2 --> U3["Unit 3: Harden launchpad persistence merges"]
+    U2 --> U4["Unit 4: Cover Tiptap and async image races"]
+    U3 --> U5["Unit 5: Verify refresh and sticky settings paths"]
+    U4 --> U5
+```
+
+- [ ] **Unit 1: Add failing Tiptap draft persistence E2E**
+
+**Goal:** Capture the reported regression in a deterministic Electron E2E before changing implementation behavior.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R14, R15, R16, R17
+
+**Dependencies:** None
+
+**Files:**
+- Create: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+- Modify: `apps/desktop/e2e/fixtures/electron-app.ts` only if the replay helper needs a small reusable operation for this fixture
+- Test: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+
+**Approach:**
+- Build a replay fixture inline in the spec, following `directory-launchpad-skills.spec.ts` and `composer-image-thread-switch.spec.ts`.
+- Seed one Git directory so Directories shows a `+` launchpad and one existing thread linked to that directory or available in Recents.
+- Launch with the Tiptap composer variant that matches current app usage, then open Directories, click `+`, type launchpad text, and paste at least one generated PNG image into the Tiptap textbox.
+- Switch to an existing thread, type reply text, and paste a different generated PNG image into the reply composer.
+- Trigger a refresh-capable boundary through replayed lifecycle or navigation update, then return to the launchpad and existing thread.
+- Assert `composer-tiptap-input` `data-value` for each scope and visible `Pasted images` previews for each scope.
+
+**Execution note:** Test-first. This unit should fail against the current broken behavior or prove the suspected gap if the implementation has already changed.
+
+**Patterns to follow:**
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` for Tiptap launchpad setup and `composer-tiptap-input` assertions.
+- `apps/desktop/e2e/composer-image-thread-switch.spec.ts` for generated image paste and delayed image-normalization race coverage.
+- `apps/desktop/e2e/composer-draft-settings.spec.ts` for existing-thread Tiptap draft assertions through settings.
+
+**Test scenarios:**
+- Integration: launchpad Tiptap text plus image -> switch away -> refresh boundary -> reopen same directory `+` -> same text and image remain.
+- Integration: existing-thread Tiptap reply text plus image -> switch away -> refresh boundary -> return to thread -> same text and image remain.
+- Edge case: the launchpad image preview remains visible while `data-value` also remains non-empty, proving partial persistence does not pass.
+- Edge case: the existing-thread reply image preview remains visible while `data-value` also remains non-empty.
+- Regression: the refresh boundary does not change the selected thread unexpectedly or materialize the launchpad before send.
+
+**Verification:**
+- The E2E fails if either scope loses text, images, or the pairing of both.
+
+- [ ] **Unit 2: Stabilize scoped draft snapshots in the composer**
+
+**Goal:** Make draft save and restore operate on one coherent scoped snapshot for Tiptap text, skill tokens, and pasted images.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R9, R10, R12
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx` only if Tiptap change timing needs a safer canonical-value callback
+- Create: `apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
+
+**Approach:**
+- Introduce a clear internal draft snapshot concept containing canonical draft text, skill tokens, and image attachments.
+- Save the current scope snapshot before switching composer scopes and when the component unmounts.
+- Restore from the snapshot for thread scopes and from the local launchpad snapshot for launchpad scopes before falling back to persisted launchpad props.
+- Ensure Tiptap text changes update the canonical snapshot promptly enough that a selection change cannot observe stale text.
+- Ensure delayed image normalization merges into the original scope snapshot without overwriting newer text for that scope.
+- Preserve existing send, steer, slash command, review command, and image attachment behaviors.
+
+**Patterns to follow:**
+- Current `composerScopeKey`, `saveThreadComposerDraft`, `pasteScopeRef`, and Tiptap `data-value` flow in `Composer.tsx`.
+- Current launchpad delayed image tests in `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
+
+**Test scenarios:**
+- Happy path: Tiptap launchpad text and image are saved as one snapshot when switching to another launchpad or thread.
+- Happy path: Tiptap existing-thread reply text and image are restored after switching to another thread and back.
+- Edge case: delayed image normalization finishing after scope switch appends to the original scope and preserves that scope's latest text.
+- Edge case: skill-token text in a Tiptap draft survives scope switch without losing the selected skill token or plain text around it.
+- Edge case: multiline Tiptap content survives scope switch and restore with the same canonical `data-value`.
+- Regression: empty draft scopes still clear from the in-memory store so stale images or text do not reappear after explicit clear/send.
+
+**Verification:**
+- Composer-level tests prove scope switching cannot separate text, skill tokens, and image attachments for Tiptap scopes.
+
+- [ ] **Unit 3: Harden launchpad overlay persistence and navigation refresh merging**
+
+**Goal:** Prevent debounced launchpad autosave, sticky setting patches, and navigation refreshes from replacing newer local launchpad drafts with older persisted state.
+
+**Requirements:** R1, R2, R3, R10, R11, R12, R13
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts` only if renderer-side merge protection is insufficient
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts` if backend launchpad merge behavior changes
+
+**Approach:**
+- Treat launchpad text and images as one patch when persisting to `updateDirectoryLaunchpad`.
+- Flush the current launchpad draft before changing selection away from a launchpad or before applying a navigation refresh that could rehydrate the same launchpad.
+- Apply launchpad updates optimistically in the renderer so the active UI and navigation snapshot reflect the latest local draft immediately.
+- Guard async `updateDirectoryLaunchpad` and `ensureDirectoryLaunchpad` responses so older responses cannot overwrite a newer local snapshot for the same directory key.
+- Ensure sticky setting patches merge with current prompt and images instead of patching only settings over a stale launchpad object.
+- Keep backend overlay persistence compatible with existing `NavigationLaunchpadDraft` and `UpdateDirectoryLaunchpadRequest`; avoid shared contract changes unless implementation proves they are necessary.
+
+**Patterns to follow:**
+- `applyLaunchpadUpdate` and `updateDirectoryLaunchpad` in `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`.
+- `updateDirectoryLaunchpad` in `apps/desktop/src/main/app-server/backend-registry.ts`.
+- `OverlayStore.upsertDirectoryLaunchpad` in `packages/agent-core/src/persistence/overlay-store.ts`.
+
+**Test scenarios:**
+- Happy path: launchpad text update followed by image update leaves both prompt and image attachment in navigation snapshot.
+- Happy path: sticky model or execution-mode update preserves current prompt and image attachments.
+- Edge case: a slow `updateDirectoryLaunchpad` response for an older prompt cannot overwrite a newer prompt already typed locally.
+- Edge case: reopening an empty launchpad can still adopt current sticky defaults without carrying stale text or images.
+- Edge case: reopening a non-empty launchpad preserves its existing prompt/images while normalizing provider/model defaults only where valid.
+- Error path: failed launchpad persistence reports `launchpadError` without clearing the visible draft.
+
+**Verification:**
+- Launchpad state in the renderer remains monotonic with respect to local user edits: older persistence or refresh data cannot erase newer unsent text or images.
+
+- [ ] **Unit 4: Keep existing-thread reply drafts stable through refresh and remount boundaries**
+
+**Goal:** Ensure existing-thread reply drafts survive thread switching, settings overlay transitions, component rerenders, and navigation refreshes without requiring restart persistence.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R10, R12
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/App.tsx` only if draft storage needs to live above `ThreadView`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/e2e/composer-draft-settings.spec.ts`
+
+**Approach:**
+- Keep thread reply drafts in renderer session state, but ensure the storage owner is stable across the UI boundaries that can currently remount or rerender the composer.
+- Use thread identity keys, not object identity, as draft keys so navigation snapshot reconciliation cannot orphan an existing draft.
+- Save current thread draft snapshots before selecting another thread and before opening settings.
+- Restore Tiptap canonical values and pasted image attachments together when returning to a thread.
+- Avoid clearing a thread draft on turn lifecycle or navigation refresh unless the user successfully sends that draft or explicitly clears it.
+
+**Patterns to follow:**
+- Current `scopedThreadDraftsRef` logic in `Composer.tsx`.
+- Existing `composer-draft-settings.spec.ts` Tiptap text-only flow.
+- `buildThreadIdentityKey` usage in `useThreadNavigation.ts`.
+
+**Test scenarios:**
+- Happy path: existing-thread Tiptap reply text and image survive switching to a second thread and back.
+- Happy path: existing-thread Tiptap reply text and image survive opening settings and returning.
+- Edge case: navigation refresh that updates another thread does not clear the selected thread draft.
+- Edge case: selected thread summary object changes but thread identity key stays the same -> draft remains.
+- Edge case: delayed image normalization finishing while another thread is selected attaches to the original thread draft and preserves that draft's latest text.
+- Regression: sending a thread reply clears only the sent draft for that thread and does not clear drafts for other threads.
+
+**Verification:**
+- Existing-thread drafts behave consistently with launchpad drafts for the current app session, without adding restart persistence.
+
+- [ ] **Unit 5: Expand regression coverage around Tiptap variants and sticky settings**
+
+**Goal:** Close the coverage gap that allowed Tiptap-specific and settings-triggered draft loss to escape.
+
+**Requirements:** R7, R8, R9, R13, R14, R15, R16, R17
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+- Modify: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+
+**Approach:**
+- Keep one required app-level E2E on the default Tiptap variant used by the app.
+- Add focused component coverage for the other Tiptap variant where the difference matters, especially multiline/markdown serialization.
+- Extend launchpad component tests so image persistence and delayed normalization run with `composerImplementation="tiptap-chips"` or the current default Tiptap setting, not only the textarea path.
+- Add a sticky settings coverage case that changes at least one launchpad setting after text/images exist and asserts both remain.
+- Keep textarea/custom-widget coverage only as compatibility regression coverage; it should not be the primary proof for this bug.
+
+**Patterns to follow:**
+- Tiptap variant loops and constants in `apps/desktop/e2e/directory-launchpad-skills.spec.ts`.
+- Tiptap `data-value` assertions in `apps/desktop/e2e/skill-autocomplete-interactions.spec.ts`.
+
+**Test scenarios:**
+- Integration: the main regression E2E runs with the primary Tiptap composer and asserts both launchpad and existing-thread drafts.
+- Happy path: launchpad setting change after text/image composition preserves Tiptap `data-value` and image preview.
+- Edge case: multiline Tiptap WYSIWYG content persists across launchpad switch or sticky setting update.
+- Edge case: selected skill chips in a Tiptap launchpad draft persist across a navigation refresh and still serialize to the same canonical draft.
+- Regression: textarea/custom-widget tests still pass but are no longer the only launchpad image persistence coverage.
+
+**Verification:**
+- The final coverage matrix includes app-level Tiptap E2E plus focused unit/component tests for launchpad, existing-thread, delayed image, and sticky settings paths.
+
+## System-Wide Impact
+
+- **Interaction graph:** `Sidebar` and `useThreadNavigation` select scopes; `ThreadView` chooses launchpad versus thread composer; `Composer.tsx` owns visible draft interactions; `updateDirectoryLaunchpad` persists launchpad scopes; replay E2Es prove the full path.
+- **Error propagation:** Launchpad persistence failures should surface as `launchpadError` while retaining the visible local draft. Image normalization failures should still show composer send errors only for the active scope.
+- **State lifecycle risks:** The main risks are partial draft writes, stale async launchpad responses, Tiptap change timing, delayed image normalization, and component remounts. Each implementation unit isolates one of those risks.
+- **API surface parity:** No IPC, app-server, or shared contract changes are planned. If implementation discovers a shared contract change is necessary, it should be treated as a scope escalation.
+- **Integration coverage:** The app-level E2E must cover the combined workflow because unit tests cannot prove navigation refresh and replay lifecycle interactions.
+- **Unchanged invariants:** Start-thread/send semantics, image normalization policy, launchpad one-draft-per-directory behavior, sticky defaults, and current accessible composer names must remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Fixing launchpad persistence only could leave existing-thread reply drafts vulnerable. | Plan separate launchpad and existing-thread units, both covered by one combined E2E. |
+| Persisting every keystroke through IPC could add churn. | Make local state immediate, then flush/merge persistence at safe boundaries rather than relying only on per-keystroke writes. |
+| Tiptap `onChange` timing could lag behind navigation clicks. | Tests must assert `data-value` after fast scope changes; implementation should save canonical values from the latest editor state before selection changes. |
+| Async image normalization can complete after the user changes scope. | Preserve the original scope key and merge image completion into that scope's current snapshot instead of captured stale text. |
+| Older navigation or persistence responses can overwrite newer local drafts. | Add stale-response protection keyed by scope and local revision/updated timestamp semantics. |
+| Hoisting draft state too broadly could accidentally add restart persistence or leak drafts between scopes. | Keep existing-thread drafts renderer-session scoped and keyed by thread identity; keep launchpad persistence constrained to the existing overlay store. |
+
+## Documentation / Operational Notes
+
+- No user-facing documentation is required.
+- If the E2E fixture needs live replay refresh work, use `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`; otherwise prefer deterministic inline replay fixture construction as current E2Es do.
+- The PR should explicitly call out that the regression E2E covers Tiptap, launchpad text/images, existing-thread text/images, and refresh boundaries.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md](../brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md)
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- Related code: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `packages/agent-core/src/persistence/overlay-store.ts`
+- Related types: `packages/shared/src/contracts/navigation.ts`
+- Related E2E: `apps/desktop/e2e/directory-launchpad-skills.spec.ts`
+- Related E2E: `apps/desktop/e2e/composer-image-thread-switch.spec.ts`
+- Related E2E: `apps/desktop/e2e/composer-draft-settings.spec.ts`
+- Related plan: `docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md`
+- Related plan: `docs/plans/2026-04-18-003-fix-desktop-thread-refresh-model-plan.md`

--- a/docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md
+++ b/docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Preserve composer drafts across navigation
 type: fix
-status: active
+status: completed
 date: 2026-05-02
 origin: docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md
 ---
@@ -118,7 +118,7 @@ flowchart TB
     U4 --> U5
 ```
 
-- [ ] **Unit 1: Add failing Tiptap draft persistence E2E**
+- [x] **Unit 1: Add failing Tiptap draft persistence E2E**
 
 **Goal:** Capture the reported regression in a deterministic Electron E2E before changing implementation behavior.
 
@@ -156,7 +156,7 @@ flowchart TB
 **Verification:**
 - The E2E fails if either scope loses text, images, or the pairing of both.
 
-- [ ] **Unit 2: Stabilize scoped draft snapshots in the composer**
+- [x] **Unit 2: Stabilize scoped draft snapshots in the composer**
 
 **Goal:** Make draft save and restore operate on one coherent scoped snapshot for Tiptap text, skill tokens, and pasted images.
 
@@ -194,7 +194,7 @@ flowchart TB
 **Verification:**
 - Composer-level tests prove scope switching cannot separate text, skill tokens, and image attachments for Tiptap scopes.
 
-- [ ] **Unit 3: Harden launchpad overlay persistence and navigation refresh merging**
+- [x] **Unit 3: Harden launchpad overlay persistence and navigation refresh merging**
 
 **Goal:** Prevent debounced launchpad autosave, sticky setting patches, and navigation refreshes from replacing newer local launchpad drafts with older persisted state.
 
@@ -234,7 +234,7 @@ flowchart TB
 **Verification:**
 - Launchpad state in the renderer remains monotonic with respect to local user edits: older persistence or refresh data cannot erase newer unsent text or images.
 
-- [ ] **Unit 4: Keep existing-thread reply drafts stable through refresh and remount boundaries**
+- [x] **Unit 4: Keep existing-thread reply drafts stable through refresh and remount boundaries**
 
 **Goal:** Ensure existing-thread reply drafts survive thread switching, settings overlay transitions, component rerenders, and navigation refreshes without requiring restart persistence.
 
@@ -273,7 +273,7 @@ flowchart TB
 **Verification:**
 - Existing-thread drafts behave consistently with launchpad drafts for the current app session, without adding restart persistence.
 
-- [ ] **Unit 5: Expand regression coverage around Tiptap variants and sticky settings**
+- [x] **Unit 5: Expand regression coverage around Tiptap variants and sticky settings**
 
 **Goal:** Close the coverage gap that allowed Tiptap-specific and settings-triggered draft loss to escape.
 


### PR DESCRIPTION
## Summary

I fixed the Directories launchpad and thread reply composer draft persistence regression for the Tiptap composer path.

- Added a shared renderer-side composer draft store above `ThreadView` so launchpad and thread reply composer instances can restore text, pasted images, selected skill, and branch mode after navigation/remounts.
- Flush launchpad prompt/image drafts on scope changes and unmounts, so quick navigation does not lose text before the existing debounce fires.
- Made delayed pasted-image normalization merge back into the original composer scope instead of overwriting newer scope state.
- Preserve current launchpad prompt/images when sticky settings change, and guard async launchpad update responses so older scheduled refreshes cannot overwrite newer local launchpad state.
- Clear submitted launchpad drafts before materialization can unmount the composer, so reopening a directory launchpad cannot resurrect a prompt that was already sent.
- Added a replay-backed desktop E2E that reproduces the reported flow: launchpad text + pasted screenshot, switch to a thread, thread reply text + pasted screenshot, trigger a refresh, then verify both composers still retain their drafts.

## Requirements and Plan

- Added requirements: `docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md`
- Added and completed plan: `docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md`

## Verification

I verified this with:

```sh
pnpm --filter @pwragnt/desktop typecheck
pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
pnpm --filter @pwragnt/desktop test:e2e composer-draft-persistence-regression.spec.ts
pnpm --filter @pwragnt/desktop test:e2e
```

The focused renderer test run passed 66 tests, the targeted replay-backed composer persistence E2E passed, and the full desktop E2E suite passed 85 tests locally.

## Review Notes

No repository PR template was present. I also did an inline review pass after implementation. That found and fixed a sticky-settings edge case where changing a launchpad sticky setting could have reused stale persisted image attachments after local removal.

I addressed review feedback about submitted launchpad prompts being saved during unmount cleanup by marking launchpad scopes as submitted before materialization and skipping stale draft flushes for those scopes. Added unit coverage for both normal launchpad submit and launchpad `/review` submit racing with unmount.

## Post-Deploy Monitoring and Validation

Healthy signals:

- Tiptap launchpad and thread reply composers retain text and pasted image previews across Directories/thread switching.
- Drafts survive directory/thread list refreshes and turn-completed notification refreshes.
- No new `launchpadError` reports while changing sticky settings.

Failure signals to watch:

- User reports that launchpad or reply composer text disappears after switching views.
- User reports that pasted screenshots disappear, duplicate, or reappear after removal.
- Renderer logs show `Desktop bridge is missing updateDirectoryLaunchpad()` or repeated launchpad update failures.

Rollback:

- Revert the commits in this PR if the shared draft-store behavior causes regressions.
- If the issue is limited to the Tiptap composer path, temporarily disable the Tiptap reply composer experiment while preserving this E2E as the regression gate.
