### PR TITLE
fix(messaging): harden remote thread status flows

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1447,6 +1447,45 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("keeps an idle newly started thread visible until the backend list includes it", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/start"] },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startThread({
+      backend: "codex",
+      cwd: "/repo-a",
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        projectKey: "/repo-a",
+        linkedDirectories: [
+          {
+            id: "/repo-a",
+            kind: "local",
+            label: "repo-a",
+            path: "/repo-a",
+          },
+        ],
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("materializes workspace launchpads into a scratch directory instead of the workspace root", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },

--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -542,6 +542,70 @@ describe("DiscordAdapter", () => {
     expect(api.createMessage).not.toHaveBeenCalled();
   });
 
+  it("pins and unpins Discord status surfaces when requested", async () => {
+    const api = createApi();
+    const adapter = new DiscordAdapter({
+      api: api as unknown as DiscordApi,
+      config: {
+        channel: "discord",
+        botToken: "discord-token",
+        authorizedActorIds: ["42"],
+      },
+      gateway: createGateway(),
+      now: () => 1000,
+    });
+
+    const pinResult = await adapter.deliver({
+      id: "status-1",
+      kind: "status",
+      createdAt: 1000,
+      status: "idle",
+      text: "Binding: active",
+      delivery: {
+        pin: true,
+      },
+      audit: {
+        actor: {
+          platformUserId: "42",
+        },
+        channel: {
+          channel: "discord",
+          conversation: {
+            id: "channel-1",
+            kind: "channel",
+            parentId: "guild-1",
+          },
+        },
+        occurredAt: 1000,
+      },
+    });
+
+    expect(pinResult.outcome).toBe("pinned");
+    expect(api.pinMessage).toHaveBeenCalledWith("channel-1", "message-1");
+
+    const unpinResult = await adapter.deliver({
+      id: "dismiss-1",
+      kind: "dismiss",
+      createdAt: 1000,
+      delivery: {
+        unpin: true,
+      },
+      targetSurface: {
+        channel: "discord",
+        id: "message-1",
+        state: {
+          opaque: {
+            channelId: "channel-1",
+            messageId: "message-1",
+          },
+        },
+      },
+    });
+
+    expect(unpinResult.outcome).toBe("unpinned");
+    expect(api.unpinMessage).toHaveBeenCalledWith("channel-1", "message-1");
+  });
+
   it("expires Discord typing activity when no idle signal arrives", async () => {
     vi.useFakeTimers();
     try {
@@ -1032,7 +1096,9 @@ function createApi(options: {
   createMessage: ReturnType<typeof vi.fn>;
   deleteApplicationCommand: ReturnType<typeof vi.fn>;
   listApplicationCommands: ReturnType<typeof vi.fn>;
+  pinMessage: ReturnType<typeof vi.fn>;
   sendTyping: ReturnType<typeof vi.fn>;
+  unpinMessage: ReturnType<typeof vi.fn>;
   updateChannelName: ReturnType<typeof vi.fn>;
   updateApplicationCommand: ReturnType<typeof vi.fn>;
   updateInteractionOriginalResponse: ReturnType<typeof vi.fn>;
@@ -1077,7 +1143,9 @@ function createApi(options: {
     listApplicationCommands: vi.fn(
       async (_applicationId: string) => applicationCommands,
     ),
+    pinMessage: vi.fn(async (_channelId: string, _messageId: string) => undefined),
     sendTyping: vi.fn(async (_channelId: string) => undefined),
+    unpinMessage: vi.fn(async (_channelId: string, _messageId: string) => undefined),
     updateChannelName: vi.fn(
       async (_channelId: string, _request: { name: string }) => undefined,
     ),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -182,6 +182,37 @@ describe("MessagingController", () => {
     });
   });
 
+  it("updates the resume picker and removes actions when selecting a thread", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    const confirmation = [...harness.delivered]
+      .reverse()
+      .find((intent) => intent.kind === "confirmation");
+    expect(confirmation).toMatchObject({
+      kind: "confirmation",
+      title: "Thread bound",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+      targetSurface: expect.objectContaining({
+        id: expect.stringContaining("surface:resume:"),
+      }),
+    });
+  });
+
   it("maps text fallback replies against pending picker actions", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -459,6 +459,88 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not restart typing from a stale assistant delivery after idle", async () => {
+    let now = 1000;
+    let resolveAssistantDelivery!: () => void;
+    const assistantDelivery = new Promise<void>((resolve) => {
+      resolveAssistantDelivery = resolve;
+    });
+    const delivered: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      now: () => now,
+      deliver: async (intent) => {
+        delivered.push(intent);
+        if (intent.kind === "message" && intent.role === "assistant") {
+          await assistantDelivery;
+        }
+        return {
+          channel: "telegram",
+          deliveredAt: now,
+          outcome: intent.kind === "status" && intent.delivery?.pin ? "pinned" : "presented",
+          surface: {
+            channel: "telegram",
+            id: `surface:${intent.id}`,
+          },
+        };
+      },
+    });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start work"));
+    delivered.length = 0;
+
+    const assistantEvent = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "agentMessage",
+            text: "Done.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    await vi.waitFor(() => {
+      expect(delivered).toEqual([
+        expect.objectContaining({
+          kind: "message",
+          role: "assistant",
+        }),
+      ]);
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-1",
+          status: {
+            type: "idle",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    const idleActivityIndex = delivered.findIndex(
+      (intent) => intent.kind === "activity" && intent.state === "idle",
+    );
+    expect(idleActivityIndex).toBeGreaterThanOrEqual(0);
+
+    now += 11_000;
+    resolveAssistantDelivery();
+    await assistantEvent;
+
+    expect(
+      delivered
+        .slice(idleActivityIndex + 1)
+        .filter((intent) => intent.kind === "activity" && intent.state === "active"),
+    ).toEqual([]);
+  });
+
   it("recreates the pinned status surface for /status commands", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -515,6 +515,35 @@ describe("MessagingController", () => {
     });
   });
 
+  it("refreshes the status card when a bound thread is renamed", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    const renamedNavigation = buildNavigationSnapshot();
+    renamedNavigation.threads[0]!.title = "Wood chuck joke";
+    renamedNavigation.threads[0]!.titleSource = "explicit";
+    harness.getNavigationSnapshot.mockResolvedValueOnce(renamedNavigation);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "Wood chuck joke",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        text: expect.stringContaining("Binding: Wood chuck joke (codex)"),
+      }),
+    ]);
+  });
+
   it("does not restart typing from a stale assistant delivery after idle", async () => {
     let now = 1000;
     let resolveAssistantDelivery!: () => void;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2148,6 +2148,68 @@ describe("MessagingController", () => {
     });
   });
 
+  it("pages large local-to-worktree handoff branch lists from the status menu", async () => {
+    const harness = await createHarness();
+    const navigation = buildLocalHandoffNavigationSnapshot();
+    navigation.directories[0]!.gitStatus = {
+      currentBranch: "feature/handoff",
+      handoffBranches: Array.from({ length: 18 }, (_, index) => `branch-${index + 1}`),
+    };
+    harness.getNavigationSnapshot.mockResolvedValue(navigation);
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: toWorktree.id,
+        value: toWorktree.value,
+      }),
+    );
+
+    const firstPage = harness.delivered.at(-1);
+    if (!firstPage || !("choices" in firstPage)) {
+      throw new Error("Expected handoff branch picker");
+    }
+    expect(firstPage.prompt).toContain("Page 1/3.");
+    expect(
+      firstPage.choices.filter((choice) => choice.id === "handoff:select-leave-branch"),
+    ).toHaveLength(8);
+    expect(firstPage.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:branches:next",
+        value: expect.objectContaining({ pageIndex: 1 }),
+      }),
+    );
+
+    const nextPage = findChoice(firstPage, "handoff:branches:next");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: nextPage.id,
+        value: nextPage.value,
+      }),
+    );
+
+    const secondPage = harness.delivered.at(-1);
+    if (!secondPage || !("choices" in secondPage)) {
+      throw new Error("Expected second handoff branch picker");
+    }
+    expect(secondPage.prompt).toContain("Page 2/3.");
+    expect(secondPage.choices[0]).toMatchObject({
+      id: "handoff:select-leave-branch",
+      label: "9. branch-9",
+    });
+    expect(secondPage.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:branches:previous",
+        value: expect.objectContaining({ pageIndex: 0 }),
+      }),
+    );
+  });
+
   it("runs a worktree-to-local handoff from the status menu", async () => {
     const harness = await createHarness();
     harness.getNavigationSnapshot.mockResolvedValue(buildWorktreeHandoffNavigationSnapshot());

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -146,6 +146,49 @@ describe("MessagingController", () => {
     });
   });
 
+  it("routes messages to the new thread after rebinding an already-bound conversation", async () => {
+    const harness = await createHarness();
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:codex:old-thread",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: buildCommandEvent("/resume").channel,
+      createdAt: 900,
+      threadId: "old-thread",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragnt",
+          label: "PwrAgnt",
+          path: "/repo/pwragnt",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("continue on the new thread"));
+
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "new-thread-1",
+        input: [
+          {
+            type: "text",
+            text: "continue on the new thread",
+          },
+        ],
+      }),
+    );
+    await expect(harness.store.getBinding("binding:telegram:dm::chat-1:codex:old-thread"))
+      .resolves.toMatchObject({
+        revokedAt: 1000,
+      });
+  });
+
   it("binds a callback-selected thread to the channel", async () => {
     const harness = await createHarness();
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -429,6 +429,62 @@ describe("MessagingController", () => {
     });
   });
 
+  it("skips duplicate status renders for backend lifecycle echoes", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start work"));
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-1",
+          status: {
+            type: "idle",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(harness.delivered).toHaveLength(2);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toHaveLength(2);
+  });
+
   it("stops typing when the backend reports idle without a turn completion event", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -137,6 +137,13 @@ describe("MessagingController", () => {
       buildCommandEvent("/resume").channel,
     );
     expect(binding).not.toHaveProperty("threadDisplay");
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Project: PwrAgnt"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      text: expect.stringContaining("Directory: /repo/pwragnt"),
+    });
   });
 
   it("binds a callback-selected thread to the channel", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -213,6 +213,63 @@ describe("MessagingController", () => {
     });
   });
 
+  it("updates the clicked resume picker when multiple pickers are active", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    const firstPicker = harness.delivered.at(-1);
+    if (firstPicker?.kind !== "thread_picker" || !firstPicker.browseSessionId) {
+      throw new Error("Expected first resume picker with a browse session id");
+    }
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    const secondPicker = harness.delivered.at(-1);
+    if (secondPicker?.kind !== "thread_picker") {
+      throw new Error("Expected second resume picker");
+    }
+
+    await harness.store.upsertCallbackHandle({
+      id: "callback:first-picker",
+      actionId: "browse:select-thread",
+      allowedActorIds: ["user-1"],
+      browseSessionId: firstPicker.browseSessionId,
+      channel: buildCommandEvent("/resume").channel,
+      createdAt: 1000,
+      updatedAt: 1000,
+      expiresAt: 2000,
+      handle: "tg:first-picker",
+      value: {
+        backend: "codex",
+        threadId: "thread-1",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        interactionId: "tg:first-picker",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    const confirmation = [...harness.delivered]
+      .reverse()
+      .find((intent) => intent.kind === "confirmation");
+    expect(confirmation).toMatchObject({
+      kind: "confirmation",
+      targetSurface: expect.objectContaining({
+        id: `surface:${firstPicker.id}`,
+      }),
+    });
+    expect(confirmation).not.toMatchObject({
+      targetSurface: expect.objectContaining({
+        id: `surface:${secondPicker.id}`,
+      }),
+    });
+  });
+
   it("maps text fallback replies against pending picker actions", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
@@ -2415,6 +2472,7 @@ function buildToolCompletedEvent(id: string, command: string): AgentEvent {
 
 function buildCallbackEvent(params: {
   actionId: string;
+  interactionId?: string;
   routingState?: MessagingInboundCallbackEvent["routingState"];
   value?: MessagingInboundCallbackEvent["value"];
 }): MessagingInboundCallbackEvent {
@@ -2435,7 +2493,7 @@ function buildCallbackEvent(params: {
     routingState: params.routingState,
     interaction: {
       channel: "telegram",
-      id: params.actionId,
+      id: params.interactionId ?? params.actionId,
     },
     actionId: params.actionId,
     value: params.value,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -684,7 +684,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("detaches a bound conversation and unpins the status surface", async () => {
+  it("detaches a bound conversation, clears status actions, and unpins the status surface", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
@@ -695,14 +695,28 @@ describe("MessagingController", () => {
         },
       }),
     );
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/detach").channel,
+    );
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
 
+    expect(harness.delivered.at(-3)).toMatchObject({
+      kind: "status",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+        fallback: "fail",
+      },
+      targetSurface: binding?.statusSurface,
+    });
     expect(harness.delivered.at(-2)).toMatchObject({
       kind: "dismiss",
       delivery: {
         unpin: true,
       },
+      targetSurface: binding?.pinnedStatusSurface,
     });
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/detach").channel),

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -100,6 +100,28 @@ describe("DesktopMessagingRuntime", () => {
     });
   });
 
+  it("logs inbound controller failures without rejecting the adapter listener", async () => {
+    const { runtime, adapter, bridge } = await createRuntimeHarness();
+    vi.mocked(bridge.getNavigationSnapshot).mockRejectedValueOnce(
+      new Error("navigation failed"),
+    );
+
+    await runtime.start();
+    await expect(adapter.listener?.(buildCommandEvent("/resume"))).resolves
+      .toBeUndefined();
+
+    expect(messagingLog.error).toHaveBeenCalledWith(
+      "messaging controller failed to handle inbound event",
+      expect.objectContaining({
+        channel: "telegram",
+        conversationId: "chat-1",
+        error: expect.any(Error),
+        eventId: "event-command",
+        eventKind: "command",
+      }),
+    );
+  });
+
   it("forwards backend turn completions to bound channel adapters", async () => {
     const { runtime, adapter, emitBackendEvent } = await createRuntimeHarness();
 

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -100,6 +100,26 @@ describe("buildBindingStatusIntent", () => {
     });
   });
 
+  it("shortens derived thread titles in the compact status binding line", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.title =
+      "How much wood would a woodchuck chuck if a woodchuck could chuck wood";
+    navigation.threads[0]!.titleSource = "derived";
+
+    const intent = buildBindingStatusIntent({
+      id: "status-derived-title",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Binding: How much wood would a woodchuck chuck if a... (codex)");
+    expect(intent.text).not.toContain(
+      "Binding: How much wood would a woodchuck chuck if a woodchuck could chuck wood",
+    );
+  });
+
   it("renders live thread permissions ahead of stale binding preferences", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0]!.executionMode = "default";

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -378,6 +378,61 @@ describe("buildBindingStatusIntent", () => {
     });
   });
 
+  it("paginates handoff branch picker choices", () => {
+    const binding = buildBinding();
+    const context = {
+      ...buildHandoffContext(),
+      leaveLocalBranches: Array.from({ length: 18 }, (_, index) => `branch-${index + 1}`),
+    };
+
+    const firstPage = buildHandoffBranchPickerIntent({
+      id: "handoff-branch-page-1",
+      binding,
+      context,
+      createdAt: 1000,
+    });
+    expect(
+      firstPage.choices.filter((choice) => choice.id === "handoff:select-leave-branch"),
+    ).toHaveLength(8);
+    expect(firstPage.prompt).toContain("Page 1/3.");
+    expect(firstPage.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:branches:next",
+        label: "Next",
+        value: expect.objectContaining({ pageIndex: 1 }),
+      }),
+    );
+    expect(firstPage.choices).not.toContainEqual(
+      expect.objectContaining({ id: "handoff:branches:previous" }),
+    );
+
+    const lastPage = buildHandoffBranchPickerIntent({
+      id: "handoff-branch-page-3",
+      binding,
+      context,
+      createdAt: 1000,
+      pageIndex: 2,
+    });
+    expect(
+      lastPage.choices.filter((choice) => choice.id === "handoff:select-leave-branch"),
+    ).toHaveLength(2);
+    expect(lastPage.prompt).toContain("Page 3/3.");
+    expect(lastPage.choices[0]).toMatchObject({
+      id: "handoff:select-leave-branch",
+      label: "17. branch-17",
+    });
+    expect(lastPage.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:branches:previous",
+        label: "Previous",
+        value: expect.objectContaining({ pageIndex: 1 }),
+      }),
+    );
+    expect(lastPage.choices).not.toContainEqual(
+      expect.objectContaining({ id: "handoff:branches:next" }),
+    );
+  });
+
   it("parses a handoff request only from complete action values", () => {
     expect(
       handoffRequestFromValue({

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -114,9 +114,28 @@ describe("buildBindingStatusIntent", () => {
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
-    expect(intent.text).toContain("Binding: How much wood would a woodchuck chuck if a... (codex)");
+    expect(intent.text).toContain("Binding: How much wood would a woodchuck... (codex)");
     expect(intent.text).not.toContain(
       "Binding: How much wood would a woodchuck chuck if a woodchuck could chuck wood",
+    );
+  });
+
+  it("compacts short derived prompt titles before the generated title arrives", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.title = "We're here for another wood chuck joke";
+    navigation.threads[0]!.titleSource = "derived";
+
+    const intent = buildBindingStatusIntent({
+      id: "status-derived-short-title",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Binding: We're here for another wood... (codex)");
+    expect(intent.text).not.toContain(
+      "Binding: We're here for another wood chuck joke (codex)",
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -275,6 +275,28 @@ describe("MessagingStore", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("replaces the active binding when a conversation is rebound", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({ id: "binding-old", threadId: "thread-old" }));
+    await store.upsertBinding(
+      buildBinding({
+        id: "binding-new",
+        threadId: "thread-new",
+        createdAt: 2000,
+        updatedAt: 2000,
+      }),
+    );
+
+    await expect(store.findActiveBindingForChannel(buildBinding().channel)).resolves
+      .toMatchObject({
+        id: "binding-new",
+        threadId: "thread-new",
+      });
+    await expect(store.getBinding("binding-old")).resolves.toMatchObject({
+      revokedAt: 2000,
+    });
+  });
+
   it("removes pending intents for a binding when the binding is revoked", async () => {
     const { store } = await createStore();
     await store.upsertBinding(buildBinding());

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -237,6 +237,60 @@ describe("TelegramAdapter", () => {
     expect(api.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("returns failed delivery results instead of throwing Telegram API errors", async () => {
+    const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    api.sendMessage.mockRejectedValueOnce(
+      new Error("Call to 'sendMessage' failed! (429: Too Many Requests)"),
+    );
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: ["42"],
+      },
+      logger,
+      now: () => 1000,
+    });
+
+    await expect(
+      adapter.deliver({
+        id: "message-1",
+        kind: "message",
+        createdAt: 1000,
+        parts: [
+          {
+            type: "text",
+            text: "Hello",
+          },
+        ],
+        audit: {
+          actor: {
+            platformUserId: "42",
+          },
+          channel: {
+            channel: "telegram",
+            conversation: {
+              id: "777",
+              kind: "dm",
+            },
+          },
+          occurredAt: 1000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      outcome: "failed",
+      errorMessage: "Call to 'sendMessage' failed! (429: Too Many Requests)",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("telegram deliver failed kind=message"),
+    );
+  });
+
   it("renames Telegram forum topics without allowing plain chat renames", async () => {
     const api = createApi();
     const adapter = new TelegramAdapter({

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -16,6 +16,7 @@ import type {
 import { TelegramAdapter } from "@pwragnt/messaging-provider-telegram";
 import type {
   TelegramBotApi,
+  TelegramBotLike,
   TelegramEditForumTopicRequest,
   TelegramEditMessageTextRequest,
   TelegramPinChatMessageRequest,
@@ -38,6 +39,50 @@ afterEach(async () => {
 });
 
 describe("TelegramAdapter", () => {
+  it("registers a Telegram bot error handler for polling middleware failures", async () => {
+    const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    const catchHandler = vi.fn<(handler: (error: unknown) => void) => void>();
+    const onHandler = vi.fn<
+      (filter: string, handler: (context: unknown) => void | Promise<void>) => void
+    >();
+    const start = vi.fn<(options?: { allowed_updates?: string[] }) => Promise<void>>(
+      async () => {},
+    );
+    const stop = vi.fn<() => void>();
+    const bot: TelegramBotLike = {
+      api: api as unknown as TelegramBotApi,
+      catch: catchHandler,
+      on: onHandler,
+      start,
+      stop,
+    };
+    const adapter = new TelegramAdapter({
+      bot,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: ["42"],
+      },
+      logger,
+      now: () => 1000,
+      pollOnStart: false,
+    });
+
+    await adapter.start(async () => {});
+    expect(catchHandler).toHaveBeenCalledTimes(1);
+
+    const handler = catchHandler.mock.calls[0]?.[0];
+    handler?.(new Error("middleware failed"));
+
+    expect(logger.warn).toHaveBeenCalledWith("telegram bot middleware failed", {
+      error: "middleware failed",
+    });
+  });
+
   it("normalizes /resume and renders a thread picker with inline keyboard handles", async () => {
     const harness = await createControllerHarness();
 

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -823,6 +823,67 @@ describe("TelegramAdapter", () => {
     });
   });
 
+  it("edits the topic resume picker when a thread is selected", async () => {
+    const harness = await createControllerHarness();
+
+    await harness.adapter.start((event) => harness.controller.handleInboundEvent(event));
+    await harness.adapter.handleUpdate({
+      update_id: 1,
+      message: {
+        chat: {
+          id: -100777,
+          title: "PwrAgnt",
+          type: "supergroup",
+        },
+        date: 1,
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+        },
+        message_id: 100,
+        message_thread_id: 55,
+        text: "/resume",
+      },
+    });
+    const callbackData =
+      harness.api.sendMessage.mock.calls.at(-1)?.[0].reply_markup?.inline_keyboard[0]?.[0]
+        ?.callback_data ?? "";
+
+    await harness.adapter.handleUpdate({
+      callback_query: {
+        data: callbackData,
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        id: "callback-1",
+        message: {
+          chat: {
+            id: -100777,
+            title: "PwrAgnt",
+            type: "supergroup",
+          },
+          message_id: 200,
+          message_thread_id: 55,
+        },
+      },
+      update_id: 2,
+    });
+
+    expect(harness.api.editMessageText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat_id: -100777,
+        message_id: 200,
+        message_thread_id: 55,
+        reply_markup: {
+          inline_keyboard: [],
+        },
+        text: expect.stringContaining("Thread bound"),
+      }),
+    );
+  });
+
   it("resolves persisted callback handles after adapter restart", async () => {
     const harness = await createControllerHarness();
 

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -109,6 +109,23 @@ describe("TelegramAdapter", () => {
     expect(callbackData).not.toContain("thread-1");
     expect(secondCallbackData).toMatch(/^tg:/);
     expect(secondCallbackData).not.toBe(callbackData);
+    await expect(
+      harness.store.resolveCallbackHandle({
+        actorId: "42",
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+        handle: callbackData ?? "",
+        now: 1000,
+      }),
+    ).resolves.toMatchObject({
+      actionId: "browse:select-thread",
+      browseSessionId: expect.stringMatching(/^browse:/),
+    });
   });
 
   it("signals typing activity without rendering a visible Telegram message", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,5 +1,6 @@
 import { app } from "electron";
 import { execFile as execFileCallback } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 import { OverlayStore } from "@pwragnt/agent-core";
 import {
@@ -31,6 +32,7 @@ import {
   type HandoffThreadWorkspaceResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type LinkedDirectorySummary,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadResponse,
   type NavigationDirectoryGitStatus,
@@ -231,6 +233,45 @@ function hasHandoffWorkspace(
   directories: AppServerThreadSummary["linkedDirectories"] = [],
 ): boolean {
   return directories.some((directory) => directory.id.startsWith("pwragnt-handoff:"));
+}
+
+function buildLocalLinkedDirectory(cwd: string | undefined): LinkedDirectorySummary[] {
+  const normalized = cwd?.trim();
+  if (!normalized) {
+    return [];
+  }
+  const directoryPath = path.resolve(normalized);
+  return [
+    {
+      id: directoryPath,
+      kind: "local",
+      label: path.basename(directoryPath) || directoryPath,
+      path: directoryPath,
+    },
+  ];
+}
+
+function pendingStartedThreadMatchesFilter(
+  thread: AppServerThreadSummary,
+  filter: string | undefined,
+): boolean {
+  const normalized = filter?.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  return [
+    thread.id,
+    thread.title,
+    thread.summary,
+    thread.projectKey,
+    ...thread.linkedDirectories.flatMap((directory) => [
+      directory.label,
+      directory.path,
+      directory.worktreePath,
+    ]),
+  ]
+    .filter(Boolean)
+    .some((value) => value!.toLowerCase().includes(normalized));
 }
 
 function resolveExpectedThreadBranch(params: {
@@ -900,6 +941,7 @@ export class DesktopBackendRegistry {
   private readonly modelCatalog: BackendModelCatalog;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
+  private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -1140,10 +1182,14 @@ export class DesktopBackendRegistry {
     }
 
     if (params.backend === "grok") {
-      return await this.grokClient.listThreads({
-        archived: params.archived,
-        filter: params.filter,
-      }, diagnostics);
+      return this.withPendingStartedThreads(
+        "grok",
+        await this.grokClient.listThreads({
+          archived: params.archived,
+          filter: params.filter,
+        }, diagnostics),
+        params,
+      );
     }
 
     const threadLists = await Promise.all([
@@ -1412,6 +1458,23 @@ export class DesktopBackendRegistry {
       approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
       sandbox: request.sandbox ?? modeSettings.sandbox,
     });
+    const startedAt = Date.now();
+    this.pendingStartedThreads.set(
+      `${backend}:${result.threadId}`,
+      {
+        id: result.threadId,
+        source: backend,
+        title: result.threadId,
+        titleSource: "fallback",
+        projectKey: cwd,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        executionMode,
+        ...modelSettings,
+        linkedDirectories: buildLocalLinkedDirectory(cwd),
+        gitBranch: cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined,
+      },
+    );
     this.invalidateThreadListCache(backend);
 
     if (backend === "codex") {
@@ -2283,13 +2346,18 @@ export class DesktopBackendRegistry {
       ...thread,
       executionMode: "default" as const,
     }));
+    const threadsWithPending = this.withPendingStartedThreads(
+      "codex",
+      allThreads,
+      params,
+    );
 
     const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
       backend: "codex",
-      threadIds: allThreads.map((thread) => thread.id),
+      threadIds: threadsWithPending.map((thread) => thread.id),
     });
 
-    return allThreads
+    return threadsWithPending
       .map((thread) => {
         const overlay = overlaysByThreadId[thread.id];
         return {
@@ -2298,6 +2366,34 @@ export class DesktopBackendRegistry {
         };
       })
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  }
+
+  private withPendingStartedThreads(
+    backend: AppServerBackendKind,
+    threads: AppServerThreadSummary[],
+    params: { archived?: boolean; filter?: string } = {},
+  ): AppServerThreadSummary[] {
+    const threadIds = new Set(threads.map((thread) => thread.id));
+    for (const threadId of threadIds) {
+      this.pendingStartedThreads.delete(`${backend}:${threadId}`);
+    }
+    if (params.archived === true) {
+      return threads;
+    }
+
+    const pendingThreads = [...this.pendingStartedThreads.values()].filter(
+      (thread) =>
+        thread.source === backend &&
+        !threadIds.has(thread.id) &&
+        pendingStartedThreadMatchesFilter(thread, params.filter),
+    );
+    if (pendingThreads.length === 0) {
+      return threads;
+    }
+
+    return [...pendingThreads, ...threads].sort(
+      (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+    );
   }
 
   private async describeCodexBackend(): Promise<BackendSummary> {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2065,7 +2065,6 @@ export class MessagingController {
       return;
     }
 
-    const statusSurface = binding.pinnedStatusSurface ?? binding.statusSurface;
     const activeTurn = this.getActiveTurn(binding);
     if (activeTurn) {
       await this.signalTurnActivity(
@@ -2079,24 +2078,11 @@ export class MessagingController {
       );
     }
     await this.flushToolUpdatesForBinding(binding, { clear: true });
-    if (statusSurface) {
-      await this.deliver(
-        {
-          id: this.newIntentId("status-dismiss"),
-          kind: "dismiss",
-          bindingId: binding.id,
-          createdAt: this.now(),
-          delivery: {
-            mode: "dismiss",
-            unpin: Boolean(binding.pinnedStatusSurface),
-          },
-          reason: "detached",
-          targetSurface: statusSurface,
-        },
-        binding,
-        event,
-      );
-    }
+    await this.retireBindingStatus(
+      binding,
+      event,
+      await this.options.backend.getNavigationSnapshot({ backend: "all" }),
+    );
 
     await this.options.store.revokeBinding({
       bindingId: binding.id,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1208,6 +1208,16 @@ export class MessagingController {
     const updatedBinding = preferences
       ? await this.updateBindingPreferences(binding, preferences)
       : binding;
+    const optimisticNavigation = navigationWithStartedThread({
+      backend: started.backend,
+      directory,
+      executionMode: started.executionMode,
+      navigation,
+      now: this.now(),
+      preferences,
+      project,
+      threadId: started.threadId,
+    });
     await this.options.store.deleteBrowseSession(session.id);
     await this.deliver(
       buildConfirmationIntent({
@@ -1227,7 +1237,7 @@ export class MessagingController {
       undefined,
       event,
     );
-    await this.renderBindingStatus(updatedBinding, event);
+    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -2993,6 +3003,81 @@ type TurnLifecycleParams = {
     startedAt?: number | null;
   };
 };
+
+function navigationWithStartedThread(params: {
+  backend: AppServerBackendKind;
+  directory?: NavigationDirectorySummary;
+  executionMode?: ThreadExecutionMode;
+  navigation: NavigationSnapshot;
+  now: number;
+  preferences?: MessagingBrowseSessionRecord["preferences"];
+  project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
+  threadId: ThreadIdentifier;
+}): NavigationSnapshot {
+  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  if (
+    params.navigation.threads.some(
+      (thread) => thread.source === params.backend && thread.id === params.threadId,
+    )
+  ) {
+    return params.navigation;
+  }
+
+  const directoryPath = params.directory?.path ?? params.project.path;
+  const linkedDirectory: LinkedDirectorySummary | undefined = directoryPath
+    ? {
+        id: params.directory?.key ?? directoryPath,
+        kind: "local",
+        label: params.directory?.label ?? params.project.label,
+        path: directoryPath,
+      }
+    : undefined;
+
+  return {
+    ...params.navigation,
+    unchanged: false,
+    threads: [
+      {
+        id: params.threadId,
+        source: params.backend,
+        title: params.threadId,
+        titleSource: "fallback",
+        projectKey: directoryPath,
+        createdAt: params.now,
+        updatedAt: params.now,
+        executionMode: params.executionMode,
+        model: params.preferences?.model ?? params.navigation.launchpadDefaults.model,
+        reasoningEffort:
+          params.preferences?.reasoningEffort ??
+          params.navigation.launchpadDefaults.reasoningEffort,
+        serviceTier:
+          params.preferences?.serviceTier ?? params.navigation.launchpadDefaults.serviceTier,
+        fastMode:
+          params.preferences?.fastMode ?? params.navigation.launchpadDefaults.fastMode,
+        linkedDirectories: linkedDirectory ? [linkedDirectory] : [],
+        inbox: {
+          inInbox: true,
+          reason: "new-thread",
+        },
+      },
+      ...params.navigation.threads,
+    ],
+    directories: params.navigation.directories.map((directory) =>
+      directory.key === params.directory?.key
+        ? {
+            ...directory,
+            threadKeys: directory.threadKeys.includes(threadKey)
+              ? directory.threadKeys
+              : [threadKey, ...directory.threadKeys],
+            latestUpdatedAt: Math.max(directory.latestUpdatedAt ?? 0, params.now),
+          }
+        : directory,
+    ),
+    inboxThreadKeys: params.navigation.inboxThreadKeys.includes(threadKey)
+      ? params.navigation.inboxThreadKeys
+      : [threadKey, ...params.navigation.inboxThreadKeys],
+  };
+}
 
 function parseTextCommand(text: string): string | undefined {
   const trimmed = text.trim();

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -8,6 +8,7 @@ import type {
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
   MessagingBindingRecord,
+  MessagingCallbackHandleRecord,
   MessagingBrowseSessionRecord,
   MessagingActiveTurnSummary,
   MessagingChannelKind,
@@ -940,11 +941,7 @@ export class MessagingController {
     event: MessagingInboundCallbackEvent,
     actionId: string,
   ): Promise<void> {
-    const session = await this.options.store.findActiveBrowseSessionForChannel({
-      actorId: event.actor.platformUserId,
-      channel: event.channel,
-      now: this.now(),
-    });
+    const session = await this.findBrowseSessionForCallback(event);
     if (!session) {
       await this.deliver(
         buildErrorIntent({
@@ -1104,6 +1101,37 @@ export class MessagingController {
     }
 
     await this.deliverInvalidBrowseSelection(event);
+  }
+
+  private async findBrowseSessionForCallback(
+    event: MessagingInboundCallbackEvent,
+  ): Promise<MessagingBrowseSessionRecord | undefined> {
+    const callbackHandle = await this.resolveCallbackHandleForEvent(event);
+    if (callbackHandle?.browseSessionId) {
+      return await this.options.store.getBrowseSession(callbackHandle.browseSessionId, {
+        now: this.now(),
+      });
+    }
+    if (callbackHandle) {
+      return undefined;
+    }
+
+    return await this.options.store.findActiveBrowseSessionForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+  }
+
+  private async resolveCallbackHandleForEvent(
+    event: MessagingInboundCallbackEvent,
+  ): Promise<MessagingCallbackHandleRecord | undefined> {
+    return await this.options.store.resolveCallbackHandle({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      handle: event.interaction.id,
+      now: this.now(),
+    });
   }
 
   private async renderResumeBrowser(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -237,16 +237,20 @@ export class MessagingController {
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
     for (const binding of bindings) {
       let activeTurn = this.getActiveTurn(binding);
+      let turnStateChanged = false;
       if (lifecycle) {
         const previousTurn = activeTurn;
         activeTurn = lifecycle;
-        this.setActiveTurn(binding, activeTurn);
-        this.logBindingTurnStateChange(
-          binding,
-          previousTurn,
-          activeTurn,
-          event.notification.method,
-        );
+        turnStateChanged = !isSameActiveTurnState(previousTurn, activeTurn);
+        if (turnStateChanged) {
+          this.setActiveTurn(binding, activeTurn);
+          this.logBindingTurnStateChange(
+            binding,
+            previousTurn,
+            activeTurn,
+            event.notification.method,
+          );
+        }
       } else if (isThreadStatusIdleEvent(event) && activeTurn) {
         const previousTurn = activeTurn;
         activeTurn = {
@@ -254,13 +258,16 @@ export class MessagingController {
           status: "completed",
           updatedAt: this.now(),
         };
-        this.setActiveTurn(binding, activeTurn);
-        this.logBindingTurnStateChange(
-          binding,
-          previousTurn,
-          activeTurn,
-          event.notification.method,
-        );
+        turnStateChanged = !isSameActiveTurnState(previousTurn, activeTurn);
+        if (turnStateChanged) {
+          this.setActiveTurn(binding, activeTurn);
+          this.logBindingTurnStateChange(
+            binding,
+            previousTurn,
+            activeTurn,
+            event.notification.method,
+          );
+        }
       }
 
       await this.deliverToolActivityForBackendEvent(
@@ -269,8 +276,9 @@ export class MessagingController {
         activeTurn?.turnId,
       );
       if (
-        isTerminalTurnLifecycle(lifecycle) ||
-        (isThreadStatusIdleEvent(event) && activeTurn)
+        turnStateChanged &&
+        (isTerminalTurnLifecycle(lifecycle) ||
+          (isThreadStatusIdleEvent(event) && activeTurn))
       ) {
         await this.flushToolUpdatesForBinding(binding, {
           clear: true,
@@ -283,7 +291,7 @@ export class MessagingController {
         await this.deliverAssistantMessage(assistantText, event, binding);
       }
 
-      if (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn)) {
+      if (turnStateChanged && (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn))) {
         await this.signalTurnActivity(binding, activeTurn!, {
           reason: event.notification.method,
           force: true,
@@ -2814,6 +2822,18 @@ function isTerminalTurnLifecycle(
   return Boolean(
     lifecycle &&
       ["completed", "failed", "interrupted"].includes(lifecycle.status),
+  );
+}
+
+function isSameActiveTurnState(
+  previous: MessagingActiveTurnSummary | undefined,
+  next: MessagingActiveTurnSummary | undefined,
+): boolean {
+  return Boolean(
+    previous &&
+      next &&
+      previous.turnId === next.turnId &&
+      previous.status === next.status,
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1085,11 +1085,19 @@ export class MessagingController {
         buildConfirmationIntent({
           id: this.newIntentId("bound"),
           createdAt: this.now(),
+          delivery: session.surface
+            ? {
+                mode: "update",
+                replaceMarkup: true,
+              }
+            : undefined,
           title: "Thread bound",
           body: "Messages in this conversation will route to the selected thread.",
           fallbackText: "Send a message to continue the thread.",
+          targetSurface: session.surface,
         }),
-        updatedBinding,
+        undefined,
+        event,
       );
       await this.renderBindingStatus(updatedBinding, event, navigation);
       return;
@@ -1177,11 +1185,19 @@ export class MessagingController {
       buildConfirmationIntent({
         id: this.newIntentId("new-thread-bound"),
         createdAt: this.now(),
+        delivery: session.surface
+          ? {
+              mode: "update",
+              replaceMarkup: true,
+            }
+          : undefined,
         title: "Thread started",
         body: `Started and bound a new thread for ${project.label}.`,
         fallbackText: "Send a message to continue the new thread.",
+        targetSurface: session.surface,
       }),
-      updatedBinding,
+      undefined,
+      event,
     );
     await this.renderBindingStatus(updatedBinding, event);
   }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1330,6 +1330,17 @@ export class MessagingController {
       await this.presentHandoffBranchPicker(binding, event);
       return;
     }
+    if (
+      actionId === "handoff:branches:next" ||
+      actionId === "handoff:branches:previous"
+    ) {
+      await this.presentHandoffBranchPicker(
+        binding,
+        event,
+        handoffBranchPageIndexFromValue(event.value),
+      );
+      return;
+    }
     if (actionId === "handoff:worktree-to-local") {
       await this.presentHandoffConfirmation(binding, event);
       return;
@@ -1428,6 +1439,7 @@ export class MessagingController {
   private async presentHandoffBranchPicker(
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
+    pageIndex = 0,
   ): Promise<void> {
     const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
     const context = handoffContextForBinding(binding, navigation);
@@ -1447,6 +1459,7 @@ export class MessagingController {
           binding,
           context,
           createdAt: this.now(),
+          pageIndex,
         }),
         audit: this.buildHandoffAudit("handoff.branch_picker", binding, event),
       },
@@ -2698,6 +2711,16 @@ function handoffContextForBinding(
     workingDirectoryPath: localDirectory.path,
     workspaceKind: "local",
   };
+}
+
+function handoffBranchPageIndexFromValue(value: MessagingJsonValue | undefined): number {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return 0;
+  }
+  const pageIndex = value.pageIndex;
+  return typeof pageIndex === "number" && Number.isFinite(pageIndex)
+    ? Math.max(0, Math.trunc(pageIndex))
+    : 0;
 }
 
 function findNavigationDirectory(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -308,8 +308,16 @@ export class MessagingController {
           force: true,
         });
         await this.renderBindingStatus(binding);
-      } else if (activeTurn?.status === "working") {
-        await this.signalTurnActivity(binding, activeTurn, {
+      } else {
+        const latestActiveTurn = this.getActiveTurn(binding);
+        if (latestActiveTurn?.status !== "working") {
+          continue;
+        }
+        const eventTurnId = turnIdForBackendEvent(event);
+        if (eventTurnId && latestActiveTurn.turnId !== eventTurnId) {
+          continue;
+        }
+        await this.signalTurnActivity(binding, latestActiveTurn, {
           reason: event.notification.method,
         });
       }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -291,6 +291,11 @@ export class MessagingController {
         await this.deliverAssistantMessage(assistantText, event, binding);
       }
 
+      if (isThreadNameUpdatedEvent(event)) {
+        await this.renderBindingStatus(binding);
+        continue;
+      }
+
       if (turnStateChanged && (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn))) {
         await this.signalTurnActivity(binding, activeTurn!, {
           reason: event.notification.method,
@@ -2835,6 +2840,10 @@ function isSameActiveTurnState(
       previous.turnId === next.turnId &&
       previous.status === next.status,
   );
+}
+
+function isThreadNameUpdatedEvent(event: AgentEvent): boolean {
+  return event.notification.method === "thread/name/updated";
 }
 
 function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -189,6 +189,7 @@ function buildThreadPickerIntent(params: {
     id: params.id,
     kind: "thread_picker",
     bindingId: params.session.bindingId,
+    browseSessionId: params.session.id,
     createdAt: params.createdAt,
     delivery: {
       mode: params.session.surface ? "update" : "present",
@@ -246,6 +247,7 @@ function buildProjectPickerIntent(params: {
     id: params.id,
     kind: "project_picker",
     bindingId: params.session.bindingId,
+    browseSessionId: params.session.id,
     createdAt: params.createdAt,
     delivery: {
       mode: params.session.surface ? "update" : "present",

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -6,6 +6,7 @@ import type {
   MessagingJsonValue,
   MessagingToolUpdateMode,
   MessagingSingleSelectIntent,
+  MessagingSurfaceAction,
   MessagingStatusIntent,
   ThreadIdentifier,
 } from "@pwragnt/shared";
@@ -23,6 +24,8 @@ export type MessagingWorkspaceHandoffContext = {
   workingDirectoryPath: string;
   workspaceKind: "local" | "worktree";
 };
+
+export const HANDOFF_BRANCH_PAGE_SIZE = 8;
 
 export function buildBindingStatusIntent(params: {
   binding: MessagingBindingRecord;
@@ -310,17 +313,61 @@ export function buildHandoffBranchPickerIntent(params: {
   context: MessagingWorkspaceHandoffContext;
   createdAt: number;
   id: string;
+  pageIndex?: number;
+  pageSize?: number;
 }): MessagingSingleSelectIntent {
-  const choices = params.context.leaveLocalBranches.map((branch, index) => ({
-    id: "handoff:select-leave-branch",
-    label: `${index + 1}. ${branch}`,
-    fallbackText: String(index + 1),
-    style: "secondary" as const,
-    value: {
-      ...handoffValue(params.context),
-      leaveLocalBranch: branch,
-    },
-  }));
+  const pageSize = Math.max(1, params.pageSize ?? HANDOFF_BRANCH_PAGE_SIZE);
+  const totalBranches = params.context.leaveLocalBranches.length;
+  const totalPages = Math.max(1, Math.ceil(totalBranches / pageSize));
+  const pageIndex = clampPageIndex(params.pageIndex ?? 0, totalPages);
+  const pageStart = pageIndex * pageSize;
+  const pageBranches = params.context.leaveLocalBranches.slice(
+    pageStart,
+    pageStart + pageSize,
+  );
+  const branchChoices = pageBranches.map((branch, index) => {
+    const branchNumber = pageStart + index + 1;
+    return {
+      id: "handoff:select-leave-branch",
+      label: `${branchNumber}. ${branch}`,
+      fallbackText: String(branchNumber),
+      style: "secondary" as const,
+      value: {
+        ...handoffValue(params.context),
+        leaveLocalBranch: branch,
+      },
+    };
+  });
+  const pageActions: MessagingSurfaceAction[] = [
+    ...(pageIndex > 0
+      ? [
+          {
+            id: "handoff:branches:previous",
+            label: "Previous",
+            fallbackText: "previous",
+            style: "secondary" as const,
+            value: {
+              ...handoffValue(params.context),
+              pageIndex: pageIndex - 1,
+            },
+          },
+        ]
+      : []),
+    ...(pageIndex < totalPages - 1
+      ? [
+          {
+            id: "handoff:branches:next",
+            label: "Next",
+            fallbackText: "next",
+            style: "secondary" as const,
+            value: {
+              ...handoffValue(params.context),
+              pageIndex: pageIndex + 1,
+            },
+          },
+        ]
+      : []),
+  ];
 
   return {
     id: params.id,
@@ -334,16 +381,23 @@ export function buildHandoffBranchPickerIntent(params: {
     targetSurface: params.binding.statusSurface,
     fallbackText: [
       "Choose the branch that should remain checked out in Local.",
-      ...choices.map((choice) => choice.label),
+      totalPages > 1 ? `Page ${pageIndex + 1}/${totalPages}.` : undefined,
+      ...branchChoices.map((choice) => choice.label),
       "Reply with a number, Back, Refresh, or Cancel.",
-    ].join("\n"),
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n"),
     prompt: [
       "Choose the branch that should remain checked out in Local.",
+      totalPages > 1 ? `Page ${pageIndex + 1}/${totalPages}.` : undefined,
       `Moving branch: ${params.context.branch ?? unavailable()}`,
       `Local: ${params.context.repositoryPath}`,
-    ].join("\n"),
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n"),
     choices: [
-      ...choices,
+      ...branchChoices,
+      ...pageActions,
       {
         id: "status:handoff",
         label: "Back",
@@ -365,6 +419,13 @@ export function buildHandoffBranchPickerIntent(params: {
       },
     ],
   };
+}
+
+function clampPageIndex(pageIndex: number, totalPages: number): number {
+  if (!Number.isFinite(pageIndex)) {
+    return 0;
+  }
+  return Math.min(Math.max(0, Math.trunc(pageIndex)), totalPages - 1);
 }
 
 export function buildHandoffConfirmationIntent(params: {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -9,6 +9,7 @@ import type {
   MessagingStatusIntent,
   ThreadIdentifier,
 } from "@pwragnt/shared";
+import { shortenDerivedThreadTitle } from "@pwragnt/shared";
 import type { MessagingResolvedThreadState } from "./messaging-thread-state.js";
 
 export type MessagingWorkspaceHandoffContext = {
@@ -55,6 +56,7 @@ export function buildBindingStatusIntent(params: {
     "default";
   const activeTurn = params.threadState.activeTurn;
   const branch = formatBranch(params.threadState);
+  const bindingTitle = formatStatusBindingTitle(params.threadState, params.binding.threadId);
   const toolUpdateMode = resolveMessagingToolUpdateMode(
     params.binding,
     params.toolUpdateMode,
@@ -73,7 +75,7 @@ export function buildBindingStatusIntent(params: {
     targetSurface: params.binding.statusSurface,
     status: statusForThreadState(params.threadState),
     text: [
-      `Binding: ${params.threadState.title ?? params.binding.threadId} (${params.binding.backend})`,
+      `Binding: ${bindingTitle} (${params.binding.backend})`,
       `Project: ${projectLabel}`,
       `Directory: ${directoryPath}`,
       params.threadState.worktreePath ? `Worktree: ${params.threadState.worktreePath}` : undefined,
@@ -170,6 +172,35 @@ export function buildBindingStatusIntent(params: {
       },
     ],
   };
+}
+
+function formatStatusBindingTitle(
+  threadState: MessagingResolvedThreadState,
+  fallbackThreadId: ThreadIdentifier,
+): string {
+  if (!threadState.title) {
+    return fallbackThreadId;
+  }
+  if (threadState.titleSource === "derived") {
+    return truncateStatusTitle(
+      shortenDerivedThreadTitle(threadState.title) ?? threadState.title,
+    );
+  }
+  return threadState.title;
+}
+
+function truncateStatusTitle(title: string, limit = 48): string {
+  const normalized = title.replace(/\s+/g, " ").trim();
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+
+  const breakpointWindow = normalized.slice(0, limit + 1);
+  const wordBreak = breakpointWindow.lastIndexOf(" ");
+  if (wordBreak >= Math.floor(limit * 0.6)) {
+    return `${normalized.slice(0, wordBreak).trim()}...`;
+  }
+  return `${normalized.slice(0, limit).trim()}...`;
 }
 
 const TOOL_UPDATE_MODE_ORDER: MessagingToolUpdateMode[] = [

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -189,7 +189,7 @@ function formatStatusBindingTitle(
   return threadState.title;
 }
 
-function truncateStatusTitle(title: string, limit = 48): string {
+function truncateStatusTitle(title: string, limit = 32): string {
   const normalized = title.replace(/\s+/g, " ").trim();
   if (normalized.length <= limit) {
     return normalized;

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -28,7 +28,18 @@ export class MessagingStore {
     binding: MessagingBindingRecord,
   ): Promise<MessagingBindingRecord> {
     const sanitized = sanitizeBinding(binding);
+    const channelKey = buildMessagingConversationKey(sanitized.channel);
     return await this.withData((data) => {
+      for (const existing of Object.values(data.bindings)) {
+        if (
+          existing.id !== sanitized.id &&
+          !existing.revokedAt &&
+          buildMessagingConversationKey(existing.channel) === channelKey
+        ) {
+          revokeBindingInData(data, existing.id, sanitized.updatedAt);
+        }
+      }
+
       data.bindings[sanitized.id] = sanitized;
       return structuredClone(sanitized);
     });
@@ -44,11 +55,13 @@ export class MessagingStore {
     const channelKey = buildMessagingConversationKey(channel);
     return await this.withReadData((data) =>
       cloneOptional(
-        Object.values(data.bindings).find(
-          (binding) =>
-            !binding.revokedAt &&
-            buildMessagingConversationKey(binding.channel) === channelKey,
-        ),
+        Object.values(data.bindings)
+          .filter(
+            (binding) =>
+              !binding.revokedAt &&
+              buildMessagingConversationKey(binding.channel) === channelKey,
+          )
+          .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)[0],
       ),
     );
   }
@@ -74,35 +87,12 @@ export class MessagingStore {
     revokedAt?: number;
   }): Promise<MessagingBindingRecord | undefined> {
     return await this.withData((data) => {
-      const current = data.bindings[params.bindingId];
-      if (!current) {
-        return undefined;
-      }
-
-      const revoked: MessagingBindingRecord = {
-        ...current,
-        revokedAt: params.revokedAt ?? Date.now(),
-        updatedAt: params.revokedAt ?? Date.now(),
-      };
-      data.bindings[params.bindingId] = revoked;
-
-      for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
-        if (intent.bindingId === params.bindingId) {
-          delete data.pendingIntents[intentId];
-        }
-      }
-      for (const [sessionId, session] of Object.entries(data.browseSessions)) {
-        if (session.bindingId === params.bindingId) {
-          delete data.browseSessions[sessionId];
-        }
-      }
-      for (const [handleId, handle] of Object.entries(data.callbackHandles)) {
-        if (handle.bindingId === params.bindingId) {
-          delete data.callbackHandles[handleId];
-        }
-      }
-
-      return structuredClone(revoked);
+      const revoked = revokeBindingInData(
+        data,
+        params.bindingId,
+        params.revokedAt ?? Date.now(),
+      );
+      return revoked ? structuredClone(revoked) : undefined;
     });
   }
 
@@ -473,6 +463,42 @@ function sanitizeDelivery(delivery: MessagingDeliveryRecord): MessagingDeliveryR
     ...delivery,
     surface: sanitizeSurfaceRef(delivery.surface),
   };
+}
+
+function revokeBindingInData(
+  data: MessagingStoreData,
+  bindingId: string,
+  revokedAt: number,
+): MessagingBindingRecord | undefined {
+  const current = data.bindings[bindingId];
+  if (!current) {
+    return undefined;
+  }
+
+  const revoked: MessagingBindingRecord = {
+    ...current,
+    revokedAt,
+    updatedAt: revokedAt,
+  };
+  data.bindings[bindingId] = revoked;
+
+  for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
+    if (intent.bindingId === bindingId) {
+      delete data.pendingIntents[intentId];
+    }
+  }
+  for (const [sessionId, session] of Object.entries(data.browseSessions)) {
+    if (session.bindingId === bindingId) {
+      delete data.browseSessions[sessionId];
+    }
+  }
+  for (const [handleId, handle] of Object.entries(data.callbackHandles)) {
+    if (handle.bindingId === bindingId) {
+      delete data.callbackHandles[handleId];
+    }
+  }
+
+  return revoked;
 }
 
 function sanitizeSurfaceRef<T extends { state?: MessagingAdapterState }>(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -91,21 +91,34 @@ export class DesktopMessagingRuntime {
 
       try {
         await adapter.start?.(async (event) => {
-          if (!authorizedActorIdSet.has(event.actor.platformUserId)) {
-            messagingLog.warn("messaging event rejected by authorization", {
+          try {
+            if (!authorizedActorIdSet.has(event.actor.platformUserId)) {
+              messagingLog.warn("messaging event rejected by authorization", {
+                actorDisplayName: event.actor.displayName,
+                actorId: event.actor.platformUserId,
+                actorIsBot: event.actor.isBot,
+                actorUsername: event.actor.username,
+                authorizedActorCount: authorizedActorIds.length,
+                channel: adapter.channel,
+                conversationId: event.channel.conversation.id,
+                conversationKind: event.channel.conversation.kind,
+                eventId: event.id,
+                eventKind: event.kind,
+              });
+            }
+            await controller.handleInboundEvent(event);
+          } catch (error) {
+            messagingLog.error("messaging controller failed to handle inbound event", {
               actorDisplayName: event.actor.displayName,
               actorId: event.actor.platformUserId,
-              actorIsBot: event.actor.isBot,
-              actorUsername: event.actor.username,
-              authorizedActorCount: authorizedActorIds.length,
               channel: adapter.channel,
               conversationId: event.channel.conversation.id,
               conversationKind: event.channel.conversation.kind,
+              error,
               eventId: event.id,
               eventKind: event.kind,
             });
           }
-          await controller.handleInboundEvent(event);
         });
       } catch (error) {
         messagingLog.error("messaging adapter failed to start", {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -429,6 +429,7 @@ export type MessagingProgressIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingThreadPickerIntent = MessagingBaseSurfaceIntent & {
   kind: "thread_picker";
+  browseSessionId?: string;
   navigation: Pick<NavigationSnapshot, "backend" | "fetchedAt" | "unchanged">;
   page: MessagingPickerPage<NavigationThreadSummary | AppServerThreadSummary>;
   prompt: string;
@@ -436,6 +437,7 @@ export type MessagingThreadPickerIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingProjectPickerIntent = MessagingBaseSurfaceIntent & {
   kind: "project_picker";
+  browseSessionId?: string;
   navigation: Pick<NavigationSnapshot, "backend" | "fetchedAt" | "unchanged">;
   page: MessagingPickerPage<NavigationDirectorySummary>;
   prompt: string;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -282,7 +282,9 @@ function createApi(overrides: Partial<DiscordApi> = {}): DiscordApi {
     }),
     deleteApplicationCommand: async () => {},
     listApplicationCommands: async () => [],
+    pinMessage: async () => {},
     sendTyping: async () => {},
+    unpinMessage: async () => {},
     updateChannelName: async () => {},
     updateApplicationCommand: async () => applicationCommand(),
     updateInteractionOriginalResponse: async () => ({

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -194,7 +194,9 @@ export type DiscordApi = DiscordApplicationCommandApi & {
     channelId: string,
     request: DiscordCreateMessageRequest,
   ): Promise<DiscordMessage>;
+  pinMessage(channelId: string, messageId: string): Promise<void>;
   sendTyping(channelId: string): Promise<void>;
+  unpinMessage(channelId: string, messageId: string): Promise<void>;
   updateMessage(
     channelId: string,
     messageId: string,
@@ -306,14 +308,6 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   }
 
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
-    if (intent.kind === "dismiss") {
-      return {
-        channel: this.channel,
-        deliveredAt: this.now(),
-        outcome: "unsupported",
-      };
-    }
-
     const target = this.resolveTarget(intent);
     if (!target) {
       return {
@@ -321,6 +315,34 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         deliveredAt: this.now(),
         errorMessage: "Discord delivery target is missing.",
         outcome: "failed",
+      };
+    }
+
+    if (intent.kind === "dismiss") {
+      if (intent.delivery?.unpin && target.messageId) {
+        try {
+          await this.api.unpinMessage(target.channelId, target.messageId);
+          return {
+            channel: this.channel,
+            deliveredAt: this.now(),
+            outcome: "unpinned",
+            surface: intent.targetSurface,
+          };
+        } catch (error) {
+          return {
+            channel: this.channel,
+            deliveredAt: this.now(),
+            errorMessage: errorMessage(error),
+            outcome: "failed",
+            surface: intent.targetSurface,
+          };
+        }
+      }
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        outcome: "unsupported",
+        surface: intent.targetSurface,
       };
     }
 
@@ -361,10 +383,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             content: chunks[0] ?? " ",
           },
         );
+        const pinned = await this.pinMessageIfRequested(intent, message, target);
         return {
           channel: this.channel,
           deliveredAt: this.now(),
-          outcome: "updated",
+          outcome: pinned ? "pinned" : "updated",
           surface: this.surfaceForMessage(message, target),
         };
       }
@@ -386,10 +409,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
               files: filesForDiscordRequest(files),
             },
           );
+          const pinned = await this.pinMessageIfRequested(intent, message, target);
           return {
             channel: this.channel,
             deliveredAt: this.now(),
-            outcome: "updated",
+            outcome: pinned ? "pinned" : "updated",
             surface: this.surfaceForMessage(message, target),
           };
         } catch (error) {
@@ -422,11 +446,15 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       }
 
       const lastMessage = messages.at(-1);
+      const pinned = lastMessage
+        ? await this.pinMessageIfRequested(intent, lastMessage, target)
+        : false;
       return {
         channel: this.channel,
         deliveredAt: this.now(),
-        outcome:
-          intent.delivery?.mode === "update" ? "presented_new" : "presented",
+        outcome: pinned
+          ? "pinned"
+          : intent.delivery?.mode === "update" ? "presented_new" : "presented",
         surface: lastMessage ? this.surfaceForMessage(lastMessage, target) : undefined,
       };
     } catch (error) {
@@ -441,6 +469,25 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         outcome: "failed",
         surface: intent.targetSurface,
       };
+    }
+  }
+
+  private async pinMessageIfRequested(
+    intent: MessagingSurfaceIntent,
+    message: DiscordMessage,
+    target: { channelId: string },
+  ): Promise<boolean> {
+    if (!intent.delivery?.pin) {
+      return false;
+    }
+    try {
+      await this.api.pinMessage(message.channel_id || target.channelId, message.id);
+      return true;
+    } catch (error) {
+      this.options.logger?.warn?.(
+        `discord pin failed channel=${message.channel_id || target.channelId} message=${message.id} error=${errorMessage(error)}`,
+      );
+      return false;
     }
   }
 
@@ -1226,6 +1273,16 @@ class DiscordRestApi implements DiscordApi {
     await this.rest.post(`/channels/${channelId}/typing`, {
       body: {},
     });
+  }
+
+  async pinMessage(channelId: string, messageId: string): Promise<void> {
+    await this.rest.put(`/channels/${channelId}/pins/${messageId}`, {
+      body: {},
+    });
+  }
+
+  async unpinMessage(channelId: string, messageId: string): Promise<void> {
+    await this.rest.delete(`/channels/${channelId}/pins/${messageId}`);
   }
 
   async updateApplicationCommand(

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -431,6 +431,26 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
+    try {
+      return await this.deliverSurface(intent);
+    } catch (error) {
+      const target = this.resolveTarget(intent);
+      this.options.logger?.warn?.(
+        `telegram deliver failed kind=${intent.kind} target=${target ? this.compactTypingTarget(target) : "missing"} error=${errorMessage(error)}`,
+      );
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        errorMessage: errorMessage(error),
+        outcome: "failed",
+        surface: intent.targetSurface,
+      };
+    }
+  }
+
+  private async deliverSurface(
+    intent: MessagingSurfaceIntent,
+  ): Promise<MessagingDeliveryResult> {
     const target = this.resolveTarget(intent);
     if (!target) {
       return {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -288,6 +288,7 @@ export type TelegramGrammyBotLike = {
       other?: Omit<TelegramUnpinChatMessageRequest, "chat_id" | "message_id">,
     ): Promise<boolean>;
   };
+  catch?(handler: (error: unknown) => void): void;
   handleUpdate?(update: TelegramUpdate): Promise<void>;
   on?(filter: string, handler: (context: unknown) => void | Promise<void>): void;
   start?(options?: { allowed_updates?: string[] }): Promise<void>;
@@ -353,6 +354,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
     this.listener = listener;
 
+    this.registerBotErrorHandler();
     this.registerBotHandlers();
 
     const webhookInfo = await this.bot.api.getWebhookInfo();
@@ -1307,6 +1309,14 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     });
   }
 
+  private registerBotErrorHandler(): void {
+    this.bot.catch?.((error) => {
+      this.options.logger?.warn?.("telegram bot middleware failed", {
+        error: errorMessage(error),
+      });
+    });
+  }
+
   private get bot(): TelegramBotLike {
     if (this.options.bot) {
       return this.options.bot;
@@ -1447,6 +1457,7 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         return await bot.api.unpinChatMessage(chat_id, message_id, other);
       },
     },
+    catch: bot.catch?.bind(bot),
     handleUpdate: bot.handleUpdate?.bind(bot),
     on: bot.on?.bind(bot),
     start: bot.start?.bind(bot),

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -968,6 +968,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         expiresAt: this.now() + 15 * 60 * 1000,
         handle,
         pendingIntentId: intent.id,
+        browseSessionId: browseSessionIdForIntent(intent),
         surface: intent.targetSurface,
         updatedAt: this.now(),
         value: action.value,
@@ -1472,6 +1473,12 @@ function coerceTelegramSentMessage(
 function parseTelegramIdentifier(value: string): number | string {
   const numeric = Number(value);
   return Number.isSafeInteger(numeric) && String(numeric) === value ? numeric : value;
+}
+
+function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
+  return intent.kind === "thread_picker" || intent.kind === "project_picker"
+    ? intent.browseSessionId
+    : undefined;
 }
 
 function sanitizeTelegramTopicName(title: string): string {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -277,6 +277,7 @@ export type MessagingProgressIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingThreadPickerIntent = MessagingBaseSurfaceIntent & {
   kind: "thread_picker";
+  browseSessionId?: string;
   navigation: Pick<NavigationSnapshot, "backend" | "fetchedAt" | "unchanged">;
   page: MessagingPickerPage<NavigationThreadSummary | AppServerThreadSummary>;
   prompt: string;
@@ -284,6 +285,7 @@ export type MessagingThreadPickerIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingProjectPickerIntent = MessagingBaseSurfaceIntent & {
   kind: "project_picker";
+  browseSessionId?: string;
   navigation: Pick<NavigationSnapshot, "backend" | "fetchedAt" | "unchanged">;
   page: MessagingPickerPage<NavigationDirectorySummary>;
   prompt: string;


### PR DESCRIPTION
## Summary

I fixed a set of messaging reliability issues found while exercising Telegram topics and Discord threads from `/resume`, `/status`, and status-card actions.

## What Changed

- I changed resume picker callbacks to resolve through the clicked picker handle, so stale or multiple active pickers do not update the wrong message.
- I retired resume pickers by updating the original picker surface and removing actions after selecting an existing thread, starting a new thread, or canceling.
- I made new messaging-created Codex threads appear in navigation/status immediately with project and directory metadata instead of showing unavailable state until a later list refresh.
- I made active conversation bindings single-writer per conversation, so replacing a broken/stale binding revokes the older active binding.
- I contained Telegram provider failures by adding `bot.catch`, catching delivery API failures, and suppressing duplicate lifecycle status renders that were causing status update bursts.
- I tightened Discord status lifecycle behavior by adding pin/unpin support, stopping stale typing restarts after idle, refreshing status cards after `thread/name/updated`, and clearing status buttons on detach.
- I shortened derived first-message titles in compact status cards, then refresh them when generated thread names arrive.
- I paged messaging handoff branch choices so Telegram and Discord no longer render large unbounded branch lists.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/discord-adapter.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
- `pnpm --filter @pwragnt/desktop typecheck`
- `pnpm --filter @pwragnt/messaging-provider-telegram typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

