### PR TITLE
feat(desktop): configurable worktree storage with cleaner naming

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -46,6 +46,7 @@ pnpm --filter @pwragnt/desktop dev:no-messaging
 - `dev:no-messaging` disables the Telegram/Discord messaging interface, which avoids bot-token prompts and Keychain access issues during development.
 - For visual verification of UI changes, use this command so you can see real threads in the sidebar and thread detail pane.
 - The `dev` script (without `no-messaging`) also works but will attempt to connect messaging providers.
+- If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
 
 ## Implementation Notes
 
@@ -53,6 +54,13 @@ pnpm --filter @pwragnt/desktop dev:no-messaging
 - Reuse shell primitives instead of adding one-off page styling.
 - When in doubt, make the interface calmer, denser, and more editorial.
 - Use the project-local [desktop E2E fixture seeding skill](../../.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when capturing or refreshing replay-backed desktop E2E fixtures.
+
+## Worktree Path Computation
+
+- **All worktree paths** must use the shared `computeWorktreePath` from `src/main/app-server/git-directory-service.ts`.
+- There are two code paths that create worktrees: `prepareLaunchpadWorkspace` (in `git-directory-service.ts`) and `handoffLocalToWorktree` / `handoffLocalChangesToDetachedWorktree` (in `git-workspace-handoff-service.ts`). Both must use the same path builder.
+- The naming pattern is `<root>/<hash>/<project-folder-name>` where `<hash>` is `Date.now().toString(36)` and `<project-folder-name>` is `path.basename(repoRoot)` preserving original casing.
+- Do not introduce additional worktree path builders — centralize in `computeWorktreePath`.
 
 ## Release Notes
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -103,6 +103,84 @@ describe("DesktopSettingsService", () => {
       value: "ghostty",
       source: "config",
     });
+    expect(snapshot.worktrees.storage).toEqual({
+      value: "user-home",
+      source: "default",
+    });
+    expect(snapshot.worktrees.effectivePath).toMatch(
+      /\.pwragnt\/worktrees$/,
+    );
+  });
+
+  it("loads the worktree storage location from TOML and exposes the effective path", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[worktrees]", 'storage = "in-repo"'].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.worktrees.storage).toEqual({
+      value: "in-repo",
+      source: "config",
+    });
+    expect(snapshot.worktrees.effectivePath).toBe(".worktrees");
+    expect(service.resolveWorktreeStorage()).toBe("in-repo");
+  });
+
+  it("treats PWRAGNT_WORKTREE_STORAGE as a high-precedence override", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[worktrees]", 'storage = "in-repo"'].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: { PWRAGNT_WORKTREE_STORAGE: "user-home" },
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.worktrees.storage).toMatchObject({
+      value: "user-home",
+      source: "env",
+      overriddenByEnv: true,
+    });
+    expect(snapshot.worktrees.effectivePath).toMatch(
+      /\.pwragnt\/worktrees$/,
+    );
+  });
+
+  it("round-trips the worktree storage setting through write + read", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    await service.writeConfigPatch({ worktrees: { storage: "in-repo" } });
+
+    const tomlOnDisk = fs.readFileSync(configPath, "utf8");
+    expect(tomlOnDisk).toContain("[worktrees]");
+    expect(tomlOnDisk).toContain('storage = "in-repo"');
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.worktrees.storage.value).toBe("in-repo");
   });
 
   it("applies env overrides above TOML and keeps the Grok API key in keychain", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { GitDirectoryService } from "../app-server/git-directory-service";
+import {
+  GitDirectoryService,
+  computeWorktreePath,
+} from "../app-server/git-directory-service";
 
 function runGit(cwd: string, args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
@@ -82,10 +85,12 @@ describe("GitDirectoryService", () => {
     expect(status?.handoffBranches).toEqual(["recent", "older"]);
   });
 
-  it("creates a detached worktree from the selected base branch without creating a new branch", async () => {
+  it("creates a detached in-repo worktree at <hash>/<project-folder> from the selected base branch", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);
-    const service = new GitDirectoryService();
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
     const branchesBefore = runGit(repoDir, ["branch", "--format=%(refname:short)"])
       .split("\n")
       .filter(Boolean);
@@ -100,7 +105,16 @@ describe("GitDirectoryService", () => {
     });
 
     expect(workspace.workMode).toBe("worktree");
-    expect(workspace.cwd).toContain(`${path.sep}.worktrees${path.sep}launchpad-fixturerepo-release-`);
+    const repoRealPath = await realpath(repoDir);
+    const projectName = path.basename(repoRealPath);
+    const expectedRoot = path.join(repoRealPath, ".worktrees");
+    expect(workspace.cwd).not.toBeUndefined();
+    expect(workspace.cwd!.startsWith(`${expectedRoot}${path.sep}`)).toBe(true);
+    expect(path.basename(workspace.cwd!)).toBe(projectName);
+    const hashSegment = path.basename(path.dirname(workspace.cwd!));
+    expect(hashSegment).toMatch(/^[0-9a-z]+(?:-\d+)?$/);
+    expect(workspace.cwd).not.toContain("launchpad-");
+
     expect(runGit(workspace.cwd!, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
     expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("");
     expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(releaseRevision);
@@ -109,6 +123,87 @@ describe("GitDirectoryService", () => {
       .split("\n")
       .filter(Boolean);
     expect(branchesAfter).toEqual(branchesBefore);
+  });
+
+  it("creates a worktree under a user-home root when storage is user-home", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "pwragnt-worktree-home-"));
+    cleanupPaths.push(homeDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "user-home",
+      homeDir,
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    const expectedRoot = path.join(homeDir, ".pwragnt", "worktrees");
+    expect(workspace.cwd!.startsWith(`${expectedRoot}${path.sep}`)).toBe(true);
+    expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
+  });
+
+  it("computeWorktreePath suffixes the hash when the path already exists", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const fixedTimestamp = 1730000000000;
+    const first = await computeWorktreePath({
+      repoRoot: repoDir,
+      storage: "in-repo",
+      timestamp: fixedTimestamp,
+    });
+    await mkdir(first, { recursive: true });
+
+    const second = await computeWorktreePath({
+      repoRoot: repoDir,
+      storage: "in-repo",
+      timestamp: fixedTimestamp,
+    });
+
+    expect(second).not.toBe(first);
+    expect(path.basename(second)).toBe(path.basename(first));
+    expect(path.basename(path.dirname(second))).toMatch(/-2$/);
+  });
+
+  it("removes the worktree and prunes the empty hash parent on cleanup", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "release",
+    });
+    const worktreePath = workspace.cwd!;
+    const hashParent = path.dirname(worktreePath);
+
+    const results = await service.cleanupThreadWorktrees({
+      gitBranch: undefined,
+      observedGitBranch: undefined,
+      linkedDirectories: [
+        {
+          id: "fixture",
+          label: "FixtureRepo",
+          path: repoDir,
+          worktreePath,
+          kind: "worktree",
+        },
+      ],
+    });
+
+    expect(results[0].removedWorktree).toBe(true);
+    await expect(stat(worktreePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(hashParent)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("does not use the workspace root as the cwd for workspace launchpads", async () => {

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -64,7 +64,9 @@ describe("GitWorkspaceHandoffService", () => {
     await mkdir(path.join(repoPath, "node_modules"));
     await writeFile(path.join(repoPath, "node_modules", "ignored.txt"), "ignored\n", "utf8");
 
-    const service = new GitWorkspaceHandoffService();
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
     const result = await service.handoff({
       backend: "codex",
       threadId: "thread-1",
@@ -83,6 +85,7 @@ describe("GitWorkspaceHandoffService", () => {
     expect(await git(result.targetPath, ["branch", "--show-current"])).toBe(
       "feature/handoff",
     );
+    expect(path.basename(result.targetPath)).toBe("PwrAgnt");
     await expect(readFile(path.join(result.targetPath, "README.md"), "utf8")).resolves.toBe(
       "dirty local\n",
     );
@@ -101,7 +104,9 @@ describe("GitWorkspaceHandoffService", () => {
     await mkdir(path.join(repoPath, "node_modules"));
     await writeFile(path.join(repoPath, "node_modules", "ignored.txt"), "ignored\n", "utf8");
 
-    const service = new GitWorkspaceHandoffService();
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
     const result = await service.handoff({
       backend: "codex",
       threadId: "thread-1",
@@ -118,6 +123,7 @@ describe("GitWorkspaceHandoffService", () => {
     expect(result.branch).toBeUndefined();
     expect(result.baseSha).toMatch(/^[0-9a-f]{40}$/);
     expect(result.linkedDirectory.kind).toBe("worktree");
+    expect(path.basename(result.targetPath)).toBe("PwrAgnt");
     expect(result.sourceStash).toMatchObject({ applied: true, dropped: true });
     expect(await git(repoPath, ["branch", "--show-current"])).toBe("feature/handoff");
     expect(await git(result.targetPath, ["branch", "--show-current"])).toBe("");
@@ -178,7 +184,9 @@ describe("GitWorkspaceHandoffService", () => {
     const repoPath = await createRepo();
     await writeFile(path.join(repoPath, "README.md"), "dirty detached\n", "utf8");
 
-    const service = new GitWorkspaceHandoffService();
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
     const detachedResult = await service.handoff({
       backend: "codex",
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -220,6 +220,33 @@ describe("GitWorkspaceHandoffService", () => {
     expect(await pathExists(detachedResult.targetPath)).toBe(false);
   });
 
+  it("allows detached-changes handoff from a detached HEAD", async () => {
+    const repoPath = await createRepo();
+    await git(repoPath, ["checkout", "--detach"]);
+    await writeFile(path.join(repoPath, "scratch.txt"), "scratch\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      now: 5000,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.strategy).toBe("detached-changes");
+    expect(path.basename(result.targetPath)).toBe("PwrAgnt");
+    await expect(readFile(path.join(result.targetPath, "scratch.txt"), "utf8")).resolves.toBe(
+      "scratch\n",
+    );
+  });
+
   it("protects dirty local changes separately when moving a worktree branch to local", async () => {
     const repoPath = await createRepo();
     await git(repoPath, ["switch", "main"]);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1062,7 +1062,12 @@ export class DesktopBackendRegistry {
         connectionObserver: grokObserver,
       });
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
-    this.gitDirectoryService = options?.gitDirectoryService ?? new GitDirectoryService();
+    this.gitDirectoryService =
+      options?.gitDirectoryService ??
+      new GitDirectoryService({
+        resolveWorktreeStorage: () =>
+          getDesktopSettingsService().resolveWorktreeStorage(),
+      });
     this.worktreeArchiveService =
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
     this.gitWorkspaceHandoffService =

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1074,6 +1074,8 @@ export class DesktopBackendRegistry {
       options?.gitWorkspaceHandoffService ??
       new GitWorkspaceHandoffService({
         worktreeArchiveService: this.worktreeArchiveService,
+        resolveWorktreeStorage: () =>
+          getDesktopSettingsService().resolveWorktreeStorage(),
       });
     this.createScratchProjectDirectory =
       options?.createScratchProjectDirectory ?? createScratchProjectDirectory;

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,15 +1,19 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { access, mkdir, rmdir } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import type {
   AppServerThreadSummary,
   ArchiveThreadCleanupResult,
+  DesktopWorktreeStorageLocation,
   LaunchpadWorkMode,
   NavigationDirectoryGitStatus,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
 } from "@pwragnt/shared";
+import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragnt/shared";
+import { userHomeWorktreesRoot } from "../settings/desktop-config";
 
 const execFile = promisify(execFileCallback);
 
@@ -29,19 +33,58 @@ function sanitizeBranchName(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function buildWorktreeDirectoryName(params: {
-  baseBranch: string;
-  directoryLabel: string;
-  timestamp?: number;
-}): string {
-  const base = sanitizeBranchName(params.baseBranch) || "main";
-  const label = sanitizeBranchName(params.directoryLabel.toLowerCase()) || "launchpad";
-  const suffix = (params.timestamp ?? Date.now()).toString(36);
-  return `launchpad-${label}-${base.replace(/\//g, "-")}-${suffix}`;
+function worktreesRootFor(
+  repoRoot: string,
+  storage: DesktopWorktreeStorageLocation,
+  homeDir?: string,
+): string {
+  return storage === "user-home"
+    ? userHomeWorktreesRoot(homeDir)
+    : path.join(repoRoot, ".worktrees");
 }
 
-function buildWorktreePath(repoRoot: string, worktreeName: string): string {
-  return path.join(repoRoot, ".worktrees", worktreeName.replace(/[\\/]/g, "-"));
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
+  const hashParent = path.dirname(worktreePath);
+  if (path.basename(hashParent) === ".worktrees" || hashParent === "/") {
+    return;
+  }
+  try {
+    await rmdir(hashParent);
+  } catch {
+    // Parent is non-empty or already gone; either is fine.
+  }
+}
+
+export async function computeWorktreePath(params: {
+  repoRoot: string;
+  storage: DesktopWorktreeStorageLocation;
+  homeDir?: string;
+  timestamp?: number;
+}): Promise<string> {
+  const root = worktreesRootFor(params.repoRoot, params.storage, params.homeDir);
+  const projectName = path.basename(path.resolve(params.repoRoot)) || "project";
+  const baseHash = (params.timestamp ?? Date.now()).toString(36);
+
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const hash = attempt === 0 ? baseHash : `${baseHash}-${attempt + 1}`;
+    const candidate = path.join(root, hash, projectName);
+    if (!(await pathExists(candidate))) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Unable to allocate a unique worktree path under ${root} for ${projectName}`,
+  );
 }
 
 type WorktreeEntry = {
@@ -137,10 +180,29 @@ type CachedDirectoryStatus = {
   status?: NavigationDirectoryGitStatus;
 };
 
+type GitDirectoryServiceOptions = {
+  cacheTtlMs?: number;
+  resolveWorktreeStorage?: () =>
+    | DesktopWorktreeStorageLocation
+    | Promise<DesktopWorktreeStorageLocation>;
+  homeDir?: string;
+};
+
 export class GitDirectoryService {
   private readonly statusCache = new Map<string, CachedDirectoryStatus>();
+  private readonly cacheTtlMs: number;
+  private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
+  private readonly homeDir: string;
 
-  constructor(private readonly cacheTtlMs = 3_000) {}
+  constructor(options: GitDirectoryServiceOptions | number = {}) {
+    const normalized: GitDirectoryServiceOptions =
+      typeof options === "number" ? { cacheTtlMs: options } : options;
+    this.cacheTtlMs = normalized.cacheTtlMs ?? 3_000;
+    this.homeDir = normalized.homeDir ?? os.homedir();
+    const resolveStorage = normalized.resolveWorktreeStorage;
+    this.resolveStorage = async () =>
+      (await resolveStorage?.()) ?? DESKTOP_WORKTREE_STORAGE_DEFAULT;
+  }
 
   async readDirectoryStatuses(
     directories: NavigationDirectorySummary[],
@@ -320,11 +382,12 @@ export class GitDirectoryService {
       sanitizeBranchName(launchpad.branchName ?? "") ||
       sanitizeBranchName(await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"])) ||
       "main";
-    const worktreeName = buildWorktreeDirectoryName({
-      baseBranch,
-      directoryLabel: launchpad.directoryLabel,
+    const storage = await this.resolveStorage();
+    const worktreePath = await computeWorktreePath({
+      repoRoot,
+      storage,
+      homeDir: this.homeDir,
     });
-    const worktreePath = buildWorktreePath(repoRoot, worktreeName);
     await mkdir(path.dirname(worktreePath), { recursive: true });
     await runGit(repoRoot, ["worktree", "add", "--detach", worktreePath, baseBranch]);
 
@@ -415,6 +478,7 @@ export class GitDirectoryService {
 
       const branch = entry.branch ?? thread.observedGitBranch ?? thread.gitBranch;
       await runGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
+      await pruneEmptyWorktreeParents(worktreePath);
 
       const result: ArchiveThreadCleanupResult = {
         ...base,

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -287,13 +287,14 @@ export class GitWorkspaceHandoffService {
     if (path.resolve(context.repositoryPath) !== path.resolve(context.sourcePath)) {
       throw new Error("Local-to-worktree handoff must start from the local checkout.");
     }
-    if (context.branch === "HEAD") {
-      throw new Error("Local-to-worktree handoff requires a named source branch.");
-    }
 
     const strategy = params.strategy ?? "move-branch";
     if (strategy === "detached-changes") {
       return await this.handoffLocalChangesToDetachedWorktree(params, context);
+    }
+
+    if (context.branch === "HEAD") {
+      throw new Error("Local-to-worktree handoff requires a named source branch.");
     }
 
     ensureBranchNotCheckedOutElsewhere({

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
-import { mkdir, realpath, stat } from "node:fs/promises";
+import { mkdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type {
   AppServerBackendKind,
+  DesktopWorktreeStorageLocation,
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
   ThreadIdentifier,
@@ -12,6 +13,8 @@ import type {
   ThreadWorkspaceHandoffStashSummary,
   WorktreeSnapshotSummary,
 } from "@pwragnt/shared";
+import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragnt/shared";
+import { computeWorktreePath } from "./git-directory-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 
 const execFileAsync = promisify(execFile);
@@ -56,6 +59,10 @@ type StashOptions = {
 
 type WorkspaceHandoffServiceOptions = {
   worktreeArchiveService?: WorktreeArchiveService;
+  resolveWorktreeStorage?: () =>
+    | DesktopWorktreeStorageLocation
+    | Promise<DesktopWorktreeStorageLocation>;
+  homeDir?: string;
 };
 
 async function runGit(cwd: string, args: string[]): Promise<GitResult> {
@@ -70,15 +77,6 @@ function trim(value: string): string {
   return value.trim();
 }
 
-function sanitizeSegment(value: string): string {
-  return value
-    .trim()
-    .replace(/^refs\/heads\//, "")
-    .replace(/[^a-zA-Z0-9._/-]+/g, "-")
-    .replace(/\//g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
 function sanitizeBranchName(value: string): string {
   return value
     .trim()
@@ -91,19 +89,6 @@ function sanitizeBranchName(value: string): string {
 function pathBaseName(value: string): string {
   const normalized = value.replace(/[\\/]+$/, "");
   return normalized.split(/[\\/]/).filter(Boolean).at(-1) ?? normalized;
-}
-
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await stat(filePath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-
-    throw error;
-  }
 }
 
 function parseWorktreeList(output: string): WorktreeInfo[] {
@@ -231,10 +216,16 @@ async function applyVerifyAndDropStash(
 
 export class GitWorkspaceHandoffService {
   private readonly worktreeArchiveService: WorktreeArchiveService;
+  private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
+  private readonly homeDir: string | undefined;
 
   constructor(options: WorkspaceHandoffServiceOptions = {}) {
     this.worktreeArchiveService =
       options.worktreeArchiveService ?? new WorktreeArchiveService();
+    const resolveStorage = options.resolveWorktreeStorage;
+    this.resolveStorage = async () =>
+      (await resolveStorage?.()) ?? DESKTOP_WORKTREE_STORAGE_DEFAULT;
+    this.homeDir = options.homeDir;
   }
 
   async handoff(params: HandoffParams): Promise<HandoffThreadWorkspaceResponse> {
@@ -319,14 +310,13 @@ export class GitWorkspaceHandoffService {
       throw new Error("Local cannot be left on the same branch being moved.");
     }
 
-    const targetPath = this.buildTargetWorktreePath({
-      repositoryPath: context.repositoryPath,
-      branch: context.branch,
-      now: context.now,
+    const storage = await this.resolveStorage();
+    const targetPath = await computeWorktreePath({
+      repoRoot: context.repositoryPath,
+      storage,
+      homeDir: this.homeDir,
+      timestamp: context.now,
     });
-    if (await pathExists(targetPath)) {
-      throw new Error(`Target worktree path already exists: ${targetPath}`);
-    }
 
     const warnings = ["Ignored files are not preserved by workspace handoff."];
     const sourceStash = await createNamedStashIfDirty({
@@ -366,14 +356,13 @@ export class GitWorkspaceHandoffService {
     context: HandoffContext,
   ): Promise<HandoffThreadWorkspaceResponse> {
     const baseSha = context.headSha;
-    const targetPath = this.buildTargetWorktreePath({
-      repositoryPath: context.repositoryPath,
-      branch: `${context.branch}-detached`,
-      now: context.now,
+    const storage = await this.resolveStorage();
+    const targetPath = await computeWorktreePath({
+      repoRoot: context.repositoryPath,
+      storage,
+      homeDir: this.homeDir,
+      timestamp: context.now,
     });
-    if (await pathExists(targetPath)) {
-      throw new Error(`Target worktree path already exists: ${targetPath}`);
-    }
 
     const warnings = [
       "Ignored files are not preserved by workspace handoff.",
@@ -540,20 +529,6 @@ export class GitWorkspaceHandoffService {
       warnings,
       completedAt: context.now,
     };
-  }
-
-  private buildTargetWorktreePath(params: {
-    repositoryPath: string;
-    branch: string;
-    now: number;
-  }): string {
-    const repoName = sanitizeSegment(pathBaseName(params.repositoryPath).toLowerCase()) || "repo";
-    const branchName = sanitizeSegment(params.branch) || "branch";
-    return path.join(
-      params.repositoryPath,
-      ".worktrees",
-      `${repoName}-${branchName}-${params.now.toString(36)}`,
-    );
   }
 
   private buildStashMessage(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import type {
   DesktopChatReplyComposer,
   DesktopMessagingImageProfile,
+  DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragnt/shared";
+import { isDesktopWorktreeStorageLocation } from "@pwragnt/shared";
 import { DESKTOP_CONFIG_PATH_ENV } from "./desktop-settings-env";
 
 type DesktopConfigPathOptions = {
@@ -51,6 +53,9 @@ export type DesktopSettingsConfig = {
       preferredId?: string;
     };
   };
+  worktrees?: {
+    storage?: DesktopWorktreeStorageLocation;
+  };
 };
 
 type TomlScalar = string | number | boolean | string[];
@@ -64,6 +69,10 @@ export function defaultDesktopConfigDir(
     options?.xdgConfigHome?.trim() || env.XDG_CONFIG_HOME?.trim();
 
   return path.join(xdgConfigHome || path.join(homeDir, ".config"), "pwragnt");
+}
+
+export function userHomeWorktreesRoot(homeDir?: string): string {
+  return path.join(homeDir ?? os.homedir(), ".pwragnt", "worktrees");
 }
 
 export function resolveDesktopConfigPath(
@@ -138,6 +147,10 @@ export function mergeDesktopSettingsConfig(
         ...current.applications?.terminal,
         ...patch.applications?.terminal,
       },
+    },
+    worktrees: {
+      ...current.worktrees,
+      ...patch.worktrees,
     },
   });
 }
@@ -295,6 +308,15 @@ export function stringifyDesktopSettingsToml(
     );
   }
 
+  const worktrees = config.worktrees;
+  if (worktrees?.storage !== undefined) {
+    sections.push(
+      ["[worktrees]", `storage = ${formatTomlValue(worktrees.storage)}`].join(
+        "\n",
+      ),
+    );
+  }
+
   return sections.join("\n\n").concat(sections.length ? "\n" : "");
 }
 
@@ -309,6 +331,7 @@ function normalizeDesktopConfig(
   const codex = tables["models.codex"];
   const editor = tables["applications.editor"];
   const terminal = tables["applications.terminal"];
+  const worktrees = tables["worktrees"];
 
   return pruneEmptyConfig({
     experimental: {
@@ -346,6 +369,9 @@ function normalizeDesktopConfig(
       terminal: {
         preferredId: readString(terminal?.preferred_id),
       },
+    },
+    worktrees: {
+      storage: readWorktreeStorage(worktrees?.storage),
     },
   });
 }
@@ -405,6 +431,11 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     if (terminal && hasDefinedValue(terminal)) {
       pruned.applications.terminal = terminal;
     }
+  }
+
+  const worktrees = config.worktrees;
+  if (worktrees && hasDefinedValue(worktrees)) {
+    pruned.worktrees = worktrees;
   }
 
   return pruned;
@@ -479,6 +510,14 @@ function isDesktopMessagingImageProfile(
   value: string,
 ): value is DesktopMessagingImageProfile {
   return value === "low" || value === "medium" || value === "high" || value === "actual";
+}
+
+function readWorktreeStorage(
+  value: TomlScalar | undefined,
+): DesktopWorktreeStorageLocation | undefined {
+  return typeof value === "string" && isDesktopWorktreeStorageLocation(value)
+    ? value
+    : undefined;
 }
 
 function parseTomlValue(

--- a/apps/desktop/src/main/settings/desktop-settings-env.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-env.ts
@@ -1,7 +1,9 @@
 import type {
   DesktopChatReplyComposer,
   DesktopMessagingImageProfile,
+  DesktopWorktreeStorageLocation,
 } from "@pwragnt/shared";
+import { isDesktopWorktreeStorageLocation } from "@pwragnt/shared";
 
 export const DESKTOP_CONFIG_PATH_ENV = "PWRAGNT_CONFIG_PATH";
 export const CHAT_REPLY_COMPOSER_ENV =
@@ -30,6 +32,7 @@ export const MESSAGING_ATTACHMENT_MAX_COUNT_ENV =
 export const MESSAGING_INPUT_DEBOUNCE_MS_ENV =
   "PWRAGNT_MESSAGING_INPUT_DEBOUNCE_MS";
 export const CODEX_COMMAND_ENV = "PWRAGNT_CODEX_COMMAND";
+export const WORKTREE_STORAGE_ENV = "PWRAGNT_WORKTREE_STORAGE";
 
 export type ParsedEnvValue<T> = {
   value?: T;
@@ -120,6 +123,21 @@ export function readEnvComposer(
   }
   if (!isDesktopChatReplyComposer(value)) {
     return { error: `Invalid composer value for ${CHAT_REPLY_COMPOSER_ENV}` };
+  }
+  return { value };
+}
+
+export function readEnvWorktreeStorage(
+  env: NodeJS.ProcessEnv,
+): ParsedEnvValue<DesktopWorktreeStorageLocation> {
+  const value = readEnvString(env, WORKTREE_STORAGE_ENV);
+  if (!value) {
+    return {};
+  }
+  if (!isDesktopWorktreeStorageLocation(value)) {
+    return {
+      error: `Invalid worktree storage value for ${WORKTREE_STORAGE_ENV}`,
+    };
   }
   return { value };
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -6,12 +6,15 @@ import type {
   DesktopSettingsSecretState,
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
+  DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragnt/shared";
+import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragnt/shared";
 import {
   mergeDesktopSettingsConfig,
   readDesktopSettingsConfig,
   resolveDesktopConfigPath,
+  userHomeWorktreesRoot,
   writeDesktopSettingsConfig,
   type DesktopSettingsConfig,
 } from "./desktop-config";
@@ -33,12 +36,14 @@ import {
   TELEGRAM_AUTHORIZED_USER_IDS_ENV,
   TELEGRAM_BOT_TOKEN_ENV,
   TELEGRAM_ENABLED_ENV,
+  WORKTREE_STORAGE_ENV,
   readEnvBoolean,
   readEnvComposer,
   readEnvInteger,
   readEnvList,
   readEnvMessagingImageProfile,
   readEnvString,
+  readEnvWorktreeStorage,
 } from "./desktop-settings-env";
 import { discoverCodexCommands } from "./codex-discovery";
 import { discoverDesktopApplications } from "./application-discovery";
@@ -206,7 +211,13 @@ export class DesktopSettingsService {
         preferredEditorId,
         preferredTerminalId,
       },
+      worktrees: this.resolveWorktrees(config.worktrees?.storage),
     };
+  }
+
+  resolveWorktreeStorage(): DesktopWorktreeStorageLocation {
+    return this.resolveWorktrees(this.readConfig().config.worktrees?.storage)
+      .storage.value;
   }
 
   async writeConfigPatch(
@@ -413,6 +424,34 @@ export class DesktopSettingsService {
     return {
       value: configValue ?? "show_some",
       source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveWorktrees(
+    configValue: DesktopWorktreeStorageLocation | undefined,
+  ): {
+    storage: DesktopSettingsValue<DesktopWorktreeStorageLocation>;
+    effectivePath: string;
+  } {
+    const envValue = readEnvWorktreeStorage(this.env);
+    const resolved: DesktopSettingsValue<DesktopWorktreeStorageLocation> =
+      envValue.value !== undefined
+        ? {
+            value: envValue.value,
+            source: "env",
+            overriddenByEnv: configValue !== undefined,
+          }
+        : {
+            value: configValue ?? DESKTOP_WORKTREE_STORAGE_DEFAULT,
+            source: configValue === undefined ? "default" : "config",
+            error: envValue.error,
+          };
+    return {
+      storage: resolved,
+      effectivePath:
+        resolved.value === "user-home"
+          ? userHomeWorktreesRoot()
+          : ".worktrees",
     };
   }
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -98,6 +98,10 @@ describe("App", () => {
         preferredEditorId: { value: "", source: "default" },
         preferredTerminalId: { value: "", source: "default" },
       },
+      worktrees: {
+        storage: { value: "user-home", source: "default" },
+        effectivePath: "/home/example/.pwragnt/worktrees",
+      },
     } satisfies DesktopSettingsSnapshot;
 
     Object.defineProperty(window, "pwragnt", {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import { ExperimentalSettings } from "./ExperimentalSettings";
 import { MessagingSettings } from "./MessagingSettings";
 import { ModelsSettings } from "./ModelsSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
+import { WorktreesSettings } from "./WorktreesSettings";
 import { useState } from "react";
 
 type SettingsSection =
@@ -16,10 +17,12 @@ type SettingsSection =
   | "messaging"
   | "models"
   | "applications"
+  | "worktrees"
   | "about";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "applications", label: "Applications" },
+  { id: "worktrees", label: "Worktrees" },
   { id: "messaging", label: "Messaging" },
   { id: "models", label: "Models" },
   { id: "experimental", label: "Experimental" },
@@ -203,6 +206,20 @@ function SettingsSectionBody(props: {
               kind === "editor"
                 ? { editor: { preferredId } }
                 : { terminal: { preferredId } },
+          });
+        }}
+      />
+    );
+  }
+
+  if (props.section === "worktrees") {
+    return (
+      <WorktreesSettings
+        saving={props.settings.saving}
+        snapshot={props.snapshot}
+        onStorageChange={async (storage) => {
+          await props.settings.writeConfig({
+            worktrees: { storage },
           });
         }}
       />

--- a/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
@@ -1,0 +1,96 @@
+import type {
+  DesktopSettingsSnapshot,
+  DesktopWorktreeStorageLocation,
+} from "@pwragnt/shared";
+import { sourceBadge } from "./settings-fields";
+
+const STORAGE_OPTIONS: Array<{
+  description: string;
+  label: string;
+  value: DesktopWorktreeStorageLocation;
+}> = [
+  {
+    description:
+      "Inside each repository at .worktrees/<hash>/<project-folder>.",
+    label: "In repository",
+    value: "in-repo",
+  },
+  {
+    description:
+      "Outside the repository under ~/.pwragnt/worktrees/<hash>/<project-folder>.",
+    label: "User home",
+    value: "user-home",
+  },
+];
+
+export function WorktreesSettings(props: {
+  saving: boolean;
+  snapshot: DesktopSettingsSnapshot;
+  onStorageChange: (value: DesktopWorktreeStorageLocation) => Promise<void>;
+}) {
+  const storage = props.snapshot.worktrees.storage;
+  const overridden = storage.source === "env";
+  const activeOption = STORAGE_OPTIONS.find(
+    (option) => option.value === storage.value,
+  );
+
+  return (
+    <section className="settings-panel" aria-labelledby="settings-worktrees-title">
+      <div className="settings-panel__header">
+        <div>
+          <p className="eyebrow">Worktrees</p>
+          <h2 id="settings-worktrees-title">Storage location</h2>
+        </div>
+        <span className="settings-source">{sourceBadge(storage)}</span>
+      </div>
+
+      <div className="settings-field">
+        <div
+          className="settings-segmented"
+          role="radiogroup"
+          aria-label="Worktree storage location"
+        >
+          {STORAGE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              aria-checked={storage.value === option.value}
+              className={`settings-segmented__button${
+                storage.value === option.value ? " is-active" : ""
+              }`}
+              disabled={props.saving || overridden}
+              role="radio"
+              type="button"
+              onClick={() => {
+                void props.onStorageChange(option.value);
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {activeOption ? (
+        <p className="settings-row__description">{activeOption.description}</p>
+      ) : null}
+
+      <div className="settings-row">
+        <span className="settings-row__label">Effective path</span>
+        <code className="settings-input" aria-readonly="true">
+          {props.snapshot.worktrees.effectivePath}
+        </code>
+      </div>
+
+      {overridden ? (
+        <p className="settings-row__description">
+          Overridden by PWRAGNT_WORKTREE_STORAGE; clear the environment
+          variable to edit this from settings.
+        </p>
+      ) : null}
+
+      {storage.error ? (
+        <p className="settings-row__error">{storage.error}</p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -116,6 +116,10 @@ function createSnapshot(
       preferredEditorId: { value: "", source: "default" },
       preferredTerminalId: { value: "", source: "default" },
     },
+    worktrees: {
+      storage: { value: "user-home", source: "default" },
+      effectivePath: "/home/example/.pwragnt/worktrees",
+    },
     ...overrides,
   };
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/runtime-identity.test.ts
@@ -41,6 +41,44 @@ describe("runtime identity formatting", () => {
     ).toBe("5d4b/PwrAgnt");
   });
 
+  it("shows hash/project for the new in-repo worktree layout", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/github/PwrAgnt/.worktrees/moit6ddw/PwrAgnt"
+      )
+    ).toBe("moit6ddw/PwrAgnt");
+  });
+
+  it("shows hash/project for the new in-repo layout with collision suffix", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/github/PwrAgnt/.worktrees/moit6ddw-2/PwrAgnt"
+      )
+    ).toBe("moit6ddw-2/PwrAgnt");
+  });
+
+  it("ignores the desktop app package below the new in-repo worktree layout", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/github/PwrAgnt/.worktrees/moit6ddw/PwrAgnt/apps/desktop"
+      )
+    ).toBe("moit6ddw/PwrAgnt");
+  });
+
+  it("shows hash/project for the user-home worktree layout", () => {
+    expect(
+      formatRuntimePath("/Users/huntharo/.pwragnt/worktrees/moit6ddw/PwrAgnt")
+    ).toBe("moit6ddw/PwrAgnt");
+  });
+
+  it("ignores the desktop app package below a user-home worktree", () => {
+    expect(
+      formatRuntimePath(
+        "/Users/huntharo/.pwragnt/worktrees/moit6ddw/PwrAgnt/apps/desktop"
+      )
+    ).toBe("moit6ddw/PwrAgnt");
+  });
+
   it("middle-truncates branch names", () => {
     expect(formatRuntimeBranch("codex/fix-thread-naming-ephemeral")).toBe(
       "codex/fix-thread-naming-ephemeral"

--- a/apps/desktop/src/renderer/src/lib/runtime-identity.ts
+++ b/apps/desktop/src/renderer/src/lib/runtime-identity.ts
@@ -41,17 +41,23 @@ export function formatRuntimePath(cwd: string): string {
   const worktreesIndex = segments.lastIndexOf(".worktrees");
 
   if (worktreesIndex >= 0 && segments[worktreesIndex + 1]) {
-    return `.worktrees/${elideMiddle(segments[worktreesIndex + 1], 30)}`;
+    const hashSegment = segments[worktreesIndex + 1];
+    const projectSegment = segments[worktreesIndex + 2];
+    if (projectSegment && /^[0-9a-z]+(?:-\d+)?$/.test(hashSegment)) {
+      return `${hashSegment}/${projectSegment}`;
+    }
+    return `.worktrees/${elideMiddle(hashSegment, 30)}`;
   }
 
-  const codexWorktreesIndex = segments.lastIndexOf("worktrees");
+  const bareWorktreesIndex = segments.lastIndexOf("worktrees");
   if (
-    codexWorktreesIndex >= 0 &&
-    segments[codexWorktreesIndex - 1] === ".codex" &&
-    segments[codexWorktreesIndex + 1] &&
-    segments[codexWorktreesIndex + 2]
+    bareWorktreesIndex >= 1 &&
+    (segments[bareWorktreesIndex - 1] === ".pwragnt" ||
+      segments[bareWorktreesIndex - 1] === ".codex") &&
+    segments[bareWorktreesIndex + 1] &&
+    segments[bareWorktreesIndex + 2]
   ) {
-    return `${segments[codexWorktreesIndex + 1]}/${segments[codexWorktreesIndex + 2]}`;
+    return `${segments[bareWorktreesIndex + 1]}/${segments[bareWorktreesIndex + 2]}`;
   }
 
   return segments.slice(-2).join("/") || cwd;

--- a/docs/plans/2026-05-02-004-feat-configurable-worktree-storage-plan.md
+++ b/docs/plans/2026-05-02-004-feat-configurable-worktree-storage-plan.md
@@ -1,0 +1,167 @@
+---
+title: Configurable Worktree Storage Location And Hash-Folder Naming
+type: feat
+status: completed
+date: 2026-05-02
+---
+
+# Configurable Worktree Storage Location And Hash-Folder Naming
+
+## Overview
+
+Replace the current single-string worktree folder name (`launchpad-<label>-<branch>-<hash>`) with a two-segment layout — `<root>/<hash>/<project-folder-name>` — and let the user choose where `<root>` lives via a new **Worktrees** settings tab. The two location options are:
+
+1. **In repo** at `<repoRoot>/.worktrees` (current behavior, structurally cleaner names)
+2. **In user home** at `~/.pwragnt/worktrees`
+
+Old `launchpad-…` worktrees keep working: `git worktree list --porcelain` still discovers them, and the cleanup path operates on the stored absolute `worktreePath` rather than recomputing it. No physical migration.
+
+## Problem Statement / Motivation
+
+The current naming pattern was added in [git-directory-service.ts:32-45](apps/desktop/src/main/app-server/git-directory-service.ts:32):
+
+```ts
+function buildWorktreeDirectoryName({ baseBranch, directoryLabel, timestamp }) {
+  const base = sanitizeBranchName(baseBranch) || "main";
+  const label = sanitizeBranchName(directoryLabel.toLowerCase()) || "launchpad";
+  const suffix = (timestamp ?? Date.now()).toString(36);
+  return `launchpad-${label}-${base.replace(/\//g, "-")}-${suffix}`;
+}
+
+function buildWorktreePath(repoRoot, worktreeName) {
+  return path.join(repoRoot, ".worktrees", worktreeName.replace(/[\\/]/g, "-"));
+}
+```
+
+Concrete pain:
+
+- The `launchpad-<label>-<branch>-<hash>` slug is long, hard to scan in a `ls`, and bakes branch + project-label into a flat string that becomes meaningless after rename. It also pollutes terminal prompts and editor titlebars (e.g. VS Code title shows `.worktrees/launchpad-pwragnt-main-moit6ddw`).
+- The location is hardcoded to **in-repo** (`<repoRoot>/.worktrees`). Users who keep many repos and want all worktrees in one place (`~/.pwragnt/worktrees`) cannot pick that today.
+- The folder basename does not match the project — when a worktree is opened in an editor, recent-projects lists and titlebars all read `launchpad-…` instead of the project name. Codex already uses a `<hash>/<name>` two-segment convention (see `formatRuntimePath` in [runtime-identity.ts:47-55](apps/desktop/src/renderer/src/lib/runtime-identity.ts:47)) and the user prefers that shape for parity and ergonomics.
+
+## Proposed Solution
+
+Two changes, kept separable:
+
+**A. Naming change (always-on, no setting).** Replace the single flat slug with a two-segment layout:
+
+- `<root>/<hash>/<project-folder-basename>`
+- `<hash>` keeps `Date.now().toString(36)` (user confirmed this is fine).
+- `<project-folder-basename>` = `path.basename(repoRoot)` (the actual checkout folder name; e.g. `PwrAgnt` for this repo).
+- Branch name and directory label move out of the path and live only in thread metadata, where they already exist.
+
+Examples:
+- In-repo: `<repoRoot>/.worktrees/moit6ddw/PwrAgnt`
+- User-home: `~/.pwragnt/worktrees/moit6ddw/PwrAgnt`
+
+**B. Storage location setting (new tab).** Add a Worktrees section to the Settings screen exposing one selector:
+
+| Option | Stored value | Effective path |
+| --- | --- | --- |
+| In repo (default) | `in-repo` | `<repoRoot>/.worktrees` |
+| User home | `user-home` | `~/.pwragnt/worktrees` |
+
+The settings panel computes and displays the resolved effective path so the user sees `~/.pwragnt/worktrees` (with `~` rendered) rather than just an enum label.
+
+**Backward compat:** No code changes to discovery — git tracks every worktree via `.git/worktrees/<name>`, and `cleanupThreadWorktrees` (see [git-directory-service.ts:337-371](apps/desktop/src/main/app-server/git-directory-service.ts:337)) uses the stored `linkedDirectories[].worktreePath` verbatim. Existing `launchpad-…` worktrees keep functioning until they are explicitly archived.
+
+## Technical Considerations
+
+- **Single source of truth.** Path computation is centralized in `buildWorktreeDirectoryName` + `buildWorktreePath`. Replacing those two helpers (and their call site at [git-directory-service.ts:323-329](apps/desktop/src/main/app-server/git-directory-service.ts:323)) is the entire core change.
+- **Settings infrastructure already supports this.** `DesktopSettingsConfig` ([desktop-config.ts:17-53](apps/desktop/src/main/settings/desktop-config.ts:17)) is a flat record of optional groups; the merge/prune/parse/stringify helpers handle a new top-level group additively. The settings UI already uses an enum-driven `SECTIONS` array ([SettingsScreen.tsx:14-19](apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx:14)) — adding `"worktrees"` is a one-line tab list change plus one new component.
+- **TOML round-trip.** The hand-rolled parser/stringifier in `desktop-config.ts` does not auto-handle new tables; both `stringifyDesktopSettingsToml` and `normalizeDesktopConfig` need explicit cases for `[worktrees]`.
+- **Path collisions in the hash bucket.** Two worktrees of two different repos that happen to land at the same `Date.now()` ms in the shared `~/.pwragnt/worktrees/<hash>/` bucket would each create a different `<project-folder-name>` subdir — fine. But two worktrees of the **same** repo at the same ms would collide on `<hash>/<sameProjectName>`. Mitigation: detect existence on the chosen path; if it exists, append `-2`, `-3`, … to the hash segment until unique.
+- **Display layer.** `formatRuntimePath` ([runtime-identity.ts:39-58](apps/desktop/src/renderer/src/lib/runtime-identity.ts:39)) hard-codes pattern recognition for `.worktrees/<one-segment>` and `.codex/worktrees/<hash>/<name>`. Extend it for the new pattern (`.worktrees/<hash>/<name>` and `.pwragnt/worktrees/<hash>/<name>`) so the runtime chip stays readable.
+- **Workspace launchpads (`directoryKind === "workspace"`)** short-circuit in `prepareLaunchpadWorkspace` ([git-directory-service.ts:296-301](apps/desktop/src/main/app-server/git-directory-service.ts:296)) and never reach the worktree path. Out of scope.
+- **Setting precedence.** Follow the established TOML + env-override precedence (see R2/R6 in [desktop-settings-config requirements](docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md)). New env override: `PWRAGNT_WORKTREE_STORAGE` accepting `in-repo` | `user-home`.
+
+## System-Wide Impact
+
+- **Interaction graph**: `prepareLaunchpadWorkspace` is invoked from `BackendRegistry.materializeDirectoryLaunchpad` (see backend-registry.ts:~2031). It reads the new setting via the desktop settings service, computes the path, calls `mkdir -p` on the parent, then `git worktree add --detach`. No callbacks fire on the rename — but every downstream consumer that reads the worktree path (thread snapshot creation, snapshot ref hashing, archive cleanup, runtime identity chip) sees the new path verbatim.
+- **Error propagation**: `prepareLaunchpadWorkspace` already lets `git worktree add` errors propagate. New error sources are minor: `mkdir` of `~/.pwragnt/worktrees/<hash>` (covered by existing `recursive: true`) and the new collision-disambiguator loop. The settings read at workspace-prep time must not throw if config is missing — fall back to default (`in-repo`).
+- **State lifecycle risks**: If a user creates a worktree under `user-home`, then flips the setting to `in-repo`, then archives the thread — the thread's stored `worktreePath` still points at the user-home location, so cleanup removes the right thing. Verified by reading [git-directory-service.ts:343-356](apps/desktop/src/main/app-server/git-directory-service.ts:343): the stored path wins over recomputation.
+- **API surface parity**: The two helpers are the sole producer of worktree paths. No other interface (CLI, IPC) lets a caller mint a worktree path independently. Display is a separate concern handled by `formatRuntimePath`.
+- **Snapshot ref stability**: The thread-worktree-archive plan ([2026-04-22-003-feat-thread-worktree-archive-restore-plan.md](docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md)) keys snapshots on `sha1(absolute-worktree-path)` for Codex compatibility. New paths produce new hashes — that is correct, because each new worktree is a new entity. Existing snapshots keep their existing hashes because the stored path on the thread is unchanged.
+- **Integration test scenarios**:
+  1. Create worktree with default setting → path is `<repoRoot>/.worktrees/<hash>/<basename>`, git worktree list shows it, archive removes it.
+  2. Switch setting to `user-home` → next worktree lands at `~/.pwragnt/worktrees/<hash>/<basename>`.
+  3. Pre-existing `launchpad-foo-main-abc` worktree from before the upgrade → archive flow still removes it (path comes from stored thread metadata).
+  4. Two worktrees of the same repo created within the same millisecond (force timestamp in test) → second one disambiguates to `<hash>-2`.
+  5. Env override `PWRAGNT_WORKTREE_STORAGE=user-home` set at runtime → settings UI shows the value as overridden, new worktrees go to user-home regardless of TOML.
+
+## Acceptance Criteria
+
+- [ ] New worktree paths follow `<root>/<hash>/<basename(repoRoot)>` for both location options, with `<hash> = Date.now().toString(36)`.
+- [ ] `prepareLaunchpadWorkspace` reads the storage-location setting and uses `~/.pwragnt/worktrees` when set to `user-home`, otherwise `<repoRoot>/.worktrees`.
+- [ ] A new **Worktrees** tab appears in the Settings screen between **Applications** and **Messaging** (or wherever fits the visual order — see open question), with a two-option storage selector and a labeled "Effective path" readout that displays the resolved location with `~` for the home directory.
+- [ ] `DesktopSettingsConfig` gains a `worktrees?: { storage?: "in-repo" | "user-home" }` group; TOML round-trip (parse → stringify → parse) preserves the value; `normalizeDesktopConfig`, `stringifyDesktopSettingsToml`, `mergeDesktopSettingsConfig`, and `pruneEmptyConfig` all handle the new group.
+- [ ] `PWRAGNT_WORKTREE_STORAGE` environment variable overrides the TOML value at runtime; the settings UI marks the field as overridden and disables the selector while the override is active (consistent with R2/R34-R36 in the [settings brainstorm](docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md)).
+- [ ] Existing `<repoRoot>/.worktrees/launchpad-…` worktrees created before this change continue to be cleaned up correctly when the owning thread is archived.
+- [ ] `formatRuntimePath` recognizes the new `.worktrees/<hash>/<name>` and `.pwragnt/worktrees/<hash>/<name>` patterns and renders something readable (e.g. `PwrAgnt @ moit6ddw` or `PwrAgnt/moit6ddw`).
+- [ ] Path-collision disambiguator: if the computed path already exists on disk, the worktree is created with a `-N` suffix on the hash segment.
+- [ ] Unit coverage in `git-directory-service.test.ts` for the new path builder (both location options, basename extraction, collision suffixing) and renderer-side tests for `formatRuntimePath` covering the new patterns.
+
+## Success Metrics
+
+- Zero regressions in `pnpm test` and `pnpm test:desktop-e2e` for launchpad → worktree → archive flows.
+- Manual smoke: opening a new worktree from the desktop app shows `PwrAgnt` (the project basename) in the editor titlebar / shell prompt rather than `launchpad-pwragnt-main-…`.
+- Settings inspector shows the resolved path including `~` expansion, and toggling the selector immediately updates the readout.
+
+## Dependencies & Risks
+
+- **Depends on** the existing desktop settings infrastructure landed per [2026-04-30-desktop-settings-config-requirements.md](docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md). All required pieces (`DesktopSettingsConfig`, TOML helpers, `SettingsScreen.tsx`, `useDesktopSettings`) are in place — confirmed by direct read.
+- **Risk:** users who manually `cd` into worktree paths from terminal history will hit `launchpad-…` paths that still work but new worktrees won't appear there. Acceptable — they were going to retire the old paths anyway via thread archive.
+- **Risk:** if the user's home directory contains an existing `~/.pwragnt/worktrees` from a prior tool/script, we coexist (we only ever write our own `<hash>/<basename>` subtree).
+- **Out of scope:** physically migrating existing in-repo worktrees to `~/.pwragnt/worktrees`. Discoverability surface for browsing existing worktrees from the new settings tab (potentially valuable but a separable feature).
+
+## Open Questions
+
+1. **Default value for the storage setting.** The user's stated preference is the user-home layout, but defaulting to `in-repo` preserves zero-surprise behavior for anyone upgrading. Recommendation: default to `in-repo` to keep the upgrade non-disruptive; surface the user-home option prominently in the Worktrees tab. Confirm during planning.
+2. **Tab ordering.** Should "Worktrees" sit next to "Applications" (both feel like environment plumbing) or after "Models"? Likely between Applications and Messaging.
+3. **Cleanup of empty `<hash>` parent directories.** When a worktree is removed, the parent `~/.pwragnt/worktrees/<hash>/` becomes empty. Worth `rmdir`-ing on cleanup to avoid orphaned hash directories piling up. Low priority; can defer.
+4. **Display tweak only:** when `<basename(repoRoot)>` collides between unrelated checkouts in the shared user-home root, the runtime chip might be ambiguous. Acceptable because the `<hash>` segment differs.
+
+## Implementation Outline
+
+Single PR, four touch points:
+
+1. **Settings schema** — [apps/desktop/src/main/settings/desktop-config.ts](apps/desktop/src/main/settings/desktop-config.ts)
+   - Extend `DesktopSettingsConfig` with `worktrees?: { storage?: WorktreeStorageLocation }`.
+   - Add normalize/stringify/merge/prune branches for `[worktrees]` table with key `storage = "in-repo" | "user-home"`.
+   - Define and export `WorktreeStorageLocation` type via `@pwragnt/shared`.
+2. **Settings env + service** — [apps/desktop/src/main/settings/desktop-settings-env.ts](apps/desktop/src/main/settings/desktop-settings-env.ts) + [apps/desktop/src/main/settings/desktop-settings-service.ts](apps/desktop/src/main/settings/desktop-settings-service.ts)
+   - Add `PWRAGNT_WORKTREE_STORAGE` to env override list with the same overridden-value semantics used for messaging fields.
+   - Expose the resolved storage value (and override flag) in the snapshot returned to the renderer.
+3. **Path computation** — [apps/desktop/src/main/app-server/git-directory-service.ts:32-45](apps/desktop/src/main/app-server/git-directory-service.ts:32) and call site at line 323-329
+   - Replace `buildWorktreeDirectoryName` + `buildWorktreePath` with one helper:
+     ```ts
+     async function computeWorktreePath(params: {
+       repoRoot: string;
+       storage: WorktreeStorageLocation;
+       homeDir?: string;
+       timestamp?: number;
+     }): Promise<string>
+     ```
+   - Helper returns `<root>/<hash>/<path.basename(params.repoRoot)>`, where `<root>` is `<repoRoot>/.worktrees` for `in-repo` or `<homeDir>/.pwragnt/worktrees` for `user-home`. Includes the `-N` collision suffix loop.
+   - `prepareLaunchpadWorkspace` accepts the storage value via constructor injection (a `getWorktreeStorage(): Promise<WorktreeStorageLocation>` callback supplied by `BackendRegistry`, parallel to how it gets settings today).
+4. **Settings UI** — `apps/desktop/src/renderer/src/features/settings/`
+   - Add `WorktreesSettings.tsx` component with a 2-radio selector and an "Effective path" readout. Mirror the `ApplicationsSettings.tsx` styling — restrained panel, `settings-row__error` for env-override badge.
+   - Update [SettingsScreen.tsx:12-19](apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx:12) to add `"worktrees"` to the `SettingsSection` union and the `SECTIONS` array, and add the rendering branch in `SettingsSectionBody`.
+   - Add a `useDesktopSettings` writer for the new field.
+5. **Display** — [apps/desktop/src/renderer/src/lib/runtime-identity.ts:39-58](apps/desktop/src/renderer/src/lib/runtime-identity.ts:39)
+   - Detect `<…>/.worktrees/<hash>/<name>` (basename + parent + grandparent === `.worktrees`) and `<…>/.pwragnt/worktrees/<hash>/<name>`. Render as `${name} @ ${hash}` (or `${name}/${hash}` to match the existing Codex branch).
+6. **Tests** — colocated in `git-directory-service.test.ts` and a new `runtime-identity.test.ts` case set; settings persistence tests in `desktop-config.test.ts`.
+
+## Sources & References
+
+- **Brainstorm reference:** [docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md](docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md) — TOML + env override precedence (R2, R6, R34-R36) and settings tab pattern (R7-R12).
+- **Brainstorm reference:** [docs/brainstorms/2026-04-18-directories-launchpad-requirements.md](docs/brainstorms/2026-04-18-directories-launchpad-requirements.md) — launchpad workMode model (R9-R16).
+- **Related plan:** [docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md](docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md) — worktree snapshot ref scheme that depends on stable absolute paths.
+- **Code:**
+  - [apps/desktop/src/main/app-server/git-directory-service.ts:32-45](apps/desktop/src/main/app-server/git-directory-service.ts:32) — current path builders.
+  - [apps/desktop/src/main/app-server/git-directory-service.ts:290-371](apps/desktop/src/main/app-server/git-directory-service.ts:290) — `prepareLaunchpadWorkspace` and `cleanupThreadWorktrees`.
+  - [apps/desktop/src/main/settings/desktop-config.ts](apps/desktop/src/main/settings/desktop-config.ts) — settings schema, TOML round-trip.
+  - [apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx](apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx) — section bar pattern.
+  - [apps/desktop/src/renderer/src/lib/runtime-identity.ts:39-58](apps/desktop/src/renderer/src/lib/runtime-identity.ts:39) — runtime path display.
+  - [apps/desktop/src/main/app-server/scratch-projects.ts](apps/desktop/src/main/app-server/scratch-projects.ts) — precedent for `~/.pwragnt/<bucket>/...` storage layout.
+- **Conventions:** [AGENTS.md](AGENTS.md) — Conventional Commit scopes (`desktop` for this PR), runtime config layout, thread-first hierarchy guidance.

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -88,6 +88,10 @@ describe("desktop settings contracts", () => {
         preferredEditorId: { value: "", source: "default" },
         preferredTerminalId: { value: "", source: "default" },
       },
+      worktrees: {
+        storage: { value: "user-home", source: "default" },
+        effectivePath: "/home/example/.pwragnt/worktrees",
+      },
     };
 
     const encoded = JSON.stringify(snapshot);

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -10,6 +10,17 @@ export const DESKTOP_CHAT_REPLY_COMPOSERS = [
 export type DesktopChatReplyComposer =
   (typeof DESKTOP_CHAT_REPLY_COMPOSERS)[number];
 
+export const DESKTOP_WORKTREE_STORAGE_LOCATIONS = [
+  "in-repo",
+  "user-home",
+] as const;
+
+export type DesktopWorktreeStorageLocation =
+  (typeof DESKTOP_WORKTREE_STORAGE_LOCATIONS)[number];
+
+export const DESKTOP_WORKTREE_STORAGE_DEFAULT: DesktopWorktreeStorageLocation =
+  "user-home";
+
 export type DesktopSettingsNonSecretSource = "default" | "config" | "env";
 export type DesktopSettingsSecretSource = "unset" | "keychain" | "env";
 export type DesktopSettingsSource =
@@ -139,6 +150,10 @@ export type DesktopSettingsSnapshot = {
     };
   };
   applications: DesktopApplicationsSnapshot;
+  worktrees: {
+    storage: DesktopSettingsValue<DesktopWorktreeStorageLocation>;
+    effectivePath: string;
+  };
 };
 
 export type DesktopSettingsConfigPatch = {
@@ -177,6 +192,9 @@ export type DesktopSettingsConfigPatch = {
     terminal?: {
       preferredId?: string;
     };
+  };
+  worktrees?: {
+    storage?: DesktopWorktreeStorageLocation;
   };
 };
 
@@ -220,5 +238,13 @@ export function isDesktopChatReplyComposer(
 ): value is DesktopChatReplyComposer {
   return DESKTOP_CHAT_REPLY_COMPOSERS.includes(
     value as DesktopChatReplyComposer,
+  );
+}
+
+export function isDesktopWorktreeStorageLocation(
+  value: string,
+): value is DesktopWorktreeStorageLocation {
+  return DESKTOP_WORKTREE_STORAGE_LOCATIONS.includes(
+    value as DesktopWorktreeStorageLocation,
   );
 }


### PR DESCRIPTION
## Summary
- Replace `launchpad-<label>-<branch>-<hash>` worktree naming with `<hash>/<project-folder-name>` layout (e.g. `~/.pwragnt/worktrees/12345678/PwrAgnt`)
- Add a **Worktrees** settings tab (between Applications and Messaging) letting users choose between in-repo (`.worktrees/`) and user-home (`~/.pwragnt/worktrees/`) storage, defaulting to user-home
- Existing worktrees continue to load and clean up correctly via stored paths — no migration needed
- Empty `<hash>` parent directories are pruned on worktree cleanup
- **Fix:** The workspace handoff service (`git-workspace-handoff-service.ts`) had its own `buildTargetWorktreePath` that produced `<repo>-<branch>-<hash>` flat names, bypassing the new layout and storage setting. Replaced with the shared `computeWorktreePath` so both launchpad and handoff flows honor the same path shape and storage preference.

## Test plan
- [x] Verify new worktrees are created under `~/.pwragnt/worktrees/<hash>/<project-name>` by default
- [x] Switch storage to in-repo in Settings → Worktrees and confirm worktrees land under `<repo>/.worktrees/<hash>/<project-name>`
- [x] Confirm existing `launchpad-...` worktrees still load and clean up correctly
- [x] Check the runtime identity chip formats the new path pattern correctly
- [ ] Verify `PWRAGNT_WORKTREE_STORAGE` env var overrides the config setting
- [x] **Handoff:** Do a local-to-worktree handoff and confirm the target path is `<hash>/<project-name>`, not the old flat pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)