### PR TITLE
fix(desktop): drop stale transcript live work

### DIFF
--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -120,6 +120,37 @@ test("thread reply Tiptap skill autocomplete filters and commits the reported mu
   }
 });
 
+test("thread reply Tiptap slash review autocomplete stays open on exact command text", async () => {
+  const app = await launchElectronApp({
+    env: tiptapWysiwygComposerEnv,
+    fixturePath,
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("/revie");
+    await expect(tiptapInput).toHaveAttribute("data-value", "/revie");
+    await expect(app.window.getByRole("listbox", { name: "Commands" })).toBeVisible();
+
+    await app.window.keyboard.type("w");
+    await expect(tiptapInput).toHaveAttribute("data-value", "/review");
+
+    const commands = app.window.getByRole("listbox", { name: "Commands" });
+    await expect(commands).toBeVisible();
+    await expect(commands.getByRole("button", { name: /\/review/i })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
 test("thread reply Tiptap skill insertion preserves rich Markdown blocks", async () => {
   const app = await launchElectronApp({
     env: tiptapWysiwygComposerEnv,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1469,6 +1469,159 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("drops stale completed live work when a newer turn hydrates without it", async () => {
+    let now = 80_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    const oldTurn = {
+      id: "turn-old",
+      status: "completed" as const,
+      durationMs: 197_000,
+    };
+    const newerTurn = {
+      id: "turn-newer",
+      status: "completed" as const,
+      durationMs: 35_000,
+    };
+    const staleLiveActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-tools-turn-old",
+      summary: "Explored 36 items · Used 3 tools",
+      createdAt: 1_500,
+      details: [
+        {
+          id: "old-tool-detail",
+          kind: "read",
+          label: "Read package.json",
+        },
+      ],
+      turn: oldTurn,
+    };
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "assistant-final-old",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Old turn is complete.",
+              createdAt: 2_000,
+              turn: oldTurn,
+            },
+          ],
+          messages: [
+            {
+              id: "assistant-final-old",
+              role: "assistant" as const,
+              text: "Old turn is complete.",
+              createdAt: 2_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }))
+      .mockImplementationOnce(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "user-newer",
+              role: "user" as const,
+              text: "We have the latest grammy version right?",
+              createdAt: 3_000,
+              turn: newerTurn,
+            },
+            {
+              type: "message" as const,
+              id: "assistant-final-newer",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Yes. The repo is on the latest published grammy.",
+              createdAt: 4_000,
+              turn: newerTurn,
+            },
+          ],
+          messages: [
+            {
+              id: "user-newer",
+              role: "user" as const,
+              text: "We have the latest grammy version right?",
+              createdAt: 3_000,
+            },
+            {
+              id: "assistant-final-newer",
+              role: "assistant" as const,
+              text: "Yes. The repo is on the latest published grammy.",
+              createdAt: 4_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }));
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Old turn is complete.",
+      ]);
+    });
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry(staleLiveActivity);
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Explored 36 items · Used 3 tools",
+      "message:Old turn is complete.",
+    ]);
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 2_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:We have the latest grammy version right?",
+        "message:Yes. The repo is on the latest published grammy.",
+      ]);
+    });
+  });
+
   it("preserves session-owned live activity across thread switches and hydration", async () => {
     let now = 20_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -274,6 +274,8 @@ function pruneOptimisticEntries(
     return optimisticEntries;
   }
 
+  const latestResponseTurnId = latestTranscriptTurnId(response.replay.entries);
+  const latestResponseCreatedAt = latestTranscriptCreatedAt(response.replay.entries);
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
       return !response.replay.messages.some((message) =>
@@ -290,6 +292,15 @@ function pruneOptimisticEntries(
     }
 
     if (entry.type === "activity") {
+      if (
+        latestResponseTurnId &&
+        entry.turn?.id !== latestResponseTurnId &&
+        isCompletedTurnMetadata(entry.turn) &&
+        !isEntryNewerThanHydratedTranscript(entry, latestResponseCreatedAt)
+      ) {
+        return false;
+      }
+
       return !response.replay.entries.some(
         (candidate) =>
           candidate.type === "activity" &&
@@ -299,6 +310,42 @@ function pruneOptimisticEntries(
 
     return !response.replay.entries.some((candidate) => candidate.id === entry.id);
   });
+}
+
+function latestTranscriptCreatedAt(entries: AppServerThreadEntry[]): number | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const createdAt = entries[index]?.createdAt;
+    if (typeof createdAt === "number") {
+      return createdAt;
+    }
+  }
+
+  return undefined;
+}
+
+function isEntryNewerThanHydratedTranscript(
+  entry: AppServerThreadEntry,
+  latestResponseCreatedAt: number | undefined
+): boolean {
+  return (
+    typeof entry.createdAt === "number" &&
+    typeof latestResponseCreatedAt === "number" &&
+    entry.createdAt > latestResponseCreatedAt
+  );
+}
+
+function isCompletedTurnMetadata(
+  turn: AppServerThreadTurnMetadata | undefined
+): boolean {
+  return Boolean(
+    turn &&
+      (turn.status === "completed" ||
+        turn.status === "failed" ||
+        turn.status === "cancelled" ||
+        turn.status === "interrupted" ||
+        typeof turn.durationMs === "number" ||
+        typeof turn.completedAt === "number")
+  );
 }
 
 function activityEntriesMatch(


### PR DESCRIPTION
## Summary

I fixed a transcript merge bug where old completed live work activity could remain in optimistic state after a newer turn hydrated from `thread/read`. That stale activity was being appended after the newer turn, which produced zombie `Worked for ...` groups at the bottom of the chat.

The fix prunes completed optimistic activity from older turns once the hydrated transcript contains newer turn content. Newer live activity is still preserved while hydration is catching up, and current-turn edited file diffs keep their existing retention behavior.

## Testing

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm lint`
- `pnpm test:desktop-e2e -- transcript-temporal-order.spec.ts`
