### PR TITLE
docs: align agent guidance for Claude

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,14 @@
 - Treat plan documents as decision artifacts, not implementation scripts.
 - Keep changes aligned with the current active plan unless the user explicitly changes scope.
 - Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
+- Exclude `apps/desktop/.local/protocol-captures/` from broad searches by default. Only search it when the task is specifically about captured E2E protocol snippets.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
 - For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragnt/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.
 - When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- packages/...` makes Vitest run the full workspace suite.
+
+## Agent Instruction Files
+
+- Keep a sibling `CLAUDE.md` symlink next to every `AGENTS.md`, pointing at that `AGENTS.md`, so Codex and Claude read the same local guidance.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/desktop/src/main/codex-app-server/CLAUDE.md
+++ b/apps/desktop/src/main/codex-app-server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/messaging/CLAUDE.md
+++ b/packages/messaging/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/shared/src/generated/CLAUDE.md
+++ b/packages/shared/src/generated/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

I updated the repository agent guidance to reduce noisy searches through captured E2E protocol snippets and to keep Claude aligned with Codex guidance.

## Changes

- Added guidance to exclude `apps/desktop/.local/protocol-captures/` from broad searches unless the task is specifically about captured protocol snippets.
- Added guidance that every `AGENTS.md` should have a sibling `CLAUDE.md` symlink pointing at it.
- Added `CLAUDE.md` symlinks next to each current `AGENTS.md`.

## Verification

I verified the branch is clean after commit and that the commit has a good SSH signature.
