### PR TITLE
fix(desktop): improve worktree handoff choices

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2565,6 +2565,91 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("records detached handoff results as HEAD immediately", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Detached handoff",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "pwragnt-handoff:codex:thread-1",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/app-main-detached",
+          kind: "worktree",
+        },
+      ],
+      source: "codex",
+      gitBranch: "main",
+      observedGitBranch: "HEAD",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock();
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      direction: "worktree-to-local" as const,
+      strategy: "detached-changes" as const,
+      workMode: "local" as const,
+      baseSha: "abc123",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app",
+      linkedDirectory: {
+        id: "pwragnt-handoff:codex:thread-1",
+        label: "app",
+        path: "/repo/app",
+        kind: "local" as const,
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [thread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+
+    await registry.handoffThreadWorkspace({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "worktree-to-local",
+    });
+
+    expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
+      threadId: "thread-1",
+      gitInfo: {
+        branch: "HEAD",
+      },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "HEAD",
+      observedGitBranch: "HEAD",
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: "pwragnt-handoff:codex:thread-1",
+          kind: "local",
+        }),
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("uses an observed handoff branch as expected when legacy overlay state has no gitBranch", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -174,6 +174,44 @@ describe("GitWorkspaceHandoffService", () => {
     );
   });
 
+  it("moves a detached worktree head back to local without treating stale branch metadata as truth", async () => {
+    const repoPath = await createRepo();
+    await writeFile(path.join(repoPath, "README.md"), "dirty detached\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService();
+    const detachedResult = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      now: 2500,
+    });
+
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "worktree-to-local",
+      repositoryPath: repoPath,
+      sourcePath: detachedResult.targetPath,
+      sourceBranch: "main",
+      now: 2600,
+    });
+
+    expect(result.workMode).toBe("local");
+    expect(result.strategy).toBe("detached-changes");
+    expect(result.branch).toBeUndefined();
+    expect(result.baseSha).toBe(detachedResult.baseSha);
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("");
+    expect(await git(repoPath, ["rev-parse", "HEAD"])).toBe(detachedResult.baseSha);
+    await expect(readFile(path.join(repoPath, "README.md"), "utf8")).resolves.toBe(
+      "dirty detached\n",
+    );
+    expect(await pathExists(detachedResult.targetPath)).toBe(false);
+  });
+
   it("protects dirty local changes separately when moving a worktree branch to local", async () => {
     const repoPath = await createRepo();
     await git(repoPath, ["switch", "main"]);

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -110,19 +110,21 @@ describe("GitWorkspaceHandoffService", () => {
       repositoryPath: repoPath,
       sourcePath: repoPath,
       sourceBranch: "feature/handoff",
-      baseBranch: "main",
       now: 1500,
     });
 
     expect(result.workMode).toBe("worktree");
     expect(result.strategy).toBe("detached-changes");
     expect(result.branch).toBeUndefined();
-    expect(result.baseBranch).toBe("main");
+    expect(result.baseSha).toMatch(/^[0-9a-f]{40}$/);
     expect(result.linkedDirectory.kind).toBe("worktree");
     expect(result.sourceStash).toMatchObject({ applied: true, dropped: true });
     expect(await git(repoPath, ["branch", "--show-current"])).toBe("feature/handoff");
     expect(await git(result.targetPath, ["branch", "--show-current"])).toBe("");
-    expect(await pathExists(path.join(result.targetPath, "feature.txt"))).toBe(false);
+    expect(await git(result.targetPath, ["rev-parse", "HEAD"])).toBe(result.baseSha);
+    await expect(readFile(path.join(result.targetPath, "feature.txt"), "utf8")).resolves.toBe(
+      "feature\n",
+    );
     await expect(readFile(path.join(result.targetPath, "README.md"), "utf8")).resolves.toBe(
       "dirty local\n",
     );

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -40,7 +40,7 @@ async function createRepo(): Promise<string> {
   await git(repoPath, ["config", "user.email", "test@example.com"]);
   await git(repoPath, ["config", "user.name", "Test User"]);
   await writeFile(path.join(repoPath, "README.md"), "main\n", "utf8");
-  await writeFile(path.join(repoPath, ".gitignore"), "node_modules/\n", "utf8");
+  await writeFile(path.join(repoPath, ".gitignore"), "node_modules/\n.worktrees/\n", "utf8");
   await git(repoPath, ["add", "."]);
   await git(repoPath, ["commit", "-m", "initial"]);
   await git(repoPath, ["switch", "-c", "feature/handoff"]);
@@ -92,6 +92,47 @@ describe("GitWorkspaceHandoffService", () => {
     expect(await pathExists(path.join(result.targetPath, "node_modules", "ignored.txt"))).toBe(
       false,
     );
+  });
+
+  it("moves dirty local changes to a detached worktree and leaves local on the current branch", async () => {
+    const repoPath = await createRepo();
+    await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");
+    await writeFile(path.join(repoPath, "notes.txt"), "untracked\n", "utf8");
+    await mkdir(path.join(repoPath, "node_modules"));
+    await writeFile(path.join(repoPath, "node_modules", "ignored.txt"), "ignored\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService();
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      baseBranch: "main",
+      now: 1500,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.strategy).toBe("detached-changes");
+    expect(result.branch).toBeUndefined();
+    expect(result.baseBranch).toBe("main");
+    expect(result.linkedDirectory.kind).toBe("worktree");
+    expect(result.sourceStash).toMatchObject({ applied: true, dropped: true });
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("feature/handoff");
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe("");
+    expect(await pathExists(path.join(result.targetPath, "feature.txt"))).toBe(false);
+    await expect(readFile(path.join(result.targetPath, "README.md"), "utf8")).resolves.toBe(
+      "dirty local\n",
+    );
+    await expect(readFile(path.join(result.targetPath, "notes.txt"), "utf8")).resolves.toBe(
+      "untracked\n",
+    );
+    expect(await pathExists(path.join(result.targetPath, "node_modules", "ignored.txt"))).toBe(
+      false,
+    );
+    expect(await git(repoPath, ["status", "--porcelain", "--untracked-files=normal"])).toBe("");
   });
 
   it("moves a dirty worktree branch back to local and archives the old worktree", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1313,7 +1313,7 @@ export class DesktopBackendRegistry {
       backend: request.backend,
       threadId: request.threadId,
       directory: result.linkedDirectory,
-      gitBranch: result.branch,
+      gitBranch: result.strategy === "detached-changes" ? null : result.branch,
     });
     await this.updateThreadGitBranchMetadata({
       backend: request.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1308,17 +1308,18 @@ export class DesktopBackendRegistry {
       sourcePath: request.sourcePath ?? candidate.sourcePath,
       sourceBranch: request.sourceBranch ?? candidate.sourceBranch,
     });
+    const resultBranch = result.strategy === "detached-changes" ? "HEAD" : result.branch;
 
     await this.overlayStore.replaceWorkspaceLinkedDirectory({
       backend: request.backend,
       threadId: request.threadId,
       directory: result.linkedDirectory,
-      gitBranch: result.strategy === "detached-changes" ? null : result.branch,
+      gitBranch: resultBranch,
     });
     await this.updateThreadGitBranchMetadata({
       backend: request.backend,
       threadId: request.threadId,
-      branch: result.branch,
+      branch: resultBranch,
     });
 
     if (result.archivedSourceWorktree) {

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -40,6 +40,7 @@ type HandoffParams = {
 
 type HandoffContext = {
   backend: AppServerBackendKind;
+  headSha: string;
   threadId: ThreadIdentifier;
   repositoryPath: string;
   sourcePath: string;
@@ -257,9 +258,16 @@ export class GitWorkspaceHandoffService {
     const worktrees = parseWorktreeList(
       (await runGit(repositoryPath, ["worktree", "list", "--porcelain"])).stdout,
     );
+    const observedBranch = sanitizeBranchName(
+      trim((await runGit(sourcePath, ["rev-parse", "--abbrev-ref", "HEAD"])).stdout),
+    );
     const branch =
-      sanitizeBranchName(params.sourceBranch ?? "") ||
-      sanitizeBranchName(trim((await runGit(sourcePath, ["branch", "--show-current"])).stdout));
+      observedBranch === "HEAD"
+        ? "HEAD"
+        : sanitizeBranchName(params.sourceBranch ?? "") || observedBranch;
+    const headSha = trim(
+      (await runGit(sourcePath, ["rev-parse", "--verify", "HEAD^{commit}"])).stdout,
+    );
 
     if (!branch) {
       throw new Error("Workspace handoff requires a named source branch.");
@@ -271,6 +279,7 @@ export class GitWorkspaceHandoffService {
 
     return {
       backend: params.backend,
+      headSha,
       threadId: params.threadId,
       repositoryPath,
       sourcePath,
@@ -286,6 +295,9 @@ export class GitWorkspaceHandoffService {
     const context = await this.buildContext(params);
     if (path.resolve(context.repositoryPath) !== path.resolve(context.sourcePath)) {
       throw new Error("Local-to-worktree handoff must start from the local checkout.");
+    }
+    if (context.branch === "HEAD") {
+      throw new Error("Local-to-worktree handoff requires a named source branch.");
     }
 
     const strategy = params.strategy ?? "move-branch";
@@ -353,9 +365,7 @@ export class GitWorkspaceHandoffService {
     params: HandoffParams,
     context: HandoffContext,
   ): Promise<HandoffThreadWorkspaceResponse> {
-    const baseSha = trim(
-      (await runGit(context.sourcePath, ["rev-parse", "--verify", "HEAD^{commit}"])).stdout,
-    );
+    const baseSha = context.headSha;
     const targetPath = this.buildTargetWorktreePath({
       repositoryPath: context.repositoryPath,
       branch: `${context.branch}-detached`,
@@ -411,6 +421,10 @@ export class GitWorkspaceHandoffService {
       throw new Error("Worktree-to-local handoff must start from a worktree.");
     }
 
+    if (context.branch === "HEAD") {
+      return await this.handoffDetachedWorktreeToLocal(context);
+    }
+
     ensureBranchNotCheckedOutElsewhere({
       allowedPath: context.sourcePath,
       branch: context.branch,
@@ -459,6 +473,64 @@ export class GitWorkspaceHandoffService {
       strategy: "move-branch",
       workMode: "local",
       branch: context.branch,
+      repositoryPath: context.repositoryPath,
+      targetPath: context.repositoryPath,
+      linkedDirectory,
+      archivedSourceWorktree,
+      sourceStash: appliedSourceStash,
+      destinationStash,
+      warnings,
+      completedAt: context.now,
+    };
+  }
+
+  private async handoffDetachedWorktreeToLocal(
+    context: HandoffContext,
+  ): Promise<HandoffThreadWorkspaceResponse> {
+    const warnings = [
+      "Ignored files are not preserved by workspace handoff.",
+      "Local will be left on a detached HEAD at the moved worktree commit.",
+    ];
+    const sourceStash = await createNamedStashIfDirty({
+      path: context.sourcePath,
+      message: this.buildStashMessage(context, "source"),
+    });
+    const destinationStash = await createNamedStashIfDirty({
+      path: context.repositoryPath,
+      message: this.buildStashMessage(context, "destination"),
+    });
+    if (destinationStash) {
+      warnings.push(
+        "Local had dirty changes; they were saved in a separate stash and not applied to the moved detached HEAD.",
+      );
+    }
+
+    await runGit(context.repositoryPath, ["switch", "--detach", context.headSha]);
+    const appliedSourceStash = await applyVerifyAndDropStash(
+      context.repositoryPath,
+      sourceStash,
+    );
+    const archivedSourceWorktree = await this.worktreeArchiveService.archive({
+      backend: context.backend,
+      threadId: context.threadId,
+      repositoryPath: context.repositoryPath,
+      worktreePath: context.sourcePath,
+      now: context.now,
+    });
+
+    const linkedDirectory = this.buildLinkedDirectory({
+      context,
+      kind: "local",
+      targetPath: context.repositoryPath,
+    });
+
+    return {
+      backend: context.backend,
+      threadId: context.threadId,
+      direction: "worktree-to-local",
+      strategy: "detached-changes",
+      workMode: "local",
+      baseSha: context.headSha,
       repositoryPath: context.repositoryPath,
       targetPath: context.repositoryPath,
       linkedDirectory,

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -34,7 +34,6 @@ type HandoffParams = {
   repositoryPath?: string;
   sourcePath?: string;
   sourceBranch?: string;
-  baseBranch?: string;
   leaveLocalBranch?: string;
   now?: number;
 };
@@ -354,14 +353,8 @@ export class GitWorkspaceHandoffService {
     params: HandoffParams,
     context: HandoffContext,
   ): Promise<HandoffThreadWorkspaceResponse> {
-    const baseBranch = sanitizeBranchName(params.baseBranch ?? "");
-    if (!baseBranch) {
-      throw new Error("Choose a base branch for detached worktree handoff.");
-    }
-
-    const baseCommit = trim(
-      (await runGit(context.repositoryPath, ["rev-parse", "--verify", `${baseBranch}^{commit}`]))
-        .stdout,
+    const baseSha = trim(
+      (await runGit(context.sourcePath, ["rev-parse", "--verify", "HEAD^{commit}"])).stdout,
     );
     const targetPath = this.buildTargetWorktreePath({
       repositoryPath: context.repositoryPath,
@@ -374,7 +367,7 @@ export class GitWorkspaceHandoffService {
 
     const warnings = [
       "Ignored files are not preserved by workspace handoff.",
-      "Committed changes from the current branch are not moved to the detached worktree.",
+      "The new worktree starts detached at the current branch tip.",
     ];
     const sourceStash = await createNamedStashIfDirty({
       path: context.sourcePath,
@@ -385,7 +378,7 @@ export class GitWorkspaceHandoffService {
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseCommit]);
+    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseSha]);
     const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
 
     const linkedDirectory = this.buildLinkedDirectory({
@@ -400,7 +393,7 @@ export class GitWorkspaceHandoffService {
       direction: "local-to-worktree",
       strategy: "detached-changes",
       workMode: "worktree",
-      baseBranch,
+      baseSha,
       repositoryPath: context.repositoryPath,
       targetPath,
       linkedDirectory,

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -8,6 +8,7 @@ import type {
   LinkedDirectorySummary,
   ThreadIdentifier,
   ThreadWorkspaceHandoffDirection,
+  ThreadWorkspaceHandoffStrategy,
   ThreadWorkspaceHandoffStashSummary,
   WorktreeSnapshotSummary,
 } from "@pwragnt/shared";
@@ -29,9 +30,11 @@ type HandoffParams = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   direction: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
   repositoryPath?: string;
   sourcePath?: string;
   sourceBranch?: string;
+  baseBranch?: string;
   leaveLocalBranch?: string;
   now?: number;
 };
@@ -286,6 +289,11 @@ export class GitWorkspaceHandoffService {
       throw new Error("Local-to-worktree handoff must start from the local checkout.");
     }
 
+    const strategy = params.strategy ?? "move-branch";
+    if (strategy === "detached-changes") {
+      return await this.handoffLocalChangesToDetachedWorktree(params, context);
+    }
+
     ensureBranchNotCheckedOutElsewhere({
       allowedPath: context.sourcePath,
       branch: context.branch,
@@ -330,8 +338,69 @@ export class GitWorkspaceHandoffService {
       backend: context.backend,
       threadId: context.threadId,
       direction: "local-to-worktree",
+      strategy: "move-branch",
       workMode: "worktree",
       branch: context.branch,
+      repositoryPath: context.repositoryPath,
+      targetPath,
+      linkedDirectory,
+      sourceStash: appliedSourceStash,
+      warnings,
+      completedAt: context.now,
+    };
+  }
+
+  private async handoffLocalChangesToDetachedWorktree(
+    params: HandoffParams,
+    context: HandoffContext,
+  ): Promise<HandoffThreadWorkspaceResponse> {
+    const baseBranch = sanitizeBranchName(params.baseBranch ?? "");
+    if (!baseBranch) {
+      throw new Error("Choose a base branch for detached worktree handoff.");
+    }
+
+    const baseCommit = trim(
+      (await runGit(context.repositoryPath, ["rev-parse", "--verify", `${baseBranch}^{commit}`]))
+        .stdout,
+    );
+    const targetPath = this.buildTargetWorktreePath({
+      repositoryPath: context.repositoryPath,
+      branch: `${context.branch}-detached`,
+      now: context.now,
+    });
+    if (await pathExists(targetPath)) {
+      throw new Error(`Target worktree path already exists: ${targetPath}`);
+    }
+
+    const warnings = [
+      "Ignored files are not preserved by workspace handoff.",
+      "Committed changes from the current branch are not moved to the detached worktree.",
+    ];
+    const sourceStash = await createNamedStashIfDirty({
+      path: context.sourcePath,
+      message: this.buildStashMessage(context, "source"),
+    });
+    if (!sourceStash) {
+      warnings.push("No dirty non-ignored changes were available to move.");
+    }
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseCommit]);
+    const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
+
+    const linkedDirectory = this.buildLinkedDirectory({
+      context,
+      kind: "worktree",
+      targetPath,
+    });
+
+    return {
+      backend: context.backend,
+      threadId: context.threadId,
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      workMode: "worktree",
+      baseBranch,
       repositoryPath: context.repositoryPath,
       targetPath,
       linkedDirectory,
@@ -394,6 +463,7 @@ export class GitWorkspaceHandoffService {
       backend: context.backend,
       threadId: context.threadId,
       direction: "worktree-to-local",
+      strategy: "move-branch",
       workMode: "local",
       branch: context.branch,
       repositoryPath: context.repositoryPath,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2287,9 +2287,13 @@ export function Composer(props: ComposerProps) {
     (application) => application.canOpenWorkspace,
   );
   const sourceBranch =
-    props.directory?.gitStatus?.currentBranch ??
-    props.thread?.observedGitBranch ??
-    props.thread?.gitBranch;
+    threadWorkspace?.mode === "worktree"
+      ? props.thread?.observedGitBranch ??
+        props.thread?.gitBranch ??
+        props.directory?.gitStatus?.currentBranch
+      : props.directory?.gitStatus?.currentBranch ??
+        props.thread?.observedGitBranch ??
+        props.thread?.gitBranch;
   const branchOptions = getLeaveLocalBranchOptions({
     currentBranch: sourceBranch,
     directory: props.directory,
@@ -3764,8 +3768,10 @@ export function Composer(props: ComposerProps) {
             <dl className="workspace-handoff-dialog__summary">
               <div>
                 <dt>
-                  {handoffDialog === "local-to-worktree" &&
-                  localHandoffStrategy === "detached-changes"
+                  {handoffDialog === "worktree-to-local" && sourceBranch === "HEAD"
+                    ? "Detached HEAD to move"
+                    : handoffDialog === "local-to-worktree" &&
+                        localHandoffStrategy === "detached-changes"
                     ? "Current branch"
                     : "Branch to move"}
                 </dt>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2313,7 +2313,7 @@ export function Composer(props: ComposerProps) {
     setHandoffError(undefined);
     setHandoffDialog(direction);
     if (direction === "local-to-worktree") {
-      setLocalHandoffStrategy(handoffBaseBranch ? "detached-changes" : "move-branch");
+      setLocalHandoffStrategy("detached-changes");
       setLeaveLocalBranch(
         handoffBaseBranch && branchOptions.includes(handoffBaseBranch)
           ? handoffBaseBranch
@@ -2342,9 +2342,6 @@ export function Composer(props: ComposerProps) {
         repositoryPath: threadWorkspace.repositoryPath,
         sourcePath: threadWorkspace.sourcePath,
         sourceBranch,
-        ...(handoffStrategy === "detached-changes" && handoffBaseBranch
-          ? { baseBranch: handoffBaseBranch }
-          : {}),
         ...(handoffDialog === "local-to-worktree" && handoffStrategy === "move-branch"
           ? { leaveLocalBranch: leaveLocalBranch || undefined }
           : {}),
@@ -2385,8 +2382,7 @@ export function Composer(props: ComposerProps) {
     handoffSubmitting ||
     !sourceBranch ||
     (handoffDialog === "local-to-worktree" &&
-      ((localHandoffStrategy === "detached-changes" && !handoffBaseBranch) ||
-        (localHandoffStrategy === "move-branch" && !leaveLocalBranch) ||
+      ((localHandoffStrategy === "move-branch" && !leaveLocalBranch) ||
         localHandoffStrategy === "suggested-branch"));
 
   const commitActiveAutocomplete = (): void => {
@@ -3786,7 +3782,7 @@ export function Composer(props: ComposerProps) {
                   <button
                     aria-checked={localHandoffStrategy === "detached-changes"}
                     className="workspace-handoff-dialog__strategy"
-                    disabled={handoffSubmitting || !handoffBaseBranch}
+                    disabled={handoffSubmitting}
                     role="radio"
                     type="button"
                     onClick={() => setLocalHandoffStrategy("detached-changes")}
@@ -3795,9 +3791,9 @@ export function Composer(props: ComposerProps) {
                       Move changes to Detached HEAD
                     </span>
                     <span>
-                      Create a new worktree from {handoffBaseBranch ?? "the default branch"}.
-                      Keep the current branch checked out here. Move dirty tracked and
-                      non-ignored files only.
+                      Create a detached worktree from the current branch tip. Keep the
+                      current branch checked out here and move dirty tracked and
+                      non-ignored files on top.
                     </span>
                   </button>
                   <button
@@ -3861,8 +3857,9 @@ export function Composer(props: ComposerProps) {
             {handoffDialog === "local-to-worktree" &&
             localHandoffStrategy === "detached-changes" ? (
               <p className="workspace-handoff-dialog__note">
-                Committed changes on {sourceBranch ?? "the current branch"} are not moved by
-                this option.
+                The new worktree starts at the current tip of{" "}
+                {sourceBranch ?? "this branch"} and receives dirty non-ignored changes on
+                top.
               </p>
             ) : null}
             <p className="workspace-handoff-dialog__note">

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -26,6 +26,7 @@ import type {
   NavigationLaunchpadDraft,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
+  ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragnt/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -126,6 +127,8 @@ type ComposerProps = {
   ) => Promise<void>;
   threadModelSettingsError?: string;
 };
+
+type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy | "suggested-branch";
 
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
@@ -869,6 +872,8 @@ export function Composer(props: ComposerProps) {
   const [handoffDialog, setHandoffDialog] = useState<
     HandoffThreadWorkspaceRequest["direction"] | undefined
   >();
+  const [localHandoffStrategy, setLocalHandoffStrategy] =
+    useState<LocalHandoffStrategy>("detached-changes");
   const [leaveLocalBranch, setLeaveLocalBranch] = useState("");
   const [handoffError, setHandoffError] = useState<string | undefined>();
   const [handoffSubmitting, setHandoffSubmitting] = useState(false);
@@ -2289,6 +2294,7 @@ export function Composer(props: ComposerProps) {
     currentBranch: sourceBranch,
     directory: props.directory,
   });
+  const handoffBaseBranch = props.directory?.gitStatus?.defaultBranch;
   const canHandoffThreadWorkspace = Boolean(
     props.thread &&
       threadWorkspace &&
@@ -2307,10 +2313,10 @@ export function Composer(props: ComposerProps) {
     setHandoffError(undefined);
     setHandoffDialog(direction);
     if (direction === "local-to-worktree") {
-      const defaultBranch = props.directory?.gitStatus?.defaultBranch;
+      setLocalHandoffStrategy(handoffBaseBranch ? "detached-changes" : "move-branch");
       setLeaveLocalBranch(
-        defaultBranch && branchOptions.includes(defaultBranch)
-          ? defaultBranch
+        handoffBaseBranch && branchOptions.includes(handoffBaseBranch)
+          ? handoffBaseBranch
           : branchOptions[0] ?? ""
       );
     }
@@ -2324,13 +2330,24 @@ export function Composer(props: ComposerProps) {
     setHandoffSubmitting(true);
     setHandoffError(undefined);
     try {
+      const handoffStrategy =
+        handoffDialog === "local-to-worktree"
+          ? localHandoffStrategy === "suggested-branch"
+            ? undefined
+            : localHandoffStrategy
+          : undefined;
       await props.onHandoffThreadWorkspace({
         direction: handoffDialog!,
+        ...(handoffStrategy ? { strategy: handoffStrategy } : {}),
         repositoryPath: threadWorkspace.repositoryPath,
         sourcePath: threadWorkspace.sourcePath,
         sourceBranch,
-        leaveLocalBranch:
-          handoffDialog === "local-to-worktree" ? leaveLocalBranch || undefined : undefined,
+        ...(handoffStrategy === "detached-changes" && handoffBaseBranch
+          ? { baseBranch: handoffBaseBranch }
+          : {}),
+        ...(handoffDialog === "local-to-worktree" && handoffStrategy === "move-branch"
+          ? { leaveLocalBranch: leaveLocalBranch || undefined }
+          : {}),
       });
       setHandoffDialog(undefined);
     } catch (error) {
@@ -2367,7 +2384,10 @@ export function Composer(props: ComposerProps) {
   const handoffDisabled =
     handoffSubmitting ||
     !sourceBranch ||
-    (handoffDialog === "local-to-worktree" && !leaveLocalBranch);
+    (handoffDialog === "local-to-worktree" &&
+      ((localHandoffStrategy === "detached-changes" && !handoffBaseBranch) ||
+        (localHandoffStrategy === "move-branch" && !leaveLocalBranch) ||
+        localHandoffStrategy === "suggested-branch"));
 
   const commitActiveAutocomplete = (): void => {
     if (autocompleteKind === "skills") {
@@ -3742,36 +3762,107 @@ export function Composer(props: ComposerProps) {
             </h2>
             <p>
               {handoffDialog === "local-to-worktree"
-                ? "Move this thread's current branch into a new worktree. Dirty tracked and non-ignored files will be stashed and applied in the new worktree."
+                ? "Choose how this thread should move into a new worktree."
                 : "Move this worktree branch back to Local. Dirty tracked and non-ignored files will be stashed and applied in Local, then the old worktree will be archived."}
             </p>
             <dl className="workspace-handoff-dialog__summary">
               <div>
-                <dt>Branch to move</dt>
+                <dt>
+                  {handoffDialog === "local-to-worktree" &&
+                  localHandoffStrategy === "detached-changes"
+                    ? "Current branch"
+                    : "Branch to move"}
+                </dt>
                 <dd>{sourceBranch ?? "Unknown branch"}</dd>
               </div>
             </dl>
             {handoffDialog === "local-to-worktree" ? (
-              <label className="workspace-handoff-dialog__field">
-                Leave Local on
-                <select
-                  aria-label="Leave Local on"
-                  className="composer__select"
-                  disabled={handoffSubmitting || branchOptions.length === 0}
-                  value={leaveLocalBranch}
-                  onChange={(event) => setLeaveLocalBranch(event.target.value)}
+              <>
+                <div
+                  aria-label="Handoff strategy"
+                  className="workspace-handoff-dialog__strategy-list"
+                  role="radiogroup"
                 >
-                  {branchOptions.map((branch) => (
-                    <option key={branch} value={branch}>
-                      {branch}
-                    </option>
-                  ))}
-                </select>
-              </label>
+                  <button
+                    aria-checked={localHandoffStrategy === "detached-changes"}
+                    className="workspace-handoff-dialog__strategy"
+                    disabled={handoffSubmitting || !handoffBaseBranch}
+                    role="radio"
+                    type="button"
+                    onClick={() => setLocalHandoffStrategy("detached-changes")}
+                  >
+                    <span className="workspace-handoff-dialog__strategy-title">
+                      Move changes to Detached HEAD
+                    </span>
+                    <span>
+                      Create a new worktree from {handoffBaseBranch ?? "the default branch"}.
+                      Keep the current branch checked out here. Move dirty tracked and
+                      non-ignored files only.
+                    </span>
+                  </button>
+                  <button
+                    aria-checked={localHandoffStrategy === "move-branch"}
+                    className="workspace-handoff-dialog__strategy"
+                    disabled={handoffSubmitting || branchOptions.length === 0}
+                    role="radio"
+                    type="button"
+                    onClick={() => setLocalHandoffStrategy("move-branch")}
+                  >
+                    <span className="workspace-handoff-dialog__strategy-title">
+                      Move current branch + changes
+                    </span>
+                    <span>
+                      Move this branch into the new worktree, then switch this checkout to
+                      a selected branch.
+                    </span>
+                  </button>
+                  <button
+                    aria-checked={localHandoffStrategy === "suggested-branch"}
+                    className="workspace-handoff-dialog__strategy"
+                    disabled
+                    role="radio"
+                    type="button"
+                  >
+                    <span className="workspace-handoff-dialog__strategy-title">
+                      Suggest branch name
+                    </span>
+                    <span>
+                      Coming soon: create a branch in the new worktree using a suggested name.
+                    </span>
+                  </button>
+                </div>
+                {localHandoffStrategy === "move-branch" ? (
+                  <label className="workspace-handoff-dialog__field">
+                    Leave current checkout on
+                    <select
+                      aria-label="Leave current checkout on"
+                      className="composer__select"
+                      disabled={handoffSubmitting || branchOptions.length === 0}
+                      value={leaveLocalBranch}
+                      onChange={(event) => setLeaveLocalBranch(event.target.value)}
+                    >
+                      {branchOptions.map((branch) => (
+                        <option key={branch} value={branch}>
+                          {branch}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+              </>
             ) : null}
-            {handoffDialog === "local-to-worktree" && branchOptions.length === 0 ? (
+            {handoffDialog === "local-to-worktree" &&
+            localHandoffStrategy === "move-branch" &&
+            branchOptions.length === 0 ? (
               <p className="workspace-handoff-dialog__note">
                 No available local branch can be checked out before moving this branch.
+              </p>
+            ) : null}
+            {handoffDialog === "local-to-worktree" &&
+            localHandoffStrategy === "detached-changes" ? (
+              <p className="workspace-handoff-dialog__note">
+                Committed changes on {sourceBranch ?? "the current branch"} are not moved by
+                this option.
               </p>
             ) : null}
             <p className="workspace-handoff-dialog__note">

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3788,12 +3788,26 @@ export function Composer(props: ComposerProps) {
                     onClick={() => setLocalHandoffStrategy("detached-changes")}
                   >
                     <span className="workspace-handoff-dialog__strategy-title">
-                      Move changes to Detached HEAD
+                      Handoff to Detached HEAD
                     </span>
                     <span>
-                      Create a detached worktree from the current branch tip. Keep the
-                      current branch checked out here and move dirty tracked and
-                      non-ignored files on top.
+                      Keep Local on the current branch. Create a detached worktree at
+                      the current branch tip and move dirty non-ignored changes on top.
+                    </span>
+                  </button>
+                  <button
+                    aria-checked={localHandoffStrategy === "suggested-branch"}
+                    className="workspace-handoff-dialog__strategy"
+                    disabled
+                    role="radio"
+                    type="button"
+                  >
+                    <span className="workspace-handoff-dialog__strategy-title">
+                      Handoff to New Branch
+                    </span>
+                    <span>
+                      Coming soon: keep Local on this branch and create a suggested
+                      branch in the new worktree.
                     </span>
                   </button>
                   <button
@@ -3805,25 +3819,11 @@ export function Composer(props: ComposerProps) {
                     onClick={() => setLocalHandoffStrategy("move-branch")}
                   >
                     <span className="workspace-handoff-dialog__strategy-title">
-                      Move current branch + changes
+                      Handoff Current Branch
                     </span>
                     <span>
                       Move this branch into the new worktree, then switch this checkout to
                       a selected branch.
-                    </span>
-                  </button>
-                  <button
-                    aria-checked={localHandoffStrategy === "suggested-branch"}
-                    className="workspace-handoff-dialog__strategy"
-                    disabled
-                    role="radio"
-                    type="button"
-                  >
-                    <span className="workspace-handoff-dialog__strategy-title">
-                      Suggest branch name
-                    </span>
-                    <span>
-                      Coming soon: create a branch in the new worktree using a suggested name.
                     </span>
                   </button>
                 </div>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1651,7 +1651,6 @@ describe("Composer", () => {
         repositoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
         sourcePath: "/Users/huntharo/pwrdrvr/PwrAgnt",
         sourceBranch: "feat/thread-workspace-handoff-plan",
-        baseBranch: "main",
       });
     });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1638,10 +1638,10 @@ describe("Composer", () => {
     expect(dialog.closest(".workspace-handoff-modal")).toBeInTheDocument();
     expect(dialog).toHaveTextContent("feat/thread-workspace-handoff-plan");
     expect(
-      screen.getByRole("radio", { name: /Move changes to Detached HEAD/ })
+      screen.getByRole("radio", { name: /Handoff to Detached HEAD/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(screen.queryByLabelText("Leave current checkout on")).not.toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /Suggest branch name/ })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: /Handoff to New Branch/ })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -1707,7 +1707,7 @@ describe("Composer", () => {
 
     fireEvent.click(screen.getByLabelText("Workspace mode"));
     fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
-    fireEvent.click(screen.getByRole("radio", { name: /Move current branch/ }));
+    fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
 
     expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("main");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1637,17 +1637,21 @@ describe("Composer", () => {
     expect(dialog).toBeInTheDocument();
     expect(dialog.closest(".workspace-handoff-modal")).toBeInTheDocument();
     expect(dialog).toHaveTextContent("feat/thread-workspace-handoff-plan");
-    expect(screen.getByLabelText("Leave Local on")).toHaveValue("main");
-    expect(screen.queryByRole("option", { name: "Detached HEAD" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: /Move changes to Detached HEAD/ })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByLabelText("Leave current checkout on")).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Suggest branch name/ })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
       expect(onHandoffThreadWorkspace).toHaveBeenCalledWith({
         direction: "local-to-worktree",
+        strategy: "detached-changes",
         repositoryPath: "/Users/huntharo/pwrdrvr/PwrAgnt",
         sourcePath: "/Users/huntharo/pwrdrvr/PwrAgnt",
         sourceBranch: "feat/thread-workspace-handoff-plan",
-        leaveLocalBranch: "main",
+        baseBranch: "main",
       });
     });
 
@@ -1655,6 +1659,69 @@ describe("Composer", () => {
 
     await waitFor(() => {
       expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
+  it("lets the desktop handoff dialog move the current branch instead", async () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/handoff",
+            defaultBranch: "main",
+            branches: ["feature/handoff", "main", "release"],
+            handoffBranches: ["main", "release"],
+            syncState: "untracked",
+          },
+        }}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "feature/handoff",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgnt",
+              path: "/repo",
+              kind: "local",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Workspace mode"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
+    fireEvent.click(screen.getByRole("radio", { name: /Move current branch/ }));
+
+    expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("main");
+    fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
+
+    await waitFor(() => {
+      expect(onHandoffThreadWorkspace).toHaveBeenCalledWith({
+        direction: "local-to-worktree",
+        strategy: "move-branch",
+        repositoryPath: "/repo",
+        sourcePath: "/repo",
+        sourceBranch: "feature/handoff",
+        leaveLocalBranch: "main",
+      });
     });
   });
 
@@ -1865,7 +1932,6 @@ describe("Composer", () => {
         repositoryPath: "/repo",
         sourcePath: "/repo/.worktrees/pwragnt-feature",
         sourceBranch: "feature/handoff",
-        leaveLocalBranch: undefined,
       });
     });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1887,6 +1887,10 @@ describe("Composer", () => {
           path: "/repo",
           threadKeys: ["codex:thread-1"],
           needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            branches: ["main", "feature/handoff"],
+          },
         }}
         onHandoffThreadWorkspace={onHandoffThreadWorkspace}
         skills={[]}
@@ -1896,7 +1900,8 @@ describe("Composer", () => {
           titleSource: "explicit",
           source: "codex",
           executionMode: "default",
-          gitBranch: "feature/handoff",
+          gitBranch: "main",
+          observedGitBranch: "HEAD",
           linkedDirectories: [
             {
               id: "dir-1",
@@ -1922,7 +1927,9 @@ describe("Composer", () => {
 
     fireEvent.click(screen.getByLabelText("Workspace mode"));
     fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to Local" }));
-    expect(screen.getByRole("dialog", { name: "Handoff to Local" })).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: "Handoff to Local" });
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("Detached HEAD to move");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -1930,7 +1937,7 @@ describe("Composer", () => {
         direction: "worktree-to-local",
         repositoryPath: "/repo",
         sourcePath: "/repo/.worktrees/pwragnt-feature",
-        sourceBranch: "feature/handoff",
+        sourceBranch: "HEAD",
       });
     });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4334,6 +4334,42 @@ textarea {
   font-weight: 600;
 }
 
+.workspace-handoff-dialog__strategy-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.workspace-handoff-dialog__strategy {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  background: var(--bg-input);
+  text-align: left;
+  cursor: pointer;
+}
+
+.workspace-handoff-dialog__strategy[aria-checked="true"] {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border-subtle));
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-input));
+}
+
+.workspace-handoff-dialog__strategy:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.workspace-handoff-dialog__strategy-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
 .workspace-handoff-dialog__note {
   color: var(--text-muted);
 }

--- a/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
+++ b/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
@@ -26,12 +26,20 @@ Also update the desktop handoff dialog so it presents the same product choices
 explicitly instead of forcing the current "branch to move / leave Local on"
 flow. The dialog should offer:
 
-- Move dirty non-ignored changes to a new detached-HEAD worktree and leave the
-  current branch checked out where it is.
-- Move the current branch plus dirty non-ignored changes to a new worktree and
-  switch the current checkout to a selected branch.
-- A disabled placeholder for a future model-suggested branch name path that
-  behaves like the detached path but creates a named branch immediately.
+- `Handoff to Detached HEAD`: leave Local on the current branch, create a new
+  detached worktree at the current branch tip, and move dirty non-ignored
+  changes on top.
+- `Handoff to New Branch`: disabled in this PR; future flow keeps Local where it
+  is, creates a new branch in the new worktree, and uses the ephemeral
+  branch-name suggestion call.
+- `Handoff Current Branch`: move the current branch plus dirty non-ignored
+  changes to a new worktree, then switch the current checkout to a selected
+  branch.
+
+For Telegram and Discord, use shorter button labels to avoid heavy repeated
+prefixes: `Detached Worktree`, `New Branch Worktree`, and `Move Branch
+Worktree`. The prompt can carry the full framing: "Choose how to create the new
+worktree."
 
 ## Problem Frame
 
@@ -240,16 +248,16 @@ stateDiagram-v2
     HandoffOverview --> DetachedConfirm: primary local-to-worktree
     DetachedConfirm --> RunningDetached: Confirm
     RunningDetached --> RefreshedStatus: success
-    HandoffOverview --> BranchMovePage: Move branch instead
+    HandoffOverview --> BranchMovePage: Move Branch Worktree
     BranchMovePage --> BranchMovePage: Next / Previous
     BranchMovePage --> BranchMoveConfirm: select branch
     BranchMoveConfirm --> RunningBranchMove: Confirm
     RunningBranchMove --> RefreshedStatus: success
     HandoffOverview --> WorktreeToLocalConfirm: worktree-to-local
     WorktreeToLocalConfirm --> RunningWorktreeToLocal: Confirm
-    DesktopDialog --> DetachedConfirm: Move changes to Detached HEAD
-    DesktopDialog --> BranchMoveConfirm: Move branch + changes
-    DesktopDialog --> SuggestedBranchPlaceholder: disabled future option
+    DesktopDialog --> DetachedConfirm: Handoff to Detached HEAD
+    DesktopDialog --> SuggestedBranchPlaceholder: Handoff to New Branch (disabled)
+    DesktopDialog --> BranchMoveConfirm: Handoff Current Branch
     RunningWorktreeToLocal --> RefreshedStatus: success
     DetachedConfirm --> HandoffOverview: Back
     BranchMovePage --> HandoffOverview: Back
@@ -409,8 +417,10 @@ with a paged secondary branch-moving path.
 - Extend handoff pending state/action values with page index for branch-moving
   selection. Keep state generic JSON, not provider-specific state.
 - Change Local handoff overview to show a primary detached-worktree action when
-  eligible and a secondary `Move branch instead` action that opens the paged
+  eligible and a secondary `Move Branch Worktree` action that opens the paged
   branch picker.
+- Use compact messaging labels: `Detached Worktree`, disabled/follow-up `New
+  Branch Worktree`, and `Move Branch Worktree`.
 - For branch-moving picker pages, render only the current page of branches plus
   Previous/Next as applicable, Back, Refresh, and Cancel.
 - Use page-local numeric fallback for visible branch choices, and show page
@@ -436,7 +446,7 @@ with a paged secondary branch-moving path.
   branch list.
 - Happy path: choosing the detached primary action renders confirmation without
   a branch picker and calls `handoffThreadWorkspace` with the detached strategy.
-- Happy path: choosing `Move branch instead` renders page 1 with eight branch
+- Happy path: choosing `Move Branch Worktree` renders page 1 with eight branch
   choices, `Next`, `Back`, `Refresh`, and `Cancel`.
 - Happy path: pressing `Next` renders page 2 with the next eight branches and
   includes `Previous`.
@@ -524,8 +534,8 @@ branch-moving handoff, and a disabled future suggested-branch placeholder.
 - Add local dialog state for the selected handoff strategy. Default
   Local-to-worktree to detached dirty-change handoff for named Local branches.
 - Render strategy choices as selectable rows inside the existing handoff modal:
-  detached dirty-change handoff, branch-moving handoff, and disabled
-  model-suggested branch placeholder.
+  `Handoff to Detached HEAD`, disabled `Handoff to New Branch`, and `Handoff
+  Current Branch`.
 - Only show `Leave Local on` / `Leave current checkout on` when the
   branch-moving strategy is selected.
 - Submit detached handoff with the explicit detached strategy and source branch
@@ -636,7 +646,7 @@ validation case that exposed the bug.
 - Update manual smoke tests for both Telegram and Discord, but prioritize
   Telegram because the live failure was observed there.
 - Mention that the primary detached path is best for moving uncommitted work out
-  of Local, while `Move branch instead` is the branch-history path.
+  of Local, while `Handoff Current Branch` is the branch-history path.
 - Mention the desktop placeholder for future model-suggested branch naming so it
   is understood as intentionally disabled.
 - No migration is required unless implementation decides to persist a new

--- a/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
+++ b/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
@@ -276,7 +276,7 @@ flowchart TB
     U5 --> U6
 ```
 
-- [ ] **Unit 1: Add explicit handoff strategy to shared contracts**
+- [x] **Unit 1: Add explicit handoff strategy to shared contracts**
 
 **Goal:** Let callers request either branch-moving handoff or detached
 dirty-change handoff without overloading missing fields.
@@ -326,7 +326,7 @@ dirty-change handoff without overloading missing fields.
 - Shared contracts can express both handoff modes, and old branch-moving tests
   still pass after compatibility updates.
 
-- [ ] **Unit 2: Support detached dirty-change handoff in the Git service**
+- [x] **Unit 2: Support detached dirty-change handoff in the Git service**
 
 **Goal:** Add the main-process Git behavior needed by the opinionated messaging
 default: create a detached worktree from the default branch commit and move dirty
@@ -511,7 +511,7 @@ choices and keep opaque callback handles.
 - Provider tests demonstrate that bounded generic intents solve the Telegram
   problem without adding Telegram/Discord branches to workflow code.
 
-- [ ] **Unit 5: Update the desktop handoff dialog**
+- [x] **Unit 5: Update the desktop handoff dialog**
 
 **Goal:** Replace the current single-path desktop Local-to-worktree dialog with
 an explicit strategy choice that supports detached dirty-change handoff,

--- a/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
+++ b/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
@@ -1,0 +1,567 @@
+---
+title: fix: Tame messaging handoff branch picker
+type: fix
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+deepened: 2026-05-02
+---
+
+# fix: Tame messaging handoff branch picker
+
+## Overview
+
+Fix the messaging workspace handoff flow so Telegram and Discord do not render
+huge branch-choice dialogs during Local-to-worktree handoff. The default
+messaging path should become more opinionated: when a bound Local thread is on
+a named branch and the repository default branch is known, the primary handoff
+choice should create a new detached worktree from the default branch commit and
+move dirty non-ignored changes there, without asking which branch Local should
+switch to.
+
+Keep the existing branch-moving handoff available as a secondary path, but make
+any branch picker paged at about eight choices per page with room for Previous,
+Next, Back, Refresh, and Cancel.
+
+## Problem Frame
+
+Live Telegram testing showed the current Local-to-worktree handoff branch picker
+can present dozens of branch buttons at once. In the observed case, the bot
+offered 56 branches to leave checked out in Local. That is technically
+channel-neutral, but it is a poor remote-control experience and undermines the
+messaging MVP requirement that rich workflows stay practical through chat
+surfaces.
+
+The deeper issue is product behavior, not only rendering. The existing
+branch-moving handoff assumes the user wants to move the current branch to a
+worktree, so it must ask what Local should check out afterward. For messaging,
+the better default is usually simpler: leave the Local branch alone, create a
+new detached worktree from the default branch commit, and move the current dirty
+non-ignored working changes into that worktree. This avoids turning a common
+remote handoff into a branch-management prompt.
+
+## Requirements Trace
+
+- R1. Messaging Local-to-worktree handoff must never present an unbounded list
+  of branches in a single Telegram or Discord prompt.
+- R2. Branch lists used by messaging handoff must paginate when they exceed the
+  page size; use eight branch choices per page unless implementation discovers
+  an existing shared constant that should be reused directly.
+- R3. Each paged branch prompt must reserve room for navigation and escape
+  controls: Previous when applicable, Next when applicable, Back, Refresh, and
+  Cancel.
+- R4. The primary Local-to-worktree messaging path should avoid branch picking
+  when the thread is on a named Local branch and the repository default branch
+  is known.
+- R5. The primary opinionated path should create a detached worktree at the
+  current commit of the default branch, stash/move dirty non-ignored Local
+  changes into that worktree, and make the thread point at the new worktree.
+- R6. The confirmation copy must state that committed changes on the Local
+  branch are not being moved by the opinionated detached-worktree path.
+- R7. The branch-moving path must remain available for cases where the user
+  explicitly wants to move the branch, or where the detached default-branch path
+  is not eligible.
+- R8. The flow must remain channel-neutral. Telegram and Discord providers
+  should render generic intents and opaque callback handles; controller logic
+  must not branch on provider identity.
+- R9. Text fallback must complete every step: detached handoff confirmation,
+  branch-page navigation, branch selection, back, refresh, and cancel.
+- R10. Worktree-to-local handoff behavior is not changed by this fix except for
+  any shared copy or fallback improvements needed for consistency.
+
+## Scope Boundaries
+
+- In scope: messaging handoff intent construction, controller handoff callback
+  routing, text fallback, branch pagination state, backend contract support for
+  a detached-worktree handoff strategy, Git handoff service behavior needed by
+  that strategy, and focused Telegram/Discord formatting tests.
+- In scope: keeping the existing branch-moving Local-to-worktree path available
+  as an explicit secondary or advanced action.
+- Out of scope: changing the desktop renderer composer handoff default unless
+  implementation finds the shared backend contract forces a small compatibility
+  adjustment.
+- Out of scope: preserving ignored files. Existing handoff behavior already
+  excludes ignored files, and the messaging copy should continue to say so.
+- Out of scope: moving committed branch history when the user chooses the
+  opinionated detached-worktree path. That path only moves dirty non-ignored
+  working changes.
+- Out of scope: a generic low-button-count policy for every messaging surface.
+  This plan fixes handoff branch lists while reusing existing picker patterns.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/messaging/AGENTS.md` requires workflow semantics to stay
+  channel-neutral and provider state to remain opaque.
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` currently
+  builds `buildHandoffBranchPickerIntent` by mapping every
+  `leaveLocalBranches` entry directly into `single_select.choices`.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` routes
+  `status:handoff`, `handoff:local-to-worktree`,
+  `handoff:select-leave-branch`, and `handoff:confirm` through the managed
+  status surface and pending-intent store.
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` already
+  has the right pagination shape: `RESUME_BROWSER_PAGE_SIZE = 8`, page-indexed
+  sessions, Previous/Next actions, and numeric text fallback.
+- `packages/messaging/interface/src/index.ts` already has generic action layout
+  hints, picker page types, and `layoutMessagingActionRows`; provider packages
+  should not need handoff-specific rendering logic.
+- `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts` currently
+  requires `leaveLocalBranch` for Local-to-worktree and then moves the current
+  branch into a new worktree.
+- `packages/shared/src/contracts/normalized-app-server.ts` currently has
+  `HandoffThreadWorkspaceRequest` with `direction`, `sourceBranch`, and
+  `leaveLocalBranch`, but no explicit strategy for detached dirty-change
+  handoff.
+- Tests already cover the current branch-moving path in
+  `apps/desktop/src/main/__tests__/messaging-controller.test.ts`,
+  `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`,
+  `apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts`,
+  `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`,
+  `packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts`,
+  and `packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts`.
+
+### Institutional Learnings
+
+- `docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md`
+  intentionally kept the first handoff flow channel-neutral and deferred broader
+  low-button-count policy.
+- `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md`
+  established that Git movement belongs in the main-process handoff service,
+  not messaging controller code.
+- `docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md`
+  requires Telegram and Discord workflow parity, button-driven choices, and text
+  fallback without leaking provider specifics into workflow logic.
+- No `docs/solutions/` directory exists in this worktree yet.
+
+### External References
+
+- Telegram Bot API `callback_data` remains byte-limited, so opaque callback
+  handles and stored action values remain the right pattern:
+  https://core.telegram.org/bots/api
+- Discord component action rows can hold up to five buttons per row, reinforcing
+  the need to keep branch-page controls bounded:
+  https://docs.discord.com/developers/components/reference
+
+## Key Technical Decisions
+
+- **Make detached dirty-change handoff the messaging default.** The observed
+  Telegram failure comes from asking the user a branch-management question at
+  the wrong time. A direct detached-worktree confirmation better matches remote
+  handoff intent when the user is moving uncommitted work out of Local.
+- **Represent handoff strategy explicitly in shared contracts.** Do not infer
+  detached behavior from a missing `leaveLocalBranch`; that would make stale
+  callbacks and compatibility paths ambiguous. Add an explicit strategy or mode
+  field to the shared handoff request/response contract while keeping the
+  existing branch-moving strategy valid.
+- **Preserve the branch-moving path as advanced behavior.** Some users do want
+  to move a branch into a worktree. The fix should make that path deliberate and
+  paged, not delete it.
+- **Use eight branch choices per messaging page.** This matches the existing
+  resume browser page size and leaves enough space for navigation and cancel
+  controls on Telegram and Discord.
+- **Keep pagination in the handoff/status-card layer, not provider packages.**
+  Providers should receive a bounded generic `single_select` or picker-like
+  intent. They should not know that a branch list had 56 total entries.
+- **Make copy explicit about what moves.** Detached handoff should say dirty
+  tracked and non-ignored untracked changes move; committed branch history and
+  ignored files do not.
+- **Fail closed when default-branch metadata is missing.** If the default branch
+  cannot be identified, the primary detached path should be unavailable or ask
+  for an explicit base in a future flow. Do not guess across repositories. Treat
+  `main` as the common case named in the request, but implement against the
+  repository's detected default branch.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this be fixed only in Telegram rendering?** No. The provider rendered
+  what the controller asked it to render. The plan changes generic messaging
+  handoff behavior and keeps providers bounded.
+- **Should branch choices always paginate?** Yes. Any branch list beyond one
+  page should use a page size around eight, with navigation and cancel controls.
+- **Should the old branch-moving behavior disappear?** No. Keep it as an
+  explicit secondary path because moving a branch into a worktree is still a
+  valid workflow.
+- **Should worktree-to-local change now?** No. The observed problem and new
+  product assumption affect Local-to-worktree.
+
+### Deferred to Implementation
+
+- Exact user-facing labels for the two Local-to-worktree choices should be
+  settled while touching the tests. The plan intent is clear: primary detached
+  dirty-change handoff, secondary branch-moving handoff.
+- Exact shared contract field names are deferred, but the strategy must be
+  explicit and serializable through existing callback values.
+- Whether desktop composer should expose the new detached strategy is deferred.
+  This plan only requires messaging to prefer it.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+    [*] --> StatusCard
+    StatusCard --> HandoffOverview: Handoff
+    HandoffOverview --> DetachedConfirm: primary local-to-worktree
+    DetachedConfirm --> RunningDetached: Confirm
+    RunningDetached --> RefreshedStatus: success
+    HandoffOverview --> BranchMovePage: Move branch instead
+    BranchMovePage --> BranchMovePage: Next / Previous
+    BranchMovePage --> BranchMoveConfirm: select branch
+    BranchMoveConfirm --> RunningBranchMove: Confirm
+    RunningBranchMove --> RefreshedStatus: success
+    HandoffOverview --> WorktreeToLocalConfirm: worktree-to-local
+    WorktreeToLocalConfirm --> RunningWorktreeToLocal: Confirm
+    RunningWorktreeToLocal --> RefreshedStatus: success
+    DetachedConfirm --> HandoffOverview: Back
+    BranchMovePage --> HandoffOverview: Back
+    HandoffOverview --> StatusCard: Cancel / Refresh
+```
+
+The branch-moving branch picker should behave like the resume browser: the
+controller owns page index and pending intent state, the renderer receives only
+the current page of branch choices, and text fallback maps visible numbers and
+navigation words to the same action IDs as native buttons.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Contract and backend strategy"] --> U2["Unit 2: Git detached handoff"]
+    U1 --> U3["Unit 3: Messaging handoff flow"]
+    U2 --> U3
+    U3 --> U4["Unit 4: Provider and contract tests"]
+    U4 --> U5["Unit 5: Documentation and smoke checklist"]
+```
+
+- [ ] **Unit 1: Add explicit handoff strategy to shared contracts**
+
+**Goal:** Let callers request either branch-moving handoff or detached
+dirty-change handoff without overloading missing fields.
+
+**Requirements:** R4, R5, R6, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/normalized-app-server.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+
+**Approach:**
+- Add an explicit Local-to-worktree handoff strategy that distinguishes
+  branch-moving behavior from detached dirty-change behavior.
+- Keep existing requests without the new field compatible by treating them as
+  branch-moving handoff when `leaveLocalBranch` is present.
+- Carry default-branch/base information from navigation metadata into the
+  detached strategy request value used by messaging callbacks.
+- Make validation reject ambiguous detached requests, especially missing
+  repository path, missing source path, or missing default branch/base commit.
+
+**Patterns to follow:**
+- Existing handoff request validation in
+  `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Backend registry handoff validation in
+  `apps/desktop/src/main/app-server/backend-registry.ts`
+
+**Test scenarios:**
+- Happy path: a detached Local-to-worktree request serializes through messaging
+  action values and parses back with direction, strategy, repository path,
+  source path, source branch, and default branch/base.
+- Happy path: an existing branch-moving request with `leaveLocalBranch` remains
+  valid and is routed as branch-moving handoff.
+- Edge case: a detached request without default branch/base metadata is rejected
+  before calling the Git service.
+- Error path: a stale callback whose strategy no longer matches current
+  workspace metadata is rejected with a refreshable handoff-unavailable message.
+- Integration: IPC/backend registry tests prove the new strategy field crosses
+  preload and main-process boundaries.
+
+**Verification:**
+- Shared contracts can express both handoff modes, and old branch-moving tests
+  still pass after compatibility updates.
+
+- [ ] **Unit 2: Support detached dirty-change handoff in the Git service**
+
+**Goal:** Add the main-process Git behavior needed by the opinionated messaging
+default: create a detached worktree from the default branch commit and move dirty
+non-ignored changes from Local into it.
+
+**Requirements:** R4, R5, R6, R10
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts`
+- Test: `apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts`
+
+**Approach:**
+- Add a Local-to-worktree strategy branch that does not switch Local to another
+  branch and does not check out the current source branch in the new worktree.
+- Resolve the repository default branch to a commit before mutation, then create
+  the target worktree detached at that commit. In most PwrAgnt repositories this
+  will be `main`, but the service should use the detected default branch rather
+  than hard-coding a branch name.
+- Stash dirty tracked and non-ignored untracked Local changes, apply them in the
+  detached worktree, and drop the stash only after apply succeeds.
+- Leave the Local checkout on its current branch after the dirty changes have
+  been moved out. The thread's active workspace metadata should point to the new
+  detached worktree.
+- Return warnings that committed branch history was not moved and ignored files
+  were not preserved.
+- Preserve existing branch-moving behavior for explicit branch-moving requests.
+
+**Execution note:** Start with temporary Git repository tests. This is easy to
+get subtly wrong with branch occupancy, stash behavior, and detached HEAD state.
+
+**Patterns to follow:**
+- Existing stash/apply/drop helpers in
+  `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts`
+- Existing launchpad detached worktree creation pattern in
+  `apps/desktop/src/main/app-server/git-directory-service.ts`
+
+**Test scenarios:**
+- Happy path: Local on `feature`, default branch `main`, dirty tracked file and
+  non-ignored untracked file -> new worktree is detached at `main`, both dirty
+  changes appear in the new worktree, Local remains on `feature` and is clean.
+- Happy path: Local has no dirty non-ignored changes -> detached worktree is
+  still created and the response warns that no working changes were moved, if
+  implementation chooses to allow that case.
+- Edge case: ignored files under Local are not moved, and the response warns
+  that ignored files are excluded.
+- Edge case: committed changes reachable only from `feature` do not appear in
+  the detached worktree, and confirmation/success copy makes that explicit.
+- Edge case: dirty changes that depend on committed `feature`-only edits may
+  conflict or produce incomplete context when applied to the default branch
+  commit; the service reports the apply failure or warning without dropping the
+  recovery stash.
+- Error path: stash apply conflict leaves the stash recoverable and does not
+  drop it.
+- Error path: missing or unresolvable default branch fails before stashing or
+  creating a worktree.
+- Regression: branch-moving Local-to-worktree with `leaveLocalBranch` still
+  switches Local to the chosen branch and checks out the moved branch in the
+  target worktree.
+
+**Verification:**
+- Temporary-repo tests prove the new strategy creates a detached target from the
+  default branch commit, moves only dirty non-ignored changes, and leaves the
+  existing branch-moving strategy intact.
+
+- [ ] **Unit 3: Rework messaging handoff flow and branch pagination**
+
+**Goal:** Make the primary messaging Local-to-worktree flow direct and bounded,
+with a paged secondary branch-moving path.
+
+**Requirements:** R1, R2, R3, R4, R6, R7, R8, R9, R10
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Add a handoff branch page size constant near the messaging handoff helpers.
+  Prefer reusing or aligning with `RESUME_BROWSER_PAGE_SIZE = 8`.
+- Extend handoff pending state/action values with page index for branch-moving
+  selection. Keep state generic JSON, not provider-specific state.
+- Change Local handoff overview to show a primary detached-worktree action when
+  eligible and a secondary `Move branch instead` action that opens the paged
+  branch picker.
+- For branch-moving picker pages, render only the current page of branches plus
+  Previous/Next as applicable, Back, Refresh, and Cancel.
+- Use page-local numeric fallback for visible branch choices, and show page
+  count/total branch count in prompt and fallback text.
+- Keep `status:refresh`, `status:handoff`, and `handoff:cancel` semantics
+  consistent with the current managed status submode behavior.
+- Ensure fallback text says that replying `next`, `previous`, `back`,
+  `refresh`, or `cancel` activates the corresponding visible control.
+- For repositories without default branch metadata, skip the detached primary
+  path and send the user to the paged branch-moving path with explanatory copy.
+
+**Patterns to follow:**
+- Pagination and fallback shape in
+  `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Pending intent lifecycle in
+  `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Current handoff status submode helpers in
+  `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+
+**Test scenarios:**
+- Happy path: a Local handoff context with default branch and 56 leave-local
+  branches renders overview with the detached primary action and no branch list.
+- Happy path: choosing the detached primary action renders confirmation without
+  a branch picker and calls `handoffThreadWorkspace` with the detached strategy.
+- Happy path: choosing `Move branch instead` renders page 1 with eight branch
+  choices, `Next`, `Back`, `Refresh`, and `Cancel`.
+- Happy path: pressing `Next` renders page 2 with the next eight branches and
+  includes `Previous`.
+- Happy path: selecting a branch on page 3 confirms branch-moving handoff with
+  the selected `leaveLocalBranch`.
+- Edge case: exactly eight branches renders one page with no `Next`.
+- Edge case: nine branches renders two pages and never puts all nine branch
+  choices on the same prompt.
+- Edge case: no default branch metadata skips detached primary action and opens
+  or explains the branch-moving fallback.
+- Error path: stale page callback after branch metadata changes is rejected with
+  a refreshable message.
+- Integration: numeric fallback `1` selects only a branch visible on the current
+  branch page, while `next`, `previous`, `back`, and `cancel` map to the same
+  actions as buttons.
+- Regression: worktree-to-local still renders direct confirmation and calls the
+  existing strategy.
+
+**Verification:**
+- Controller and status-card tests prove the 56-branch case is bounded, the
+  detached path is primary, and branch-moving remains available through pages.
+
+- [ ] **Unit 4: Keep provider rendering bounded and generic**
+
+**Goal:** Verify Telegram and Discord render only bounded generic handoff
+choices and keep opaque callback handles.
+
+**Requirements:** R1, R2, R3, R8, R9
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- Modify: `packages/messaging/providers/telegram/src/__tests__/telegram-formatting.test.ts`
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-formatting.test.ts`
+- Modify if needed: `packages/messaging/providers/telegram/src/telegram-formatting.ts`
+- Modify if needed: `packages/messaging/providers/discord/src/discord-formatting.ts`
+
+**Approach:**
+- Prefer no provider source changes. The desired provider behavior should fall
+  out of receiving bounded generic intents.
+- Extend tests so a 56-branch handoff fixture never produces 56 inline keyboard
+  buttons/components.
+- Assert Telegram callback data and Discord custom IDs remain opaque handles,
+  not branch names or serialized strategy payloads.
+- Assert Discord rows remain inside current component limits and Telegram rows
+  remain readable.
+
+**Patterns to follow:**
+- Existing workspace handoff formatting tests in Telegram and Discord provider
+  packages.
+- `layoutMessagingActionRows` tests in
+  `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`.
+
+**Test scenarios:**
+- Happy path: Telegram branch page renders eight branch buttons plus navigation
+  and cancel controls, not the full 56 branches.
+- Happy path: Discord branch page renders within action-row limits and includes
+  Previous/Next only when applicable.
+- Edge case: long branch names stay labels only; callback payloads remain short
+  opaque handles.
+- Regression: existing handoff overview and worktree-to-local confirmation
+  rendering still works.
+
+**Verification:**
+- Provider tests demonstrate that bounded generic intents solve the Telegram
+  problem without adding Telegram/Discord branches to workflow code.
+
+- [ ] **Unit 5: Update documentation and manual smoke coverage**
+
+**Goal:** Document the new opinionated messaging handoff behavior and the manual
+validation case that exposed the bug.
+
+**Requirements:** R1, R4, R5, R6, R7, R9
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/messaging-platform-integration.md`
+- Test expectation: none -- this unit updates operator-facing documentation and
+  manual validation steps; behavioral coverage lives in Units 1-4.
+
+**Approach:**
+- Update the workspace handoff docs to distinguish:
+  - primary messaging Local-to-worktree detached dirty-change handoff;
+  - secondary branch-moving handoff with paged branch selection;
+  - unchanged worktree-to-local confirmation.
+- Add a manual Telegram smoke step with a repository that has more than 50
+  branches and verify that branch choices are paged.
+- Add copy guidance that committed branch history is not moved by the detached
+  dirty-change path.
+
+**Patterns to follow:**
+- Existing messaging handoff manual validation section in
+  `docs/messaging-platform-integration.md`.
+
+**Test scenarios:**
+- Test expectation: none -- documentation only.
+
+**Verification:**
+- A maintainer can follow the docs to reproduce the original 56-branch scenario
+  and verify the new bounded behavior from Telegram.
+
+## System-Wide Impact
+
+- **Interaction graph:** `/status` still starts the flow, but Local-to-worktree
+  now splits into primary detached confirmation and secondary paged branch-moving
+  selection. Existing worktree-to-local flow remains direct confirmation.
+- **Error propagation:** Backend strategy validation failures should surface as
+  recoverable handoff-unavailable or handoff-failed intents, not provider
+  exceptions. Git stash/apply recovery details should pass through existing
+  handoff error/success text.
+- **State lifecycle risks:** Branch page index must survive through pending
+  intents and stale callbacks must fail closed after metadata changes. Do not
+  rely on provider process memory.
+- **API surface parity:** Desktop IPC, shared app-server contracts, messaging
+  controller action values, and provider-facing interface tests all need to
+  agree on the new explicit strategy.
+- **Integration coverage:** Unit tests need to cover controller-to-bridge
+  invocation for detached strategy and provider rendering for bounded branch
+  pages. Temporary Git tests need to prove the detached strategy actually moves
+  dirty changes.
+- **Unchanged invariants:** Providers keep opaque callback handles; messaging
+  workflow does not inspect Telegram chat IDs or Discord component IDs; ignored
+  files remain excluded from handoff.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Detached handoff surprises users who expected committed branch history to move | Make confirmation copy explicit and keep branch-moving as a secondary path |
+| Strategy contract breaks old desktop branch-moving callers | Treat existing `leaveLocalBranch` requests as branch-moving and preserve old tests |
+| Branch pagination state goes stale after repository branch changes | Re-read navigation before confirmation and reject invalid selections with refresh guidance |
+| Provider buttons remain too dense despite pagination | Use eight choices per page and reserve rows for navigation/cancel; provider tests assert bounded output |
+| Git service drops a stash before apply is safely complete | Reuse apply-then-drop behavior and add temporary Git tests for conflict/recovery paths |
+| Dirty changes depend on commits that exist only on the Local branch | Confirmation copy says committed branch history is not moved; stash apply failures keep recovery details |
+
+## Documentation / Operational Notes
+
+- Update manual smoke tests for both Telegram and Discord, but prioritize
+  Telegram because the live failure was observed there.
+- Mention that the primary detached path is best for moving uncommitted work out
+  of Local, while `Move branch instead` is the branch-history path.
+- No migration is required unless implementation decides to persist a new
+  handoff submode/session record shape outside pending intents.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md`
+- Related plan: `docs/plans/2026-05-02-001-feat-messaging-handoff-surface-plan.md`
+- Related plan: `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Package guidance: `packages/messaging/AGENTS.md`
+- Telegram Bot API: https://core.telegram.org/bots/api
+- Discord component reference: https://docs.discord.com/developers/components/reference

--- a/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
+++ b/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
@@ -23,6 +23,17 @@ Keep the existing branch-moving handoff available as a secondary path, but make
 any branch picker paged at about eight choices per page with room for Previous,
 Next, Back, Refresh, and Cancel.
 
+Also update the desktop handoff dialog so it presents the same product choices
+explicitly instead of forcing the current "branch to move / leave Local on"
+flow. The dialog should offer:
+
+- Move dirty non-ignored changes to a new detached-HEAD worktree and leave the
+  current branch checked out where it is.
+- Move the current branch plus dirty non-ignored changes to a new worktree and
+  switch the current checkout to a selected branch.
+- A disabled placeholder for a future model-suggested branch name path that
+  behaves like the detached path but creates a named branch immediately.
+
 ## Problem Frame
 
 Live Telegram testing showed the current Local-to-worktree handoff branch picker
@@ -68,18 +79,25 @@ remote handoff into a branch-management prompt.
   branch-page navigation, branch selection, back, refresh, and cancel.
 - R10. Worktree-to-local handoff behavior is not changed by this fix except for
   any shared copy or fallback improvements needed for consistency.
+- R11. Desktop Local-to-worktree handoff must present the same two implemented
+  strategies explicitly: detached dirty-change handoff, and branch-moving
+  handoff with selected leave-current-checkout branch.
+- R12. Desktop Local-to-worktree handoff must show a disabled placeholder for a
+  future model-suggested branch-name strategy, without making a backend call.
+- R13. Desktop confirmation copy must make clear whether the current branch
+  stays where it is, whether the branch moves, and whether ignored or committed
+  changes are excluded.
 
 ## Scope Boundaries
 
-- In scope: messaging handoff intent construction, controller handoff callback
+- In scope: desktop and messaging handoff intent/dialog construction, controller handoff callback
   routing, text fallback, branch pagination state, backend contract support for
   a detached-worktree handoff strategy, Git handoff service behavior needed by
   that strategy, and focused Telegram/Discord formatting tests.
 - In scope: keeping the existing branch-moving Local-to-worktree path available
   as an explicit secondary or advanced action.
-- Out of scope: changing the desktop renderer composer handoff default unless
-  implementation finds the shared backend contract forces a small compatibility
-  adjustment.
+- In scope: changing the desktop renderer composer handoff dialog so it no
+  longer presents branch-moving as the only Local-to-worktree choice.
 - Out of scope: preserving ignored files. Existing handoff behavior already
   excludes ignored files, and the messaging copy should continue to say so.
 - Out of scope: moving committed branch history when the user chooses the
@@ -110,6 +128,12 @@ remote handoff into a branch-management prompt.
 - `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts` currently
   requires `leaveLocalBranch` for Local-to-worktree and then moves the current
   branch into a new worktree.
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` currently
+  renders the desktop `Handoff to New Worktree` dialog as a branch-moving flow
+  with one `Leave Local on` select and no strategy choice.
+- `apps/desktop/src/renderer/src/styles/app.css` owns the existing handoff
+  dialog visual treatment; desktop updates should extend those classes rather
+  than introducing a new modal system.
 - `packages/shared/src/contracts/normalized-app-server.ts` currently has
   `HandoffThreadWorkspaceRequest` with `direction`, `sourceBranch`, and
   `leaveLocalBranch`, but no explicit strategy for detached dirty-change
@@ -187,6 +211,12 @@ remote handoff into a branch-management prompt.
   valid workflow.
 - **Should worktree-to-local change now?** No. The observed problem and new
   product assumption affect Local-to-worktree.
+- **Should the desktop dialog change too?** Yes. Desktop should expose the same
+  product model so Local-to-worktree is not only branch-moving in one surface and
+  detached dirty-change handoff in another.
+- **Should the model-suggested branch path be implemented now?** No. Add a
+  visible disabled placeholder only; the branch-name suggestion side call is
+  being prepared separately.
 
 ### Deferred to Implementation
 
@@ -195,8 +225,9 @@ remote handoff into a branch-management prompt.
   dirty-change handoff, secondary branch-moving handoff.
 - Exact shared contract field names are deferred, but the strategy must be
   explicit and serializable through existing callback values.
-- Whether desktop composer should expose the new detached strategy is deferred.
-  This plan only requires messaging to prefer it.
+- Exact future contract for model-suggested branch names is deferred to the
+  upcoming ephemeral model side-call work. This plan should only leave a clear
+  UI placeholder and avoid fake branch suggestions.
 
 ## High-Level Technical Design
 
@@ -218,6 +249,9 @@ stateDiagram-v2
     RunningBranchMove --> RefreshedStatus: success
     HandoffOverview --> WorktreeToLocalConfirm: worktree-to-local
     WorktreeToLocalConfirm --> RunningWorktreeToLocal: Confirm
+    DesktopDialog --> DetachedConfirm: Move changes to Detached HEAD
+    DesktopDialog --> BranchMoveConfirm: Move branch + changes
+    DesktopDialog --> SuggestedBranchPlaceholder: disabled future option
     RunningWorktreeToLocal --> RefreshedStatus: success
     DetachedConfirm --> HandoffOverview: Back
     BranchMovePage --> HandoffOverview: Back
@@ -237,7 +271,9 @@ flowchart TB
     U1 --> U3["Unit 3: Messaging handoff flow"]
     U2 --> U3
     U3 --> U4["Unit 4: Provider and contract tests"]
-    U4 --> U5["Unit 5: Documentation and smoke checklist"]
+    U2 --> U5["Unit 5: Desktop handoff dialog"]
+    U4 --> U6["Unit 6: Documentation and smoke checklist"]
+    U5 --> U6
 ```
 
 - [ ] **Unit 1: Add explicit handoff strategy to shared contracts**
@@ -475,14 +511,70 @@ choices and keep opaque callback handles.
 - Provider tests demonstrate that bounded generic intents solve the Telegram
   problem without adding Telegram/Discord branches to workflow code.
 
-- [ ] **Unit 5: Update documentation and manual smoke coverage**
+- [ ] **Unit 5: Update the desktop handoff dialog**
+
+**Goal:** Replace the current single-path desktop Local-to-worktree dialog with
+an explicit strategy choice that supports detached dirty-change handoff,
+branch-moving handoff, and a disabled future suggested-branch placeholder.
+
+**Requirements:** R4, R5, R6, R7, R11, R12, R13
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Add local dialog state for the selected handoff strategy. Default
+  Local-to-worktree to detached dirty-change handoff when a default branch is
+  available.
+- Render strategy choices as selectable rows inside the existing handoff modal:
+  detached dirty-change handoff, branch-moving handoff, and disabled
+  model-suggested branch placeholder.
+- Only show `Leave Local on` / `Leave current checkout on` when the
+  branch-moving strategy is selected.
+- Submit detached handoff with the explicit detached strategy and default branch
+  metadata. Submit branch-moving handoff with the explicit branch-moving
+  strategy and selected `leaveLocalBranch`.
+- Keep existing worktree-to-local confirmation behavior.
+- Use existing modal, button, select, and theme classes. Add only scoped styles
+  needed for strategy rows and disabled placeholder state.
+
+**Patterns to follow:**
+- Existing composer setup controls in
+  `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Existing workspace handoff modal classes in
+  `apps/desktop/src/renderer/src/styles/app.css`
+
+**Test scenarios:**
+- Happy path: opening `Handoff to New Worktree` shows three strategy rows, with
+  detached dirty-change handoff selected by default and the suggested-branch row
+  disabled.
+- Happy path: submitting the default selected strategy calls
+  `onHandoffThreadWorkspace` with the detached strategy and default branch/base
+  metadata, without `leaveLocalBranch`.
+- Happy path: selecting branch-moving handoff reveals the leave-current-checkout
+  branch select and submits the branch-moving strategy with `leaveLocalBranch`.
+- Edge case: when default branch metadata is missing, detached strategy is
+  disabled or clearly unavailable, and branch-moving remains selectable when
+  branch choices exist.
+- Regression: worktree-to-local still renders direct confirmation and submits
+  `worktree-to-local` unchanged.
+
+**Verification:**
+- Desktop composer tests prove the dialog exposes the intended choices and sends
+  the right strategy-specific request shape.
+
+- [ ] **Unit 6: Update documentation and manual smoke coverage**
 
 **Goal:** Document the new opinionated messaging handoff behavior and the manual
 validation case that exposed the bug.
 
 **Requirements:** R1, R4, R5, R6, R7, R9
 
-**Dependencies:** Units 1-4
+**Dependencies:** Units 1-5
 
 **Files:**
 - Modify: `docs/messaging-platform-integration.md`
@@ -493,6 +585,7 @@ validation case that exposed the bug.
 - Update the workspace handoff docs to distinguish:
   - primary messaging Local-to-worktree detached dirty-change handoff;
   - secondary branch-moving handoff with paged branch selection;
+  - desktop dialog strategy selection and disabled suggested-branch placeholder;
   - unchanged worktree-to-local confirmation.
 - Add a manual Telegram smoke step with a repository that has more than 50
   branches and verify that branch choices are paged.
@@ -514,7 +607,8 @@ validation case that exposed the bug.
 
 - **Interaction graph:** `/status` still starts the flow, but Local-to-worktree
   now splits into primary detached confirmation and secondary paged branch-moving
-  selection. Existing worktree-to-local flow remains direct confirmation.
+  selection. Desktop Local-to-worktree now presents the same strategies inside
+  the handoff modal. Existing worktree-to-local flow remains direct confirmation.
 - **Error propagation:** Backend strategy validation failures should surface as
   recoverable handoff-unavailable or handoff-failed intents, not provider
   exceptions. Git stash/apply recovery details should pass through existing
@@ -543,6 +637,7 @@ validation case that exposed the bug.
 | Provider buttons remain too dense despite pagination | Use eight choices per page and reserve rows for navigation/cancel; provider tests assert bounded output |
 | Git service drops a stash before apply is safely complete | Reuse apply-then-drop behavior and add temporary Git tests for conflict/recovery paths |
 | Dirty changes depend on commits that exist only on the Local branch | Confirmation copy says committed branch history is not moved; stash apply failures keep recovery details |
+| Desktop and messaging drift into different handoff semantics | Share the explicit strategy contract and cover both surfaces in tests |
 
 ## Documentation / Operational Notes
 
@@ -550,6 +645,8 @@ validation case that exposed the bug.
   Telegram because the live failure was observed there.
 - Mention that the primary detached path is best for moving uncommitted work out
   of Local, while `Move branch instead` is the branch-history path.
+- Mention the desktop placeholder for future model-suggested branch naming so it
+  is understood as intentionally disabled.
 - No migration is required unless implementation decides to persist a new
   handoff submode/session record shape outside pending intents.
 

--- a/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
+++ b/docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md
@@ -14,10 +14,9 @@ deepened: 2026-05-02
 Fix the messaging workspace handoff flow so Telegram and Discord do not render
 huge branch-choice dialogs during Local-to-worktree handoff. The default
 messaging path should become more opinionated: when a bound Local thread is on
-a named branch and the repository default branch is known, the primary handoff
-choice should create a new detached worktree from the default branch commit and
-move dirty non-ignored changes there, without asking which branch Local should
-switch to.
+a named branch, the primary handoff choice should create a new detached
+worktree from the current branch tip and move dirty non-ignored changes there,
+without asking which branch Local should switch to.
 
 Keep the existing branch-moving handoff available as a secondary path, but make
 any branch picker paged at about eight choices per page with room for Previous,
@@ -47,9 +46,10 @@ The deeper issue is product behavior, not only rendering. The existing
 branch-moving handoff assumes the user wants to move the current branch to a
 worktree, so it must ask what Local should check out afterward. For messaging,
 the better default is usually simpler: leave the Local branch alone, create a
-new detached worktree from the default branch commit, and move the current dirty
-non-ignored working changes into that worktree. This avoids turning a common
-remote handoff into a branch-management prompt.
+new detached worktree from the current branch tip, and move the current dirty
+non-ignored working changes into that worktree. This keeps committed branch
+context intact while avoiding turning a common remote handoff into a
+branch-management prompt.
 
 ## Requirements Trace
 
@@ -62,16 +62,15 @@ remote handoff into a branch-management prompt.
   controls: Previous when applicable, Next when applicable, Back, Refresh, and
   Cancel.
 - R4. The primary Local-to-worktree messaging path should avoid branch picking
-  when the thread is on a named Local branch and the repository default branch
-  is known.
+  when the thread is on a named Local branch.
 - R5. The primary opinionated path should create a detached worktree at the
-  current commit of the default branch, stash/move dirty non-ignored Local
-  changes into that worktree, and make the thread point at the new worktree.
-- R6. The confirmation copy must state that committed changes on the Local
-  branch are not being moved by the opinionated detached-worktree path.
+  current branch tip, stash/move dirty non-ignored Local changes into that
+  worktree, and make the thread point at the new worktree.
+- R6. The confirmation copy must state that committed changes reachable from the
+  current branch tip are included as the detached worktree base, while ignored
+  files are not moved.
 - R7. The branch-moving path must remain available for cases where the user
-  explicitly wants to move the branch, or where the detached default-branch path
-  is not eligible.
+  explicitly wants to move the branch.
 - R8. The flow must remain channel-neutral. Telegram and Discord providers
   should render generic intents and opaque callback handles; controller logic
   must not branch on provider identity.
@@ -100,9 +99,10 @@ remote handoff into a branch-management prompt.
   longer presents branch-moving as the only Local-to-worktree choice.
 - Out of scope: preserving ignored files. Existing handoff behavior already
   excludes ignored files, and the messaging copy should continue to say so.
-- Out of scope: moving committed branch history when the user chooses the
-  opinionated detached-worktree path. That path only moves dirty non-ignored
-  working changes.
+- Out of scope: switching Local away from the current branch when the user
+  chooses the opinionated detached-worktree path. That path keeps Local on the
+  current branch and moves dirty non-ignored working changes to a detached
+  worktree based on the current branch tip.
 - Out of scope: a generic low-button-count policy for every messaging surface.
   This plan fixes handoff branch lists while reusing existing picker patterns.
 
@@ -188,14 +188,12 @@ remote handoff into a branch-management prompt.
 - **Keep pagination in the handoff/status-card layer, not provider packages.**
   Providers should receive a bounded generic `single_select` or picker-like
   intent. They should not know that a branch list had 56 total entries.
-- **Make copy explicit about what moves.** Detached handoff should say dirty
-  tracked and non-ignored untracked changes move; committed branch history and
-  ignored files do not.
-- **Fail closed when default-branch metadata is missing.** If the default branch
-  cannot be identified, the primary detached path should be unavailable or ask
-  for an explicit base in a future flow. Do not guess across repositories. Treat
-  `main` as the common case named in the request, but implement against the
-  repository's detected default branch.
+- **Make copy explicit about what moves.** Detached handoff should say the new
+  worktree starts at the current branch tip, dirty tracked and non-ignored
+  untracked changes move on top, and ignored files do not.
+- **Fail closed when source branch metadata is missing.** If the source checkout
+  has no named branch or resolvable `HEAD`, the primary detached path should be
+  unavailable rather than guessing across repositories.
 
 ## Open Questions
 
@@ -298,10 +296,10 @@ dirty-change handoff without overloading missing fields.
   branch-moving behavior from detached dirty-change behavior.
 - Keep existing requests without the new field compatible by treating them as
   branch-moving handoff when `leaveLocalBranch` is present.
-- Carry default-branch/base information from navigation metadata into the
-  detached strategy request value used by messaging callbacks.
+- Carry source branch information from navigation metadata into the detached
+  strategy request value used by messaging callbacks.
 - Make validation reject ambiguous detached requests, especially missing
-  repository path, missing source path, or missing default branch/base commit.
+  repository path, missing source path, or missing source branch.
 
 **Patterns to follow:**
 - Existing handoff request validation in
@@ -312,11 +310,11 @@ dirty-change handoff without overloading missing fields.
 **Test scenarios:**
 - Happy path: a detached Local-to-worktree request serializes through messaging
   action values and parses back with direction, strategy, repository path,
-  source path, source branch, and default branch/base.
+  source path, and source branch.
 - Happy path: an existing branch-moving request with `leaveLocalBranch` remains
   valid and is routed as branch-moving handoff.
-- Edge case: a detached request without default branch/base metadata is rejected
-  before calling the Git service.
+- Edge case: a detached request without source branch metadata is rejected before
+  calling the Git service.
 - Error path: a stale callback whose strategy no longer matches current
   workspace metadata is rejected with a refreshable handoff-unavailable message.
 - Integration: IPC/backend registry tests prove the new strategy field crosses
@@ -329,7 +327,7 @@ dirty-change handoff without overloading missing fields.
 - [x] **Unit 2: Support detached dirty-change handoff in the Git service**
 
 **Goal:** Add the main-process Git behavior needed by the opinionated messaging
-default: create a detached worktree from the default branch commit and move dirty
+default: create a detached worktree from the current branch tip and move dirty
 non-ignored changes from Local into it.
 
 **Requirements:** R4, R5, R6, R10
@@ -343,17 +341,16 @@ non-ignored changes from Local into it.
 **Approach:**
 - Add a Local-to-worktree strategy branch that does not switch Local to another
   branch and does not check out the current source branch in the new worktree.
-- Resolve the repository default branch to a commit before mutation, then create
-  the target worktree detached at that commit. In most PwrAgnt repositories this
-  will be `main`, but the service should use the detected default branch rather
-  than hard-coding a branch name.
+- Resolve the source checkout's `HEAD` to a commit before mutation, then create
+  the target worktree detached at that commit. This preserves any committed
+  branch context that dirty working changes may depend on.
 - Stash dirty tracked and non-ignored untracked Local changes, apply them in the
   detached worktree, and drop the stash only after apply succeeds.
 - Leave the Local checkout on its current branch after the dirty changes have
   been moved out. The thread's active workspace metadata should point to the new
   detached worktree.
-- Return warnings that committed branch history was not moved and ignored files
-  were not preserved.
+- Return warnings that the new worktree is detached at the current branch tip
+  and ignored files were not preserved.
 - Preserve existing branch-moving behavior for explicit branch-moving requests.
 
 **Execution note:** Start with temporary Git repository tests. This is easy to
@@ -366,23 +363,19 @@ get subtly wrong with branch occupancy, stash behavior, and detached HEAD state.
   `apps/desktop/src/main/app-server/git-directory-service.ts`
 
 **Test scenarios:**
-- Happy path: Local on `feature`, default branch `main`, dirty tracked file and
-  non-ignored untracked file -> new worktree is detached at `main`, both dirty
-  changes appear in the new worktree, Local remains on `feature` and is clean.
+- Happy path: Local on `feature`, dirty tracked file and non-ignored untracked
+  file -> new worktree is detached at the `feature` tip, both dirty changes
+  appear in the new worktree, Local remains on `feature` and is clean.
 - Happy path: Local has no dirty non-ignored changes -> detached worktree is
   still created and the response warns that no working changes were moved, if
   implementation chooses to allow that case.
 - Edge case: ignored files under Local are not moved, and the response warns
   that ignored files are excluded.
-- Edge case: committed changes reachable only from `feature` do not appear in
-  the detached worktree, and confirmation/success copy makes that explicit.
-- Edge case: dirty changes that depend on committed `feature`-only edits may
-  conflict or produce incomplete context when applied to the default branch
-  commit; the service reports the apply failure or warning without dropping the
-  recovery stash.
+- Edge case: committed changes reachable only from `feature` do appear in the
+  detached worktree because the target starts from the current branch tip.
 - Error path: stash apply conflict leaves the stash recoverable and does not
   drop it.
-- Error path: missing or unresolvable default branch fails before stashing or
+- Error path: missing or unresolvable source `HEAD` fails before stashing or
   creating a worktree.
 - Regression: branch-moving Local-to-worktree with `leaveLocalBranch` still
   switches Local to the chosen branch and checks out the moved branch in the
@@ -390,8 +383,8 @@ get subtly wrong with branch occupancy, stash behavior, and detached HEAD state.
 
 **Verification:**
 - Temporary-repo tests prove the new strategy creates a detached target from the
-  default branch commit, moves only dirty non-ignored changes, and leaves the
-  existing branch-moving strategy intact.
+  current branch tip, moves dirty non-ignored changes, preserves committed
+  branch context, and leaves the existing branch-moving strategy intact.
 
 - [ ] **Unit 3: Rework messaging handoff flow and branch pagination**
 
@@ -426,8 +419,8 @@ with a paged secondary branch-moving path.
   consistent with the current managed status submode behavior.
 - Ensure fallback text says that replying `next`, `previous`, `back`,
   `refresh`, or `cancel` activates the corresponding visible control.
-- For repositories without default branch metadata, skip the detached primary
-  path and send the user to the paged branch-moving path with explanatory copy.
+- When the source branch cannot be resolved, skip the detached primary path and
+  send the user to the paged branch-moving path with explanatory copy.
 
 **Patterns to follow:**
 - Pagination and fallback shape in
@@ -438,8 +431,9 @@ with a paged secondary branch-moving path.
   `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
 
 **Test scenarios:**
-- Happy path: a Local handoff context with default branch and 56 leave-local
-  branches renders overview with the detached primary action and no branch list.
+- Happy path: a Local handoff context with a named source branch and 56
+  leave-local branches renders overview with the detached primary action and no
+  branch list.
 - Happy path: choosing the detached primary action renders confirmation without
   a branch picker and calls `handoffThreadWorkspace` with the detached strategy.
 - Happy path: choosing `Move branch instead` renders page 1 with eight branch
@@ -451,8 +445,8 @@ with a paged secondary branch-moving path.
 - Edge case: exactly eight branches renders one page with no `Next`.
 - Edge case: nine branches renders two pages and never puts all nine branch
   choices on the same prompt.
-- Edge case: no default branch metadata skips detached primary action and opens
-  or explains the branch-moving fallback.
+- Edge case: no source branch metadata skips detached primary action and opens or
+  explains the branch-moving fallback.
 - Error path: stale page callback after branch metadata changes is rejected with
   a refreshable message.
 - Integration: numeric fallback `1` selects only a branch visible on the current
@@ -528,14 +522,13 @@ branch-moving handoff, and a disabled future suggested-branch placeholder.
 
 **Approach:**
 - Add local dialog state for the selected handoff strategy. Default
-  Local-to-worktree to detached dirty-change handoff when a default branch is
-  available.
+  Local-to-worktree to detached dirty-change handoff for named Local branches.
 - Render strategy choices as selectable rows inside the existing handoff modal:
   detached dirty-change handoff, branch-moving handoff, and disabled
   model-suggested branch placeholder.
 - Only show `Leave Local on` / `Leave current checkout on` when the
   branch-moving strategy is selected.
-- Submit detached handoff with the explicit detached strategy and default branch
+- Submit detached handoff with the explicit detached strategy and source branch
   metadata. Submit branch-moving handoff with the explicit branch-moving
   strategy and selected `leaveLocalBranch`.
 - Keep existing worktree-to-local confirmation behavior.
@@ -553,13 +546,12 @@ branch-moving handoff, and a disabled future suggested-branch placeholder.
   detached dirty-change handoff selected by default and the suggested-branch row
   disabled.
 - Happy path: submitting the default selected strategy calls
-  `onHandoffThreadWorkspace` with the detached strategy and default branch/base
+  `onHandoffThreadWorkspace` with the detached strategy and source branch
   metadata, without `leaveLocalBranch`.
 - Happy path: selecting branch-moving handoff reveals the leave-current-checkout
   branch select and submits the branch-moving strategy with `leaveLocalBranch`.
-- Edge case: when default branch metadata is missing, detached strategy is
-  disabled or clearly unavailable, and branch-moving remains selectable when
-  branch choices exist.
+- Edge case: when branch choices are missing, detached strategy remains
+  available for a named Local branch and branch-moving is disabled.
 - Regression: worktree-to-local still renders direct confirmation and submits
   `worktree-to-local` unchanged.
 
@@ -589,8 +581,8 @@ validation case that exposed the bug.
   - unchanged worktree-to-local confirmation.
 - Add a manual Telegram smoke step with a repository that has more than 50
   branches and verify that branch choices are paged.
-- Add copy guidance that committed branch history is not moved by the detached
-  dirty-change path.
+- Add copy guidance that the detached dirty-change path starts from the current
+  branch tip and therefore includes committed branch context.
 
 **Patterns to follow:**
 - Existing messaging handoff manual validation section in
@@ -631,12 +623,12 @@ validation case that exposed the bug.
 
 | Risk | Mitigation |
 |------|------------|
-| Detached handoff surprises users who expected committed branch history to move | Make confirmation copy explicit and keep branch-moving as a secondary path |
+| Detached handoff surprises users who expected the branch itself to move | Make confirmation copy explicit that the new worktree is detached at the branch tip and keep branch-moving as a secondary path |
 | Strategy contract breaks old desktop branch-moving callers | Treat existing `leaveLocalBranch` requests as branch-moving and preserve old tests |
 | Branch pagination state goes stale after repository branch changes | Re-read navigation before confirmation and reject invalid selections with refresh guidance |
 | Provider buttons remain too dense despite pagination | Use eight choices per page and reserve rows for navigation/cancel; provider tests assert bounded output |
 | Git service drops a stash before apply is safely complete | Reuse apply-then-drop behavior and add temporary Git tests for conflict/recovery paths |
-| Dirty changes depend on commits that exist only on the Local branch | Confirmation copy says committed branch history is not moved; stash apply failures keep recovery details |
+| Dirty changes depend on commits that exist only on the Local branch | Start the detached worktree from the current branch tip before applying dirty changes |
 | Desktop and messaging drift into different handoff semantics | Share the explicit strategy contract and cover both surfaces in tests |
 
 ## Documentation / Operational Notes

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -179,7 +179,7 @@ export class OverlayStore {
   async replaceWorkspaceLinkedDirectory(params: {
     backend: ThreadOverlayState["backend"];
     directory: LinkedDirectorySummary;
-    gitBranch?: string;
+    gitBranch?: string | null;
     threadId: string;
   }): Promise<ThreadOverlayState> {
     return await this.withData(async (data) => {
@@ -204,10 +204,14 @@ export class OverlayStore {
         }),
         params.directory,
       ];
+      const nextGitBranch =
+        params.gitBranch === null ? undefined : params.gitBranch ?? current.gitBranch;
+      const nextObservedGitBranch =
+        params.gitBranch === null ? undefined : params.gitBranch ?? current.observedGitBranch;
       const nextState: ThreadOverlayState = {
         ...current,
-        gitBranch: params.gitBranch ?? current.gitBranch,
-        observedGitBranch: params.gitBranch ?? current.observedGitBranch,
+        gitBranch: nextGitBranch,
+        observedGitBranch: nextObservedGitBranch,
         extraLinkedDirectories: nextDirectories,
       };
       data.threads[threadKey] = nextState;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -369,7 +369,6 @@ export type HandoffThreadWorkspaceRequest = {
   repositoryPath?: string;
   sourcePath?: string;
   sourceBranch?: string;
-  baseBranch?: string;
   leaveLocalBranch?: string;
 };
 
@@ -380,7 +379,7 @@ export type HandoffThreadWorkspaceResponse = {
   strategy?: ThreadWorkspaceHandoffStrategy;
   workMode: "local" | "worktree";
   branch?: string;
-  baseBranch?: string;
+  baseSha?: string;
   repositoryPath: string;
   targetPath: string;
   linkedDirectory: LinkedDirectorySummary;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -349,6 +349,10 @@ export type ThreadWorkspaceHandoffDirection =
   | "local-to-worktree"
   | "worktree-to-local";
 
+export type ThreadWorkspaceHandoffStrategy =
+  | "move-branch"
+  | "detached-changes";
+
 export type ThreadWorkspaceHandoffStashSummary = {
   ref?: string;
   message: string;
@@ -361,9 +365,11 @@ export type HandoffThreadWorkspaceRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   direction: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
   repositoryPath?: string;
   sourcePath?: string;
   sourceBranch?: string;
+  baseBranch?: string;
   leaveLocalBranch?: string;
 };
 
@@ -371,8 +377,10 @@ export type HandoffThreadWorkspaceResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   direction: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
   workMode: "local" | "worktree";
   branch?: string;
+  baseBranch?: string;
   repositoryPath: string;
   targetPath: string;
   linkedDirectory: LinkedDirectorySummary;


### PR DESCRIPTION
## Summary

I updated the handoff plan to cover the messaging branch-picker problem and the desktop handoff dialog changes, then implemented the desktop side of the new flow.

The desktop handoff dialog now offers explicit strategies:

- Move changes to a detached HEAD worktree based on the default branch, leaving the current checkout on its branch
- Move the current branch and dirty changes to a new worktree, while switching the current checkout to a selected branch
- Show a disabled placeholder for the future suggested-branch flow

The backend now supports detached-change handoff by creating a detached worktree from the selected base branch commit, moving non-ignored dirty changes into it, and leaving committed branch-only work behind on the current branch.

## Validation

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm typecheck`
- `git diff --check`
