### PR TITLE
fix(desktop): move sidebar masthead into titlebar drag region

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -34,6 +34,19 @@ The desktop style guide defines:
 - Keep radius at `8px` or below.
 - Favor one accent color and neutral surfaces.
 
+## Running the App for Development
+
+To launch the desktop app with live threads and real user state, run from the **repo root** (or worktree root):
+
+```bash
+pnpm --filter @pwragnt/desktop dev:no-messaging
+```
+
+- Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
+- `dev:no-messaging` disables the Telegram/Discord messaging interface, which avoids bot-token prompts and Keychain access issues during development.
+- For visual verification of UI changes, use this command so you can see real threads in the sidebar and thread detail pane.
+- The `dev` script (without `no-messaging`) also works but will attempt to connect messaging providers.
+
 ## Implementation Notes
 
 - Centralize visual tokens in `styles/app.css` before expanding renderer surfaces.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -142,9 +142,14 @@ textarea {
   -webkit-app-region: drag;
 }
 
+.sidebar__masthead *,
+.thread-header * {
+  -webkit-app-region: drag;
+}
+
 .sidebar__masthead {
   align-items: center;
-  padding: 10px 0 14px 60px;
+  padding: 10px 0 14px 80px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -159,6 +164,10 @@ textarea {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.sidebar__masthead-actions,
+.sidebar__masthead-actions * {
   -webkit-app-region: no-drag;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -84,7 +84,7 @@ textarea {
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 42px 16px 0;
+  padding: 0 16px;
   overflow: hidden;
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border-subtle);
@@ -144,8 +144,7 @@ textarea {
 
 .sidebar__masthead {
   align-items: center;
-  padding-bottom: 14px;
-  padding-left: 60px;
+  padding: 10px 0 14px 60px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -161,6 +160,10 @@ textarea {
   align-items: center;
   gap: 8px;
   -webkit-app-region: no-drag;
+}
+
+.thread-header {
+  padding-top: 10px;
 }
 
 .thread-header button,
@@ -1185,7 +1188,6 @@ textarea {
   flex-direction: column;
   gap: 18px;
   min-height: 0;
-  padding-top: 10px;
   overflow: hidden;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1176,7 +1176,7 @@ textarea {
   display: flex;
   min-height: 0;
   min-width: 0;
-  padding: 24px 0 24px 28px;
+  padding: 0 0 24px 28px;
   overflow: hidden;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -61,6 +61,13 @@ textarea {
   font: inherit;
 }
 
+input,
+textarea,
+[contenteditable] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 .app-shell {
   display: grid;
   position: relative;
@@ -71,6 +78,8 @@ textarea {
   overflow: hidden;
   background: var(--bg-app);
   color: var(--text-primary);
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .app-shell--fatal-settings {
@@ -1899,6 +1908,8 @@ textarea {
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .transcript-message--user {


### PR DESCRIPTION
## Summary
- Moves the PwrAgnt masthead (app name, settings gear, new-thread button) up into the traffic-light row so it serves as both drag region and useful UI
- Removes the empty 42px top padding on the sidebar that created a dead zone above the masthead
- Adds 10px top padding to the thread-header on the right pane for consistent spacing

## Test plan
- [x] Launch the app and verify the PwrAgnt name sits in the same row as the traffic lights
- [x] Verify clicking and dragging the titlebar area (masthead row) moves the window
- [x] Verify the settings gear and "New thread" button are still clickable (not captured by drag)
- [x] Verify the right pane thread header area is also draggable
- [x] Verify the settings overlay still has proper top spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)