### PR TITLE
fix(desktop): use two-column segmented control for worktree storage setting

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
@@ -46,7 +46,7 @@ export function WorktreesSettings(props: {
 
       <div className="settings-field">
         <div
-          className="settings-segmented"
+          className="settings-segmented settings-segmented--two"
           role="radiogroup"
           aria-label="Worktree storage location"
         >

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -238,6 +238,23 @@ describe("SettingsScreen", () => {
       });
     });
 
+    fireEvent.click(within(sections).getByRole("button", { name: "Worktrees" }));
+    expect(screen.getByRole("heading", { name: "Storage location" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "User home" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("radio", { name: "In repository" }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByText("/home/example/.pwragnt/worktrees")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "In repository" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        worktrees: { storage: "in-repo" },
+      });
+    });
+
     fireEvent.click(within(sections).getByRole("button", { name: "Applications" }));
     expect(within(sections).getByRole("button", { name: "Experimental" })).not.toHaveAttribute(
       "aria-current",


### PR DESCRIPTION
## Summary
- The `settings-segmented` CSS class defaults to a 3-column grid, but the worktree storage picker only has two options ("In repository" / "User home"), leaving an awkward empty third column
- Adds the `settings-segmented--two` modifier already used by the models settings
- Adds Worktrees tab interaction coverage to the settings screen test (navigates to tab, verifies radio state, clicks to change storage, asserts `writeConfig` call)

## Test plan
- [x] `settings-screen.test.tsx` — 5 tests pass, including new Worktrees tab interaction
- [x] `git-workspace-handoff-service.test.ts` — 7 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)