### PR TITLE
fix(desktop): limit messaging startup eligibility logs

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -66,6 +66,57 @@ describe("DesktopMessagingRuntime", () => {
     });
   });
 
+  it("requests messaging startup eligibility logging only for the startup config load", async () => {
+    await prepareRuntimeStore();
+    const adapter = createAdapter("telegram");
+    const configLoader = vi.fn(() => ({
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram" as const,
+        botToken: "telegram-token",
+        authorizedActorIds: ["user-1"],
+      },
+    }));
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: configLoader,
+    });
+
+    await runtime.start();
+    await adapter.listener?.(
+      buildCallbackEvent("bind:codex:thread-1", {
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+    await bridge.emitBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "command-1",
+            type: "commandExecution",
+            command: "pnpm test",
+            status: "completed",
+          },
+        },
+      },
+    });
+
+    expect(configLoader).toHaveBeenNthCalledWith(1, {
+      logStartupEligibility: true,
+    });
+    expect(configLoader).toHaveBeenNthCalledWith(2, undefined);
+  });
+
   it("uses adapter-supplied authorization without provider-specific runtime config", async () => {
     await prepareRuntimeStore();
     const adapter = createAdapter("custom", {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -112,8 +112,12 @@ export function bootstrapApp(): void {
         reason: messagingOverride.reason,
       });
     } else {
-      await getDesktopMessagingRuntime(() =>
-        loadDesktopMessagingConfigFromSettings(getDesktopSettingsService()),
+      await getDesktopMessagingRuntime((options) =>
+        loadDesktopMessagingConfigFromSettings(
+          getDesktopSettingsService(),
+          process.env,
+          options,
+        ),
       ).start();
     }
     createMainWindow({

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -52,6 +52,10 @@ export type DesktopMessagingSettingsSource = Pick<
   "readSettings" | "resolveDiscordBotTokenSync" | "resolveTelegramBotTokenSync"
 >;
 
+export type DesktopMessagingConfigLoadOptions = {
+  logStartupEligibility?: boolean;
+};
+
 export function loadDesktopMessagingConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): DesktopMessagingConfig {
@@ -100,6 +104,7 @@ export function loadDesktopMessagingConfig(
 export async function loadDesktopMessagingConfigFromSettings(
   settings: DesktopMessagingSettingsSource,
   env: NodeJS.ProcessEnv = process.env,
+  options: DesktopMessagingConfigLoadOptions = {},
 ): Promise<DesktopMessagingConfig> {
   const log = getMainLogger("pwragent:messaging");
   const snapshot = await settings.readSettings();
@@ -139,6 +144,7 @@ export async function loadDesktopMessagingConfigFromSettings(
     channel: "telegram",
     enabled: telegramEnabled,
     hasToken: Boolean(telegramBotToken),
+    logStartupEligibility: options.logStartupEligibility === true,
     authorizedActorCount: telegramAuthorizedActorIds.length,
   })
     ? {
@@ -157,6 +163,7 @@ export async function loadDesktopMessagingConfigFromSettings(
     channel: "discord",
     enabled: discordEnabled,
     hasToken: Boolean(discordBotToken),
+    logStartupEligibility: options.logStartupEligibility === true,
     authorizedActorCount: discordAuthorizedActorIds.length,
   })
     ? {
@@ -192,38 +199,48 @@ function buildChannelConfig(params: {
   channel: string;
   enabled: boolean;
   hasToken: boolean;
+  logStartupEligibility: boolean;
   authorizedActorCount: number;
 }): boolean {
-  const { log, channel, enabled, hasToken, authorizedActorCount } = params;
+  const { log, channel, enabled, hasToken, logStartupEligibility, authorizedActorCount } =
+    params;
 
   if (!enabled) {
-    log.info(`${channel}: disabled in settings — skipping`, {
-      channel,
-    });
+    if (logStartupEligibility) {
+      log.info(`${channel}: disabled in settings — skipping`, {
+        channel,
+      });
+    }
     return false;
   }
 
   // Channel is enabled — any missing prerequisite is an error
   if (!hasToken) {
-    log.error(
-      `${channel}: enabled but bot token is missing or could not be decrypted — cannot start`,
-      { channel },
-    );
+    if (logStartupEligibility) {
+      log.error(
+        `${channel}: enabled but bot token is missing or could not be decrypted — cannot start`,
+        { channel },
+      );
+    }
     return false;
   }
 
   if (authorizedActorCount === 0) {
-    log.error(
-      `${channel}: enabled but no authorized user IDs configured — cannot start`,
-      { channel },
-    );
+    if (logStartupEligibility) {
+      log.error(
+        `${channel}: enabled but no authorized user IDs configured — cannot start`,
+        { channel },
+      );
+    }
     return false;
   }
 
-  log.info(`${channel}: enabled — will attempt to start`, {
-    channel,
-    authorizedActorCount,
-  });
+  if (logStartupEligibility) {
+    log.info(`${channel}: enabled — will attempt to start`, {
+      channel,
+      authorizedActorCount,
+    });
+  }
   return true;
 }
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -16,6 +16,7 @@ import type {
 import { getMainLogger } from "../log";
 import { getDesktopMessagingStore } from "./desktop-messaging-store";
 import {
+  type DesktopMessagingConfigLoadOptions,
   loadDesktopMessagingConfig,
   redactDesktopMessagingConfig,
   type DesktopMessagingConfig,
@@ -40,7 +41,9 @@ export type DesktopMessagingAdapterFactory = (params: {
   store: MessagingStoreLike;
 }) => DesktopMessagingAdapter[] | Promise<DesktopMessagingAdapter[]>;
 
-export type DesktopMessagingConfigLoader = () =>
+export type DesktopMessagingConfigLoader = (
+  options?: DesktopMessagingConfigLoadOptions,
+) =>
   | DesktopMessagingConfig
   | Promise<DesktopMessagingConfig>;
 
@@ -69,7 +72,7 @@ export class DesktopMessagingRuntime {
     this.started = true;
 
     const store = getDesktopMessagingStore();
-    const config = await this.loadConfig();
+    const config = await this.loadConfig({ logStartupEligibility: true });
     const configuredAdapters = await this.options.adapterFactory({
       config,
       store,
@@ -188,9 +191,11 @@ export class DesktopMessagingRuntime {
     this.controllers = [];
   }
 
-  private async loadConfig(): Promise<DesktopMessagingConfig> {
+  private async loadConfig(
+    options?: DesktopMessagingConfigLoadOptions,
+  ): Promise<DesktopMessagingConfig> {
     return typeof this.options.config === "function"
-      ? await this.options.config()
+      ? await this.options.config(options)
       : this.options.config;
   }
 }
@@ -204,7 +209,7 @@ export function getDesktopMessagingRuntime(
     runtime = new DesktopMessagingRuntime({
       adapterFactory: createConfiguredAdapters,
       backendBridge: new DesktopMessagingBackendBridge(),
-      config: config ?? loadDesktopMessagingConfig,
+      config: config ?? (() => loadDesktopMessagingConfig()),
     });
   }
 


### PR DESCRIPTION
## Summary

I limited the messaging startup eligibility logs so they are emitted only for the actual runtime startup config load.

This keeps the useful Telegram/Discord startup diagnostics, but prevents later config reloads for status cards and tool update preferences from repeatedly logging `enabled — will attempt to start`.

## Verification

I verified this in the target worktree with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
