### PR TITLE
fix(desktop): keep launchpad worktree threads deduped

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -277,6 +277,152 @@ async function createDirectoryLaunchpadFixture(): Promise<{
   };
 }
 
+async function createLocalHandoffSessionFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  codexHome: string;
+  fixturePath: string;
+  repoDir: string;
+  sessionPath: string;
+  threadId: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-e2e-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const codexHome = path.join(rootDir, ".codex");
+  const threadId = "thread-local-handoff";
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed handoff fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const sessionDir = path.join(codexHome, "sessions", "2026", "05", "04");
+  const sessionPath = path.join(
+    sessionDir,
+    `rollout-2026-05-04T13-22-52-${threadId}.jsonl`,
+  );
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    sessionPath,
+    `${JSON.stringify({
+      timestamp: "2026-05-04T17:22:52.000Z",
+      type: "session_meta",
+      payload: {
+        id: threadId,
+        cwd: repoDir,
+        originator: "pwragent-desktop",
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const fixturePath = path.join(rootDir, "local-handoff-session.fixture.json");
+  const thread = {
+    id: threadId,
+    title: "Local handoff thread",
+    titleSource: "explicit",
+    summary: "Move this local thread into a worktree",
+    source: "codex",
+    executionMode: "default",
+    gitBranch: "main",
+    observedGitBranch: "main",
+    linkedDirectories: [
+      {
+        id: "fixture-repo",
+        label: "FixtureRepo",
+        path: repoDir,
+        kind: "local",
+      },
+    ],
+    updatedAt: 1760000000000,
+  };
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "local-handoff-session-cwd",
+          threadId,
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [thread],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Keep this thread visible after handoff.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Keep this thread visible after handoff.",
+                },
+              ],
+              lastUserMessage: "Keep this thread visible after handoff.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    codexHome,
+    fixturePath,
+    repoDir,
+    sessionPath,
+    threadId,
+  };
+}
+
 function readOverlayState(homeRoot: string): {
   directoryLaunchpads: Record<string, unknown>;
 } {
@@ -561,6 +707,59 @@ test("directory launchpad keeps new worktree as the sticky default after startin
 
     await expect(settings.getByLabel("Workspace mode")).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("local-to-worktree handoff updates Codex session cwd metadata", async () => {
+  const fixture = await createLocalHandoffSessionFixture();
+  const app = await launchElectronApp({
+    env: {
+      CODEX_HOME: fixture.codexHome,
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: "Local handoff thread" })
+      .click();
+
+    const workspaceMode = app.window.getByLabel("Workspace mode");
+    await workspaceMode.click();
+    await app.window
+      .getByRole("menuitem", { name: "Handoff to New Worktree" })
+      .click();
+
+    const dialog = app.window.getByRole("dialog", { name: "Handoff to New Worktree" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("radio", { name: /Handoff to Detached HEAD/ }),
+    ).toHaveAttribute("aria-checked", "true");
+    await dialog.getByRole("button", { name: "Handoff" }).click();
+
+    await expect
+      .poll(async () => {
+        const firstLine = (await readFile(fixture.sessionPath, "utf8")).split("\n")[0]!;
+        return JSON.parse(firstLine).payload.cwd as string;
+      })
+      .toContain(`${path.sep}.codex${path.sep}worktrees${path.sep}`);
+
+    const firstLine = (await readFile(fixture.sessionPath, "utf8")).split("\n")[0]!;
+    const cwd = JSON.parse(firstLine).payload.cwd as string;
+    expect(cwd).not.toBe(fixture.repoDir);
+
+    const ownerFile = execFileSync(
+      "git",
+      ["-C", cwd, "rev-parse", "--git-path", "codex-thread.json"],
+      { encoding: "utf8" },
+    ).trim();
+    await expect(readFile(ownerFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      version: 1,
+      ownerThreadId: fixture.threadId,
+    });
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -25,6 +25,7 @@ async function createDirectoryLaunchpadFixture(): Promise<{
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-launchpad-e2e-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
   const otherRepoDir = path.join(rootDir, "OtherRepo");
+  const worktreeDir = path.join(rootDir, ".pwragent", "worktrees", "mord46hf", "FixtureRepo");
   await mkdir(repoDir, { recursive: true });
   await mkdir(otherRepoDir, { recursive: true });
 
@@ -187,10 +188,10 @@ async function createDirectoryLaunchpadFixture(): Promise<{
                 gitBranch: "HEAD",
                 linkedDirectories: [
                   {
-                    id: "fixture-repo",
+                    id: worktreeDir,
                     label: "FixtureRepo",
-                    path: repoDir,
-                    kind: "worktree",
+                    path: worktreeDir,
+                    kind: "local",
                   },
                 ],
                 updatedAt: 1760000001000,
@@ -549,6 +550,99 @@ test("directory launchpad keeps new worktree as the sticky default after startin
 
     await expect(settings.getByLabel("Workspace mode")).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad does not duplicate a materialized worktree thread under path-shaped directory rows", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    const settings = app.window.getByLabel("New thread settings");
+    await selectComposerOption({
+      select: settings.getByLabel("Workspace mode"),
+      window: app.window,
+      option: "New worktree",
+    });
+
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("Use a sticky worktree default");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Use a sticky worktree default",
+      }),
+    ).toBeVisible();
+
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await expect(app.window.locator(".directory-row").filter({
+      has: app.window.getByText("FixtureRepo", { exact: true }),
+    })).toHaveCount(1);
+    await expect(
+      app.window.getByRole("button", { name: /Use a sticky worktree default/ }),
+    ).toHaveCount(1);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad keeps Tiptap Markdown focus and fenced-code formatting after changing workspace mode", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGENT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "tiptap-wysiwyg-markdown-chips",
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+    await textbox.click();
+    await app.window.keyboard.type("```ts ");
+    await app.window.keyboard.type("const answer = 42;");
+
+    const composer = app.window.getByTestId("composer-tiptap-input");
+    await expect(composer.locator("pre")).toBeVisible();
+
+    const settings = app.window.getByLabel("New thread settings");
+    await selectComposerOption({
+      select: settings.getByLabel("Workspace mode"),
+      window: app.window,
+      option: "New worktree",
+    });
+
+    await expect(composer.locator("pre")).toBeVisible();
+    await expect(textbox).toBeFocused();
+
+    await app.window
+      .getByRole("button", { name: /Directory launchpad replay/ })
+      .first()
+      .click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(app.window.getByTestId("composer-tiptap-input").locator("pre")).toBeVisible();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeFocused();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -540,6 +540,17 @@ test("directory launchpad keeps new worktree as the sticky default after startin
         name: "Use a sticky worktree default",
       }),
     ).toBeVisible();
+    const startTurn = (await app.getLastStartTurn()) as { cwd?: string } | undefined;
+    expect(startTurn?.cwd).toContain(`${path.sep}.pwragent${path.sep}worktrees${path.sep}`);
+    const ownerFile = execFileSync(
+      "git",
+      ["-C", startTurn!.cwd!, "rev-parse", "--git-path", "codex-thread.json"],
+      { encoding: "utf8" },
+    ).trim();
+    await expect(readFile(ownerFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      version: 1,
+      ownerThreadId: "thread-new-worktree",
+    });
 
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -541,7 +541,7 @@ test("directory launchpad keeps new worktree as the sticky default after startin
       }),
     ).toBeVisible();
     const startTurn = (await app.getLastStartTurn()) as { cwd?: string } | undefined;
-    expect(startTurn?.cwd).toContain(`${path.sep}.pwragent${path.sep}worktrees${path.sep}`);
+    expect(startTurn?.cwd).toContain(`${path.sep}.codex${path.sep}worktrees${path.sep}`);
     const ownerFile = execFileSync(
       "git",
       ["-C", startTurn!.cwd!, "rev-parse", "--git-path", "codex-thread.json"],

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -503,9 +503,11 @@ class MockBackendClient {
     threadId: string;
     input: AppServerTurnInputItem[];
     executionMode?: "default" | "full-access";
+    cwd?: string;
     approvalPolicy?: string;
     sandbox?: string;
     model?: string;
+    collaborationMode?: unknown;
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
@@ -1529,6 +1531,55 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("records Codex owner metadata when materializing a worktree launchpad", async () => {
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app/.worktrees/thread-1/app",
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread,
+      } as never,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      launchpad: {
+        directoryKey: "directory:/repo/app",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "worktree",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
+      worktreePath: "/repo/app/.worktrees/thread-1/app",
+      threadId: "thread-1",
+    });
+
+    await registry.close();
+  });
+
   it("materializes Grok workspace launchpads into a scratch directory", async () => {
     const grokClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },
@@ -1639,6 +1690,52 @@ describe("DesktopBackendRegistry", () => {
       serviceTier: undefined,
       reasoningEffort: "medium",
       fastMode: undefined,
+    });
+
+    await registry.close();
+  });
+
+  it("resumes Codex turns in the current handoff worktree cwd", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [
+              {
+                id: "pwragent-handoff:codex:thread-1",
+                label: "app",
+                path: "/repo/app",
+                worktreePath: "/repo/app/.worktrees/thread-1/app",
+                kind: "worktree",
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "What is the CWD?" }],
+    });
+
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-1",
+      cwd: "/repo/app/.worktrees/thread-1/app",
     });
 
     await registry.close();
@@ -2548,6 +2645,7 @@ describe("DesktopBackendRegistry", () => {
       warnings: [],
       completedAt: 1000,
     }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [thread],
@@ -2562,6 +2660,9 @@ describe("DesktopBackendRegistry", () => {
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      gitDirectoryService: {
+        recordCodexWorktreeOwnerThread,
+      } as never,
       gitWorkspaceHandoffService: {
         handoff,
       } as never,
@@ -2584,6 +2685,10 @@ describe("DesktopBackendRegistry", () => {
       sourceBranch: undefined,
     });
     expect(response.workMode).toBe("worktree");
+    expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
+      worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      threadId: "thread-1",
+    });
     expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
       threadId: "thread-1",
       gitInfo: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1471,6 +1471,8 @@ describe("DesktopBackendRegistry", () => {
     await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
       expect.objectContaining({
         id: "thread-1",
+        title: "Untitled thread",
+        titleSource: "fallback",
         projectKey: "/repo-a",
         linkedDirectories: [
           {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2646,6 +2646,7 @@ describe("DesktopBackendRegistry", () => {
       completedAt: 1000,
     }));
     const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const updateThreadCwd = vi.fn(async () => ({ updated: true }));
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [thread],
@@ -2662,6 +2663,9 @@ describe("DesktopBackendRegistry", () => {
       overlayStore,
       gitDirectoryService: {
         recordCodexWorktreeOwnerThread,
+      } as never,
+      codexSessionMetadataService: {
+        updateThreadCwd,
       } as never,
       gitWorkspaceHandoffService: {
         handoff,
@@ -2687,6 +2691,10 @@ describe("DesktopBackendRegistry", () => {
     expect(response.workMode).toBe("worktree");
     expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
       worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      threadId: "thread-1",
+    });
+    expect(updateThreadCwd).toHaveBeenCalledWith({
+      cwd: "/repo/app/.worktrees/app-feature-handoff",
       threadId: "thread-1",
     });
     expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
@@ -2749,6 +2757,7 @@ describe("DesktopBackendRegistry", () => {
       warnings: [],
       completedAt: 1000,
     }));
+    const updateThreadCwd = vi.fn(async () => ({ updated: true }));
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [thread],
@@ -2763,6 +2772,9 @@ describe("DesktopBackendRegistry", () => {
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      codexSessionMetadataService: {
+        updateThreadCwd,
+      } as never,
       gitWorkspaceHandoffService: {
         handoff,
       } as never,
@@ -2779,6 +2791,10 @@ describe("DesktopBackendRegistry", () => {
       gitInfo: {
         branch: "HEAD",
       },
+    });
+    expect(updateThreadCwd).toHaveBeenCalledWith({
+      cwd: "/repo/app",
+      threadId: "thread-1",
     });
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3412,6 +3412,7 @@ describe("CodexAppServerClient", () => {
     const result = await client.startTurn({
       threadId: "thread-2",
       input: [{ type: "text", text: "Reply to the existing thread" }],
+      cwd: "/repo/app/.worktrees/thread-2/app",
       model: "gpt-5.4"
     });
 
@@ -3435,6 +3436,20 @@ describe("CodexAppServerClient", () => {
     const startIndex = rpcMethods.indexOf("turn/start");
     expect(resumeIndex).toBeGreaterThan(-1);
     expect(startIndex).toBeGreaterThan(resumeIndex);
+    const resumePayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/resume");
+    const turnStartPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "turn/start");
+    expect(resumePayload?.params).toMatchObject({
+      threadId: "thread-2",
+      cwd: "/repo/app/.worktrees/thread-2/app",
+    });
+    expect(turnStartPayload?.params).toMatchObject({
+      threadId: "thread-2",
+      cwd: "/repo/app/.worktrees/thread-2/app",
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-session-metadata-service.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-session-metadata-service.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CodexSessionMetadataService } from "../app-server/codex-session-metadata-service";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-codex-session-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("CodexSessionMetadataService", () => {
+  it("updates the session metadata cwd for a handed-off thread", async () => {
+    const codexHome = await makeTempDir();
+    const threadId = "019df34d-d561-7763-b1a0-6591048e7e55";
+    const sessionDir = path.join(codexHome, "sessions", "2026", "05", "04");
+    const sessionPath = path.join(
+      sessionDir,
+      `rollout-2026-05-04T10-04-17-${threadId}.jsonl`,
+    );
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      sessionPath,
+      [
+        JSON.stringify({
+          timestamp: "2026-05-04T14:04:35.539Z",
+          type: "session_meta",
+          payload: {
+            id: threadId,
+            cwd: "/Users/huntharo/github/PwrAgnt",
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-05-04T17:23:01.854Z",
+          type: "turn_context",
+          payload: {
+            cwd: "/Users/huntharo/github/PwrAgnt",
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const result = await new CodexSessionMetadataService({ codexHome }).updateThreadCwd({
+      cwd: "/Users/huntharo/.codex/worktrees/morgwp0f/PwrAgnt",
+      threadId,
+    });
+
+    expect(result).toMatchObject({
+      path: sessionPath,
+      updated: true,
+    });
+    const [metaLine, turnContextLine] = (await readFile(sessionPath, "utf8")).trim().split("\n");
+    expect(JSON.parse(metaLine!)).toMatchObject({
+      payload: {
+        cwd: "/Users/huntharo/.codex/worktrees/morgwp0f/PwrAgnt",
+        id: threadId,
+      },
+      type: "session_meta",
+    });
+    expect(JSON.parse(turnContextLine!)).toMatchObject({
+      payload: {
+        cwd: "/Users/huntharo/github/PwrAgnt",
+      },
+      type: "turn_context",
+    });
+  });
+
+  it("reports a missing session without throwing", async () => {
+    const codexHome = await makeTempDir();
+
+    await expect(
+      new CodexSessionMetadataService({ codexHome }).updateThreadCwd({
+        cwd: "/repo/app/.worktrees/thread-1/app",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual({
+      reason: "missing-session",
+      updated: false,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, realpath, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -146,6 +146,36 @@ describe("GitDirectoryService", () => {
     const expectedRoot = path.join(homeDir, ".pwragent", "worktrees");
     expect(workspace.cwd!.startsWith(`${expectedRoot}${path.sep}`)).toBe(true);
     expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
+  });
+
+  it("records Codex owner metadata in the worktree git directory", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    await service.recordCodexWorktreeOwnerThread({
+      worktreePath: workspace.cwd!,
+      threadId: "thread-1",
+    });
+
+    const ownerFile = runGit(workspace.cwd!, [
+      "rev-parse",
+      "--git-path",
+      "codex-thread.json",
+    ]);
+    await expect(readFile(ownerFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      version: 1,
+      ownerThreadId: "thread-1",
+    });
   });
 
   it("computeWorktreePath suffixes the hash when the path already exists", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -148,6 +148,30 @@ describe("GitDirectoryService", () => {
     expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
   });
 
+  it("creates Codex user-home worktrees under the Codex worktree root", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-codex-home-"));
+    cleanupPaths.push(homeDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "user-home",
+      homeDir,
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      backend: "codex",
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    const expectedRoot = path.join(homeDir, ".codex", "worktrees");
+    expect(workspace.cwd!.startsWith(`${expectedRoot}${path.sep}`)).toBe(true);
+    expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
+  });
+
   it("records Codex owner metadata in the worktree git directory", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1476,7 +1476,7 @@ export class DesktopBackendRegistry {
       {
         id: result.threadId,
         source: backend,
-        title: result.threadId,
+        title: "Untitled thread",
         titleSource: "fallback",
         projectKey: cwd,
         createdAt: startedAt,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -166,6 +166,7 @@ type BackendClient = {
   startTurn(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
+    cwd?: string;
     approvalPolicy?: string;
     sandbox?: string;
     model?: string;
@@ -221,12 +222,19 @@ function resolveThreadGitSourcePath(
     ...overlayDirectories,
     ...thread.linkedDirectories,
   ];
+
+  return resolveLinkedDirectoryCwd(linkedDirectories) ?? thread.projectKey;
+}
+
+function resolveLinkedDirectoryCwd(
+  linkedDirectories: AppServerThreadSummary["linkedDirectories"] = [],
+): string | undefined {
   const directory =
     linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
     linkedDirectories.find((candidate) => candidate.kind === "local") ??
     linkedDirectories[0];
 
-  return directory?.worktreePath ?? directory?.path ?? thread.projectKey;
+  return directory?.worktreePath ?? directory?.path;
 }
 
 function hasHandoffWorkspace(
@@ -1379,6 +1387,13 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
       branch: resultBranch,
     });
+    if (result.workMode === "worktree") {
+      await this.recordCodexWorktreeOwnerThread({
+        backend: request.backend,
+        threadId: request.threadId,
+        worktreePath: result.linkedDirectory.worktreePath ?? result.targetPath,
+      });
+    }
 
     if (result.archivedSourceWorktree) {
       await this.overlayStore.upsertWorktreeSnapshot({
@@ -1540,6 +1555,10 @@ export class DesktopBackendRegistry {
       reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
       fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
     });
+    const cwd =
+      params.backend === "codex"
+        ? await this.resolveCodexThreadTurnCwd(params.threadId, overlay)
+        : undefined;
     let activeTurnMode: ThreadExecutionMode | undefined;
     const result =
       params.backend === "codex"
@@ -1549,6 +1568,7 @@ export class DesktopBackendRegistry {
             const started = await client.startTurn({
               threadId: params.threadId,
               input: params.input,
+              ...(cwd ? { cwd } : {}),
               collaborationMode: params.collaborationMode,
               ...turnParams,
               approvalPolicy: params.approvalPolicy ?? modeSettings.approvalPolicy,
@@ -2121,6 +2141,13 @@ export class DesktopBackendRegistry {
       serviceTier: launchpad.serviceTier,
       fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
     });
+    if (workspace.workMode === "worktree") {
+      await this.recordCodexWorktreeOwnerThread({
+        backend: launchpad.backend,
+        threadId: startThreadResponse.threadId,
+        worktreePath: workspace.cwd,
+      });
+    }
 
     const input =
       request.input ??
@@ -2636,6 +2663,53 @@ export class DesktopBackendRegistry {
     })
       .then((threads) => threads.find((thread) => thread.id === params.threadId))
       .catch(() => undefined);
+  }
+
+  private async resolveCodexThreadTurnCwd(
+    threadId: string,
+    overlay?: ThreadOverlayState,
+  ): Promise<string | undefined> {
+    const overlayCwd = resolveLinkedDirectoryCwd(overlay?.extraLinkedDirectories);
+    if (overlayCwd?.trim()) {
+      return overlayCwd.trim();
+    }
+
+    const pendingThread = this.pendingStartedThreads.get(`codex:${threadId}`);
+    const pendingCwd = resolveThreadGitSourcePath(pendingThread);
+    if (pendingCwd?.trim()) {
+      return pendingCwd.trim();
+    }
+
+    const thread = await this.findThreadForWorkspaceHandoff({
+      backend: "codex",
+      callerReason: "turn-cwd",
+      threadId,
+    });
+    return resolveThreadGitSourcePath(thread)?.trim() || undefined;
+  }
+
+  private async recordCodexWorktreeOwnerThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    worktreePath?: string;
+  }): Promise<void> {
+    const worktreePath = params.worktreePath?.trim();
+    if (params.backend !== "codex" || !worktreePath) {
+      return;
+    }
+
+    try {
+      await this.gitDirectoryService.recordCodexWorktreeOwnerThread({
+        worktreePath,
+        threadId: params.threadId,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("failed to record Codex worktree owner thread", {
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+        worktreePath,
+      });
+    }
   }
 
   private resolveHandoffWorkspaceCandidate(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -76,6 +76,7 @@ import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
+import { CodexSessionMetadataService } from "./codex-session-metadata-service";
 import { GitDirectoryService } from "./git-directory-service";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
@@ -946,6 +947,7 @@ export class DesktopBackendRegistry {
   private readonly grokClient: BackendClient;
   private readonly overlayStore: OverlayStoreLike;
   private readonly gitDirectoryService: GitDirectoryService;
+  private readonly codexSessionMetadataService: CodexSessionMetadataService;
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly createScratchProjectDirectory: () => Promise<string>;
@@ -977,6 +979,7 @@ export class DesktopBackendRegistry {
     grokClient?: BackendClient;
     overlayStore?: OverlayStoreLike;
     gitDirectoryService?: GitDirectoryService;
+    codexSessionMetadataService?: CodexSessionMetadataService;
     gitWorkspaceHandoffService?: GitWorkspaceHandoffService;
     worktreeArchiveService?: WorktreeArchiveService;
     createScratchProjectDirectory?: () => Promise<string>;
@@ -1077,6 +1080,8 @@ export class DesktopBackendRegistry {
         resolveWorktreeStorage: () =>
           getDesktopSettingsService().resolveWorktreeStorage(),
       });
+    this.codexSessionMetadataService =
+      options?.codexSessionMetadataService ?? new CodexSessionMetadataService();
     this.worktreeArchiveService =
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
     this.gitWorkspaceHandoffService =
@@ -1394,6 +1399,11 @@ export class DesktopBackendRegistry {
         worktreePath: result.linkedDirectory.worktreePath ?? result.targetPath,
       });
     }
+    await this.updateCodexSessionCwdAfterHandoff({
+      backend: request.backend,
+      cwd: result.linkedDirectory.worktreePath ?? result.targetPath,
+      threadId: request.threadId,
+    });
 
     if (result.archivedSourceWorktree) {
       await this.overlayStore.upsertWorktreeSnapshot({
@@ -2708,6 +2718,38 @@ export class DesktopBackendRegistry {
         error: error instanceof Error ? error.message : String(error),
         threadId: params.threadId,
         worktreePath,
+      });
+    }
+  }
+
+  private async updateCodexSessionCwdAfterHandoff(params: {
+    backend: AppServerBackendKind;
+    cwd?: string;
+    threadId: string;
+  }): Promise<void> {
+    const cwd = params.cwd?.trim();
+    if (params.backend !== "codex" || !cwd) {
+      return;
+    }
+
+    try {
+      const result = await this.codexSessionMetadataService.updateThreadCwd({
+        cwd,
+        threadId: params.threadId,
+      });
+      if (!result.updated && result.reason !== "unchanged") {
+        backendRegistryLog.warn("failed to update Codex session cwd after handoff", {
+          cwd,
+          reason: result.reason,
+          sessionPath: result.path,
+          threadId: params.threadId,
+        });
+      }
+    } catch (error) {
+      backendRegistryLog.warn("failed to update Codex session cwd after handoff", {
+        cwd,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
       });
     }
   }

--- a/apps/desktop/src/main/app-server/codex-session-metadata-service.ts
+++ b/apps/desktop/src/main/app-server/codex-session-metadata-service.ts
@@ -1,0 +1,179 @@
+import { readdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type CodexSessionMetadataServiceOptions = {
+  codexHome?: string;
+  homeDir?: string;
+};
+
+type UpdateCodexSessionCwdResult = {
+  path?: string;
+  reason?: "missing-session" | "missing-session-meta" | "unchanged";
+  updated: boolean;
+};
+
+type SessionFileCandidate = {
+  mtimeMs: number;
+  path: string;
+};
+
+export class CodexSessionMetadataService {
+  private readonly codexHome?: string;
+  private readonly homeDir?: string;
+
+  constructor(options: CodexSessionMetadataServiceOptions = {}) {
+    this.codexHome = options.codexHome;
+    this.homeDir = options.homeDir;
+  }
+
+  async updateThreadCwd(params: {
+    cwd: string;
+    threadId: string;
+  }): Promise<UpdateCodexSessionCwdResult> {
+    const threadId = params.threadId.trim();
+    const cwd = params.cwd.trim();
+    if (!threadId || !cwd) {
+      return { updated: false, reason: "missing-session" };
+    }
+
+    const sessionPath = await this.findSessionFile(threadId);
+    if (!sessionPath) {
+      return { updated: false, reason: "missing-session" };
+    }
+
+    const contents = await readFile(sessionPath, "utf8");
+    const hadTrailingNewline = contents.endsWith("\n");
+    const lines = contents.split("\n");
+    let changed = false;
+    let foundSessionMeta = false;
+
+    const nextLines = lines.map((line) => {
+      if (!line.trim() || foundSessionMeta) {
+        return line;
+      }
+
+      let record: unknown;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        return line;
+      }
+
+      if (!isSessionMetaRecord(record, threadId)) {
+        return line;
+      }
+
+      foundSessionMeta = true;
+      if (record.payload.cwd === cwd) {
+        return line;
+      }
+
+      changed = true;
+      return JSON.stringify({
+        ...record,
+        payload: {
+          ...record.payload,
+          cwd,
+        },
+      });
+    });
+
+    if (!foundSessionMeta) {
+      return { updated: false, path: sessionPath, reason: "missing-session-meta" };
+    }
+    if (!changed) {
+      return { updated: false, path: sessionPath, reason: "unchanged" };
+    }
+
+    const nextContents = normalizeTrailingNewline(nextLines.join("\n"), hadTrailingNewline);
+    const tempPath = `${sessionPath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tempPath, nextContents, "utf8");
+    await rename(tempPath, sessionPath);
+
+    return { updated: true, path: sessionPath };
+  }
+
+  private async findSessionFile(threadId: string): Promise<string | undefined> {
+    const sessionsRoot = path.join(this.resolveCodexHome(), "sessions");
+    const candidates = await collectSessionFileCandidates(sessionsRoot, threadId);
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    return candidates[0]?.path;
+  }
+
+  private resolveCodexHome(): string {
+    if (this.codexHome?.trim()) {
+      return this.codexHome.trim();
+    }
+
+    if (this.homeDir === undefined) {
+      const envCodexHome = process.env.CODEX_HOME?.trim();
+      if (envCodexHome) {
+        return envCodexHome;
+      }
+    }
+
+    return path.join(this.homeDir ?? os.homedir(), ".codex");
+  }
+}
+
+async function collectSessionFileCandidates(
+  root: string,
+  threadId: string,
+): Promise<SessionFileCandidate[]> {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: SessionFileCandidate[] = [];
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        candidates.push(...(await collectSessionFileCandidates(entryPath, threadId)));
+        return;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith(`${threadId}.jsonl`)) {
+        return;
+      }
+
+      const fileStat = await stat(entryPath);
+      candidates.push({ path: entryPath, mtimeMs: fileStat.mtimeMs });
+    }),
+  );
+
+  return candidates;
+}
+
+function isSessionMetaRecord(
+  record: unknown,
+  threadId: string,
+): record is {
+  payload: { cwd?: string; id?: string };
+  type: "session_meta";
+} {
+  if (!record || typeof record !== "object") {
+    return false;
+  }
+  const candidate = record as { payload?: unknown; type?: unknown };
+  if (candidate.type !== "session_meta") {
+    return false;
+  }
+  if (!candidate.payload || typeof candidate.payload !== "object") {
+    return false;
+  }
+  const payload = candidate.payload as { id?: unknown };
+  return payload.id === undefined || payload.id === threadId;
+}
+
+function normalizeTrailingNewline(contents: string, hadTrailingNewline: boolean): string {
+  if (hadTrailingNewline) {
+    return contents.endsWith("\n") ? contents : `${contents}\n`;
+  }
+
+  return contents.endsWith("\n") ? contents.slice(0, -1) : contents;
+}

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { access, mkdir, rmdir } from "node:fs/promises";
+import { access, mkdir, rmdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -22,6 +22,33 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
     env: process.env,
   });
   return stdout.trim();
+}
+
+export async function recordCodexWorktreeOwnerThread(params: {
+  worktreePath: string;
+  threadId: string;
+}): Promise<void> {
+  const worktreePath = params.worktreePath.trim();
+  const threadId = params.threadId.trim();
+  if (!worktreePath || !threadId) {
+    return;
+  }
+
+  const ownerFile = await runGit(worktreePath, [
+    "rev-parse",
+    "--git-path",
+    "codex-thread.json",
+  ]);
+  if (!ownerFile) {
+    throw new Error(`Unable to resolve Codex worktree owner file for ${worktreePath}`);
+  }
+
+  await mkdir(path.dirname(ownerFile), { recursive: true });
+  await writeFile(
+    ownerFile,
+    `${JSON.stringify({ version: 1, ownerThreadId: threadId }, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 function sanitizeBranchName(value: string): string {
@@ -395,6 +422,13 @@ export class GitDirectoryService {
       cwd: worktreePath,
       workMode: "worktree",
     };
+  }
+
+  async recordCodexWorktreeOwnerThread(params: {
+    worktreePath: string;
+    threadId: string;
+  }): Promise<void> {
+    await recordCodexWorktreeOwnerThread(params);
   }
 
   async cleanupThreadWorktrees(

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type {
   AppServerThreadSummary,
+  AppServerBackendKind,
   ArchiveThreadCleanupResult,
   DesktopWorktreeStorageLocation,
   LaunchpadWorkMode,
@@ -63,11 +64,24 @@ function sanitizeBranchName(value: string): string {
 function worktreesRootFor(
   repoRoot: string,
   storage: DesktopWorktreeStorageLocation,
-  homeDir?: string,
+  options?: {
+    backend?: AppServerBackendKind;
+    homeDir?: string;
+  },
 ): string {
+  if (storage === "user-home" && options?.backend === "codex") {
+    return codexHomeWorktreesRoot(options.homeDir);
+  }
+
   return storage === "user-home"
-    ? userHomeWorktreesRoot(homeDir)
+    ? userHomeWorktreesRoot(options?.homeDir)
     : path.join(repoRoot, ".worktrees");
+}
+
+function codexHomeWorktreesRoot(homeDir?: string): string {
+  const codexHome =
+    homeDir === undefined ? process.env.CODEX_HOME?.trim() : undefined;
+  return path.join(codexHome || path.join(homeDir ?? os.homedir(), ".codex"), "worktrees");
 }
 
 async function pathExists(target: string): Promise<boolean> {
@@ -92,12 +106,16 @@ async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
 }
 
 export async function computeWorktreePath(params: {
+  backend?: AppServerBackendKind;
   repoRoot: string;
   storage: DesktopWorktreeStorageLocation;
   homeDir?: string;
   timestamp?: number;
 }): Promise<string> {
-  const root = worktreesRootFor(params.repoRoot, params.storage, params.homeDir);
+  const root = worktreesRootFor(params.repoRoot, params.storage, {
+    backend: params.backend,
+    homeDir: params.homeDir,
+  });
   const projectName = path.basename(path.resolve(params.repoRoot)) || "project";
   const baseHash = (params.timestamp ?? Date.now()).toString(36);
 
@@ -380,7 +398,8 @@ export class GitDirectoryService {
     launchpad: Pick<
       NavigationLaunchpadDraft,
       "branchName" | "directoryKind" | "directoryLabel" | "directoryPath" | "workMode"
-    >,
+    > &
+      Partial<Pick<NavigationLaunchpadDraft, "backend">>,
   ): Promise<{ cwd?: string; workMode: LaunchpadWorkMode }> {
     if (launchpad.directoryKind === "workspace") {
       return {
@@ -411,6 +430,7 @@ export class GitDirectoryService {
       "main";
     const storage = await this.resolveStorage();
     const worktreePath = await computeWorktreePath({
+      backend: launchpad.backend,
       repoRoot,
       storage,
       homeDir: this.homeDir,

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -313,6 +313,7 @@ export class GitWorkspaceHandoffService {
 
     const storage = await this.resolveStorage();
     const targetPath = await computeWorktreePath({
+      backend: context.backend,
       repoRoot: context.repositoryPath,
       storage,
       homeDir: this.homeDir,
@@ -359,6 +360,7 @@ export class GitWorkspaceHandoffService {
     const baseSha = context.headSha;
     const storage = await this.resolveStorage();
     const targetPath = await computeWorktreePath({
+      backend: context.backend,
       repoRoot: context.repositoryPath,
       storage,
       homeDir: this.homeDir,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3125,6 +3125,7 @@ function toCodexUserInput(input: AppServerTurnInputItem): CodexUserInput {
 function buildTurnStartPayload(params: {
   threadId: string;
   input: AppServerTurnInputItem[];
+  cwd?: string;
   model?: string;
   reasoningEffort?: string;
   serviceTier?: string;
@@ -3138,6 +3139,9 @@ function buildTurnStartPayload(params: {
     input: params.input.map(toCodexUserInput),
   };
 
+  if (params.cwd?.trim()) {
+    base.cwd = params.cwd.trim();
+  }
   if (params.model?.trim()) {
     base.model = params.model.trim();
   }
@@ -3835,6 +3839,7 @@ export class CodexAppServerClient {
   async startTurn(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
+    cwd?: string;
     approvalPolicy?: string;
     sandbox?: string;
     model?: string;
@@ -3850,6 +3855,7 @@ export class CodexAppServerClient {
       methods: ["thread/resume"],
       payloads: buildThreadResumePayloads({
         threadId: params.threadId,
+        cwd: params.cwd,
         approvalPolicy: params.approvalPolicy,
         sandbox: params.sandbox,
         model: params.model,
@@ -3867,8 +3873,10 @@ export class CodexAppServerClient {
         buildTurnStartPayload({
           threadId: params.threadId,
           input: params.input,
+          cwd: params.cwd,
           model: params.model,
           reasoningEffort: params.reasoningEffort,
+          serviceTier: params.serviceTier,
           collaborationMode: params.collaborationMode,
           collaborationFallbackModel:
             params.model?.trim() || extractStringProperty(resumeResult, "model"),

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -41,6 +41,7 @@ export class ReplayClient {
   private lastStartTurnParams?: {
     threadId: string;
     input: AppServerTurnInputItem[];
+    cwd?: string;
     model?: string;
     collaborationMode?: AppServerCollaborationModeRequest;
     serviceTier?: string;
@@ -141,6 +142,7 @@ export class ReplayClient {
   async startTurn(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
+    cwd?: string;
     model?: string;
     collaborationMode?: AppServerCollaborationModeRequest;
     serviceTier?: string;
@@ -228,6 +230,7 @@ export class ReplayClient {
     | {
         threadId: string;
         input: AppServerTurnInputItem[];
+        cwd?: string;
         model?: string;
         collaborationMode?: AppServerCollaborationModeRequest;
         serviceTier?: string;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1308,6 +1308,9 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
     setPendingSteer(undefined);
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
   }, [
     composerScopeKey,
     composerSupportsSkillTokens,
@@ -2230,6 +2233,9 @@ export function Composer(props: ComposerProps) {
         stickySettingsChanged: true,
       },
     );
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
   };
 
   const handleThreadModelSettingsPatch = (

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -138,7 +138,12 @@ function splitTextContent(text: string): JSONContent[] {
 function buildTiptapContent(
   value: string,
   skillTokens: ComposerSkillToken[],
+  options?: { markdownConversion?: boolean },
 ): JSONContent {
+  if (options?.markdownConversion && skillTokens.length === 0) {
+    return buildMarkdownTiptapContent(value);
+  }
+
   const sortedTokens = [...skillTokens].sort((left, right) => {
     if (left.index !== right.index) {
       return left.index - right.index;
@@ -173,6 +178,69 @@ function buildTiptapContent(
         content: content.length > 0 ? content : undefined,
       },
     ],
+  };
+}
+
+function buildMarkdownTiptapContent(value: string): JSONContent {
+  const lines = value.replace(/\r\n/g, "\n").split("\n");
+  const content: JSONContent[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    const codeFence = line.match(/^```([A-Za-z0-9_-]*)\s*$/);
+    if (codeFence) {
+      index += 1;
+      const codeLines: string[] = [];
+      while (index < lines.length && !/^```\s*$/.test(lines[index] ?? "")) {
+        codeLines.push(lines[index] ?? "");
+        index += 1;
+      }
+      if (index < lines.length) {
+        index += 1;
+      }
+      content.push({
+        type: "codeBlock",
+        attrs: { language: codeFence[1] || null },
+        content: codeLines.length > 0
+          ? [{ type: "text", text: codeLines.join("\n") }]
+          : undefined,
+      });
+      continue;
+    }
+
+    if (line.trim().length === 0) {
+      content.push({ type: "paragraph" });
+      index += 1;
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (
+      index < lines.length &&
+      (lines[index] ?? "").trim().length > 0 &&
+      !/^```([A-Za-z0-9_-]*)\s*$/.test(lines[index] ?? "")
+    ) {
+      paragraphLines.push(lines[index] ?? "");
+      index += 1;
+    }
+    content.push({
+      type: "paragraph",
+      content: splitTextContent(paragraphLines.join("\n")),
+    });
+  }
+
+  while (
+    content.length > 1 &&
+    content.at(-1)?.type === "paragraph" &&
+    !content.at(-1)?.content
+  ) {
+    content.pop();
+  }
+
+  return {
+    type: "doc",
+    content: content.length > 0 ? content : [{ type: "paragraph" }],
   };
 }
 
@@ -727,8 +795,12 @@ export const ComposerTiptapInput = forwardRef<
 
   propsRef.current = props;
   const initialContent = useMemo(
-    () => props.editorDocument ?? buildTiptapContent(props.value, props.skillTokens),
-    []
+    () =>
+      props.editorDocument ??
+      buildTiptapContent(props.value, props.skillTokens, {
+        markdownConversion: props.markdownConversion,
+      }),
+    [],
   );
   const editor = useEditor({
     content: initialContent,
@@ -904,7 +976,9 @@ export const ComposerTiptapInput = forwardRef<
 
     pendingExternalSignatureRef.current = propsSignature;
     editor.commands.setContent(
-      buildTiptapContent(props.value, props.skillTokens),
+      buildTiptapContent(props.value, props.skillTokens, {
+        markdownConversion: props.markdownConversion,
+      }),
       { emitUpdate: false },
     );
     pendingExternalSignatureRef.current = undefined;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { shortenDerivedThreadTitle } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadNavigation } from "../useThreadNavigation";
@@ -663,6 +664,113 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.observedGitBranch).toBe("HEAD");
     expect(result.current.directories[0]?.threadKeys).toEqual(["codex:thread-new"]);
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
+  });
+
+  it("keeps a launchpad prompt-derived title when the hydrated thread only has a fallback id title", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const threadId = "019df3a2-75b2-73d1-a273-5f94ac425966";
+    const prompt =
+      "What went wrong with Discord? Investigate the adapter path and explain the failure";
+    const initialSnapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt,
+            workMode: "worktree" as const,
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(initialSnapshot)
+      .mockResolvedValueOnce({
+        ...initialSnapshot,
+        inboxThreadKeys: [`codex:${threadId}`],
+        threads: [
+          {
+            id: threadId,
+            title: threadId,
+            titleSource: "fallback" as const,
+            summary: undefined,
+            source: "codex" as const,
+            linkedDirectories: [
+              {
+                id: directoryKey,
+                label: "PwrAgent",
+                path: "/Users/huntharo/github/PwrAgent",
+                kind: "worktree" as const,
+              },
+            ],
+            gitBranch: "HEAD",
+            observedGitBranch: "HEAD",
+            inbox: {
+              inInbox: true,
+              reason: "new-thread" as const,
+            },
+            updatedAt: 2,
+          },
+        ],
+        directories: [
+          {
+            ...initialSnapshot.directories[0]!,
+            threadKeys: [`codex:${threadId}`],
+            needsAttentionCount: 1,
+            launchpad: undefined,
+          },
+        ],
+      });
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId,
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe(prompt);
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    expect(result.current.selectedThread?.id).toBe(threadId);
+    expect(result.current.selectedThread?.title).toBe(shortenDerivedThreadTitle(prompt));
+    expect(result.current.selectedThread?.titleSource).toBe("derived");
+    expect(result.current.selectedThread?.title).not.toBe(threadId);
   });
 
   it("does not let a materialized thread refresh override a newer user thread selection", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1140,12 +1140,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   }, [optimisticThread, state.response?.threads]);
 
   const directories = useMemo(
-    () =>
-      projectOptimisticThreadIntoDirectories(
+    () => {
+      if (!optimisticThread) {
+        return state.response?.directories ?? [];
+      }
+
+      const optimisticThreadKey = buildThreadIdentityKey(
+        optimisticThread.source,
+        optimisticThread.id
+      );
+      const hasHydratedThread = state.response?.threads.some(
+        (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
+      );
+
+      return projectOptimisticThreadIntoDirectories(
         state.response?.directories ?? [],
-        optimisticThread
-      ),
-    [optimisticThread, state.response?.directories]
+        hasHydratedThread ? undefined : optimisticThread
+      );
+    },
+    [optimisticThread, state.response?.directories, state.response?.threads]
   );
 
   const inboxThreads = useMemo(() => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -14,7 +14,7 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import { buildThreadIdentityKey, shortenDerivedThreadTitle } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 
 export type BrowseMode = "inbox" | "recents" | "directories";
@@ -149,6 +149,13 @@ function threadSummariesEqual(
     linkedDirectoriesEqual(left.linkedDirectories, right.linkedDirectories) &&
     worktreeSnapshotsEqual(left.worktreeSnapshots, right.worktreeSnapshots) &&
     threadInboxEqual(left.inbox, right.inbox)
+  );
+}
+
+function hasPlaceholderThreadTitle(thread: NavigationThreadSummary): boolean {
+  return (
+    thread.titleSource === "fallback" &&
+    (thread.title === thread.id || thread.title === "Untitled thread")
   );
 }
 
@@ -611,11 +618,15 @@ function buildOptimisticThreadFromLaunchpad(params: {
   workMode: NavigationLaunchpadDraft["workMode"];
   optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
 }): NavigationThreadSummary {
+  const titlePrompt =
+    params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
+  const derivedTitle = shortenDerivedThreadTitle(titlePrompt);
+
   return {
     id: params.threadId,
-    title: "Untitled thread",
-    titleSource: "fallback",
-    summary: params.launchpad.prompt.trim() || undefined,
+    title: derivedTitle ?? "Untitled thread",
+    titleSource: derivedTitle ? "derived" : "fallback",
+    summary: titlePrompt || undefined,
     projectKey: params.launchpad.directoryPath,
     source: params.backend,
     executionMode: params.executionMode,
@@ -644,6 +655,26 @@ function buildOptimisticThreadFromLaunchpad(params: {
       inInbox: true,
       reason: "new-thread",
     },
+  };
+}
+
+function mergeHydratedThreadWithOptimisticTitle(
+  thread: NavigationThreadSummary,
+  optimisticThread: NavigationThreadSummary,
+): NavigationThreadSummary {
+  if (optimisticThread.titleSource !== "derived") {
+    return thread;
+  }
+
+  if (!hasPlaceholderThreadTitle(thread)) {
+    return thread;
+  }
+
+  return {
+    ...thread,
+    summary: thread.summary ?? optimisticThread.summary,
+    title: optimisticThread.title,
+    titleSource: optimisticThread.titleSource,
   };
 }
 
@@ -895,9 +926,25 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
             (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
           )
         ) {
-          setOptimisticThread((current) =>
-            current?.optimisticUserMessage ? current : undefined
+          const hydratedOptimisticThread = response.threads.find(
+            (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
           );
+
+          setOptimisticThread((current) => {
+            if (current?.optimisticUserMessage) {
+              return current;
+            }
+
+            if (
+              current?.titleSource === "derived" &&
+              hydratedOptimisticThread &&
+              hasPlaceholderThreadTitle(hydratedOptimisticThread)
+            ) {
+              return current;
+            }
+
+            return undefined;
+          });
         }
 
         setSelectedItemKey((current) => {
@@ -1121,14 +1168,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       (thread) => buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
     );
     if (hasHydratedThread) {
-      if (!optimisticThread.optimisticUserMessage) {
-        return currentThreads;
-      }
-
       return currentThreads.map((thread) =>
         buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
           ? {
-              ...thread,
+              ...mergeHydratedThreadWithOptimisticTitle(thread, optimisticThread),
               optimisticUserMessage:
                 thread.optimisticUserMessage ?? optimisticThread.optimisticUserMessage,
             }

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -362,6 +362,45 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("groups PwrAgent-managed worktree paths under the stable same-label home repo row", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-home",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/claude-worktrees/PwrAgnt/modest/apps/desktop",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/claude-worktrees/PwrAgnt/modest/apps/desktop",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-worktree",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragent/worktrees/mord46hf/PwrAgnt",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.pwragent/worktrees/mord46hf/PwrAgnt",
+              kind: "local",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/claude-worktrees/PwrAgnt/modest/apps/desktop",
+        label: "PwrAgnt",
+        path: "/Users/huntharo/claude-worktrees/PwrAgnt/modest/apps/desktop",
+        threadKeys: ["codex:thread-home", "codex:thread-worktree"],
+      }),
+    ]);
+  });
+
   it("uses handoff overlay workspace metadata as the active local/worktree directory", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -52,6 +52,12 @@ function pathFromDirectoryKey(directoryKey: string): string | undefined {
   return directoryPath?.trim() || undefined;
 }
 
+function isToolManagedWorktreePath(value: string): boolean {
+  return /[\\/]\.(?:codex|pwrag(?:ent|nt))[\\/]worktrees[\\/][^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/.test(
+    value,
+  );
+}
+
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
   // Match both current ".pwragent" and legacy ".pwragnt" home directory names
   // so pre-rebrand thread data classifies correctly.
@@ -126,6 +132,9 @@ function collectStablePathByLabel(
     for (const directory of thread.linkedDirectories) {
       const descriptor = classifyDirectory(directory);
       if (!descriptor.path || descriptor.kind !== "directory") {
+        continue;
+      }
+      if (isToolManagedWorktreePath(descriptor.path)) {
         continue;
       }
 
@@ -206,14 +215,21 @@ export function buildDirectorySummaries(params: {
     const seenDescriptors = new Set<string>();
     for (const directory of thread.linkedDirectories) {
       const descriptor = classifyDirectory(directory);
+      const stablePath = stablePathByLabel.get(descriptor.label);
       const normalizedDescriptor =
-        descriptor.path || descriptor.kind !== "directory"
+        descriptor.path && isToolManagedWorktreePath(descriptor.path) && stablePath
+          ? {
+              ...descriptor,
+              key: `directory:${stablePath}`,
+              path: stablePath,
+            }
+          : descriptor.path || descriptor.kind !== "directory"
           ? descriptor
-          : stablePathByLabel.get(descriptor.label)
+          : stablePath
             ? {
                 ...descriptor,
-                key: `directory:${stablePathByLabel.get(descriptor.label)}`,
-                path: stablePathByLabel.get(descriptor.label),
+                key: `directory:${stablePath}`,
+                path: stablePath,
               }
             : descriptor;
       if (seenDescriptors.has(normalizedDescriptor.key)) {


### PR DESCRIPTION
## Summary

I fixed the desktop directory launchpad path normalization that could show the same materialized worktree thread under duplicate same-named directory rows.

I also fixed the launchpad composer path where changing Workspace mode could leave the Tiptap Markdown composer unfocused and flatten fenced-code formatting after reopening the launchpad.

I also restored prompt-derived interim titles for materialized launchpad threads so Codex fallback GUID titles do not replace the user's first prompt while title generation is pending.

I also mirrored Codex Desktop's worktree ownership marker and place Codex backend worktrees under Codex's own worktree root so PwrAgent-created Codex worktree threads are discoverable by Codex Desktop. I fixed handoff resumes so subsequent Codex turns run in the current worktree CWD, and I update Codex session metadata during handoff so Codex Desktop itself resumes the thread from the handed-off worktree.

## Root Cause

The sidebar could temporarily combine an optimistic launchpad thread with the hydrated backend thread. When the backend reported a managed worktree path such as `~/.pwragent/worktrees/<id>/PwrAgnt`, directory grouping treated that path as a separate stable directory row instead of grouping it under the existing same-label source directory.

The WYSIWYG Tiptap composer also rebuilt saved Markdown as plain paragraph content, so a saved fenced code block could lose its block structure when the launchpad was rehydrated.

The interim GUID title regression came from the pending-started-thread path added in `76559aab` and carried into main by `cf9c853e`: backend placeholder rows used `threadId` as the fallback title, and the renderer dropped the optimistic launchpad title as soon as the hydrated backend row appeared.

Codex Desktop records worktree ownership in the Git worktree metadata file `codex-thread.json`, but its worker also filters owner-marked worktrees to paths under `CODEX_HOME/worktrees` (default `~/.codex/worktrees`). PwrAgent was creating direct Codex worktree launches under `~/.pwragent/worktrees`, so even after the owner marker existed Codex Desktop still filtered those worktrees out. Local-to-worktree handoffs updated PwrAgent overlay state, but the Codex session JSONL still had the original `session_meta.cwd`; when Codex Desktop opened or resumed the thread, it continued using the local checkout.

## Changes

- Group `.pwragent`, `.pwragnt`, and `.codex` managed worktree paths under the existing same-label stable directory row when one is available.
- Stop projecting optimistic launchpad directory membership once the hydrated backend thread exists.
- Rehydrate saved fenced code blocks in the Tiptap WYSIWYG Markdown composer.
- Restore composer focus after launchpad open and Workspace mode changes.
- Use `Untitled thread` for backend pending fallback rows instead of the thread id.
- Preserve a prompt-derived optimistic launchpad title across hydrated backend fallback rows until a real non-placeholder title arrives.
- Create Codex backend user-home worktrees under `CODEX_HOME/worktrees` / `~/.codex/worktrees` instead of `~/.pwragent/worktrees`.
- Write Codex-compatible `{ version: 1, ownerThreadId }` metadata to each new Codex worktree's `codex-thread.json`.
- Record the same Codex worktree owner metadata during local-to-worktree handoffs.
- Resume/start Codex turns with the current linked worktree CWD after handoff or immediate launchpad materialization.
- Update the Codex session JSONL `session_meta.cwd` after Codex handoff in either direction, so Codex Desktop resumes the same thread from the new workspace.
- Added E2E coverage for duplicate directory rows, New Worktree composer focus/Markdown preservation, Codex worktree owner metadata, Codex worktree root placement, worktree CWD propagation, and Codex session CWD metadata after handoff.
- Added unit coverage for the launchpad prompt-derived title regression, Codex worktree ownership/CWD protocol paths, and Codex session metadata rewriting.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/codex-session-metadata-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test:desktop-e2e apps/desktop/e2e/directory-launchpad-workspace.spec.ts`
- `pnpm typecheck`
- `pnpm lint`
