### PR TITLE
fix(desktop): preserve Tiptap rendered drafts

### DIFF
--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -297,3 +297,52 @@ test("keeps Tiptap launchpad and reply drafts with pasted images across switchin
     await fixture.cleanup();
   }
 });
+
+test("restores an already-open Tiptap WYSIWYG reply as rendered markdown after switching away", async () => {
+  const fixture = await createComposerDraftPersistenceFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGENT_EXPERIMENTAL_CHAT_REPLY_COMPOSER:
+        "tiptap-wysiwyg-markdown-chips",
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openExistingThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("```ts ");
+    await app.window.keyboard.type("const threadId = 'thread-existing';");
+    await app.window.keyboard.press("Shift+Enter");
+    await app.window.keyboard.type("return threadId;");
+
+    const expectedMarkdown =
+      "```ts\nconst threadId = 'thread-existing';\nreturn threadId;\n```";
+    await expect(
+      tiptapInput.locator("pre", {
+        hasText: "const threadId = 'thread-existing';\nreturn threadId;",
+      }),
+    ).toBeVisible();
+    await expect(tiptapInput).toHaveAttribute("data-value", expectedMarkdown);
+
+    await openDirectoryLaunchpad(app);
+    await openExistingThread(app);
+
+    const restoredTiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await expect(restoredTiptapInput).toHaveAttribute(
+      "data-value",
+      expectedMarkdown,
+    );
+    await expect(
+      restoredTiptapInput.locator("pre", {
+        hasText: "const threadId = 'thread-existing';\nreturn threadId;",
+      }),
+    ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -56,6 +56,7 @@ export async function launchElectronApp(params: {
   Object.assign(env, {
     HOME: homeRoot,
     NODE_ENV: "production",
+    PWRAGENT_EXPERIMENTAL_CHAT_REPLY_COMPOSER: "textarea",
     PWRAGENT_REPLAY_FIXTURE_PATH: params.fixturePath,
   });
   delete env.ELECTRON_RENDERER_URL;

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -371,7 +371,7 @@ describe("DesktopSettingsService", () => {
 
     expect(snapshot.configError).toContain("Invalid TOML line");
     expect(snapshot.experimental.chatReplyComposer).toEqual({
-      value: "textarea",
+      value: "tiptap-wysiwyg-markdown-chips",
       source: "default",
     });
   });

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -9,7 +9,10 @@ import type {
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
-import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
+import {
+  DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
+  DESKTOP_WORKTREE_STORAGE_DEFAULT,
+} from "@pwragent/shared";
 import {
   mergeDesktopSettingsConfig,
   readDesktopSettingsConfig,
@@ -313,7 +316,7 @@ export class DesktopSettingsService {
     }
 
     return {
-      value: configValue ?? "textarea",
+      value: configValue ?? DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
       source: configValue === undefined ? "default" : "config",
       error: envValue.error,
     };

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -54,7 +54,7 @@ describe("App", () => {
       },
       experimental: {
         chatReplyComposer: {
-          value: "textarea",
+          value: "tiptap-wysiwyg-markdown-chips",
           source: "default",
         },
       },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -44,6 +44,7 @@ import {
 import { parseReviewCommand } from "../../../../shared/review-command";
 import {
   ComposerRichInput,
+  type ComposerRichInputChangeMetadata,
   type ComposerRichInputHandle,
   type ComposerSkillToken,
 } from "./ComposerRichInput";
@@ -850,6 +851,7 @@ export function Composer(props: ComposerProps) {
     scopeKey: composerScopeKey,
     snapshot: {
       draft: savedInitialDraft?.draft ?? hydratedInitialLaunchpad?.draft ?? "",
+      editorDocument: savedInitialDraft?.editorDocument,
       imageAttachments:
         savedInitialDraft?.imageAttachments ??
         props.launchpad?.imageAttachments ??
@@ -863,6 +865,9 @@ export function Composer(props: ComposerProps) {
   const launchpadUpdateRef = useRef(props.onUpdateLaunchpad);
   const [draft, setDraft] = useState(
     latestDraftSnapshotRef.current.snapshot.draft
+  );
+  const [editorDocument, setEditorDocument] = useState(
+    latestDraftSnapshotRef.current.snapshot.editorDocument
   );
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const workspaceMenuRef = useDismissableMenu<HTMLDivElement>(
@@ -933,12 +938,14 @@ export function Composer(props: ComposerProps) {
     scopeKey: composerScopeKey,
     snapshot: {
       draft,
+      editorDocument,
       imageAttachments,
       skillTokens: composerSupportsSkillTokens ? skillTokens : [],
     },
   };
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
     deletedSkillTokenHistoryRef.current = [];
+    setEditorDocument(undefined);
     if (!composerSupportsSkillTokens) {
       setDraft(nextDraft);
       setSkillTokens([]);
@@ -951,6 +958,7 @@ export function Composer(props: ComposerProps) {
   };
   const clearComposerDraft = (): void => {
     deletedSkillTokenHistoryRef.current = [];
+    setEditorDocument(undefined);
     setDraft("");
     setSkillTokens([]);
   };
@@ -959,6 +967,7 @@ export function Composer(props: ComposerProps) {
     nextSkillTokens?: ComposerSkillToken[],
   ): void => {
     deletedSkillTokenHistoryRef.current = [];
+    setEditorDocument(undefined);
     if (!composerSupportsSkillTokens) {
       setSkillTokens([]);
     } else if (nextSkillTokens) {
@@ -1012,6 +1021,7 @@ export function Composer(props: ComposerProps) {
   const clearSubmittedComposerDraft = (scopeKey: string): void => {
     const emptySnapshot: ComposerDraftSnapshot = {
       draft: "",
+      editorDocument: undefined,
       imageAttachments: [],
       skillTokens: [],
     };
@@ -1162,6 +1172,7 @@ export function Composer(props: ComposerProps) {
 
     const previousSnapshot = {
       draft,
+      editorDocument,
       imageAttachments,
       skillTokens,
     };
@@ -1177,6 +1188,7 @@ export function Composer(props: ComposerProps) {
     if (props.thread) {
       const saved = draftStore.get(composerScopeKey);
       setDraft(saved?.draft ?? "");
+      setEditorDocument(saved?.editorDocument);
       setImageAttachments(saved?.imageAttachments ?? []);
       setSkillTokens(saved?.skillTokens ?? []);
     }
@@ -1188,7 +1200,7 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setQueuedTurn(undefined);
     setPendingSteer(undefined);
-  }, [composerScopeKey, draft, imageAttachments, skillTokens]);
+  }, [composerScopeKey, draft, editorDocument, imageAttachments, skillTokens]);
 
   useEffect(() => {
     setActiveSkillIndex(0);
@@ -1281,6 +1293,7 @@ export function Composer(props: ComposerProps) {
     const saved = draftStore.get(composerScopeKey);
     if (saved) {
       setDraft(saved.draft);
+      setEditorDocument(saved.editorDocument);
       setImageAttachments(saved.imageAttachments);
       setSkillTokens(composerSupportsSkillTokens ? saved.skillTokens : []);
     } else {
@@ -2037,6 +2050,7 @@ export function Composer(props: ComposerProps) {
       const nextAttachments = current.filter((attachment) => attachment.id !== id);
       saveComposerDraftSnapshot(composerScopeKey, {
         draft,
+        editorDocument,
         imageAttachments: nextAttachments,
         skillTokens,
       });
@@ -2092,6 +2106,7 @@ export function Composer(props: ComposerProps) {
   const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
     const pasteDraft = draft;
+    const pasteEditorDocument = editorDocument;
     const pasteImageAttachments = imageAttachments;
 
     try {
@@ -2145,11 +2160,13 @@ export function Composer(props: ComposerProps) {
       if (activeComposerScopeKeyRef.current !== pasteScope.key) {
         const saved = draftStore.get(pasteScope.key) ?? {
           draft: pasteDraft,
+          editorDocument: pasteEditorDocument,
           imageAttachments: pasteImageAttachments,
           skillTokens,
         };
         const nextSnapshot = {
           draft: saved.draft,
+          editorDocument: saved.editorDocument,
           imageAttachments: [...saved.imageAttachments, ...nextAttachments],
           skillTokens: saved.skillTokens,
         };
@@ -2162,6 +2179,7 @@ export function Composer(props: ComposerProps) {
         const mergedAttachments = [...current, ...nextAttachments];
         const nextSnapshot = {
           draft,
+          editorDocument,
           imageAttachments: mergedAttachments,
           skillTokens,
         };
@@ -2566,10 +2584,12 @@ export function Composer(props: ComposerProps) {
       skillTokens,
     });
     flushSync(() => {
+      setEditorDocument(undefined);
       setSkillTokens(nextSkillTokens);
     });
     saveComposerDraftSnapshot(composerScopeKey, {
       draft,
+      editorDocument: undefined,
       imageAttachments,
       skillTokens: nextSkillTokens,
     });
@@ -2852,6 +2872,7 @@ export function Composer(props: ComposerProps) {
   const handleComposerChange = (
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
+    metadata?: ComposerRichInputChangeMetadata,
   ): void => {
     unmarkComposerDraftSubmitted(composerScopeKey);
     const pendingProgrammaticChange =
@@ -2894,8 +2915,10 @@ export function Composer(props: ComposerProps) {
       : [];
 
     updateVisibleDraft(nextDraft, nextSkillTokens);
+    setEditorDocument(metadata?.editorDocument);
     saveComposerDraftSnapshot(composerScopeKey, {
       draft: nextDraft,
+      editorDocument: metadata?.editorDocument,
       imageAttachments,
       skillTokens: storedSkillTokens,
     });
@@ -3293,6 +3316,7 @@ export function Composer(props: ComposerProps) {
               composerImplementation === "tiptap-wysiwyg-markdown-chips"
             }
             placeholder={composerPlaceholder}
+            editorDocument={editorDocument}
             skillTokens={skillTokens}
             value={draft}
             onChange={handleComposerChange}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerRichInput.tsx
@@ -12,11 +12,16 @@ import {
   type MouseEvent,
 } from "react";
 import type { AppServerSkillSummary } from "@pwragent/shared";
+import type { JSONContent } from "@tiptap/react";
 import { SkillChip } from "./SkillChip";
 
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
+};
+
+export type ComposerRichInputChangeMetadata = {
+  editorDocument?: JSONContent;
 };
 
 export type ComposerRichInputHandle = {
@@ -34,7 +39,11 @@ export type ComposerRichInputProps = {
   disabled?: boolean;
   id: string;
   label: string;
-  onChange: (value: string, skillTokens?: ComposerSkillToken[]) => void;
+  onChange: (
+    value: string,
+    skillTokens?: ComposerSkillToken[],
+    metadata?: ComposerRichInputChangeMetadata,
+  ) => void;
   onBeforeInput?: (event: FormEvent<HTMLDivElement>) => void;
   onBeforeInputCapture?: (event: FormEvent<HTMLDivElement>) => void;
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -22,6 +22,7 @@ import type {
 } from "./ComposerRichInput";
 
 type ComposerTiptapInputProps = ComposerRichInputProps & {
+  editorDocument?: JSONContent;
   markdownConversion?: boolean;
 };
 
@@ -726,7 +727,7 @@ export const ComposerTiptapInput = forwardRef<
 
   propsRef.current = props;
   const initialContent = useMemo(
-    () => buildTiptapContent(props.value, props.skillTokens),
+    () => props.editorDocument ?? buildTiptapContent(props.value, props.skillTokens),
     []
   );
   const editor = useEditor({
@@ -801,7 +802,10 @@ export const ComposerTiptapInput = forwardRef<
       const pendingSignature = pendingExternalSignatureRef.current;
       if (
         pendingSignature &&
-        getContentSignature(next) !== pendingSignature
+        getContentSignature({
+          value: next.value,
+          skillTokens: next.skillTokens,
+        }) !== pendingSignature
       ) {
         return;
       }
@@ -811,7 +815,9 @@ export const ComposerTiptapInput = forwardRef<
         nextEditor.state.selection.from,
         readMode,
       );
-      propsRef.current.onChange(next.value, next.skillTokens);
+      propsRef.current.onChange(next.value, next.skillTokens, {
+        editorDocument: nextEditor.getJSON(),
+      });
     },
     onSelectionUpdate: ({ editor: nextEditor }) => {
       selectionIndexRef.current = getDraftIndexAtPosition(
@@ -857,7 +863,26 @@ export const ComposerTiptapInput = forwardRef<
 
     const current = readTiptapContent(editor, readMode);
     const currentSignature = getContentSignature(current);
+    const currentEditorDocumentSignature = JSON.stringify(editor.getJSON());
+    const nextEditorDocumentSignature = props.editorDocument
+      ? JSON.stringify(props.editorDocument)
+      : undefined;
     if (currentSignature === propsSignature) {
+      if (
+        !nextEditorDocumentSignature ||
+        currentEditorDocumentSignature === nextEditorDocumentSignature
+      ) {
+        pendingExternalSignatureRef.current = undefined;
+        return;
+      }
+    }
+
+    if (
+      nextEditorDocumentSignature &&
+      currentEditorDocumentSignature !== nextEditorDocumentSignature
+    ) {
+      pendingExternalSignatureRef.current = propsSignature;
+      editor.commands.setContent(props.editorDocument!, { emitUpdate: false });
       pendingExternalSignatureRef.current = undefined;
       return;
     }
@@ -892,7 +917,14 @@ export const ComposerTiptapInput = forwardRef<
         getPositionAtDraftIndex(editor, nextSelectionIndex, readMode),
       );
     }
-  }, [editor, props.skillTokens, props.value, propsSignature, readMode]);
+  }, [
+    editor,
+    props.editorDocument,
+    props.skillTokens,
+    props.value,
+    propsSignature,
+    readMode,
+  ]);
 
   useEffect(() => {
     if (!editor) {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -1,9 +1,11 @@
 import { useMemo, useRef } from "react";
+import type { JSONContent } from "@tiptap/react";
 import type { NavigationLaunchpadImageAttachment } from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerRichInput";
 
 export type ComposerDraftSnapshot = {
   draft: string;
+  editorDocument?: JSONContent;
   imageAttachments: NavigationLaunchpadImageAttachment[];
   skillTokens: ComposerSkillToken[];
 };

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -2,12 +2,14 @@ import type { DesktopChatReplyComposer, DesktopSettingsSnapshot } from "@pwragen
 import { sourceBadge } from "./settings-fields";
 
 const COMPOSER_OPTIONS: Array<{
+  default?: boolean;
   label: string;
   value: DesktopChatReplyComposer;
 }> = [
   { label: "Textarea", value: "textarea" },
   { label: "TipTap raw Markdown + chips", value: "tiptap-chips" },
   {
+    default: true,
     label: "TipTap WYSIWYG Markdown + chips",
     value: "tiptap-wysiwyg-markdown-chips",
   },
@@ -51,7 +53,12 @@ export function ExperimentalSettings(props: {
                 void props.onComposerChange(option.value);
               }}
             >
-              {option.label}
+              <span>{option.label}</span>
+              {option.default ? (
+                <span aria-hidden="true" className="settings-segmented__meta">
+                  Default
+                </span>
+              ) : null}
             </button>
           ))}
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -27,7 +27,7 @@ function createSnapshot(
     },
     experimental: {
       chatReplyComposer: {
-        value: "textarea",
+        value: "tiptap-wysiwyg-markdown-chips",
         source: "default",
       },
     },

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -8,6 +8,7 @@ import type {
   ReplaceDesktopSettingsSecretRequest,
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
+import { DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 
@@ -138,7 +139,10 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     () => ({
       clearSecret,
       composerImplementation:
-        snapshot?.experimental.chatReplyComposer.value ?? "textarea",
+        snapshot?.experimental.chatReplyComposer.value ??
+        (desktopApi?.readSettings
+          ? DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT
+          : "textarea"),
       error,
       loading,
       refresh,
@@ -149,6 +153,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
     }),
     [
       clearSecret,
+      desktopApi?.readSettings,
       error,
       loading,
       refresh,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1461,6 +1461,11 @@ textarea,
 }
 
 .settings-segmented__button {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
   min-height: 34px;
   appearance: none;
   cursor: pointer;
@@ -1473,6 +1478,13 @@ textarea,
   font-weight: 650;
 }
 
+.settings-segmented__meta {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
 .settings-segmented__button:hover,
 .settings-segmented__button:focus-visible,
 .settings-segmented__button.is-active {
@@ -1480,6 +1492,12 @@ textarea,
   background: var(--accent-soft);
   color: var(--text-primary);
   outline: none;
+}
+
+.settings-segmented__button:hover .settings-segmented__meta,
+.settings-segmented__button:focus-visible .settings-segmented__meta,
+.settings-segmented__button.is-active .settings-segmented__meta {
+  color: var(--text-secondary);
 }
 
 .settings-secret {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -20,7 +20,7 @@ describe("desktop settings contracts", () => {
       },
       experimental: {
         chatReplyComposer: {
-          value: "textarea",
+          value: "tiptap-wysiwyg-markdown-chips",
           source: "default",
         },
       },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -10,6 +10,9 @@ export const DESKTOP_CHAT_REPLY_COMPOSERS = [
 export type DesktopChatReplyComposer =
   (typeof DESKTOP_CHAT_REPLY_COMPOSERS)[number];
 
+export const DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT: DesktopChatReplyComposer =
+  "tiptap-wysiwyg-markdown-chips";
+
 export const DESKTOP_WORKTREE_STORAGE_LOCATIONS = [
   "in-repo",
   "user-home",


### PR DESCRIPTION
## Summary

I made Tiptap WYSIWYG Markdown the default desktop composer and fixed draft restoration so already-rendered Tiptap content is preserved when switching away from a thread or launchpad and returning.

The key change is that composer draft snapshots now keep the Tiptap editor document in memory alongside the canonical markdown text, skill tokens, and pasted images. That means a rendered code block, including the exact markdown text behind it, restores as the same rendered editor state instead of being rebuilt from a lossy markdown string.

## Verification

I verified:

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm --filter @pwragent/desktop test:e2e composer-draft-persistence-regression.spec.ts`

The E2E coverage now includes a WYSIWYG Tiptap reply with a rendered fenced code block that survives switching away to a directory launchpad and back.
