### PR TITLE
ci(release): guard desktop release metadata

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: release
+description: Prepare, validate, tag, publish, and monitor guarded PwrAgent desktop releases. Use when the user asks to release PwrAgent, prepare a vX.Y.Z or vX.Y.Z-prerelease tag, update release notes or CHANGELOG.md for a desktop release, verify package.json/tag/changelog alignment, trigger the macOS signed/notarized release workflow, or inspect release workflow status.
+---
+
+# Release
+
+Use this skill for PwrAgent desktop releases published by
+`.github/workflows/release.yml`.
+
+## Read First
+
+Read these files before changing release metadata:
+
+1. [../../../docs/desktop-release-runbook.md](../../../docs/desktop-release-runbook.md)
+2. [../../../docs/desktop-distribution-phase-2-runbook.md](../../../docs/desktop-distribution-phase-2-runbook.md) when the release affects update feeds or distribution repos
+3. [../../../.github/workflows/release.yml](../../../.github/workflows/release.yml)
+4. [../../../scripts/check-desktop-release-metadata.mjs](../../../scripts/check-desktop-release-metadata.mjs)
+
+## Guardrails
+
+- Release from the repository default branch unless the user explicitly approves
+  another ref.
+- Start from a clean working tree. If tracked files are dirty, stop and ask
+  before changing release metadata.
+- Fetch tags before planning:
+
+  ```bash
+  git fetch origin --tags
+  ```
+
+- Treat `apps/desktop/package.json` as the desktop release version source.
+  The root `package.json` version is not the desktop app release version.
+- Always use a leading-`v` tag such as `v1.0.0-alpha.5`.
+- The tag version, `apps/desktop/package.json` version, and
+  `CHANGELOG.md` release heading must match.
+- Do not create or push the tag until the version and changelog are committed.
+- Do not use GitHub generated release notes as the final notes.
+- Do not force-push the default branch or rewrite an existing release tag
+  without explicit user approval.
+- Keep v1.0 proprietary licensing intact: do not add OSS license language.
+
+## Prepare Release Metadata
+
+1. Determine the next version from the previous tag and user intent:
+
+   ```bash
+   git tag --sort=-version:refname | head -n 10
+   gh release list --limit 10
+   ```
+
+2. Update `apps/desktop/package.json` without creating a tag yet:
+
+   ```bash
+   pnpm --filter @pwragent/desktop version <version> --no-git-tag-version
+   ```
+
+   If that command is not available in the current pnpm version, edit only
+   `apps/desktop/package.json` and preserve JSON formatting.
+
+3. Add a top `CHANGELOG.md` entry:
+
+   ```md
+   ## v1.0.0-alpha.5 - YYYY-MM-DD
+   ```
+
+   Write user-facing bullets from merged PRs and direct commits since the last
+   release. Preserve the same substance in GitHub release notes.
+
+4. Run the metadata gate locally before committing:
+
+   ```bash
+   RELEASE_TAG=v<version> pnpm release:check
+   ```
+
+5. Run normal repo gates unless the user explicitly narrows verification:
+
+   ```bash
+   pnpm typecheck
+   pnpm test
+   ```
+
+## Commit And Tag
+
+Commit the version and changelog together. Use a signed commit; this repo's git
+config should already sign commits with SSH.
+
+```bash
+git add apps/desktop/package.json CHANGELOG.md
+git commit -m "chore(release): prepare v<version>"
+```
+
+Create the tag on that exact commit:
+
+```bash
+git tag v<version>
+```
+
+If signing tags is configured and works locally, prefer a signed annotated tag:
+
+```bash
+git tag -s v<version> -m "v<version>"
+```
+
+Do not silently fall back from a failed signed tag to an unsigned tag. Ask the
+user which tag form to use.
+
+## Publish
+
+Push the branch and tag together:
+
+```bash
+git push origin HEAD:main
+git push origin v<version>
+```
+
+The tag push triggers `Release Desktop (macOS arm64)`. The workflow must pass
+`Check release metadata` before build/sign/notarize/publish starts.
+
+For a manual dispatch, verify the tag already exists on GitHub:
+
+```bash
+git ls-remote --tags origin v<version>
+gh workflow run release.yml -f tag=v<version>
+```
+
+## Monitor And Verify
+
+Find the run for the release tag and watch it. If it takes a while to appear,
+sleep for 5-10 minutes before deciding it failed to start.
+
+```bash
+gh run list --workflow release.yml --limit 10
+gh run watch <run-id>
+```
+
+On failure, inspect logs yourself:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+After success, verify the release and generated assets:
+
+```bash
+gh release view v<version>
+gh release download v<version> --dir .local/release/v<version>
+ls .local/release/v<version>
+```
+
+Expect signed/notarized macOS arm64 assets, including DMG/ZIP files and
+`latest-mac.yml`.
+
+## Local Fallback
+
+Use the local path only when CI is unavailable or the user explicitly asks for
+local signing/notarization. Follow
+[../../../docs/desktop-release-runbook.md](../../../docs/desktop-release-runbook.md)
+for required Apple and GitHub secrets.
+
+```bash
+pnpm --filter @pwragent/desktop package:dryrun
+pnpm --filter @pwragent/desktop package
+pnpm --filter @pwragent/desktop release
+```

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -90,16 +90,19 @@ git add apps/desktop/package.json CHANGELOG.md
 git commit -m "chore(release): prepare v<version>"
 ```
 
-Create the tag on that exact commit:
-
-```bash
-git tag v<version>
-```
+Create exactly one tag on that exact commit.
 
 If signing tags is configured and works locally, prefer a signed annotated tag:
 
 ```bash
 git tag -s v<version> -m "v<version>"
+```
+
+If signed tags are not available and the user approves an unsigned release tag,
+create a lightweight tag instead:
+
+```bash
+git tag v<version>
 ```
 
 Do not silently fall back from a failed signed tag to an unsigned tag. Ask the

--- a/.agents/skills/release/agents/openai.yaml
+++ b/.agents/skills/release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release"
+  short_description: "Cut guarded PwrAgent desktop releases"
+  default_prompt: "Prepare or publish a guarded PwrAgent desktop release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
 
+      - name: Check release metadata
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: pnpm release:check
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1.0.0-alpha.4 - 2026-05-04
+
+- Rebranded the desktop app from PwrAgnt to PwrAgent.
+- Relocated desktop config and state under the PwrAgent home/profile layout backed by SQLite.
+- Added optional streaming responses for hosted messaging providers.
+- Fixed recent desktop regressions around worktree thread deduplication, Tiptap draft preservation, Better SQLite rebuilds, messaging startup logging, and worktree storage controls.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pwragent/desktop",
   "productName": "PwrAgent",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "private": true,
   "description": "Thread-centric coding agent desktop app",
   "author": "PwrDrvr LLC",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:op": "node ./scripts/op-run.mjs dev",
     "lint": "pnpm typecheck && pnpm lint:boundaries",
     "lint:boundaries": "depcruise --config .dependency-cruiser.cjs apps/desktop/src/main/messaging packages/messaging",
+    "release:check": "node ./scripts/check-desktop-release-metadata.mjs",
     "test:desktop-e2e": "pnpm --filter @pwragent/desktop test:e2e",
     "test:desktop-e2e:nice": "node ./scripts/nice-run.mjs pnpm test:desktop-e2e",
     "test": "vitest run --config vitest.workspace.ts",

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const desktopPackagePath = resolve(repoRoot, "apps/desktop/package.json");
+const changelogPath = resolve(repoRoot, "CHANGELOG.md");
+
+function usage() {
+  console.error("Usage: RELEASE_TAG=v1.0.0-alpha.4 pnpm release:check");
+  console.error("   or: pnpm release:check --tag v1.0.0-alpha.4");
+}
+
+function parseTagArg(argv) {
+  const tagIndex = argv.indexOf("--tag");
+  if (tagIndex !== -1) {
+    return argv[tagIndex + 1];
+  }
+  const inline = argv.find((arg) => arg.startsWith("--tag="));
+  if (inline) {
+    return inline.slice("--tag=".length);
+  }
+  return process.env.RELEASE_TAG || process.env.GITHUB_REF_NAME;
+}
+
+function fail(message) {
+  console.error(`release metadata check failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const tag = parseTagArg(process.argv.slice(2));
+if (!tag) {
+  usage();
+  fail("no release tag was provided");
+  process.exit();
+}
+
+if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag)) {
+  fail(`tag "${tag}" must look like vX.Y.Z or vX.Y.Z-prerelease`);
+}
+
+const expectedVersion = tag.slice(1);
+const desktopPackage = JSON.parse(readFileSync(desktopPackagePath, "utf8"));
+if (desktopPackage.version !== expectedVersion) {
+  fail(
+    `apps/desktop/package.json version is ${desktopPackage.version}, but release tag ${tag} requires ${expectedVersion}`,
+  );
+}
+
+let changelog = "";
+try {
+  changelog = readFileSync(changelogPath, "utf8");
+} catch (error) {
+  if (error && error.code === "ENOENT") {
+    fail("CHANGELOG.md is missing");
+  } else {
+    throw error;
+  }
+}
+
+const headingPattern = new RegExp(`^##\\s+v?${escapeRegex(expectedVersion)}(?:\\s|$)`, "m");
+if (!headingPattern.test(changelog)) {
+  fail(`CHANGELOG.md must contain a second-level heading for ${tag}`);
+}
+
+if (process.exitCode) {
+  process.exit();
+}
+
+console.log(`release metadata check passed for ${tag}`);


### PR DESCRIPTION
## Summary

I added a guarded desktop release metadata check so future release tags must match `apps/desktop/package.json` and have a corresponding `CHANGELOG.md` entry before signing/notarization starts.

I also added a repo-local `.agents/skills/release` skill that points agents at the PwrAgent release runbooks, the release workflow, and the new metadata gate.

## Details

- Add `pnpm release:check` via `scripts/check-desktop-release-metadata.mjs`.
- Run the metadata check in `.github/workflows/release.yml` before typecheck/test/build/publish.
- Align `apps/desktop/package.json` to the already-published `v1.0.0-alpha.4` tag and add a baseline changelog entry.
- Add the repo-local release skill and OpenAI skill metadata.

## Verification

- `RELEASE_TAG=v1.0.0-alpha.4 pnpm release:check`
- `uv run --with pyyaml python /Users/huntharo/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/release`
- `pnpm typecheck`
- `pnpm test`
