### PR TITLE
chore(release): prepare v1.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.0-alpha.5 - 2026-05-04
+
+- Fixed launchpad composer drafts so rich text formatting and intentional blank lines survive app restarts without compounding extra spacing.
+- Added a guarded desktop release metadata check so release tags must match `apps/desktop/package.json` and `CHANGELOG.md` before signing and notarization begin.
+
 ## v1.0.0-alpha.4 - 2026-05-04
 
 - Rebranded the desktop app from PwrAgnt to PwrAgent.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pwragent/desktop",
   "productName": "PwrAgent",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "private": true,
   "description": "Thread-centric coding agent desktop app",
   "author": "PwrDrvr LLC",


### PR DESCRIPTION
## Summary

I prepared the desktop release metadata for `v1.0.0-alpha.5`.

## Release notes

- Fixed launchpad composer drafts so rich text formatting and intentional blank lines survive app restarts without compounding extra spacing.
- Added a guarded desktop release metadata check so release tags must match `apps/desktop/package.json` and `CHANGELOG.md` before signing and notarization begin.

## Verification

- `RELEASE_TAG=v1.0.0-alpha.5 pnpm release:check`
- `pnpm typecheck`
- `pnpm test` (135 test files passed, 1 skipped; 1055 tests passed, 3 skipped)
