### PR TITLE
feat(desktop): wireframe-level visual pass (design overhaul v2 — Phase 1)

### DIFF
--- a/apps/desktop/e2e/composer-draft-settings.spec.ts
+++ b/apps/desktop/e2e/composer-draft-settings.spec.ts
@@ -216,7 +216,7 @@ test("keeps a thread reply draft after opening settings and returning to the thr
       });
     expect(threadButtonCoveredBySettings).toBe(true);
 
-    await app.window.getByRole("button", { name: "Back" }).click();
+    await app.window.getByRole("button", { name: /Exit Settings/i }).click();
     await expect(
       app.window.getByRole("heading", {
         level: 2,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -30,6 +30,7 @@ import type {
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
+import { EditorIcon, TerminalIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
@@ -803,6 +804,20 @@ function ComposerApplicationButton(props: {
           className="composer__application-icon"
           src={props.application.iconDataUrl}
         />
+      ) : props.application.kind === "editor" ? (
+        <span
+          aria-hidden="true"
+          className="composer__application-icon composer__application-icon--glyph"
+        >
+          <EditorIcon size={14} />
+        </span>
+      ) : props.application.kind === "terminal" ? (
+        <span
+          aria-hidden="true"
+          className="composer__application-icon composer__application-icon--glyph"
+        >
+          <TerminalIcon size={14} />
+        </span>
       ) : (
         <span
           aria-hidden="true"

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -5,6 +5,7 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
+import { FolderIcon, UnlinkedDotIcon, WorkspaceIcon } from "../../icons";
 import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
@@ -118,7 +119,13 @@ export function DirectoriesList(props: DirectoriesListProps) {
               >
                 <span className="directory-row__summary-main">
                   <span aria-hidden="true" className="directory-row__icon">
-                    {directory.kind === "workspace" ? "🗂" : directory.kind === "unlinked" ? "•" : "📁"}
+                    {directory.kind === "workspace" ? (
+                      <WorkspaceIcon size={14} />
+                    ) : directory.kind === "unlinked" ? (
+                      <UnlinkedDotIcon size={14} />
+                    ) : (
+                      <FolderIcon size={14} />
+                    )}
                   </span>
                   <span className="directory-row__title-wrap">
                     <span className="thread-row__title">{directory.label}</span>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@pwragent/shared";
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
+import { BranchIcon, FolderIcon } from "../../icons";
 import type { BrowseMode } from "../../lib/useThreadNavigation";
 import {
   formatRuntimeGitRef,
@@ -577,11 +578,7 @@ function RuntimeIdentityButton(props: {
       }}
     >
       <span aria-hidden="true" className="runtime-identity__icon">
-        {props.valueKind === "cwd" ? (
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2z"/></svg>
-        ) : (
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
-        )}
+        {props.valueKind === "cwd" ? <FolderIcon size={13} /> : <BranchIcon size={13} />}
       </span>
       <span className="runtime-identity__text">{props.label}</span>
     </button>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,4 +1,5 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
+import { BranchIcon, FolderIcon, WorktreeIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 
@@ -104,7 +105,7 @@ export function ThreadMetaChips({
                 }}
               >
                 <span aria-hidden="true" className="thread-row__chip-icon">
-                  {directory.kind === "worktree" ? "🔀" : "📁"}
+                  {directory.kind === "worktree" ? <WorktreeIcon size={12} /> : <FolderIcon size={12} />}
                 </span>
                 {directory.label}
               </span>
@@ -138,7 +139,7 @@ export function ThreadMetaChips({
       {thread.gitBranch ? (
         <span className="thread-row__chip thread-row__chip--mono">
           <span aria-hidden="true" className="thread-row__chip-icon">
-            🌿
+            <BranchIcon size={12} />
           </span>
           {thread.gitBranch}
         </span>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+
+/**
+ * Layout primitives for settings screens. New settings should compose
+ * <SettingsSection> + <SettingsRow> rather than rolling their own panel
+ * markup so that layout, spacing, inline help, and accessibility stay
+ * consistent as we add more settings.
+ *
+ * Existing settings panels predate these primitives and continue to use
+ * the legacy .settings-panel / .settings-row CSS classes — both styles
+ * coexist and read the same in the shell.
+ */
+
+export function SettingsSection(props: {
+  title: string;
+  eyebrow?: string;
+  description?: ReactNode;
+  children: ReactNode;
+  "aria-label"?: string;
+}) {
+  const headingId = `settings-section-${props.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")}`;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      aria-label={props["aria-label"]}
+      className="settings-panel"
+    >
+      <div className="settings-panel__header">
+        <div>
+          {props.eyebrow ? <p className="eyebrow">{props.eyebrow}</p> : null}
+          <h2 id={headingId}>{props.title}</h2>
+          {props.description ? (
+            <p className="settings-section__description">{props.description}</p>
+          ) : null}
+        </div>
+      </div>
+      <div className="settings-section__body">{props.children}</div>
+    </section>
+  );
+}
+
+export function SettingsRow(props: {
+  label: string;
+  /** Optional inline help text rendered under the label. */
+  help?: ReactNode;
+  /** Control element (input, select, button, etc.). */
+  control: ReactNode;
+  /**
+   * Render the control inline with the label instead of stacked. Default
+   * stacked layout matches the current .settings-row treatment for
+   * complex controls.
+   */
+  inline?: boolean;
+  /** Optional inline error message rendered under the control. */
+  error?: ReactNode;
+}) {
+  return (
+    <div
+      className={`settings-row${props.inline ? " settings-row--inline" : ""}`}
+    >
+      <div className="settings-row__label">
+        <span className="settings-row__label-text">{props.label}</span>
+        {props.help ? (
+          <span className="settings-row__help">{props.help}</span>
+        ) : null}
+      </div>
+      <div className="settings-row__control">{props.control}</div>
+      {props.error ? (
+        <p className="settings-row__error" role="alert">
+          {props.error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -40,15 +40,24 @@ export function SettingsScreen(props: {
   return (
     <section className="settings-screen" aria-label="Settings">
       <header className="settings-header">
-        <div>
+        <div className="settings-header__identity">
+          <p className="settings-header__brand">
+            Pwr<span className="sidebar__brand-accent">Agent</span>
+          </p>
+          {props.onClose ? (
+            <button
+              className="settings-header__exit"
+              type="button"
+              onClick={props.onClose}
+            >
+              <span aria-hidden="true">←</span> Exit Settings
+            </button>
+          ) : null}
+        </div>
+        <div className="settings-header__title">
           <p className="eyebrow">Settings</p>
           <h1>Settings</h1>
         </div>
-        {props.onClose ? (
-          <button className="button button--secondary" type="button" onClick={props.onClose}>
-            Back
-          </button>
-        ) : null}
       </header>
 
       <div className="settings-layout">

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -281,7 +281,7 @@ describe("SettingsScreen", () => {
     const onClose = vi.fn();
     render(<SettingsScreen settings={createSettingsState()} onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: /Exit Settings/i }));
 
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -16,6 +16,7 @@ import type {
   NavigationThreadSummary,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
+import { FolderIcon, WorktreeIcon } from "../../icons";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 
@@ -260,7 +261,11 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                           onShowTooltip={showRailTooltip}
                         >
                           <span aria-hidden="true" className="context-list__icon">
-                            {directory.kind === "worktree" ? "🔀" : "📁"}
+                            {directory.kind === "worktree" ? (
+                              <WorktreeIcon size={14} />
+                            ) : (
+                              <FolderIcon size={14} />
+                            )}
                           </span>
                           {directory.label}
                         </TooltipValue>
@@ -324,7 +329,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         onShowTooltip={showRailTooltip}
                       >
                         <span aria-hidden="true" className="context-list__icon">
-                          📁
+                          <FolderIcon size={14} />
                         </span>
                         {pathBaseName(props.thread.projectKey)}
                       </TooltipValue>
@@ -383,7 +388,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                         onMouseLeave={hideRailTooltip}
                       >
                         <span aria-hidden="true" className="context-list__icon">
-                          🔀
+                          <WorktreeIcon size={14} />
                         </span>
                         {pathBaseName(snapshot.worktreePath)}
                       </button>

--- a/apps/desktop/src/renderer/src/icons/EditorIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/EditorIcon.tsx
@@ -1,0 +1,17 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Generic editor glyph (curly braces) used when we don't have an
+ * OS-extracted icon for an editor application. We intentionally avoid
+ * replicating any specific editor's brand mark — distribution licensing
+ * for third-party logos is fraught, and the Tangerine Terminal thesis
+ * is monochrome anyway.
+ */
+export function EditorIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M9 4H7.5a2.5 2.5 0 0 0-2.5 2.5v3a2.5 2.5 0 0 1-2 2.45 2.5 2.5 0 0 1 2 2.45v3A2.5 2.5 0 0 0 7.5 20H9" />
+      <path d="M15 4h1.5a2.5 2.5 0 0 1 2.5 2.5v3a2.5 2.5 0 0 0 2 2.45 2.5 2.5 0 0 0-2 2.45v3a2.5 2.5 0 0 1-2.5 2.5H15" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/TerminalIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/TerminalIcon.tsx
@@ -1,0 +1,15 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Generic terminal glyph (prompt + caret) used when we don't have an
+ * OS-extracted icon for a terminal application. Same rationale as
+ * EditorIcon — generic mark, not a specific terminal's brand.
+ */
+export function TerminalIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <polyline points="5 8 9 12 5 16" />
+      <line x1="13" y1="16" x2="19" y2="16" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,7 +1,9 @@
 export { BranchIcon } from "./BranchIcon";
+export { EditorIcon } from "./EditorIcon";
 export { FolderIcon } from "./FolderIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { SettingsIcon } from "./SettingsIcon";
+export { TerminalIcon } from "./TerminalIcon";
 export { UnlinkedDotIcon } from "./UnlinkedDotIcon";
 export { WorkspaceIcon } from "./WorkspaceIcon";
 export { WorktreeIcon } from "./WorktreeIcon";

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1229,10 +1229,56 @@ textarea,
 
 .settings-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
-  gap: 16px;
+  gap: 24px;
   padding-right: 8px;
+  -webkit-app-region: drag;
+}
+
+.settings-header__identity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  -webkit-app-region: no-drag;
+}
+
+.settings-header__brand {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.01em;
+}
+
+.settings-header__exit {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  cursor: pointer;
+  gap: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-header__exit:hover,
+.settings-header__exit:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.settings-header__exit:focus-visible {
+  text-decoration: underline;
+}
+
+.settings-header__title {
+  text-align: right;
 }
 
 .settings-header h1 {
@@ -1361,6 +1407,40 @@ textarea,
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 650;
+}
+
+.settings-row__label-text {
+  display: block;
+}
+
+.settings-row__help {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.settings-row--inline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 16px;
+}
+
+.settings-section__description {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.settings-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 .settings-source {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -349,8 +349,7 @@ textarea,
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  color: var(--accent-bright);
-  opacity: 0.9;
+  color: var(--accent);
 }
 
 .runtime-identity__text {
@@ -875,6 +874,8 @@ textarea,
 }
 
 .thread-row__chip-icon {
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
   line-height: 1;
 }
@@ -932,6 +933,8 @@ textarea,
 }
 
 .directory-row__icon {
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
   line-height: 1;
 }
@@ -3573,6 +3576,8 @@ textarea,
 }
 
 .context-list__icon {
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
   line-height: 1;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4244,6 +4244,15 @@ textarea,
   font-weight: 700;
 }
 
+.composer__application-icon--glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+}
+
 .composer__select {
   appearance: none;
   min-width: 168px;


### PR DESCRIPTION
## Summary

Phase 1 of the [Desktop Design Overhaul (Tangerine Terminal v2) plan](docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md). Wireframe-level visual pass — no behavior changes, no wiring changes, no persistence shape changes. Stacked on top of Phase 0 [#173](https://github.com/pwrdrvr/PwrAgent/pull/173).

### Units shipped

**U1.1 — Sidebar masthead icons heavier and higher contrast** ([f7794b50](../commit/f7794b50))
- Replaced inline SVG folder/branch glyphs in `RuntimeIdentityButton` with `FolderIcon` / `BranchIcon` from the icon library at `size=13` and the new default `strokeWidth: 1.75` (was inline at 1.5)
- Dropped the `.runtime-identity__icon` opacity dimming so the chips read at full tangerine strength against the near-black sidebar surface — directly addresses the user complaint that the masthead chip glyphs were "super thin, super difficult (low contrast) to see"

**U1.2 — Replace emoji glyphs across renderer** ([f7794b50](../commit/f7794b50))
- Every emoji-as-icon usage swapped for the matching icon component: `📁` `🗂` `🔀` `🌿` `•` retired
- Touched: `DirectoriesList.tsx`, `ThreadMetaChips.tsx`, `ThreadContextPanel.tsx`
- Icon wrappers (`.thread-row__chip-icon`, `.directory-row__icon`, `.context-list__icon`) tightened with `display: inline-flex; align-items: center` so SVGs sit on the text baseline cleanly
- Verification: `grep emoji renderer` returns zero matches after this PR

**U1.3 — Settings header rework + layout primitives** ([f1295f1e](../commit/f1295f1e))
- Settings header now puts the **PwrAgent** brand top-left with **`← Exit Settings`** directly below — replaces the right-side "Back" button. Header is a drag region matching the main app titlebar
- New `SettingsLayout.tsx` with `<SettingsSection>` and `<SettingsRow>` primitives — these will be used by Phase 2's Diff Eliding setting and any future settings without forcing a migration of the 6 existing settings panels
- The existing `.settings-panel` / `.settings-row` markup keeps working (deferred panel-by-panel migration)
- Updated unit + E2E tests that asserted on the old "Back" label

**U1.5 — Editor / terminal application launcher glyphs** ([125d4d2d](../commit/125d4d2d))
- The composer's app launcher buttons (under the chat entry) used to fall back to a single-letter chip ("V" for VS Code, "G" for Ghostty) when the OS-extracted icon was missing. Now they fall back to a kind-based monochrome glyph: `EditorIcon` for editors, `TerminalIcon` for terminals, lettered chip only for genuinely unknown apps
- Why generic over brand marks: distribution licensing for third-party logos is fraught and the Tangerine Terminal thesis is monochrome anyway. The OS icon path (`iconDataUrl`) still wins when present — users still see the real VS Code / Ghostty icon when the OS exposes it

### Deferred from this phase

**U1.4 — Test/status pills for credential-based settings** is intentionally deferred to a focused follow-up PR. It needs new IPC handlers (`testTelegramToken`, `testDiscordToken`, `testXaiApiKey`), exported test methods on each messaging adapter, and a new `SettingsTestButton` component. Worth doing — the user asked for it specifically — but the cleanest path is a dedicated PR rather than smuggling it into the visual-pass.

## Testing
- Full unit test suite: 1065 passed / 3 skipped (no change from Phase 0 baseline)
- Updated `settings-screen.test.tsx` and `composer-draft-settings.spec.ts` (E2E) for the new "Exit Settings" affordance
- `pnpm typecheck` clean across all 6 workspace projects
- No persistence shape, IPC contract, or event-handler change in this PR

## Post-Deploy Monitoring & Validation
- **What to monitor/search:** N/A — pure visual change, no runtime behavior altered.
- **Expected healthy behavior:** App renders with consistent monochrome iconography across the sidebar, thread rows, context rail, and composer launcher buttons. Settings screen has brand top-left, "← Exit Settings" link below, no right-side back button.
- **Failure signal / rollback trigger:** Visual regression report from a user. Roll back is `git revert` of these four commits.
- **Validation window & owner:** Visual review by user.
- **No additional operational monitoring required:** No data, network, or persistence behavior modified.

## Plan
[docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md](docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md)

## Stacking
This PR stacks on top of Phase 0 [#173](https://github.com/pwrdrvr/PwrAgent/pull/173). Merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context)