### PR TITLE
feat(desktop): sticky directory headers (design overhaul v2 — Phase 3 partial)

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -906,9 +906,13 @@ textarea,
 
 .directory-row__header {
   display: grid;
+  position: sticky;
+  top: 0;
+  z-index: 5;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
   align-items: center;
+  background: var(--bg-sidebar);
 }
 
 .directory-row__summary {


### PR DESCRIPTION
## Summary

Phase 3 starter — only U3.1 (sticky directory headers) is in this PR. **U3.2 (thread reactions) and U3.3 (PR chips) are deferred to focused follow-up PRs** because they each carry their own persistence / IPC / external-CLI surfaces and warrant dedicated review.

Stacked on Phase 2 [#175](https://github.com/pwrdrvr/PwrAgent/pull/175).

### U3.1 — Sticky directory headers

Adds `position: sticky; top: 0; z-index: 5; background: var(--bg-sidebar)` to `.directory-row__header`. Each directory's header stays pinned to the top of the Directories scroll viewport until the next directory's header pushes it out, so the user always knows which directory the visible threads belong to.

z-index constrained to 5 so popovers, menus, and the context rail (z-index 10+) still layer above sticky headers.

CSS-only. No DOM, no JS, no event handlers, no persistence.

### Deferred from this phase

- **U3.2 — Thread reactions on rows:** Needs a new field on `ThreadOverlayState`, an IPC handler (`setThreadReaction`), surface through the navigation snapshot, and a `ReactionPicker` component. Each is small but together they warrant a focused PR.
- **U3.3 — PR chips:** Needs `gh` CLI integration for status fetching, a 60-second cache, IPC plumbing, and graceful degradation when `gh` isn't installed. Most ambitious of the three Phase 3 units; deserves its own PR.

## Testing
- Full unit test suite: 1066 passed / 3 skipped (no change)
- `pnpm typecheck` clean
- Visual: scroll a 10+ directory list — header pins until next directory takes over

## Post-Deploy Monitoring & Validation
- **No additional operational monitoring required** — pure CSS layout change. Failure mode is a visual regression detectable on first load.

## Plan
[docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md](docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md) (U3.1)

## Stacking
Stacked on Phase 2 [#175](https://github.com/pwrdrvr/PwrAgent/pull/175) → Phase 1 [#174](https://github.com/pwrdrvr/PwrAgent/pull/174) → Phase 0 [#173](https://github.com/pwrdrvr/PwrAgent/pull/173). Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context)