### PR TITLE
ci: run on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary
- Drop the `branches: [main]` filter from the `pull_request` trigger in `.github/workflows/ci.yml` so CI runs on stacked PRs (PRs whose base is another feature branch, not `main`).
- Push-triggered runs remain limited to `main`.

## Why
Stacked PRs (e.g. [#174](https://github.com/pwrdrvr/PwrAgent/pull/174), which targets `feat/desktop-icon-library-and-tokens`) were not getting CI runs, because the `pull_request` trigger was scoped to `main`-targeting PRs only.

## Test plan
- [ ] Confirm CI runs on this PR (targets `main`).
- [ ] Confirm CI runs on a stacked PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)