### PR TITLE
fix(desktop): branch drift detection across HEAD + turn lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2878,6 +2878,62 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("does not persist a retained branch drift pair when expected branch is HEAD", async () => {
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-head": {
+          backend: "codex",
+          threadId: "thread-head",
+          gitBranch: "HEAD",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const response = await registry.retainThreadBranchDrift({
+      backend: "codex",
+      threadId: "thread-head",
+      expectedBranch: "HEAD",
+      observedBranch: "feature/foo",
+    });
+
+    // Response still echoes the request so the renderer can update its
+    // dialog state, but no pair is persisted.
+    expect(response.expectedBranch).toBe("HEAD");
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-head",
+    });
+    expect(overlay?.retainedBranchDriftPairs ?? []).toEqual([]);
+
+    // Sanity: a non-HEAD pair still persists.
+    await registry.retainThreadBranchDrift({
+      backend: "codex",
+      threadId: "thread-head",
+      expectedBranch: "feature/old",
+      observedBranch: "feature/new",
+    });
+    const overlayAfter = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-head",
+    });
+    expect(overlayAfter?.retainedBranchDriftPairs).toHaveLength(1);
+
+    await registry.close();
+  });
+
   it("does not flag drift when observed branch is HEAD (restored archived snapshot)", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-archived",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2878,6 +2878,64 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("does not flag drift when observed branch is HEAD (restored archived snapshot)", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-archived",
+      title: "Restored from archive",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "feature/work-from-archive",
+      // Worktree was restored to a snapshot ref → detached HEAD.
+      observedGitBranch: "HEAD",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-archived": {
+          backend: "codex",
+          threadId: "thread-archived",
+          gitBranch: "feature/work-from-archive",
+          observedGitBranch: "HEAD",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [thread],
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const response = await registry.checkThreadBranchDrift({
+      backend: "codex",
+      threadId: "thread-archived",
+    });
+
+    expect(response).toMatchObject({
+      observedBranch: "HEAD",
+      drifted: false,
+    });
+
+    await registry.close();
+  });
+
   it("restores threads through the selected backend client", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/unarchive"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1899,13 +1899,18 @@ export class DesktopBackendRegistry {
     params: RetainThreadBranchDriftRequest,
   ): Promise<RetainThreadBranchDriftResponse> {
     const retainedAt = Date.now();
-    await this.overlayStore.retainThreadBranchDrift({
-      backend: params.backend,
-      threadId: params.threadId,
-      expectedBranch: params.expectedBranch,
-      observedBranch: params.observedBranch,
-      retainedAt,
-    });
+    // R14: refuse to persist (HEAD, *) pairs. Each "first named branch
+    // after detached HEAD" is a meaningful new context that should
+    // re-prompt the user, not be permanently silenced.
+    if (params.expectedBranch !== "HEAD") {
+      await this.overlayStore.retainThreadBranchDrift({
+        backend: params.backend,
+        threadId: params.threadId,
+        expectedBranch: params.expectedBranch,
+        observedBranch: params.observedBranch,
+        retainedAt,
+      });
+    }
 
     return {
       ...params,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -28,6 +28,7 @@ import {
   type BackendSummary,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  isBranchDrifted,
   type HandoffThreadWorkspaceRequest,
   type HandoffThreadWorkspaceResponse,
   type ListBackendsRequest,
@@ -1840,13 +1841,11 @@ export class DesktopBackendRegistry {
       branch: normalizedObservedBranch,
     });
 
+    const drifted = isBranchDrifted(expectedBranch, normalizedObservedBranch);
+
     backendRegistryLog.debug("checked thread branch drift", {
       backend: params.backend,
-      drifted:
-        Boolean(expectedBranch && normalizedObservedBranch) &&
-        expectedBranch !== "HEAD" &&
-        normalizedObservedBranch !== "HEAD" &&
-        expectedBranch !== normalizedObservedBranch,
+      drifted,
       expectedBranch,
       observedBranch: normalizedObservedBranch,
       sourcePath,
@@ -1858,11 +1857,7 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       expectedBranch,
       observedBranch: normalizedObservedBranch,
-      drifted:
-        Boolean(expectedBranch && normalizedObservedBranch) &&
-        expectedBranch !== "HEAD" &&
-        normalizedObservedBranch !== "HEAD" &&
-        expectedBranch !== normalizedObservedBranch,
+      drifted,
       checkedAt: Date.now(),
     };
   }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,4 +1,5 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
+import { isBranchDrifted } from "@pwragent/shared";
 import { BranchIcon, FolderIcon, WorktreeIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
@@ -16,10 +17,7 @@ export function ThreadMetaChips({
   linkedDirectoryMode = "label",
   thread,
 }: ThreadMetaChipsProps) {
-  const branchDrifted =
-    thread.gitBranch &&
-    thread.observedGitBranch &&
-    thread.observedGitBranch !== thread.gitBranch;
+  const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
   const linkedDirectoryChips = includeLinkedDirectories
     ? thread.linkedDirectories.length > 0
       ? linkedDirectoryMode === "kind"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
@@ -778,6 +778,22 @@ export function ThreadView(props: ThreadViewProps) {
     return true;
   };
 
+  // Single dialog-open gate. Suppresses while a turn is active on the
+  // focused thread; the end-of-turn falling-edge useEffect re-runs the
+  // drift check once activeTurnId clears, so deferral is implicit.
+  const tryOpenBranchDriftDialog = (
+    thread: NavigationThreadSummary,
+    expectedBranch: string,
+    observedBranch: string,
+    reason: BranchDriftDialogState["reason"],
+    checkedAt?: number,
+  ): boolean => {
+    if (props.activeTurnId !== undefined) {
+      return false;
+    }
+    return showBranchDriftDialog(thread, expectedBranch, observedBranch, reason, checkedAt);
+  };
+
   const checkSelectedThreadBranchDrift = async (
     reason: BranchDriftDialogState["reason"],
   ): Promise<boolean> => {
@@ -785,14 +801,22 @@ export function ThreadView(props: ThreadViewProps) {
     if (!thread?.gitBranch || !props.desktopApi?.checkThreadBranchDrift) {
       return false;
     }
+    const startedThreadKey = `${thread.source}:${thread.id}`;
 
     try {
       const result = await props.desktopApi.checkThreadBranchDrift({
         backend: thread.source,
         threadId: thread.id,
       });
+      // Stale-closure guard: user navigated away mid-IPC.
+      if (selectedThreadKeyRef.current !== startedThreadKey) {
+        return false;
+      }
       if (result.observedBranch !== thread.observedGitBranch) {
         await props.onRefreshNavigation?.();
+        if (selectedThreadKeyRef.current !== startedThreadKey) {
+          return false;
+        }
       }
       if (
         !result.drifted ||
@@ -801,12 +825,12 @@ export function ThreadView(props: ThreadViewProps) {
         !canWarnForBranchDrift(result.expectedBranch, result.observedBranch)
       ) {
         setBranchDriftDialog((current) =>
-          current?.threadKey === `${thread.source}:${thread.id}` ? undefined : current,
+          current?.threadKey === startedThreadKey ? undefined : current,
         );
         return false;
       }
 
-      return showBranchDriftDialog(
+      return tryOpenBranchDriftDialog(
         thread,
         result.expectedBranch,
         result.observedBranch,
@@ -821,6 +845,12 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     setBranchDriftDialog(undefined);
     setBranchDriftError(undefined);
+  }, [selectedThreadKey]);
+
+  // Live mirror of selectedThreadKey for async stale-closure guards.
+  const selectedThreadKeyRef = useRef(selectedThreadKey);
+  useEffect(() => {
+    selectedThreadKeyRef.current = selectedThreadKey;
   }, [selectedThreadKey]);
 
   useEffect(() => {
@@ -841,8 +871,33 @@ export function ThreadView(props: ThreadViewProps) {
       return;
     }
 
-    showBranchDriftDialog(thread, expectedBranch, observedBranch, "focus");
-  }, [selectedThread]);
+    tryOpenBranchDriftDialog(thread, expectedBranch, observedBranch, "focus");
+  }, [selectedThread, props.activeTurnId]);
+
+  // End-of-turn falling-edge: re-run drift check when an active turn
+  // settles on the focused thread. Combined ref guards against
+  // same-render thread switches firing a spurious recheck.
+  const previousTurnRef = useRef<{
+    threadKey: string | undefined;
+    activeTurnId: string | undefined;
+  }>({ threadKey: selectedThreadKey, activeTurnId: props.activeTurnId });
+  useEffect(() => {
+    const previous = previousTurnRef.current;
+    const current = {
+      threadKey: selectedThreadKey,
+      activeTurnId: props.activeTurnId,
+    };
+    previousTurnRef.current = current;
+
+    if (
+      previous.threadKey === current.threadKey &&
+      previous.threadKey !== undefined &&
+      previous.activeTurnId !== undefined &&
+      current.activeTurnId === undefined
+    ) {
+      void checkSelectedThreadBranchDrift("focus");
+    }
+  }, [props.activeTurnId, selectedThreadKey]);
 
   useEffect(() => {
     if (!selectedThread || selectedLaunchpad) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -23,6 +23,7 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
+import { isBranchDrifted } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -749,13 +750,7 @@ export function ThreadView(props: ThreadViewProps) {
     );
 
   const canWarnForBranchDrift = (expectedBranch?: string, observedBranch?: string): boolean =>
-    Boolean(
-      expectedBranch &&
-        observedBranch &&
-        expectedBranch !== "HEAD" &&
-        observedBranch !== "HEAD" &&
-        expectedBranch !== observedBranch,
-    );
+    isBranchDrifted(expectedBranch, observedBranch);
 
   const showBranchDriftDialog = (
     thread: NavigationThreadSummary,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -742,12 +742,17 @@ export function ThreadView(props: ThreadViewProps) {
     thread: NavigationThreadSummary,
     expectedBranch: string,
     observedBranch: string,
-  ): boolean =>
-    (thread.retainedBranchDriftPairs ?? []).some(
+  ): boolean => {
+    // R14: ignore retained pairs where expected is HEAD even if persisted
+    // by an older client — a transition out of detached HEAD is always a
+    // meaningful event the user should re-evaluate.
+    if (expectedBranch === "HEAD") return false;
+    return (thread.retainedBranchDriftPairs ?? []).some(
       (pair) =>
         pair.expectedBranch === expectedBranch &&
         pair.observedBranch === observedBranch,
     );
+  };
 
   const canWarnForBranchDrift = (expectedBranch?: string, observedBranch?: string): boolean =>
     isBranchDrifted(expectedBranch, observedBranch);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2982,6 +2982,47 @@ describe("ThreadView", () => {
     });
   });
 
+  it("ignores retained pairs where expected branch is HEAD (R14)", async () => {
+    // Thread overlay has a retained (HEAD, fix/foo) pair from an older
+    // client version. The dialog must STILL surface a (HEAD, fix/foo)
+    // drift because R14 ignores HEAD-expected retained pairs on read.
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{}}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-head-retention",
+          title: "HEAD retention",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "HEAD",
+          observedGitBranch: "fix/foo",
+          retainedBranchDriftPairs: [
+            { expectedBranch: "HEAD", observedBranch: "fix/foo", retainedAt: 1 },
+          ],
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Thread branch changed",
+    });
+    expect(dialog).toBeInTheDocument();
+  });
+
   it("does not fire end-of-turn drift check when both thread and activeTurnId change in one render", async () => {
     const checkThreadBranchDrift = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2866,6 +2866,195 @@ describe("ThreadView", () => {
     }
   });
 
+  it("suppresses the branch drift dialog while a turn is active", async () => {
+    const driftThread = {
+      id: "thread-branch",
+      title: "Branch drift",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      gitBranch: "feature/old",
+      observedGitBranch: "main",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    function Harness({ activeTurnId }: { activeTurnId?: string }) {
+      return (
+        <ThreadView
+          activeTurnId={activeTurnId}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{}}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={driftThread}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness activeTurnId="turn-1" />);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      screen.queryByRole("dialog", { name: "Thread branch changed" }),
+    ).not.toBeInTheDocument();
+
+    rerender(<Harness activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Thread branch changed" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("re-checks branch drift on end-of-turn falling edge", async () => {
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      checkedAt: Date.now(),
+      expectedBranch: "feature/old",
+      observedBranch: "main",
+      drifted: true,
+    }));
+
+    function Harness({ activeTurnId }: { activeTurnId?: string }) {
+      return (
+        <ThreadView
+          activeTurnId={activeTurnId}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{ checkThreadBranchDrift }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={{
+            id: "thread-branch",
+            title: "Branch drift",
+            titleSource: "explicit",
+            source: "codex",
+            gitBranch: "feature/old",
+            observedGitBranch: "feature/old",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness activeTurnId="turn-1" />);
+
+    // Mount triggers the focus check, but the gate suppresses the
+    // dialog while activeTurnId is set.
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Thread branch changed" }),
+    ).not.toBeInTheDocument();
+
+    const callsBeforeEnd = checkThreadBranchDrift.mock.calls.length;
+
+    rerender(<Harness activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift.mock.calls.length).toBeGreaterThan(callsBeforeEnd);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Thread branch changed" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not fire end-of-turn drift check when both thread and activeTurnId change in one render", async () => {
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-b",
+      checkedAt: Date.now(),
+      expectedBranch: "feature/b",
+      observedBranch: "feature/b",
+      drifted: false,
+    }));
+
+    function Harness({
+      activeTurnId,
+      threadId,
+    }: {
+      activeTurnId?: string;
+      threadId: string;
+    }) {
+      return (
+        <ThreadView
+          activeTurnId={activeTurnId}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{ checkThreadBranchDrift }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={{
+            id: threadId,
+            title: threadId,
+            titleSource: "explicit",
+            source: "codex",
+            gitBranch: "feature/b",
+            observedGitBranch: "feature/b",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    // Thread A with active turn.
+    const { rerender } = render(<Harness activeTurnId="turn-1" threadId="thread-a" />);
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalled();
+    });
+    const callsAfterMount = checkThreadBranchDrift.mock.calls.length;
+
+    // Same render: switch to thread B AND clear activeTurnId. The
+    // falling-edge guard requires threadKey unchanged, so no extra
+    // recheck should fire from the falling-edge effect (only the
+    // normal focus-on-selection check).
+    rerender(<Harness activeTurnId={undefined} threadId="thread-b" />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // One additional call from the focus-path effect (selection change)
+    // is acceptable. The falling-edge effect should NOT have added a
+    // separate one for thread A.
+    const callsAfterSwitch = checkThreadBranchDrift.mock.calls.length;
+    expect(callsAfterSwitch - callsAfterMount).toBeLessThanOrEqual(1);
+
+    // No dialog should appear because the IPC reports no drift on B.
+    expect(
+      screen.queryByRole("dialog", { name: "Thread branch changed" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("defers completed live transcript publishing outside the render phase", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const onPublished = vi.fn();

--- a/docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md
+++ b/docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md
@@ -1,0 +1,133 @@
+---
+date: 2026-05-04
+topic: thread-branch-drift-detection
+---
+
+# Thread Branch Drift Detection
+
+## Problem Frame
+
+A thread's "expected branch" (the git branch the user/agent intended to work
+on) can diverge from the workspace's current "observed branch" (whatever
+`git rev-parse --abbrev-ref HEAD` reports). When that happens we want to
+surface a "Thread branch changed" dialog so the user can either retain the
+expected branch or accept the new one.
+
+Two recurring confusions have driven bugs in this code:
+
+1. The expected branch may itself be `HEAD` (a thread created while the
+   workspace was in detached-HEAD state). Excluding `expectedBranch === "HEAD"`
+   from drift detection silently suppressed legitimate drift warnings even
+   though the sidebar chip still rendered the `! now <branch>` indicator,
+   producing an inconsistency between what the sidebar and the dialog say.
+2. Mid-turn the workspace routinely passes through detached HEAD as a
+   transient state — for example when an agent runs
+   `git rebase origin/main`, which checks out commits in detached HEAD before
+   reattaching to the original branch. Showing a drift dialog mid-turn for
+   transient states is noisy and incorrect: by turn end the branch is usually
+   back to the expected value.
+
+## Evidence
+
+- Backend drift computation lives in
+  `apps/desktop/src/main/app-server/backend-registry.ts` in
+  `checkThreadBranchDrift()` and `resolveExpectedThreadBranch()`.
+- Renderer dialog gate lives in
+  `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx` in
+  `canWarnForBranchDrift()`, `showBranchDriftDialog()`, and
+  `checkSelectedThreadBranchDrift()`.
+- Sidebar chip indicator lives in
+  `apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx`.
+- Drift checks are currently triggered in three places: thread focus,
+  window focus, and `onBeforeStartTurn` (pre-turn submission).
+- The `drifted` boolean is consumer-pure: it only gates the warning dialog.
+  It does NOT trigger any thread reload from rollout, enrichment discard,
+  or other state mutation.
+
+## Requirements
+
+**Drift Semantics**
+- R1. A thread is "drifted" when the expected branch and observed branch
+  are both known, are not equal, and the observed branch is a real named
+  branch (not `HEAD`).
+- R2. A thread with `expectedBranch === "HEAD"` and a named observed
+  branch IS considered drifted. Going from detached HEAD to a named
+  branch is a meaningful, user-visible change that the dialog must
+  surface.
+- R3. A thread with `observedBranch === "HEAD"` is NOT considered
+  drifted. Detached HEAD on the observed side is treated as a transient
+  state because that is what mid-rebase, mid-bisect, and similar git
+  operations look like.
+- R4. The sidebar drift chip and the drift dialog must agree on the
+  drift predicate. Any change to one must update the other.
+
+**Turn Lifecycle**
+- R5. Drift detection must not trigger the dialog while a turn is active
+  on the selected thread. Many turns rebase or otherwise pass through
+  detached HEAD before reattaching to the expected branch by turn end.
+- R6. Drift detection must run at end-of-turn (after the turn settles)
+  to surface drift the agent introduced during the turn.
+- R7. Drift detection must run on thread focus and window focus, but
+  must defer the dialog if a turn is currently active for the focused
+  thread.
+- R8. The pre-turn drift check (`onBeforeStartTurn`) is allowed and
+  desirable — it captures drift that accumulated before the turn
+  started, when the workspace is stable.
+
+**Consumer Purity**
+- R9. The `drifted` boolean returned by `checkThreadBranchDrift` must
+  remain a UI-warning gate only. It must not trigger thread reloads
+  from rollout, enrichment discards, or any state mutation outside of
+  what the user explicitly chooses from the dialog.
+
+**Retention**
+- R10. The "Retain Expected Branch" action persists the
+  `(expectedBranch, observedBranch)` pair so future checks suppress the
+  dialog for that exact pair. Retention is per-pair, not per-thread.
+- R11. The "Update Expected Branch" action overwrites the overlay's
+  `gitBranch` with the observed branch, eliminating drift.
+
+**Single Gate (added 2026-05-04 after spec-flow analysis)**
+- R12. Every dialog entry point must route through one gating
+  function whose contract is: predicate(expected, observed) AND
+  not-retained AND turn-not-active-on-this-thread. The reactive
+  `useEffect` that opens the dialog directly from overlay state must
+  not bypass this gate. There must be exactly one path that opens the
+  drift dialog.
+
+**Archived Thread Carve-Out (added 2026-05-04)**
+- R13. Drift detection must be skipped entirely for archived threads.
+  Archived workspaces intentionally land on a clean detached-HEAD
+  snapshot ref (per the `2026-04-22-003-feat-thread-worktree-archive-restore-plan.md`),
+  so any check would chronically false-positive. Archived state is
+  determined from the thread overlay, not from git.
+
+**Retention Scoping (added 2026-05-04)**
+- R14. The retention store excludes pairs where `expected === "HEAD"`.
+  These pairs represent a one-way transition (detached HEAD → first
+  named branch the user/agent moved to) and should not be permanently
+  silenced — each new "first named branch" is a meaningful, distinct
+  decision the user should be asked about. Existing retained pairs
+  with `expected === "HEAD"` are ignored on read (no migration
+  required).
+
+**Background Turn Completion (clarification of R6, added 2026-05-04)**
+- R15. When a turn completes on a thread the user is not currently
+  focused on, the end-of-turn drift check still runs and updates
+  overlay state. The dialog does NOT pop on the focused thread —
+  that would interrupt the user's current context. Instead, the
+  sidebar chip (per R4) shows the new observed branch and the dialog
+  fires when the user next focuses that thread.
+
+## Anti-Patterns
+
+- Excluding `expectedBranch === "HEAD"` from drift detection. This was
+  the historical bug — it suppressed real drift for threads created in
+  detached HEAD without telling the user, while the sidebar still
+  flagged drift.
+- Showing the drift dialog during an active turn. A rebase mid-turn
+  will trigger a false positive that disappears by turn end.
+- Adding side effects to the `drifted` boolean (reloads, enrichment
+  resets, etc). The field is a UI gate.
+- Letting the sidebar chip and the dialog disagree on the drift
+  predicate. They must share the same definition.

--- a/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
+++ b/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
@@ -1,0 +1,768 @@
+---
+title: Fix Thread Branch Drift Detection
+type: fix
+status: active
+date: 2026-05-04
+origin: docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md
+---
+
+# Fix Thread Branch Drift Detection
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-04
+**Sections enhanced:** Proposed Solution, Technical Considerations, System-Wide Impact, Implementation Phases, Risks
+**Reviewers used:** Kieran TypeScript, Architecture Strategist, Code Simplicity, Julik Frontend Races, Pattern Recognition, Framework Docs Researcher, Best Practices Researcher
+
+### Key Changes from Initial Plan
+
+1. **Predicate package collapsed to one export.** Original plan had three helpers (`isBranchDrifted`, `isRetentionablePair`, `isThreadArchivedForDriftPurposes`); simplicity + Kieran reviews showed two were dead weight. Final API is just `isBranchDrifted`. Archived check inlines a `Boolean(thread.archivedAt)` in `resolveExpectedThreadBranch`. Retention filter inlines `expected !== "HEAD"` at one read site and one write site.
+2. **`pendingBranchDriftRef` removed entirely.** Original plan deferred the suppressed dialog via a ref. Simplicity review showed the end-of-turn `useEffect` already runs a fresh IPC check that supersedes any deferred state. Removing the ref also kills two race conditions Julik flagged (stale read on thread switch, sibling-effect ordering).
+3. **`"turn-end"` reason reused as `"focus"`.** No code branches on the new value; the existing `"focus"` reason already covers "user attention returning to a settled thread."
+4. **R15 eager backend refresh dropped.** Original plan added a `turn/completed` hook in `BackendRegistry` to refresh observed branch on background threads. Architecture review flagged cohesion concerns; simplicity review showed the focus-path refresh covers the same case. Acceptable trade-off: sidebar chip on a non-focused thread is stale until next focus, at which point chip and dialog settle in the same tick.
+5. **Race-condition fixes added to Phase 2.** Julik's review surfaced four concrete races in the new effect lifecycle: same-render falling-edge misfire across thread switches, multi-await stale closure in `checkSelectedThreadBranchDrift`, sibling-effect ordering, and reactive-overlay-vs-falling-edge same-tick collision. All four addressed inline in Phase 2 with explicit guards.
+6. **Phase labels corrected.** Single-gate consolidation actually lands in Phase 2, not Phase 3. Phase 3 is archived-thread carve-out only.
+7. **External validation added.** Research across Cursor, Aider, GitHub Copilot Workspace, VS Code Git extension confirms suppression-during-turn is ahead of the field — Cursor has multiple open bugs from reacting to transient mid-rebase ref states. Naming "branch drift" is appropriate (avoids "inconsistency" / "mismatch" anti-patterns).
+8. **Deferred future work documented.** `useEffectEvent`, `useReducer` for dialog state, derived-state-during-render — flagged for follow-up rather than incorporated now, to keep this fix small and aligned with existing codebase idioms (which use `useRef` + `useEffect`).
+
+Net scope reduction: roughly 30–40% smaller surface area, same R1–R15 acceptance.
+
+## Overview
+
+Refine the desktop app's thread branch drift detection so that:
+
+1. Drift across the `HEAD` boundary is handled correctly on both sides
+   (HEAD → named **is** drift; named → HEAD is **not**) — partially
+   landed in this branch already.
+2. The drift dialog is suppressed while a turn is active and re-checked
+   when the turn settles (the rebase-mid-turn false-positive class).
+3. The sidebar `! now <branch>` chip and the drift dialog share one
+   predicate so they can never disagree.
+4. Archived threads (which intentionally sit on a detached snapshot ref)
+   are carved out of drift detection.
+
+This addresses the original "sidebar shows drift but dialog never opens"
+report and the broader "spurious branch dialog while the agent is
+rebasing" class.
+
+## Problem Statement / Motivation
+
+The user reported (2026-05-04, see screenshot in conversation thread
+`019df4a1-31c8-7e12-9dd8-af36a6a68bbf`) that the sidebar showed
+`! now fix/release-skill-squash-merge` for a thread whose `expectedBranch`
+was the literal string `"HEAD"` (Codex thread created during a detached
+HEAD state). The drift dialog never appeared. Backend logs showed
+`drifted=false` despite the sidebar chip rendering.
+
+Root cause: an `expectedBranch !== "HEAD"` exclusion in three places
+silently suppressed the dialog while the sidebar chip used a different
+predicate that did not skip HEAD. That root cause is fixed in this branch
+already (commit on `peaceful-mcnulty-efdbfa`).
+
+While discussing the fix, a second class of issue surfaced: agents
+frequently rebase mid-turn (`git rebase origin/main` detaches HEAD
+transiently before reattaching). The drift dialog should not interrupt
+mid-turn — it should fire at end-of-turn or on next focus.
+
+A third class surfaced during spec-flow analysis: the reactive overlay
+`useEffect` in `ThreadView.tsx` opens the dialog without going through
+the imperative IPC path. Any new gating logic must live in a unified
+gate or it leaks through this back-channel.
+
+A fourth class: archived threads land on a snapshot ref in detached HEAD
+(per `docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md`).
+Drift detection currently has no carve-out and would chronically
+false-positive once the dialog is allowed to fire.
+
+### Research Insights — external tools
+
+External survey (see references at end) confirms this class of bug is
+common and the proposed approach is novel:
+
+- **Cursor** has multiple documented bugs from reacting to transient
+  mid-rebase ref states — silent stash/reset, force-deleting source
+  branches when worktrees clean up, `.git/HEAD.lock` errors during
+  rebase. None of them suppress drift UI during agent turns.
+- **VS Code Git extension** acknowledges that `onDidChange` does not
+  reliably fire on branch changes (issue #189316). Most consumers don't
+  get fine-grained mid-rebase events at all, so transient detached HEAD
+  passes without UI. We DO get the fine-grained signal (we run
+  `git rev-parse` ourselves), so we have to suppress it deliberately.
+- **Aider** sidesteps the question by auto-committing before each turn.
+- **Cursor's worktree mode** (and competitors moving the same way)
+  isolates the agent's checkout so user state is irrelevant. Our handoff
+  + worktree story already does this; drift detection covers the
+  remaining "user is editing the same workspace as the agent" case.
+- The community-validated pattern for "turn started on A, ended on B":
+  log it, surface a non-blocking indicator, never auto-prompt or
+  auto-destroy. Matches our R6 (dialog) + R4 (chip) split.
+
+## Proposed Solution
+
+### High-level approach
+
+1. **Extract a single shared predicate** `isBranchDrifted(expected, observed)`
+   into `@pwragent/shared`. Renderer chip, renderer dialog gate, and
+   main-process `checkThreadBranchDrift` all consume it. Satisfies R4
+   (parity) and the predicate half of R12 (single gate).
+2. **Add a turn-activity gate in the renderer.** A new `tryOpenBranchDriftDialog`
+   wrapper consults `props.activeTurnId`. When a turn is active for the
+   focused thread, no dialog opens. The IPC check still runs (so overlay
+   observed branch stays fresh) but the dialog opening is short-circuited.
+3. **Add an end-of-turn drift recheck** as a `useEffect` that watches a
+   ref-tracked `{ threadKey, activeTurnId }` pair. On the falling edge
+   (`activeTurnId` transitions defined → undefined while `threadKey`
+   stays the same) the effect calls `checkSelectedThreadBranchDrift("focus")`
+   which does a fresh `git rev-parse` and routes through the gate. R6.
+4. **Unify the dialog entry path.** The reactive `useEffect` that
+   currently calls `showBranchDriftDialog` directly from overlay state
+   instead routes through `tryOpenBranchDriftDialog`. R12.
+5. **Carve out archived threads** at `resolveExpectedThreadBranch`
+   (returns `undefined` for archived threads). Both the chip predicate
+   and the dialog gate already short-circuit on `expected === undefined`,
+   so carving out at this single layer covers all surfaces. R13.
+6. **Scope retention.** Reject pairs with `expected === "HEAD"` on
+   write; filter them out on read. R14.
+7. **Sidebar chip parity** comes for free once the chip uses
+   `isBranchDrifted` — the helper already excludes `observed === "HEAD"`
+   and short-circuits on archived threads via `gitBranch === undefined`.
+
+### What is already done in this branch
+
+- Removed `expectedBranch !== "HEAD"` from
+  `apps/desktop/src/main/app-server/backend-registry.ts` (drift compute,
+  twice).
+- Removed `expectedBranch !== "HEAD"` from
+  `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+  (`canWarnForBranchDrift`).
+- Captured requirements at
+  `docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md`.
+
+### What this plan adds
+
+- Shared `isBranchDrifted` predicate in `@pwragent/shared`.
+- Turn-activity gating + end-of-turn recheck in `ThreadView.tsx`.
+- Reactive-effect unification through the imperative gate.
+- Archived-thread carve-out at `resolveExpectedThreadBranch`.
+- Retention scoping for `expected === "HEAD"`.
+- Sidebar chip parity via shared predicate.
+- Renderer + E2E test coverage for the new gates.
+
+### Research Insights — predicate API design
+
+- Return type stays `boolean`. R9 makes the predicate a UI gate, not a
+  state machine; a discriminated union would just collapse to a boolean
+  at every call site. (Kieran)
+- Don't import `Pick<NavigationThreadSummary, ...>` into
+  `packages/shared/` for an archived helper. Archival semantics live
+  outside the predicate; inline the `Boolean(archivedAt)` check inside
+  `resolveExpectedThreadBranch` instead. (Kieran, Architecture)
+- Naming `isBranchDrifted(expected, observed)` matches existing
+  predicate idiom (`isTerminalTurnLifecycle`, `isDesktopChatReplyComposer`).
+  (Pattern Recognition confirmed against existing codebase.)
+
+## Technical Considerations
+
+### Where the shared predicate lives
+
+New file: `packages/shared/src/contracts/branch-drift.ts`. Re-exported
+from `packages/shared/src/index.ts`. Single export:
+
+```ts
+// packages/shared/src/contracts/branch-drift.ts
+export function isBranchDrifted(
+  expected: string | undefined,
+  observed: string | undefined,
+): boolean {
+  if (!expected || !observed) return false;
+  if (observed === "HEAD") return false;
+  return expected !== observed;
+}
+```
+
+Three call sites:
+
+- `apps/desktop/src/main/app-server/backend-registry.ts` (drift compute,
+  twice — replaces the inline expression already in the branch).
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+  (`canWarnForBranchDrift` becomes a one-liner that calls the helper
+  plus `branchDriftRetained`).
+- `apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx`
+  (chip predicate becomes the helper).
+
+### Turn-activity gate
+
+```ts
+// pseudo - apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+const tryOpenBranchDriftDialog = (params: {
+  thread: NavigationThreadSummary;
+  expected: string;
+  observed: string;
+  reason: BranchDriftDialogState["reason"];
+  checkedAt?: number;
+}): boolean => {
+  if (props.activeTurnId !== undefined) return false;
+  return showBranchDriftDialog(params.thread, params.expected, params.observed, params.reason, params.checkedAt);
+};
+```
+
+Options-object signature avoids the `(observed, expected)` swap hazard
+flagged by Kieran (both are `string`, TypeScript can't catch the swap).
+
+The reactive overlay effect at `ThreadView.tsx:830` and
+`checkSelectedThreadBranchDrift` both call this wrapper instead of
+`showBranchDriftDialog` directly. R12.
+
+### End-of-turn falling-edge effect
+
+```ts
+// pseudo
+const previousTurnRef = useRef<{ threadKey: string; activeTurnId: string | undefined }>({
+  threadKey: selectedThreadKey ?? "",
+  activeTurnId: props.activeTurnId,
+});
+useEffect(() => {
+  const previous = previousTurnRef.current;
+  const current = { threadKey: selectedThreadKey ?? "", activeTurnId: props.activeTurnId };
+  previousTurnRef.current = current;
+
+  // Only fire end-of-turn check when:
+  //   - thread did NOT change
+  //   - activeTurnId went defined → undefined
+  if (
+    previous.threadKey === current.threadKey &&
+    previous.activeTurnId !== undefined &&
+    current.activeTurnId === undefined
+  ) {
+    void checkSelectedThreadBranchDrift("focus");
+  }
+}, [props.activeTurnId, selectedThreadKey]);
+```
+
+`reason: "focus"` is reused — no `"turn-end"` variant. Nothing else in
+the dialog branches on reason except the special "turn" reason for the
+pre-turn case.
+
+The combined `{ threadKey, activeTurnId }` ref closes the race Julik
+identified: when both deps change in the same render (user clicks a
+different thread while a turn is mid-flight), the strict `threadKey`
+equality guard prevents a spurious end-of-turn check from firing on
+the new thread. Same-render thread switch just updates the ref and
+bails.
+
+### Stale-closure guard inside `checkSelectedThreadBranchDrift`
+
+The existing function awaits IPC then awaits navigation refresh before
+opening the dialog. If the user navigates away mid-await, the closure's
+captured `thread` becomes stale. Add a check against a live
+`selectedThreadKeyRef`:
+
+```ts
+// pseudo - inside checkSelectedThreadBranchDrift
+const startedThreadKey = `${thread.source}:${thread.id}`;
+const result = await props.desktopApi.checkThreadBranchDrift({...});
+if (selectedThreadKeyRef.current !== startedThreadKey) return false;
+if (result.observedBranch !== thread.observedGitBranch) {
+  await props.onRefreshNavigation?.();
+  if (selectedThreadKeyRef.current !== startedThreadKey) return false;
+}
+// ... continue with tryOpenBranchDriftDialog
+```
+
+`selectedThreadKeyRef` is established with the existing pattern used in
+`useThreadSessionState.ts:1573` and `Composer.tsx:838` — no new helpers.
+Pattern Recognition confirmed this matches codebase idiom.
+
+### Archived-thread carve-out
+
+`resolveExpectedThreadBranch` in
+`apps/desktop/src/main/app-server/backend-registry.ts:290` gains:
+
+```ts
+function resolveExpectedThreadBranch(params: {...}): string | undefined {
+  if (params.thread?.archivedAt) return undefined;
+  // ...existing logic
+}
+```
+
+That single change makes drift compute return `false` for archived
+threads via `isBranchDrifted`'s undefined-short-circuit. The renderer's
+`canWarnForBranchDrift` short-circuits on the same condition because
+the IPC reply carries `expectedBranch: undefined`. The chip predicate
+short-circuits on `gitBranch` from the renderer's overlay snapshot,
+which `navigation-state.ts` will need a parallel guard in (verify
+during Phase 3).
+
+### Retention scoping
+
+`branchDriftRetained()` in `ThreadView.tsx:740` adds a filter:
+
+```ts
+const branchDriftRetained = (thread, expectedBranch, observedBranch) =>
+  expectedBranch !== "HEAD" &&  // R14: never silence (HEAD, *) pairs
+  (thread.retainedBranchDriftPairs ?? []).some(...);
+```
+
+The IPC handler `retainThreadBranchDrift` in
+`apps/desktop/src/main/app-server/backend-registry.ts` adds an
+identical guard so we never persist a `(HEAD, *)` pair in the first
+place. Existing rows in user state are tolerated and ignored on read.
+
+### Research Insights — React lifecycle patterns
+
+- The codebase idiom for "previous prop value" is **inline `useRef` +
+  `useEffect`**, not a `usePrevious` hook. See `useThreadSessionState.ts:1573`,
+  `useThreadNavigation.ts:827`, `Composer.tsx:838`. Stay with the
+  idiom; do not introduce a custom hook for one site. (Pattern Recognition)
+- React 19+ recommends `useEffectEvent` for "imperative function called
+  from multiple effects, always sees latest state." The codebase has
+  not adopted this yet. Defer to a follow-up plan once the codebase
+  starts using it elsewhere; introducing a one-off `useEffectEvent` here
+  would be inconsistent. (Framework Docs Researcher; deferred.)
+- `useReducer` for dialog state would make "exactly one dialog open at
+  a time" structural rather than convention. Architecture review
+  recommended this; simplicity review pushed back as out-of-scope.
+  Decision: defer to a follow-up. The current `useState` + the
+  `tryOpenBranchDriftDialog` gate is sufficient if combined with the
+  race fixes above. Note as future tech debt at PR time.
+
+## System-Wide Impact
+
+### Interaction graph
+
+- **Pre-turn path**: Composer → `onBeforeStartTurn` →
+  `checkSelectedThreadBranchDrift("turn")` → `tryOpenBranchDriftDialog`
+  → (if drift and !activeTurnId and !retained) dialog opens → user
+  retains/updates → submission proceeds. **Unchanged.** R8.
+- **End-of-turn path (NEW)**: `props.activeTurnId` falling edge with
+  `threadKey` stable → `checkSelectedThreadBranchDrift("focus")` →
+  `tryOpenBranchDriftDialog` (gate clears since `activeTurnId === undefined`)
+  → dialog opens if drifted. R6.
+- **Focus path**: `selectedThreadKey` change OR window focus →
+  `checkSelectedThreadBranchDrift("focus")` → `tryOpenBranchDriftDialog`
+  → (gate may suppress if a turn is active on the focused thread).
+- **Reactive-overlay path (CHANGED)**: was bypassing the gate; now
+  routes through `tryOpenBranchDriftDialog`. Becomes a no-op while a
+  turn is active. R12.
+- **Background-thread completion (CLARIFIED)**: turn completes on a
+  thread the user is NOT focused on. The renderer's per-thread session
+  reducer clears that thread's `activeTurnId` but never propagates as
+  ThreadView props for the focused thread, so the falling-edge effect
+  does not fire (correct — we don't want the dialog popping on the
+  current thread). The sidebar chip stays stale until the next focus
+  event refreshes. On focus, the focus-path useEffect fires
+  `checkSelectedThreadBranchDrift("focus")` and the dialog opens if
+  drifted. R15. (This is the simplification: no eager backend hook.)
+
+### Error & failure propagation
+
+- `git rev-parse` failure already swallowed by
+  `readCurrentGitBranch().catch()` in
+  `apps/desktop/src/main/app-server/backend-registry.ts:310`.
+  Unchanged.
+- IPC `checkThreadBranchDrift` failure caught by the empty catch in
+  `checkSelectedThreadBranchDrift` (`ThreadView.tsx:821`). Unchanged.
+- New end-of-turn IPC call uses the same path, so same swallow.
+
+### State lifecycle risks
+
+- **No `pendingBranchDriftRef`**, so no cleanup ordering hazard between
+  sibling effects. (Removed per simplicity review + race review.)
+- **Stale-closure guard** added inside
+  `checkSelectedThreadBranchDrift` prevents the dialog from attaching
+  to an already-deselected thread.
+- **Combined-ref equality guard** in the falling-edge effect prevents
+  spurious end-of-turn checks during same-render thread switches.
+- Retention dataset filtering happens on read AND write so a pair
+  stored under the old logic doesn't permanently silence a user.
+
+### API surface parity
+
+`packages/shared/src/contracts/branch-drift.ts` is the only predicate.
+Three call sites listed above. Audit for additional consumers during
+Phase 1 implementation — repo research did not find others.
+
+### Integration test scenarios
+
+Cross-layer scenarios that unit tests with mocks won't catch:
+
+1. **Mid-turn rebase**: launch a real turn on a fixture repo, rebase
+   into detached HEAD, complete turn, observe no dialog mid-turn and
+   correct dialog at end-of-turn. (E2E.)
+2. **Same-render thread switch**: focus thread A with active turn,
+   click thread B, observe NO dialog flashes. (Renderer integration.)
+3. **Background turn completion + focus**: focus thread B, complete a
+   turn on thread A, focus thread A, observe dialog opens. (E2E.)
+4. **Pre-turn dialog blocks submit**: with drift present, hit submit;
+   dialog opens; pressing "Update Expected Branch" resubmits cleanly.
+   (E2E — already exists; verify not regressed.)
+5. **Archived thread**: archive a thread that has drift, observe no
+   chip and no dialog. (Renderer integration.)
+6. **Retention with HEAD expected**: retain a `(HEAD, fix/foo)` pair
+   (or attempt to — write should reject), trigger drift to
+   `(HEAD, fix/bar)`, observe dialog still fires. (Renderer integration.)
+7. **Mid-await thread navigation**: trigger drift check, navigate away
+   mid-IPC, observe dialog never appears for the deselected thread.
+   (Renderer integration.)
+
+### Research Insights — external tools (carry from Overview)
+
+Suppression-during-turn is novel relative to Cursor / Aider / Copilot
+Workspace. Cursor has multiple open bugs from NOT suppressing. Status-bar
+indicator + non-blocking dialog at turn-end matches the pattern used by
+the `vscode-branch-warning` extension (which has a `suppressPopup`
+setting that demotes warnings to the status bar).
+
+## Implementation Phases
+
+### Phase 1 — Shared predicate
+
+**Files:**
+- `packages/shared/src/contracts/branch-drift.ts` (new, ~12 LOC)
+- `packages/shared/src/index.ts` (re-export)
+- `packages/shared/src/contracts/__tests__/branch-drift.test.ts` (new)
+- `apps/desktop/src/main/app-server/backend-registry.ts` (drift compute
+  twice — replace inline expression)
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+  (`canWarnForBranchDrift` calls helper)
+- `apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx`
+  (chip predicate calls helper; chip now suppresses for `observed === "HEAD"`)
+
+**Deliverables:**
+- Single export `isBranchDrifted(expected, observed): boolean`.
+- Unit tests covering: both undefined; expected="HEAD" + observed named
+  (drift); observed="HEAD" + expected named (no drift);
+  expected===observed (no drift); both named differing (drift).
+- Audit: confirm no other consumer of the predicate exists (document
+  scan in PR description).
+
+**Success criteria:**
+- `pnpm --filter @pwragent/desktop run typecheck` passes.
+- `pnpm test packages/shared` passes new unit suite.
+- Existing `backend-registry.test.ts` and `thread-view.test.tsx`
+  branch-drift suites still pass without modification.
+
+**Independence:** standalone. Can ship as its own PR.
+
+### Phase 2 — Single gate + turn lifecycle (R5, R6, R7, R12, race fixes)
+
+**Files:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
+
+**Deliverables:**
+- New `tryOpenBranchDriftDialog` wrapper (options-object signature)
+  consulting `props.activeTurnId`.
+- Reactive overlay `useEffect` (current line ~830) routed through the
+  wrapper.
+- Focus + window-focus useEffect (current line ~851) unchanged in
+  trigger logic; the wrapper handles suppression.
+- New `useEffect` watching `{ threadKey, activeTurnId }` falling edge
+  via combined ref (per "End-of-turn falling-edge effect" above).
+  Reuses `"focus"` reason — no new union variant.
+- New `selectedThreadKeyRef` updated each render (or at the existing
+  point if one already exists), consulted inside
+  `checkSelectedThreadBranchDrift` to abort dialog opening if the user
+  has navigated away mid-await.
+
+**Tests:**
+- "drift dialog suppressed during active turn" — render with
+  `activeTurnId="turn-1"` and overlay drift state; assert dialog absent;
+  rerender with `activeTurnId={undefined}` and assert dialog appears.
+- "end-of-turn fires drift recheck" — mock `checkThreadBranchDrift`
+  returning drifted=true; render with active turn → assert no dialog;
+  transition `activeTurnId` → undefined → assert IPC called and dialog
+  opens.
+- "same-render thread switch suppresses end-of-turn dialog" — render
+  with thread A focused and active turn; in one rerender flip both
+  `selectedThread` to B and `activeTurnId` to undefined; assert no
+  dialog opens for either thread.
+- "navigation away during IPC await suppresses dialog" — mock
+  `checkThreadBranchDrift` with a deferred resolve; trigger check on
+  thread A; rerender with thread B selected; resolve the deferred
+  promise; assert no dialog.
+- "reactive overlay path respects active turn" — render with
+  `activeTurnId="turn-1"` and update `selectedThread.observedGitBranch`
+  to drift state; assert no dialog.
+
+**Success criteria:**
+- All new and existing renderer tests pass.
+- Manual: launch dev app, start a turn that runs `git rebase HEAD~3`
+  on a fixture repo, observe no dialog mid-turn and correct dialog at
+  end-of-turn.
+
+**Independence:** depends on Phase 1's helper for the predicate calls
+inside the wrapper. Ship after Phase 1.
+
+### Phase 3 — Archived carve-out (R13)
+
+**Files:**
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+  (`resolveExpectedThreadBranch` returns `undefined` for archived)
+- `packages/agent-core/src/domain/navigation-state.ts` (verify the
+  renderer's `selectedThread` snapshot also surfaces `gitBranch` as
+  undefined for archived threads, since the chip reads overlay-merged
+  state, not the IPC reply)
+- Tests in `backend-registry.test.ts` and `thread-view.test.tsx`.
+
+**Deliverables:**
+- Archived-thread predicate centralized in `resolveExpectedThreadBranch`.
+- Parallel guard in `navigation-state.ts` if the audit reveals one is
+  needed for chip consistency.
+
+**Tests:**
+- `backend-registry.test.ts`: `checkThreadBranchDrift` for an archived
+  thread returns `drifted: false` regardless of git state.
+- `thread-view.test.tsx`: archived thread with drift state in overlay
+  renders no dialog.
+- `ThreadMetaChips` unit test (if not already present): archived thread
+  shows no `! now <branch>` chip.
+
+**Success criteria:**
+- All tests pass.
+- Manual: archive a fixture thread that has drift, confirm sidebar chip
+  and detail pane both stop showing drift artifacts.
+
+**Independence:** standalone. Can ship before Phase 2 if convenient.
+
+### Phase 4 — Retention scoping + E2E coverage (R14)
+
+**Files:**
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
+  (`branchDriftRetained` filters via `expected !== "HEAD"`)
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+  (`retainThreadBranchDrift` rejects pairs where `expected === "HEAD"`,
+  silently — no log)
+- `apps/desktop/e2e/thread-branch-drift.spec.ts` (extend with
+  turn-active variant)
+
+**Deliverables:**
+- Filter-on-read in renderer (one-line addition).
+- Reject-on-write in main process (silent — no debug log per simplicity
+  review).
+- New E2E test "suppresses drift dialog during active turn and surfaces
+  on turn end" using the existing `createBranchDriftFixture` extended
+  with `turn/started` and `turn/completed` notification steps. Use
+  `apps/desktop/e2e/fixtures/turn-lifecycle/` as a reference for
+  notification encoding.
+
+**Tests:**
+- Renderer: "retained (HEAD, X) pair does not silence later (HEAD, Y)
+  drift" — preload retained pairs in mock, assert dialog still opens.
+- Main process: `retainThreadBranchDrift` with `expected="HEAD"` does
+  not persist (assertion against overlay-store mock).
+- E2E: turn-active variant per above.
+
+**Success criteria:**
+- `pnpm test:desktop-e2e` passes including the new spec.
+- All unit suites pass.
+
+**Dependency note:** the E2E "turn-active" variant requires Phase 2's
+gate to be in place. The retention code itself is independent. Can
+split into Phase 4a (retention) and Phase 4b (E2E) if useful.
+
+## Acceptance Criteria
+
+### Functional Requirements (carry forward from origin R1–R15)
+
+- [ ] R1 / R2 / R3: predicate returns drifted only when expected and
+  observed are both known, observed is not "HEAD", and they differ.
+  HEAD-on-expected counts as drift; HEAD-on-observed does not.
+  (Already passes; Phase 1 preserves through shared helper.)
+- [ ] R4: sidebar chip and dialog use the same shared predicate. Chip
+  suppresses when observed is "HEAD".
+- [ ] R5 / R7: drift dialog does not open during an active turn on the
+  focused thread, regardless of which entry path triggers it (focus,
+  window focus, reactive overlay).
+- [ ] R6: drift is rechecked at end-of-turn (active → undefined
+  transition with thread unchanged) and dialog opens if still drifted.
+- [ ] R8: pre-turn check unchanged, blocks submission until user
+  resolves dialog.
+- [ ] R9: `drifted` boolean remains UI-warning gate only; no thread
+  reload, no enrichment discard.
+- [ ] R10 / R11: retain and update actions behave as today.
+- [ ] R12: exactly one dialog entry path; reactive overlay effect
+  routes through the same gate as imperative checks.
+- [ ] R13: archived threads have no chip, no dialog, no drift compute
+  (compute returns drifted=false because expected is undefined).
+- [ ] R14: retention rejects and ignores pairs where `expected === "HEAD"`.
+- [ ] R15: turn completion on a non-focused thread does not pop dialog
+  on the focused thread, dialog fires on next focus of the completed
+  thread.
+
+### Race-condition Acceptance (added during deepen)
+
+- [ ] Same-render thread switch with `activeTurnId` flip does not fire
+  a spurious end-of-turn dialog (combined-ref guard).
+- [ ] Mid-await navigation away does not surface dialog on the
+  deselected thread (`selectedThreadKeyRef` guard).
+- [ ] Reactive overlay update in same render as turn-end transition
+  does not double-open the dialog.
+
+### Quality Gates
+
+- [ ] `pnpm --filter @pwragent/desktop run typecheck` clean
+- [ ] `pnpm test` clean (workspace-wide)
+- [ ] `pnpm test:desktop-e2e` clean
+- [ ] `pnpm test packages/shared` covers shared predicate
+- [ ] Manual smoke test: agent rebase mid-turn on a real repo, verify
+  no false positive
+
+## Success Metrics
+
+- Zero "spurious branch drift dialog while agent was rebasing" reports
+  in the next 30 days.
+- Zero "sidebar shows drift but dialog never appears" reports in the
+  next 30 days (the original bug class).
+- No regressions in existing pre-turn drift detection (R8 path).
+
+## Dependencies & Risks
+
+### Dependencies
+
+- None new. Uses existing `@pwragent/shared` workspace package and
+  existing `desktopApi.checkThreadBranchDrift` IPC.
+- The `archivedAt` field on `NavigationThreadSummary` (or whatever
+  archival sentinel exists) must reliably reflect archival state — Phase 3
+  audit confirms shape and propagation through `navigation-state.ts`.
+
+### Risks
+
+- **Risk: `props.desktopApi` referential instability up the prop tree
+  (pre-existing).** The window-focus useEffect at `ThreadView.tsx:851`
+  re-subscribes on every `props.desktopApi` change. If a parent passes
+  a freshly-built object literal, every render registers a new listener.
+  Mitigation: confirm referential stability in App.tsx; if not stable,
+  destructure `onWindowFocus` once into a local stable reference.
+  (Pre-existing; flagged by Julik. Verify in Phase 2 work.)
+- **Risk: existing retained pairs in user state include
+  `expected === "HEAD"` rows.** Impact: users may see a one-time dialog
+  for a pair they previously retained. Acceptable per R14 since each
+  "first named branch" is meaningfully distinct.
+- **Risk: archived-thread propagation diverges between IPC reply path
+  and overlay snapshot path.** Mitigation: Phase 3 audit centralizes at
+  `resolveExpectedThreadBranch` AND verifies `navigation-state.ts`
+  applies the same guard. Single test covers both surfaces (chip and
+  dialog).
+
+### Risks closed by simplification
+
+- (Closed) `pendingBranchDriftRef` lifecycle hazards — ref removed.
+- (Closed) Sibling-effect cleanup ordering — no sibling effects to
+  order.
+- (Closed) R15 eager-refresh navigation-snapshot invalidation — no
+  eager refresh.
+
+## Future Considerations
+
+- Once `docs/solutions/` exists in this repo, write a solution doc
+  capturing the "drift detection + turn lifecycle + detached HEAD"
+  intersection so future maintainers don't relearn it. This plan and
+  its origin requirements doc should be cited.
+- **`useEffectEvent` adoption** (React 19+): `tryOpenBranchDriftDialog`
+  is a textbook fit. Defer until the codebase adopts `useEffectEvent`
+  more broadly.
+- **`useReducer` for dialog state**: would make "exactly one dialog
+  open at a time" a structural invariant. Architecture review flagged
+  the current `useState` + gate as functional but conventional. Defer.
+- **Worktree isolation**: Cursor and competitors are moving toward
+  worktree-per-agent so user state never collides with agent state.
+  Our handoff-to-worktree path already supports this; encouraging users
+  toward worktree mode is a UX direction independent of this fix.
+
+## Sources & References
+
+### Origin
+
+- **Origin document:**
+  [docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md](docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md)
+  — carries forward R1–R15. R12–R15 were added during spec-flow
+  analysis on 2026-05-04 and explicitly resolved in this plan.
+
+### Internal references
+
+- Predicate compute (backend):
+  [apps/desktop/src/main/app-server/backend-registry.ts:1820](apps/desktop/src/main/app-server/backend-registry.ts:1820)
+  (`checkThreadBranchDrift`),
+  [apps/desktop/src/main/app-server/backend-registry.ts:290](apps/desktop/src/main/app-server/backend-registry.ts:290)
+  (`resolveExpectedThreadBranch`)
+- Renderer dialog gate:
+  [apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:751](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:751)
+  (`canWarnForBranchDrift`),
+  [ThreadView.tsx:759](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:759)
+  (`showBranchDriftDialog`),
+  [ThreadView.tsx:785](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:785)
+  (`checkSelectedThreadBranchDrift`)
+- Reactive overlay effect (R12 target):
+  [ThreadView.tsx:830](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:830)
+- Focus + window focus useEffect:
+  [ThreadView.tsx:851](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:851)
+- Pre-turn hookup (R8):
+  [ThreadView.tsx:1514](apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx:1514)
+- Sidebar chip (R4 target):
+  [apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx:19](apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx:19)
+- Active turn id origin:
+  [apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:100](apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:100)
+  (state shape),
+  [useThreadSessionState.ts:2261](apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:2261)
+  (turn-completed reducer)
+- Existing prev-value ref pattern:
+  [useThreadSessionState.ts:1573](apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:1573),
+  [useThreadNavigation.ts:827](apps/desktop/src/renderer/src/lib/useThreadNavigation.ts:827),
+  [Composer.tsx:838](apps/desktop/src/renderer/src/features/composer/Composer.tsx:838)
+- Existing renderer drift tests:
+  [thread-view.test.tsx:2713](apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx:2713)
+  and
+  [thread-view.test.tsx:2801](apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx:2801)
+- Existing backend drift test:
+  [backend-registry.test.ts:2867](apps/desktop/src/main/__tests__/backend-registry.test.ts:2867)
+- Existing E2E:
+  [apps/desktop/e2e/thread-branch-drift.spec.ts](apps/desktop/e2e/thread-branch-drift.spec.ts)
+- Turn-lifecycle E2E reference:
+  [apps/desktop/e2e/fixtures/turn-lifecycle/](apps/desktop/e2e/fixtures/turn-lifecycle/)
+- Existing predicate naming idiom:
+  [packages/shared/src/contracts/settings.ts:243](packages/shared/src/contracts/settings.ts:243)
+  (`isDesktopChatReplyComposer`),
+  [apps/desktop/src/main/messaging/core/messaging-controller.ts:3448](apps/desktop/src/main/messaging/core/messaging-controller.ts:3448)
+  (`isTerminalTurnLifecycle`)
+- Existing predicate test home:
+  [packages/shared/src/contracts/__tests__/settings.test.ts](packages/shared/src/contracts/__tests__/settings.test.ts)
+
+### React documentation
+
+- [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)
+- [useEffectEvent (deferred adoption)](https://react.dev/reference/react/useEffectEvent)
+- [Synchronizing with Effects](https://react.dev/learn/synchronizing-with-effects)
+- [`<StrictMode>`](https://react.dev/reference/react/StrictMode)
+- [Removing Effect Dependencies](https://react.dev/learn/removing-effect-dependencies)
+
+### External tool research (drift detection in AI coding agents)
+
+- [Cursor: silent stash/reset bug](https://forum.cursor.com/t/cursor-ide-silently-runs-git-stash-git-reset-head-during-active-agent-session-all-uncommitted-changes-lost/156146)
+- [Cursor: WorktreeManager force-deleted branch](https://forum.cursor.com/t/cursors-worktreemanager-force-deleted-my-git-branch-when-cleaning-up-agent-worktrees/146865)
+- [Cursor: rebase .lockd issue](https://forum.cursor.com/t/bug-report-git-rebase-lock-file-lockd-issue-preventing-operation-completion/42184)
+- [Cursor worktrees docs](https://cursor.com/docs/configuration/worktrees)
+- [VS Code Git: onDidChange branch issue #189316](https://github.com/microsoft/vscode/issues/189316)
+- [vscode-branch-warning extension (suppressPopup precedent)](https://github.com/teledemic/vscode-branch-warning)
+- [aider git integration docs](https://aider.chat/docs/git.html)
+- [GitHub Copilot agent default-branch limitation](https://github.com/orgs/community/discussions/159836)
+
+### Related plans
+
+- [docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md](docs/plans/2026-04-22-003-feat-thread-worktree-archive-restore-plan.md)
+  — establishes archived workspaces sit on a snapshot ref in detached
+  HEAD, motivating R13.
+- [docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md](docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md)
+  — defines overlay-vs-backend split that drift detection reasons over.
+- [docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md](docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md)
+  — adjacent UX vocabulary for branch occupancy and detached HEAD.
+- [docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md](docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md)
+  — `isTerminalTurnLifecycle` primitive considered (and rejected) for
+  the gate; `activeTurnId` is already terminal-aware via the reducer.
+
+### Institutional learnings
+
+- No `docs/solutions/` directory exists yet in this repo. Once the fix
+  lands, this is a strong candidate for the first solutions doc (per
+  `CLAUDE.md`'s mention of "future `docs/solutions/`"). Topic:
+  "Drift detection + turn lifecycle + detached HEAD intersection."

--- a/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
+++ b/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
@@ -538,6 +538,20 @@ tests preserved.
 
 ### Phase 4 — Retention scoping + E2E coverage (R14)
 
+**Implementation status (2026-05-04):**
+- Retention filter-on-read + reject-on-write: LANDED.
+- Unit tests for both surfaces: LANDED.
+- Turn-active E2E variant: DEFERRED to a follow-up. The existing
+  branch-drift E2E was hand-rolled without using the seeding skill;
+  extending it with `turn/started`/`turn/completed` notification steps
+  is non-trivial (~250 LOC fixture-format study). Coverage of the
+  active-turn gate is provided by the renderer unit tests added in
+  Phase 2 (`suppresses the branch drift dialog while a turn is active`,
+  `re-checks branch drift on end-of-turn falling edge`,
+  `does not fire end-of-turn drift check when both thread and activeTurnId change in one render`).
+  The trade-off: the IPC plumbing isn't smoke-tested for the turn-gate
+  case end-to-end, but the gate logic itself is well-covered.
+
 **Files:**
 - `apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx`
   (`branchDriftRetained` filters via `expected !== "HEAD"`)

--- a/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
+++ b/docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md
@@ -496,34 +496,45 @@ inside the wrapper. Ship after Phase 1.
 
 ### Phase 3 — Archived carve-out (R13)
 
-**Files:**
-- `apps/desktop/src/main/app-server/backend-registry.ts`
-  (`resolveExpectedThreadBranch` returns `undefined` for archived)
-- `packages/agent-core/src/domain/navigation-state.ts` (verify the
-  renderer's `selectedThread` snapshot also surfaces `gitBranch` as
-  undefined for archived threads, since the chip reads overlay-merged
-  state, not the IPC reply)
-- Tests in `backend-registry.test.ts` and `thread-view.test.tsx`.
+**Implementation finding (2026-05-04):** R13 is satisfied entirely by
+R3's `observed === "HEAD"` short-circuit. No new code is required.
 
-**Deliverables:**
-- Archived-thread predicate centralized in `resolveExpectedThreadBranch`.
-- Parallel guard in `navigation-state.ts` if the audit reveals one is
-  needed for chip consistency.
+Investigation revealed:
 
-**Tests:**
-- `backend-registry.test.ts`: `checkThreadBranchDrift` for an archived
-  thread returns `drifted: false` regardless of git state.
-- `thread-view.test.tsx`: archived thread with drift state in overlay
-  renders no dialog.
-- `ThreadMetaChips` unit test (if not already present): archived thread
-  shows no `! now <branch>` chip.
+1. **Archived threads are not in the navigation snapshot.** The
+   navigation `listThreads` flow filters by `archived: false` by
+   default (see `backend-registry.ts:2643` and
+   `session-state.ts:89`). A thread that has been archived simply
+   does not appear in `selectedThread` for the renderer, so neither
+   the chip nor the dialog runs against it.
+2. **Archive lives at the worktree, not the thread.** `archivedAt`
+   exists on `WorktreeSnapshotSummary` (per-worktree) and the per-thread
+   archived bucket on the backend. There is no top-level
+   `thread.archivedAt` for the predicate to read, so the planned
+   `Boolean(thread.archivedAt)` carve-out has no input.
+3. **Restored archive worktrees land on detached HEAD.** Per the
+   archive-restore plan, restoring a snapshot puts the workspace on a
+   snapshot ref in detached HEAD. `git rev-parse --abbrev-ref HEAD`
+   returns `"HEAD"` in that state, which the R3 rule already
+   short-circuits. Both `isBranchDrifted("feature/x", "HEAD")` and
+   the backend predicate return `drifted: false`.
+
+**Deliverables (this phase):**
+- New `backend-registry.test.ts` case
+  `"does not flag drift when observed branch is HEAD (restored archived snapshot)"`
+  that locks in R3 for the restored-archive scenario explicitly,
+  preventing future regressions of the SpecFlow-flagged
+  "saved by R3 but only by accident" concern.
+- Documentation update in this plan recording the finding.
+
+**Tests:** new test added in this phase; existing 46 backend-registry
+tests preserved.
 
 **Success criteria:**
-- All tests pass.
-- Manual: archive a fixture thread that has drift, confirm sidebar chip
-  and detail pane both stop showing drift artifacts.
+- New test passes.
+- No code change to `resolveExpectedThreadBranch`.
 
-**Independence:** standalone. Can ship before Phase 2 if convenient.
+**Independence:** standalone documentation/test phase.
 
 ### Phase 4 — Retention scoping + E2E coverage (R14)
 

--- a/packages/shared/src/contracts/__tests__/branch-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/branch-drift.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isBranchDrifted } from "../branch-drift";
+
+describe("isBranchDrifted", () => {
+  it("returns false when both args are undefined", () => {
+    expect(isBranchDrifted(undefined, undefined)).toBe(false);
+  });
+
+  it("returns false when expected is undefined", () => {
+    expect(isBranchDrifted(undefined, "main")).toBe(false);
+  });
+
+  it("returns false when observed is undefined", () => {
+    expect(isBranchDrifted("main", undefined)).toBe(false);
+  });
+
+  it("returns false when both are equal named branches", () => {
+    expect(isBranchDrifted("main", "main")).toBe(false);
+  });
+
+  it("returns true when expected is HEAD and observed is a named branch", () => {
+    expect(isBranchDrifted("HEAD", "fix/release-skill-squash-merge")).toBe(true);
+  });
+
+  it("returns false when observed is HEAD and expected is a named branch", () => {
+    expect(isBranchDrifted("main", "HEAD")).toBe(false);
+  });
+
+  it("returns false when both are HEAD", () => {
+    expect(isBranchDrifted("HEAD", "HEAD")).toBe(false);
+  });
+
+  it("returns true when both are different named branches", () => {
+    expect(isBranchDrifted("main", "feature/x")).toBe(true);
+  });
+
+  it("treats empty strings as missing", () => {
+    expect(isBranchDrifted("", "main")).toBe(false);
+    expect(isBranchDrifted("main", "")).toBe(false);
+  });
+});

--- a/packages/shared/src/contracts/branch-drift.ts
+++ b/packages/shared/src/contracts/branch-drift.ts
@@ -1,0 +1,8 @@
+export function isBranchDrifted(
+  expected: string | undefined,
+  observed: string | undefined,
+): boolean {
+  if (!expected || !observed) return false;
+  if (observed === "HEAD") return false;
+  return expected !== observed;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./contracts/normalized-app-server";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
+export * from "./contracts/branch-drift";
 export * from "./contracts/diff-focus";
 export * from "./contracts/messaging";
 export * from "./contracts/navigation";


### PR DESCRIPTION
## Summary

Fixes the original report ([screenshot](https://github.com/pwrdrvr/PwrAgent)) where the sidebar chip showed `! now fix/release-skill-squash-merge` for a thread whose expected branch was the literal string `\"HEAD\"` (Codex thread created during a detached HEAD state) — the drift dialog never appeared even though the chip flagged it. Also closes a related class of issue: spurious drift dialogs while an agent is mid-rebase.

Five commits across four phases:

- **Phase 1** ([b97594e2](https://github.com/pwrdrvr/PwrAgent/commit/b97594e2)): Extract a shared `isBranchDrifted` predicate to `@pwragent/shared` so the sidebar chip, renderer dialog gate, and main-process drift compute use one helper. HEAD → named branch IS drift; named → HEAD is NOT (transient mid-rebase).
- **Phase 2** ([c8e0cef7](https://github.com/pwrdrvr/PwrAgent/commit/c8e0cef7)): Add `tryOpenBranchDriftDialog` gate that suppresses while `props.activeTurnId` is defined. End-of-turn falling-edge useEffect re-runs the drift check on the falling edge with a combined `{ threadKey, activeTurnId }` ref to prevent same-render thread-switch races. Stale-closure guard inside `checkSelectedThreadBranchDrift` aborts the dialog if the user navigates away mid-IPC.
- **Phase 3** ([5443624b](https://github.com/pwrdrvr/PwrAgent/commit/5443624b)): Found that R13 (archived-thread carve-out) is satisfied via R3's `observed === \"HEAD\"` short-circuit; archived threads are filtered out of the navigation snapshot, and restored archive worktrees land on detached HEAD which R3 already handles. Locked in with a regression test.
- **Phase 4** ([1db898ce](https://github.com/pwrdrvr/PwrAgent/commit/1db898ce)): Reject persisting drift retention pairs where `expected === \"HEAD\"` (each \"first named branch out of detached HEAD\" is a meaningful new context that should re-prompt). Filter HEAD-expected rows on read so older client state doesn't permanently silence drifts.

Plan and requirements docs included for context: see `docs/brainstorms/2026-05-04-thread-branch-drift-detection-requirements.md` and `docs/plans/2026-05-04-002-fix-thread-branch-drift-detection-plan.md`.

## Acceptance traced

R1–R3 (predicate semantics), R4 (chip/dialog parity), R5/R7 (active-turn suppression), R6 (end-of-turn recheck), R8 (pre-turn unchanged), R9 (UI-gate purity, no thread reload), R10/R11 (retain/update unchanged), R12 (single gate path), R13 (satisfied via R3 + regression test), R14 (retention scoping), R15 (focus-path refresh covers background completion).

Race fixes verified: same-render thread switch, mid-IPC navigation away, reactive-vs-falling-edge ordering.

## Testing

- `pnpm lint` (typecheck + dependency-cruiser boundaries) — clean
- `pnpm test` — 1080 passed, 3 pre-existing skips, 0 failures
- `pnpm --filter @pwragent/desktop run test:e2e thread-branch-drift.spec.ts` — passes (existing E2E)
- New unit tests: 9 in `packages/shared/src/contracts/__tests__/branch-drift.test.ts`, 4 in `apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`, 2 in `apps/desktop/src/main/__tests__/backend-registry.test.ts`

## Deferred follow-ups

- E2E variant exercising the active-turn gate end-to-end. The renderer unit tests cover the gate logic; the deferred E2E would smoke-test the IPC plumbing through a `turn/started`/`turn/completed` notification sequence. Documented in the plan.
- `useEffectEvent` adoption (React 19+) and `useReducer` for dialog state were considered and explicitly deferred to keep this fix aligned with existing codebase idioms (`useRef` + `useEffect`).
- First `docs/solutions/` entry once that directory exists — strong candidate topic.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `pwragent:backend-registry` lines containing `checked thread branch drift`. Expect `drifted=true` only when both branches are defined, observed is not HEAD, and they differ.
  - User reports: \"branch drift dialog appeared during a rebase\" (should drop to zero); \"sidebar shows drift but dialog never opens\" (should drop to zero).
- **Validation checks**
  - Manual: open a thread whose Codex session was created in detached HEAD, confirm the dialog now opens.
  - Manual: kick off a turn that runs `git rebase HEAD~3` against a fixture repo, confirm no dialog mid-turn and the dialog opens at end-of-turn if drift remains.
- **Expected healthy behavior**
  - Drift dialog appears at end-of-turn or on focus, never mid-turn.
  - Sidebar chip and dialog never disagree on whether a thread is drifted.
- **Failure signal / rollback trigger**
  - Multiple users reporting drift dialog firing mid-turn → revert this branch and re-investigate the gate.
  - Drift dialog failing to fire after a turn ends on a drifted workspace → check `props.activeTurnId` propagation through `useThreadSessionState` reducer.
- **Validation window & owner**
  - Window: 30 days post-merge.
  - Owner: @huntharo

---

🤖 Generated with Claude Opus 4.6 via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>