### PR TITLE
fix(desktop): keep new worktree threads consistent

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -188,10 +188,11 @@ async function createDirectoryLaunchpadFixture(): Promise<{
                 gitBranch: "HEAD",
                 linkedDirectories: [
                   {
-                    id: worktreeDir,
+                    id: repoDir,
                     label: "FixtureRepo",
-                    path: worktreeDir,
-                    kind: "local",
+                    path: repoDir,
+                    worktreePath: worktreeDir,
+                    kind: "worktree",
                   },
                 ],
                 updatedAt: 1760000001000,
@@ -697,6 +698,24 @@ test("directory launchpad keeps new worktree as the sticky default after startin
       version: 1,
       ownerThreadId: "thread-new-worktree",
     });
+
+    const startedThreadRow = app.window
+      .getByRole("button", { name: /Use a sticky worktree default/ })
+      .first();
+    const startedThreadMeta = startedThreadRow.locator(".thread-row__meta");
+    await expect(startedThreadMeta.getByText("worktree", { exact: true })).toBeVisible();
+    await expect(startedThreadMeta.getByText("local", { exact: true })).toHaveCount(0);
+
+    await app.window.getByRole("button", { name: "Open context rail" }).click();
+    const contextRail = app.window.getByRole("complementary", {
+      name: "Thread context",
+    });
+    await expect(
+      contextRail.getByLabel("Path for worktree FixtureRepo", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      contextRail.getByLabel("Path for local FixtureRepo", { exact: true }),
+    ).toHaveCount(0);
 
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1580,6 +1580,67 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("keeps materialized worktree threads linked as worktrees before the backend list catches up", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/start"] },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list", "thread/start"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app/.worktrees/thread-1/app",
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      launchpad: {
+        directoryKey: "directory:/repo/app",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "worktree",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        projectKey: "/repo/app/.worktrees/thread-1/app",
+        linkedDirectories: [
+          {
+            id: "/repo/app",
+            kind: "worktree",
+            label: "app",
+            path: "/repo/app",
+            worktreePath: "/repo/app/.worktrees/thread-1/app",
+          },
+        ],
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("materializes Grok workspace launchpads into a scratch directory", async () => {
     const grokClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -265,6 +265,44 @@ function buildLocalLinkedDirectory(cwd: string | undefined): LinkedDirectorySumm
   ];
 }
 
+function buildWorktreeLinkedDirectory(params: {
+  repositoryPath?: string;
+  worktreePath?: string;
+  label?: string;
+}): LinkedDirectorySummary[] {
+  const normalizedWorktreePath = params.worktreePath?.trim();
+  if (!normalizedWorktreePath) {
+    return [];
+  }
+
+  const worktreePath = path.resolve(normalizedWorktreePath);
+  const repositoryPath = path.resolve(params.repositoryPath?.trim() || worktreePath);
+  const label = params.label?.trim() || path.basename(repositoryPath) || repositoryPath;
+
+  return [
+    {
+      id: repositoryPath,
+      kind: "worktree",
+      label,
+      path: repositoryPath,
+      worktreePath,
+    },
+  ];
+}
+
+function normalizeLinkedDirectoryKind(
+  directory: LinkedDirectorySummary,
+): LinkedDirectorySummary {
+  if (directory.kind === "local" && directory.worktreePath?.trim()) {
+    return {
+      ...directory,
+      kind: "worktree",
+    };
+  }
+
+  return directory;
+}
+
 function pendingStartedThreadMatchesFilter(
   thread: AppServerThreadSummary,
   filter: string | undefined,
@@ -1480,8 +1518,9 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
-    const { backend, executionMode = "default", ...request } = params;
+    const { backend, executionMode = "default", linkedDirectories, ...request } = params;
     const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
     const modelSettings = await this.resolveModelSettings(backend, request);
     const cwd =
@@ -1509,7 +1548,9 @@ export class DesktopBackendRegistry {
         updatedAt: startedAt,
         executionMode,
         ...modelSettings,
-        linkedDirectories: buildLocalLinkedDirectory(cwd),
+        linkedDirectories: (
+          linkedDirectories?.length ? linkedDirectories : buildLocalLinkedDirectory(cwd)
+        ).map(normalizeLinkedDirectoryKind),
         gitBranch: cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined,
       },
     );
@@ -2146,6 +2187,14 @@ export class DesktopBackendRegistry {
       backend: launchpad.backend,
       executionMode: launchpad.executionMode,
       cwd: workspace.cwd,
+      linkedDirectories:
+        workspace.workMode === "worktree"
+          ? buildWorktreeLinkedDirectory({
+              label: launchpad.directoryLabel,
+              repositoryPath: workspace.repositoryPath ?? launchpad.directoryPath,
+              worktreePath: workspace.cwd,
+            })
+          : undefined,
       model: launchpad.model,
       reasoningEffort: launchpad.reasoningEffort,
       serviceTier: launchpad.serviceTier,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -400,7 +400,7 @@ export class GitDirectoryService {
       "branchName" | "directoryKind" | "directoryLabel" | "directoryPath" | "workMode"
     > &
       Partial<Pick<NavigationLaunchpadDraft, "backend">>,
-  ): Promise<{ cwd?: string; workMode: LaunchpadWorkMode }> {
+  ): Promise<{ cwd?: string; repositoryPath?: string; workMode: LaunchpadWorkMode }> {
     if (launchpad.directoryKind === "workspace") {
       return {
         cwd: undefined,
@@ -440,6 +440,7 @@ export class GitDirectoryService {
 
     return {
       cwd: worktreePath,
+      repositoryPath: repoRoot,
       workMode: "worktree",
     };
   }

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { buildDirectorySummaries } from "../domain/directory-navigation";
+import { materializeNavigationThreads } from "../domain/navigation-state";
 
 function buildThread(
   overrides: Partial<NavigationThreadSummary> = {},
@@ -431,6 +432,39 @@ describe("buildDirectorySummaries", () => {
         path: "/repo",
         threadKeys: ["codex:thread-1"],
       }),
+    ]);
+  });
+});
+
+describe("materializeNavigationThreads", () => {
+  it("normalizes linked directories so a worktree path cannot render as local", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "thread-worktree",
+              label: "PwrAgent",
+              path: "/Users/huntharo/github/PwrAgent",
+              worktreePath: "/Users/huntharo/.codex/worktrees/morkpkco/PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(thread?.linkedDirectories).toEqual([
+      {
+        id: "thread-worktree",
+        label: "PwrAgent",
+        path: "/Users/huntharo/github/PwrAgent",
+        worktreePath: "/Users/huntharo/.codex/worktrees/morkpkco/PwrAgent",
+        kind: "worktree",
+      },
     ]);
   });
 });

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -24,19 +24,20 @@ function isHandoffDirectory(directory: LinkedDirectorySummary): boolean {
 function dedupeLinkedDirectories(
   directories: LinkedDirectorySummary[],
 ): LinkedDirectorySummary[] {
+  const normalizedDirectories = directories.map(normalizeLinkedDirectoryKind);
   let overlayWorkspace: LinkedDirectorySummary | undefined;
-  for (const directory of directories) {
+  for (const directory of normalizedDirectories) {
     if (isHandoffDirectory(directory)) {
       overlayWorkspace = directory;
     }
   }
   const filteredDirectories = overlayWorkspace
-    ? directories.filter(
+    ? normalizedDirectories.filter(
         (directory) =>
           directory.id === overlayWorkspace.id ||
           (directory.kind !== "local" && directory.kind !== "worktree"),
       )
-    : directories;
+    : normalizedDirectories;
   const byId = new Map<string, LinkedDirectorySummary>();
 
   for (const directory of filteredDirectories) {
@@ -48,8 +49,21 @@ function dedupeLinkedDirectories(
   );
 }
 
+function normalizeLinkedDirectoryKind(
+  directory: LinkedDirectorySummary,
+): LinkedDirectorySummary {
+  if (directory.kind === "local" && directory.worktreePath?.trim()) {
+    return {
+      ...directory,
+      kind: "worktree",
+    };
+  }
+
+  return directory;
+}
+
 function hasHandoffWorkspace(directories: LinkedDirectorySummary[]): boolean {
-  return directories.some(isHandoffDirectory);
+  return directories.map(normalizeLinkedDirectoryKind).some(isHandoffDirectory);
 }
 
 export function materializeNavigationThreads(params: {


### PR DESCRIPTION
## Summary

I fixed a worktree thread creation inconsistency where a new thread launched in a worktree could temporarily be represented as `local` while still carrying a worktree path. That made the renderer able to show Local chips and worktree path tooltips for the same thread.

The fix makes materialized worktree launchpad threads publish explicit worktree linked-directory metadata immediately, and adds a defensive navigation normalization step so `local + worktreePath` cannot render as Local if malformed metadata appears again.

## What changed

- Materialized worktree launchpad thread creation now passes `{ kind: "worktree", path: repoRoot, worktreePath }` into pending thread state.
- Git directory workspace preparation now returns the source repository path alongside the worktree cwd.
- Navigation materialization normalizes malformed linked directory summaries from `local` to `worktree` when `worktreePath` is present.
- Backend and agent-core regression tests cover the impossible mixed Local/Worktree state.
- Directory launchpad E2E coverage now asserts that the started worktree thread row and context rail both render Worktree state consistently.

## Verification

I verified this on the rebased branch with:

- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop test:e2e -- directory-launchpad-workspace.spec.ts`
