### PR TITLE
feat(desktop): header messaging platform status indicators (Phase 4 — U4.1)

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -26,6 +26,8 @@ const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
+const registerMessagingStatusIpcHandlersMock = vi.fn();
+const disposeMessagingStatusIpcHandlersMock = vi.fn();
 const setApplicationMenuMock = vi.fn();
 const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
 const setNameMock = vi.fn();
@@ -129,8 +131,15 @@ vi.mock("../log", () => ({
 vi.mock("../messaging/messaging-runtime", () => ({
   getDesktopMessagingRuntime: vi.fn(() => ({
     start: messagingRuntimeStartMock,
+    onPlatformStatus: vi.fn(() => () => {}),
+    getPlatformStatuses: vi.fn(() => []),
   })),
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
+}));
+
+vi.mock("../ipc/messaging-status", () => ({
+  registerMessagingStatusIpcHandlers: registerMessagingStatusIpcHandlersMock,
+  disposeMessagingStatusIpcHandlers: disposeMessagingStatusIpcHandlersMock,
 }));
 
 vi.mock("../diagnostics/startup-cpu-profiler", () => ({
@@ -167,6 +176,8 @@ describe("bootstrapApp", () => {
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     disposeDesktopMessagingRuntimeMock.mockReset();
+    registerMessagingStatusIpcHandlersMock.mockReset();
+    disposeMessagingStatusIpcHandlersMock.mockReset();
     setApplicationMenuMock.mockReset();
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -615,6 +615,109 @@ describe("DesktopMessagingRuntime", () => {
       });
   });
 
+  it("emits health=enabled for each adapter that successfully starts", async () => {
+    const { runtime } = await createRuntimeHarness();
+    const events: unknown[] = [];
+    const unsubscribe = runtime.onPlatformStatus((event) => {
+      events.push(event);
+    });
+
+    await runtime.start();
+    await Promise.resolve();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "enabled",
+      }),
+    );
+    unsubscribe();
+  });
+
+  it("emits health=errored when an adapter fails to start", async () => {
+    await prepareRuntimeStore();
+    const failingAdapter = createAdapter("telegram", {
+      start: vi.fn(async () => {
+        throw new Error("telegram unavailable");
+      }),
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [failingAdapter],
+      backendBridge: bridge,
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await runtime.start();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "errored",
+        reason: expect.stringContaining("telegram unavailable"),
+      }),
+    );
+  });
+
+  it("emits an activity event when an inbound message arrives", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await adapter.listener?.(buildCommandEvent("/resume"));
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "activity",
+        platform: "telegram",
+      }),
+    );
+  });
+
+  it("emits health=suspended for each running adapter when stopped", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await runtime.stop();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "suspended",
+      }),
+    );
+  });
+
+  it("getPlatformStatuses returns a snapshot keyed by platform", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+
+    const snapshot = runtime.getPlatformStatuses();
+    expect(snapshot).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "enabled",
+      }),
+    ]);
+  });
+
   it("stops the started adapter instances without rebuilding the factory", async () => {
     await prepareRuntimeStore();
     const adapter = createAdapter("telegram");

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,6 +19,10 @@ import {
   registerImageNormalizationIpcHandlers,
 } from "./ipc/image-normalization";
 import {
+  disposeMessagingStatusIpcHandlers,
+  registerMessagingStatusIpcHandlers,
+} from "./ipc/messaging-status";
+import {
   disposePreloadLogIpcHandlers,
   registerPreloadLogIpcHandlers,
 } from "./ipc/preload-log";
@@ -120,6 +124,11 @@ export function bootstrapApp(): void {
         ),
       ).start();
     }
+    // Register status IPC after the runtime is constructed so the
+    // initial subscriber attaches before the renderer asks for the
+    // current snapshot. When messaging is disabled the runtime singleton
+    // still exists (default config); status returns []  / never emits.
+    registerMessagingStatusIpcHandlers();
     createMainWindow({
       startupCpuProfiler,
     });
@@ -154,6 +163,7 @@ export function bootstrapApp(): void {
     if (isDevelopment) {
       disposeRuntimeIdentityIpcHandlers();
     }
+    void disposeMessagingStatusIpcHandlers();
     void disposeDesktopMessagingRuntime();
     void disposeAppServerIpcHandlers();
     disposeAppState();

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -1,0 +1,47 @@
+import { BrowserWindow, ipcMain } from "electron";
+import type {
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
+import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import {
+  MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+  MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+} from "../../shared/ipc";
+
+let unsubscribePlatformStatus: (() => void) | undefined;
+
+function broadcastPlatformStatusEvent(event: MessagingPlatformStatusEvent): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+      continue;
+    }
+    if (typeof window.webContents.send !== "function") {
+      continue;
+    }
+    window.webContents.send(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, event);
+  }
+}
+
+export function registerMessagingStatusIpcHandlers(): void {
+  const runtime = getDesktopMessagingRuntime();
+
+  unsubscribePlatformStatus?.();
+  unsubscribePlatformStatus = runtime.onPlatformStatus(
+    broadcastPlatformStatusEvent,
+  );
+
+  ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+    async (): Promise<MessagingPlatformStatus[]> => {
+      return runtime.getPlatformStatuses();
+    },
+  );
+}
+
+export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
+  unsubscribePlatformStatus?.();
+  unsubscribePlatformStatus = undefined;
+  ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+}

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -6,7 +6,13 @@ import type {
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
 } from "./core/messaging-adapter";
-import type { AgentEvent, AppServerPendingRequestNotification } from "@pwragent/shared";
+import type {
+  AgentEvent,
+  AppServerPendingRequestNotification,
+  MessagingPlatformHealth,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
 import type {
   MessagingChannelKind,
   MessagingDeliveryResult,
@@ -54,6 +60,19 @@ export class DesktopMessagingRuntime {
   private controllers: MessagingController[] = [];
   private unsubscribeBackendEvents?: () => void;
   private started = false;
+  /**
+   * Per-platform health snapshot. Keyed by `MessagingChannelKind`. Updated
+   * by `setPlatformHealth` and read by `getPlatformStatuses` for the
+   * renderer's initial paint. Survives `stop()` so a paused state shows
+   * `suspended` in the UI rather than disappearing.
+   */
+  private readonly platformStatuses = new Map<
+    MessagingChannelKind,
+    MessagingPlatformStatus
+  >();
+  private readonly platformStatusListeners = new Set<
+    (event: MessagingPlatformStatusEvent) => void
+  >();
 
   constructor(
     private readonly options: {
@@ -96,6 +115,10 @@ export class DesktopMessagingRuntime {
 
       try {
         await adapter.start?.(async (event) => {
+          // Activity ping fires on every inbound, *before* authorization
+          // checks — the platform is active even when the message is
+          // rejected, and the user wants the dot to reflect that.
+          this.emitPlatformActivity(adapter.channel);
           try {
             if (!authorizedActorIdSet.has(event.actor.platformUserId)) {
               messagingLog.warn("messaging event rejected by authorization", {
@@ -131,6 +154,9 @@ export class DesktopMessagingRuntime {
           error: error instanceof Error ? error.message : String(error),
         });
         failedChannels.push(adapter.channel);
+        this.setPlatformHealth(adapter.channel, "errored", {
+          reason: error instanceof Error ? error.message : String(error),
+        });
         continue;
       }
 
@@ -139,6 +165,7 @@ export class DesktopMessagingRuntime {
       });
       this.adapters.push(adapter);
       this.controllers.push(controller);
+      this.setPlatformHealth(adapter.channel, "enabled");
     }
 
     this.unsubscribeBackendEvents = this.options.backendBridge.onEvent?.(async (event) => {
@@ -186,9 +213,92 @@ export class DesktopMessagingRuntime {
     this.unsubscribeBackendEvents?.();
     this.unsubscribeBackendEvents = undefined;
     this.controllers.forEach((controller) => controller.dispose());
+    const stoppedChannels = this.adapters.map((adapter) => adapter.channel);
     await Promise.all(this.adapters.map(async (adapter) => adapter.stop?.()));
     this.adapters = [];
     this.controllers = [];
+    // Mark each previously-running platform as suspended (not removed),
+    // so the renderer keeps the icon visible with a gray dot — the user
+    // knows it's configured but currently off.
+    for (const channel of stoppedChannels) {
+      this.setPlatformHealth(channel, "suspended");
+    }
+  }
+
+  /**
+   * Subscribe to platform status transitions. Returns an unsubscribe.
+   * Listeners receive every `health-changed` and `activity` event;
+   * synchronous, off the runtime's event loop. The renderer uses this
+   * to keep its `MessagingPlatformStatus[]` cache in sync without
+   * polling.
+   */
+  onPlatformStatus(
+    listener: (event: MessagingPlatformStatusEvent) => void,
+  ): () => void {
+    this.platformStatusListeners.add(listener);
+    return () => {
+      this.platformStatusListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Snapshot of the current per-platform health. Used by the IPC
+   * handler that backs the renderer's initial paint — the renderer
+   * subscribes to the event stream right after to stay current.
+   */
+  getPlatformStatuses(): MessagingPlatformStatus[] {
+    return [...this.platformStatuses.values()];
+  }
+
+  private setPlatformHealth(
+    platform: MessagingChannelKind,
+    health: MessagingPlatformHealth,
+    options: { reason?: string } = {},
+  ): void {
+    const at = Date.now();
+    const previous = this.platformStatuses.get(platform);
+    const next: MessagingPlatformStatus = {
+      ...previous,
+      platform,
+      health,
+      changedAt: at,
+      reason: options.reason,
+      // Preserve the existing activity timestamp through health
+      // transitions; activity is independent of health and shouldn't
+      // be reset just because the user toggled messaging off.
+      lastActivityAt: previous?.lastActivityAt,
+    };
+    this.platformStatuses.set(platform, next);
+    this.broadcastPlatformStatus({
+      kind: "health-changed",
+      platform,
+      health,
+      reason: options.reason,
+      at,
+    });
+  }
+
+  private emitPlatformActivity(platform: MessagingChannelKind): void {
+    const at = Date.now();
+    const previous = this.platformStatuses.get(platform);
+    if (previous) {
+      this.platformStatuses.set(platform, { ...previous, lastActivityAt: at });
+    }
+    this.broadcastPlatformStatus({ kind: "activity", platform, at });
+  }
+
+  private broadcastPlatformStatus(event: MessagingPlatformStatusEvent): void {
+    for (const listener of this.platformStatusListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        messagingLog.error("messaging platform status listener threw", {
+          error: error instanceof Error ? error.message : String(error),
+          platform: event.platform,
+          kind: event.kind,
+        });
+      }
+    }
   }
 
   private async loadConfig(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -38,6 +38,8 @@ import type {
   SetThreadReactionResponse,
   GetGhStatusRequest,
   GhStatus,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -111,6 +113,8 @@ import {
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   IMAGE_UPLOAD_FALLBACK_CHANNEL,
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
+  MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+  MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -342,6 +346,20 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(AGENT_EVENT_CHANNEL, listener);
     return () => {
       ipcRenderer.off(AGENT_EVENT_CHANNEL, listener);
+    };
+  },
+  getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
+    await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+  onMessagingPlatformStatusEvent: (
+    callback: (event: MessagingPlatformStatusEvent) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: MessagingPlatformStatusEvent,
+    ) => callback(payload);
+    ipcRenderer.on(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
     };
   },
   platform: process.platform,

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -1,0 +1,119 @@
+import type { ReactElement } from "react";
+import type {
+  MessagingChannelKind,
+  MessagingPlatformHealth,
+  MessagingPlatformStatus,
+} from "@pwragent/shared";
+import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
+import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const ICONS: Partial<
+  Record<MessagingChannelKind, (props: IconProps) => ReactElement>
+> = {
+  telegram: TelegramIcon,
+  discord: DiscordIcon,
+};
+
+const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
+  enabled: "Enabled",
+  suspended: "Suspended",
+  errored: "Errored",
+  unknown: "Unknown",
+};
+
+/**
+ * Right-of-header status indicators for each *configured* messaging
+ * platform. Health controls the dot color (green/gray/red); a recent
+ * activity timestamp adds the slow-blink animation. Platforms without a
+ * dedicated icon (custom adapters, future channels) get a small text
+ * pill instead so we never silently drop a configured platform.
+ *
+ * Renders nothing when no platforms are configured — keeps the header
+ * tight for users who don't use messaging.
+ */
+export function MessagingStatusBar(props: { desktopApi?: DesktopApi }) {
+  const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
+    props.desktopApi,
+  );
+
+  if (statuses.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="messaging-status-bar" role="group" aria-label="Messaging platform status">
+      {statuses.map((status) => (
+        <PlatformChip
+          key={status.platform}
+          status={status}
+          active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PlatformChip(props: {
+  status: MessagingPlatformStatus;
+  active: boolean;
+}) {
+  const { status, active } = props;
+  const Icon = ICONS[status.platform];
+  const label = `${formatPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}${
+    status.reason ? ` (${status.reason})` : ""
+  }`;
+  return (
+    <span
+      className={`messaging-status-chip messaging-status-chip--${status.health}${
+        active ? " is-active" : ""
+      }`}
+      title={label}
+      aria-label={label}
+    >
+      {Icon ? (
+        <Icon size={14} />
+      ) : (
+        <span className="messaging-status-chip__fallback">
+          {status.platform.slice(0, 2)}
+        </span>
+      )}
+      <span
+        className={`status-dot status-dot--${dotTone(status.health)}${
+          active ? " status-dot--blink" : ""
+        }`}
+        aria-hidden="true"
+      />
+    </span>
+  );
+}
+
+function hasRecentActivity(
+  status: MessagingPlatformStatus,
+  observedAt: number | undefined,
+): boolean {
+  // Suspended/errored platforms shouldn't blink even if a stale activity
+  // timestamp is hanging around — the dot is a status indicator first.
+  if (status.health !== "enabled") return false;
+  return Boolean(observedAt);
+}
+
+function dotTone(
+  health: MessagingPlatformHealth,
+): "ok" | "warning" | "error" | "suspended" {
+  switch (health) {
+    case "enabled":
+      return "ok";
+    case "suspended":
+      return "suspended";
+    case "errored":
+      return "error";
+    case "unknown":
+      return "warning";
+  }
+}
+
+function formatPlatformName(platform: MessagingChannelKind): string {
+  if (platform.length === 0) return platform;
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import type {
+  MessagingChannelKind,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const ACTIVITY_TAIL_MS = 2_000;
+
+/**
+ * Subscribes to per-platform messaging health + activity. Maintains the
+ * canonical `MessagingPlatformStatus[]` view: takes the initial snapshot
+ * via IPC, then folds incoming events. The list itself only mutates when
+ * health changes — activity-driven re-renders go through a separate
+ * `activeAtByPlatform` map so the rest of the row doesn't re-render
+ * just because a dot flickered.
+ */
+export function useMessagingPlatformStatuses(
+  desktopApi: DesktopApi | undefined,
+): {
+  statuses: MessagingPlatformStatus[];
+  activeAtByPlatform: Record<string, number>;
+} {
+  const [statuses, setStatuses] = useState<MessagingPlatformStatus[]>([]);
+  const [activeAtByPlatform, setActiveAtByPlatform] = useState<
+    Record<string, number>
+  >({});
+
+  useEffect(() => {
+    if (!desktopApi?.getMessagingPlatformStatuses) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const initial = await desktopApi.getMessagingPlatformStatuses!();
+        if (cancelled) return;
+        setStatuses(initial);
+      } catch {
+        // Logged in main; ignore in renderer.
+      }
+    })();
+
+    const unsubscribe = desktopApi.onMessagingPlatformStatusEvent?.(
+      (event: MessagingPlatformStatusEvent) => {
+        if (event.kind === "activity") {
+          setActiveAtByPlatform((current) => ({
+            ...current,
+            [event.platform]: event.at,
+          }));
+          return;
+        }
+        // health-changed
+        setStatuses((current) => upsertHealth(current, event));
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [desktopApi]);
+
+  // Sweep stale activity timestamps so the dot stops blinking even if
+  // we never receive an "activity end" event (we don't; the runtime
+  // only emits per-event, not per-burst).
+  useEffect(() => {
+    if (Object.keys(activeAtByPlatform).length === 0) {
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      const cutoff = Date.now() - ACTIVITY_TAIL_MS;
+      setActiveAtByPlatform((current) => {
+        const next: Record<string, number> = {};
+        let mutated = false;
+        for (const [platform, at] of Object.entries(current)) {
+          if (at >= cutoff) {
+            next[platform] = at;
+          } else {
+            mutated = true;
+          }
+        }
+        return mutated ? next : current;
+      });
+    }, ACTIVITY_TAIL_MS / 2);
+    return () => window.clearInterval(intervalId);
+  }, [activeAtByPlatform]);
+
+  return { statuses, activeAtByPlatform };
+}
+
+function upsertHealth(
+  current: MessagingPlatformStatus[],
+  event: Extract<MessagingPlatformStatusEvent, { kind: "health-changed" }>,
+): MessagingPlatformStatus[] {
+  const platform: MessagingChannelKind = event.platform;
+  const existing = current.find((entry) => entry.platform === platform);
+  const next: MessagingPlatformStatus = {
+    ...existing,
+    platform,
+    health: event.health,
+    changedAt: event.at,
+    reason: event.reason,
+    lastActivityAt: existing?.lastActivityAt,
+  };
+  if (!existing) {
+    return [...current, next];
+  }
+  return current.map((entry) => (entry.platform === platform ? next : entry));
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,8 +1,11 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+import type { DesktopApi } from "../../lib/desktop-api";
 
 type ThreadHeaderProps = {
+  desktopApi?: DesktopApi;
   thread: NavigationThreadSummary;
 };
 
@@ -20,7 +23,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
 
   return (
     <header className="thread-header">
-      <div>
+      <div className="thread-header__main">
         <div className="thread-header__eyebrow-row">
           <h2 className="thread-header__compact-title" title={props.thread.title}>
             {props.thread.title}
@@ -39,6 +42,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           </p>
         ) : null}
       </div>
+      <MessagingStatusBar desktopApi={props.desktopApi} />
     </header>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1496,7 +1496,7 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section className="thread-view">
-      <ThreadHeader thread={selectedThread!} />
+      <ThreadHeader desktopApi={props.desktopApi} thread={selectedThread!} />
 
       <div
         className={`thread-view__layout${

--- a/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
@@ -1,0 +1,16 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Discord controller-shaped glyph, simplified to a monochrome silhouette
+ * filled with `currentColor`. Matches the visual weight of `TelegramIcon`
+ * at 16px and avoids the brand purple / gradient that would clash with
+ * the Tangerine Terminal theme.
+ */
+export function DiscordIcon(props: IconProps) {
+  const svgProps = resolveIconSvgProps(props);
+  return (
+    <svg {...svgProps} fill="currentColor" stroke="none">
+      <path d="M19.27 5.33A19.66 19.66 0 0 0 14.6 4l-.21.31a14.6 14.6 0 0 0-4.78 0L9.4 4a19.66 19.66 0 0 0-4.67 1.33A20.6 20.6 0 0 0 1.5 16.42a19.84 19.84 0 0 0 6 3.04l.49-.66a13.5 13.5 0 0 1-2.13-1.05l.45-.36a14.45 14.45 0 0 0 11.38 0l.45.36a13.5 13.5 0 0 1-2.14 1.05l.5.66a19.84 19.84 0 0 0 6-3.04 20.6 20.6 0 0 0-3.23-11.09zM8.5 14.16c-1.18 0-2.15-1.1-2.15-2.45s.95-2.45 2.15-2.45 2.16 1.1 2.15 2.45c0 1.35-.96 2.45-2.15 2.45zm7 0c-1.18 0-2.15-1.1-2.15-2.45s.95-2.45 2.15-2.45 2.16 1.1 2.15 2.45c0 1.35-.96 2.45-2.15 2.45z" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/TelegramIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/TelegramIcon.tsx
@@ -1,0 +1,15 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Telegram paper-plane glyph, simplified to a monochrome silhouette
+ * filled with `currentColor`. Uses `fill` instead of stroke so the mark
+ * reads cleanly at 16px against the near-black header background.
+ */
+export function TelegramIcon(props: IconProps) {
+  const svgProps = resolveIconSvgProps(props);
+  return (
+    <svg {...svgProps} fill="currentColor" stroke="none">
+      <path d="M21.6 3.2 2.7 10.6c-.7.3-.7 1.3 0 1.5l4.4 1.4 1.7 5.5c.2.6.9.7 1.3.3l2.6-2.6 4.5 3.3c.6.4 1.5.1 1.6-.6L22.9 4c.2-.7-.5-1.3-1.3-.8zM9.5 13.7l8.6-5.3-7 6.5z" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -3,9 +3,11 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchIcon,
+  DiscordIcon,
   FolderIcon,
   NewThreadIcon,
   SettingsIcon,
+  TelegramIcon,
   UnlinkedDotIcon,
   WorkspaceIcon,
   WorktreeIcon,
@@ -57,6 +59,24 @@ describe("icon library", () => {
     expect(svg).toHaveAttribute("aria-label", "Local directory");
     expect(svg).toHaveAttribute("aria-hidden", "false");
   });
+
+  it.each([
+    ["TelegramIcon", TelegramIcon],
+    ["DiscordIcon", DiscordIcon],
+  ] as const)(
+    "%s renders as a filled glyph using currentColor",
+    (_name, Icon) => {
+      const { container } = render(<Icon />);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("width", "16");
+      expect(svg).toHaveAttribute("height", "16");
+      expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+      expect(svg).toHaveAttribute("fill", "currentColor");
+      expect(svg).toHaveAttribute("stroke", "none");
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    },
+  );
 
   it("flows currentColor through to children via parent CSS", () => {
     const { container } = render(

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,8 +1,10 @@
 export { BranchIcon } from "./BranchIcon";
+export { DiscordIcon } from "./DiscordIcon";
 export { EditorIcon } from "./EditorIcon";
 export { FolderIcon } from "./FolderIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { SettingsIcon } from "./SettingsIcon";
+export { TelegramIcon } from "./TelegramIcon";
 export { TerminalIcon } from "./TerminalIcon";
 export { UnlinkedDotIcon } from "./UnlinkedDotIcon";
 export { WorkspaceIcon } from "./WorkspaceIcon";

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -38,6 +38,8 @@ import type {
   SetThreadReactionResponse,
   GetGhStatusRequest,
   GhStatus,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -199,6 +201,10 @@ export type DesktopApi = {
   logRendererDiagnostic?: (request: RendererDiagnosticLogRequest) => Promise<void>;
   reportRendererError?: (report: RendererErrorReport) => Promise<void>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
+  getMessagingPlatformStatuses?: () => Promise<MessagingPlatformStatus[]>;
+  onMessagingPlatformStatusEvent?: (
+    callback: (event: MessagingPlatformStatusEvent) => void,
+  ) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -190,6 +190,63 @@ textarea,
   -webkit-app-region: no-drag;
 }
 
+.thread-header__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.messaging-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  -webkit-app-region: no-drag;
+}
+
+.messaging-status-bar * {
+  -webkit-app-region: no-drag;
+}
+
+.messaging-status-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.messaging-status-chip--enabled {
+  color: var(--text-primary);
+}
+
+.messaging-status-chip--errored {
+  color: var(--danger-text);
+}
+
+.messaging-status-chip__fallback {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.messaging-status-chip > .status-dot {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 7px;
+  height: 7px;
+  border: 1.5px solid var(--bg-panel);
+}
+
 .sidebar__icon-button {
   display: inline-flex;
   width: 34px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -34,6 +34,10 @@ export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
 export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
+export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
+  "messaging:get-platform-statuses";
+export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
+  "messaging:platform-status-event";
 export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -93,6 +93,63 @@ export type MessagingChannelKind =
   | "voice-call"
   | "custom";
 
+/**
+ * Health/lifecycle state for a single configured messaging platform.
+ *
+ *   - `enabled`   adapter started successfully and is currently listening
+ *   - `suspended` configured but stopped (user toggled messaging off, or the
+ *                 platform is paused mid-session)
+ *   - `errored`   the adapter failed to start, or hit a fatal runtime error
+ *   - `unknown`   we know the platform is configured but haven't observed
+ *                 a transition yet (initial-load / pre-start state)
+ */
+export type MessagingPlatformHealth =
+  | "enabled"
+  | "suspended"
+  | "errored"
+  | "unknown";
+
+/**
+ * Snapshot of one platform's current state. Renderer holds an array of
+ * these (one per *configured* platform) and updates it from individual
+ * `MessagingPlatformStatusEvent`s. The optional `activeAt` lets the UI
+ * blink the status dot while the platform is sending or receiving.
+ */
+export type MessagingPlatformStatus = {
+  platform: MessagingChannelKind;
+  health: MessagingPlatformHealth;
+  /** Wall-clock ms when the health last changed. */
+  changedAt: number;
+  /** When errored, a human-readable reason for the UI tooltip. */
+  reason?: string;
+  /**
+   * Wall-clock ms of the last sent or received message that the runtime
+   * told us about. Renderer uses this to keep the activity dot blinking
+   * for a short tail (~2s) after the last event.
+   */
+  lastActivityAt?: number;
+};
+
+/**
+ * One status transition emitted by the messaging runtime. Subscribers on
+ * the renderer side fold this into their `MessagingPlatformStatus[]`
+ * cache. For the initial render, callers should fetch the current full
+ * snapshot via the IPC layer rather than waiting for the next event.
+ */
+export type MessagingPlatformStatusEvent =
+  | {
+      kind: "health-changed";
+      platform: MessagingChannelKind;
+      health: MessagingPlatformHealth;
+      reason?: string;
+      at: number;
+    }
+  | {
+      kind: "activity";
+      platform: MessagingChannelKind;
+      at: number;
+    };
+
 export type MessagingJsonPrimitive = string | number | boolean | null;
 export type MessagingJsonValue =
   | MessagingJsonPrimitive


### PR DESCRIPTION
First of four stacked PRs for Phase 4 of the design overhaul. Adds per-platform status chips to the right side of the thread header so users can see at a glance which messaging platforms are configured, healthy, and active.

## What lands

**Runtime (main process)**
- \`DesktopMessagingRuntime\` gains a small per-platform status state machine: \`enabled\` / \`suspended\` / \`errored\`, plus per-event activity pings.
- Status survives \`stop()\` so a paused/errored platform stays visible (gray/red dot) — the user knows it's configured, not vanished.
- New emitter API: \`onPlatformStatus(listener)\` + \`getPlatformStatuses()\` snapshot.

**Contract (shared)**
- \`MessagingPlatformHealth\`, \`MessagingPlatformStatus\`, \`MessagingPlatformStatusEvent\` exported from \`@pwragent/shared\`.

**IPC**
- \`messaging:get-platform-statuses\` for initial paint (renderer fetches once).
- \`messaging:platform-status-event\` push bus from main → all renderer windows. Mirrors the agent-event bus pattern.

**Renderer**
- New monochrome \`TelegramIcon\` + \`DiscordIcon\` glyphs filled with \`currentColor\` to match the Tangerine Terminal theme.
- New \`MessagingStatusBar\` renders one chip per configured platform with the \`--status-*\` dot tokens from U0.2. Activity pulses the dot via \`.status-dot--blink\` with a 2s tail; \`prefers-reduced-motion\` disables the animation.
- \`ThreadHeader\` hosts the bar on the right. Renders nothing when no platforms are configured — non-messaging users see the same header.

## Why this shape

The plan's exit condition for U4.1 says:
> Telegram-only configured → only Telegram icon in header. Both configured → both icons. Disabling Telegram in settings → its dot turns gray within 1s. Sending a Telegram message → dot blinks during streaming, stops within ~1s of completion.

The renderer hook \`useMessagingPlatformStatuses\` keeps the canonical \`MessagingPlatformStatus[]\` cache and a separate \`activeAtByPlatform\` map so a flickering activity dot doesn't re-render the rest of the row. The activity tail (2s) is swept by a shared interval rather than per-platform timers.

\`stop()\` marks each previously-running platform as \`suspended\` so the chip stays visible after the user toggles messaging off (U4.2 will exercise this path).

## Tests

5 new runtime tests cover the emission contract:
- \`enabled\` on successful start
- \`errored\` on adapter start failure (with reason)
- \`activity\` on inbound message
- \`suspended\` for each running adapter on stop
- \`getPlatformStatuses()\` snapshot

\`index.test.ts\` mocks updated for the new IPC module + runtime methods.

Full workspace suite: 1126 passing / 3 skipped.

## Stacking

This is PR 1 of 4. Next:
- **U4.2** stacks here: header on/off toggle (runtime pause/resume + setting + IPC).
- **U4.3** stacks here: per-thread binding chips + unbind menu.
- **U4.4** stacks on U4.3: Messaging Activity screen + activity log.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: \`pwragent:messaging\` channel — new \`messaging platform status listener threw\` lines indicate a renderer broadcaster bug.
- **Validation checks**
  - Launch with Telegram + Discord configured → see both chips. With \`--disable-messaging\` → no chips.
  - Send an inbound message → dot blinks slowly for ~2s, then stops.
  - Stop the runtime (quit) → no orphaned listeners (status bar test \`unsubscribe\` is wired).
- **Expected healthy behavior**
  - Status bar appears within 250ms of first paint.
  - No console warnings about IPC handlers in renderer devtools.
- **Failure signal(s)**
  - Status bar shows nothing when Telegram is configured → IPC channel name mismatch or handler not registered.
  - Dot stuck blinking after 5s with no inbound traffic → \`activity\` events being broadcast spuriously.
- **Validation window & owner**
  - Window: First post-deploy launch + 5 min of normal use.
  - Owner: @huntharo

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with [Claude Opus 4.7 (1M context, extended thinking)](https://claude.com/claude-code) via Compound Engineering v2.49.0