### PR TITLE
feat(desktop): header messaging on/off toggle (Phase 4 — U4.2)

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -354,6 +354,7 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.runtime.messaging).toEqual({
       disabled: true,
       disabledReason: "--disable-messaging was provided at startup",
+      userEnabled: true,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -28,6 +28,11 @@ const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
 const disposeMessagingStatusIpcHandlersMock = vi.fn();
+const settingsReadSettingsMock = vi.fn(async () => ({
+  fetchedAt: 0,
+  configPath: "/tmp",
+  runtime: { messaging: { disabled: false, userEnabled: true } },
+}));
 const setApplicationMenuMock = vi.fn();
 const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
 const setNameMock = vi.fn();
@@ -140,6 +145,12 @@ vi.mock("../messaging/messaging-runtime", () => ({
 vi.mock("../ipc/messaging-status", () => ({
   registerMessagingStatusIpcHandlers: registerMessagingStatusIpcHandlersMock,
   disposeMessagingStatusIpcHandlers: disposeMessagingStatusIpcHandlersMock,
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: vi.fn(() => ({
+    readSettings: settingsReadSettingsMock,
+  })),
 }));
 
 vi.mock("../diagnostics/startup-cpu-profiler", () => ({

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -743,6 +743,90 @@ describe("DesktopMessagingRuntime", () => {
     expect(factory).toHaveBeenCalledTimes(1);
     expect(adapter.stop).toHaveBeenCalledTimes(1);
   });
+
+  it("pause() stops adapters and emits suspended for each platform", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await runtime.pause();
+
+    expect(adapter.stop).toHaveBeenCalledTimes(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "suspended",
+      }),
+    );
+  });
+
+  it("resume() rebuilds adapters from the same factory and re-emits enabled", async () => {
+    await prepareRuntimeStore();
+    const adapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(() => [adapter]);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.pause();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+    await runtime.resume();
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(adapter.start).toHaveBeenCalledTimes(2);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "enabled",
+      }),
+    );
+  });
+
+  it("multiple pause()/resume() cycles are safe", async () => {
+    await prepareRuntimeStore();
+    const adapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(() => [adapter]);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.pause();
+    await runtime.pause(); // idempotent
+    await runtime.resume();
+    await runtime.resume(); // idempotent
+    await runtime.pause();
+
+    expect(adapter.stop).toHaveBeenCalledTimes(2);
+    expect(adapter.start).toHaveBeenCalledTimes(2);
+  });
 });
 
 async function createRuntimeHarness(): Promise<{

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -116,13 +116,20 @@ export function bootstrapApp(): void {
         reason: messagingOverride.reason,
       });
     } else {
-      await getDesktopMessagingRuntime((options) =>
+      const settingsSnapshot = await getDesktopSettingsService().readSettings();
+      const userEnabled = settingsSnapshot.runtime.messaging.userEnabled;
+      const runtime = getDesktopMessagingRuntime((options) =>
         loadDesktopMessagingConfigFromSettings(
           getDesktopSettingsService(),
           process.env,
           options,
         ),
-      ).start();
+      );
+      if (userEnabled) {
+        await runtime.start();
+      } else {
+        mainLog.info("messaging runtime not started — disabled by user setting");
+      }
     }
     // Register status IPC after the runtime is constructed so the
     // initial subscriber attaches before the renderer asks for the

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -2,11 +2,16 @@ import { BrowserWindow, ipcMain } from "electron";
 import type {
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
 } from "@pwragent/shared";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import { resolveRuntimeMessagingOverride } from "../runtime-flags";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import {
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_SET_ENABLED_CHANNEL,
 } from "../../shared/ipc";
 
 let unsubscribePlatformStatus: (() => void) | undefined;
@@ -38,10 +43,44 @@ export function registerMessagingStatusIpcHandlers(): void {
       return runtime.getPlatformStatuses();
     },
   );
+
+  ipcMain.removeHandler(MESSAGING_SET_ENABLED_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_SET_ENABLED_CHANNEL,
+    async (
+      _event,
+      request: SetMessagingEnabledRequest,
+    ): Promise<SetMessagingEnabledResponse> => {
+      const override = resolveRuntimeMessagingOverride();
+      if (override.disabled) {
+        // Startup --disable-messaging / PWRAGENT_DISABLE_MESSAGING wins.
+        // Don't touch the user setting; report the override so the UI
+        // can render an explanatory tooltip on the locked toggle.
+        return {
+          enabled: false,
+          overridden: true,
+          overrideReason: override.reason,
+        };
+      }
+      // Persist the user choice so the next launch respects it. We
+      // write before pause/resume so a crash mid-toggle still leaves a
+      // consistent on-disk truth.
+      await getDesktopSettingsService().writeConfigPatch({
+        messaging: { userEnabled: request.enabled },
+      });
+      if (request.enabled) {
+        await runtime.resume();
+      } else {
+        await runtime.pause();
+      }
+      return { enabled: request.enabled, overridden: false };
+    },
+  );
 }
 
 export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   unsubscribePlatformStatus?.();
   unsubscribePlatformStatus = undefined;
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_SET_ENABLED_CHANNEL);
 }

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -226,6 +226,37 @@ export class DesktopMessagingRuntime {
   }
 
   /**
+   * User-driven "messaging off" — drains running adapters and marks
+   * each platform as suspended, but keeps the per-platform status
+   * snapshot in place so the UI keeps showing the icons (gray dots).
+   * Idempotent: a second pause() while already paused is a no-op.
+   *
+   * Equivalent to `stop()` today; kept as a separate name so callers
+   * (the IPC handler + unit tests) signal intent. Future work may
+   * differentiate (e.g. pause keeps backend-event subscription alive
+   * but ignores inbound; stop tears everything down for shutdown).
+   */
+  async pause(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    await this.stop();
+  }
+
+  /**
+   * Re-enable messaging after a `pause()`. Re-runs the adapter factory
+   * with the current config — picks up settings changes that landed
+   * while we were paused. Idempotent: a second resume() while already
+   * running is a no-op.
+   */
+  async resume(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+    await this.start();
+  }
+
+  /**
    * Subscribe to platform status transitions. Returns an unsubscribe.
    * Listeners receive every `health-changed` and `activity` event;
    * synchronous, off the runtime's event loop. The renderer uses this

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -28,6 +28,8 @@ export type DesktopSettingsConfig = {
   messaging?: {
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    /** Persisted on/off toggle for the whole messaging subsystem. */
+    userEnabled?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;
       maxAttachmentBytes?: number;
@@ -126,6 +128,8 @@ export function mergeDesktopSettingsConfig(
         patch.messaging?.inputDebounceMs ?? current.messaging?.inputDebounceMs,
       toolUpdateMode:
         patch.messaging?.toolUpdateMode ?? current.messaging?.toolUpdateMode,
+      userEnabled:
+        patch.messaging?.userEnabled ?? current.messaging?.userEnabled,
       attachments: {
         ...current.messaging?.attachments,
         ...patch.messaging?.attachments,
@@ -237,6 +241,7 @@ export function stringifyDesktopSettingsToml(
   if (
     config.messaging?.toolUpdateMode
     || config.messaging?.inputDebounceMs !== undefined
+    || config.messaging?.userEnabled !== undefined
   ) {
     sections.push(
       [
@@ -246,6 +251,7 @@ export function stringifyDesktopSettingsToml(
           config.messaging.inputDebounceMs,
         ),
         formatOptionalTomlEntry("tool_update_mode", config.messaging.toolUpdateMode),
+        formatOptionalTomlEntry("user_enabled", config.messaging.userEnabled),
       ]
         .filter(Boolean)
         .join("\n"),
@@ -376,6 +382,7 @@ function normalizeDesktopConfig(
     messaging: {
       inputDebounceMs: readNumber(messaging?.input_debounce_ms),
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
+      userEnabled: readBoolean(messaging?.user_enabled),
       attachments: {
         imageProfile: readImageProfile(attachments?.image_profile),
         maxAttachmentBytes: readNumber(attachments?.max_attachment_bytes),
@@ -426,9 +433,11 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const discord = config.messaging?.discord;
   const inputDebounceMs = config.messaging?.inputDebounceMs;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
+  const userEnabled = config.messaging?.userEnabled;
   if (
     inputDebounceMs !== undefined ||
     toolUpdateMode !== undefined ||
+    userEnabled !== undefined ||
     (attachments && hasDefinedValue(attachments))
     || (telegram && hasDefinedValue(telegram))
     || (discord && hasDefinedValue(discord))
@@ -439,6 +448,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (toolUpdateMode !== undefined) {
       pruned.messaging.toolUpdateMode = toolUpdateMode;
+    }
+    if (userEnabled !== undefined) {
+      pruned.messaging.userEnabled = userEnabled;
     }
     if (attachments && hasDefinedValue(attachments)) {
       pruned.messaging.attachments = attachments;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -132,6 +132,11 @@ export class DesktopSettingsService {
           ...(messagingOverride.reason
             ? { disabledReason: messagingOverride.reason }
             : {}),
+          // Persisted user toggle. Defaults to true so existing users —
+          // who never wrote this setting — keep messaging on. Setting
+          // `messaging.userEnabled = false` in config.toml (or via the
+          // header toggle) disables the runtime on next launch.
+          userEnabled: config.messaging?.userEnabled !== false,
         },
       },
       secretStorage,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -40,6 +40,8 @@ import type {
   GhStatus,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -115,6 +117,7 @@ import {
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_SET_ENABLED_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -350,6 +353,10 @@ const desktopApi = Object.freeze({
   },
   getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
     await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+  setMessagingEnabled: async (
+    request: SetMessagingEnabledRequest,
+  ): Promise<SetMessagingEnabledResponse> =>
+    await ipcRenderer.invoke(MESSAGING_SET_ENABLED_CHANNEL, request),
   onMessagingPlatformStatusEvent: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ): (() => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -142,6 +142,7 @@ function DesktopAppShell(props: {
           backendError={backendSummaries.error}
           backends={backendSummaries.backends}
           applications={settings.snapshot?.applications}
+          settingsSnapshot={settings.snapshot}
           clearPendingRequest={session.clearPendingRequest}
           composerDisabled={
             !navigation.selectedThread ||

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -45,6 +45,7 @@ describe("App", () => {
       runtime: {
         messaging: {
           disabled: false,
+          userEnabled: true,
         },
       },
       secretStorage: {

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import type {
   MessagingChannelKind,
   MessagingPlatformHealth,
@@ -7,6 +7,14 @@ import type {
 import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
 import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
 import type { DesktopApi } from "../../lib/desktop-api";
+
+type MessagingEnablementState = {
+  /** True when the runtime is currently allowed to run. */
+  userEnabled: boolean;
+  /** True when a startup override (CLI/env) is forcing messaging off. */
+  overridden: boolean;
+  overrideReason?: string;
+};
 
 const ICONS: Partial<
   Record<MessagingChannelKind, (props: IconProps) => ReactElement>
@@ -29,17 +37,50 @@ const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
  * dedicated icon (custom adapters, future channels) get a small text
  * pill instead so we never silently drop a configured platform.
  *
- * Renders nothing when no platforms are configured — keeps the header
- * tight for users who don't use messaging.
+ * The bar also hosts the global on/off toggle. When `--disable-messaging`
+ * fired at startup, the toggle is locked off with an explanatory tooltip.
+ *
+ * Renders nothing when no platforms are configured AND the user has
+ * never toggled messaging — keeps the header tight for users who don't
+ * use messaging.
  */
-export function MessagingStatusBar(props: { desktopApi?: DesktopApi }) {
+export function MessagingStatusBar(props: {
+  desktopApi?: DesktopApi;
+  enablement?: MessagingEnablementState;
+}) {
   const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
     props.desktopApi,
   );
+  const [enablement, setEnablement] = useState<MessagingEnablementState | undefined>(
+    props.enablement,
+  );
 
-  if (statuses.length === 0) {
+  // Adopt the latest prop value on each render but keep local state for
+  // optimistic updates after the user clicks the toggle.
+  const effectiveEnablement = enablement ?? props.enablement;
+
+  // Show nothing when there's nothing to show and no toggle to surface.
+  if (statuses.length === 0 && !effectiveEnablement) {
     return null;
   }
+
+  const onToggle = async (): Promise<void> => {
+    if (!effectiveEnablement || effectiveEnablement.overridden) return;
+    if (!props.desktopApi?.setMessagingEnabled) return;
+    const next = !effectiveEnablement.userEnabled;
+    setEnablement({ ...effectiveEnablement, userEnabled: next });
+    try {
+      const result = await props.desktopApi.setMessagingEnabled({ enabled: next });
+      setEnablement({
+        userEnabled: result.enabled,
+        overridden: result.overridden,
+        overrideReason: result.overrideReason,
+      });
+    } catch {
+      // Roll back the optimistic flip on failure.
+      setEnablement(effectiveEnablement);
+    }
+  };
 
   return (
     <div className="messaging-status-bar" role="group" aria-label="Messaging platform status">
@@ -50,7 +91,47 @@ export function MessagingStatusBar(props: { desktopApi?: DesktopApi }) {
           active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
         />
       ))}
+      {effectiveEnablement ? (
+        <ToggleButton enablement={effectiveEnablement} onToggle={onToggle} />
+      ) : null}
     </div>
+  );
+}
+
+function ToggleButton(props: {
+  enablement: MessagingEnablementState;
+  onToggle: () => Promise<void>;
+}) {
+  const { enablement, onToggle } = props;
+  const overrideTooltip = enablement.overrideReason
+    ? `Messaging is locked off: ${enablement.overrideReason}`
+    : "Messaging is locked off by startup override";
+  const tooltip = enablement.overridden
+    ? overrideTooltip
+    : enablement.userEnabled
+      ? "Messaging is on. Click to pause."
+      : "Messaging is off. Click to resume.";
+  return (
+    <button
+      type="button"
+      className={`messaging-toggle${
+        enablement.userEnabled ? " is-on" : ""
+      }${enablement.overridden ? " is-locked" : ""}`}
+      title={tooltip}
+      aria-label={tooltip}
+      aria-pressed={enablement.userEnabled}
+      disabled={enablement.overridden}
+      onClick={() => {
+        void onToggle();
+      }}
+    >
+      <span className="messaging-toggle__track" aria-hidden="true">
+        <span className="messaging-toggle__thumb" />
+      </span>
+      <span className="messaging-toggle__label">
+        {enablement.overridden ? "Off" : enablement.userEnabled ? "On" : "Off"}
+      </span>
+    </button>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -18,6 +18,7 @@ function createSnapshot(
     runtime: {
       messaging: {
         disabled: false,
+        userEnabled: true,
       },
     },
     secretStorage: {
@@ -299,6 +300,7 @@ describe("SettingsScreen", () => {
               messaging: {
                 disabled: true,
                 disabledReason: "--disable-messaging was provided at startup",
+                userEnabled: true,
               },
             },
           }),

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,4 +1,4 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopSettingsSnapshot, NavigationThreadSummary } from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
@@ -6,6 +6,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 
 type ThreadHeaderProps = {
   desktopApi?: DesktopApi;
+  settingsSnapshot?: DesktopSettingsSnapshot;
   thread: NavigationThreadSummary;
 };
 
@@ -42,7 +43,18 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           </p>
         ) : null}
       </div>
-      <MessagingStatusBar desktopApi={props.desktopApi} />
+      <MessagingStatusBar
+        desktopApi={props.desktopApi}
+        enablement={
+          props.settingsSnapshot
+            ? {
+                userEnabled: props.settingsSnapshot.runtime.messaging.userEnabled,
+                overridden: props.settingsSnapshot.runtime.messaging.disabled,
+                overrideReason: props.settingsSnapshot.runtime.messaging.disabledReason,
+              }
+            : undefined
+        }
+      />
     </header>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -17,6 +17,7 @@ import type {
   BackendSummary,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
+  DesktopSettingsSnapshot,
   HandoffThreadWorkspaceRequest,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -602,6 +603,7 @@ type ThreadViewProps = {
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
+  settingsSnapshot?: DesktopSettingsSnapshot;
   setExecutionModeError?: string;
   setThreadModelSettingsError?: string;
   worktreeArchiveError?: string;
@@ -1496,7 +1498,11 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section className="thread-view">
-      <ThreadHeader desktopApi={props.desktopApi} thread={selectedThread!} />
+      <ThreadHeader
+        desktopApi={props.desktopApi}
+        settingsSnapshot={props.settingsSnapshot}
+        thread={selectedThread!}
+      />
 
       <div
         className={`thread-view__layout${

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -40,6 +40,8 @@ import type {
   GhStatus,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -205,6 +207,9 @@ export type DesktopApi = {
   onMessagingPlatformStatusEvent?: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ) => () => void;
+  setMessagingEnabled?: (
+    request: SetMessagingEnabledRequest,
+  ) => Promise<SetMessagingEnabledResponse>;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -247,6 +247,69 @@ textarea,
   border: 1.5px solid var(--bg-panel);
 }
 
+.messaging-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 4px;
+  padding: 4px 10px 4px 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+}
+
+.messaging-toggle:hover:not([disabled]) {
+  border-color: var(--accent-border);
+}
+
+.messaging-toggle[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.messaging-toggle__track {
+  position: relative;
+  display: inline-block;
+  width: 24px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  transition: background 120ms ease;
+}
+
+.messaging-toggle__thumb {
+  position: absolute;
+  left: 1px;
+  top: 1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.messaging-toggle.is-on {
+  color: var(--text-primary);
+}
+
+.messaging-toggle.is-on .messaging-toggle__track {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+}
+
+.messaging-toggle.is-on .messaging-toggle__thumb {
+  background: var(--accent);
+  transform: translateX(10px);
+}
+
 .sidebar__icon-button {
   display: inline-flex;
   width: 34px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -38,6 +38,7 @@ export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
   "messaging:platform-status-event";
+export const MESSAGING_SET_ENABLED_CHANNEL = "messaging:set-enabled";
 export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -11,6 +11,7 @@ describe("desktop settings contracts", () => {
       runtime: {
         messaging: {
           disabled: false,
+          userEnabled: true,
         },
       },
       secretStorage: {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -150,6 +150,23 @@ export type MessagingPlatformStatusEvent =
       at: number;
     };
 
+export type SetMessagingEnabledRequest = {
+  enabled: boolean;
+};
+
+export type SetMessagingEnabledResponse = {
+  /**
+   * Effective state after the toggle. May not equal the requested
+   * `enabled` if the startup override (`--disable-messaging` /
+   * `PWRAGENT_DISABLE_MESSAGING`) is in force.
+   */
+  enabled: boolean;
+  /** True when the runtime had to ignore the request because of an override. */
+  overridden: boolean;
+  /** Human-readable explanation of the override, when applicable. */
+  overrideReason?: string;
+};
+
 export type MessagingJsonPrimitive = string | number | boolean | null;
 export type MessagingJsonValue =
   | MessagingJsonPrimitive

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -117,8 +117,20 @@ export type DesktopSettingsSnapshot = {
   configError?: string;
   runtime: {
     messaging: {
+      /**
+       * True when messaging is hard-disabled by a startup override
+       * (`--disable-messaging` arg or `PWRAGENT_DISABLE_MESSAGING` env).
+       * The user cannot toggle messaging on while this is true.
+       */
       disabled: boolean;
       disabledReason?: string;
+      /**
+       * The user's persisted on/off choice (defaults to true). Independent
+       * of the startup override — the override always wins, but this is
+       * what the toggle UI binds to and what the app respects on next
+       * launch when no override fires.
+       */
+      userEnabled: boolean;
     };
   };
   secretStorage: DesktopSettingsSecretStorageState;
@@ -188,6 +200,12 @@ export type DesktopSettingsConfigPatch = {
   messaging?: {
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    /**
+     * User's on/off toggle for the whole messaging subsystem. Defaults
+     * to true. Cleared back to true by writing `true`. Independent of
+     * the startup --disable-messaging override.
+     */
+    userEnabled?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;
       maxAttachmentBytes?: number;


### PR DESCRIPTION
PR 2 of 4 in Phase 4. Stacks on #184 (U4.1). Adds a global on/off toggle to the right of the per-platform status chips. Persists across launches and respects the startup \`--disable-messaging\` override.

## Runtime

- New \`pause()\` / \`resume()\` on \`DesktopMessagingRuntime\`. \`pause()\` drains via the existing \`stop()\` teardown and emits \`health=suspended\` for each previously-running platform. \`resume()\` re-runs the adapter factory with the *current* config so settings landing during the paused window take effect on resume.
- Both methods are idempotent — multiple \`pause()\`/\`resume()\` cycles are safe.

## Settings

- New \`messaging.userEnabled\` config field (defaults \`true\`). Persists to \`config.toml\` as \`user_enabled\`. Surfaces on the snapshot under \`runtime.messaging.userEnabled\` so the renderer toggle binds to it.
- Bootstrap reads the snapshot and skips \`runtime.start()\` when \`userEnabled\` is \`false\`.

## IPC

- New \`messaging:set-enabled\` handler. When the startup override is in force, returns \`{ overridden: true }\` and refuses to mutate state. Otherwise persists the setting and calls \`runtime.pause()\`/\`resume()\`.
- Settings write fires *before* the runtime transition so a crash mid-toggle leaves a consistent on-disk truth.

## UI

- \`MessagingStatusBar\` gains a small pill toggle on the right with optimistic state and rollback on IPC failure.
- When the CLI/env override is in force, the toggle renders disabled with a tooltip explaining which override fired.

## Tests

- 3 new runtime tests for pause/resume + idempotent cycle.
- Snapshot fixtures updated across renderer + service tests for the new \`userEnabled\` field.

Total: 1129 passing / 3 skipped.

## Stacking

- This is PR 2 of 4. Stacks on [#184](https://github.com/pwrdrvr/PwrAgent/pull/184) (U4.1).
- Next: **U4.3** — per-thread binding chips + unbind menu (independent of U4.2; will stack on U4.1 directly).
- After: **U4.4** — Messaging Activity screen (stacks on U4.3).

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: \`pwragent:main\` for \`messaging runtime not started — disabled by user setting\` on launch (should fire for users who toggled off).
  - Logs: \`pwragent:messaging\` for \`messaging runtime started\` on resume (should fire when the user toggles back on).
- **Validation checks**
  - Toggle off → adapters stop within ~1s; chips persist with gray dots.
  - Toggle on → adapters re-init and report green within 2s.
  - Quit + relaunch → toggle state remembered.
  - Launch with \`--disable-messaging\` → toggle is disabled with the tooltip explaining the flag.
- **Expected healthy behavior**
  - No flicker mid-toggle; pill animation is smooth.
  - Settings file gains \`messaging.user_enabled = true|false\` after first toggle.
- **Failure signal(s)**
  - Toggle gets stuck in optimistic state → IPC handler rejected without rollback (look for unhandled exceptions in renderer devtools).
  - \`adapter.stop is not a function\` or hangs → adapter author missing the \`stop()\` impl; would surface as a stuck \"Off\".
- **Validation window & owner**
  - Window: First post-deploy launch + 5 min of toggle exercise.
  - Owner: @huntharo

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with [Claude Opus 4.7 (1M context, extended thinking)](https://claude.com/claude-code) via Compound Engineering v2.49.0