### PR TITLE
feat(desktop): per-thread messaging binding chips + unbind (Phase 4 — U4.3)

### DIFF
--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -66,6 +66,7 @@ import {
 } from "../../shared/ipc";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { getMainLogger } from "../log";
+import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindings-snapshot";
 import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
@@ -327,9 +328,11 @@ class DesktopAppServerService {
       callerReason: "navigation-snapshot",
       filter: request.filter,
     });
+    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
+      messagingBindingsByThreadKey,
       threads,
     });
     const directoryStatuses =

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -2,12 +2,19 @@ import { BrowserWindow, ipcMain } from "electron";
 import type {
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
 } from "@pwragent/shared";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
+import { getMainLogger } from "../log";
 import {
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_UNBIND_THREAD_CHANNEL,
 } from "../../shared/ipc";
+
+const log = getMainLogger("pwragent:messaging-ipc");
 
 let unsubscribePlatformStatus: (() => void) | undefined;
 
@@ -38,10 +45,31 @@ export function registerMessagingStatusIpcHandlers(): void {
       return runtime.getPlatformStatuses();
     },
   );
+
+  ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_UNBIND_THREAD_CHANNEL,
+    async (
+      _event,
+      request: UnbindMessagingThreadRequest,
+    ): Promise<UnbindMessagingThreadResponse> => {
+      const store = getDesktopMessagingStore();
+      const revoked = await store.revokeBinding({ bindingId: request.bindingId });
+      log.info("messaging binding unbound", {
+        bindingId: request.bindingId,
+        revoked: Boolean(revoked),
+        platform: revoked?.channel?.channel ?? null,
+        backend: revoked?.backend ?? null,
+        threadId: revoked?.threadId ?? null,
+      });
+      return { revoked: Boolean(revoked), bindingId: request.bindingId };
+    },
+  );
 }
 
 export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   unsubscribePlatformStatus?.();
   unsubscribePlatformStatus = undefined;
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
 }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -29,6 +29,7 @@ import type { MessagingBackendBridge } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   constructor(
@@ -44,9 +45,11 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
     });
+    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
+      messagingBindingsByThreadKey,
       threads,
     });
     const directoryStatuses = await this.registry.readDirectoryStatuses(

--- a/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
+++ b/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
@@ -1,0 +1,65 @@
+import type {
+  AppServerThreadSummary,
+  MessagingThreadBindingSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { getDesktopMessagingStore } from "./desktop-messaging-store";
+import { getMainLogger } from "../log";
+
+const log = getMainLogger("pwragent:messaging-bindings");
+
+/**
+ * Build the `messagingBindingsByThreadKey` map for the navigation
+ * snapshot. Walks the threads in the current snapshot and asks the
+ * messaging store for active bindings per thread. Returns `undefined`
+ * (rather than an empty object) when nothing is bound — `buildNavigationSnapshot`
+ * treats `undefined` and `{}` the same, but `undefined` keeps the hash
+ * inputs minimal for users with no messaging configured.
+ */
+export async function buildMessagingBindingsByThreadKey(
+  threads: AppServerThreadSummary[],
+): Promise<Record<string, MessagingThreadBindingSummary[]> | undefined> {
+  if (threads.length === 0) return undefined;
+  let store;
+  try {
+    store = getDesktopMessagingStore();
+  } catch (error) {
+    // The messaging store is initialized lazily after the app state is
+    // brought up. If we somehow ask for bindings before then, return
+    // undefined rather than crashing the navigation snapshot path.
+    log.warn("messaging store unavailable for navigation snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  const result: Record<string, MessagingThreadBindingSummary[]> = {};
+  for (const thread of threads) {
+    let bindings;
+    try {
+      bindings = await store.findActiveBindingsForThread({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+    } catch (error) {
+      log.warn("failed to resolve bindings for thread", {
+        backend: thread.source,
+        threadId: thread.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    if (bindings.length === 0) continue;
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    result[threadKey] = bindings.map((binding) => ({
+      bindingId: binding.id,
+      platform: binding.channel.channel,
+      conversationTitle:
+        binding.channel.conversation.title
+        ?? binding.threadDisplay?.threadTitle
+        ?? binding.displayName,
+      activeAt: binding.updatedAt,
+    }));
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -4,6 +4,7 @@ import type {
   DirectoryLaunchpadOverlayState,
   LinkedDirectorySummary,
   MarkThreadSeenResponse,
+  MessagingThreadBindingSummary,
   NavigationDirectoryGitStatus,
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
@@ -26,6 +27,15 @@ export class SqliteOverlayStore {
     backend: AppServerBackendScope;
     fetchedAt: number;
     gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
+    /**
+     * Active messaging bindings per thread, keyed by thread identity key.
+     * Sourced from the desktop messaging sqlite store. Optional so tests
+     * (and any future callers without messaging) can keep working.
+     */
+    messagingBindingsByThreadKey?: Record<
+      string,
+      MessagingThreadBindingSummary[] | undefined
+    >;
     threads: AppServerThreadSummary[];
   }): Promise<NavigationSnapshot> {
     const backendState = this.getBackend(params.backend);
@@ -71,6 +81,7 @@ export class SqliteOverlayStore {
       gitStatusByDirectoryKey: params.gitStatusByDirectoryKey,
       launchpadDefaults,
       launchpadsByKey,
+      messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
       overlayByThreadKey,
       previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
       threads: params.threads,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -40,6 +40,8 @@ import type {
   GhStatus,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -115,6 +117,7 @@ import {
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -350,6 +353,10 @@ const desktopApi = Object.freeze({
   },
   getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
     await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+  unbindMessagingThread: async (
+    request: UnbindMessagingThreadRequest,
+  ): Promise<UnbindMessagingThreadResponse> =>
+    await ipcRenderer.invoke(MESSAGING_UNBIND_THREAD_CHANNEL, request),
   onMessagingPlatformStatusEvent: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ): (() => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -129,6 +129,11 @@ function DesktopAppShell(props: {
         onRenameThread={navigation.renameThread}
         onSetThreadReaction={navigation.setThreadReaction}
         onPrefetchPullRequests={pullRequests.prefetch}
+        onUnbindMessagingBinding={async (_thread, binding) => {
+          if (!desktopApi?.unbindMessagingThread) return;
+          await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });
+          await navigation.refresh?.();
+        }}
         onResizeStart={startSidebarResize}
         onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
       />

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
+  MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
@@ -28,6 +29,10 @@ type DirectoriesListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -185,6 +190,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
+                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
                         />
                       );
                     })}

--- a/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import { ThreadRow } from "./ThreadRow";
 
@@ -17,6 +20,10 @@ type InboxListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -45,6 +52,7 @@ export function InboxList(props: InboxListProps) {
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import { ThreadRow } from "./ThreadRow";
 
@@ -17,6 +20,10 @@ type RecentsListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -37,6 +44,7 @@ export function RecentsList(props: RecentsListProps) {
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
+  MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
   ThreadExecutionMode,
@@ -68,6 +69,15 @@ type SidebarProps = {
    * fresh PR status before they click in.
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  /**
+   * Called when the user unbinds a messaging conversation from a
+   * thread via the binding chip. Receives the thread + binding so the
+   * parent can call the IPC and refresh navigation.
+   */
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
+  ) => Promise<void>;
   onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
   onResizeByKeyboard?: (delta: number) => void;
 };
@@ -364,6 +374,7 @@ export function Sidebar(props: SidebarProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
@@ -377,6 +388,7 @@ export function Sidebar(props: SidebarProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
             props.threads.length === 0 ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -1,10 +1,22 @@
-import { useEffect, useRef, useState } from "react";
-import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+  PrSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
+import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
 import { PrChip } from "../pr-status/PrChip";
 import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
+
+const PLATFORM_ICONS: Partial<
+  Record<MessagingThreadBindingSummary["platform"], (props: IconProps) => ReactElement>
+> = {
+  telegram: TelegramIcon,
+  discord: DiscordIcon,
+};
 
 const HOVER_PREFETCH_DELAY_MS = 750;
 
@@ -26,6 +38,15 @@ type ThreadRowProps = {
    * thread key, respect terminal-state short-circuit on the main side).
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  /**
+   * Called when the user picks "Unbind" from a per-thread messaging
+   * binding chip. Receives the binding id; the parent owns the IPC call
+   * and any optimistic UI rollback.
+   */
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
+  ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onSetReaction?: (
     thread: NavigationThreadSummary,
@@ -141,6 +162,23 @@ export function ThreadRow(props: ThreadRowProps) {
             ))}
           </span>
         ) : null}
+
+        {(props.thread.messagingBindings ?? []).length > 0 ? (
+          <span className="thread-row__binding-chips">
+            {(props.thread.messagingBindings ?? []).map((binding) => (
+              <BindingChip
+                key={binding.bindingId}
+                binding={binding}
+                onUnbind={
+                  props.onUnbindMessagingBinding
+                    ? (target) =>
+                        void props.onUnbindMessagingBinding!(props.thread, target)
+                    : undefined
+                }
+              />
+            ))}
+          </span>
+        ) : null}
       </button>
 
       {canReact || reactions.length > 0 ? (
@@ -210,6 +248,53 @@ export function ThreadRow(props: ThreadRowProps) {
         ...
       </button>
     </div>
+  );
+}
+
+function BindingChip(props: {
+  binding: MessagingThreadBindingSummary;
+  onUnbind?: (binding: MessagingThreadBindingSummary) => void;
+}) {
+  const { binding, onUnbind } = props;
+  const Icon = PLATFORM_ICONS[binding.platform];
+  const platformLabel =
+    binding.platform.charAt(0).toUpperCase() + binding.platform.slice(1);
+  const detail = binding.conversationTitle
+    ? `${platformLabel}: ${binding.conversationTitle}`
+    : platformLabel;
+  const ariaLabel = onUnbind
+    ? `Unbind ${detail} from this thread`
+    : detail;
+  return (
+    <button
+      type="button"
+      className="thread-row__binding-chip"
+      title={onUnbind ? `${detail} (click to unbind)` : detail}
+      aria-label={ariaLabel}
+      disabled={!onUnbind}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (!onUnbind) return;
+        if (
+          window.confirm(
+            `Stop responding to ${detail} from this thread? You can rebind from the messaging app.`,
+          )
+        ) {
+          onUnbind(binding);
+        }
+      }}
+    >
+      {Icon ? (
+        <Icon size={12} />
+      ) : (
+        <span aria-hidden="true">{binding.platform.slice(0, 2)}</span>
+      )}
+      {binding.conversationTitle ? (
+        <span className="thread-row__binding-chip-label">
+          {binding.conversationTitle}
+        </span>
+      ) : null}
+    </button>
   );
 }
 

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -40,6 +40,8 @@ import type {
   GhStatus,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -205,6 +207,9 @@ export type DesktopApi = {
   onMessagingPlatformStatusEvent?: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ) => () => void;
+  unbindMessagingThread?: (
+    request: UnbindMessagingThreadRequest,
+  ) => Promise<UnbindMessagingThreadResponse>;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -247,6 +247,44 @@ textarea,
   border: 1.5px solid var(--bg-panel);
 }
 
+.thread-row__binding-chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.thread-row__binding-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.thread-row__binding-chip:hover:not([disabled]) {
+  color: var(--text-primary);
+  border-color: var(--accent-border);
+}
+
+.thread-row__binding-chip[disabled] {
+  cursor: default;
+}
+
+.thread-row__binding-chip-label {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sidebar__icon-button {
   display: inline-flex;
   width: 34px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -38,6 +38,7 @@ export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
   "messaging:platform-status-event";
+export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
 export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -4,6 +4,7 @@ import type {
   AppServerBackendScope,
   AppServerThreadSummary,
   LinkedDirectorySummary,
+  MessagingThreadBindingSummary,
   NavigationSnapshot,
   NavigationThreadSummary,
   NavigationLaunchpadDefaults,
@@ -56,6 +57,13 @@ export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
+  /**
+   * Active messaging bindings per thread, keyed by thread identity key.
+   * Sourced from the desktop's messaging store (sqlite). When omitted,
+   * threads have no `messagingBindings` field — non-desktop callers
+   * (tests, server-side use) don't need to wire it.
+   */
+  messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
 }): NavigationThreadSummary[] {
@@ -73,6 +81,7 @@ export function materializeNavigationThreads(params: {
       (overlay?.observedGitBranch && hasHandoffWorkspace(overlay.extraLinkedDirectories)
         ? overlay.observedGitBranch
         : undefined);
+    const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
 
     return {
       ...thread,
@@ -88,6 +97,9 @@ export function materializeNavigationThreads(params: {
       worktreeSnapshots: overlay?.worktreeSnapshots ?? thread.worktreeSnapshots ?? [],
       reactions: overlay?.reactions ?? [],
       prs: overlay?.prs ?? [],
+      messagingBindings: messagingBindings && messagingBindings.length > 0
+        ? messagingBindings
+        : undefined,
       inbox: deriveInboxState({
         firstSnapshot: params.firstSnapshot,
         isNewThread: !previousKnownThreadKeys.has(threadKey),
@@ -107,6 +119,7 @@ export function buildNavigationSnapshot(params: {
   gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
   launchpadDefaults?: NavigationLaunchpadDefaults;
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
+  messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
@@ -116,6 +129,7 @@ export function buildNavigationSnapshot(params: {
     firstSnapshot: params.firstSnapshot,
     now: params.now,
     overlayByThreadKey: params.overlayByThreadKey,
+    messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
     previousKnownThreadKeys: params.previousKnownThreadKeys,
     threads: params.threads,
   });
@@ -198,6 +212,11 @@ export function buildNavigationSnapshotHash(params: {
         repo: pr.repo,
         state: pr.state,
         url: pr.url,
+      })),
+      messagingBindings: (thread.messagingBindings ?? []).map((binding) => ({
+        bindingId: binding.bindingId,
+        platform: binding.platform,
+        conversationTitle: binding.conversationTitle ?? null,
       })),
     })),
     directories: (params.directories ?? []).map((directory) => ({

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -150,6 +150,17 @@ export type MessagingPlatformStatusEvent =
       at: number;
     };
 
+export type UnbindMessagingThreadRequest = {
+  bindingId: string;
+};
+
+export type UnbindMessagingThreadResponse = {
+  /** True when the binding existed and was revoked. */
+  revoked: boolean;
+  /** The binding id we just revoked, echoed for client-side cache eviction. */
+  bindingId: string;
+};
+
 export type MessagingJsonPrimitive = string | number | boolean | null;
 export type MessagingJsonValue =
   | MessagingJsonPrimitive

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -8,6 +8,7 @@ import type {
   ThreadIdentifier,
   WorktreeSnapshotSummary,
 } from "./normalized-app-server";
+import type { MessagingChannelKind } from "./messaging";
 
 export type InboxReason = "new-thread" | "updated-since-seen";
 
@@ -30,6 +31,29 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   reactions?: string[];
   /** GitHub pull requests detected for this thread's linked directories + branch. */
   prs?: PrSummary[];
+  /**
+   * Messaging platform conversations bound to this thread. Each binding
+   * represents a single conversation (DM, channel, topic, etc.) on one
+   * platform. The renderer renders one chip per active binding and lets
+   * the user unbind from the desktop side via the chip menu.
+   */
+  messagingBindings?: MessagingThreadBindingSummary[];
+};
+
+/**
+ * Renderer-facing slice of a single active messaging binding for a
+ * thread. Carries enough to render the chip + the unbind action without
+ * exposing the full `MessagingBindingRecord` (which has adapter-opaque
+ * routing state the UI must not parse).
+ */
+export type MessagingThreadBindingSummary = {
+  /** Stable id of the binding row in sqlite — pass back to unbind. */
+  bindingId: string;
+  platform: MessagingChannelKind;
+  /** Human-readable conversation title (DM nickname, channel name). */
+  conversationTitle?: string;
+  /** Wall-clock ms when the binding last had inbound or outbound activity. */
+  activeAt?: number;
 };
 
 /**


### PR DESCRIPTION
PR 3 of 4 in Phase 4. Stacks on [#184](https://github.com/pwrdrvr/PwrAgent/pull/184) (U4.1). Surfaces each thread's active messaging conversations as small chips next to the PR chips, and lets the user unbind from the desktop side with a confirmation prompt.

## Contracts (shared)

- New \`MessagingThreadBindingSummary { bindingId, platform, conversationTitle?, activeAt? }\` — renderer-facing slice (no opaque routing state).
- \`NavigationThreadSummary\` gains \`messagingBindings?: MessagingThreadBindingSummary[]\`.
- New \`UnbindMessagingThreadRequest\`/\`Response\`.
- Bindings included in the navigation snapshot hash so unbind/rebind changes propagate (lesson learned from the U3.3 PR-chip propagation bug).

## Main

- New \`buildMessagingBindingsByThreadKey()\` walks the thread list and asks the messaging sqlite store for active bindings per thread.
- \`SqliteOverlayStore.reconcileNavigationSnapshot\` accepts an optional \`messagingBindingsByThreadKey\` injection and forwards it through \`buildNavigationSnapshot\`.
- Both snapshot call sites (app-server IPC, messaging backend bridge) populate the map before reconciling.
- New \`messaging:unbind-thread\` IPC. Calls \`SqliteMessagingStore.revokeBinding\`, which already cleans up pending intents, browse sessions, and callback handles tied to the binding (no schema additions needed).

## Renderer

- \`ThreadRow\` renders a binding chip per active messaging binding using the same monochrome Telegram/Discord glyphs from U4.1. Click prompts a \`confirm()\` and calls the unbind IPC.
- \`App.tsx\` wires the unbind handler + refreshes navigation so the chip disappears immediately on success.
- \`Sidebar\` / \`InboxList\` / \`RecentsList\` / \`DirectoriesList\` all forward the new \`onUnbindMessagingBinding\` callback.

## Tests

- Workspace suite: 1129 passing / 3 skipped — no regressions.
- The unbind path uses \`SqliteMessagingStore.revokeBinding\`, which already has coverage; the new IPC is a thin wrapper. Per-thread chip rendering relies on existing snapshot coverage + the navigation-state hash logic that's already exercised by U3.2 reaction tests.

## Stacking

- This is PR 3 of 4. Stacks on [#184](https://github.com/pwrdrvr/PwrAgent/pull/184) (U4.1). Independent of [#185](https://github.com/pwrdrvr/PwrAgent/pull/185) (U4.2) — both stack directly on U4.1.
- Next: **U4.4** — Messaging Activity screen + activity log (stacks on this).

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: \`pwragent:messaging-ipc\` for \`messaging binding unbound\` lines (one per user-initiated unbind).
  - Logs: \`pwragent:messaging-bindings\` for \`failed to resolve bindings for thread\` warnings (signal the messaging store is unhealthy).
- **Validation checks**
  - Thread bound via Telegram → see Telegram chip with conversation title in the thread row.
  - Click the chip → confirm prompt → accept → chip disappears within ~1s.
  - Send a new Telegram message from the same conversation after unbinding → no thread row update (binding stays revoked).
- **Expected healthy behavior**
  - Chips appear instantly on app launch for any threads with active bindings.
  - Unbind is irreversible from the desktop side (rebind requires re-sending from the platform); confirm dialog should make this clear.
- **Failure signal(s)**
  - Chip remains after unbind → snapshot hash isn't picking up the change OR navigation refresh isn't firing.
  - \`messaging store unavailable for navigation snapshot\` log spam → bootstrap order regression.
- **Validation window & owner**
  - Window: First post-deploy launch + 5 min of bound-thread interaction.
  - Owner: @huntharo

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with [Claude Opus 4.7 (1M context, extended thinking)](https://claude.com/claude-code) via Compound Engineering v2.49.0