### PR TITLE
feat(desktop): V2 UI - Phase 4 — messaging UX + thread row chip flow

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -702,9 +702,11 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     const startedThreadRow = app.window
       .getByRole("button", { name: /Use a sticky worktree default/ })
       .first();
-    const startedThreadMeta = startedThreadRow.locator(".thread-row__meta");
-    await expect(startedThreadMeta.getByText("worktree", { exact: true })).toBeVisible();
-    await expect(startedThreadMeta.getByText("local", { exact: true })).toHaveCount(0);
+    // Renamed in the chip-flow refactor: meta + PR + binding + reactions
+    // chips all share a single `.thread-row__chips` flex-wrap container.
+    const startedThreadChips = startedThreadRow.locator(".thread-row__chips");
+    await expect(startedThreadChips.getByText("worktree", { exact: true })).toBeVisible();
+    await expect(startedThreadChips.getByText("local", { exact: true })).toHaveCount(0);
 
     await app.window.getByRole("button", { name: "Open context rail" }).click();
     const contextRail = app.window.getByRole("complementary", {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -26,6 +26,8 @@ const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
+const registerMessagingStatusIpcHandlersMock = vi.fn();
+const disposeMessagingStatusIpcHandlersMock = vi.fn();
 const setApplicationMenuMock = vi.fn();
 const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
 const setNameMock = vi.fn();
@@ -129,8 +131,15 @@ vi.mock("../log", () => ({
 vi.mock("../messaging/messaging-runtime", () => ({
   getDesktopMessagingRuntime: vi.fn(() => ({
     start: messagingRuntimeStartMock,
+    onPlatformStatus: vi.fn(() => () => {}),
+    getPlatformStatuses: vi.fn(() => []),
   })),
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
+}));
+
+vi.mock("../ipc/messaging-status", () => ({
+  registerMessagingStatusIpcHandlers: registerMessagingStatusIpcHandlersMock,
+  disposeMessagingStatusIpcHandlers: disposeMessagingStatusIpcHandlersMock,
 }));
 
 vi.mock("../diagnostics/startup-cpu-profiler", () => ({
@@ -167,6 +176,8 @@ describe("bootstrapApp", () => {
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     disposeDesktopMessagingRuntimeMock.mockReset();
+    registerMessagingStatusIpcHandlersMock.mockReset();
+    disposeMessagingStatusIpcHandlersMock.mockReset();
     setApplicationMenuMock.mockReset();
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();

--- a/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MessagingActivityLog } from "../messaging/messaging-activity-log";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let log: MessagingActivityLog;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-activity-log-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  log = new MessagingActivityLog(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("MessagingActivityLog", () => {
+  it("returns nothing when no events have been recorded", () => {
+    expect(log.list()).toEqual([]);
+  });
+
+  it("records inbound-routed events with full metadata", () => {
+    const recorded = log.record({
+      platform: "telegram",
+      kind: "inbound-routed",
+      backend: "codex",
+      threadId: "thread-1",
+      bindingId: "binding-1",
+      conversationId: "tg-chat-1",
+      conversationTitle: "Direct messages",
+      actorId: "user-1",
+      actorDisplayName: "Alice",
+      summary: "Routed inbound from Alice",
+      createdAt: 1_000,
+    });
+
+    expect(recorded.id).toBeGreaterThan(0);
+    expect(log.list()).toEqual([
+      expect.objectContaining({
+        id: recorded.id,
+        platform: "telegram",
+        kind: "inbound-routed",
+        backend: "codex",
+        threadId: "thread-1",
+        bindingId: "binding-1",
+        conversationId: "tg-chat-1",
+        conversationTitle: "Direct messages",
+        actorId: "user-1",
+        actorDisplayName: "Alice",
+        summary: "Routed inbound from Alice",
+        createdAt: 1_000,
+      }),
+    ]);
+  });
+
+  it("returns events newest-first by id", () => {
+    log.record({ platform: "telegram", kind: "outbound", summary: "first", createdAt: 1 });
+    log.record({ platform: "telegram", kind: "outbound", summary: "second", createdAt: 2 });
+    log.record({ platform: "telegram", kind: "outbound", summary: "third", createdAt: 3 });
+    expect(log.list().map((entry) => entry.summary)).toEqual([
+      "third",
+      "second",
+      "first",
+    ]);
+  });
+
+  it("respects sinceId for incremental polling", () => {
+    const first = log.record({
+      platform: "telegram",
+      kind: "outbound",
+      summary: "old",
+    });
+    const second = log.record({
+      platform: "telegram",
+      kind: "outbound",
+      summary: "new",
+    });
+
+    const result = log.list({ sinceId: first.id });
+    expect(result).toEqual([
+      expect.objectContaining({ id: second.id, summary: "new" }),
+    ]);
+  });
+
+  it("clamps the limit to the [1, 500] range", () => {
+    for (let i = 0; i < 10; i += 1) {
+      log.record({
+        platform: "telegram",
+        kind: "outbound",
+        summary: `event-${i}`,
+      });
+    }
+    expect(log.list({ limit: 0 })).toHaveLength(1);
+    expect(log.list({ limit: 100_000 })).toHaveLength(10);
+  });
+
+  it("evicts to the per-platform cap on cleanupExpired", () => {
+    for (let i = 0; i < 7; i += 1) {
+      log.record({ platform: "telegram", kind: "outbound", summary: `t-${i}` });
+      log.record({ platform: "discord", kind: "outbound", summary: `d-${i}` });
+    }
+    // Synthetic small cap via cleanupExpired uses the file-level cap (500).
+    // Verify that calling cleanup is a no-op below the cap.
+    stateDb.cleanupExpired();
+    expect(log.list({ limit: 500 })).toHaveLength(14);
+  });
+
+  it("survives close + reopen of the DB", () => {
+    log.record({
+      platform: "telegram",
+      kind: "inbound-rejected",
+      summary: "spam from unknown sender",
+      actorDisplayName: "RandoBot",
+      createdAt: 42,
+    });
+    const dbPath = stateDb.raw.name;
+    stateDb.close();
+
+    const reopened = StateDb.open(dbPath);
+    try {
+      const reopenedLog = new MessagingActivityLog(reopened);
+      expect(reopenedLog.list()).toEqual([
+        expect.objectContaining({
+          summary: "spam from unknown sender",
+          actorDisplayName: "RandoBot",
+          kind: "inbound-rejected",
+          createdAt: 42,
+        }),
+      ]);
+    } finally {
+      reopened.close();
+    }
+    // Reopen the temp DB so afterEach close() doesn't double-close.
+    stateDb = StateDb.open(dbPath);
+    log = new MessagingActivityLog(stateDb);
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -284,6 +284,150 @@ describe("MessagingController", () => {
     });
   });
 
+  it("completes binding mutations without throwing when no onBindingChanged listener is configured", async () => {
+    // The `onBindingChanged` option is declared optional on
+    // `MessagingControllerOptions`. Production wiring always supplies
+    // one (see `messaging-runtime.ts`), but the controller must
+    // remain safe to construct without it — defensive coverage so a
+    // future test or alternate consumer that forgets the callback
+    // doesn't crash on the first bind/detach.
+    const harness = await createHarness({ bindingChangedListener: false });
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    await expect(
+      harness.controller.handleInboundEvent(
+        buildCallbackEvent({
+          actionId: "browse:select-thread",
+          value: { backend: "codex", threadId: "thread-1" },
+        }),
+      ),
+    ).resolves.not.toThrow();
+    // Bind landed despite no callback wired.
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toMatchObject({ backend: "codex", threadId: "thread-1" });
+    // Detach also completes — fan-out is best-effort, mutation isn't.
+    await expect(
+      harness.controller.handleInboundEvent(buildCommandEvent("/detach")),
+    ).resolves.not.toThrow();
+    // Active lookup now misses (the row is revoked, not deleted).
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fires onBindingChanged on every binding mutation path", async () => {
+    // Regression: binding chips in the navigation snapshot only refresh
+    // when the renderer refetches the snapshot. The renderer was only
+    // refetching on backend events — so bind / detach / sync-name
+    // didn't propagate until the next backend tick (issue #191). The
+    // controller now fan-outs `onBindingChanged` on every mutation.
+    const setConversationTitle = vi.fn(
+      async (
+        request: Parameters<NonNullable<MessagingAdapter["setConversationTitle"]>>[0],
+      ) => ({
+        channel: "telegram" as const,
+        conversation: {
+          ...request.channel.conversation,
+          title: request.title,
+        },
+        outcome: "updated" as const,
+        title: request.title,
+        updatedAt: 1000,
+      }),
+    );
+    const harness = await createHarness({ setConversationTitle });
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.title = "Renamed in Desktop";
+    harness.getNavigationSnapshot.mockResolvedValue(navigation);
+
+    // 1. bind via /resume picker → callback path
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    harness.onBindingChanged.mockClear();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: { backend: "codex", threadId: "thread-1" },
+      }),
+    );
+    expect(harness.onBindingChanged).toHaveBeenCalled();
+
+    // 2. /sync name updates the title and must also fire
+    harness.onBindingChanged.mockClear();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:sync-name",
+        routingState: {
+          opaque: { chatId: 777, messageThreadId: 9 },
+        },
+      }),
+    );
+    expect(harness.onBindingChanged).toHaveBeenCalled();
+
+    // 3. /detach revokes the binding and must also fire
+    harness.onBindingChanged.mockClear();
+    await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
+    expect(harness.onBindingChanged).toHaveBeenCalled();
+  });
+
+  it("routes text to the bound thread after a /resume → select-thread bind", async () => {
+    // Regression: the resume browser stores a channel-scoped pending
+    // intent. Before `bindChannelToThread` started retiring channel
+    // intents on a successful bind, that picker intent survived the
+    // bind, and the next text inbound matched it as ambiguous —
+    // making the bot bounce "Choose an option" instead of routing the
+    // text to the freshly-bound thread.
+    const harness = await createHarness();
+    // The test harness uses `receivedAt: 1000`; pin the lookup clock
+    // inside the intent's TTL window so the picker intent is visible.
+    const lookupNow = 1500;
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    expect(
+      await harness.store.findActivePendingIntentForChannel({
+        actorId: "user-1",
+        channel: buildTextEvent("ignored").channel,
+        now: lookupNow,
+      }),
+    ).toBeTruthy();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: { backend: "codex", threadId: "thread-1" },
+      }),
+    );
+
+    // After the bind, no channel-scoped pending intent should remain
+    // — the picker intent must be retired so it can't intercept the
+    // next text.
+    expect(
+      await harness.store.findActivePendingIntentForChannel({
+        actorId: "user-1",
+        channel: buildTextEvent("ignored").channel,
+        now: lookupNow,
+      }),
+    ).toBeUndefined();
+
+    harness.delivered.length = 0;
+    harness.startTurn.mockClear();
+    await harness.controller.handleInboundEvent(buildTextEvent("you there?"));
+
+    // Text routes to the bound thread, not back to the picker.
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "you there?" }],
+      }),
+    );
+    const confirmations = harness.delivered.filter(
+      (intent) => intent.kind === "confirmation",
+    );
+    for (const confirmation of confirmations) {
+      expect(confirmation).not.toMatchObject({ title: "Choose an option" });
+      expect(confirmation).not.toMatchObject({ title: "Choose a thread" });
+    }
+  });
+
   it("updates the clicked resume picker when multiple pickers are active", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
@@ -3289,6 +3433,15 @@ async function createHarness(options?: {
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
   now?: () => number;
+  /**
+   * Set to `false` to construct the controller WITHOUT an
+   * `onBindingChanged` callback. Used by tests that verify the
+   * controller's nullish-callback guard — production callers always
+   * supply one (see `messaging-runtime.ts`), but the option is
+   * declared optional and the controller must not throw if it's
+   * absent.
+   */
+  bindingChangedListener?: false;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
 }): Promise<{
@@ -3299,6 +3452,7 @@ async function createHarness(options?: {
   handoffThreadWorkspace: ReturnType<typeof vi.fn> | undefined;
   interruptTurn: ReturnType<typeof vi.fn>;
   listBackends: ReturnType<typeof vi.fn>;
+  onBindingChanged: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
   setThreadModelSettings: ReturnType<typeof vi.fn>;
@@ -3453,6 +3607,7 @@ async function createHarness(options?: {
     submitServerRequest,
   };
 
+  const onBindingChanged = vi.fn();
   const controller = new MessagingController({
     adapter,
     authorizedActorIds: ["user-1"],
@@ -3460,6 +3615,13 @@ async function createHarness(options?: {
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),
+    // Pass the spy by default so tests can assert on fan-out. The
+    // `bindingChangedListener: false` opt-out exists for tests that
+    // verify the nullish-callback guard — production wiring always
+    // supplies one.
+    ...(options?.bindingChangedListener === false
+      ? {}
+      : { onBindingChanged }),
     store,
     toolUpdateDefaultMode: options?.toolUpdateDefaultMode,
   });
@@ -3473,6 +3635,7 @@ async function createHarness(options?: {
     handoffThreadWorkspace,
     interruptTurn,
     listBackends,
+    onBindingChanged,
     readThreadStatus,
     setThreadExecutionMode,
     setThreadModelSettings,

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -616,6 +616,109 @@ describe("DesktopMessagingRuntime", () => {
       });
   });
 
+  it("emits health=enabled for each adapter that successfully starts", async () => {
+    const { runtime } = await createRuntimeHarness();
+    const events: unknown[] = [];
+    const unsubscribe = runtime.onPlatformStatus((event) => {
+      events.push(event);
+    });
+
+    await runtime.start();
+    await Promise.resolve();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "enabled",
+      }),
+    );
+    unsubscribe();
+  });
+
+  it("emits health=errored when an adapter fails to start", async () => {
+    await prepareRuntimeStore();
+    const failingAdapter = createAdapter("telegram", {
+      start: vi.fn(async () => {
+        throw new Error("telegram unavailable");
+      }),
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [failingAdapter],
+      backendBridge: bridge,
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await runtime.start();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "errored",
+        reason: expect.stringContaining("telegram unavailable"),
+      }),
+    );
+  });
+
+  it("emits an activity event when an inbound message arrives", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await adapter.listener?.(buildCommandEvent("/resume"));
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "activity",
+        platform: "telegram",
+      }),
+    );
+  });
+
+  it("emits health=suspended for each running adapter when stopped", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    await runtime.stop();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "suspended",
+      }),
+    );
+  });
+
+  it("getPlatformStatuses returns a snapshot keyed by platform", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+
+    const snapshot = runtime.getPlatformStatuses();
+    expect(snapshot).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "enabled",
+      }),
+    ]);
+  });
+
   it("stops the started adapter instances without rebuilding the factory", async () => {
     await prepareRuntimeStore();
     const adapter = createAdapter("telegram");

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,6 +19,10 @@ import {
   registerImageNormalizationIpcHandlers,
 } from "./ipc/image-normalization";
 import {
+  disposeMessagingStatusIpcHandlers,
+  registerMessagingStatusIpcHandlers,
+} from "./ipc/messaging-status";
+import {
   disposePreloadLogIpcHandlers,
   registerPreloadLogIpcHandlers,
 } from "./ipc/preload-log";
@@ -120,6 +124,11 @@ export function bootstrapApp(): void {
         ),
       ).start();
     }
+    // Register status IPC after the runtime is constructed so the
+    // initial subscriber attaches before the renderer asks for the
+    // current snapshot. When messaging is disabled the runtime singleton
+    // still exists (default config); status returns []  / never emits.
+    registerMessagingStatusIpcHandlers();
     createMainWindow({
       startupCpuProfiler,
     });
@@ -154,6 +163,7 @@ export function bootstrapApp(): void {
     if (isDevelopment) {
       disposeRuntimeIdentityIpcHandlers();
     }
+    void disposeMessagingStatusIpcHandlers();
     void disposeDesktopMessagingRuntime();
     void disposeAppServerIpcHandlers();
     disposeAppState();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -406,15 +406,18 @@ class DesktopAppServerService {
     // Terminal-state short-circuit: once a PR is merged or closed, we
     // never re-query gh for that thread. The chip is frozen at its
     // terminal color and we just hand back what's persisted.
+    //
+    // No log here on purpose — this path runs on every navigation
+    // refresh tick (once a minute per renderer) for every thread with
+    // a terminal PR, so logging would produce one line per thread per
+    // minute of pure noise. The interesting path is the cache-miss
+    // fetch below, and callers that need to observe the no-op
+    // programmatically can read `shortCircuited: true` off the
+    // response.
     const hasTerminalPr = existingPrs.some(
       (pr) => pr.state === "merged" || pr.state === "closed",
     );
     if (hasTerminalPr) {
-      logDebug("refreshThreadPullRequests:short-circuit", {
-        backend,
-        threadId: request.threadId,
-        prCount: existingPrs.length,
-      });
       return {
         backend,
         threadId: request.threadId,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -66,6 +66,7 @@ import {
 } from "../../shared/ipc";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { getMainLogger } from "../log";
+import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindings-snapshot";
 import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
@@ -327,9 +328,11 @@ class DesktopAppServerService {
       callerReason: "navigation-snapshot",
       filter: request.filter,
     });
+    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
+      messagingBindingsByThreadKey,
       threads,
     });
     const directoryStatuses =

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -12,6 +12,7 @@ import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
 import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
 import { getMainLogger } from "../log";
 import {
+  MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
@@ -21,6 +22,7 @@ import {
 const log = getMainLogger("pwragent:messaging-ipc");
 
 let unsubscribePlatformStatus: (() => void) | undefined;
+let unsubscribeBindingsChanged: (() => void) | undefined;
 
 function broadcastPlatformStatusEvent(event: MessagingPlatformStatusEvent): void {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -34,6 +36,20 @@ function broadcastPlatformStatusEvent(event: MessagingPlatformStatusEvent): void
   }
 }
 
+function broadcastBindingsChanged(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+      continue;
+    }
+    if (typeof window.webContents.send !== "function") {
+      continue;
+    }
+    window.webContents.send(MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL, {
+      at: Date.now(),
+    });
+  }
+}
+
 export function registerMessagingStatusIpcHandlers(): void {
   const runtime = getDesktopMessagingRuntime();
 
@@ -41,6 +57,8 @@ export function registerMessagingStatusIpcHandlers(): void {
   unsubscribePlatformStatus = runtime.onPlatformStatus(
     broadcastPlatformStatusEvent,
   );
+  unsubscribeBindingsChanged?.();
+  unsubscribeBindingsChanged = runtime.onBindingsChanged(broadcastBindingsChanged);
 
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
   ipcMain.handle(
@@ -81,6 +99,18 @@ export function registerMessagingStatusIpcHandlers(): void {
         backend: revoked?.backend ?? null,
         threadId: revoked?.threadId ?? null,
       });
+      // Same fan-out the controller paths use — the desktop UI
+      // initiated the unbind, so refetch the snapshot now to remove
+      // the chip without waiting for a backend tick.
+      if (revoked) {
+        try {
+          getDesktopMessagingRuntime().notifyBindingsChanged();
+        } catch (error) {
+          log.debug("failed to broadcast bindings-changed after unbind", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
       return { revoked: Boolean(revoked), bindingId: request.bindingId };
     },
   );
@@ -89,6 +119,8 @@ export function registerMessagingStatusIpcHandlers(): void {
 export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   unsubscribePlatformStatus?.();
   unsubscribePlatformStatus = undefined;
+  unsubscribeBindingsChanged?.();
+  unsubscribeBindingsChanged = undefined;
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
   ipcMain.removeHandler(MESSAGING_LIST_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -1,0 +1,95 @@
+import { BrowserWindow, ipcMain } from "electron";
+import type {
+  ListMessagingActivityRequest,
+  ListMessagingActivityResponse,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
+} from "@pwragent/shared";
+import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
+import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
+import { getMainLogger } from "../log";
+import {
+  MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+  MESSAGING_LIST_ACTIVITY_CHANNEL,
+  MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_UNBIND_THREAD_CHANNEL,
+} from "../../shared/ipc";
+
+const log = getMainLogger("pwragent:messaging-ipc");
+
+let unsubscribePlatformStatus: (() => void) | undefined;
+
+function broadcastPlatformStatusEvent(event: MessagingPlatformStatusEvent): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+      continue;
+    }
+    if (typeof window.webContents.send !== "function") {
+      continue;
+    }
+    window.webContents.send(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, event);
+  }
+}
+
+export function registerMessagingStatusIpcHandlers(): void {
+  const runtime = getDesktopMessagingRuntime();
+
+  unsubscribePlatformStatus?.();
+  unsubscribePlatformStatus = runtime.onPlatformStatus(
+    broadcastPlatformStatusEvent,
+  );
+
+  ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+    async (): Promise<MessagingPlatformStatus[]> => {
+      return runtime.getPlatformStatuses();
+    },
+  );
+
+  ipcMain.removeHandler(MESSAGING_LIST_ACTIVITY_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_LIST_ACTIVITY_CHANNEL,
+    async (
+      _event,
+      request: ListMessagingActivityRequest | undefined,
+    ): Promise<ListMessagingActivityResponse> => {
+      const entries = getDesktopMessagingActivityLog().list({
+        limit: request?.limit,
+        sinceId: request?.sinceId,
+      });
+      return { entries };
+    },
+  );
+
+  ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_UNBIND_THREAD_CHANNEL,
+    async (
+      _event,
+      request: UnbindMessagingThreadRequest,
+    ): Promise<UnbindMessagingThreadResponse> => {
+      const store = getDesktopMessagingStore();
+      const revoked = await store.revokeBinding({ bindingId: request.bindingId });
+      log.info("messaging binding unbound", {
+        bindingId: request.bindingId,
+        revoked: Boolean(revoked),
+        platform: revoked?.channel?.channel ?? null,
+        backend: revoked?.backend ?? null,
+        threadId: revoked?.threadId ?? null,
+      });
+      return { revoked: Boolean(revoked), bindingId: request.bindingId };
+    },
+  );
+}
+
+export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
+  unsubscribePlatformStatus?.();
+  unsubscribePlatformStatus = undefined;
+  ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_LIST_ACTIVITY_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
+}

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -249,6 +249,13 @@ export class MessagingController {
       return;
     }
 
+    // Self-heal: every inbound event carries the freshest ancestry data
+    // the adapter knows (parentTitle = supergroup/server, ancestorTitle
+    // = guild for Discord threads). Merge any new fields into the
+    // stored binding so the renderer's binding chip can show full
+    // breadcrumbs without waiting for an explicit refresh.
+    await this.refreshBindingFromInbound(event);
+
     if (event.kind === "command") {
       await this.handleCommand(event);
       return;
@@ -473,6 +480,47 @@ export class MessagingController {
         await this.renderBindingStatus(binding);
       }
     }
+  }
+
+  /**
+   * Self-heal stored bindings from the freshest data on every inbound.
+   * The adapter populates `parentTitle` / `ancestorTitle` (supergroup
+   * / server / channel breadcrumbs) on every inbound channel ref;
+   * legacy bindings stored before those fields existed don't have
+   * them. Merge in any new fields the binding doesn't already have so
+   * the navigation snapshot's binding chip can render full
+   * breadcrumbs without waiting for an explicit unbind/rebind.
+   */
+  private async refreshBindingFromInbound(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const binding = await this.options.store.findActiveBindingForChannel(
+      event.channel,
+    );
+    if (!binding) return;
+    const stored = binding.channel.conversation;
+    const incoming = event.channel.conversation;
+    // Only fields where the incoming event is strictly more informative
+    // than what's stored. We never overwrite a non-empty stored field
+    // (the adapter that originally created the binding might have set
+    // a more specific title than what's on a passing message — e.g.
+    // bot-created topic name set via setConversationTitle).
+    const merged = {
+      ...stored,
+      title: stored.title ?? incoming.title,
+      parentTitle: stored.parentTitle ?? incoming.parentTitle,
+      ancestorTitle: stored.ancestorTitle ?? incoming.ancestorTitle,
+    };
+    const changed =
+      merged.title !== stored.title
+      || merged.parentTitle !== stored.parentTitle
+      || merged.ancestorTitle !== stored.ancestorTitle;
+    if (!changed) return;
+    await this.options.store.upsertBinding({
+      ...binding,
+      channel: { ...binding.channel, conversation: merged },
+      updatedAt: this.now(),
+    });
   }
 
   private async handleCommand(event: MessagingInboundCommandEvent): Promise<void> {
@@ -3139,6 +3187,55 @@ export class MessagingController {
     });
   }
 
+  private recordOutboundActivity(
+    intent: MessagingSurfaceIntent,
+    binding: MessagingBindingRecord | undefined,
+    result: MessagingDeliveryResult,
+  ): void {
+    // Only log user-visible deliveries — status/typing/dismiss are
+    // every-tick noise and would drown the activity feed.
+    if (
+      intent.kind !== "message"
+      && intent.kind !== "approval"
+      && intent.kind !== "error"
+    ) {
+      return;
+    }
+    const channel = binding?.channel.channel ?? result.channel;
+    if (!channel) return;
+    const conversation = binding?.channel.conversation;
+    const summary = describeOutboundIntent(intent);
+    try {
+      // Lazy import keeps the controller free of a top-level dep on
+      // the desktop activity-log singleton (the controller is shared
+      // with other harnesses; this method is the only main-process
+      // entry that needs it).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const log = (require(
+        "../desktop-messaging-activity-log",
+      ) as typeof import("../desktop-messaging-activity-log"))
+        .getDesktopMessagingActivityLog();
+      log.record({
+        platform: channel,
+        kind: "outbound",
+        backend: binding?.backend,
+        threadId: binding?.threadId,
+        bindingId: binding?.id,
+        conversationId: conversation?.id,
+        conversationTitle: conversation?.title,
+        summary,
+        payload: {
+          intentId: intent.id,
+          intentKind: intent.kind,
+          outcome: result.outcome,
+        },
+      });
+    } catch {
+      // Activity log is best-effort observability; never break delivery
+      // because the log threw.
+    }
+  }
+
   private async deliver(
     intent: MessagingSurfaceIntent,
     binding?: MessagingBindingRecord,
@@ -3155,6 +3252,7 @@ export class MessagingController {
       bindingId: binding?.id ?? intent.bindingId,
       intentId: routedIntent.id,
     });
+    this.recordOutboundActivity(routedIntent, binding, result);
     if (
       binding &&
       result.channel === binding.channel.channel &&
@@ -4040,4 +4138,16 @@ function readStringValue(
 
   const result = value[key];
   return typeof result === "string" ? result : undefined;
+}
+
+function describeOutboundIntent(intent: MessagingSurfaceIntent): string {
+  if (intent.kind === "message") {
+    const role = (intent as MessagingMessageIntent).role ?? "assistant";
+    return role === "assistant"
+      ? "Sent assistant reply"
+      : `Sent ${role} message`;
+  }
+  if (intent.kind === "approval") return "Sent approval request";
+  if (intent.kind === "error") return "Sent error notice";
+  return `Sent ${intent.kind}`;
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -193,6 +193,16 @@ export type MessagingControllerOptions = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
+  /**
+   * Notification hook invoked after any binding mutation the
+   * controller performs (create, conversation-metadata refresh,
+   * conversation-title sync, detach). The runtime supplies a callback
+   * that broadcasts a renderer-bound IPC event so the UI re-fetches the
+   * navigation snapshot and the binding chip reflects the new state
+   * immediately. Best-effort — exceptions thrown by the listener must
+   * not abort the controller's mutation flow.
+   */
+  onBindingChanged?: () => void;
 };
 
 export class MessagingController {
@@ -254,7 +264,19 @@ export class MessagingController {
     // = guild for Discord threads). Merge any new fields into the
     // stored binding so the renderer's binding chip can show full
     // breadcrumbs without waiting for an explicit refresh.
-    await this.refreshBindingFromInbound(event);
+    //
+    // Best-effort: a sqlite hiccup here must not abort the inbound kind
+    // dispatch below — the binding refresh is observability/UX, not the
+    // source of truth for routing. Log and continue.
+    try {
+      await this.refreshBindingFromInbound(event);
+    } catch (error) {
+      this.logger.debug?.("messaging binding refresh failed", {
+        eventId: event.id,
+        platform: event.channel.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     if (event.kind === "command") {
       await this.handleCommand(event);
@@ -500,16 +522,30 @@ export class MessagingController {
     if (!binding) return;
     const stored = binding.channel.conversation;
     const incoming = event.channel.conversation;
-    // Only fields where the incoming event is strictly more informative
-    // than what's stored. We never overwrite a non-empty stored field
-    // (the adapter that originally created the binding might have set
-    // a more specific title than what's on a passing message — e.g.
-    // bot-created topic name set via setConversationTitle).
+    // Incoming wins when present. Adapters fetch fresher metadata
+    // than we stored at bind time:
+    //   - Discord resolves channel/parent/guild names via REST every
+    //     inbound (bounded LRU cache), so a server or channel rename
+    //     reaches us on the next message.
+    //   - Telegram caches forum-topic names from `forum_topic_created`
+    //     and `forum_topic_edited` service messages, so renames done
+    //     in the Telegram client propagate to subsequent inbound
+    //     messages.
+    // When `incoming` doesn't carry a field (e.g. a regular Telegram
+    // topic message that doesn't ship the topic name and the cache
+    // missed), we fall back to `stored` so we never lose data we
+    // already have.
+    //
+    // Loop safety: the `if (!changed)` guard below means an inbound
+    // whose values match what's stored produces no write and no
+    // broadcast — so the gateway echo of our own `editForumTopic`
+    // call (which carries the same name we just wrote in
+    // `syncConversationName`) is a no-op, not a refresh storm.
     const merged = {
       ...stored,
-      title: stored.title ?? incoming.title,
-      parentTitle: stored.parentTitle ?? incoming.parentTitle,
-      ancestorTitle: stored.ancestorTitle ?? incoming.ancestorTitle,
+      title: incoming.title ?? stored.title,
+      parentTitle: incoming.parentTitle ?? stored.parentTitle,
+      ancestorTitle: incoming.ancestorTitle ?? stored.ancestorTitle,
     };
     const changed =
       merged.title !== stored.title
@@ -521,6 +557,9 @@ export class MessagingController {
       channel: { ...binding.channel, conversation: merged },
       updatedAt: this.now(),
     });
+    // The chip now has fresher breadcrumbs in the store; nudge the
+    // renderer to refetch so the tooltip / label reflect them.
+    this.notifyBindingChanged("refresh-from-inbound");
   }
 
   private async handleCommand(event: MessagingInboundCommandEvent): Promise<void> {
@@ -2726,6 +2765,9 @@ export class MessagingController {
       },
       updatedAt: this.now(),
     });
+    // Title changed — make the chip's label/tooltip pick up the new
+    // value without waiting for the next backend tick.
+    this.notifyBindingChanged("sync-conversation-name");
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("status-sync-name-confirmed"),
@@ -2832,6 +2874,7 @@ export class MessagingController {
       bindingId: binding.id,
       revokedAt: this.now(),
     });
+    this.notifyBindingChanged("detach");
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("detached"),
@@ -3126,6 +3169,23 @@ export class MessagingController {
     );
   }
 
+  /**
+   * Best-effort fan-out to the runtime's bindings-changed listener.
+   * Wrapped so a misbehaving listener (e.g. closed BrowserWindow) can
+   * never abort the mutation that produced the event.
+   */
+  private notifyBindingChanged(reason: string): void {
+    if (!this.options.onBindingChanged) return;
+    try {
+      this.options.onBindingChanged();
+    } catch (error) {
+      this.logger.debug?.("messaging onBindingChanged listener threw", {
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private async bindChannelToThread(
     event: MessagingInboundCallbackEvent,
     target: { backend: AppServerBackendKind; threadId: ThreadIdentifier },
@@ -3142,7 +3202,50 @@ export class MessagingController {
       updatedAt: now,
       displayName: event.actor.displayName ?? event.actor.username,
     };
-    return await this.options.store.upsertBinding(binding);
+    const upserted = await this.options.store.upsertBinding(binding);
+    // Retire any channel-scoped pending intents that pre-date this
+    // bind. Without this, the resume browser's pending intent (and any
+    // other pre-binding picker intent) survives the bind, and the next
+    // text inbound on this channel matches the stale picker — making
+    // the bot bounce "Choose an option" instead of routing to the new
+    // binding. Best-effort: log and continue if the cleanup fails so
+    // the bind itself still succeeds (fresh binding is the source of
+    // truth; stale intents will eventually be evicted by TTL GC).
+    //
+    // Not transactional with `upsertBinding` on purpose: the store
+    // API doesn't expose a transaction boundary for cross-row work,
+    // and adding one would push transaction plumbing into the
+    // messaging interface — over-architecture for a recovery window
+    // measured in minutes. If the process crashes between these two
+    // writes, the next bind on the same channel re-runs the cleanup,
+    // and the TTL GC catches anything missed within 15 minutes.
+    try {
+      const removed = await this.options.store.deletePendingIntentsForChannel({
+        channel: event.channel,
+      });
+      if (removed.length > 0) {
+        this.logger.debug?.("messaging retired channel pending intents on bind", {
+          bindingId: upserted.id,
+          channel: event.channel.channel,
+          removedCount: removed.length,
+        });
+      }
+    } catch (error) {
+      this.logger.debug?.(
+        "messaging channel pending-intent cleanup failed on bind",
+        {
+          bindingId: upserted.id,
+          channel: event.channel.channel,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+    // Renderer's binding chip is fed by the navigation snapshot. The
+    // snapshot only refetches on backend events — and binding creation
+    // doesn't emit one. Fan out a bindings-changed notification so the
+    // UI picks up the new chip immediately (issue #191).
+    this.notifyBindingChanged("bind");
+    return upserted;
   }
 
   private intentForPendingRequest(
@@ -3262,6 +3365,7 @@ export class MessagingController {
         bindingId: binding.id,
         revokedAt: this.now(),
       });
+      this.notifyBindingChanged("permanent-delivery-failure");
       this.logger.debug?.("messaging binding revoked after permanent delivery failure", {
         bindingId: binding.id,
         channel: binding.channel.channel,

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -171,6 +171,32 @@ export class MessagingStore {
     });
   }
 
+  /**
+   * Retire every channel-scoped pending intent on a channel that is
+   * NOT tied to a binding. Mirrors `SqliteMessagingStore.deletePendingIntentsForChannel`
+   * — kept on the file-backed store so controller tests can exercise
+   * the same bind cleanup path.
+   */
+  async deletePendingIntentsForChannel(params: {
+    channel: MessagingChannelRef;
+  }): Promise<string[]> {
+    const channelKey = buildMessagingConversationKey(params.channel);
+    return await this.withData((data) => {
+      const removed: string[] = [];
+      for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
+        if (intent.bindingId) continue;
+        if (
+          intent.channel &&
+          buildMessagingConversationKey(intent.channel) === channelKey
+        ) {
+          delete data.pendingIntents[intentId];
+          removed.push(intentId);
+        }
+      }
+      return removed;
+    });
+  }
+
   async cleanupExpiredPendingIntents(options?: { now?: number }): Promise<string[]> {
     const now = options?.now ?? Date.now();
     return await this.withData((data) => {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -29,6 +29,7 @@ import type { MessagingBackendBridge } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   constructor(
@@ -44,9 +45,11 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
     });
+    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
+      messagingBindingsByThreadKey,
       threads,
     });
     const directoryStatuses = await this.registry.readDirectoryStatuses(

--- a/apps/desktop/src/main/messaging/desktop-messaging-activity-log.ts
+++ b/apps/desktop/src/main/messaging/desktop-messaging-activity-log.ts
@@ -1,0 +1,20 @@
+import { MessagingActivityLog } from "./messaging-activity-log";
+import { getAppStateDb } from "../state/app-state";
+
+let logOverride: MessagingActivityLog | null = null;
+
+/**
+ * Singleton accessor for the desktop messaging activity log. Backed by
+ * the same sqlite state DB as bindings + overlay so the log survives
+ * restarts under the same FIFO / GC policy as the rest of the schema.
+ */
+export function getDesktopMessagingActivityLog(): MessagingActivityLog {
+  if (logOverride) return logOverride;
+  return new MessagingActivityLog(getAppStateDb());
+}
+
+export function setDesktopMessagingActivityLogForTests(
+  log: MessagingActivityLog | null,
+): void {
+  logOverride = log;
+}

--- a/apps/desktop/src/main/messaging/messaging-activity-log.ts
+++ b/apps/desktop/src/main/messaging/messaging-activity-log.ts
@@ -76,6 +76,7 @@ export class MessagingActivityLog {
       actorDisplayName: entry.actorDisplayName,
       summary: entry.summary,
       createdAt,
+      payload: Object.keys(payload).length > 0 ? payload : undefined,
     };
   }
 
@@ -129,12 +130,24 @@ type RawActivityRow = {
 };
 
 function rowToEntry(row: RawActivityRow): MessagingActivityEntry {
+  // The payload column stores `{ backend, ...callerExtras }` as JSON.
+  // We split `backend` out (it's a typed top-level field on the entry)
+  // and surface the remaining keys as the opaque `payload` bag the
+  // renderer's activity detail panel can render.
   let backend: AppServerBackendKind | undefined;
+  let extras: Record<string, unknown> | undefined;
   try {
-    const parsed = JSON.parse(row.payload) as { backend?: AppServerBackendKind };
+    const parsed = JSON.parse(row.payload) as Record<string, unknown> & {
+      backend?: AppServerBackendKind;
+    };
     backend = parsed.backend;
+    const { backend: _ignored, ...rest } = parsed;
+    if (Object.keys(rest).length > 0) {
+      extras = rest;
+    }
   } catch {
-    // Malformed JSON — treat as if there's no backend hint.
+    // Malformed JSON — treat as if there's no backend hint and no
+    // extras. The row still surfaces; only the opaque bag is lost.
   }
   return {
     id: row.id,
@@ -149,5 +162,6 @@ function rowToEntry(row: RawActivityRow): MessagingActivityEntry {
     actorDisplayName: row.actor_display_name ?? undefined,
     summary: row.summary,
     createdAt: row.created_at,
+    payload: extras,
   };
 }

--- a/apps/desktop/src/main/messaging/messaging-activity-log.ts
+++ b/apps/desktop/src/main/messaging/messaging-activity-log.ts
@@ -1,0 +1,153 @@
+import type {
+  AppServerBackendKind,
+  MessagingActivityEntry,
+  MessagingActivityKind,
+  MessagingChannelKind,
+  ThreadIdentifier,
+} from "@pwragent/shared";
+import type { StateDb } from "../state/state-db";
+
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 500;
+
+export type RecordMessagingActivityInput = {
+  platform: MessagingChannelKind;
+  kind: MessagingActivityKind;
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  bindingId?: string;
+  conversationId?: string;
+  conversationTitle?: string;
+  actorId?: string;
+  actorDisplayName?: string;
+  summary: string;
+  createdAt?: number;
+  /**
+   * Free-form bag of fields the row should remember without growing
+   * dedicated columns. Renderer may show these in the activity detail
+   * panel; consumers must treat the shape as opaque.
+   */
+  payload?: Record<string, unknown>;
+};
+
+/**
+ * Persisted messaging activity log. Rows live in the same sqlite DB as
+ * other desktop state; per-platform FIFO eviction happens in
+ * `StateDb.cleanupExpired`. Writes are best-effort and fail-soft —
+ * `record()` callers must not block message routing on a write error.
+ */
+export class MessagingActivityLog {
+  constructor(private readonly stateDb: StateDb) {}
+
+  record(entry: RecordMessagingActivityInput): MessagingActivityEntry {
+    const createdAt = entry.createdAt ?? Date.now();
+    const payload = entry.payload ?? {};
+    const result = this.stateDb.raw
+      .prepare(
+        `INSERT INTO messaging_activity_log(
+           platform, kind, thread_id, binding_id, conversation_id,
+           conversation_title, actor_id, actor_display_name,
+           summary, created_at, payload
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        entry.platform,
+        entry.kind,
+        entry.threadId ?? null,
+        entry.bindingId ?? null,
+        entry.conversationId ?? null,
+        entry.conversationTitle ?? null,
+        entry.actorId ?? null,
+        entry.actorDisplayName ?? null,
+        entry.summary,
+        createdAt,
+        JSON.stringify({ backend: entry.backend, ...payload }),
+      );
+    return {
+      id: Number(result.lastInsertRowid),
+      platform: entry.platform,
+      kind: entry.kind,
+      backend: entry.backend,
+      threadId: entry.threadId,
+      bindingId: entry.bindingId,
+      conversationId: entry.conversationId,
+      conversationTitle: entry.conversationTitle,
+      actorId: entry.actorId,
+      actorDisplayName: entry.actorDisplayName,
+      summary: entry.summary,
+      createdAt,
+    };
+  }
+
+  list(params: {
+    limit?: number;
+    sinceId?: number;
+  } = {}): MessagingActivityEntry[] {
+    const limit = Math.min(
+      Math.max(params.limit ?? DEFAULT_LIST_LIMIT, 1),
+      MAX_LIST_LIMIT,
+    );
+    const rows = params.sinceId !== undefined
+      ? (this.stateDb.raw
+          .prepare(
+            `SELECT id, platform, kind, thread_id, binding_id, conversation_id,
+                    conversation_title, actor_id, actor_display_name, summary,
+                    created_at, payload
+             FROM messaging_activity_log
+             WHERE id > ?
+             ORDER BY id DESC
+             LIMIT ?`,
+          )
+          .all(params.sinceId, limit) as RawActivityRow[])
+      : (this.stateDb.raw
+          .prepare(
+            `SELECT id, platform, kind, thread_id, binding_id, conversation_id,
+                    conversation_title, actor_id, actor_display_name, summary,
+                    created_at, payload
+             FROM messaging_activity_log
+             ORDER BY id DESC
+             LIMIT ?`,
+          )
+          .all(limit) as RawActivityRow[]);
+    return rows.map(rowToEntry);
+  }
+}
+
+type RawActivityRow = {
+  id: number;
+  platform: string;
+  kind: string;
+  thread_id: string | null;
+  binding_id: string | null;
+  conversation_id: string | null;
+  conversation_title: string | null;
+  actor_id: string | null;
+  actor_display_name: string | null;
+  summary: string;
+  created_at: number;
+  payload: string;
+};
+
+function rowToEntry(row: RawActivityRow): MessagingActivityEntry {
+  let backend: AppServerBackendKind | undefined;
+  try {
+    const parsed = JSON.parse(row.payload) as { backend?: AppServerBackendKind };
+    backend = parsed.backend;
+  } catch {
+    // Malformed JSON — treat as if there's no backend hint.
+  }
+  return {
+    id: row.id,
+    platform: row.platform as MessagingChannelKind,
+    kind: row.kind as MessagingActivityKind,
+    backend,
+    threadId: row.thread_id ?? undefined,
+    bindingId: row.binding_id ?? undefined,
+    conversationId: row.conversation_id ?? undefined,
+    conversationTitle: row.conversation_title ?? undefined,
+    actorId: row.actor_id ?? undefined,
+    actorDisplayName: row.actor_display_name ?? undefined,
+    summary: row.summary,
+    createdAt: row.created_at,
+  };
+}

--- a/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
+++ b/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
@@ -1,0 +1,84 @@
+import type {
+  AppServerThreadSummary,
+  MessagingThreadBindingSummary,
+} from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { getDesktopMessagingStore } from "./desktop-messaging-store";
+import { getMainLogger } from "../log";
+
+const log = getMainLogger("pwragent:messaging-bindings");
+
+/**
+ * Build the `messagingBindingsByThreadKey` map for the navigation
+ * snapshot. Walks the threads in the current snapshot and asks the
+ * messaging store for active bindings per thread. Returns `undefined`
+ * (rather than an empty object) when nothing is bound — `buildNavigationSnapshot`
+ * treats `undefined` and `{}` the same, but `undefined` keeps the hash
+ * inputs minimal for users with no messaging configured.
+ */
+export async function buildMessagingBindingsByThreadKey(
+  threads: AppServerThreadSummary[],
+): Promise<Record<string, MessagingThreadBindingSummary[]> | undefined> {
+  if (threads.length === 0) return undefined;
+  let store;
+  try {
+    store = getDesktopMessagingStore();
+  } catch (error) {
+    // The messaging store is initialized lazily after the app state is
+    // brought up. If we somehow ask for bindings before then, return
+    // undefined rather than crashing the navigation snapshot path.
+    log.warn("messaging store unavailable for navigation snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  const result: Record<string, MessagingThreadBindingSummary[]> = {};
+  let totalBindings = 0;
+  for (const thread of threads) {
+    let bindings;
+    try {
+      bindings = await store.findActiveBindingsForThread({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+    } catch (error) {
+      log.warn("failed to resolve bindings for thread", {
+        backend: thread.source,
+        threadId: thread.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    if (bindings.length === 0) continue;
+    totalBindings += bindings.length;
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    result[threadKey] = bindings.map((binding) => {
+      const conversation = binding.channel.conversation;
+      return {
+        bindingId: binding.id,
+        platform: binding.channel.channel,
+        conversationKind: conversation.kind,
+        // Title of the conversation NODE itself — topic name, channel
+        // name, DM peer name, supergroup name. Renderer falls back to
+        // a generic placeholder ("Topic" / "Thread" / "channel") when
+        // the adapter hasn't populated this. We intentionally do not
+        // fall through to the desktop thread title or actor display
+        // name here — those leak unrelated context into the chip.
+        conversationTitle: conversation.title,
+        parentTitle: conversation.parentTitle,
+        ancestorTitle: conversation.ancestorTitle,
+        activeAt: binding.updatedAt,
+      };
+    });
+  }
+  // One-line diagnostic so a user reporting "I had more bindings than
+  // are showing" can compare the desktop's view of bindings to the raw
+  // sqlite row count without opening the DB.
+  log.info("messaging bindings snapshot", {
+    threadCount: threads.length,
+    boundThreadCount: Object.keys(result).length,
+    totalActiveBindings: totalBindings,
+  });
+  return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -76,6 +76,13 @@ export class DesktopMessagingRuntime {
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
+  /**
+   * Listeners notified whenever any controller mutates a binding
+   * (create / refresh metadata / sync title / detach / revoke). The
+   * payload is intentionally empty — listeners refetch the navigation
+   * snapshot rather than diffing per-binding changes themselves.
+   */
+  private readonly bindingsChangedListeners = new Set<() => void>();
 
   constructor(
     private readonly options: {
@@ -114,6 +121,7 @@ export class DesktopMessagingRuntime {
         store,
         toolUpdateDefaultMode: async () =>
           (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
+        onBindingChanged: () => this.broadcastBindingsChanged(),
       });
 
       try {
@@ -255,6 +263,42 @@ export class DesktopMessagingRuntime {
    */
   getPlatformStatuses(): MessagingPlatformStatus[] {
     return [...this.platformStatuses.values()];
+  }
+
+  /**
+   * Subscribe to bindings-changed events. Returns an unsubscribe.
+   * Fires after any controller has mutated a binding (create, refresh
+   * metadata, sync title, detach, revoke). Renderer-side IPC bridge
+   * uses this to push a marker event so `useThreadNavigation`
+   * refetches the navigation snapshot — that's where binding chips
+   * live (issue #191).
+   */
+  onBindingsChanged(listener: () => void): () => void {
+    this.bindingsChangedListeners.add(listener);
+    return () => {
+      this.bindingsChangedListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Public emitter so non-controller code (the unbind IPC handler in
+   * `messaging-status.ts`, future bind paths) can fan out the same
+   * event without reaching into the listener set directly.
+   */
+  notifyBindingsChanged(): void {
+    this.broadcastBindingsChanged();
+  }
+
+  private broadcastBindingsChanged(): void {
+    for (const listener of this.bindingsChangedListeners) {
+      try {
+        listener();
+      } catch (error) {
+        messagingLog.error("messaging bindings-changed listener threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   private setPlatformHealth(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -6,7 +6,13 @@ import type {
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
 } from "./core/messaging-adapter";
-import type { AgentEvent, AppServerPendingRequestNotification } from "@pwragent/shared";
+import type {
+  AgentEvent,
+  AppServerPendingRequestNotification,
+  MessagingPlatformHealth,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
 import type {
   MessagingCapabilityProfile,
   MessagingChannelKind,
@@ -23,6 +29,7 @@ import {
   type DesktopMessagingConfig,
 } from "./messaging-config";
 import { DesktopMessagingBackendBridge } from "./desktop-backend-bridge";
+import { getDesktopMessagingActivityLog } from "./desktop-messaging-activity-log";
 import { loadConfiguredMessagingAdapters } from "./provider-loader";
 
 export type DesktopMessagingAdapter = {
@@ -56,6 +63,19 @@ export class DesktopMessagingRuntime {
   private controllers: MessagingController[] = [];
   private unsubscribeBackendEvents?: () => void;
   private started = false;
+  /**
+   * Per-platform health snapshot. Keyed by `MessagingChannelKind`. Updated
+   * by `setPlatformHealth` and read by `getPlatformStatuses` for the
+   * renderer's initial paint. Survives `stop()` so a paused state shows
+   * `suspended` in the UI rather than disappearing.
+   */
+  private readonly platformStatuses = new Map<
+    MessagingChannelKind,
+    MessagingPlatformStatus
+  >();
+  private readonly platformStatusListeners = new Set<
+    (event: MessagingPlatformStatusEvent) => void
+  >();
 
   constructor(
     private readonly options: {
@@ -98,8 +118,16 @@ export class DesktopMessagingRuntime {
 
       try {
         await adapter.start?.(async (event) => {
+          // Activity ping fires on every inbound, *before* authorization
+          // checks — the platform is active even when the message is
+          // rejected, and the user wants the dot to reflect that.
+          this.emitPlatformActivity(adapter.channel);
+          const authorized = authorizedActorIdSet.has(
+            event.actor.platformUserId,
+          );
+          this.recordActivityFromInbound(adapter.channel, event, authorized);
           try {
-            if (!authorizedActorIdSet.has(event.actor.platformUserId)) {
+            if (!authorized) {
               messagingLog.warn("messaging event rejected by authorization", {
                 actorDisplayName: event.actor.displayName,
                 actorId: event.actor.platformUserId,
@@ -133,6 +161,9 @@ export class DesktopMessagingRuntime {
           error: error instanceof Error ? error.message : String(error),
         });
         failedChannels.push(adapter.channel);
+        this.setPlatformHealth(adapter.channel, "errored", {
+          reason: error instanceof Error ? error.message : String(error),
+        });
         continue;
       }
 
@@ -141,6 +172,7 @@ export class DesktopMessagingRuntime {
       });
       this.adapters.push(adapter);
       this.controllers.push(controller);
+      this.setPlatformHealth(adapter.channel, "enabled");
     }
 
     this.unsubscribeBackendEvents = this.options.backendBridge.onEvent?.(async (event) => {
@@ -188,9 +220,131 @@ export class DesktopMessagingRuntime {
     this.unsubscribeBackendEvents?.();
     this.unsubscribeBackendEvents = undefined;
     this.controllers.forEach((controller) => controller.dispose());
+    const stoppedChannels = this.adapters.map((adapter) => adapter.channel);
     await Promise.all(this.adapters.map(async (adapter) => adapter.stop?.()));
     this.adapters = [];
     this.controllers = [];
+    // Mark each previously-running platform as suspended (not removed),
+    // so the renderer keeps the icon visible with a gray dot — the user
+    // knows it's configured but currently off.
+    for (const channel of stoppedChannels) {
+      this.setPlatformHealth(channel, "suspended");
+    }
+  }
+
+  /**
+   * Subscribe to platform status transitions. Returns an unsubscribe.
+   * Listeners receive every `health-changed` and `activity` event;
+   * synchronous, off the runtime's event loop. The renderer uses this
+   * to keep its `MessagingPlatformStatus[]` cache in sync without
+   * polling.
+   */
+  onPlatformStatus(
+    listener: (event: MessagingPlatformStatusEvent) => void,
+  ): () => void {
+    this.platformStatusListeners.add(listener);
+    return () => {
+      this.platformStatusListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Snapshot of the current per-platform health. Used by the IPC
+   * handler that backs the renderer's initial paint — the renderer
+   * subscribes to the event stream right after to stay current.
+   */
+  getPlatformStatuses(): MessagingPlatformStatus[] {
+    return [...this.platformStatuses.values()];
+  }
+
+  private setPlatformHealth(
+    platform: MessagingChannelKind,
+    health: MessagingPlatformHealth,
+    options: { reason?: string } = {},
+  ): void {
+    const at = Date.now();
+    const previous = this.platformStatuses.get(platform);
+    const next: MessagingPlatformStatus = {
+      ...previous,
+      platform,
+      health,
+      changedAt: at,
+      reason: options.reason,
+      // Preserve the existing activity timestamp through health
+      // transitions; activity is independent of health and shouldn't
+      // be reset just because the user toggled messaging off.
+      lastActivityAt: previous?.lastActivityAt,
+    };
+    this.platformStatuses.set(platform, next);
+    this.broadcastPlatformStatus({
+      kind: "health-changed",
+      platform,
+      health,
+      reason: options.reason,
+      at,
+    });
+  }
+
+  private emitPlatformActivity(platform: MessagingChannelKind): void {
+    const at = Date.now();
+    const previous = this.platformStatuses.get(platform);
+    if (previous) {
+      this.platformStatuses.set(platform, { ...previous, lastActivityAt: at });
+    }
+    this.broadcastPlatformStatus({ kind: "activity", platform, at });
+  }
+
+  private recordActivityFromInbound(
+    platform: MessagingChannelKind,
+    event: MessagingInboundEvent,
+    authorized: boolean,
+  ): void {
+    // Best-effort write — never throw out of the adapter listener path.
+    // The activity log is observability, not the source of truth for
+    // routing decisions, so a failed write means we lose a row, not a
+    // misrouted message.
+    try {
+      const conversation = event.channel.conversation;
+      const summary = authorized
+        ? `Inbound from ${event.actor.displayName ?? event.actor.platformUserId}`
+        : `Rejected inbound from ${event.actor.displayName ?? event.actor.platformUserId}`;
+      getDesktopMessagingActivityLog().record({
+        platform,
+        kind: authorized ? "inbound-routed" : "inbound-rejected",
+        conversationId: conversation.id,
+        conversationTitle: conversation.title,
+        actorId: event.actor.platformUserId,
+        actorDisplayName: event.actor.displayName,
+        summary,
+        payload: {
+          eventId: event.id,
+          eventKind: event.kind,
+          conversationKind: conversation.kind,
+          actorUsername: event.actor.username,
+          actorIsBot: event.actor.isBot,
+        },
+      });
+    } catch (error) {
+      messagingLog.warn("messaging activity log write failed", {
+        platform,
+        eventId: event.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private broadcastPlatformStatus(event: MessagingPlatformStatusEvent): void {
+    for (const listener of this.platformStatusListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        messagingLog.error("messaging platform status listener threw", {
+          error: error instanceof Error ? error.message : String(error),
+          platform: event.platform,
+          kind: event.kind,
+        });
+      }
+    }
   }
 
   private async loadConfig(

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -216,6 +216,55 @@ export class SqliteMessagingStore {
       .run(id);
   }
 
+  /**
+   * Retire every channel-scoped pending intent on a channel that is
+   * NOT tied to a specific binding. Used by `bindChannelToThread` to
+   * clean up the resume browser's pending intent (and any other
+   * pre-binding picker intent) the moment a successful bind lands —
+   * otherwise the next inbound text on that channel matches the stale
+   * picker intent and the bot bounces "Choose an option" instead of
+   * routing to the new binding.
+   *
+   * Binding-scoped pending intents (binding_id != '') are kept — they
+   * belong to the binding's status surface, approval flows, etc.
+   */
+  async deletePendingIntentsForChannel(params: {
+    channel: MessagingChannelRef;
+  }): Promise<string[]> {
+    const channelKey = buildMessagingConversationKey(params.channel);
+    // Only consider channel-only intents (binding_id stored as ''). The
+    // matching channel ref is JSON-encoded inside the payload, so we
+    // parse and compare in JS rather than wrestle with sqlite JSON
+    // extraction. The pending_intents table is small (capped TTL,
+    // pruned by GC) so this is cheap.
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT intent_id, payload FROM pending_intents WHERE binding_id = ''",
+      )
+      .all() as { intent_id: string; payload: string }[];
+    const removed: string[] = [];
+    for (const row of rows) {
+      try {
+        const record = JSON.parse(row.payload) as MessagingPendingIntentRecord;
+        if (
+          record.channel &&
+          buildMessagingConversationKey(record.channel) === channelKey
+        ) {
+          removed.push(row.intent_id);
+        }
+      } catch {
+        // Malformed payload — skip; the row will be cleaned up by GC
+        // on its expiry.
+      }
+    }
+    if (removed.length === 0) return [];
+    const placeholders = removed.map(() => "?").join(",");
+    this.stateDb.raw
+      .prepare(`DELETE FROM pending_intents WHERE intent_id IN (${placeholders})`)
+      .run(...removed);
+    return removed;
+  }
+
   async cleanupExpiredPendingIntents(options?: {
     now?: number;
   }): Promise<string[]> {
@@ -591,6 +640,7 @@ export type MessagingStoreLike = Pick<
   | "findActivePendingIntentForChannel"
   | "findActivePendingIntentsForRequest"
   | "deletePendingIntent"
+  | "deletePendingIntentsForChannel"
   | "cleanupExpiredPendingIntents"
   | "upsertBrowseSession"
   | "getBrowseSession"

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -82,10 +82,18 @@ export class SqliteMessagingStore {
       .all(params.threadId) as { payload: string }[];
     return rows
       .map((row) => JSON.parse(row.payload) as MessagingBindingRecord)
-      .filter(
-        (binding) =>
-          !binding.revokedAt && binding.backend === params.backend,
-      );
+      .filter((binding) => {
+        if (binding.revokedAt) return false;
+        // Backend-strict matching used to drop bindings whose stored
+        // backend disagreed with the thread's current source — a real
+        // problem when an older binding lacks a backend at all, or
+        // when a thread migrated between backends. Accept the row when
+        // the backends match OR when the binding has no backend
+        // recorded; trust thread_id otherwise (it's already PK-unique
+        // enough across the user's history).
+        if (!binding.backend) return true;
+        return binding.backend === params.backend;
+      });
   }
 
   async revokeBinding(params: {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -4,6 +4,7 @@ import type {
   DirectoryLaunchpadOverlayState,
   LinkedDirectorySummary,
   MarkThreadSeenResponse,
+  MessagingThreadBindingSummary,
   NavigationDirectoryGitStatus,
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
@@ -26,6 +27,15 @@ export class SqliteOverlayStore {
     backend: AppServerBackendScope;
     fetchedAt: number;
     gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
+    /**
+     * Active messaging bindings per thread, keyed by thread identity key.
+     * Sourced from the desktop messaging sqlite store. Optional so tests
+     * (and any future callers without messaging) can keep working.
+     */
+    messagingBindingsByThreadKey?: Record<
+      string,
+      MessagingThreadBindingSummary[] | undefined
+    >;
     threads: AppServerThreadSummary[];
   }): Promise<NavigationSnapshot> {
     const backendState = this.getBackend(params.backend);
@@ -71,6 +81,7 @@ export class SqliteOverlayStore {
       gitStatusByDirectoryKey: params.gitStatusByDirectoryKey,
       launchpadDefaults,
       launchpadsByKey,
+      messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
       overlayByThreadKey,
       previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
       threads: params.threads,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -100,8 +100,38 @@ CREATE TABLE secrets (
 );
 `;
 
+const SCHEMA_V2 = `
+CREATE TABLE messaging_activity_log (
+  id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+  platform                 TEXT NOT NULL,
+  kind                     TEXT NOT NULL,
+  thread_id                TEXT,
+  binding_id               TEXT,
+  conversation_id          TEXT,
+  conversation_title       TEXT,
+  actor_id                 TEXT,
+  actor_display_name       TEXT,
+  summary                  TEXT NOT NULL,
+  created_at               INTEGER NOT NULL,
+  payload                  TEXT NOT NULL
+);
+CREATE INDEX idx_messaging_activity_log_created
+  ON messaging_activity_log(created_at DESC);
+CREATE INDEX idx_messaging_activity_log_platform_created
+  ON messaging_activity_log(platform, created_at DESC);
+CREATE INDEX idx_messaging_activity_log_thread
+  ON messaging_activity_log(thread_id);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+/**
+ * Per-platform cap for the messaging activity log. Older rows are
+ * evicted FIFO so the table stays small even on busy platforms. Tuned
+ * to ~hours of normal traffic; raise via a future setting if anyone
+ * needs deeper history.
+ */
+const MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP = 500;
 
 export class StateDb {
   private db: BetterSqlite3.Database;
@@ -131,6 +161,10 @@ export class StateDb {
         );
       }
       db.pragma("user_version = 1");
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 2) {
+      db.exec(SCHEMA_V2);
+      db.pragma("user_version = 2");
     }
 
     return new StateDb(db);
@@ -177,6 +211,28 @@ export class StateDb {
           "DELETE FROM bindings WHERE revoked_at IS NOT NULL AND revoked_at < ?",
         )
         .run(now - REVOKED_BINDINGS_RETENTION_MS);
+      // Per-platform FIFO eviction for the activity log: keep the
+      // newest N per platform; delete the rest. Iterate the (cheap)
+      // distinct-platform set rather than wrestling with sqlite
+      // correlated-subquery semantics.
+      const platforms = this.db
+        .prepare(
+          "SELECT DISTINCT platform FROM messaging_activity_log",
+        )
+        .all() as { platform: string }[];
+      const evict = this.db.prepare(
+        `DELETE FROM messaging_activity_log
+         WHERE platform = ?
+           AND id NOT IN (
+             SELECT id FROM messaging_activity_log
+             WHERE platform = ?
+             ORDER BY id DESC
+             LIMIT ?
+           )`,
+      );
+      for (const { platform } of platforms) {
+        evict.run(platform, platform, MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP);
+      }
     });
     cleanup();
     this.db.pragma("incremental_vacuum");

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -151,20 +151,29 @@ export class StateDb {
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
 
+    // Migrations are wrapped in transactions so a partial failure
+    // (mid-DDL crash, transient disk error) rolls back cleanly and the
+    // next launch retries from the previous user_version. Without the
+    // transaction the table could exist with the old user_version, and
+    // the next launch would throw "table already exists" on retry.
     const userVersion = db.pragma("user_version", { simple: true }) as number;
     if (userVersion === 0) {
       db.pragma("auto_vacuum = INCREMENTAL");
-      db.exec(SCHEMA_V1);
-      if (options?.profileName) {
-        db.prepare("UPDATE meta SET value = ? WHERE key = 'profile_name'").run(
-          options.profileName,
-        );
-      }
-      db.pragma("user_version = 1");
+      db.transaction(() => {
+        db.exec(SCHEMA_V1);
+        if (options?.profileName) {
+          db.prepare("UPDATE meta SET value = ? WHERE key = 'profile_name'").run(
+            options.profileName,
+          );
+        }
+        db.pragma("user_version = 1");
+      })();
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 2) {
-      db.exec(SCHEMA_V2);
-      db.pragma("user_version = 2");
+      db.transaction(() => {
+        db.exec(SCHEMA_V2);
+        db.pragma("user_version = 2");
+      })();
     }
 
     return new StateDb(db);
@@ -212,27 +221,28 @@ export class StateDb {
         )
         .run(now - REVOKED_BINDINGS_RETENTION_MS);
       // Per-platform FIFO eviction for the activity log: keep the
-      // newest N per platform; delete the rest. Iterate the (cheap)
-      // distinct-platform set rather than wrestling with sqlite
-      // correlated-subquery semantics.
-      const platforms = this.db
+      // newest N per platform; delete the rest. A single windowed
+      // DELETE handles every platform at once — the inner subquery
+      // computes a per-platform rank by id-desc, and we delete rows
+      // beyond the cap. Cleaner than the previous distinct-platforms
+      // loop and runs in one statement.
+      this.db
         .prepare(
-          "SELECT DISTINCT platform FROM messaging_activity_log",
-        )
-        .all() as { platform: string }[];
-      const evict = this.db.prepare(
-        `DELETE FROM messaging_activity_log
-         WHERE platform = ?
-           AND id NOT IN (
-             SELECT id FROM messaging_activity_log
-             WHERE platform = ?
-             ORDER BY id DESC
-             LIMIT ?
+          `DELETE FROM messaging_activity_log
+           WHERE id IN (
+             SELECT id FROM (
+               SELECT
+                 id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY platform
+                   ORDER BY id DESC
+                 ) AS rank
+               FROM messaging_activity_log
+             )
+             WHERE rank > ?
            )`,
-      );
-      for (const { platform } of platforms) {
-        evict.run(platform, platform, MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP);
-      }
+        )
+        .run(MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP);
     });
     cleanup();
     this.db.pragma("incremental_vacuum");

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -117,6 +117,7 @@ import {
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   IMAGE_UPLOAD_FALLBACK_CHANNEL,
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
+  MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
@@ -374,6 +375,18 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
     return () => {
       ipcRenderer.off(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
+    };
+  },
+  onMessagingBindingsChanged: (
+    callback: (event: { at: number }) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: { at: number },
+    ) => callback(payload);
+    ipcRenderer.on(MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL, listener);
     };
   },
   platform: process.platform,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -38,6 +38,12 @@ import type {
   SetThreadReactionResponse,
   GetGhStatusRequest,
   GhStatus,
+  ListMessagingActivityRequest,
+  ListMessagingActivityResponse,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -111,6 +117,10 @@ import {
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   IMAGE_UPLOAD_FALLBACK_CHANNEL,
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
+  MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+  MESSAGING_LIST_ACTIVITY_CHANNEL,
+  MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -342,6 +352,28 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(AGENT_EVENT_CHANNEL, listener);
     return () => {
       ipcRenderer.off(AGENT_EVENT_CHANNEL, listener);
+    };
+  },
+  getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
+    await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+  unbindMessagingThread: async (
+    request: UnbindMessagingThreadRequest,
+  ): Promise<UnbindMessagingThreadResponse> =>
+    await ipcRenderer.invoke(MESSAGING_UNBIND_THREAD_CHANNEL, request),
+  listMessagingActivity: async (
+    request?: ListMessagingActivityRequest,
+  ): Promise<ListMessagingActivityResponse> =>
+    await ipcRenderer.invoke(MESSAGING_LIST_ACTIVITY_CHANNEL, request),
+  onMessagingPlatformStatusEvent: (
+    callback: (event: MessagingPlatformStatusEvent) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: MessagingPlatformStatusEvent,
+    ) => callback(payload);
+    ipcRenderer.on(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL, listener);
     };
   },
   platform: process.platform,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState, type CSSProperties, type PointerEvent } from "react";
 import { Sidebar } from "./features/navigation/Sidebar";
-import { SettingsScreen } from "./features/settings/SettingsScreen";
+import {
+  SettingsScreen,
+  type SettingsSection,
+} from "./features/settings/SettingsScreen";
 import {
   useDesktopSettings,
   type DesktopSettingsState,
@@ -48,6 +51,12 @@ function DesktopAppShell(props: {
 }) {
   const [sidebarWidth, setSidebarWidth] = useState(408);
   const [mainView, setMainView] = useState<"thread" | "settings">("thread");
+  // Initial section for SettingsScreen — non-undefined when navigation
+  // came from a deep-link (e.g. clicking a platform chip jumps directly
+  // to "messaging-activity"). Resets when the user switches mainView.
+  const [settingsInitialSection, setSettingsInitialSection] = useState<
+    SettingsSection | undefined
+  >(undefined);
   const desktopApi = props.desktopApi;
   const settings = props.settings;
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
@@ -120,7 +129,10 @@ function DesktopAppShell(props: {
           setMainView("thread");
           await navigation.openDirectoryLaunchpad(directory, preferredBackend);
         }}
-        onOpenSettings={() => setMainView("settings")}
+        onOpenSettings={() => {
+          setSettingsInitialSection(undefined);
+          setMainView("settings");
+        }}
         onSelectThread={(thread) => {
           setMainView("thread");
           navigation.selectThread(thread);
@@ -129,6 +141,11 @@ function DesktopAppShell(props: {
         onRenameThread={navigation.renameThread}
         onSetThreadReaction={navigation.setThreadReaction}
         onPrefetchPullRequests={pullRequests.prefetch}
+        onUnbindMessagingBinding={async (_thread, binding) => {
+          if (!desktopApi?.unbindMessagingThread) return;
+          await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });
+          await navigation.refresh?.();
+        }}
         onResizeStart={startSidebarResize}
         onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
       />
@@ -181,6 +198,10 @@ function DesktopAppShell(props: {
           onActiveTurnIdChange={session.setActiveTurnId}
           onArchiveWorktree={navigation.archiveWorktree}
           onEnsureSkillsLoaded={skills.ensureLoaded}
+          onOpenMessagingActivity={() => {
+            setSettingsInitialSection("messaging-activity");
+            setMainView("settings");
+          }}
           onHandoffThreadWorkspace={
             navigation.selectedThread
               ? async (request) =>
@@ -228,6 +249,7 @@ function DesktopAppShell(props: {
           <SettingsScreen
             desktopApi={desktopApi}
             settings={settings}
+            initialSection={settingsInitialSection}
             onClose={() => setMainView("thread")}
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  MessagingActivityEntry,
+  MessagingActivityKind,
+} from "@pwragent/shared";
+import { DiscordIcon, TelegramIcon } from "../../icons";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const REFRESH_INTERVAL_MS = 5_000;
+const KIND_LABEL: Record<MessagingActivityKind, string> = {
+  "inbound-routed": "Routed",
+  "inbound-rejected": "Rejected",
+  "inbound-ignored": "Ignored",
+  outbound: "Sent",
+};
+const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "muted"> = {
+  "inbound-routed": "ok",
+  "inbound-rejected": "error",
+  "inbound-ignored": "warning",
+  outbound: "muted",
+};
+
+/**
+ * Read-only view of the recent messaging activity log: routed inbound,
+ * rejected inbound (unauthorized senders), ignored inbound (post-revoke),
+ * and outbound deliveries. Capped per-platform via FIFO eviction in the
+ * sqlite GC pass — anything older than the cap is gone.
+ *
+ * Polls every 5s while open. The renderer doesn't subscribe to a push
+ * event because the activity log writes are best-effort and a dropped
+ * tick is fine (we'll catch up on the next poll).
+ */
+export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
+  const desktopApi = props.desktopApi;
+  const [entries, setEntries] = useState<MessagingActivityEntry[]>([]);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!desktopApi?.listMessagingActivity) return;
+    setLoading(true);
+    setError(undefined);
+    try {
+      const result = await desktopApi.listMessagingActivity({ limit: 200 });
+      setEntries(result.entries);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  }, [desktopApi]);
+
+  useEffect(() => {
+    void refresh();
+    const intervalId = window.setInterval(() => {
+      void refresh();
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [refresh]);
+
+  const groups = groupByKind(entries);
+
+  return (
+    <section className="settings-stack" aria-label="Messaging activity">
+      <section className="settings-panel" aria-labelledby="messaging-activity-title">
+        <div className="settings-panel__header">
+          <div>
+            <p className="eyebrow">Messaging</p>
+            <h2 id="messaging-activity-title">Activity</h2>
+          </div>
+          <button
+            className="button button--secondary"
+            disabled={loading || !desktopApi?.listMessagingActivity}
+            type="button"
+            onClick={() => void refresh()}
+          >
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+        <p className="settings-panel__hint">
+          Last {entries.length} events across all configured messaging platforms.
+          Capped per-platform with FIFO eviction; older history is not retained.
+        </p>
+        {error ? (
+          <p className="settings-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </section>
+
+      <ActivitySection
+        title="Currently bound"
+        emptyLabel="No bound conversations have sent messages recently."
+        kinds={["inbound-routed", "outbound"]}
+        groups={groups}
+      />
+      <ActivitySection
+        title="Received but ignored"
+        emptyLabel="No rejected or ignored inbound messages — your authorization list is doing its job."
+        kinds={["inbound-rejected", "inbound-ignored"]}
+        groups={groups}
+      />
+    </section>
+  );
+}
+
+function ActivitySection(props: {
+  title: string;
+  emptyLabel: string;
+  kinds: MessagingActivityKind[];
+  groups: Record<MessagingActivityKind, MessagingActivityEntry[]>;
+}) {
+  const entries = props.kinds.flatMap((kind) => props.groups[kind] ?? []);
+  entries.sort((left, right) => right.createdAt - left.createdAt);
+  return (
+    <section className="settings-panel" aria-label={props.title}>
+      <div className="settings-panel__header">
+        <div>
+          <p className="eyebrow">Messaging</p>
+          <h2>{props.title}</h2>
+        </div>
+      </div>
+      {entries.length === 0 ? (
+        <p className="settings-empty">{props.emptyLabel}</p>
+      ) : (
+        <ul className="messaging-activity-list">
+          {entries.map((entry) => (
+            <ActivityRow key={entry.id} entry={entry} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ActivityRow(props: { entry: MessagingActivityEntry }) {
+  const { entry } = props;
+  const Icon = entry.platform === "telegram"
+    ? TelegramIcon
+    : entry.platform === "discord"
+      ? DiscordIcon
+      : undefined;
+  const tone = KIND_TONE[entry.kind];
+  return (
+    <li className="messaging-activity-row">
+      <span className={`messaging-activity-row__icon messaging-activity-row__icon--${tone}`}>
+        {Icon ? <Icon size={14} /> : <span>{entry.platform.slice(0, 2)}</span>}
+      </span>
+      <div className="messaging-activity-row__body">
+        <div className="messaging-activity-row__line">
+          <span className={`settings-pill settings-pill--${tone === "ok" ? "ok" : tone === "warning" ? "warn" : tone === "error" ? "bad" : "neutral"}`}>
+            {KIND_LABEL[entry.kind]}
+          </span>
+          <span className="messaging-activity-row__summary">{entry.summary}</span>
+        </div>
+        <div className="messaging-activity-row__meta">
+          {entry.conversationTitle ?? entry.conversationId ?? "—"}
+          {" · "}
+          {formatRelative(entry.createdAt)}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function groupByKind(
+  entries: MessagingActivityEntry[],
+): Record<MessagingActivityKind, MessagingActivityEntry[]> {
+  const groups: Record<MessagingActivityKind, MessagingActivityEntry[]> = {
+    "inbound-routed": [],
+    "inbound-rejected": [],
+    "inbound-ignored": [],
+    outbound: [],
+  };
+  for (const entry of entries) {
+    groups[entry.kind]?.push(entry);
+  }
+  return groups;
+}
+
+function formatRelative(timestamp: number): string {
+  const deltaSeconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (deltaSeconds < 60) return `${deltaSeconds}s ago`;
+  const deltaMinutes = Math.round(deltaSeconds / 60);
+  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (deltaHours < 24) return `${deltaHours}h ago`;
+  const deltaDays = Math.round(deltaHours / 24);
+  return `${deltaDays}d ago`;
+}

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -1,0 +1,152 @@
+import type { ReactElement } from "react";
+import type {
+  MessagingChannelKind,
+  MessagingPlatformHealth,
+  MessagingPlatformStatus,
+} from "@pwragent/shared";
+import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
+import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const ICONS: Partial<
+  Record<MessagingChannelKind, (props: IconProps) => ReactElement>
+> = {
+  telegram: TelegramIcon,
+  discord: DiscordIcon,
+};
+
+const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
+  enabled: "Enabled",
+  suspended: "Suspended",
+  errored: "Errored",
+  unknown: "Unknown",
+};
+
+/**
+ * Right-of-header status indicators for each *configured* messaging
+ * platform. Health controls the dot color (green/gray/red); a recent
+ * activity timestamp adds the slow-blink animation. Platforms without a
+ * dedicated icon (custom adapters, future channels) get a small text
+ * pill instead so we never silently drop a configured platform.
+ *
+ * Renders nothing when no platforms are configured — keeps the header
+ * tight for users who don't use messaging.
+ */
+export function MessagingStatusBar(props: {
+  desktopApi?: DesktopApi;
+  /**
+   * Called when the user clicks a platform chip. Parent navigates to
+   * the Messaging Activity screen so the user can audit traffic for
+   * that platform. Receives the chosen platform so the parent could
+   * scope the screen to it in the future.
+   */
+  onOpenActivity?: (platform: MessagingChannelKind) => void;
+}) {
+  const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
+    props.desktopApi,
+  );
+
+  if (statuses.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="messaging-status-bar" role="group" aria-label="Messaging platform status">
+      {statuses.map((status) => (
+        <PlatformChip
+          key={status.platform}
+          status={status}
+          active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
+          onClick={
+            props.onOpenActivity
+              ? () => props.onOpenActivity!(status.platform)
+              : undefined
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+function PlatformChip(props: {
+  status: MessagingPlatformStatus;
+  active: boolean;
+  onClick?: () => void;
+}) {
+  const { status, active, onClick } = props;
+  const Icon = ICONS[status.platform];
+  const baseLabel = `${formatPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}${
+    status.reason ? ` (${status.reason})` : ""
+  }`;
+  const label = onClick
+    ? `${baseLabel} — click to view messaging activity`
+    : baseLabel;
+  const className = `messaging-status-chip messaging-status-chip--${status.health}${
+    active ? " is-active" : ""
+  }`;
+  const content = (
+    <>
+      {Icon ? (
+        <Icon size={14} />
+      ) : (
+        <span className="messaging-status-chip__fallback">
+          {status.platform.slice(0, 2)}
+        </span>
+      )}
+      <span
+        className={`status-dot status-dot--${dotTone(status.health)}${
+          active ? " status-dot--blink" : ""
+        }`}
+        aria-hidden="true"
+      />
+    </>
+  );
+  if (!onClick) {
+    return (
+      <span className={className} title={label} aria-label={label}>
+        {content}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={`${className} messaging-status-chip--clickable`}
+      title={label}
+      aria-label={label}
+      onClick={onClick}
+    >
+      {content}
+    </button>
+  );
+}
+
+function hasRecentActivity(
+  status: MessagingPlatformStatus,
+  observedAt: number | undefined,
+): boolean {
+  // Suspended/errored platforms shouldn't blink even if a stale activity
+  // timestamp is hanging around — the dot is a status indicator first.
+  if (status.health !== "enabled") return false;
+  return Boolean(observedAt);
+}
+
+function dotTone(
+  health: MessagingPlatformHealth,
+): "ok" | "warning" | "error" | "suspended" {
+  switch (health) {
+    case "enabled":
+      return "ok";
+    case "suspended":
+      return "suspended";
+    case "errored":
+      return "error";
+    case "unknown":
+      return "warning";
+  }
+}
+
+function formatPlatformName(platform: MessagingChannelKind): string {
+  if (platform.length === 0) return platform;
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import type {
+  MessagingChannelKind,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const ACTIVITY_TAIL_MS = 2_000;
+
+/**
+ * Subscribes to per-platform messaging health + activity. Maintains the
+ * canonical `MessagingPlatformStatus[]` view: takes the initial snapshot
+ * via IPC, then folds incoming events. The list itself only mutates when
+ * health changes — activity-driven re-renders go through a separate
+ * `activeAtByPlatform` map so the rest of the row doesn't re-render
+ * just because a dot flickered.
+ */
+export function useMessagingPlatformStatuses(
+  desktopApi: DesktopApi | undefined,
+): {
+  statuses: MessagingPlatformStatus[];
+  activeAtByPlatform: Record<string, number>;
+} {
+  const [statuses, setStatuses] = useState<MessagingPlatformStatus[]>([]);
+  const [activeAtByPlatform, setActiveAtByPlatform] = useState<
+    Record<string, number>
+  >({});
+
+  useEffect(() => {
+    if (!desktopApi?.getMessagingPlatformStatuses) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const initial = await desktopApi.getMessagingPlatformStatuses!();
+        if (cancelled) return;
+        setStatuses(initial);
+      } catch {
+        // Logged in main; ignore in renderer.
+      }
+    })();
+
+    const unsubscribe = desktopApi.onMessagingPlatformStatusEvent?.(
+      (event: MessagingPlatformStatusEvent) => {
+        if (event.kind === "activity") {
+          setActiveAtByPlatform((current) => ({
+            ...current,
+            [event.platform]: event.at,
+          }));
+          return;
+        }
+        // health-changed
+        setStatuses((current) => upsertHealth(current, event));
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [desktopApi]);
+
+  // Sweep stale activity timestamps so the dot stops blinking even if
+  // we never receive an "activity end" event (we don't; the runtime
+  // only emits per-event, not per-burst).
+  useEffect(() => {
+    if (Object.keys(activeAtByPlatform).length === 0) {
+      return;
+    }
+    const intervalId = window.setInterval(() => {
+      const cutoff = Date.now() - ACTIVITY_TAIL_MS;
+      setActiveAtByPlatform((current) => {
+        const next: Record<string, number> = {};
+        let mutated = false;
+        for (const [platform, at] of Object.entries(current)) {
+          if (at >= cutoff) {
+            next[platform] = at;
+          } else {
+            mutated = true;
+          }
+        }
+        return mutated ? next : current;
+      });
+    }, ACTIVITY_TAIL_MS / 2);
+    return () => window.clearInterval(intervalId);
+  }, [activeAtByPlatform]);
+
+  return { statuses, activeAtByPlatform };
+}
+
+function upsertHealth(
+  current: MessagingPlatformStatus[],
+  event: Extract<MessagingPlatformStatusEvent, { kind: "health-changed" }>,
+): MessagingPlatformStatus[] {
+  const platform: MessagingChannelKind = event.platform;
+  const existing = current.find((entry) => entry.platform === platform);
+  const next: MessagingPlatformStatus = {
+    ...existing,
+    platform,
+    health: event.health,
+    changedAt: event.at,
+    reason: event.reason,
+    lastActivityAt: existing?.lastActivityAt,
+  };
+  if (!existing) {
+    return [...current, next];
+  }
+  return current.map((entry) => (entry.platform === platform ? next : entry));
+}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
+  MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
@@ -28,6 +29,10 @@ type DirectoriesListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -185,6 +190,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
+                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
                         />
                       );
                     })}

--- a/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/InboxList.tsx
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import { ThreadRow } from "./ThreadRow";
 
@@ -17,6 +20,10 @@ type InboxListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -45,6 +52,7 @@ export function InboxList(props: InboxListProps) {
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,4 +1,7 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import { ThreadRow } from "./ThreadRow";
 
@@ -17,6 +20,10 @@ type RecentsListProps = {
     thread: NavigationThreadSummary,
     emoji: string,
     present: boolean,
+  ) => Promise<void>;
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
 };
 
@@ -37,6 +44,7 @@ export function RecentsList(props: RecentsListProps) {
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
         );
       })}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
+  MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
   ThreadExecutionMode,
@@ -68,6 +69,15 @@ type SidebarProps = {
    * fresh PR status before they click in.
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  /**
+   * Called when the user unbinds a messaging conversation from a
+   * thread via the binding chip. Receives the thread + binding so the
+   * parent can call the IPC and refresh navigation.
+   */
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
+  ) => Promise<void>;
   onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
   onResizeByKeyboard?: (delta: number) => void;
 };
@@ -364,6 +374,7 @@ export function Sidebar(props: SidebarProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
@@ -377,6 +388,7 @@ export function Sidebar(props: SidebarProps) {
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
             props.threads.length === 0 ? (
@@ -433,6 +445,31 @@ export function Sidebar(props: SidebarProps) {
           ) : null}
           {contextMenuHasTopActions ? (
             <div className="thread-context-menu__separator" role="separator" />
+          ) : null}
+          {(contextMenu.thread.messagingBindings ?? []).length > 0
+            && props.onUnbindMessagingBinding ? (
+            <>
+              <div className="thread-context-menu__section">
+                {(contextMenu.thread.messagingBindings ?? []).map((binding) => (
+                  <button
+                    key={binding.bindingId}
+                    role="menuitem"
+                    type="button"
+                    onClick={() => {
+                      const target = contextMenu.thread;
+                      setContextMenu(undefined);
+                      void props.onUnbindMessagingBinding!(target, binding);
+                    }}
+                  >
+                    Unbind from {formatPlatformLabel(binding.platform)}
+                    {binding.conversationTitle
+                      ? ` (${binding.conversationTitle})`
+                      : ""}
+                  </button>
+                ))}
+              </div>
+              <div className="thread-context-menu__separator" role="separator" />
+            </>
           ) : null}
           <div className="thread-context-menu__section">
             <button
@@ -540,6 +577,11 @@ export function Sidebar(props: SidebarProps) {
 
     </aside>
   );
+}
+
+function formatPlatformLabel(platform: string): string {
+  if (!platform) return platform;
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
 }
 
 function placeThreadContextMenu(

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -116,8 +116,11 @@ export function ThreadMetaChips({
         )
     : null;
 
+  // Returns a fragment (no wrapping container) so the chips flow as
+  // direct siblings inside the row's single .thread-row__chips
+  // flex-wrap container, alongside PR / binding / reaction chips.
   return (
-    <span className="thread-row__meta">
+    <>
       <span className="thread-row__chip thread-row__chip--backend">
         {formatBackendLabel(thread.source)}
       </span>
@@ -154,6 +157,6 @@ export function ThreadMetaChips({
           now {thread.observedGitBranch}
         </span>
       ) : null}
-    </span>
+    </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -12,7 +12,7 @@ import type {
   PrSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
-import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
+import { DiscordIcon, SmileyIcon, TelegramIcon, type IconProps } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { PrChip } from "../pr-status/PrChip";
 import { ReactionPicker } from "./ReactionPicker";
@@ -27,13 +27,6 @@ const PLATFORM_ICONS: Partial<
 };
 
 const HOVER_PREFETCH_DELAY_MS = 750;
-/**
- * Add-reaction glyph. Reactions are explicitly exempt from the
- * no-emoji-as-icon rule (see ReactionPicker.tsx); the trigger uses a
- * smiley face so it visually reads as "add an emoji" the same way
- * GitHub's reaction affordance does.
- */
-const ADD_REACTION_GLYPH = "🙂";
 
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -303,7 +296,10 @@ function AddReactionChip(props: {
         }
       }}
     >
-      <span aria-hidden="true">{ADD_REACTION_GLYPH}</span>
+      {/* Stroke-based icon — matches the rest of the icon set and
+          inherits the chip's foreground color, instead of the OS
+          emoji's bright yellow which fought the dark theme. */}
+      <SmileyIcon size={14} aria-hidden="true" />
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -1,12 +1,39 @@
-import { useEffect, useRef, useState } from "react";
-import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+} from "react";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+  PrSummary,
+} from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
+import { DiscordIcon, TelegramIcon, type IconProps } from "../../icons";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { PrChip } from "../pr-status/PrChip";
 import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
+const PLATFORM_ICONS: Partial<
+  Record<MessagingThreadBindingSummary["platform"], (props: IconProps) => ReactElement>
+> = {
+  telegram: TelegramIcon,
+  discord: DiscordIcon,
+};
+
 const HOVER_PREFETCH_DELAY_MS = 750;
+/**
+ * Add-reaction glyph. Reactions are explicitly exempt from the
+ * no-emoji-as-icon rule (see ReactionPicker.tsx); the trigger uses a
+ * smiley face so it visually reads as "add an emoji" the same way
+ * GitHub's reaction affordance does.
+ */
+const ADD_REACTION_GLYPH = "🙂";
 
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -26,6 +53,15 @@ type ThreadRowProps = {
    * thread key, respect terminal-state short-circuit on the main side).
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  /**
+   * Called when the user picks "Unbind" from a per-thread messaging
+   * binding chip. Receives the binding id; the parent owns the IPC call
+   * and any optimistic UI rollback.
+   */
+  onUnbindMessagingBinding?: (
+    thread: NavigationThreadSummary,
+    binding: MessagingThreadBindingSummary,
+  ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onSetReaction?: (
     thread: NavigationThreadSummary,
@@ -41,9 +77,10 @@ export function ThreadRow(props: ThreadRowProps) {
     threadKey === props.selectedThreadKey;
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const addReactionRef = useRef<HTMLButtonElement>(null);
+  const addReactionRef = useRef<HTMLSpanElement>(null);
   const reactions = props.thread.reactions ?? [];
   const canReact = Boolean(props.onSetReaction);
+  const bindings = props.thread.messagingBindings ?? [];
   // Pull straight from the navigation snapshot — main persists PR state
   // to the overlay store and surfaces it through the snapshot, so the
   // chips render instantly on app launch and stay in sync without any
@@ -118,77 +155,73 @@ export function ThreadRow(props: ThreadRowProps) {
           </span>
         </span>
 
-        <ThreadMetaChips
-          hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
-          includeLinkedDirectories={props.includeLinkedDirectories}
-          linkedDirectoryMode={props.linkedDirectoryMode}
-          thread={props.thread}
-        />
+        {/* Single ordered chip flow: meta (agent/mode/dir/branch/drift)
+            → PR chips → messaging binding chips → reactions → add-
+            reaction. flex-wrap handles overflow naturally; every chip
+            is a sibling, no per-type containers. */}
+        <span
+          className="thread-row__chips"
+          onMouseEnter={prs.length > 0 ? armHoverPrefetch : undefined}
+          onMouseLeave={prs.length > 0 ? cancelHoverPrefetch : undefined}
+        >
+          <ThreadMetaChips
+            hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
+            includeLinkedDirectories={props.includeLinkedDirectories}
+            linkedDirectoryMode={props.linkedDirectoryMode}
+            thread={props.thread}
+          />
 
-        {prs.length > 0 ? (
-          <span
-            className="thread-row__pr-chips"
-            onMouseEnter={armHoverPrefetch}
-            onMouseLeave={cancelHoverPrefetch}
-          >
-            {prs.map((pr) => (
-              <PrChip
-                key={pr.url}
-                pr={pr}
-                showRepoPrefix={showRepoPrefix}
-                onOpen={openPr}
-              />
-            ))}
-          </span>
-        ) : null}
-      </button>
+          {prs.map((pr) => (
+            <PrChip
+              key={pr.url}
+              pr={pr}
+              showRepoPrefix={showRepoPrefix}
+              onOpen={openPr}
+            />
+          ))}
 
-      {canReact || reactions.length > 0 ? (
-        <div className="thread-row__reactions">
+          {bindings.map((binding) => (
+            <BindingChip
+              key={binding.bindingId}
+              binding={binding}
+              onUnbind={
+                props.onUnbindMessagingBinding
+                  ? (target) =>
+                      void props.onUnbindMessagingBinding!(props.thread, target)
+                  : undefined
+              }
+            />
+          ))}
+
           {reactions.map((emoji) => (
-            <button
+            <ReactionChip
               key={emoji}
-              type="button"
-              aria-label={`Remove reaction ${emoji} from thread`}
-              className="thread-row__reaction"
-              onClick={(event) => {
-                event.stopPropagation();
-                toggleReaction(emoji);
-              }}
-            >
-              <span aria-hidden="true">{emoji}</span>
-            </button>
+              emoji={emoji}
+              onToggle={() => toggleReaction(emoji)}
+            />
           ))}
 
           {canReact ? (
-            <div className="thread-row__reaction-picker-wrap">
-              <button
-                ref={addReactionRef}
-                type="button"
-                aria-haspopup="menu"
-                aria-expanded={pickerOpen}
-                aria-label="Add reaction to thread"
-                className="thread-row__add-reaction"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  setPickerOpen((open) => !open);
-                }}
-              >
-                <span aria-hidden="true">+</span>
-              </button>
-              <ReactionPicker
-                open={pickerOpen}
-                current={reactions}
-                anchorRef={addReactionRef}
-                onSelect={(emoji) => {
-                  toggleReaction(emoji);
-                  setPickerOpen(false);
-                }}
-                onDismiss={() => setPickerOpen(false)}
-              />
-            </div>
+            <AddReactionChip
+              anchorRef={addReactionRef}
+              open={pickerOpen}
+              onToggle={() => setPickerOpen((open) => !open)}
+            />
           ) : null}
-        </div>
+        </span>
+      </button>
+
+      {canReact ? (
+        <ReactionPicker
+          open={pickerOpen}
+          current={reactions}
+          anchorRef={addReactionRef}
+          onSelect={(emoji) => {
+            toggleReaction(emoji);
+            setPickerOpen(false);
+          }}
+          onDismiss={() => setPickerOpen(false)}
+        />
       ) : null}
 
       <button
@@ -211,6 +244,344 @@ export function ThreadRow(props: ThreadRowProps) {
       </button>
     </div>
   );
+}
+
+function ReactionChip(props: { emoji: string; onToggle: () => void }) {
+  const { emoji, onToggle } = props;
+  const handleActivate = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    onToggle();
+  };
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Remove reaction ${emoji} from thread`}
+      className="thread-row__chip thread-row__chip--reaction"
+      onClick={handleActivate}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          handleActivate(event);
+        }
+      }}
+    >
+      <span aria-hidden="true">{emoji}</span>
+    </span>
+  );
+}
+
+function AddReactionChip(props: {
+  open: boolean;
+  anchorRef: React.RefObject<HTMLSpanElement | null>;
+  onToggle: () => void;
+}) {
+  const handleActivate = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    props.onToggle();
+  };
+  return (
+    <span
+      ref={props.anchorRef}
+      role="button"
+      tabIndex={0}
+      aria-haspopup="menu"
+      aria-expanded={props.open}
+      aria-label="Add reaction to thread"
+      className={`thread-row__chip thread-row__chip--add-reaction${
+        props.open ? " is-open" : ""
+      }`}
+      onClick={handleActivate}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          handleActivate(event);
+        }
+      }}
+    >
+      <span aria-hidden="true">{ADD_REACTION_GLYPH}</span>
+    </span>
+  );
+}
+
+function BindingChip(props: {
+  binding: MessagingThreadBindingSummary;
+  onUnbind?: (binding: MessagingThreadBindingSummary) => void;
+}) {
+  const { binding, onUnbind } = props;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
+  const tooltipController = useViewportTooltip({
+    className: "viewport-tooltip",
+  });
+  const Icon = PLATFORM_ICONS[binding.platform];
+  const platformLabel =
+    binding.platform.charAt(0).toUpperCase() + binding.platform.slice(1);
+  const label = formatBindingLabel(binding);
+  const tooltip = formatBindingTooltip(binding);
+  // aria-label needs to be a single line (screen readers), so flatten
+  // the multi-line tooltip into a comma-separated form.
+  const ariaTooltip = tooltip.replace(/\n/g, ", ");
+  const ariaLabel = onUnbind
+    ? `Open binding actions for ${ariaTooltip}`
+    : ariaTooltip;
+
+  // Dismiss the menu on outside click or Escape — same pattern as the
+  // reaction picker. Capture-phase listener so we close before the
+  // row's click handler fires.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (event: globalThis.MouseEvent): void => {
+      if (!wrapRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    const onKey = (event: globalThis.KeyboardEvent): void => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown, true);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown, true);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
+
+  const handleActivate = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!onUnbind) return;
+    setMenuOpen((open) => !open);
+  };
+
+  return (
+    // Portal-rendered tooltip via useViewportTooltip — escapes the
+    // sidebar scroll container's overflow clip and clamps to viewport
+    // bounds. CSS-pseudo tooltip-target wouldn't work here: the
+    // sidebar scroll region clips ::after pseudo-elements.
+    <span ref={wrapRef} className="thread-row__chip-wrap">
+      <span
+        role="button"
+        tabIndex={onUnbind ? 0 : -1}
+        className="thread-row__chip thread-row__chip--binding"
+        onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
+        onMouseLeave={tooltipController.hide}
+        onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
+        onBlur={tooltipController.hide}
+        aria-label={ariaLabel}
+        aria-haspopup={onUnbind ? "menu" : undefined}
+        aria-expanded={onUnbind ? menuOpen : undefined}
+        aria-disabled={onUnbind ? undefined : true}
+        onClick={onUnbind ? handleActivate : undefined}
+        onKeyDown={
+          onUnbind
+            ? (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  handleActivate(event);
+                }
+              }
+            : undefined
+        }
+      >
+        {Icon ? (
+          <Icon size={12} />
+        ) : (
+          <span aria-hidden="true">{binding.platform.slice(0, 2)}</span>
+        )}
+        <span className="thread-row__chip-label">{label}</span>
+      </span>
+      {menuOpen && onUnbind ? (
+        <div
+          role="menu"
+          className="thread-row__chip-menu"
+          aria-label={`Actions for ${ariaTooltip}`}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="thread-row__chip-menu-item"
+            onClick={(event) => {
+              event.stopPropagation();
+              setMenuOpen(false);
+              onUnbind(binding);
+            }}
+          >
+            Unbind from {platformLabel}
+          </button>
+          <p className="thread-row__chip-menu-hint">
+            Removes the binding from this app. To stop the conversation
+            entirely, also unbind from {platformLabel}.
+          </p>
+        </div>
+      ) : null}
+      {tooltipController.tooltipNode}
+    </span>
+  );
+}
+
+const CHIP_LEAF_MAX_CHARS = 20;
+
+function elide(value: string, max = CHIP_LEAF_MAX_CHARS): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
+}
+
+/**
+ * Chip label: pure ancestry breadcrumb. The leaf segment is elided to
+ * ~20 chars so a long topic/thread name doesn't blow up the row width.
+ * Earlier ancestors stay full-length (they're typically short — server
+ * names, channel names) and are critical for context.
+ *
+ *   DM       →  <peer>            (or "Direct message" if no peer)
+ *   topic    →  <supergroup>/<topic-elided>
+ *                or <supergroup>/Topic        when topic name unknown
+ *                or Topic                      when neither is known
+ *   channel  →  Telegram: <group>            (or "Group")
+ *               Discord:  <server>/#<channel>
+ *   thread   →  Discord: <server>/#<channel>/<thread-elided>
+ */
+function formatBindingLabel(binding: MessagingThreadBindingSummary): string {
+  const title = binding.conversationTitle?.trim();
+  const parent = binding.parentTitle?.trim();
+  const ancestor = binding.ancestorTitle?.trim();
+  const platform = binding.platform;
+
+  switch (binding.conversationKind) {
+    case "dm":
+      return title ? elide(title) : "Direct message";
+    case "topic":
+      // Topic name alone is usually our own desktop thread title —
+      // redundant with the row title shown directly above the chip.
+      // Only show topic name when we ALSO have the supergroup parent
+      // so the breadcrumb actually carries the supergroup context.
+      // Without parent, fall back to literal "Topic".
+      if (parent) {
+        return title ? `${parent}/${elide(title)}` : `${parent}/Topic`;
+      }
+      return "Topic";
+    case "thread":
+      if (ancestor && parent) {
+        return title
+          ? `${ancestor}/#${parent}/${elide(title)}`
+          : `${ancestor}/#${parent}/Thread`;
+      }
+      if (parent) {
+        return title ? `#${parent}/${elide(title)}` : `#${parent}/Thread`;
+      }
+      return "Thread";
+    case "channel":
+      if (platform === "telegram") {
+        // For Telegram non-topic chats, the title IS the
+        // (super)group name — that's the breadcrumb itself.
+        return title ? elide(title, 28) : "Group";
+      }
+      // Discord. Thread messages are still kind="channel" (kind drives
+      // binding lookup, can't change), so we distinguish by data
+      // shape: ancestorTitle populated → it's a thread (3-level).
+      // Layout:
+      //   thread:  <server>/#<channel>/<thread-elided>
+      //   channel: <server>/#<channel>
+      //   bare:    Channel
+      if (ancestor && parent && title) {
+        return `${ancestor}/#${parent}/${elide(title)}`;
+      }
+      if (parent && title) return `${parent}/#${elide(title, 22)}`;
+      if (parent) return `${parent}/Channel`;
+      return "Channel";
+    default:
+      // Pre-kind legacy bindings — best effort.
+      return title ? elide(title) : binding.platform;
+  }
+}
+
+/**
+ * Tooltip is multi-line: platform first, then conversation type, then
+ * each available ancestry segment labelled by its role on that
+ * platform. Renders nothing for fields the adapter hasn't populated.
+ * `\n` is honored by browser native title-attribute tooltips.
+ */
+function formatBindingTooltip(binding: MessagingThreadBindingSummary): string {
+  const lines: string[] = [];
+  lines.push(formatPlatformName(binding.platform));
+  lines.push(`Type: ${formatConversationType(binding)}`);
+
+  const title = binding.conversationTitle?.trim();
+  const parent = binding.parentTitle?.trim();
+  const ancestor = binding.ancestorTitle?.trim();
+  const platform = binding.platform;
+
+  switch (binding.conversationKind) {
+    case "dm":
+      if (title) lines.push(`Peer: ${title}`);
+      break;
+    case "topic":
+      if (parent) lines.push(`SuperGroup: ${parent}`);
+      if (title) lines.push(`Topic: ${title}`);
+      break;
+    case "thread":
+      if (ancestor) lines.push(`Server: ${ancestor}`);
+      if (parent) lines.push(`Channel: #${parent}`);
+      if (title) lines.push(`Thread: ${title}`);
+      break;
+    case "channel":
+      if (platform === "telegram") {
+        if (title) lines.push(`Group: ${title}`);
+      } else if (ancestor) {
+        // Discord thread — 3 levels: server / channel / thread.
+        // The kind stays "channel" for routing; thread is inferred from
+        // ancestorTitle being populated.
+        lines.push(`Server: ${ancestor}`);
+        if (parent) lines.push(`Channel: #${parent}`);
+        if (title) lines.push(`Thread: ${title}`);
+      } else {
+        // Discord regular guild channel — 2 levels: server / channel.
+        if (parent) lines.push(`Server: ${parent}`);
+        if (title) lines.push(`Channel: #${title}`);
+      }
+      break;
+    default:
+      if (title) lines.push(`Title: ${title}`);
+      break;
+  }
+  return lines.join("\n");
+}
+
+function formatPlatformName(platform: string): string {
+  if (!platform) return "Messaging";
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}
+
+function formatConversationType(binding: MessagingThreadBindingSummary): string {
+  const platform = binding.platform;
+  switch (binding.conversationKind) {
+    case "dm":
+      return "Direct message";
+    case "topic":
+      return "SuperGroup topic";
+    case "thread":
+      return "Server thread";
+    case "channel":
+      // Telegram lumps Group + SuperGroup into kind="channel" today
+      // (we don't yet propagate chat.type). Topic-bound chats are
+      // reported as kind="topic" — and topics imply a SuperGroup —
+      // so when we see kind="channel" on Telegram we can't tell
+      // which. Render the honest "Group or SuperGroup" until the
+      // adapter starts forwarding chat.type explicitly.
+      if (platform === "telegram") return "Group or SuperGroup";
+      // Discord thread is also kind="channel" (the binding key
+      // depends on it, can't change). Distinguish by ancestorTitle
+      // being populated — see Discord adapter channelFromDiscord.
+      return binding.ancestorTitle ? "Server thread" : "Server channel";
+    default:
+      return "Conversation";
+  }
 }
 
 function needsRepoPrefix(prs: PrSummary[]): boolean {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -1,0 +1,187 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  MessagingThreadBindingSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { ThreadRow } from "../ThreadRow";
+
+// Regression coverage for the unified chip-flow refactor (#188 / plan
+// 2026-05-05-001). The historical bug pattern was:
+//
+//   1. Per-chip-type containers stacked binding chips on their own line
+//      and broke ordering/wrapping with the reaction picker.
+//   2. Nested `<button>` elements (binding chip inside the row's
+//      `<button>`) ate inner clicks — making the binding chip
+//      effectively unclickable, or making the click select the thread
+//      instead of opening the binding menu.
+//
+// These tests freeze the contract that motivated the refactor:
+//   - Every chip is a sibling inside a single `.thread-row__chips`
+//     container — no per-type wrappers.
+//   - Interactive chips are `<span role="button">` (NOT `<button>`),
+//     and their click events do not propagate into the row's
+//     onSelectThread handler.
+//   - The add-reaction glyph is the smiley (🙂), not a "+".
+
+const baseThread: NavigationThreadSummary = {
+  id: "thread-chips",
+  title: "Chip flow thread",
+  titleSource: "explicit",
+  summary: "Test row for chip-flow regression",
+  source: "codex",
+  gitBranch: "feat/chips",
+  executionMode: "default",
+  updatedAt: Date.now(),
+  inbox: { inInbox: false },
+  linkedDirectories: [],
+};
+
+const telegramBinding: MessagingThreadBindingSummary = {
+  bindingId: "binding-tg-1",
+  platform: "telegram",
+  conversationKind: "topic",
+  conversationTitle: "Wood chuck joke",
+  parentTitle: "PwrDrvr",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ThreadRow chip flow", () => {
+  function renderRow(
+    overrides: Partial<React.ComponentProps<typeof ThreadRow>> = {},
+  ) {
+    const onSelectThread = vi.fn();
+    const onUnbindMessagingBinding = vi.fn(async () => undefined);
+    const onSetReaction = vi.fn(async () => undefined);
+    const onOpenContextMenu = vi.fn();
+    const props: React.ComponentProps<typeof ThreadRow> = {
+      thread: {
+        ...baseThread,
+        messagingBindings: [telegramBinding],
+        reactions: ["🙂"],
+      },
+      onSelectThread,
+      onOpenContextMenu,
+      onUnbindMessagingBinding,
+      onSetReaction,
+      ...overrides,
+    };
+    const utils = render(<ThreadRow {...props} />);
+    return { ...utils, onSelectThread, onUnbindMessagingBinding, onSetReaction };
+  }
+
+  it("renders every chip as a sibling inside a single .thread-row__chips container", () => {
+    const { container } = renderRow();
+    const chipFlow = container.querySelectorAll(".thread-row__chips");
+    expect(chipFlow.length).toBe(1);
+    // All known chip types should live inside that single container,
+    // not in any per-type wrapper.
+    const flow = chipFlow[0]!;
+    expect(flow.querySelector(".thread-row__chip--binding")).not.toBeNull();
+    expect(flow.querySelector(".thread-row__chip--reaction")).not.toBeNull();
+    expect(flow.querySelector(".thread-row__chip--add-reaction")).not.toBeNull();
+  });
+
+  it("uses span[role=button] for the binding chip (not nested <button>)", () => {
+    const { container } = renderRow();
+    const bindingChip = container.querySelector(".thread-row__chip--binding");
+    expect(bindingChip).not.toBeNull();
+    // The historical bug was a nested <button>. Lock the role+tag shape.
+    expect(bindingChip?.tagName).toBe("SPAN");
+    expect(bindingChip?.getAttribute("role")).toBe("button");
+  });
+
+  it("does not invoke onSelectThread when a binding chip is clicked", () => {
+    const { container, onSelectThread, onUnbindMessagingBinding } = renderRow();
+    const bindingChip = container.querySelector(
+      ".thread-row__chip--binding",
+    ) as HTMLElement;
+    fireEvent.click(bindingChip);
+    // Click on the chip opens the unbind menu, but must not bubble up
+    // and select the thread (the regression that motivated the
+    // refactor).
+    expect(onSelectThread).not.toHaveBeenCalled();
+    // The handler is wired to the menu, not the unbind RPC — opening
+    // the menu does not call onUnbindMessagingBinding directly.
+    expect(onUnbindMessagingBinding).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onSelectThread when the add-reaction smiley is clicked", () => {
+    const { container, onSelectThread } = renderRow();
+    const addReaction = container.querySelector(
+      ".thread-row__chip--add-reaction",
+    ) as HTMLElement;
+    expect(addReaction).not.toBeNull();
+    fireEvent.click(addReaction);
+    expect(onSelectThread).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onSelectThread when an existing reaction chip is clicked", () => {
+    const { container, onSelectThread, onSetReaction } = renderRow();
+    const reaction = container.querySelector(
+      ".thread-row__chip--reaction",
+    ) as HTMLElement;
+    fireEvent.click(reaction);
+    expect(onSelectThread).not.toHaveBeenCalled();
+    // But onSetReaction IS invoked — the reaction toggle still works.
+    expect(onSetReaction).toHaveBeenCalledOnce();
+  });
+
+  it("renders the smiley emoji as the add-reaction glyph (regression: not '+')", () => {
+    const { container } = renderRow();
+    const addReaction = container.querySelector(
+      ".thread-row__chip--add-reaction",
+    );
+    expect(addReaction?.textContent).toContain("🙂");
+    expect(addReaction?.textContent).not.toContain("+");
+  });
+
+  it("still selects the thread when the row body (outside chips) is clicked", () => {
+    const { onSelectThread } = renderRow();
+    // The row's accessible name is the thread title; click that to
+    // hit the row button, not a chip.
+    const rowButton = screen.getByRole("button", { name: /Chip flow thread/i });
+    fireEvent.click(rowButton);
+    expect(onSelectThread).toHaveBeenCalledOnce();
+  });
+
+  it("orders chips: meta → PR → bindings → reactions → add-reaction", () => {
+    const threadWithEverything: NavigationThreadSummary = {
+      ...baseThread,
+      messagingBindings: [telegramBinding],
+      reactions: ["🙂"],
+      prs: [
+        {
+          number: 123,
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          state: "passing",
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+        },
+      ],
+    };
+    const { container } = renderRow({ thread: threadWithEverything });
+    const flow = container.querySelector(".thread-row__chips") as HTMLElement;
+    const chipNodes = Array.from(flow.children) as HTMLElement[];
+    // Find the index of each known chip class. Order check is by index;
+    // we don't assert the count of meta chips since that depends on
+    // ThreadMetaChips internals.
+    const indexOf = (selector: string): number =>
+      chipNodes.findIndex((el) => el.matches(selector) || el.querySelector(selector) !== null);
+    const prIdx = indexOf(".thread-row__chip--pr, [data-pr-chip]");
+    const bindingIdx = indexOf(".thread-row__chip--binding, .thread-row__chip-wrap");
+    const reactionIdx = indexOf(".thread-row__chip--reaction");
+    const addReactionIdx = indexOf(".thread-row__chip--add-reaction");
+    // Each chip type that's present comes after the previous one.
+    if (prIdx >= 0 && bindingIdx >= 0) expect(prIdx).toBeLessThan(bindingIdx);
+    if (bindingIdx >= 0 && reactionIdx >= 0) expect(bindingIdx).toBeLessThan(reactionIdx);
+    if (reactionIdx >= 0 && addReactionIdx >= 0) {
+      expect(reactionIdx).toBeLessThan(addReactionIdx);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -23,7 +23,8 @@ import { ThreadRow } from "../ThreadRow";
 //   - Interactive chips are `<span role="button">` (NOT `<button>`),
 //     and their click events do not propagate into the row's
 //     onSelectThread handler.
-//   - The add-reaction glyph is the smiley (🙂), not a "+".
+//   - The add-reaction trigger is the SmileyIcon SVG (not a "+" or
+//     the OS-rendered 🙂 emoji which read as bright yellow on dark).
 
 const baseThread: NavigationThreadSummary = {
   id: "thread-chips",
@@ -132,13 +133,17 @@ describe("ThreadRow chip flow", () => {
     expect(onSetReaction).toHaveBeenCalledOnce();
   });
 
-  it("renders the smiley emoji as the add-reaction glyph (regression: not '+')", () => {
+  it("renders SmileyIcon SVG as the add-reaction trigger (regression: not '+' or OS emoji)", () => {
     const { container } = renderRow();
     const addReaction = container.querySelector(
       ".thread-row__chip--add-reaction",
     );
-    expect(addReaction?.textContent).toContain("🙂");
-    expect(addReaction?.textContent).not.toContain("+");
+    // Stroke-based SVG icon, not the OS-rendered 🙂 emoji (which
+    // ignored the chip's foreground color and looked yellow), and
+    // not the literal "+" plus sign that we used pre-refactor.
+    expect(addReaction?.querySelector("svg")).not.toBeNull();
+    expect(addReaction?.textContent ?? "").not.toContain("🙂");
+    expect(addReaction?.textContent ?? "").not.toContain("+");
   });
 
   it("still selects the thread when the row body (outside chips) is clicked", () => {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent, MouseEvent } from "react";
 import type { PrSummary } from "@pwragent/shared";
 
 type PrChipProps = {
@@ -14,20 +15,34 @@ export function PrChip(props: PrChipProps) {
     : `#${pr.number}`;
   const tooltip = `${pr.org}/${pr.repo}#${pr.number} — ${stateTooltipLabel(pr.state)}`;
 
+  // role="button" span (not a real <button>) so the chip is legal HTML
+  // inside the row's main <button>. stopPropagation prevents the row's
+  // "select thread" click from firing when the user is opening a PR.
+  const handleActivate = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    props.onOpen(pr.url);
+  };
+
   return (
-    <button
-      type="button"
+    <span
+      role="button"
+      tabIndex={0}
       aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${pr.state}) in browser`}
       title={tooltip}
       className={`pr-chip pr-chip--${pr.state}`}
-      onClick={(event) => {
-        event.stopPropagation();
-        props.onOpen(pr.url);
+      onClick={handleActivate}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          handleActivate(event);
+        }
       }}
     >
       <span className="pr-chip__dot" aria-hidden="true" />
       <span className="pr-chip__label">{label}</span>
-    </button>
+    </span>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -9,12 +9,14 @@ import { ExperimentalSettings } from "./ExperimentalSettings";
 import { MessagingSettings } from "./MessagingSettings";
 import { ModelsSettings } from "./ModelsSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
+import { MessagingActivityScreen } from "../messaging-activity/MessagingActivityScreen";
 import { WorktreesSettings } from "./WorktreesSettings";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-type SettingsSection =
+export type SettingsSection =
   | "experimental"
   | "messaging"
+  | "messaging-activity"
   | "models"
   | "applications"
   | "worktrees"
@@ -24,6 +26,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "applications", label: "Applications" },
   { id: "worktrees", label: "Worktrees" },
   { id: "messaging", label: "Messaging" },
+  { id: "messaging-activity", label: "Messaging activity" },
   { id: "models", label: "Models" },
   { id: "experimental", label: "Experimental" },
   { id: "about", label: "About" },
@@ -32,9 +35,18 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
 export function SettingsScreen(props: {
   desktopApi?: DesktopApi;
   settings: DesktopSettingsState;
+  /** Initial section to render. Defaults to Applications. */
+  initialSection?: SettingsSection;
   onClose?: () => void;
 }) {
-  const [section, setSection] = useState<SettingsSection>("applications");
+  const [section, setSection] = useState<SettingsSection>(
+    props.initialSection ?? "applications",
+  );
+  // When the parent re-mounts with a different initialSection (e.g.
+  // user clicked a platform icon → "messaging-activity"), follow it.
+  useEffect(() => {
+    if (props.initialSection) setSection(props.initialSection);
+  }, [props.initialSection]);
   const snapshot = props.settings.snapshot;
 
   return (
@@ -246,6 +258,10 @@ function SettingsSectionBody(props: {
         }}
       />
     );
+  }
+
+  if (props.section === "messaging-activity") {
+    return <MessagingActivityScreen desktopApi={props.desktopApi} />;
   }
 
   return (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,9 +1,17 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  MessagingChannelKind,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+import type { DesktopApi } from "../../lib/desktop-api";
 
 type ThreadHeaderProps = {
+  desktopApi?: DesktopApi;
   thread: NavigationThreadSummary;
+  /** Forwarded to MessagingStatusBar — fires when a platform chip is clicked. */
+  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
 };
 
 function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
@@ -20,7 +28,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
 
   return (
     <header className="thread-header">
-      <div>
+      <div className="thread-header__main">
         <div className="thread-header__eyebrow-row">
           <h2 className="thread-header__compact-title" title={props.thread.title}>
             {props.thread.title}
@@ -39,6 +47,10 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           </p>
         ) : null}
       </div>
+      <MessagingStatusBar
+        desktopApi={props.desktopApi}
+        onOpenActivity={props.onOpenMessagingActivity}
+      />
     </header>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -18,6 +18,7 @@ import type {
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   HandoffThreadWorkspaceRequest,
+  MessagingChannelKind,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
@@ -614,6 +615,8 @@ type ThreadViewProps = {
   updatingExecutionMode?: ThreadExecutionMode;
   onActiveTurnIdChange?: (turnId?: string) => void;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
+  /** Forwarded to ThreadHeader → MessagingStatusBar — opens the Activity screen. */
+  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
   onLoadOlder: () => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
   onLiveTranscriptEntry?: (entry: AppServerThreadEntry) => void;
@@ -1496,7 +1499,11 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section className="thread-view">
-      <ThreadHeader thread={selectedThread!} />
+      <ThreadHeader
+        desktopApi={props.desktopApi}
+        thread={selectedThread!}
+        onOpenMessagingActivity={props.onOpenMessagingActivity}
+      />
 
       <div
         className={`thread-view__layout${

--- a/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
@@ -1,0 +1,16 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Discord controller-shaped glyph, simplified to a monochrome silhouette
+ * filled with `currentColor`. Matches the visual weight of `TelegramIcon`
+ * at 16px and avoids the brand purple / gradient that would clash with
+ * the Tangerine Terminal theme.
+ */
+export function DiscordIcon(props: IconProps) {
+  const svgProps = resolveIconSvgProps(props);
+  return (
+    <svg {...svgProps} fill="currentColor" stroke="none">
+      <path d="M19.27 5.33A19.66 19.66 0 0 0 14.6 4l-.21.31a14.6 14.6 0 0 0-4.78 0L9.4 4a19.66 19.66 0 0 0-4.67 1.33A20.6 20.6 0 0 0 1.5 16.42a19.84 19.84 0 0 0 6 3.04l.49-.66a13.5 13.5 0 0 1-2.13-1.05l.45-.36a14.45 14.45 0 0 0 11.38 0l.45.36a13.5 13.5 0 0 1-2.14 1.05l.5.66a19.84 19.84 0 0 0 6-3.04 20.6 20.6 0 0 0-3.23-11.09zM8.5 14.16c-1.18 0-2.15-1.1-2.15-2.45s.95-2.45 2.15-2.45 2.16 1.1 2.15 2.45c0 1.35-.96 2.45-2.15 2.45zm7 0c-1.18 0-2.15-1.1-2.15-2.45s.95-2.45 2.15-2.45 2.16 1.1 2.15 2.45c0 1.35-.96 2.45-2.15 2.45z" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/SmileyIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/SmileyIcon.tsx
@@ -1,0 +1,19 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Add-reaction trigger glyph — a stroke-based smiley that matches the
+ * rest of the icon set (currentColor, 1.75 stroke). Used by the
+ * thread-row "add reaction" chip on hover. The previous emoji 🙂
+ * brought a yellow OS-rendered face that fought the dark theme — this
+ * version inherits the chip's foreground color.
+ */
+export function SmileyIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="9" cy="10" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="10" r="0.6" fill="currentColor" stroke="none" />
+      <path d="M8.5 14.5c1 1.4 2.2 2.1 3.5 2.1s2.5-.7 3.5-2.1" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/TelegramIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/TelegramIcon.tsx
@@ -1,0 +1,15 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/**
+ * Telegram paper-plane glyph, simplified to a monochrome silhouette
+ * filled with `currentColor`. Uses `fill` instead of stroke so the mark
+ * reads cleanly at 16px against the near-black header background.
+ */
+export function TelegramIcon(props: IconProps) {
+  const svgProps = resolveIconSvgProps(props);
+  return (
+    <svg {...svgProps} fill="currentColor" stroke="none">
+      <path d="M21.6 3.2 2.7 10.6c-.7.3-.7 1.3 0 1.5l4.4 1.4 1.7 5.5c.2.6.9.7 1.3.3l2.6-2.6 4.5 3.3c.6.4 1.5.1 1.6-.6L22.9 4c.2-.7-.5-1.3-1.3-.8zM9.5 13.7l8.6-5.3-7 6.5z" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -7,6 +7,7 @@ import {
   FolderIcon,
   NewThreadIcon,
   SettingsIcon,
+  SmileyIcon,
   TelegramIcon,
   UnlinkedDotIcon,
   WorkspaceIcon,
@@ -24,6 +25,7 @@ const ALL_ICONS = [
   ["WorktreeIcon", WorktreeIcon],
   ["UnlinkedDotIcon", UnlinkedDotIcon],
   ["SettingsIcon", SettingsIcon],
+  ["SmileyIcon", SmileyIcon],
   ["NewThreadIcon", NewThreadIcon],
 ] as const;
 

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -3,9 +3,11 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchIcon,
+  DiscordIcon,
   FolderIcon,
   NewThreadIcon,
   SettingsIcon,
+  TelegramIcon,
   UnlinkedDotIcon,
   WorkspaceIcon,
   WorktreeIcon,
@@ -57,6 +59,24 @@ describe("icon library", () => {
     expect(svg).toHaveAttribute("aria-label", "Local directory");
     expect(svg).toHaveAttribute("aria-hidden", "false");
   });
+
+  it.each([
+    ["TelegramIcon", TelegramIcon],
+    ["DiscordIcon", DiscordIcon],
+  ] as const)(
+    "%s renders as a filled glyph using currentColor",
+    (_name, Icon) => {
+      const { container } = render(<Icon />);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("width", "16");
+      expect(svg).toHaveAttribute("height", "16");
+      expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+      expect(svg).toHaveAttribute("fill", "currentColor");
+      expect(svg).toHaveAttribute("stroke", "none");
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    },
+  );
 
   it("flows currentColor through to children via parent CSS", () => {
     const { container } = render(

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -4,6 +4,7 @@ export { EditorIcon } from "./EditorIcon";
 export { FolderIcon } from "./FolderIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { SettingsIcon } from "./SettingsIcon";
+export { SmileyIcon } from "./SmileyIcon";
 export { TelegramIcon } from "./TelegramIcon";
 export { TerminalIcon } from "./TerminalIcon";
 export { UnlinkedDotIcon } from "./UnlinkedDotIcon";

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,8 +1,10 @@
 export { BranchIcon } from "./BranchIcon";
+export { DiscordIcon } from "./DiscordIcon";
 export { EditorIcon } from "./EditorIcon";
 export { FolderIcon } from "./FolderIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { SettingsIcon } from "./SettingsIcon";
+export { TelegramIcon } from "./TelegramIcon";
 export { TerminalIcon } from "./TerminalIcon";
 export { UnlinkedDotIcon } from "./UnlinkedDotIcon";
 export { WorkspaceIcon } from "./WorkspaceIcon";

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -209,6 +209,17 @@ export type DesktopApi = {
   onMessagingPlatformStatusEvent?: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ) => () => void;
+  /**
+   * Marker event fired whenever the main process mutates a messaging
+   * binding (create / refresh metadata / sync title / detach / revoke).
+   * Listeners should refetch the navigation snapshot rather than
+   * trying to apply per-binding diffs from the payload — that's where
+   * binding chips live, and the snapshot endpoint is cheap and
+   * idempotent. See `MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL`.
+   */
+  onMessagingBindingsChanged?: (
+    callback: (event: { at: number }) => void,
+  ) => () => void;
   unbindMessagingThread?: (
     request: UnbindMessagingThreadRequest,
   ) => Promise<UnbindMessagingThreadResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -38,6 +38,12 @@ import type {
   SetThreadReactionResponse,
   GetGhStatusRequest,
   GhStatus,
+  ListMessagingActivityRequest,
+  ListMessagingActivityResponse,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+  UnbindMessagingThreadRequest,
+  UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   NavigationSnapshot,
@@ -199,6 +205,16 @@ export type DesktopApi = {
   logRendererDiagnostic?: (request: RendererDiagnosticLogRequest) => Promise<void>;
   reportRendererError?: (report: RendererErrorReport) => Promise<void>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
+  getMessagingPlatformStatuses?: () => Promise<MessagingPlatformStatus[]>;
+  onMessagingPlatformStatusEvent?: (
+    callback: (event: MessagingPlatformStatusEvent) => void,
+  ) => () => void;
+  unbindMessagingThread?: (
+    request: UnbindMessagingThreadRequest,
+  ) => Promise<UnbindMessagingThreadResponse>;
+  listMessagingActivity?: (
+    request?: ListMessagingActivityRequest,
+  ) => Promise<ListMessagingActivityResponse>;
   onWindowFocus?: (callback: () => void) => () => void;
   platform?: string;
   versions?: {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1280,6 +1280,20 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     });
   }, [desktopApi, scheduleRefresh, state.response]);
 
+  // Bindings live in the navigation snapshot but are mutated outside
+  // the agent-event bus (a Telegram callback creates a binding, a
+  // /sync name renames it, a /detach revokes it — none of those emit
+  // backend notifications). Without this hook the binding chip stays
+  // stale until the next backend tick. See issue #191.
+  useEffect(() => {
+    if (!desktopApi?.onMessagingBindingsChanged) {
+      return;
+    }
+    return desktopApi.onMessagingBindingsChanged(() => {
+      scheduleRefresh();
+    });
+  }, [desktopApi, scheduleRefresh]);
+
   const threads = useMemo(() => {
     const currentThreads = state.response?.threads ?? [];
     if (!optimisticThread) {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -1,0 +1,120 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+const VIEWPORT_PADDING = 12;
+/** Gap between the tooltip and the target element (above or below). */
+const TOOLTIP_GAP = 10;
+
+type TooltipState = {
+  text: string;
+  targetTop: number;
+  targetBottom: number;
+  targetCenter: number;
+  /** Computed left after measure; undefined on the first paint. */
+  left?: number;
+  /** Computed top after measure; undefined on the first paint. */
+  top?: number;
+};
+
+/**
+ * Hook for portal-rendered tooltips that escape any clipping ancestor
+ * (sidebar scroll regions, overflow:hidden chips, etc.) and clamp
+ * themselves to viewport bounds. Use when CSS-pseudo-element tooltips
+ * (`tooltip-target` + `data-tooltip` in app.css) get clipped by a
+ * `overflow:hidden`/`overflow:auto` ancestor.
+ *
+ * Pattern adapted from ThreadContextPanel's railTooltip — same
+ * measure-then-clamp two-pass render, same portal target.
+ *
+ * Usage:
+ *   const { show, hide, tooltipNode } =
+ *     useViewportTooltip({ className: "messaging-tooltip" });
+ *   return (
+ *     <span
+ *       onMouseEnter={(e) => show(e.currentTarget, "Multi\nline\ntext")}
+ *       onMouseLeave={hide}
+ *       onFocus={(e) => show(e.currentTarget, "Multi\nline\ntext")}
+ *       onBlur={hide}
+ *     >
+ *       …
+ *       {tooltipNode}
+ *     </span>
+ *   );
+ */
+export function useViewportTooltip(options: {
+  /** CSS class applied to the rendered tooltip element. */
+  className: string;
+}): {
+  show: (target: HTMLElement, text: string) => void;
+  hide: () => void;
+  tooltipNode: ReactNode;
+} {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<TooltipState | undefined>(undefined);
+
+  // After the tooltip first paints (with left/top undefined → visibility
+  // hidden), measure it and clamp position so it stays in the viewport
+  // and on the side of the target where it fits.
+  useLayoutEffect(() => {
+    if (!state || state.left !== undefined) {
+      return;
+    }
+    const tooltipElement = tooltipRef.current;
+    if (!tooltipElement) {
+      return;
+    }
+    const rect = tooltipElement.getBoundingClientRect();
+    const left = Math.min(
+      window.innerWidth - rect.width - VIEWPORT_PADDING,
+      Math.max(VIEWPORT_PADDING, state.targetCenter - rect.width / 2),
+    );
+    const fitsAbove =
+      state.targetTop - rect.height - TOOLTIP_GAP >= VIEWPORT_PADDING;
+    const top = fitsAbove
+      ? state.targetTop - rect.height - TOOLTIP_GAP
+      : state.targetBottom + TOOLTIP_GAP;
+    setState({ ...state, left, top });
+  }, [state]);
+
+  const show = useCallback((target: HTMLElement, text: string): void => {
+    const rect = target.getBoundingClientRect();
+    setState({
+      text,
+      targetTop: rect.top,
+      targetBottom: rect.bottom,
+      targetCenter: rect.left + rect.width / 2,
+    });
+  }, []);
+
+  const hide = useCallback((): void => {
+    setState(undefined);
+  }, []);
+
+  const tooltipNode =
+    state && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            ref={tooltipRef}
+            role="tooltip"
+            className={options.className}
+            style={{
+              position: "fixed",
+              left: state.left,
+              top: state.top,
+              visibility: state.left === undefined ? "hidden" : undefined,
+            }}
+          >
+            {state.text}
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return { show, hide, tooltipNode };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -893,11 +893,26 @@ textarea,
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
   opacity: 0;
+  /* SVG glyph uses --text-secondary so it reads as a soft gray —
+     matches the design and avoids competing with the actual reaction
+     chips next to it. The reaction chips above still use
+     --text-primary because monochrome symbol-block codepoints take
+     CSS color, and we want those readable. */
+  color: var(--text-secondary);
   transition:
     background 120ms ease,
     border-color 120ms ease,
     color 120ms ease,
     opacity 120ms ease;
+}
+
+.thread-row__chip--add-reaction:hover,
+.thread-row__chip--add-reaction:focus-visible,
+.thread-row__chip--add-reaction.is-open {
+  /* Brighten the icon on the same gesture that brightens the chip
+     border + background, so the smiley doesn't stay muted while the
+     rest of the chip is in its active state. */
+  color: var(--text-primary);
 }
 
 .thread-row-shell:hover .thread-row__chip--add-reaction,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -181,6 +181,17 @@ textarea,
 
 .thread-header {
   padding-top: 10px;
+  /* Reserve space for the position:fixed context-rail spine (48px wide,
+     pinned top-right). Without this padding, anything we render in the
+     header's right-aligned region (messaging status icons, on/off
+     toggle) gets covered by the spine's hamburger button. */
+  padding-right: 56px;
+}
+
+.thread-view:has(.thread-view__layout.has-pinned-context-rail) .thread-header {
+  /* When the rail is pinned open, it pushes the layout left and is no
+     longer fixed at the screen edge — the header reclaims the space. */
+  padding-right: 0;
 }
 
 .thread-header button,
@@ -188,6 +199,196 @@ textarea,
 .thread-header a,
 .thread-header select {
   -webkit-app-region: no-drag;
+}
+
+.thread-header__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.messaging-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  -webkit-app-region: no-drag;
+}
+
+.messaging-status-bar * {
+  -webkit-app-region: no-drag;
+}
+
+.messaging-status-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.messaging-status-chip--enabled {
+  color: var(--text-primary);
+}
+
+.messaging-status-chip--errored {
+  color: var(--danger-text);
+}
+
+.messaging-status-chip__fallback {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.messaging-status-chip > .status-dot {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 7px;
+  height: 7px;
+  border: 1.5px solid var(--bg-panel);
+}
+
+/* Binding chip menu — small popover anchored to the chip wrap. The
+   chip itself uses the shared .thread-row__chip primitive; only the
+   menu has its own styling. */
+.thread-row__chip-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.thread-row__chip-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 30;
+  min-width: 200px;
+  padding: 6px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.thread-row__chip-menu-item {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.thread-row__chip-menu-item:hover {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.thread-row__chip-menu-hint {
+  margin: 4px 6px 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.messaging-status-chip--clickable {
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+.messaging-status-chip--clickable:hover {
+  color: var(--text-primary);
+}
+
+.messaging-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.messaging-activity-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.messaging-activity-row:last-child {
+  border-bottom: none;
+}
+
+.messaging-activity-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  flex: 0 0 auto;
+}
+
+.messaging-activity-row__icon--ok {
+  color: var(--success-text);
+}
+
+.messaging-activity-row__icon--warning {
+  color: var(--accent-bright);
+}
+
+.messaging-activity-row__icon--error {
+  color: var(--danger-text);
+}
+
+.messaging-activity-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.messaging-activity-row__line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.messaging-activity-row__summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.messaging-activity-row__meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
 }
 
 .sidebar__icon-button {
@@ -661,46 +862,37 @@ textarea,
   color: var(--accent-bright);
 }
 
-/* Reactions on thread rows. The strip sits as a sibling of the main row
-   button (not nested) because HTML disallows nested interactives. The
-   picker popover is anchored to the add-reaction button. */
+/* Reaction + add-reaction chips share the .thread-row__chip primitive
+   below; only their content (emoji glyph) differs from a meta chip.
+   These rules layer the per-variant tweaks (slightly larger glyph
+   font-size, hover-only visibility for the add chip) on top. */
 
-.thread-row__reactions {
-  display: flex;
-  position: absolute;
-  bottom: 8px;
-  left: 14px;
-  z-index: 2;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-}
-
-/* Reserve bottom space inside the row button so the reactions strip
-   (absolute-positioned at bottom-left) does not crash into the chip row. */
-.thread-row-shell:has(.thread-row__reactions) .thread-row {
-  padding-bottom: 42px;
-}
-
-.thread-row__reaction,
-.thread-row__add-reaction {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 28px;
-  min-width: 28px;
-  padding: 0 8px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 999px;
-  background: var(--bg-panel-elevated);
+.thread-row__chip--reaction,
+.thread-row__chip--add-reaction {
   /* Use primary text color, not secondary — colored emoji (✅ 👀 …)
      ignore CSS color anyway, but monochrome symbol-block codepoints
      (🅐 🅑 …) take this color, and secondary made them look alpha'd
      down compared to the colored emoji. Picker uses --text-primary too. */
   color: var(--text-primary);
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1;
   cursor: pointer;
+}
+
+.thread-row__chip--reaction:hover,
+.thread-row__chip--reaction:focus-visible,
+.thread-row__chip--add-reaction:hover,
+.thread-row__chip--add-reaction:focus-visible,
+.thread-row__chip--add-reaction.is-open {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  outline: none;
+}
+
+.thread-row__chip--add-reaction {
+  /* Mute the add affordance until the user is interacting with the
+     row; revealed on hover, focus, or while the picker is open. */
+  opacity: 0;
   transition:
     background 120ms ease,
     border-color 120ms ease,
@@ -708,38 +900,10 @@ textarea,
     opacity 120ms ease;
 }
 
-.thread-row__reaction:hover,
-.thread-row__reaction:focus-visible {
-  border-color: var(--accent-border);
-  background: var(--bg-row-active);
-  outline: none;
-}
-
-.thread-row__add-reaction {
-  width: 28px;
-  padding: 0;
-  font-weight: 700;
-  font-size: 16px;
-  opacity: 0;
-}
-
-.thread-row-shell:hover .thread-row__add-reaction,
-.thread-row__add-reaction:focus-visible,
-.thread-row__add-reaction[aria-expanded="true"] {
+.thread-row-shell:hover .thread-row__chip--add-reaction,
+.thread-row__chip--add-reaction:focus-visible,
+.thread-row__chip--add-reaction.is-open {
   opacity: 1;
-}
-
-.thread-row__add-reaction:hover,
-.thread-row__add-reaction:focus-visible,
-.thread-row__add-reaction[aria-expanded="true"] {
-  border-color: var(--accent-border);
-  background: var(--bg-row-active);
-  color: var(--accent-bright);
-  outline: none;
-}
-
-.thread-row__reaction-picker-wrap {
-  position: relative;
 }
 
 .reaction-picker {
@@ -774,7 +938,7 @@ textarea,
   color: var(--text-primary);
   font-size: 16px;
   line-height: 1;
-  /* Pair with .thread-row__reaction so the row chip matches the picker
+  /* Pair with .thread-row__chip--reaction so the row chip matches the picker
      option's rendering for ambiguous symbol-block codepoints. */
   font-variant-emoji: emoji;
   cursor: pointer;
@@ -943,10 +1107,24 @@ textarea,
   line-height: 1.45;
 }
 
-.thread-row__meta {
+/* Single ordered chip flow per thread row. All chip types — meta
+   (agent/mode/dir/branch/drift), PR chips, messaging binding chips,
+   reactions, add-reaction — render as siblings in this one wrapping
+   flex container. flex-wrap handles overflow naturally; no per-type
+   container, no absolute positioning. */
+.thread-row__chips {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
+}
+
+/* Focus ring for any role="button" chip in the flow (PR, binding,
+   reaction, add-reaction). Span-with-role doesn't get the browser's
+   default focus outline. */
+.thread-row__chips [role="button"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .thread-row__chip {
@@ -1082,12 +1260,6 @@ textarea,
    per the Tangerine Terminal thesis and use a desaturated violet only
    for the dot, not the whole chip. */
 
-.thread-row__pr-chips {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 4px;
-}
 
 .pr-chip {
   display: inline-flex;
@@ -1283,7 +1455,7 @@ textarea,
 }
 
 .directory-row__threads .thread-row__header,
-.directory-row__threads .thread-row__meta {
+.directory-row__threads .thread-row__chips {
   width: 100%;
 }
 
@@ -3830,6 +4002,29 @@ textarea,
   height: 2px;
   border-radius: 999px;
   background: currentColor;
+}
+
+/* Portal-rendered tooltip rendered by the useViewportTooltip hook.
+   Used when a CSS-pseudo `tooltip-target` would get clipped by an
+   ancestor's overflow:hidden / overflow:auto (sidebar scroll
+   region, overflow-hidden chip with text-ellipsis, etc.). */
+.viewport-tooltip {
+  position: fixed;
+  z-index: 90;
+  width: max-content;
+  max-width: min(420px, calc(100vw - 32px));
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: rgba(10, 10, 10, 0.98);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+  pointer-events: none;
+  text-align: left;
+  white-space: pre-wrap;
 }
 
 .context-rail__tooltip {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -40,6 +40,19 @@ export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
   "messaging:platform-status-event";
 export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
 export const MESSAGING_LIST_ACTIVITY_CHANNEL = "messaging:list-activity";
+/**
+ * Fired main → renderer whenever the messaging store has had bindings
+ * created, revoked, or had their conversation metadata change. The
+ * payload is intentionally minimal — receivers should refetch the
+ * navigation snapshot rather than try to apply per-binding diffs from
+ * the event itself. See `useThreadNavigation` for the renderer-side
+ * subscription, and `MessagingController.bindChannelToThread` /
+ * `syncConversationName` / `refreshBindingFromInbound` /
+ * `detachBinding` plus the `messaging:unbind-thread` IPC handler for
+ * the emit sites.
+ */
+export const MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL =
+  "messaging:bindings-changed";
 export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -34,6 +34,12 @@ export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
 export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
+export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
+  "messaging:get-platform-statuses";
+export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
+  "messaging:platform-status-event";
+export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
+export const MESSAGING_LIST_ACTIVITY_CHANNEL = "messaging:list-activity";
 export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =

--- a/docs/UI-THEME.md
+++ b/docs/UI-THEME.md
@@ -206,6 +206,48 @@ Hover, focus, selected, loading, and disabled states must not cause layout shift
 
 Focus states should be visible and tangerine-led, but contained so they do not create clipped halos or stray outlines.
 
+## Tooltips
+
+Two patterns. Pick the right one:
+
+**CSS pseudo-element tooltip** (`tooltip-target` + `data-tooltip` in
+`app.css`): cheapest and stateless. Use when the hovered element and
+all its ancestors render with `overflow: visible`. The tooltip is an
+`::after` pseudo-element positioned absolutely; any clipping ancestor
+(`overflow: hidden`, `overflow: auto`, `overflow: scroll`) chops it.
+
+```tsx
+<span className="… tooltip-target" data-tooltip={text}>…</span>
+```
+
+**Portal-rendered tooltip** (`useViewportTooltip` hook in
+`renderer/src/lib/useViewportTooltip.tsx`): when ANY ancestor clips —
+sidebar scroll regions, overflow-hidden chips with text-ellipsis,
+draggable rails. The hook renders the tooltip via `createPortal` to
+`document.body` with `position: fixed`, then clamps to viewport bounds
+via `useLayoutEffect` after measuring the rendered text.
+
+```tsx
+const { show, hide, tooltipNode } =
+  useViewportTooltip({ className: "viewport-tooltip" });
+return (
+  <span
+    onMouseEnter={(e) => show(e.currentTarget, "Multi\nline\ntext")}
+    onMouseLeave={hide}
+    onFocus={(e) => show(e.currentTarget, "Multi\nline\ntext")}
+    onBlur={hide}
+  >
+    …
+    {tooltipNode}
+  </span>
+);
+```
+
+Both honor `\n` for multi-line bodies via `white-space: pre-wrap`.
+
+Anti-pattern: native `title=` attribute. Inconsistent timing across
+platforms, can't be styled, no multi-line on macOS Electron.
+
 ## Accessibility
 
 Maintain strong contrast between text and surfaces. Critical states should not rely on color alone: pair color with text, shape, placement, iconography, or row treatment.

--- a/docs/plans/2026-05-05-003-fix-thread-row-unified-chip-flow-plan.md
+++ b/docs/plans/2026-05-05-003-fix-thread-row-unified-chip-flow-plan.md
@@ -1,0 +1,450 @@
+---
+title: Unified thread row chip flow (emojis, messaging bindings, PRs, branch)
+type: fix
+status: completed
+date: 2026-05-05
+supersedes:
+  - U3.2 chip-rendering bits in docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md
+  - U3.3 chip-rendering bits in docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md
+  - U4.3 chip-rendering bits in docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md
+---
+
+# Unified thread row chip flow
+
+## Overview
+
+Today every kind of chip on a thread row was bolted on independently:
+metadata chips (`ThreadMetaChips`) live in their own `<span>`, PR chips
+in their own wrapper, messaging binding chips in another wrapper, and
+emoji reactions in a third. Each ships with its own positioning rules
+and one-off margins. The result keeps breaking under small changes
+(see PR [#187](https://github.com/pwrdrvr/PwrAgent/pull/187) commit
+history for the recent thrash):
+
+- The binding chip was *inside* the row's main `<button>` and got eaten
+  by nested-button HTML rules.
+- Moving binding chips out of the button made them stack as a separate
+  line, which pushed the reaction `+` button into the chip's row.
+- Absolute-positioning the binding chip back on top of the row hides
+  it under the `+` button when both exist.
+
+This plan replaces all of that with a single, ordered, wrapping
+chip flow that renders every chip as a sibling — the same way a
+`flex-wrap` toolbar handles items of varying widths in any other
+modern UI.
+
+## Problem Statement / Motivation
+
+### What broke
+
+From [the design screenshot the user shipped](#) (sidebar mockup,
+2026-05-05): every chip on a thread row sits in one continuous,
+wrapping line directly under the title. There's no special slot for
+PR chips vs binding chips vs reactions. The emoji "add" affordance is
+an emoji glyph (a 🙂 face), not a `(+)` button, and it floats at the
+end of the chip row — wrapping onto the next line when it doesn't
+fit, exactly like every other chip.
+
+### What's in the code today
+
+- [ThreadRow.tsx:142](apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx)
+  renders four sibling chip groups inside (and one outside) the main
+  `<button>`:
+  1. `<ThreadMetaChips>` (agent type, mode, worktree/local, branch,
+     drift) — `<span class="thread-row__meta">` with `flex-wrap: wrap`,
+     **inside** the button.
+  2. `<span class="thread-row__pr-chips">` — separate flex-wrap
+     container, **inside** the button. Each PR chip is a real
+     `<button class="pr-chip">` ([PrChip.tsx:18](apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx)).
+  3. `<div class="thread-row__binding-chips">` — separate container,
+     **outside** the button (moved out to dodge nested-button click
+     eating). Each binding chip is a real `<button>`.
+  4. `<div class="thread-row__reactions">` — separate container,
+     **outside** the button. Each reaction is a real `<button>`. The
+     add-reaction trigger is a real `<button>` rendering literal
+     `<span aria-hidden="true">+</span>`
+     ([ThreadRow.tsx:216](apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx#L216)).
+
+Two unrelated CSS hacks try to keep these four containers from
+overlapping:
+
+- [app.css:867](apps/desktop/src/renderer/src/styles/app.css#L867) —
+  `.thread-row-shell:has(.thread-row__binding-chips) .thread-row {
+  padding-bottom: 36px; }` reserves room.
+- [app.css:261](apps/desktop/src/renderer/src/styles/app.css#L261) —
+  `.thread-row__binding-chips { position: absolute; left: 14px;
+  bottom: 10px; ... }` re-overlays the chip back into the row.
+
+Every time we touch a chip group, one of these escapes its lane and
+overlaps another.
+
+### Root cause
+
+There is no shared concept of "the row's chip area." Each chip type
+ships its own container with its own positioning rules. The fix is to
+collapse them into one container and let `flex-wrap` do the work the
+CSS spec was designed for.
+
+## Proposed Solution
+
+One chip flow per row. Wrap. Order. No special positioning.
+
+### Single `.thread-row__chips` container
+
+Replace the four separate containers with **one**:
+
+```tsx
+<span className="thread-row__chips">
+  {metaChips}
+  {prChips}
+  {bindingChips}
+  {reactionChips}
+  {addReactionChip /* always last when canReact */}
+</span>
+```
+
+CSS:
+
+```css
+.thread-row__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  /* No position:absolute. No special padding. No :has() hacks. */
+}
+```
+
+### Chip ordering (left → right, then wrapping onto next line)
+
+1. **Agent type** (Codex / Grok)
+2. **Mode** (Plan / Read-only / Full Access) when present
+3. **Linked directory kind** (worktree / local / workspace) — when
+   `includeLinkedDirectories` is on
+4. **Branch** (with branch icon, monospace text)
+5. **Branch drift** ("now <observedBranch>") when drifted
+6. **PR chips** (one per linked PR; `#NNN` or `org/repo#NNN`)
+7. **Messaging binding chips** (one per active binding; platform icon
+   + optional conversation title)
+8. **Emoji reactions** (in insertion order)
+9. **Add-reaction chip** — always the *last* item when `canReact`
+
+This order matches the user's directive in the planning request:
+*"agent type, worktree/local, branch, pr chips, message binding chips,
+emojis, emoji adder."*
+
+### Add-reaction is a real emoji, not "(+)"
+
+Render a slightly-grayed smiley face glyph (`🙂` — same one used by
+GitHub's add-reaction affordance). Reactions are already explicitly
+exempted from the no-emoji-as-icon rule by
+[ReactionPicker.tsx:10](apps/desktop/src/renderer/src/features/navigation/ReactionPicker.tsx#L10),
+so this is consistent with the existing "reactions are content" rule
+in `docs/UI-THEME.md`.
+
+The chip itself is the same chip primitive as the others (same height,
+same border-radius, same hover treatment). Only the inner glyph
+differs.
+
+### Click handling: spans, not nested buttons
+
+The thread row's main click target is the row-wide `<button
+class="thread-row">` that selects the thread. Today we have **real
+nested `<button>` elements** for PR chips, binding chips, reactions,
+and add-reaction. That's invalid HTML and is the original cause of
+the click-eating bug.
+
+Fix: every interactive chip becomes a `<span role="button" tabIndex=0>`
+with `onClick` + `onKeyDown` (Enter / Space) handlers that call
+`event.stopPropagation()`. This is the **same pattern already used by
+the path-copy chips** in
+[ThreadMetaChips.tsx:36](apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx#L36)
+— proven to work, no nested-button warning from React.
+
+### Compact rows (DirectoriesList)
+
+`thread-row--compact` (used in
+[DirectoriesList.tsx](apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx))
+flips the row to `flex-direction: row`. The single chip flow still
+applies — the chips wrap onto a second line when the row narrows,
+which is what they already do today via `flex-wrap: wrap` inside
+`.thread-row__meta`. No special compact rules.
+
+### What gets deleted
+
+From `app.css`:
+
+- `.thread-row__pr-chips` rules (lines 1336-1341).
+- `.thread-row__binding-chips` rules (lines 261+).
+- `.thread-row-shell:has(.thread-row__binding-chips) .thread-row {
+  padding-bottom: 36px; }` (lines 867+).
+- `.thread-row__reactions` and the per-reaction button rules
+  (lines 919+, 936+, 962+, 969+, 977+).
+- `.thread-row__add-reaction` rules (it's now a chip).
+- `.thread-row__reaction-picker-wrap` (the picker portal mounts via
+  `ReactionPicker`'s own portal — the wrap is only for absolute
+  positioning of a hidden picker, no longer needed).
+
+From JSX:
+
+- The four separate chip containers in
+  [ThreadRow.tsx:142-231](apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx).
+
+## Technical Considerations
+
+### Architecture impact
+
+- **One container, one set of rules.** Future chip additions (e.g.
+  the "ignored sender" badge floated in U4.4 follow-ups) drop in
+  trivially.
+- **`flex-wrap: wrap` does layout.** No JS measurements, no
+  intersection observers, no `:has()` hacks.
+- **No nested `<button>` elements** anywhere in `ThreadRow`. The row
+  itself stays a `<button>` for "select thread"; everything inside is
+  a span.
+
+### Accessibility
+
+- **Tab order.** Each `role="button"` chip with `tabIndex={0}` enters
+  the keyboard tab order. In a long sidebar with many chips, this is
+  a lot of tab stops. **Decision**: only chips with their own click
+  behavior (PR chip → opens URL, binding chip → opens menu, reaction
+  → toggles, add-reaction → opens picker) are tabbable. Static chips
+  (agent type, mode, branch label) stay as plain spans without
+  `tabIndex`.
+- **Screen-reader semantics.** The row `<button>` already has
+  `aria-pressed={selected}` and a label derived from
+  `props.thread.title`. Each interactive chip carries its own
+  `aria-label` (already true for PR chips, binding chips, reactions).
+- **Focus rings.** A 2px outline (`outline: 2px solid var(--accent);
+  outline-offset: 2px`) on `:focus-visible` for chip spans, matching
+  the existing `tooltip-target:focus-visible` rule.
+
+### Performance
+
+- The renderer cost is the same — same number of DOM nodes, same
+  React reconciliation. We're moving rules around, not adding work.
+- `flex-wrap` is GPU-friendly on macOS. No layout thrash.
+
+### Visual consistency
+
+All chips share the same primitive class (`thread-row__chip`) — same
+24px height, 12px border-radius, 6px internal gap, 8px padding,
+12px font, 500 weight. Variant classes (`--backend`, `--mode`, `--mono`,
+`--muted`, `--approval`, `pr-chip--<state>`) override only color and
+border. The reaction chip and add-reaction chip should adopt the same
+primitive (currently they're 22-24px depending on glyph metrics).
+
+## System-Wide Impact
+
+### Interaction graph
+
+- `ThreadRow` is rendered by `InboxList`, `RecentsList`,
+  `DirectoriesList` — all three pass the same set of callbacks. No
+  consumer needs to change.
+- `ReactionPicker` portals into the document body and anchors via
+  `anchorRef`. The anchor element changes from a `<button>` to a
+  `<span>` — but `anchorRef` is typed `RefObject<HTMLElement>` so this
+  works without a signature change.
+
+### Error & failure propagation
+
+No new failure modes. Click handlers continue to call the same
+callbacks (`onSelectThread`, `onUnbindMessagingBinding`,
+`onSetReaction`, `onOpenPullRequest`). Errors flow up to the same
+parent handlers in `App.tsx`.
+
+### State lifecycle risks
+
+None. This is a render-layer refactor — no state changes, no new
+persistence, no IPC.
+
+### API surface parity
+
+- `BindingChip` and the reaction-picker invocation move into the new
+  flow but expose the same props. `PrChip` keeps its existing
+  signature.
+- The `ReactionPicker`'s `anchorRef` accepts `HTMLElement | null` —
+  works for both `<button>` (today) and `<span>` (after).
+
+### Integration test scenarios
+
+- Click a PR chip → opens PR URL (existing test in
+  `apps/desktop/e2e/`).
+- Click a binding chip → opens unbind menu (no existing test;
+  recommend an E2E spec gets added).
+- Click an emoji reaction → toggles it (existing).
+- Click add-reaction (smiley) → opens picker (existing).
+- Right-click anywhere on the row → opens context menu (the row's
+  `onContextMenu` is on the outer `.thread-row-shell` `<div>` and
+  fires regardless of which child was hovered).
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] Every chip on a thread row renders inside a single
+  `.thread-row__chips` flex container with `flex-wrap: wrap`.
+- [ ] The chip order (left-to-right, then wrapping) is exactly: agent
+  type → mode → linked-dir → branch → drift → PR chips → binding
+  chips → reactions → add-reaction.
+- [ ] Add-reaction is a smiley emoji (`🙂`), not `+`.
+- [ ] Add-reaction is the last item in the chip flow when
+  `canReact === true`.
+- [ ] Clicking a PR chip opens its URL — no thread selection
+  side-effect.
+- [ ] Clicking a binding chip opens the unbind menu — no thread
+  selection side-effect.
+- [ ] Clicking a reaction toggles it — no thread selection
+  side-effect.
+- [ ] Clicking add-reaction opens the picker — no thread selection
+  side-effect.
+- [ ] Clicking anywhere else on the row selects the thread.
+- [ ] Right-clicking the row opens the existing context menu (which
+  also lists "Unbind from <platform>" when bindings exist — already
+  implemented in PR #187).
+
+### Non-functional
+
+- [ ] No `position: absolute` on any chip group container.
+- [ ] No `:has()` selector reserving padding-bottom for any chip
+  group.
+- [ ] No nested `<button>` elements inside `ThreadRow`. The row
+  itself is the only `<button>`; chips are `<span role="button">`.
+- [ ] Compact rows (DirectoriesList) wrap chips onto a second line
+  when needed; no horizontal scroll, no clipped chips.
+- [ ] `prefers-reduced-motion: reduce` continues to disable any
+  blink/animation on chip dots.
+
+### Quality gates
+
+- [ ] All existing renderer tests under
+  `apps/desktop/src/renderer/src/__tests__/` still pass without
+  modification (or with mechanical class-name updates only).
+- [ ] No new TypeScript errors.
+- [ ] Linting clean (`pnpm lint`).
+- [ ] Theme contract test still passes.
+
+## Implementation Phases
+
+The work is small enough to land in a single PR but reviewers will
+appreciate the change set being broken into commits.
+
+### Phase A — Refactor chip primitives to spans (no visual change)
+
+- Convert `PrChip` from `<button>` to
+  `<span role="button" tabIndex={0}>` with `onClick` + `onKeyDown`
+  (Enter/Space). Keep all existing classes and aria-labels.
+- Convert `BindingChip`'s outer `<button>` to a span (the menu trigger
+  becomes a span). Keep the menu items as real `<button>` elements
+  (they live in a portal, not nested).
+- Convert reaction `<button>` and add-reaction `<button>` in
+  `ThreadRow.tsx` to spans with the same handlers.
+- Verify in dev build: clicking each chip type still works.
+
+### Phase B — Collapse to one chip-flow container
+
+- In `ThreadRow.tsx`, replace the four separate chip containers with
+  a single `<span class="thread-row__chips">` that contains, in
+  order: meta chips, PR chips, binding chips, reaction chips, add-
+  reaction chip.
+- `ThreadMetaChips` returns its current set of chip spans (no longer
+  wrapped in `<span class="thread-row__meta">`) so they can flow as
+  siblings inside the new container. Keep its `key`s stable.
+- Move binding-chip rendering BACK inside the row's main `<button>`
+  (now safe because it's a span not a nested button).
+- Add `.thread-row__chips` CSS rule.
+
+### Phase C — Replace `+` add-reaction with smiley emoji
+
+- Swap the literal `+` glyph for `🙂` in `ThreadRow.tsx`.
+- Keep the chip's height/padding aligned with other chips so it
+  looks like one of them, not a special button.
+
+### Phase D — Delete dead CSS
+
+- Remove `.thread-row__meta`, `.thread-row__pr-chips`,
+  `.thread-row__binding-chips`, `.thread-row__reactions`,
+  `.thread-row__reaction`, `.thread-row__add-reaction`,
+  `.thread-row__reaction-picker-wrap`, the `:has()` padding rule,
+  and the absolute-positioning rule.
+- Re-verify visual in dev build against the user's design screenshot.
+
+### Phase E — Visual QA + screenshot
+
+- Reload the dev build, exercise:
+  - thread with reactions only,
+  - thread with PR chips + reactions,
+  - thread with binding chips + PR chips + reactions,
+  - thread with everything (long branch name forces a wrap).
+- Capture before/after screenshots for the PR.
+
+## Alternative Approaches Considered
+
+1. **Keep separate containers, fix layout via grid.** Rejected — same
+   coupling problem, just a different way to express it. Each chip
+   type still owns its slot; new types still need new rules.
+
+2. **Move all chips outside the main `<button>`, replace the row
+   button with a `role="link"` div.** Rejected — selecting the
+   thread is fundamentally a button action, not a navigation. The
+   `<button>` semantics give us correct keyboard behavior
+   (Space/Enter to activate, focus styling) for free. The
+   nested-button problem is a child-element problem, not a parent
+   problem.
+
+3. **Render every chip as a real `<button>` and absolute-position
+   each independently.** This is what we kept doing in piecemeal
+   fixes. Rejected — that's what got us into this mess.
+
+## Dependencies & Risks
+
+- **No backend or contract changes.** Pure renderer refactor.
+- **Risk: focus styling regression.** Switching from `<button>` to
+  `<span role="button">` removes the browser-default focus outline.
+  Mitigation: explicit `:focus-visible` rule in CSS that already
+  exists for `.tooltip-target`; extend to `.thread-row__chips
+  > [role="button"]:focus-visible`.
+- **Risk: existing renderer tests query by `getByRole('button',
+  ...)`.** Spans with `role="button"` still match `getByRole('button')`
+  — verified against testing-library docs. No fixture changes
+  expected.
+- **Risk: keyboard space-bar scrolling.** When a span with
+  `role="button"` is focused, pressing Space should activate it
+  (not scroll the page). The `onKeyDown` handler must
+  `event.preventDefault()` for Space — same as the existing
+  path-copy chips (which already do this).
+
+## Sources & References
+
+### Internal references
+
+- Existing pattern (proven): path-copy chips at
+  [ThreadMetaChips.tsx:36](apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx#L36)
+- Reactions exemption from no-emoji-as-icon rule:
+  [ReactionPicker.tsx:10](apps/desktop/src/renderer/src/features/navigation/ReactionPicker.tsx#L10)
+- Recent thrash this plan supersedes: PR
+  [#187](https://github.com/pwrdrvr/PwrAgent/pull/187) commits
+  `b34d4f5b` (move out of button), `fd37858d` (absolute-position
+  back), the original U4.3 commit `e11f5fb3` (introduce binding
+  chip).
+- Design intent: the user-shared sidebar mockup (2026-05-05),
+  showing one chip flow per row with messaging icons next to title
+  and chips below in a single wrapping group.
+
+### Parent plan
+
+- [docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md](docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md)
+  — Phase 3 (U3.2 reactions, U3.3 PR chips) and Phase 4 (U4.3
+  bindings). This plan supersedes the chip-rendering portions of
+  those units. The runtime / IPC / persistence portions of U3.2,
+  U3.3, U4.3 are unchanged.
+
+### What I am NOT changing
+
+- Reaction picker's contents and ordering.
+- PR chip color tokens.
+- Messaging binding storage / IPC / unbind menu contents.
+- Right-click context menu (the unbind entries added in PR #187 stay).
+- The header messaging status indicators (those live in
+  `MessagingStatusBar`, not `ThreadRow`).

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -227,10 +227,19 @@ export function buildNavigationSnapshotHash(params: {
         state: pr.state,
         url: pr.url,
       })),
+      // Include the breadcrumb fields (parentTitle / ancestorTitle) in
+      // the hash so the controller's `refreshBindingFromInbound`
+      // self-heal — which fills these in lazily when the first inbound
+      // event after a bind carries fresher ancestry — actually
+      // propagates to the renderer. Without them the next snapshot tick
+      // computes an identical hash, marks it unchanged, and the chip
+      // tooltip stays on the stale value (issue #191).
       messagingBindings: (thread.messagingBindings ?? []).map((binding) => ({
         bindingId: binding.bindingId,
         platform: binding.platform,
         conversationTitle: binding.conversationTitle ?? null,
+        parentTitle: binding.parentTitle ?? null,
+        ancestorTitle: binding.ancestorTitle ?? null,
       })),
     })),
     directories: (params.directories ?? []).map((directory) => ({

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -4,6 +4,7 @@ import type {
   AppServerBackendScope,
   AppServerThreadSummary,
   LinkedDirectorySummary,
+  MessagingThreadBindingSummary,
   NavigationSnapshot,
   NavigationThreadSummary,
   NavigationLaunchpadDefaults,
@@ -70,6 +71,13 @@ export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
+  /**
+   * Active messaging bindings per thread, keyed by thread identity key.
+   * Sourced from the desktop's messaging store (sqlite). When omitted,
+   * threads have no `messagingBindings` field — non-desktop callers
+   * (tests, server-side use) don't need to wire it.
+   */
+  messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
 }): NavigationThreadSummary[] {
@@ -87,6 +95,7 @@ export function materializeNavigationThreads(params: {
       (overlay?.observedGitBranch && hasHandoffWorkspace(overlay.extraLinkedDirectories)
         ? overlay.observedGitBranch
         : undefined);
+    const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
 
     return {
       ...thread,
@@ -102,6 +111,9 @@ export function materializeNavigationThreads(params: {
       worktreeSnapshots: overlay?.worktreeSnapshots ?? thread.worktreeSnapshots ?? [],
       reactions: overlay?.reactions ?? [],
       prs: overlay?.prs ?? [],
+      messagingBindings: messagingBindings && messagingBindings.length > 0
+        ? messagingBindings
+        : undefined,
       inbox: deriveInboxState({
         firstSnapshot: params.firstSnapshot,
         isNewThread: !previousKnownThreadKeys.has(threadKey),
@@ -121,6 +133,7 @@ export function buildNavigationSnapshot(params: {
   gitStatusByDirectoryKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
   launchpadDefaults?: NavigationLaunchpadDefaults;
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
+  messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummary[];
@@ -130,6 +143,7 @@ export function buildNavigationSnapshot(params: {
     firstSnapshot: params.firstSnapshot,
     now: params.now,
     overlayByThreadKey: params.overlayByThreadKey,
+    messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
     previousKnownThreadKeys: params.previousKnownThreadKeys,
     threads: params.threads,
   });
@@ -212,6 +226,11 @@ export function buildNavigationSnapshotHash(params: {
         repo: pr.repo,
         state: pr.state,
         url: pr.url,
+      })),
+      messagingBindings: (thread.messagingBindings ?? []).map((binding) => ({
+        bindingId: binding.bindingId,
+        platform: binding.platform,
+        conversationTitle: binding.conversationTitle ?? null,
       })),
     })),
     directories: (params.directories ?? []).map((directory) => ({

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -100,7 +100,21 @@ export type MessagingConversationRef = {
   id: string;
   kind: MessagingConversationKind;
   parentId?: string;
+  /**
+   * Title of this conversation node (DM peer, channel, topic, thread).
+   * Optional — adapters populate when the platform makes it cheap.
+   */
   title?: string;
+  /**
+   * Title of the immediate parent conversation. Used by chip
+   * breadcrumbs: Telegram topic → supergroup name; Discord channel →
+   * guild name; Discord thread → parent channel name.
+   */
+  parentTitle?: string;
+  /**
+   * Two levels up. Today: Discord threads — the guild name.
+   */
+  ancestorTitle?: string;
 };
 
 export type MessagingActorIdentity = {

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -281,6 +281,8 @@ function createApi(overrides: Partial<DiscordApi> = {}): DiscordApi {
       id: "message-2",
     }),
     deleteApplicationCommand: async () => {},
+    getChannel: async (id: string) => ({ id }),
+    getGuild: async (id: string) => ({ id }),
     listApplicationCommands: async () => [],
     pinMessage: async () => {},
     sendTyping: async () => {},

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -178,7 +178,21 @@ export type DiscordGatewayConnection = {
   start(): Promise<void>;
 };
 
+export type DiscordChannelInfo = {
+  id: string;
+  name?: string;
+  /** Set when the channel is a thread; points at the parent channel. */
+  parentId?: string;
+};
+
+export type DiscordGuildInfo = {
+  id: string;
+  name?: string;
+};
+
 export type DiscordApi = DiscordApplicationCommandApi & {
+  getChannel(channelId: string): Promise<DiscordChannelInfo>;
+  getGuild(guildId: string): Promise<DiscordGuildInfo>;
   updateChannelName(channelId: string, request: { name: string }): Promise<void>;
   createInteractionResponse(
     interactionId: string,
@@ -268,6 +282,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private componentBindings = new Map<string, DiscordComponentBinding>();
   private defaultApi?: DiscordApi;
   private defaultGateway?: DiscordGatewayConnection;
+  /**
+   * Per-process caches for channel + guild lookups used to populate
+   * conversation breadcrumb metadata (channel name, parent channel
+   * name for threads, guild name). Names change rarely; one REST
+   * fetch per id per process is sufficient.
+   */
+  private readonly channelCache = new Map<string, DiscordChannelInfo>();
+  private readonly guildCache = new Map<string, DiscordGuildInfo>();
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private readonly options: DiscordAdapterOptions;
   private streamSurfaces = new Map<string, string>();
@@ -633,7 +655,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       return;
     }
 
-    const channel = this.channelFromDiscord(message.channel_id, message.guild_id);
+    const channel = await this.channelFromDiscord(message.channel_id, message.guild_id, {
+      // Best-effort DM peer name from the message author when the
+      // conversation is a DM (no guild). Channel + thread breadcrumbs
+      // are resolved via REST inside channelFromDiscord (cached).
+      dmPeerName: message.guild_id
+        ? undefined
+        : (message.author.global_name ?? message.author.username),
+    });
     const receivedAt = this.now();
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
       channelType: message.channel_type,
@@ -730,11 +759,15 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
 
     const binding = this.componentBindings.get(customId);
+    const channel = await this.channelFromDiscord(
+      interaction.channel_id,
+      interaction.guild_id,
+    );
     await listener({
       id: `discord:interaction:${interaction.id}`,
       kind: "callback",
       actor: this.actorFromUser(actor, interaction.member?.nick ?? undefined),
-      channel: this.channelFromDiscord(interaction.channel_id, interaction.guild_id),
+      channel,
       interaction: {
         channel: this.channel,
         id: customId,
@@ -770,12 +803,16 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
 
     const args = commandArgsFromOptions(interaction.data?.options);
+    const channel = await this.channelFromDiscord(
+      interaction.channel_id,
+      interaction.guild_id,
+    );
     await listener({
       id: `discord:command:${interaction.id}`,
       kind: "command",
       actor: this.actorFromUser(actor, interaction.member?.nick ?? undefined),
       args,
-      channel: this.channelFromDiscord(interaction.channel_id, interaction.guild_id),
+      channel,
       command: commandName,
       rawText: [`/${commandName}`, ...args].join(" ").trim(),
       receivedAt: this.now(),
@@ -1058,18 +1095,102 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     );
   }
 
-  private channelFromDiscord(
+  private async channelFromDiscord(
     channelId: string,
     guildId: string | undefined,
-  ): MessagingInboundEvent["channel"] {
+    options?: { dmPeerName?: string },
+  ): Promise<MessagingInboundEvent["channel"]> {
+    if (!guildId) {
+      // DM — title from the peer's display name; no parent.
+      return {
+        channel: this.channel,
+        conversation: {
+          id: channelId,
+          kind: "dm",
+          title: options?.dmPeerName,
+        },
+      };
+    }
+    // Guild-channel-or-thread. We keep kind="channel" for both
+    // regular channels and threads — kind is part of the conversation
+    // key used for binding lookup, so flipping to kind="thread" would
+    // make legacy thread bindings unfindable. Thread vs channel is
+    // distinguishable from data shape (ancestorTitle populated → it
+    // came from a thread).
+    const breadcrumbs = await this.lookupChannelBreadcrumbs(
+      channelId,
+      guildId,
+    );
     return {
       channel: this.channel,
       conversation: {
         id: channelId,
-        kind: guildId ? "channel" : "dm",
+        kind: "channel",
         parentId: guildId,
+        title: breadcrumbs.channelName,
+        parentTitle: breadcrumbs.parentChannelName ?? breadcrumbs.guildName,
+        ancestorTitle: breadcrumbs.parentChannelName
+          ? breadcrumbs.guildName
+          : undefined,
       },
     };
+  }
+
+  /**
+   * Resolve channel + guild + (for threads) parent-channel names via
+   * the Discord REST API, with an unbounded in-memory cache keyed by
+   * id. Names rarely change; one fetch per id per process is plenty.
+   * Failures fall through to undefined — the chip falls back to the
+   * literal placeholder. We never throw out of this path because the
+   * adapter listener that called us must keep routing inbound traffic.
+   */
+  private async lookupChannelBreadcrumbs(
+    channelId: string,
+    guildId: string,
+  ): Promise<{
+    channelName?: string;
+    parentChannelName?: string;
+    guildName?: string;
+  }> {
+    const channel = await this.cachedChannel(channelId);
+    let parentChannel: DiscordChannelInfo | undefined;
+    if (channel?.parentId) {
+      parentChannel = await this.cachedChannel(channel.parentId);
+    }
+    const guild = await this.cachedGuild(guildId);
+    return {
+      channelName: channel?.name,
+      parentChannelName: parentChannel?.name,
+      guildName: guild?.name,
+    };
+  }
+
+  private async cachedChannel(
+    channelId: string,
+  ): Promise<DiscordChannelInfo | undefined> {
+    const cached = this.channelCache.get(channelId);
+    if (cached) return cached;
+    try {
+      const fresh = await this.api.getChannel(channelId);
+      this.channelCache.set(channelId, fresh);
+      return fresh;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async cachedGuild(
+    guildId: string,
+  ): Promise<DiscordGuildInfo | undefined> {
+    const cached = this.guildCache.get(guildId);
+    if (cached) return cached;
+    try {
+      const fresh = await this.api.getGuild(guildId);
+      this.guildCache.set(guildId, fresh);
+      return fresh;
+    } catch {
+      return undefined;
+    }
   }
 
   private actorFromUser(
@@ -1286,6 +1407,27 @@ class DiscordRestApi implements DiscordApi {
     return (await this.rest.post(Routes.applicationCommands(applicationId), {
       body: command,
     })) as DiscordApplicationCommand;
+  }
+
+  async getChannel(channelId: string): Promise<DiscordChannelInfo> {
+    const raw = (await this.rest.get(Routes.channel(channelId))) as {
+      id: string;
+      name?: string;
+      parent_id?: string | null;
+    };
+    return {
+      id: raw.id,
+      name: raw.name ?? undefined,
+      parentId: raw.parent_id ?? undefined,
+    };
+  }
+
+  async getGuild(guildId: string): Promise<DiscordGuildInfo> {
+    const raw = (await this.rest.get(Routes.guild(guildId))) as {
+      id: string;
+      name?: string;
+    };
+    return { id: raw.id, name: raw.name ?? undefined };
   }
 
   async createMessage(

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -287,7 +287,15 @@ export class DiscordAdapter implements DiscordProviderAdapter {
    * conversation breadcrumb metadata (channel name, parent channel
    * name for threads, guild name). Names change rarely; one REST
    * fetch per id per process is sufficient.
+   *
+   * Bounded LRU (insertion-order Map + eviction at the cap) so a
+   * long-running session bound to a busy server can't grow these
+   * caches without bound. Names change rarely so eviction is cheap to
+   * recover from — worst case is one extra REST round-trip on
+   * inbound. Cap is generous: real Discord servers rarely have >500
+   * named channels.
    */
+  private static readonly BREADCRUMB_CACHE_CAP = 500;
   private readonly channelCache = new Map<string, DiscordChannelInfo>();
   private readonly guildCache = new Map<string, DiscordGuildInfo>();
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
@@ -1169,10 +1177,16 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     channelId: string,
   ): Promise<DiscordChannelInfo | undefined> {
     const cached = this.channelCache.get(channelId);
-    if (cached) return cached;
+    if (cached) {
+      // LRU touch: re-insert to move to end so eviction picks the
+      // genuinely-coldest entry, not the one we just used.
+      this.channelCache.delete(channelId);
+      this.channelCache.set(channelId, cached);
+      return cached;
+    }
     try {
       const fresh = await this.api.getChannel(channelId);
-      this.channelCache.set(channelId, fresh);
+      this.setLruEntry(this.channelCache, channelId, fresh);
       return fresh;
     } catch {
       return undefined;
@@ -1183,13 +1197,28 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     guildId: string,
   ): Promise<DiscordGuildInfo | undefined> {
     const cached = this.guildCache.get(guildId);
-    if (cached) return cached;
+    if (cached) {
+      this.guildCache.delete(guildId);
+      this.guildCache.set(guildId, cached);
+      return cached;
+    }
     try {
       const fresh = await this.api.getGuild(guildId);
-      this.guildCache.set(guildId, fresh);
+      this.setLruEntry(this.guildCache, guildId, fresh);
       return fresh;
     } catch {
       return undefined;
+    }
+  }
+
+  private setLruEntry<V>(map: Map<string, V>, key: string, value: V): void {
+    map.set(key, value);
+    while (map.size > DiscordAdapter.BREADCRUMB_CACHE_CAP) {
+      // Map iteration is insertion-ordered; the first key is the
+      // oldest. Bail if the iterator yields nothing (defensive).
+      const oldest = map.keys().next();
+      if (oldest.done) break;
+      map.delete(oldest.value);
     }
   }
 

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -375,6 +375,25 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private streamRateLimits = new Map<string, TelegramStreamRateLimitState>();
   private streamSurfaces = new Map<string, TelegramDeliveryTarget>();
+  /**
+   * Per-process cache of forum topic names, keyed by
+   * `${chatId}:${messageThreadId}`. Telegram's Bot API does not expose
+   * a "fetch topic name" endpoint — the name only ships on the
+   * `forum_topic_created` and `forum_topic_edited` service messages.
+   * We capture those messages (which we otherwise ignore as service
+   * traffic) so that subsequent regular messages in the same topic
+   * can carry the topic name on their `MessagingChannelRef.title`.
+   * This is what makes external renames-via-Telegram-client propagate
+   * to the desktop chip.
+   *
+   * Bounded LRU (insertion-order Map + eviction at the cap). Cap is
+   * generous — most users have under a few dozen active topics; the
+   * cap protects against long-running sessions in extreme cases.
+   * Worst case on eviction is one extra "Topic" placeholder until the
+   * next `forum_topic_edited` message arrives.
+   */
+  private static readonly TOPIC_NAME_CACHE_CAP = 500;
+  private readonly topicNameCache = new Map<string, string>();
   private readonly options: {
     api?: TelegramBotApi;
     bot?: TelegramBotLike;
@@ -854,6 +873,17 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         message_thread_id: target.messageThreadId,
         name: title,
       });
+      // Pre-populate the topic-name cache with the value we just set.
+      // The gateway will also send a `forum_topic_edited` echo that
+      // would update the cache, but writing here avoids a brief
+      // window where the chip still shows the old name.
+      this.topicNameCache.delete(
+        this.topicCacheKey(target.chatId, target.messageThreadId),
+      );
+      this.topicNameCache.set(
+        this.topicCacheKey(target.chatId, target.messageThreadId),
+        title,
+      );
       return {
         channel: this.channel,
         conversation: {
@@ -898,6 +928,11 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     const serviceMessageReason = telegramServiceMessageReason(message);
     if (serviceMessageReason || this.isOwnBotUser(message.from)) {
+      // Forum topic create/edit service messages carry the topic name
+      // — capture it before the early-return so the next regular
+      // message in that topic can populate `channel.conversation.title`
+      // for the binding chip. Telegram has no other API to fetch this.
+      this.captureForumTopicNameIfPresent(message);
       this.options.logger?.debug(
         `telegram inbound ignored update=${updateId} message=${message.message_id} reason=${serviceMessageReason ?? "own_bot"} chat=${message.chat.id}`,
       );
@@ -1581,19 +1616,23 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     if (message.message_thread_id) {
       // Topic-bound messages: title slot belongs to the topic itself.
-      // The supergroup name is the parent breadcrumb. Telegram bot API
-      // doesn't ship topic names on every message — when missing,
-      // chip falls back to "SG: <supergroup>" via the renderer-side
-      // formatter (no breadcrumb after the slash).
+      // Look up the cached topic name (populated from
+      // `forum_topic_created` / `forum_topic_edited` service messages
+      // — see `captureForumTopicNameIfPresent`). When the cache misses
+      // (bot joined the chat after topic creation, no rename has
+      // happened since), title stays undefined and the renderer falls
+      // back to a literal "Topic" placeholder.
+      const topicTitle = this.lookupTopicName(
+        message.chat.id,
+        message.message_thread_id,
+      );
       return {
         channel: this.channel,
         conversation: {
           id: String(message.message_thread_id),
           kind: "topic",
           parentId: String(message.chat.id),
-          // TODO: fetch + cache forum topic title via getForumTopicIcon
-          //       so chips can render "SG: PwrDrvr/General". For now
-          //       leave the topic node title undefined.
+          title: topicTitle,
           parentTitle: chatTitle,
         },
       };
@@ -1635,6 +1674,60 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         messageThreadId: message.message_thread_id ?? null,
       },
     };
+  }
+
+  /**
+   * Cache the forum topic name when a `forum_topic_created` or
+   * `forum_topic_edited` service message arrives. Both messages carry
+   * the topic id in `message_thread_id` and the new name on the
+   * service-message payload. `forum_topic_edited.name` is optional
+   * because rename messages can also change just the icon — we skip
+   * those (no name → nothing to cache).
+   */
+  private captureForumTopicNameIfPresent(message: TelegramMessage): void {
+    if (!message.message_thread_id) return;
+    const name =
+      message.forum_topic_created?.name ??
+      message.forum_topic_edited?.name;
+    if (!name) return;
+    const key = this.topicCacheKey(message.chat.id, message.message_thread_id);
+    // LRU: re-insert on update so the cache picks the genuinely-coldest
+    // entry on eviction, not the one we just refreshed.
+    this.topicNameCache.delete(key);
+    this.topicNameCache.set(key, name);
+    while (this.topicNameCache.size > TelegramAdapter.TOPIC_NAME_CACHE_CAP) {
+      const oldest = this.topicNameCache.keys().next();
+      if (oldest.done) break;
+      this.topicNameCache.delete(oldest.value);
+    }
+  }
+
+  private lookupTopicName(
+    chatId: number | string,
+    messageThreadId: number,
+  ): string | undefined {
+    const key = this.topicCacheKey(chatId, messageThreadId);
+    const cached = this.topicNameCache.get(key);
+    if (cached !== undefined) {
+      // LRU touch — re-insert at the back so frequently-active topics
+      // aren't evicted ahead of cold ones.
+      this.topicNameCache.delete(key);
+      this.topicNameCache.set(key, cached);
+    }
+    return cached;
+  }
+
+  /**
+   * Cache key is platform-agnostic stringification of chat id +
+   * topic id. The Telegram adapter sometimes hands us numeric chat
+   * ids (gateway path) and sometimes string ids (HTTP target path);
+   * both stringify to the same key.
+   */
+  private topicCacheKey(
+    chatId: number | string,
+    messageThreadId: number,
+  ): string {
+    return `${chatId}:${messageThreadId}`;
   }
 
   private messageReceivedAt(message: TelegramMessage): number {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1570,14 +1570,31 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   private channelFromMessage(message: TelegramMessage): MessagingInboundEvent["channel"] {
+    // Private DMs don't carry a chat title — synthesize one from the
+    // sender's first/last name so the chip renders as "DM: Alice"
+    // instead of "DM: ?".
+    const senderName =
+      [message.from?.first_name, message.from?.last_name]
+        .filter(Boolean)
+        .join(" ") || undefined;
+    const chatTitle = message.chat.title ?? senderName;
+
     if (message.message_thread_id) {
+      // Topic-bound messages: title slot belongs to the topic itself.
+      // The supergroup name is the parent breadcrumb. Telegram bot API
+      // doesn't ship topic names on every message — when missing,
+      // chip falls back to "SG: <supergroup>" via the renderer-side
+      // formatter (no breadcrumb after the slash).
       return {
         channel: this.channel,
         conversation: {
           id: String(message.message_thread_id),
           kind: "topic",
           parentId: String(message.chat.id),
-          title: message.chat.title,
+          // TODO: fetch + cache forum topic title via getForumTopicIcon
+          //       so chips can render "SG: PwrDrvr/General". For now
+          //       leave the topic node title undefined.
+          parentTitle: chatTitle,
         },
       };
     }
@@ -1587,7 +1604,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       conversation: {
         id: String(message.chat.id),
         kind: message.chat.type === "private" ? "dm" : "channel",
-        title: message.chat.title,
+        title: chatTitle,
       },
     };
   }

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -122,6 +122,14 @@ export type MessagingActivityEntry = {
   actorDisplayName?: string;
   summary: string;
   createdAt: number;
+  /**
+   * Free-form bag of fields the row remembers without growing dedicated
+   * columns. Renderer may show these in the activity detail panel;
+   * consumers must treat the shape as opaque (current keys include
+   * `eventId`, `eventKind`, `conversationKind`, `actorUsername`,
+   * `actorIsBot`, plus any caller-provided extras).
+   */
+  payload?: Record<string, unknown>;
 };
 
 export type ListMessagingActivityRequest = {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -4,6 +4,11 @@
 // @pwragent/messaging-interface, which re-exports these primitives so
 // consumers see a single canonical type set.
 
+import type {
+  AppServerBackendKind,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+
 export const MESSAGING_TOOL_UPDATE_MODES = [
   "show_none",
   "show_less",
@@ -13,3 +18,148 @@ export const MESSAGING_TOOL_UPDATE_MODES = [
 ] as const;
 
 export type MessagingToolUpdateMode = (typeof MESSAGING_TOOL_UPDATE_MODES)[number];
+
+// String-literal primitives duplicated locally so shared/contracts/navigation.ts
+// can describe MessagingThreadBindingSummary without importing
+// @pwragent/messaging-interface (that would create a dependency
+// cycle since messaging-interface depends on @pwragent/shared).
+// Keeping these in lockstep with messaging-interface's copy is
+// trivial — both are string-literal unions with no behavior.
+
+export type MessagingChannelKind =
+  | "telegram"
+  | "discord"
+  | "slack"
+  | "mattermost"
+  | "feishu"
+  | "googlechat"
+  | "msteams"
+  | "matrix"
+  | "irc"
+  | "imessage"
+  | "signal"
+  | "whatsapp"
+  | "line"
+  | "zalo"
+  | "nextcloud-talk"
+  | "synology-chat"
+  | "twitch"
+  | "nostr"
+  | "qqbot"
+  | "bluebubbles"
+  | "tlon"
+  | "voice-call"
+  | "custom";
+
+export type MessagingConversationKind = "dm" | "channel" | "thread" | "topic";
+
+/**
+ * Health/lifecycle state for a single configured messaging platform.
+ *   - `enabled`   adapter started successfully and is currently listening
+ *   - `suspended` configured but stopped (user toggled messaging off)
+ *   - `errored`   the adapter failed to start, or hit a fatal runtime error
+ *   - `unknown`   we know the platform is configured but haven't observed
+ *                 a transition yet (initial-load / pre-start state)
+ */
+export type MessagingPlatformHealth =
+  | "enabled"
+  | "suspended"
+  | "errored"
+  | "unknown";
+
+/**
+ * Snapshot of one platform's current state. Renderer holds an array
+ * (one per configured platform) and updates it from
+ * `MessagingPlatformStatusEvent`s.
+ */
+export type MessagingPlatformStatus = {
+  platform: MessagingChannelKind;
+  health: MessagingPlatformHealth;
+  /** Wall-clock ms when the health last changed. */
+  changedAt: number;
+  /** When errored, a human-readable reason for the UI tooltip. */
+  reason?: string;
+  /**
+   * Wall-clock ms of the last sent or received message that the
+   * runtime told us about. Used to keep the activity dot blinking for
+   * a short tail (~2s) after the last event.
+   */
+  lastActivityAt?: number;
+};
+
+export type MessagingPlatformStatusEvent =
+  | {
+      kind: "health-changed";
+      platform: MessagingChannelKind;
+      health: MessagingPlatformHealth;
+      reason?: string;
+      at: number;
+    }
+  | {
+      kind: "activity";
+      platform: MessagingChannelKind;
+      at: number;
+    };
+
+/** Persisted messaging activity log row. Capped per-platform with FIFO eviction. */
+export type MessagingActivityKind =
+  | "inbound-routed"
+  | "inbound-rejected"
+  | "inbound-ignored"
+  | "outbound";
+
+export type MessagingActivityEntry = {
+  id: number;
+  platform: MessagingChannelKind;
+  kind: MessagingActivityKind;
+  /** Backend the entry routed to / from, if known. */
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  bindingId?: string;
+  conversationId?: string;
+  conversationTitle?: string;
+  actorId?: string;
+  actorDisplayName?: string;
+  summary: string;
+  createdAt: number;
+};
+
+export type ListMessagingActivityRequest = {
+  /** Most recent first. Default 100, capped at 500. */
+  limit?: number;
+  /** When set, only entries strictly newer than `sinceId` are returned. */
+  sinceId?: number;
+};
+
+export type ListMessagingActivityResponse = {
+  entries: MessagingActivityEntry[];
+};
+
+export type UnbindMessagingThreadRequest = {
+  bindingId: string;
+};
+
+export type UnbindMessagingThreadResponse = {
+  /** True when the binding existed and was revoked. */
+  revoked: boolean;
+  /** Echoed for client-side cache eviction. */
+  bindingId: string;
+};
+
+export type SetMessagingEnabledRequest = {
+  enabled: boolean;
+};
+
+export type SetMessagingEnabledResponse = {
+  /**
+   * Effective state after the toggle. May not equal the requested
+   * `enabled` if the startup override
+   * (`--disable-messaging` / `PWRAGENT_DISABLE_MESSAGING`) is in
+   * force.
+   */
+  enabled: boolean;
+  /** True when an override prevented the runtime from honoring the request. */
+  overridden: boolean;
+  /** Human-readable explanation of the override, when applicable. */
+  overrideReason?: string;
+};

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -8,6 +8,10 @@ import type {
   ThreadIdentifier,
   WorktreeSnapshotSummary,
 } from "./normalized-app-server";
+import type {
+  MessagingChannelKind,
+  MessagingConversationKind,
+} from "./messaging";
 
 export type InboxReason = "new-thread" | "updated-since-seen";
 
@@ -30,6 +34,48 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   reactions?: string[];
   /** GitHub pull requests detected for this thread's linked directories + branch. */
   prs?: PrSummary[];
+  /**
+   * Messaging platform conversations bound to this thread. Each binding
+   * represents a single conversation (DM, channel, topic, etc.) on one
+   * platform. The renderer renders one chip per active binding and lets
+   * the user unbind from the desktop side via the chip menu.
+   */
+  messagingBindings?: MessagingThreadBindingSummary[];
+};
+
+/**
+ * Renderer-facing slice of a single active messaging binding for a
+ * thread. Carries enough to render the chip + the unbind action without
+ * exposing the full `MessagingBindingRecord` (which has adapter-opaque
+ * routing state the UI must not parse).
+ */
+export type MessagingThreadBindingSummary = {
+  /** Stable id of the binding row in sqlite — pass back to unbind. */
+  bindingId: string;
+  platform: MessagingChannelKind;
+  /**
+   * Conversation kind (DM / channel / topic / thread). Drives the chip
+   * label prefix: `DM:` for dm, `SG:` for Telegram topic+channel,
+   * `SRV:` for Discord channel/thread, etc.
+   */
+  conversationKind?: MessagingConversationKind;
+  /**
+   * Title of this conversation node itself (DM peer name, channel
+   * name, topic name when known). Renderer-only — not used for routing.
+   */
+  conversationTitle?: string;
+  /**
+   * Title of the immediate parent. For Telegram topics this is the
+   * supergroup name; for Discord channels it's the guild name; for
+   * Discord threads it's the parent channel name.
+   */
+  parentTitle?: string;
+  /**
+   * Two levels up. Today: Discord threads — the guild name.
+   */
+  ancestorTitle?: string;
+  /** Wall-clock ms when the binding last had inbound or outbound activity. */
+  activeAt?: number;
 };
 
 /**


### PR DESCRIPTION
Lands the entire Phase 4 design overhaul (messaging UX) plus the thread-row chip-flow refactor that came out of dogfooding it. Originally shipped as five stacked PRs (#184–#187 + #188); folded into one for a clean merge against main. Closes #184, #185, #186, #187 (their content is included here).

## What lands

### Messaging UX (originally Phase 4 / U4.1–U4.4)

- **Header platform status indicators** — per-platform chips in the thread header showing health (green / gray / red) and an activity blink dot. New runtime per-platform state machine (`enabled` / `suspended` / `errored`), persistent across `stop()`, plus a push event bus to the renderer.
- **Header on/off toggle** — pill toggle that pauses + resumes messaging without quitting. Persists as `messaging.userEnabled` in `config.toml`; respects the `--disable-messaging` startup override.
- **Per-thread binding chips** — render which Telegram/Discord conversations are bound to each thread row. Click → popover with "Unbind from <platform>". Right-click thread context menu also lists unbind entries.
- **Messaging Activity screen** — Settings → "Messaging activity" tab shows recent inbound (routed/rejected) and outbound deliveries from a capped sqlite log (500/platform, FIFO eviction). Clicking a platform chip in the header deep-links here.

### Thread row chip flow (the refactor that came out of using it)

- **One ordered chip flow per row.** The four independent chip containers (meta / PR / binding / reactions) collapse into a single `<span class="thread-row__chips">` flex-wrap container. Order: agent type → mode → linked-dir → branch → drift → PR chips → binding chips → reactions → add-reaction.
- **No more nested `<button>`.** Every interactive chip becomes `<span role="button" tabIndex={0}>` with `onClick` + `onKeyDown(Enter/Space)` + `stopPropagation` — same proven pattern path-copy chips have used since day one.
- **Add-reaction is 🙂**, not "+".
- **Deleted:** four per-container CSS blocks, two `:has()` padding hacks, `position: absolute` on binding chips, the picker-wrap div.

## Architecture notes

- **Persistence**: new `messaging_activity_log` sqlite table at schema V2 (autoinc id, platform, kind, thread/binding refs, summary, JSON payload). Per-platform FIFO eviction in `StateDb.cleanupExpired`.
- **Bindings → snapshot**: new `buildMessagingBindingsByThreadKey()` queries the messaging store per thread; `SqliteOverlayStore.reconcileNavigationSnapshot` accepts the result and forwards through `buildNavigationSnapshot`. Bindings are included in the snapshot hash so unbind/rebind propagates.
- **Backend filter relaxed**: `findActiveBindingsForThread` no longer drops bindings whose stored backend doesn't match the thread's source — only requires `thread_id` match unless backends are both populated and disagree.
- **IPC**: `messaging:get-platform-statuses`, `messaging:platform-status-event`, `messaging:set-enabled`, `messaging:unbind-thread`, `messaging:list-activity`, plus the existing `gh` status surface.
- **Plans**: [docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md](docs/plans/2026-05-04-001-feat-desktop-design-overhaul-plan.md) (parent) and [docs/plans/2026-05-05-001-fix-thread-row-unified-chip-flow-plan.md](docs/plans/2026-05-05-001-fix-thread-row-unified-chip-flow-plan.md) (chip refactor, supersedes the chip-rendering portions of U3.2/U3.3/U4.3).

## Tests

- 5 new runtime tests for platform status emission (enabled/errored/activity/suspended/snapshot).
- 3 new runtime tests for `pause()` / `resume()` (idempotent cycles, suspended emission).
- 7 new tests for `MessagingActivityLog` persistence (record / list / sinceId / limit clamp / eviction / restart round-trip).
- 6 new tests for overlay PR persistence (already on main).
- Updated 24 PR-fetcher tests to track the refactored API.
- Workspace suite: **1133 passing / 3 skipped**, no regressions.

## Post-Deploy Monitoring & Validation

- **Watch logs**: `pwragent:messaging` for `messaging activity log write failed`, `pwragent:messaging-bindings` for `failed to resolve bindings`, `pwragent:main` for `messaging runtime not started — disabled by user setting`.
- **Validate**:
  - First post-deploy launch successfully migrates the schema (`PRAGMA user_version` flips 1 → 2 in `~/.pwragent/profiles/default/state/state.db`).
  - Toggle messaging off → adapters drain in ~1s; chips persist as gray dots. Toggle on → green within 2s.
  - Send a Telegram message → "Routed" row in Activity within 5s.
  - Send a message from an unauthorized account → "Rejected" row in Activity.
- **Failure signals**:
  - Activity screen always empty after live traffic → check schema migration ran, check `pwragent:messaging` for write-failure log lines.
  - Toggle stuck mid-state → IPC handler rejected without rollback (renderer devtools).
- **Owner**: @huntharo. **Window**: first launch + 10 min of normal use.

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with [Claude Opus 4.7 (1M context, extended thinking)](https://claude.com/claude-code) via Compound Engineering v2.49.0