### PR TITLE
fix(messaging): route UI unbind through bus so platforms get the detach notification

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -719,6 +719,152 @@ describe("DesktopMessagingRuntime", () => {
     ]);
   });
 
+  it("requestBindingRevoke routes through the controller so the platform adapter receives a Thread-detached confirmation", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    await adapter.listener?.(
+      buildCallbackEvent("bind:codex:thread-1", {
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    const store = getDesktopMessagingStore();
+    const binding = await store.findActiveBindingForChannel({
+      channel: "telegram",
+      conversation: { id: "chat-1", kind: "dm" },
+    });
+    expect(binding).toBeDefined();
+
+    adapter.delivered.length = 0;
+
+    const result = await runtime.requestBindingRevoke({
+      bindingId: binding!.id,
+      origin: "ui",
+    });
+
+    expect(result).toEqual({ revoked: true, notifiedPlatform: true });
+    expect(adapter.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Thread detached",
+    });
+    await expect(store.getBinding(binding!.id)).resolves.toMatchObject({
+      revokedAt: expect.any(Number),
+    });
+  });
+
+  it("requestBindingRevoke falls back to a store-only revoke when no controller scopes the binding's channel", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    await adapter.listener?.(
+      buildCallbackEvent("bind:codex:thread-1", {
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    const store = getDesktopMessagingStore();
+    const binding = await store.findActiveBindingForChannel({
+      channel: "telegram",
+      conversation: { id: "chat-1", kind: "dm" },
+    });
+    expect(binding).toBeDefined();
+
+    await runtime.stop();
+    adapter.delivered.length = 0;
+
+    const result = await runtime.requestBindingRevoke({
+      bindingId: binding!.id,
+      origin: "ui",
+    });
+
+    expect(result).toEqual({ revoked: true, notifiedPlatform: false });
+    expect(adapter.delivered).toHaveLength(0);
+    await expect(store.getBinding(binding!.id)).resolves.toMatchObject({
+      revokedAt: expect.any(Number),
+    });
+  });
+
+  it("requestBindingRevoke is a no-op for unknown or already-revoked bindings", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+
+    const result = await runtime.requestBindingRevoke({
+      bindingId: "binding:does-not-exist",
+      origin: "ui",
+    });
+    expect(result).toEqual({ revoked: false, notifiedPlatform: false });
+  });
+
+  it("requestBindingRevokeAllForThread fans out to every binding on the thread, regardless of platform", async () => {
+    await prepareRuntimeStore();
+    const telegramAdapter = createAdapter("telegram");
+    const discordAdapter = createAdapter("discord");
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [telegramAdapter, discordAdapter],
+      backendBridge: bridge,
+      config: {
+        inputDebounceMs: 0,
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          applicationId: "app-1",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+    await runtime.start();
+
+    await telegramAdapter.listener?.(
+      buildCallbackEvent(
+        "bind:codex:thread-1",
+        { backend: "codex", threadId: "thread-1" },
+        "telegram",
+      ),
+    );
+    await discordAdapter.listener?.(
+      buildCallbackEvent(
+        "bind:codex:thread-1",
+        { backend: "codex", threadId: "thread-1" },
+        "discord",
+      ),
+    );
+
+    telegramAdapter.delivered.length = 0;
+    discordAdapter.delivered.length = 0;
+
+    const result = await runtime.requestBindingRevokeAllForThread({
+      backend: "codex",
+      threadId: "thread-1",
+      origin: "thread-archive",
+    });
+
+    expect(result).toEqual({ revokedCount: 2, notifiedCount: 2 });
+    expect(telegramAdapter.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Thread detached",
+    });
+    expect(discordAdapter.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Thread detached",
+    });
+  });
+
   it("stops the started adapter instances without rebuilding the factory", async () => {
     await prepareRuntimeStore();
     const adapter = createAdapter("telegram");

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -8,7 +8,6 @@ import type {
   UnbindMessagingThreadResponse,
 } from "@pwragent/shared";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
-import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
 import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
 import { getMainLogger } from "../log";
 import {
@@ -90,28 +89,22 @@ export function registerMessagingStatusIpcHandlers(): void {
       _event,
       request: UnbindMessagingThreadRequest,
     ): Promise<UnbindMessagingThreadResponse> => {
-      const store = getDesktopMessagingStore();
-      const revoked = await store.revokeBinding({ bindingId: request.bindingId });
+      // Emit on the runtime bus rather than touching the store
+      // directly. The runtime fans out to whichever controller owns
+      // the binding's channel, which delivers the platform-side
+      // retirement + "Thread detached" confirmation. This keeps the
+      // IPC layer free of any per-platform knowledge — adding
+      // Slack / Mattermost requires zero changes here.
+      const result = await runtime.requestBindingRevoke({
+        bindingId: request.bindingId,
+        origin: "ui",
+      });
       log.info("messaging binding unbound", {
         bindingId: request.bindingId,
-        revoked: Boolean(revoked),
-        platform: revoked?.channel?.channel ?? null,
-        backend: revoked?.backend ?? null,
-        threadId: revoked?.threadId ?? null,
+        revoked: result.revoked,
+        notifiedPlatform: result.notifiedPlatform,
       });
-      // Same fan-out the controller paths use — the desktop UI
-      // initiated the unbind, so refetch the snapshot now to remove
-      // the chip without waiting for a backend tick.
-      if (revoked) {
-        try {
-          getDesktopMessagingRuntime().notifyBindingsChanged();
-        } catch (error) {
-          log.debug("failed to broadcast bindings-changed after unbind", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-      return { revoked: Boolean(revoked), bindingId: request.bindingId };
+      return { revoked: result.revoked, bindingId: request.bindingId };
     },
   );
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2850,7 +2850,25 @@ export class MessagingController {
       );
       return;
     }
+    await this.runDetachPipeline(binding, event);
+  }
 
+  /**
+   * Platform-agnostic detach pipeline. Called by both the inbound
+   * `/detach` slash-command path and the bus-driven UI / archive
+   * paths. The only seam for platform-specific behavior is
+   * `this.options.adapter.deliver`, which the registered adapter
+   * implements per the messaging contract — adding a new platform
+   * requires zero changes to this method. `event` is supplied only
+   * when the detach was initiated by an inbound command (used for
+   * audit context and reply targeting); for non-inbound origins
+   * (`requestBindingRevoke` from IPC, archive flows) the binding's
+   * own channel is the routing source.
+   */
+  private async runDetachPipeline(
+    binding: MessagingBindingRecord,
+    event?: MessagingInboundEvent,
+  ): Promise<void> {
     const activeTurn = this.getActiveTurn(binding);
     if (activeTurn) {
       await this.signalTurnActivity(
@@ -2883,9 +2901,27 @@ export class MessagingController {
         title: "Thread detached",
         body: "Messages in this conversation will no longer route to PwrAgent.",
       }),
-      undefined,
+      binding,
       event,
     );
+  }
+
+  /**
+   * Bus-driven entry point used by the runtime when an UI / archive
+   * caller emits `requestBindingRevoke`. Returns true if this
+   * controller's adapter owns the binding's channel and therefore
+   * handled the revoke; false otherwise so the runtime can try the
+   * next controller (or fall back to a direct store revoke if no
+   * controller matches — e.g., messaging is currently disabled).
+   */
+  async handleBindingRevokeRequest(
+    binding: MessagingBindingRecord,
+  ): Promise<boolean> {
+    if (!this.isChannelInScope(binding.channel)) {
+      return false;
+    }
+    await this.runDetachPipeline(binding, undefined);
+    return true;
   }
 
   private async recreateBindingStatus(
@@ -2917,7 +2953,7 @@ export class MessagingController {
 
   private async retireBindingStatus(
     binding: MessagingBindingRecord,
-    event: MessagingInboundEvent,
+    event: MessagingInboundEvent | undefined,
     navigation: NavigationSnapshot,
   ): Promise<MessagingBindingRecord> {
     const statusSurface = binding.statusSurface ?? binding.pinnedStatusSurface;

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -14,6 +14,7 @@ import type {
   MessagingPlatformStatusEvent,
 } from "@pwragent/shared";
 import type {
+  MessagingBindingRecord,
   MessagingCapabilityProfile,
   MessagingChannelKind,
   MessagingDeliveryResult,
@@ -57,6 +58,49 @@ export type DesktopMessagingConfigLoader = (
   | Promise<DesktopMessagingConfig>;
 
 const messagingLog = getMainLogger("pwragent:messaging");
+
+/**
+ * Origin tag carried on `requestBindingRevoke` /
+ * `requestBindingRevokeAllForThread` so subscribers and observability
+ * can distinguish UI-initiated detaches from archive flows or
+ * platform-side commands. Adding a new origin must NOT introduce a
+ * platform branch — origins are routing-neutral metadata.
+ */
+export type BindingRevokeOrigin =
+  | "ui"
+  | "platform-command"
+  | "thread-archive"
+  | "permanent-failure";
+
+export type BindingRevokeRequest = {
+  bindingId: string;
+  origin: BindingRevokeOrigin;
+};
+
+export type BindingRevokeAllForThreadRequest = {
+  backend: MessagingBindingRecord["backend"];
+  threadId: MessagingBindingRecord["threadId"];
+  origin: BindingRevokeOrigin;
+};
+
+export type BindingRevokeResult = {
+  /** True if the binding existed and was either retired by a
+   * controller or removed via the runtime fallback. */
+  revoked: boolean;
+  /** True if a controller's adapter scoped the binding's channel and
+   * delivered the platform-side retirement + confirmation. False
+   * means the binding was removed from the store but no platform
+   * notification was sent (e.g., messaging is currently disabled). */
+  notifiedPlatform: boolean;
+};
+
+export type BindingRevokeAllForThreadResult = {
+  /** Number of bindings revoked in total. */
+  revokedCount: number;
+  /** Number that were retired through a controller's platform
+   * notification flow. The remainder were store-only fallbacks. */
+  notifiedCount: number;
+};
 
 export class DesktopMessagingRuntime {
   private adapters: DesktopMessagingAdapter[] = [];
@@ -287,6 +331,123 @@ export class DesktopMessagingRuntime {
    */
   notifyBindingsChanged(): void {
     this.broadcastBindingsChanged();
+  }
+
+  /**
+   * Bus entry point for "the user wants this binding revoked,
+   * source-of-request agnostic." Used by the desktop unbind IPC
+   * handler today; future archive flows and CLI tools route through
+   * the same call.
+   *
+   * The runtime fans the request out to every running controller.
+   * The controller whose adapter owns the binding's channel runs the
+   * platform-agnostic detach pipeline (retire status surface →
+   * revoke in store → "Thread detached" confirmation). This keeps
+   * the IPC layer free of any per-platform knowledge — adding Slack
+   * / Mattermost requires zero changes here.
+   *
+   * If no controller's scope matches (e.g., messaging is currently
+   * disabled, or the platform's adapter failed to start), the
+   * runtime still revokes the binding in the store so the renderer
+   * chip clears. Best-effort platform notification, guaranteed local
+   * state cleanup.
+   */
+  async requestBindingRevoke(
+    request: BindingRevokeRequest,
+  ): Promise<BindingRevokeResult> {
+    const store = getDesktopMessagingStore();
+    const binding = await store.getBinding(request.bindingId);
+    if (!binding || binding.revokedAt) {
+      return { revoked: false, notifiedPlatform: false };
+    }
+
+    const notifiedPlatform = await this.dispatchRevokeToControllers(binding);
+    if (!notifiedPlatform) {
+      await store.revokeBinding({ bindingId: binding.id });
+      this.broadcastBindingsChanged();
+    }
+
+    messagingLog.info("messaging binding revoke handled", {
+      bindingId: binding.id,
+      origin: request.origin,
+      backend: binding.backend,
+      platform: binding.channel.channel,
+      threadId: binding.threadId,
+      notifiedPlatform,
+    });
+
+    return { revoked: true, notifiedPlatform };
+  }
+
+  /**
+   * Bus entry point for "revoke every binding on this thread." Used
+   * for the upcoming "Unbind all" context-menu item and for implicit
+   * unbind-on-archive. Mirrors `requestBindingRevoke` semantics: per
+   * binding, in-scope controller handles platform notification; any
+   * unmatched binding falls back to store-only revoke.
+   */
+  async requestBindingRevokeAllForThread(
+    request: BindingRevokeAllForThreadRequest,
+  ): Promise<BindingRevokeAllForThreadResult> {
+    const store = getDesktopMessagingStore();
+    const bindings = await store.findActiveBindingsForThread({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    if (bindings.length === 0) {
+      return { revokedCount: 0, notifiedCount: 0 };
+    }
+
+    let notifiedCount = 0;
+    const fallbackBindings: MessagingBindingRecord[] = [];
+    for (const binding of bindings) {
+      const notified = await this.dispatchRevokeToControllers(binding);
+      if (notified) {
+        notifiedCount++;
+      } else {
+        fallbackBindings.push(binding);
+      }
+    }
+
+    for (const binding of fallbackBindings) {
+      await store.revokeBinding({ bindingId: binding.id });
+    }
+    if (fallbackBindings.length > 0) {
+      this.broadcastBindingsChanged();
+    }
+
+    messagingLog.info("messaging binding revoke-all handled", {
+      backend: request.backend,
+      threadId: request.threadId,
+      origin: request.origin,
+      revokedCount: bindings.length,
+      notifiedCount,
+    });
+
+    return { revokedCount: bindings.length, notifiedCount };
+  }
+
+  private async dispatchRevokeToControllers(
+    binding: MessagingBindingRecord,
+  ): Promise<boolean> {
+    for (const controller of this.controllers) {
+      try {
+        if (await controller.handleBindingRevokeRequest(binding)) {
+          return true;
+        }
+      } catch (error) {
+        messagingLog.error("messaging controller revoke handler threw", {
+          bindingId: binding.id,
+          platform: binding.channel.channel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Swallow — try the next controller; if none handle, the
+        // runtime fallback revokes from the store. We never want a
+        // platform-side failure to leave the binding visibly attached
+        // in the renderer.
+      }
+    }
+    return false;
   }
 
   private broadcastBindingsChanged(): void {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1457,4 +1457,105 @@ describe("useThreadNavigation", () => {
     // Push-driven patch — no full snapshot re-fetch.
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
+
+  it("removes a revoked messaging binding from the thread row after onMessagingBindingsChanged fires", async () => {
+    const bindingsListeners = new Set<(event: { at: number }) => void>();
+    let navigationCallCount = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      navigationCallCount += 1;
+      const messagingBindings =
+        navigationCallCount === 1
+          ? [
+              {
+                bindingId: "binding:telegram:topic:-1003841603622:5642:codex:thread-1",
+                platform: "telegram" as const,
+                conversationKind: "topic" as const,
+                conversationTitle: "Knock Knock Rock",
+                parentTitle: "PwrDrvr",
+              },
+              {
+                bindingId: "binding:discord:channel:1480554271907905731:1501244021886943405:codex:thread-1",
+                platform: "discord" as const,
+                conversationKind: "channel" as const,
+                conversationTitle: "knock-knock-rock",
+                parentTitle: "PwrDrvr",
+              },
+            ]
+          : [
+              {
+                bindingId: "binding:discord:channel:1480554271907905731:1501244021886943405:codex:thread-1",
+                platform: "discord" as const,
+                conversationKind: "channel" as const,
+                conversationTitle: "knock-knock-rock",
+                parentTitle: "PwrDrvr",
+              },
+            ];
+      return {
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [
+          {
+            id: "thread-1",
+            title: "Knock Knock Rock",
+            titleSource: "explicit" as const,
+            summary: "A thread that's bound to two messaging platforms.",
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+            // The reconciler bug we're regression-testing: this updatedAt
+            // does NOT change between fetches, because the messaging
+            // store mutates only the binding row, not the thread row.
+            // Without `messagingBindings` in `threadSummariesEqual`, the
+            // reconciler decides "nothing changed" and reuses the
+            // previous thread reference (with stale bindings).
+            updatedAt: 1_000,
+            messagingBindings,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      onMessagingBindingsChanged: (callback: (event: { at: number }) => void) => {
+        bindingsListeners.add(callback);
+        return () => {
+          bindingsListeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+    expect(result.current.selectedThread?.messagingBindings).toHaveLength(2);
+
+    // Simulate the bus event the runtime fans out after a UI-originated
+    // unbind: backend revokes the binding, fires onMessagingBindingsChanged,
+    // and the renderer refetches. The next snapshot has only one binding.
+    await act(async () => {
+      for (const listener of bindingsListeners) {
+        listener({ at: Date.now() });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.messagingBindings).toHaveLength(1);
+    });
+    expect(
+      result.current.selectedThread?.messagingBindings?.[0]?.platform,
+    ).toBe("discord");
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -122,6 +122,52 @@ function retainedBranchDriftPairsEqual(
   });
 }
 
+function messagingBindingsEqual(
+  left: NavigationThreadSummary["messagingBindings"],
+  right: NavigationThreadSummary["messagingBindings"]
+): boolean {
+  const leftBindings = left ?? [];
+  const rightBindings = right ?? [];
+  if (leftBindings.length !== rightBindings.length) {
+    return false;
+  }
+
+  return leftBindings.every((binding, index) => {
+    const candidate = rightBindings[index];
+    return (
+      candidate?.bindingId === binding.bindingId &&
+      candidate.platform === binding.platform &&
+      candidate.conversationKind === binding.conversationKind &&
+      candidate.conversationTitle === binding.conversationTitle &&
+      candidate.parentTitle === binding.parentTitle &&
+      candidate.ancestorTitle === binding.ancestorTitle &&
+      candidate.activeAt === binding.activeAt
+    );
+  });
+}
+
+function prSummariesEqual(
+  left: NavigationThreadSummary["prs"],
+  right: NavigationThreadSummary["prs"]
+): boolean {
+  const leftPrs = left ?? [];
+  const rightPrs = right ?? [];
+  if (leftPrs.length !== rightPrs.length) {
+    return false;
+  }
+
+  return leftPrs.every((pr, index) => {
+    const candidate = rightPrs[index];
+    return (
+      candidate?.number === pr.number &&
+      candidate.org === pr.org &&
+      candidate.repo === pr.repo &&
+      candidate.state === pr.state &&
+      candidate.url === pr.url
+    );
+  });
+}
+
 function threadSummariesEqual(
   left: NavigationThreadSummary,
   right: NavigationThreadSummary
@@ -148,7 +194,15 @@ function threadSummariesEqual(
     ) &&
     linkedDirectoriesEqual(left.linkedDirectories, right.linkedDirectories) &&
     worktreeSnapshotsEqual(left.worktreeSnapshots, right.worktreeSnapshots) &&
-    threadInboxEqual(left.inbox, right.inbox)
+    threadInboxEqual(left.inbox, right.inbox) &&
+    // Bindings and PRs mutate independently of `updatedAt`: the messaging
+    // store revokes a binding row without touching the thread row, and
+    // GitHub PR detection runs on its own cadence. Without these checks
+    // the reconciler reuses the previous thread reference whenever
+    // nothing else changed and chips on the row stay stale until
+    // something else triggers a re-render.
+    messagingBindingsEqual(left.messagingBindings, right.messagingBindings) &&
+    prSummariesEqual(left.prs, right.prs)
   );
 }
 

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -244,6 +244,49 @@ const items = actions
 
 If the producer respected the profile, the slices are no-ops. If the producer somehow emitted too much, the adapter clips it rather than letting the platform reject the request. The numbers come from the same profile the adapter declared, so producer and adapter caps stay in sync.
 
+## Architectural principles
+
+These rules exist to make adding the next ten messaging platforms a quiet, mechanical exercise. Every line of platform-branching code in the desktop or interface layer is a future bug; every direct DB import inside a provider is a future migration mess. Treat them as non-negotiable.
+
+### Single platform-agnostic detach pipeline
+
+The detach flow — retire the channel's status surface, revoke the binding in the store, deliver a "Thread detached" confirmation — has exactly one implementation: `MessagingController.runDetachPipeline`. Every detach origin (Discord `/detach`, Telegram `/detach`, the desktop right-click "Unbind" chip, future archive-on-delete flows, future "Unbind all") routes through it.
+
+The pipeline is platform-agnostic because the only platform-shaped seam is `adapter.deliver(intent)`, which every adapter already implements as part of the inbound-message contract. **A new platform inherits detach for free** by registering as an adapter — no detach-specific code is required in any provider, controller, IPC handler, or runtime call site.
+
+If you find yourself writing `if (binding.channel.channel === "discord") …` or wiring up a per-platform "tell platform X about detach" method, stop: the pipeline already does this through the generic adapter dispatch. Add the missing capability to the adapter contract instead.
+
+### Bus-driven cross-layer coordination
+
+Layers above the controller (Electron IPC handlers, desktop windowing code, future CLI / scheduled-task entry points) **must not import controller classes or call controller methods directly**. They emit events on the runtime bus; the runtime fans them out to whichever controller's adapter scopes the affected binding's channel.
+
+Two reasons: it prevents circular references between IPC and controller modules (IPC imports runtime, runtime imports controller; controller never sees IPC), and it stops every new caller from learning the per-platform layout. The right-click "Unbind" handler does not look up `DiscordMessagingController`; it calls `runtime.requestBindingRevoke({ bindingId, origin: "ui" })` and the runtime routes by binding metadata.
+
+Available command-bus entry points today, all on `DesktopMessagingRuntime`:
+
+| Method | Origin examples | Direction |
+|---|---|---|
+| `requestBindingRevoke(req)` | UI context-menu unbind, future archive flow on a single binding | caller → controllers |
+| `requestBindingRevokeAllForThread(req)` | Future "Unbind all" context-menu item, implicit unbind on thread archive | caller → controllers |
+| `notifyBindingsChanged()` | Controller mutations after bind/sync/detach | controllers → renderer |
+
+**Direction-typed events.** Each topic flows in one direction only. `notifyBindingsChanged` is mutation-broadcast (controllers and the runtime fallback emit; renderer subscribes). The two `request*` methods are commands (callers emit; controllers handle). Do not invert either — a command that broadcasts to the renderer becomes a state-mutation race; a mutation event that controllers subscribe to becomes a re-entrancy footgun.
+
+If no controller's scope matches a `request*` event (messaging is disabled, or the platform's adapter failed to start), the runtime falls back to a store-only revoke so the renderer chip clears regardless. Best-effort platform notification, guaranteed local cleanup.
+
+### Providers never touch persistence directly
+
+Provider packages under `packages/messaging/providers/*` **must not** import any of:
+
+- `apps/desktop/**` (any path)
+- `better-sqlite3`, `drizzle`, or any DB driver
+- The desktop store implementation (`apps/desktop/src/main/state/messaging-store-sqlite.ts`)
+- Any module that exposes raw SQL or schema definitions
+
+Providers receive persistent state only through opaque interfaces declared in `@pwragent/messaging-interface` — today that's `MessagingCallbackHandleStore` (`resolveCallbackHandle` / `upsertCallbackHandle`), and `MessagingAdapterState.opaque` for routing/surface state that the workflow layer echoes but never parses. New persistence needs become new interface methods, not new tables.
+
+This is enforced by package boundaries (`pnpm lint:boundaries`) and reinforced in [`packages/messaging/AGENTS.md`](../packages/messaging/AGENTS.md). The reason matters as much as the rule: providers come and go, the schema is shared, and a provider that owns its own table effectively owns a piece of the desktop migration plan it has no business owning. Keep the seam at the interface, not the database.
+
 ## How to add a provider
 
 The full procedure is in [`docs/messaging-adapter-contract.md`](messaging-adapter-contract.md). At a high level:

--- a/packages/messaging/AGENTS.md
+++ b/packages/messaging/AGENTS.md
@@ -11,6 +11,7 @@ For a layered architecture overview with diagrams, data-flow sequences, the capa
 - Provider packages under `packages/messaging/providers/*` are isolated TypeScript packages. They may import `@pwragent/messaging-interface` and their own provider SDKs, but they must not import desktop, agent-core, shared app contracts, or sibling providers.
 - Provider SDKs such as `grammy` and `discord.js` belong only inside their provider package. Do not import those SDKs from desktop messaging workflow code or from the generic interface.
 - Desktop messaging orchestration lives outside this tree, currently in `apps/desktop/src/main/messaging`. It should speak the generic interface and load providers through the provider loader, not through provider-specific workflow branches.
+- **Providers must not touch persistence directly.** No provider may import `apps/desktop/**`, `better-sqlite3`, `drizzle`, any module that exposes raw SQL, or the desktop messaging store implementation. Persistent state reaches providers only through opaque interfaces declared in `@pwragent/messaging-interface` (today: `MessagingCallbackHandleStore`, plus `MessagingAdapterState.opaque` for routing/surface state the workflow layer echoes but never parses). New persistence needs become new interface methods, not new tables. Providers that want to own a schema are doing it wrong — see [`docs/messaging-architecture.md` § Architectural principles](../../docs/messaging-architecture.md#architectural-principles).
 
 ## Design Rules
 


### PR DESCRIPTION
## Summary

- Fix bug where right-clicking **Unbind** on a binding chip revoked the binding locally but never told the source platform — Discord still showed the status card as live and no \"Thread detached\" confirmation was sent. The Discord `/detach` slash-command path was correct because it ran the full retire + revoke + confirmation pipeline inline; the UI path bypassed the controller and only hit the sqlite store.
- Introduce a platform-agnostic command bus on `DesktopMessagingRuntime` so the IPC layer can ask for a binding to be revoked without knowing anything about Discord, Telegram, or any future provider. Each controller subscribes; whichever controller's adapter scopes the binding's channel runs the canonical detach pipeline. New providers (Slack, Mattermost, …) inherit detach for free by registering as an adapter — zero changes to any detach call site.
- Wire `requestBindingRevokeAllForThread` end-to-end so the upcoming \"Unbind all\" context-menu item and the implicit unbind-on-archive flow can call it without further runtime/controller plumbing.
- Document the architectural principles (single platform-agnostic detach pipeline; bus-driven cross-layer coordination with direction-typed events; providers must access persistence only via interfaces, never the desktop store or DB primitives).

## What changed

- **[apps/desktop/src/main/messaging/core/messaging-controller.ts](apps/desktop/src/main/messaging/core/messaging-controller.ts)** — extract `runDetachPipeline(binding, event?)` from the inbound `/detach` handler so both origins share one implementation. Add `handleBindingRevokeRequest(binding)` as the bus-driven entry point that returns true iff this controller's adapter scopes the binding's channel.
- **[apps/desktop/src/main/messaging/messaging-runtime.ts](apps/desktop/src/main/messaging/messaging-runtime.ts)** — add `requestBindingRevoke({ bindingId, origin })` and `requestBindingRevokeAllForThread({ backend, threadId, origin })`. Origins are routing-neutral metadata (`\"ui\"`, `\"platform-command\"`, `\"thread-archive\"`, `\"permanent-failure\"`). When no controller's scope matches a request (messaging disabled, adapter failed to start), the runtime falls back to a store-only revoke so the renderer chip still clears.
- **[apps/desktop/src/main/ipc/messaging-status.ts](apps/desktop/src/main/ipc/messaging-status.ts)** — replace the direct `store.revokeBinding` call with `runtime.requestBindingRevoke({ origin: \"ui\" })`. The IPC layer no longer imports the store and contains no per-platform knowledge.
- **[docs/messaging-architecture.md](docs/messaging-architecture.md)** — new \"Architectural principles\" section: single platform-agnostic detach pipeline, bus-driven cross-layer coordination with direction-typed events, providers-must-not-touch-persistence rule.
- **[packages/messaging/AGENTS.md](packages/messaging/AGENTS.md)** — hard-rule bullet that providers may not import `apps/desktop/**`, `better-sqlite3`, `drizzle`, or any DB primitive; persistent state reaches providers only through opaque interfaces in `@pwragent/messaging-interface`. Audit confirmed providers are already DB-clean today; the doc change pins the rule for new providers.

## Why

The user is planning ~10 more messaging platforms. Any per-platform detach branch in IPC, the controller, or the runtime would multiply by N each time. Routing through the bus keeps every layer above the adapter contract platform-blind, and the asymmetry that caused the original bug (bind path called the controller; unbind path didn't) is gone — both directions now go through the same canonical pipeline.

## Reviewer notes

- The eager local revoke is intentional: the chip clears as soon as the user clicks Unbind, even if the platform-side retire/confirmation `deliver` calls fail (those are logged best-effort). Trade-off discussed in conversation; the alternative (\"until-confirmed\" UI) would leave the chip stuck whenever Discord is rate-limited.
- Platforms don't model bindings, so there is no \"detach acknowledged\" event coming back from them — `notifyBindingChanged(\"detach\")` fires exactly once per detach, regardless of origin. No double chip-removal.
- A thread bound to multiple platforms (Discord + Telegram) gets one chip per binding. UI right-click revokes one specific binding. \"Unbind all\" is wired at the bus level but no UI/archive caller exists yet — that lands in the next PR.
- The `MessagingCallbackHandleStore` interface in `@pwragent/messaging-interface` is the existing seam Telegram uses to persist callback handles. The new doc rule formalizes \"all provider persistence flows through interfaces of this shape.\"

## Test plan

- [x] `pnpm --filter @pwragent/desktop typecheck` — clean
- [x] `pnpm test apps/desktop/src/main/__tests__/` — 598 tests pass, including 4 new runtime tests:
  - `requestBindingRevoke` routes through controller so adapter receives \"Thread detached\"
  - `requestBindingRevoke` falls back to store-only revoke when no controller is in scope
  - `requestBindingRevoke` is a no-op for unknown / already-revoked bindings
  - `requestBindingRevokeAllForThread` fans out across two platforms (Telegram + Discord)
- [x] Existing `/detach` slash-command test still passes — confirms `runDetachPipeline` extraction preserved inbound behavior
- [x] `pnpm lint:boundaries` — clean (108 modules, 232 dependencies)
- [x] Manual: bind a thread to Discord, right-click \"Unbind\" in desktop, confirm Discord channel receives the retire + \"Thread detached\" messages and the chip disappears from the renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)