### PR TITLE
fix(messaging): catch Grammy poll-loop rejection eagerly on shutdown

### DIFF
--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -462,6 +462,13 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       this.startPromise = this.bot.start?.({
         allowed_updates: [...TELEGRAM_ALLOWED_UPDATES],
       });
+      // Eagerly handle rejection so it doesn't become unhandled if the
+      // process exits before stop() can await startPromise.
+      this.startPromise?.catch((error) => {
+        this.options.logger?.warn?.("telegram polling loop exited with error", {
+          error: errorMessage(error),
+        });
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- Attach a `.catch()` handler to the Grammy `bot.start()` polling promise as soon as it's created, so a rejection from the polling loop is always handled — even when the process exits before `stop()` can `await` the same promise.

## Why

Reproduced during a Command-Q shutdown:

```
(node:84049) UnhandledPromiseRejectionWarning: GrammyError: Call to 'getUpdates' failed!
(409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running)
    at o.fetchUpdates (.../index-DsOx-_ci.js:6865:17)
    at o.loop (.../index-DsOx-_ci.js:6842:23)
    at o.start (.../index-DsOx-_ci.js:6771:131)
```

Root cause:

1. `TelegramAdapter.start()` stores `bot.start()`'s long-lived polling promise as `this.startPromise`.
2. The only rejection handler was inside `stop()` (`await this.startPromise?.catch(() => undefined)`).
3. The desktop main process's `before-quit` handler at [apps/desktop/src/main/index.ts:167](apps/desktop/src/main/index.ts:167) calls `void disposeDesktopMessagingRuntime()` — it does not `await` it.
4. If the process exits before `stop()` finishes awaiting `startPromise`, Grammy's 409 rejection (the polling loop being interrupted) becomes an unhandled rejection.

The middleware-level `bot.catch()` handler does not catch errors from Grammy's internal polling loop — only from message/middleware handlers.

## Fix

Attach the rejection handler eagerly at promise creation in [packages/messaging/providers/telegram/src/telegram-adapter.ts](packages/messaging/providers/telegram/src/telegram-adapter.ts):

```ts
this.startPromise = this.bot.start?.({ allowed_updates: [...TELEGRAM_ALLOWED_UPDATES] });
this.startPromise?.catch((error) => {
  this.options.logger?.warn?.("telegram polling loop exited with error", {
    error: errorMessage(error),
  });
});
```

The existing `stop()` await is left in place so callers that *do* await the runtime teardown still get deterministic completion. Adding an eager `.catch()` does not "consume" the promise — `stop()` can still `await` the same promise without issue.

## Test plan

- [x] `pnpm --filter @pwragent/messaging-provider-telegram typecheck`
- [x] `pnpm test packages/messaging/providers/telegram` (12 passed)
- [x] Manual: launch desktop with Telegram enabled, Command-Q during active polling, verify no `UnhandledPromiseRejectionWarning` for `getUpdates` 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)