### PR TITLE
chore(infra): expand dependency boundary enforcement repo-wide

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -3,10 +3,59 @@ module.exports = {
     {
       name: "no-circular",
       severity: "error",
-      comment: "Messaging package and desktop messaging dependencies must stay acyclic.",
+      comment:
+        "All dependencies in the repository must remain acyclic.",
       from: {},
       to: {
         circular: true,
+      },
+    },
+    {
+      name: "shared-is-a-leaf",
+      severity: "error",
+      comment:
+        "packages/shared must not import any internal workspace package.",
+      from: {
+        path: "^packages/shared/",
+      },
+      to: {
+        path: "^(@pwragent/|apps/|packages/(?!shared/))",
+      },
+    },
+    {
+      name: "codex-protocol-is-a-leaf",
+      severity: "error",
+      comment:
+        "packages/codex-app-server-protocol must not import any internal workspace package.",
+      from: {
+        path: "^packages/codex-app-server-protocol/",
+      },
+      to: {
+        path: "^(@pwragent/|apps/|packages/(?!codex-app-server-protocol/))",
+      },
+    },
+    {
+      name: "agent-core-only-imports-shared",
+      severity: "error",
+      comment:
+        "agent-core may only depend on packages/shared internally.",
+      from: {
+        path: "^packages/agent-core/",
+      },
+      to: {
+        path: "^(@pwragent/(?!shared)|apps/|packages/(?!shared/|agent-core/))",
+      },
+    },
+    {
+      name: "desktop-renderer-only-imports-shared",
+      severity: "error",
+      comment:
+        "The renderer process may only import @pwragent/shared. All other package access goes through IPC.",
+      from: {
+        path: "^apps/desktop/src/renderer/",
+      },
+      to: {
+        path: "^(@pwragent/(?!shared)|packages/(?!shared/))",
       },
     },
     {
@@ -18,7 +67,7 @@ module.exports = {
         path: "^packages/messaging/interface/",
       },
       to: {
-        path: "^(apps/|packages/agent-core/|packages/messaging/providers/)",
+        path: "^(@pwragent/(agent-core|messaging-provider|codex-app-server-protocol|desktop)|apps/|packages/agent-core/|packages/codex-app-server-protocol/|packages/messaging/providers/)",
       },
     },
     {
@@ -30,7 +79,7 @@ module.exports = {
         path: "^packages/messaging/providers/",
       },
       to: {
-        path: "^(apps/|packages/agent-core/)",
+        path: "^(@pwragent/(agent-core|codex-app-server-protocol|desktop)|apps/|packages/agent-core/|packages/codex-app-server-protocol/)",
       },
     },
     {
@@ -42,7 +91,7 @@ module.exports = {
         path: "^packages/messaging/providers/",
       },
       to: {
-        path: "^packages/shared/",
+        path: "^(@pwragent/shared|packages/shared/)",
       },
     },
     {
@@ -54,7 +103,7 @@ module.exports = {
         path: "^packages/messaging/providers/([^/]+)/",
       },
       to: {
-        path: "^packages/messaging/providers/",
+        path: "^(@pwragent/messaging-provider-|packages/messaging/providers/)",
         pathNot: "^packages/messaging/providers/$1/",
       },
     },
@@ -67,7 +116,7 @@ module.exports = {
         path: "^apps/desktop/src/main/messaging/core/",
       },
       to: {
-        path: "^packages/messaging/providers/",
+        path: "^(@pwragent/messaging-provider-|packages/messaging/providers/)",
       },
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,20 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Dependency boundaries
+        run: |
+          pnpm exec depcruise --config .dependency-cruiser.cjs \
+            --output-type json --output-to cruise-result.json \
+            packages/ apps/desktop/src/
+          pnpm exec depcruise-fmt --exit-code cruise-result.json
+
+      - name: Boundary violation summary
+        if: failure()
+        run: |
+          pnpm exec depcruise-fmt -T markdown cruise-result.json >> "$GITHUB_STEP_SUMMARY"
 
   build:
     name: Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,28 @@
 - Recents is the default browsing lens.
 - A thread may be associated with multiple linked Git directories.
 
+## Dependency Boundary Enforcement
+
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This repository enforces a strict layered dependency architecture via
+`dependency-cruiser` (`.dependency-cruiser.cjs`). These rules are load-bearing:
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from packages above a package's layer in the dependency hierarchy
+- **DO NOT** introduce circular dependencies between any modules
+- **DO NOT** move or restructure code to circumvent boundary rules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+The dependency hierarchy (bottom to top):
+- **Leaves** (import nothing internal): `packages/shared`, `packages/codex-app-server-protocol`
+- **Mid-tier**: `packages/messaging/interface` (→ shared only), `packages/messaging/providers/*` (→ messaging/interface only), `packages/agent-core` (→ shared only)
+- **Top**: `apps/desktop` (→ any package)
+
+Additional renderer constraint: `apps/desktop/src/renderer/` may only import `@pwragent/shared`. All other package access crosses the IPC bridge via the main process.
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation. Run it locally before pushing.
+
 ## App-Specific Guidance
 
 - Additional desktop-app instructions live in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -87,6 +87,22 @@ For binding-local mutations that do NOT flow through the registry
 (e.g. `cycleToolUpdateMode`, `syncConversationName`), keep the inline
 `renderBindingStatus` call — there's no bus event for those.
 
+## Dependency Boundary Enforcement
+
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+The desktop app sits at the **top** of the dependency hierarchy and may import any `@pwragent/*` package. However:
+
+- The **renderer** (`src/renderer/`) may only import `@pwragent/shared`. All other package access must go through IPC to the main process.
+- The **main process** may import any package but must not create circular dependencies.
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** import provider SDKs (`grammy`, `discord.js`, `telegraf`) in `src/main/messaging/core/`
+- **DO NOT** introduce circular dependencies between any modules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.
+
 ## Implementation Notes
 
 - Centralize visual tokens in `styles/app.css` before expanding renderer surfaces.

--- a/docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md
+++ b/docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md
@@ -1,0 +1,62 @@
+---
+date: 2026-05-05
+topic: dependency-boundary-enforcement
+---
+
+# Dependency Boundary Enforcement
+
+## Problem Frame
+
+The repo has a clear layered architecture where packages at the bottom of the dependency graph must not import packages above them. Today, dependency-cruiser enforces this for the messaging tree only (`packages/messaging` and `apps/desktop/src/main/messaging`). The rest of the repo — `packages/agent-core`, `packages/shared`, `packages/codex-app-server-protocol`, and the broader desktop app — has no automated boundary checking.
+
+AI coding agents and future developers may inadvertently (or in the name of convenience) introduce circular dependencies or upward imports that create tightly coupled spaghetti. Once introduced, these are expensive to unwind. The existing AGENTS.md files describe boundaries but do not explicitly forbid weakening the enforcement tooling itself.
+
+## Requirements
+
+- R1. Expand `depcruise` coverage to enforce the full repo dependency hierarchy, not just the messaging subtree.
+- R2. Enforce the following dependency DAG (each layer may only import layers below it):
+  - **Leaves** (import nothing internal): `packages/shared`, `packages/codex-app-server-protocol`
+  - **Mid-tier packages**: `packages/messaging/interface` (→ shared only), `packages/messaging/providers/*` (→ messaging/interface only), `packages/agent-core` (→ shared only)
+  - **Top**: `apps/desktop` (may import any package)
+- R3. Retain and preserve all existing messaging-specific rules (interface isolation, provider isolation, no sibling provider imports, no provider SDK leakage into desktop messaging core).
+- R4. Add stern, unambiguous warnings to the root `AGENTS.md` and every package-level `AGENTS.md` stating that dependency boundary rules must not be loosened, exceptions must not be added to `.dependency-cruiser.cjs`, and circular dependencies are never acceptable.
+- R5. The `pnpm lint:boundaries` command must scan all packages and apps, not just the messaging subtree.
+- R6. CI continues to fail on boundary violations (already wired via `pnpm lint` → `pnpm lint:boundaries`).
+- R7. The global `no-circular` rule must apply to all scanned source, not just messaging.
+- R8. When `lint:boundaries` fails in CI, produce a readable GitHub Actions step summary showing which rules were violated, which files are involved, and the dependency path — using depcruise's built-in reporters rather than a custom report script.
+
+## Success Criteria
+
+- Running `pnpm lint:boundaries` catches any import from a leaf package (`shared`, `codex-app-server-protocol`) into a higher-level package.
+- Running `pnpm lint:boundaries` catches any import from `agent-core` into `apps/desktop` or messaging providers.
+- Running `pnpm lint:boundaries` catches any circular dependency anywhere in the scanned source.
+- An AI agent reading any package's AGENTS.md encounters an explicit prohibition against loosening boundary rules or adding exceptions.
+- The `.dependency-cruiser.cjs` file itself is called out in AGENTS.md as protected — agents must not modify it to add allowances.
+
+## Scope Boundaries
+
+- This work does not restructure existing code to fix violations (if any are found, they are flagged as separate follow-up work).
+- This work does not add pre-commit hooks (CI is the enforcement gate).
+- This work does not change the package dependency declarations in `package.json` files — it enforces the import graph at the source level.
+- This work does not cover runtime/dynamic imports or `require()` calls that bypass static analysis (dependency-cruiser handles most of these, but edge cases are accepted).
+- This work does not add a full custom report generator (like the openclaw 617-line script with Mermaid/SCC analysis). It uses depcruise's built-in output reporters for CI summaries.
+
+## Key Decisions
+
+- **Expand depcruise scope to whole repo**: The `lint:boundaries` command will scan all source under `packages/` and `apps/`, not just the messaging paths.
+- **AGENTS.md warnings in all locations**: Root and every package-level AGENTS.md will carry the warning, even if redundant, to maximize visibility for AI agents that read local context.
+- **CI already enforces**: No new CI step needed — `pnpm lint` already runs `lint:boundaries` and the CI `lint` job already runs `pnpm lint`.
+- **Readable CI failure output**: Use depcruise's built-in reporters to emit a GitHub Actions step summary on failure (inspired by openclaw/openclaw#61519), not a custom report script.
+- **codex-app-server-protocol is a leaf**: It has zero internal dependencies today and the rules will prevent any from being added.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Are there any existing violations when depcruise scans the full repo? If so, they need to be cataloged and tracked as separate cleanup work.
+- [Affects R5][Technical] Does the depcruise `tsConfig` option need adjustment (currently points to `tsconfig.base.json`) when scanning the full repo, or do individual package tsconfigs need to be resolved?
+- [Affects R2][Needs research] Should `packages/agent-core` be allowed to import `packages/codex-app-server-protocol` (both are mid-tier but unrelated), or should they be fully isolated from each other?
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-05-06-001-feat-repo-wide-dependency-boundary-enforcement-plan.md
+++ b/docs/plans/2026-05-06-001-feat-repo-wide-dependency-boundary-enforcement-plan.md
@@ -1,0 +1,229 @@
+---
+title: "feat: Expand dependency boundary enforcement repo-wide"
+type: feat
+status: active
+date: 2026-05-06
+origin: docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md
+---
+
+# feat: Expand dependency boundary enforcement repo-wide
+
+## Overview
+
+Expand the existing dependency-cruiser setup from messaging-only coverage to the full monorepo, add new rules for all package layers, produce readable CI summaries on failure, and add stern AGENTS.md warnings that prevent AI agents and developers from weakening the enforcement.
+
+## Problem Statement / Motivation
+
+The repo has a layered architecture, but only the messaging subtree is checked by dependency-cruiser today. The rest (`packages/shared`, `packages/codex-app-server-protocol`, `packages/agent-core`, `apps/desktop` main/renderer) has no automated boundary enforcement. AI agents may introduce circular or upward imports without realizing the architectural cost. (see origin: docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md)
+
+## Proposed Solution
+
+Three-layer approach:
+
+1. **Expand `.dependency-cruiser.cjs`** with new rules for all package tiers
+2. **Widen `lint:boundaries`** to scan the full source tree
+3. **Add CI step summary** using depcruise's `markdown` reporter via JSON intermediate + `depcruise-fmt`
+4. **Add AGENTS.md warnings** to root and every package-level AGENTS.md
+
+## Technical Considerations
+
+### Architecture
+
+The dependency DAG is already clean (verified: 942 modules, 1227 dependencies, 0 violations when scanning the full repo today). This is purely additive enforcement — no existing code needs changing.
+
+### Resolution
+
+`tsconfig.base.json` has no path aliases. All `@pwragent/*` imports resolve through pnpm workspace symlinks in `node_modules/`. The existing `doNotFollow` option in depcruise skips actual npm packages but follows workspace symlinks correctly.
+
+### CI Integration
+
+`pnpm lint` → `pnpm lint:boundaries` is already gated in CI (`ci.yml` lint job). Expanding the depcruise scan arguments is automatically enforced.
+
+## Implementation Phases
+
+### Phase 1: Expand dependency-cruiser rules
+
+Add these new rules to `.dependency-cruiser.cjs`:
+
+**New rule: `shared-is-a-leaf`**
+```javascript
+{
+  name: "shared-is-a-leaf",
+  severity: "error",
+  comment: "packages/shared must not import any internal workspace package.",
+  from: { path: "^packages/shared/" },
+  to: { path: "^(apps/|packages/(?!shared/))" },
+}
+```
+
+**New rule: `codex-protocol-is-a-leaf`**
+```javascript
+{
+  name: "codex-protocol-is-a-leaf",
+  severity: "error",
+  comment: "packages/codex-app-server-protocol must not import any internal workspace package.",
+  from: { path: "^packages/codex-app-server-protocol/" },
+  to: { path: "^(apps/|packages/(?!codex-app-server-protocol/))" },
+}
+```
+
+**New rule: `agent-core-only-imports-shared`**
+```javascript
+{
+  name: "agent-core-only-imports-shared",
+  severity: "error",
+  comment: "agent-core may only depend on packages/shared internally.",
+  from: { path: "^packages/agent-core/" },
+  to: { path: "^(apps/|packages/(?!shared/|agent-core/))" },
+}
+```
+
+**New rule: `desktop-renderer-only-imports-shared`**
+```javascript
+{
+  name: "desktop-renderer-only-imports-shared",
+  severity: "error",
+  comment: "The renderer process may only import @pwragent/shared. All other package access goes through IPC.",
+  from: { path: "^apps/desktop/src/renderer/" },
+  to: { path: "^packages/(?!shared/)" },
+}
+```
+
+**Existing rules retained intact** (R3 from origin): all 7 messaging-specific rules stay unchanged.
+
+### Phase 2: Widen lint:boundaries scan scope
+
+Update root `package.json` script:
+
+```diff
+- "lint:boundaries": "depcruise --config .dependency-cruiser.cjs apps/desktop/src/main/messaging packages/messaging",
++ "lint:boundaries": "depcruise --config .dependency-cruiser.cjs packages/ apps/desktop/src/",
+```
+
+This scans all packages and the full desktop app source in a single pass. The `no-circular` rule (already present) will now enforce acyclicity repo-wide (R7).
+
+### Phase 3: CI step summary on failure
+
+Update `.github/workflows/ci.yml` lint step to produce a readable markdown summary when violations are detected:
+
+```yaml
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: install-deps
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Restore dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Type check
+        run: pnpm typecheck
+      - name: Dependency boundaries
+        run: |
+          pnpm exec depcruise --config .dependency-cruiser.cjs \
+            --output-type json --output-to cruise-result.json \
+            packages/ apps/desktop/src/
+          pnpm exec depcruise-fmt --exit-code cruise-result.json
+      - name: Boundary violation summary
+        if: failure()
+        run: |
+          pnpm exec depcruise-fmt -T markdown cruise-result.json >> "$GITHUB_STEP_SUMMARY"
+```
+
+This splits the lint script: `typecheck` stays as `pnpm typecheck` but the boundary check uses the JSON-then-format pattern so violations produce a readable GitHub step summary with rule names, file paths, and dependency chains (R8).
+
+### Phase 4: AGENTS.md warnings
+
+Add a `## Dependency Boundary Enforcement` section to these files:
+
+1. **Root `AGENTS.md`** (canonical rules + stern warning)
+2. **`packages/shared/AGENTS.md`** (new file — leaf declaration + warning)
+3. **`packages/codex-app-server-protocol/AGENTS.md`** (existing file — add section)
+4. **`packages/agent-core/AGENTS.md`** (new file — boundary + warning)
+5. **`packages/messaging/AGENTS.md`** (existing file — strengthen existing section)
+6. **`apps/desktop/AGENTS.md`** (existing file — add section)
+
+**Warning template** (adapted per package):
+
+```markdown
+## Dependency Boundary Enforcement
+
+⚠️ **DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This repository enforces a strict layered dependency architecture via
+`dependency-cruiser` (`.dependency-cruiser.cjs`). These rules are load-bearing:
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from packages above this package's layer in the dependency hierarchy
+- **DO NOT** introduce circular dependencies between any modules
+- **DO NOT** move or restructure code to circumvent boundary rules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+The dependency hierarchy (bottom to top):
+- Leaves: `packages/shared`, `packages/codex-app-server-protocol`
+- Mid-tier: `packages/messaging/interface` (→ shared), `packages/messaging/providers/*` (→ interface), `packages/agent-core` (→ shared)
+- Top: `apps/desktop` (→ any package)
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.
+```
+
+Each package-level AGENTS.md adds a line specifying what **this** package may import:
+- `shared`: "This package is a leaf. It must not import any `@pwragent/*` package."
+- `codex-app-server-protocol`: "This package is a leaf. It must not import any `@pwragent/*` package."
+- `agent-core`: "This package may only import `@pwragent/shared`."
+- `messaging/interface`: "This package may only import `@pwragent/shared`."
+- `messaging/providers/*`: "This package may only import `@pwragent/messaging-interface`."
+- `apps/desktop` renderer: "The renderer process may only import `@pwragent/shared`. Everything else crosses the IPC bridge."
+
+## Acceptance Criteria
+
+- [ ] `.dependency-cruiser.cjs` has rules enforcing the full dependency DAG (R1, R2)
+- [ ] All existing messaging rules remain intact and passing (R3)
+- [ ] `pnpm lint:boundaries` scans all packages and apps (R5)
+- [ ] `no-circular` rule applies repo-wide (R7)
+- [ ] CI produces a markdown step summary on boundary violations (R8)
+- [ ] Root AGENTS.md contains the stern boundary warning (R4)
+- [ ] Every package-level AGENTS.md contains the boundary warning (R4)
+- [ ] `pnpm lint:boundaries` passes on the current codebase (verified: 0 violations)
+- [ ] A simulated violation (e.g., adding `import '@pwragent/agent-core'` in `packages/shared`) is caught
+
+## Dependencies & Risks
+
+- **Risk**: `depcruise-fmt` needs to be available in CI. It ships with the `dependency-cruiser` npm package (already in devDependencies), so no new install needed.
+- **Risk**: Scanning the full `packages/` and `apps/desktop/src/` may increase lint time. Current messaging-only scan is fast; the full scan (942 modules) completed in under 5 seconds locally — acceptable.
+- **Risk**: Future packages added to the workspace won't automatically get AGENTS.md warnings. Mitigation: the root AGENTS.md warning covers everything, and `no-circular` + leaf rules apply globally regardless of AGENTS.md presence.
+
+## Resolved Deferred Questions
+
+| Question | Resolution |
+|----------|-----------|
+| Existing violations when scanning full repo? | **None** — verified 0 violations across 942 modules. |
+| Does tsConfig need adjustment? | **No** — `tsconfig.base.json` has no path aliases. Resolution works via pnpm workspace symlinks. |
+| Should agent-core import codex-app-server-protocol? | **No** — they are unrelated mid-tier packages. Both import only `shared`. Enforce isolation. |
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md](docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md) — Key decisions: expand coverage repo-wide, warnings in all AGENTS.md files, use built-in reporters for CI summaries.
+
+### Internal References
+
+- Current depcruise config: [.dependency-cruiser.cjs](../../.dependency-cruiser.cjs)
+- Root package.json lint scripts: [package.json:16-17](../../package.json:16)
+- CI workflow lint job: [.github/workflows/ci.yml:29-41](../../.github/workflows/ci.yml:29)
+- Messaging AGENTS.md boundary section: [packages/messaging/AGENTS.md:9-13](../../packages/messaging/AGENTS.md:9)
+
+### External References
+
+- dependency-cruiser CLI docs: https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md
+- dependency-cruiser `markdown` reporter for step summaries
+- `depcruise-fmt` for JSON-to-reporter formatting without re-scanning
+- Inspiration: openclaw/openclaw#61519 (non-blocking circular report in CI)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:no-messaging": "PWRAGENT_DISABLE_MESSAGING=1 pnpm --filter @pwragent/desktop dev -- --disable-messaging",
     "dev:op": "node ./scripts/op-run.mjs dev",
     "lint": "pnpm typecheck && pnpm lint:boundaries",
-    "lint:boundaries": "depcruise --config .dependency-cruiser.cjs apps/desktop/src/main/messaging packages/messaging",
+    "lint:boundaries": "depcruise --config .dependency-cruiser.cjs packages/ apps/desktop/src/",
     "release:check": "node ./scripts/check-desktop-release-metadata.mjs",
     "test:desktop-e2e": "pnpm --filter @pwragent/desktop test:e2e",
     "test:desktop-e2e:nice": "node ./scripts/nice-run.mjs pnpm test:desktop-e2e",

--- a/packages/agent-core/AGENTS.md
+++ b/packages/agent-core/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Core Package Guidance
+
+This package contains the coding agent implementation (currently the Grok coding agent via AI SDK).
+
+## Dependency Boundary Enforcement
+
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This package may only import `@pwragent/shared`. It must not import desktop, messaging, codex-app-server-protocol, or any other internal package.
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from any internal package other than `@pwragent/shared`
+- **DO NOT** introduce circular dependencies between any modules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.

--- a/packages/agent-core/CLAUDE.md
+++ b/packages/agent-core/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/codex-app-server-protocol/AGENTS.md
+++ b/packages/codex-app-server-protocol/AGENTS.md
@@ -17,3 +17,16 @@ pnpm --filter @pwragent/codex-app-server-protocol generate
 Do not edit generated files by hand. Use the stable bindings by default; only add experimental protocol imports when clients intentionally opt into experimental App Server APIs.
 
 Keep this package as a leaf-level generated protocol package. Normalized PwrAgent app-server contracts belong in `@pwragent/shared`, not here.
+
+## Dependency Boundary Enforcement
+
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This package is a **leaf**. It must not import any `@pwragent/*` package or any other internal workspace package.
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from any internal package — this is generated protocol types only
+- **DO NOT** introduce circular dependencies between any modules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.

--- a/packages/messaging/AGENTS.md
+++ b/packages/messaging/AGENTS.md
@@ -47,8 +47,18 @@ for binding-scoped preferences.
 See `apps/desktop/AGENTS.md` for the registry-side emit pattern and
 the renderer-side subscription branches.
 
-## Enforcement
+## Dependency Boundary Enforcement
 
-- Boundary rules are enforced by `.dependency-cruiser.cjs` via `pnpm lint:boundaries`.
-- Each package has its own `tsconfig.json`; keep provider source inside its package root and avoid cross-package relative imports.
-- Run `pnpm lint` after changing this tree. For provider behavior, add tests in the provider package or the relevant desktop messaging adapter test, depending on where the behavior is exercised.
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This tree's allowed imports:
+- `packages/messaging/interface` may only import `@pwragent/shared`
+- `packages/messaging/providers/*` may only import `@pwragent/messaging-interface` (not shared, not desktop, not agent-core, not sibling providers)
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from packages above this tree's layer in the dependency hierarchy
+- **DO NOT** introduce circular dependencies between any modules
+- **DO NOT** import provider SDKs (`grammy`, `discord.js`, `telegraf`) from the interface package or from desktop messaging core
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+Boundary rules are enforced by `.dependency-cruiser.cjs` via `pnpm lint:boundaries`. Each package has its own `tsconfig.json`; keep provider source inside its package root and avoid cross-package relative imports. Run `pnpm lint` after changing this tree. For provider behavior, add tests in the provider package or the relevant desktop messaging adapter test, depending on where the behavior is exercised.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,16 @@
+# Shared Package Guidance
+
+This package contains types, contracts, and utility functions shared across the monorepo. It is the lowest-level internal package.
+
+## Dependency Boundary Enforcement
+
+**DO NOT, under any circumstances, loosen the dependency boundary rules.**
+
+This package is a **leaf**. It must not import any `@pwragent/*` package or any other internal workspace package.
+
+- **DO NOT** add exceptions, allowlists, or `severity: "ignore"` overrides to `.dependency-cruiser.cjs`
+- **DO NOT** add imports from any internal package — shared is the foundation layer
+- **DO NOT** introduce circular dependencies between any modules
+- If a rule blocks your change, the change is architecturally wrong — redesign it
+
+Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Expands `dependency-cruiser` enforcement from the messaging subtree to the entire monorepo, codifies the layered dependency DAG, adds a readable markdown CI summary on violations, and embeds stern warnings in every package-level `AGENTS.md` so agents and devs can't quietly weaken the rules.

Origin: [docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md](docs/brainstorms/2026-05-05-dependency-boundary-enforcement-requirements.md) → [docs/plans/2026-05-06-001-feat-repo-wide-dependency-boundary-enforcement-plan.md](docs/plans/2026-05-06-001-feat-repo-wide-dependency-boundary-enforcement-plan.md).

## What Changed

### New depcruise rules (`.dependency-cruiser.cjs`)
- `shared-is-a-leaf` — `packages/shared` may not import any internal package
- `codex-protocol-is-a-leaf` — `packages/codex-app-server-protocol` may not import any internal package
- `agent-core-only-imports-shared` — `packages/agent-core` may only import `@pwragent/shared`
- `desktop-renderer-only-imports-shared` — renderer may only import `@pwragent/shared` (everything else crosses IPC)
- All existing rules retained and updated

### Resolution fix
Workspace imports via `@pwragent/*` resolve to bare specifiers (depcruise can't follow pnpm `node_modules` symlinks). Every rule's `to.path` now matches both forms — the resolved file path (`^packages/...`) and the bare specifier (`^@pwragent/...`). Without this, the existing messaging rules also wouldn't have caught cross-package workspace imports.

### Scan scope (`package.json`)
```diff
- "lint:boundaries": "depcruise --config .dependency-cruiser.cjs apps/desktop/src/main/messaging packages/messaging"
+ "lint:boundaries": "depcruise --config .dependency-cruiser.cjs packages/ apps/desktop/src/"
```

### CI step summary (`.github/workflows/ci.yml`)
Lint job now runs the JSON+format pattern. On boundary violations, a readable markdown summary (rule name → from-file → to-file) is emitted to `$GITHUB_STEP_SUMMARY` via `depcruise-fmt -T markdown`. Inspired by [openclaw/openclaw#61519](https://github.com/openclaw/openclaw/pull/61519), but blocking instead of advisory since this repo has 0 existing violations.

### AGENTS.md hardening
Stern "DO NOT loosen the rules" warning added to:
- Root [AGENTS.md](AGENTS.md)
- [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md)
- [packages/messaging/AGENTS.md](packages/messaging/AGENTS.md)
- [packages/codex-app-server-protocol/AGENTS.md](packages/codex-app-server-protocol/AGENTS.md)
- New [packages/shared/AGENTS.md](packages/shared/AGENTS.md) (+ CLAUDE.md symlink)
- New [packages/agent-core/AGENTS.md](packages/agent-core/AGENTS.md) (+ CLAUDE.md symlink)

## Verification

- `pnpm lint:boundaries` passes on current codebase: **0 violations across 949 modules / 1233 dependencies**
- Confirmed each new rule catches its violation:
  - `shared/index.ts → @pwragent/agent-core` → `shared-is-a-leaf`
  - `agent-core/index.ts → @pwragent/messaging-interface` → `agent-core-only-imports-shared`
  - `renderer/App.tsx → @pwragent/agent-core` → `desktop-renderer-only-imports-shared`
  - `messaging/interface/index.ts → @pwragent/agent-core` → `messaging-interface-has-no-provider-dependencies`

## Dependency Hierarchy (codified)

- **Leaves**: `packages/shared`, `packages/codex-app-server-protocol`
- **Mid-tier**: `packages/messaging/interface` (→ shared), `packages/messaging/providers/*` (→ interface), `packages/agent-core` (→ shared)
- **Top**: `apps/desktop` (→ any package; renderer restricted to shared)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is build-time/CI tooling only with no runtime impact. Validation is the green CI lint job on this PR.

## Test Plan

- [x] `pnpm lint:boundaries` passes locally
- [x] CI lint job passes
- [ ] CI step summary renders correctly on a simulated violation (will be exercised the first time a real violation is introduced)

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0