### PR TITLE
fix(desktop): pin default-access codex client to workspace-write sandbox at spawn

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -8,13 +8,15 @@ const REPLAY_FIXTURE_PATH_ENV = "PWRAGENT_REPLAY_FIXTURE_PATH";
 
 const constructorState = vi.hoisted(() => ({
   codexCount: 0,
+  codexArgs: [] as Array<string[] | undefined>,
   grokCount: 0,
 }));
 
 vi.mock("../codex-app-server/client", () => ({
   CodexAppServerClient: class {
-    constructor() {
+    constructor(options?: { args?: string[] }) {
       constructorState.codexCount += 1;
+      constructorState.codexArgs.push(options?.args);
     }
 
     async close(): Promise<void> {
@@ -64,6 +66,12 @@ vi.mock("../codex-app-server/client", () => ({
       return { threadId: "noop-thread", turnId: "noop-turn" };
     }
   }
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: () => ({
+    resolveCodexCommandPreference: () => undefined,
+  }),
 }));
 
 vi.mock("../grok-app-server/client", () => ({
@@ -147,6 +155,7 @@ function createOverlayStoreMock() {
 
 beforeEach(() => {
   constructorState.codexCount = 0;
+  constructorState.codexArgs = [];
   constructorState.grokCount = 0;
 });
 
@@ -234,6 +243,30 @@ describe("DesktopBackendRegistry replay isolation", () => {
     await expect(registry.listThreads({ backend: "grok" })).resolves.toEqual([]);
     expect(constructorState.codexCount).toBe(0);
     expect(constructorState.grokCount).toBe(0);
+
+    await registry.close();
+  });
+
+  it("spawns both codex clients with explicit sandbox args so neither inherits permissive upstream defaults", async () => {
+    const registry = new DesktopBackendRegistry({
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    expect(constructorState.codexCount).toBe(2);
+    expect(constructorState.codexArgs).toEqual([
+      [
+        "-c",
+        'approval_policy="on-request"',
+        "-c",
+        'sandbox_mode="workspace-write"',
+      ],
+      [
+        "-c",
+        'approval_policy="never"',
+        "-c",
+        'sandbox_mode="danger-full-access"',
+      ],
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2662,6 +2662,17 @@ export class DesktopBackendRegistry {
     requestedMode?: ThreadExecutionMode,
   ): Promise<T> {
     if (requestedMode) {
+      // Diagnostic for #203-class regressions: any silent escalation
+      // from Default → Full Access (or vice versa) is the load-bearing
+      // security property of execution-mode routing. Log the
+      // requestedMode and the client we resolved to so post-mortem
+      // log review can prove which Codex sandbox actually ran a turn.
+      backendRegistryLog.info("codex thread client routing", {
+        threadId,
+        requestedMode,
+        resolvedMode: requestedMode,
+        source: "explicit",
+      });
       return await operation(this.getClient("codex", requestedMode), requestedMode);
     }
 
@@ -2677,7 +2688,15 @@ export class DesktopBackendRegistry {
     let lastError: unknown;
     for (const mode of modes) {
       try {
-        return await operation(this.getClient("codex", mode), mode);
+        const result = await operation(this.getClient("codex", mode), mode);
+        backendRegistryLog.info("codex thread client routing", {
+          threadId,
+          requestedMode: undefined,
+          resolvedMode: mode,
+          source: preferredMode === mode ? "overlay" : "fallback",
+          overlayMode: preferredMode,
+        });
+        return result;
       } catch (error) {
         lastError = error;
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -515,15 +515,20 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
 }
 
 function buildCodexClientArgs(mode: ThreadExecutionMode): string[] {
-  if (mode !== "full-access") {
-    return [];
+  if (mode === "full-access") {
+    return [
+      "-c",
+      'approval_policy="never"',
+      "-c",
+      'sandbox_mode="danger-full-access"',
+    ];
   }
 
   return [
     "-c",
-    'approval_policy="never"',
+    'approval_policy="on-request"',
     "-c",
-    'sandbox_mode="danger-full-access"',
+    'sandbox_mode="workspace-write"',
   ];
 }
 
@@ -1092,6 +1097,7 @@ export class DesktopBackendRegistry {
       options?.codexClient ??
       replayClients?.codexDefaultClient ??
       new CodexAppServerClient({
+        args: buildCodexClientArgs("default"),
         command: codexCommand,
         connectionObserver: codexDefaultObserver,
         clientVersion,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -117,17 +117,36 @@ type AssistantStreamBuffer = AssistantStreamDelta & {
   text: string;
 };
 
+type ExecutionModeResolution = {
+  mode: ThreadExecutionMode | undefined;
+  source: "thread" | "binding-preferences" | "permissions-mode" | "unset";
+};
+
+function resolveExecutionModeForBinding(
+  binding: MessagingBindingRecord,
+  navigation?: NavigationSnapshot,
+): ExecutionModeResolution {
+  const thread = findThreadForBinding(navigation, binding);
+  if (thread?.executionMode) {
+    return { mode: thread.executionMode, source: "thread" };
+  }
+  if (binding.preferences?.executionMode) {
+    return { mode: binding.preferences.executionMode, source: "binding-preferences" };
+  }
+  if (binding.preferences?.permissionsMode === "full-access") {
+    return { mode: "full-access", source: "permissions-mode" };
+  }
+  if (binding.preferences?.permissionsMode === "default") {
+    return { mode: "default", source: "permissions-mode" };
+  }
+  return { mode: undefined, source: "unset" };
+}
+
 function executionModeForBinding(
   binding: MessagingBindingRecord,
   navigation?: NavigationSnapshot,
 ): ThreadExecutionMode | undefined {
-  const thread = findThreadForBinding(navigation, binding);
-  return (
-    thread?.executionMode ??
-    binding.preferences?.executionMode ??
-    (binding.preferences?.permissionsMode === "full-access" ? "full-access" : undefined) ??
-    (binding.preferences?.permissionsMode === "default" ? "default" : undefined)
-  );
+  return resolveExecutionModeForBinding(binding, navigation).mode;
 }
 
 function turnSettingsForBinding(
@@ -169,6 +188,8 @@ function formatAttachmentRejections(
 
 type MessagingControllerLogger = {
   debug?(message: string, data?: Record<string, unknown>): void;
+  info?(message: string, data?: Record<string, unknown>): void;
+  warn?(message: string, data?: Record<string, unknown>): void;
 };
 
 type MessagingToolUpdateDefaultModeResolver =
@@ -851,6 +872,31 @@ export class MessagingController {
         backend: "all",
       });
       const turnSettings = turnSettingsForBinding(params.binding, navigation);
+      const executionResolution = resolveExecutionModeForBinding(
+        params.binding,
+        navigation,
+      );
+      // Diagnostic for #203-class regressions: a turn that the UI shows
+      // as Default Access but routes to the Full Access codex client is
+      // a silent security bug — the user thinks they're sandboxed but
+      // commands like `npm view` succeed because the full-access client
+      // skipped the network sandbox. We log the resolved mode + where
+      // it came from here at the messaging layer; the registry's
+      // `codex thread client routing` log shows which client actually
+      // received the turn. Cross-reference both lines by threadId to
+      // verify the routing matched intent. `executionModeSource` of
+      // anything other than `thread` is suspicious for a thread the UI
+      // claims has been explicitly toggled.
+      this.logger.info?.("messaging starting turn", {
+        backend: params.binding.backend,
+        bindingId: params.binding.id,
+        channel: params.binding.channel.channel,
+        threadId: params.binding.threadId,
+        executionMode: turnSettings.executionMode ?? "unset",
+        executionModeSource: executionResolution.source,
+        model: turnSettings.model,
+        fastMode: turnSettings.fastMode,
+      });
       const started = await this.options.backend.startTurn({
         backend: params.binding.backend,
         threadId: params.binding.threadId,
@@ -858,6 +904,12 @@ export class MessagingController {
         ...turnSettings,
       });
       turnStarted = true;
+      this.logger.info?.("messaging turn started", {
+        bindingId: params.binding.id,
+        threadId: params.binding.threadId,
+        turnId: started.turnId,
+        requestedExecutionMode: turnSettings.executionMode ?? "unset",
+      });
       const activeTurn: MessagingActiveTurnSummary = {
         turnId: started.turnId,
         status: "working",


### PR DESCRIPTION
## Summary

The default-access codex client was being spawned with **no `args`**, so the spawned codex process inherited whatever sandbox + approval policy upstream codex chose by compiled-in default and whatever the user's `~/.codex/config.toml` set. Recent codex builds default to permissive auto-approval, which meant the "Default Access" client was actually running turns with effectively **no sandbox** at the OS level — silently allowing network and arbitrary filesystem writes despite the UI labeling the thread as workspace-write / on-request.

Per-turn `approvalPolicy` / `sandbox` parameters passed to `turn/start` are advisory hints; they don't retroactively constrain the OS sandbox of an already-running codex process. The only reliable way to guarantee the sandbox is to pin it via `-c` flags at spawn time, which the full-access client was already doing — but the default client wasn't.

## What changed

`buildCodexClientArgs("default")` now returns:

```
-c approval_policy="on-request"
-c sandbox_mode="workspace-write"
```

…and the default codex client constructor uses it, mirroring the full-access client's spawn pattern:

```ts
this.codexDefaultClient = new CodexAppServerClient({
  args: buildCodexClientArgs("default"),  // ← was missing entirely
  command: codexCommand,
  ...
});
```

`EXECUTION_MODE_SUMMARIES` still holds the per-mode authoritative values; both per-turn hints and process-level args now agree.

## How this was found

PR #203 fixed the Composer's missing-`executionMode` bug and the registry's cross-mode fallback. After merge, the user reproduced the silent-network behavior from a freshly-restarted desktop with a Default Access thread. The diagnostic logging commit on `feat/messaging-mattermost-adapter` (cherry-picked here as `783a20a0`) showed:

```
messaging starting turn  executionMode=default executionModeSource=thread
codex thread client routing  requestedMode=default resolvedMode=default source=explicit
```

…both correct. That cleanly exonerated the messaging path, the Composer, and the registry routing layer. The bug was upstream of all three — at codex process spawn, where the default client had been picking up permissive upstream defaults all along.

## Verification

- After this change, restarting the desktop and running `npm view <pkg>` in a Default Access thread fires the approval prompt instead of silently running. Confirmed in user testing.
- Adds a regression test in `backend-registry-replay-isolation.test.ts` that asserts both clients receive the expected `-c` args from the registry constructor, so future drift in `buildCodexClientArgs` or its callers fails CI rather than silently loosening the default sandbox.

## Commits

1. `783a20a0` — `feat(messaging): log codex execution-mode routing for #203-class diagnostics` (cherry-picked from `feat/messaging-mattermost-adapter`). Already shipped on the parallel mattermost branch but useful baseline diagnostics for any future #203-class regression.
2. `2f1a0e57` — the actual fix.

## Test plan

- [x] `npx vitest run --config vitest.workspace.ts apps/desktop/src/main/__tests__/backend-registry*` — 58/58 pass (1 new regression test).
- [x] User confirmed end-to-end: after restart, `npm view esbuild` on a Default Access thread fires approval; before this fix, it ran silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)