### PR TITLE
feat(messaging): /help command + canonical verb catalog

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  MESSAGING_COMMAND_CATALOG,
+  formatMessagingCommandHelpBody,
+  matchMessagingCommandVerb,
+} from "../messaging/core/messaging-command-catalog.js";
+
+describe("MESSAGING_COMMAND_CATALOG", () => {
+  it("declares the canonical verb set in the documented order", () => {
+    // Order is intentional — `resume` is the most common entry
+    // point, `help` is the meta-command. The `/help` body relies on
+    // this order; if you reorder, the help text reorders too.
+    expect(MESSAGING_COMMAND_CATALOG.map((spec) => spec.verb)).toEqual([
+      "resume",
+      "status",
+      "detach",
+      "help",
+    ]);
+  });
+
+  it("provides a non-empty description for every verb", () => {
+    for (const spec of MESSAGING_COMMAND_CATALOG) {
+      expect(spec.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses lowercase verbs (matches dispatch contract — controller lowercases inbound commands before lookup)", () => {
+    for (const spec of MESSAGING_COMMAND_CATALOG) {
+      expect(spec.verb).toBe(spec.verb.toLowerCase());
+    }
+  });
+});
+
+describe("matchMessagingCommandVerb", () => {
+  it("recognizes every catalog verb", () => {
+    for (const spec of MESSAGING_COMMAND_CATALOG) {
+      expect(matchMessagingCommandVerb(spec.verb)).toBe(spec.verb);
+    }
+  });
+
+  it("strips a leading slash before matching", () => {
+    expect(matchMessagingCommandVerb("/resume")).toBe("resume");
+    expect(matchMessagingCommandVerb("/status")).toBe("status");
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchMessagingCommandVerb("RESUME")).toBe("resume");
+    expect(matchMessagingCommandVerb("/Status")).toBe("status");
+    expect(matchMessagingCommandVerb("HELP")).toBe("help");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(matchMessagingCommandVerb("  resume  ")).toBe("resume");
+    expect(matchMessagingCommandVerb("  /status  ")).toBe("status");
+  });
+
+  it("returns undefined for unknown commands (controller falls through to help)", () => {
+    expect(matchMessagingCommandVerb("threads")).toBeUndefined();
+    expect(matchMessagingCommandVerb("/quit")).toBeUndefined();
+    expect(matchMessagingCommandVerb("foo bar")).toBeUndefined();
+  });
+
+  it("returns undefined for empty / whitespace / slash-only input", () => {
+    expect(matchMessagingCommandVerb("")).toBeUndefined();
+    expect(matchMessagingCommandVerb("   ")).toBeUndefined();
+    expect(matchMessagingCommandVerb("/")).toBeUndefined();
+    expect(matchMessagingCommandVerb("//")).toBeUndefined();
+  });
+});
+
+describe("formatMessagingCommandHelpBody", () => {
+  it("renders one bullet per catalog entry, in catalog order", () => {
+    const body = formatMessagingCommandHelpBody();
+    const expectedBullets = MESSAGING_COMMAND_CATALOG.map(
+      (spec) => `• \`${spec.verb}\` — ${spec.description}`,
+    );
+    for (const expected of expectedBullets) {
+      expect(body).toContain(expected);
+    }
+    // Order check: resume must come before status, status before
+    // detach, etc. — catalog order is the contract.
+    const resumeIdx = body.indexOf("`resume`");
+    const statusIdx = body.indexOf("`status`");
+    const detachIdx = body.indexOf("`detach`");
+    const helpIdx = body.indexOf("`help`");
+    expect(resumeIdx).toBeGreaterThanOrEqual(0);
+    expect(statusIdx).toBeGreaterThan(resumeIdx);
+    expect(detachIdx).toBeGreaterThan(statusIdx);
+    expect(helpIdx).toBeGreaterThan(detachIdx);
+  });
+
+  it("appends the default invocation footer with both styles", () => {
+    const body = formatMessagingCommandHelpBody();
+    expect(body).toContain("/<cmd>");
+    expect(body).toContain("@<bot>");
+  });
+
+  it("accepts a custom invocation footer (provider-specific overrides)", () => {
+    const body = formatMessagingCommandHelpBody({
+      invocationFooter: "Type `/pwragent_resume` or `@pwragent resume`.",
+    });
+    expect(body).toContain("Type `/pwragent_resume`");
+    // Default footer should NOT appear when caller supplied one.
+    expect(body).not.toContain("/<cmd>");
+  });
+
+  it("accepts a custom catalog (e.g., a subset for a constrained surface)", () => {
+    const subset = MESSAGING_COMMAND_CATALOG.filter(
+      (spec) => spec.verb === "resume" || spec.verb === "help",
+    );
+    const body = formatMessagingCommandHelpBody({ catalog: subset });
+    expect(body).toContain("`resume`");
+    expect(body).toContain("`help`");
+    expect(body).not.toContain("`status`");
+    expect(body).not.toContain("`detach`");
+  });
+
+  it("separates the bullet list from the footer with a blank line", () => {
+    const body = formatMessagingCommandHelpBody();
+    // Last bullet should be followed by an empty line, then the footer.
+    const lastBulletIdx = body.lastIndexOf("•");
+    const footerIdx = body.indexOf("Invoke");
+    expect(footerIdx).toBeGreaterThan(lastBulletIdx);
+    // Between them: at least one blank line.
+    const between = body.slice(lastBulletIdx, footerIdx);
+    expect(between).toMatch(/\n\n/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
+import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
+import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import {
-  MESSAGING_COMMAND_CATALOG,
+  buildHelpActions,
   formatMessagingCommandHelpBody,
+  helpPageSize,
   matchMessagingCommandVerb,
+  MESSAGING_COMMAND_CATALOG,
+  paginateHelpCatalog,
+  type MessagingCommandSpec,
 } from "../messaging/core/messaging-command-catalog.js";
 
 describe("MESSAGING_COMMAND_CATALOG", () => {
@@ -124,5 +130,195 @@ describe("formatMessagingCommandHelpBody", () => {
     // Between them: at least one blank line.
     const between = body.slice(lastBulletIdx, footerIdx);
     expect(between).toMatch(/\n\n/);
+  });
+});
+
+// Capability-profile fixtures for pagination tests. Override the
+// permissive profile's `actions.maxActions` to exercise the
+// page-size math; everything else stays at the test-friendly
+// defaults. The `!` is safe — `PERMISSIVE_CAPABILITY_PROFILE.actions`
+// is statically known to be defined (the permissive profile's whole
+// purpose is to declare every field), but the type marks it
+// optional because the production profile shape allows omission.
+function profileWithMaxActions(maxActions: number): MessagingCapabilityProfile {
+  return {
+    ...PERMISSIVE_CAPABILITY_PROFILE,
+    actions: {
+      ...PERMISSIVE_CAPABILITY_PROFILE.actions!,
+      maxActions,
+    },
+  };
+}
+
+// Synthetic catalog used to exercise multi-page rendering without
+// touching the canonical catalog. 12 entries × 8 page-size cap →
+// two pages.
+function syntheticCatalog(count: number): MessagingCommandSpec[] {
+  return Array.from({ length: count }, (_, i) => ({
+    // The catalog type expects the canonical verb union. Cast
+    // through `unknown` because synthetic verbs only exist in
+    // tests; the catalog never exposes these names at runtime.
+    verb: (`v${i}` as unknown) as MessagingCommandSpec["verb"],
+    description: `synthetic verb ${i}`,
+  }));
+}
+
+describe("helpPageSize", () => {
+  it("returns the soft cap (8) when no profile is provided", () => {
+    expect(helpPageSize(undefined)).toBe(8);
+  });
+
+  it("returns the soft cap when the profile's action budget is generous", () => {
+    expect(helpPageSize(profileWithMaxActions(25))).toBe(8);
+  });
+
+  it("clamps to the available budget when the profile is constrained", () => {
+    // 5 maxActions − 3 nav reservation = 2 command buttons / page.
+    expect(helpPageSize(profileWithMaxActions(5))).toBe(2);
+  });
+
+  it("returns 0 when the profile has fewer slots than the nav budget", () => {
+    // 2 maxActions − 3 nav reservation = -1 → 0 (text-only fallback).
+    expect(helpPageSize(profileWithMaxActions(2))).toBe(0);
+  });
+});
+
+describe("paginateHelpCatalog", () => {
+  it("returns a single page with every catalog entry when the profile fits all", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(25),
+    });
+    expect(page.totalPages).toBe(1);
+    expect(page.pageIndex).toBe(0);
+    expect(page.commands.map((c) => c.verb)).toEqual([
+      "resume",
+      "status",
+      "detach",
+      "help",
+    ]);
+  });
+
+  it("paginates correctly when the catalog overflows page size", () => {
+    const synthetic = syntheticCatalog(12);
+    const profile = profileWithMaxActions(25); // 8-cap → page size 8
+    const first = paginateHelpCatalog({
+      catalog: synthetic,
+      profile,
+      pageIndex: 0,
+    });
+    expect(first.totalPages).toBe(2);
+    expect(first.commands).toHaveLength(8);
+    expect(first.commands[0].verb).toBe("v0");
+    expect(first.commands[7].verb).toBe("v7");
+
+    const second = paginateHelpCatalog({
+      catalog: synthetic,
+      profile,
+      pageIndex: 1,
+    });
+    expect(second.commands).toHaveLength(4);
+    expect(second.commands[0].verb).toBe("v8");
+    expect(second.commands[3].verb).toBe("v11");
+  });
+
+  it("clamps pageIndex past the last page back to the last page", () => {
+    const synthetic = syntheticCatalog(12);
+    const page = paginateHelpCatalog({
+      catalog: synthetic,
+      profile: profileWithMaxActions(25),
+      pageIndex: 99,
+    });
+    // Last page is index 1 (totalPages = 2).
+    expect(page.pageIndex).toBe(1);
+    expect(page.commands[0].verb).toBe("v8");
+  });
+
+  it("clamps negative pageIndex to 0", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(25),
+      pageIndex: -5,
+    });
+    expect(page.pageIndex).toBe(0);
+  });
+
+  it("returns an empty page when the profile is too constrained to render any buttons", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(2),
+    });
+    expect(page.pageSize).toBe(0);
+    expect(page.totalPages).toBe(0);
+    expect(page.commands).toHaveLength(0);
+  });
+});
+
+describe("buildHelpActions", () => {
+  it("emits one command:<verb> button per catalog entry, no nav when single page", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(25),
+    });
+    const actions = buildHelpActions({ page });
+    const ids = actions.map((a) => a.id);
+    expect(ids).toEqual([
+      "command:resume",
+      "command:status",
+      "command:detach",
+      "command:help",
+    ]);
+  });
+
+  it("styles `command:resume` as primary, leaves the rest neutral (matches existing single-button shape)", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(25),
+    });
+    const actions = buildHelpActions({ page });
+    const resume = actions.find((a) => a.id === "command:resume");
+    expect(resume?.style).toBe("primary");
+    const status = actions.find((a) => a.id === "command:status");
+    expect(status?.style).toBeUndefined();
+  });
+
+  it("renders Next + Cancel on the first page of a multi-page catalog (no Prev)", () => {
+    const synthetic = syntheticCatalog(12);
+    const page = paginateHelpCatalog({
+      catalog: synthetic,
+      profile: profileWithMaxActions(25),
+      pageIndex: 0,
+    });
+    const ids = buildHelpActions({ page }).map((a) => a.id);
+    expect(ids).toContain("help:page:next");
+    expect(ids).toContain("help:cancel");
+    expect(ids).not.toContain("help:page:prev");
+  });
+
+  it("renders Prev + Cancel on the last page of a multi-page catalog (no Next)", () => {
+    const synthetic = syntheticCatalog(12);
+    const page = paginateHelpCatalog({
+      catalog: synthetic,
+      profile: profileWithMaxActions(25),
+      pageIndex: 1,
+    });
+    const ids = buildHelpActions({ page }).map((a) => a.id);
+    expect(ids).toContain("help:page:prev");
+    expect(ids).toContain("help:cancel");
+    expect(ids).not.toContain("help:page:next");
+  });
+
+  it("nav buttons carry pageIndex in `value` so the callback handler is stateless", () => {
+    const synthetic = syntheticCatalog(12);
+    const page = paginateHelpCatalog({
+      catalog: synthetic,
+      profile: profileWithMaxActions(25),
+      pageIndex: 0,
+    });
+    const actions = buildHelpActions({ page });
+    const next = actions.find((a) => a.id === "help:page:next");
+    expect(next?.value).toEqual({ pageIndex: 1 });
+  });
+
+  it("emits an empty action array when the profile is too constrained for buttons", () => {
+    const page = paginateHelpCatalog({
+      profile: profileWithMaxActions(2),
+    });
+    expect(buildHelpActions({ page })).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -915,7 +915,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("does not treat legacy /threads as a resume alias", async () => {
+  it("does not treat legacy /threads as a resume alias — falls through to the help surface", async () => {
     const harness = await createHarness();
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/threads"));
@@ -923,7 +923,52 @@ describe("MessagingController", () => {
     expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      title: "PwrAgent",
+      title: "PwrAgent commands",
+    });
+  });
+
+  it("renders the help surface for an explicit /help command", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent commands",
+    });
+  });
+
+  it("help surface body lists every canonical verb (catalog-derived)", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+
+    const last = harness.delivered.at(-1) as { body?: string } | undefined;
+    expect(last?.body).toBeDefined();
+    expect(last?.body).toContain("`resume`");
+    expect(last?.body).toContain("`status`");
+    expect(last?.body).toContain("`detach`");
+    expect(last?.body).toContain("`help`");
+    // Both invocation styles must be discoverable from the help text
+    // — the whole reason we ship a catalog-derived body.
+    expect(last?.body).toContain("/<cmd>");
+    expect(last?.body).toContain("@<bot>");
+  });
+
+  it("help surface keeps the Resume action button as the primary tap-driven entry point", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: [
+        {
+          id: "command:resume",
+          label: "Resume",
+          style: "primary",
+        },
+      ],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -956,19 +956,120 @@ describe("MessagingController", () => {
     expect(last?.body).toContain("@<bot>");
   });
 
-  it("help surface keeps the Resume action button as the primary tap-driven entry point", async () => {
+  it("help surface renders one button per canonical verb with Resume styled primary", async () => {
     const harness = await createHarness();
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
 
+    const last = harness.delivered.at(-1) as
+      | { actions?: Array<{ id?: string; label?: string; style?: string }> }
+      | undefined;
+    expect(last?.actions).toBeDefined();
+    // One button per canonical verb (today: 4). Catalog fits a
+    // single page on every reasonable provider profile, so no nav
+    // buttons are rendered.
+    const ids = (last?.actions ?? []).map((a) => a.id);
+    expect(ids).toEqual([
+      "command:resume",
+      "command:status",
+      "command:detach",
+      "command:help",
+    ]);
+    // Resume retains primary styling — matches the previous
+    // single-button shape for users who tap rather than read.
+    const resume = last?.actions?.find((a) => a.id === "command:resume");
+    expect(resume?.style).toBe("primary");
+  });
+
+  it("help surface omits nav buttons when the catalog fits in one page", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+
+    const last = harness.delivered.at(-1) as
+      | { actions?: Array<{ id?: string }> }
+      | undefined;
+    const navIds = (last?.actions ?? [])
+      .map((a) => a.id ?? "")
+      .filter((id) => id.startsWith("help:"));
+    // Today's catalog is 4 verbs and the test capability profile
+    // grants well over 4 + 3 (nav) action slots — single page,
+    // no navigation needed.
+    expect(navIds).toEqual([]);
+  });
+
+  it("clicking the Resume button on the help surface dispatches the resume command", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "command:resume",
+      }),
+    );
+
     expect(harness.delivered.at(-1)).toMatchObject({
-      actions: [
-        {
-          id: "command:resume",
-          label: "Resume",
-          style: "primary",
-        },
-      ],
+      kind: "thread_picker",
+    });
+  });
+
+  it("clicking the Detach button on the help surface dispatches the detach command", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "command:detach",
+      }),
+    );
+
+    // No active binding for this channel, so detach is a no-op
+    // confirmation rather than a real revoke. The point is the
+    // routing reaches `handleCommand("detach")`, not that the
+    // detach itself succeeds.
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+    });
+  });
+
+  it("clicking the help-page Cancel button replaces the surface with a dismissal", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "help:cancel",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Help dismissed",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+    });
+  });
+
+  it("clicking help:page:next re-renders the help surface (passes value.pageIndex through)", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "help:page:next",
+        value: { pageIndex: 1 },
+      }),
+    );
+
+    // Today's catalog only paginates to a single page, so the
+    // re-render clamps back to page 0 — but the surface is still
+    // a help surface targeted at the existing post (update mode).
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent commands",
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
     });
   });
 

--- a/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
@@ -1,0 +1,142 @@
+/**
+ * Channel-neutral catalog of the canonical PwrAgent slash commands.
+ *
+ * Single source of truth for the verb list shared by:
+ *   - The controller's `handleCommand` dispatch (verb → handler).
+ *   - The user-facing `/help` body, which lists every verb here with
+ *     its description.
+ *   - Provider adapters that register native slash commands
+ *     (Discord's application commands, Mattermost's
+ *     `/api/v4/commands`). Today each adapter declares its own
+ *     command list; future work can collapse those onto this catalog
+ *     so adding a new verb only requires touching one file.
+ *
+ * Why a catalog instead of inline strings? The previous shape had
+ * the verb list hardcoded in two places (the if/else routing and the
+ * help body), which silently went stale every time we added or
+ * renamed a command. Driving help generation from the catalog means
+ * the documentation stays in lockstep with the routing.
+ *
+ * To add a new verb:
+ *   1. Add an entry here with a stable `verb`, a one-line
+ *      `description`, and an `aliases` array if you want extra text
+ *      synonyms (e.g., `"projects"` → `"resume"`).
+ *   2. Wire the handler in `MessagingController.handleCommand` (this
+ *      module deliberately does NOT export the dispatch table — the
+ *      controller owns its own state and shouldn't be coupled to a
+ *      data structure that lives elsewhere).
+ *   3. Bump the `MessagingCommandVerb` union below.
+ *   4. Each provider adapter that registers native slash commands
+ *      should pick up the new verb from its own list (until the
+ *      shared-catalog refactor lands).
+ */
+
+/**
+ * Stable string identifiers for every canonical command verb. Used
+ * as the dispatch key in the controller and the trigger name in
+ * provider adapters (with optional namespacing — e.g. Mattermost
+ * registers them as `pwragent_resume`, `pwragent_status`, etc.).
+ *
+ * Keep this in sync with `MESSAGING_COMMAND_CATALOG` below.
+ */
+export type MessagingCommandVerb = "resume" | "status" | "detach" | "help";
+
+export type MessagingCommandSpec = {
+  verb: MessagingCommandVerb;
+  /**
+   * One-line summary shown in the `/help` body. Should fit on a
+   * single line and use the imperative form (matches the existing
+   * Discord application-command and Mattermost slash-command
+   * descriptions).
+   */
+  description: string;
+};
+
+/**
+ * Canonical command set, in the order they should appear in the
+ * `/help` body. Order is intentional — `resume` first because it's
+ * the most common entry point, `help` last because it's the
+ * meta-command.
+ */
+export const MESSAGING_COMMAND_CATALOG: readonly MessagingCommandSpec[] = [
+  {
+    verb: "resume",
+    description: "choose a thread to control from this conversation",
+  },
+  {
+    verb: "status",
+    description: "show the current binding and controls",
+  },
+  {
+    verb: "detach",
+    description: "detach this conversation from its thread",
+  },
+  {
+    verb: "help",
+    description: "show this message",
+  },
+];
+
+/**
+ * Format the `/help` body as a single string, derived from
+ * `MESSAGING_COMMAND_CATALOG` so adding a new verb keeps the help
+ * surface in sync automatically.
+ *
+ * The `invocationFooter` is appended verbatim; callers pass a
+ * provider-aware string that documents BOTH invocation styles
+ * (slash menu and bot mention). The default is provider-neutral
+ * (works on every messaging platform that accepts at least one of
+ * the two styles).
+ *
+ * Output format:
+ *
+ *   • `verb` — description
+ *   • `verb` — description
+ *
+ *   <invocation footer>
+ */
+export function formatMessagingCommandHelpBody(options?: {
+  catalog?: readonly MessagingCommandSpec[];
+  invocationFooter?: string;
+}): string {
+  const catalog = options?.catalog ?? MESSAGING_COMMAND_CATALOG;
+  const footer =
+    options?.invocationFooter
+    ?? "Invoke via the slash menu (`/<cmd>`) or by mentioning the bot (`@<bot> <cmd>`).";
+  const lines = catalog.map(
+    (spec) => `• \`${spec.verb}\` — ${spec.description}`,
+  );
+  return [...lines, "", footer].join("\n");
+}
+
+/**
+ * Resolve a raw command string (as it arrives in
+ * `MessagingInboundCommandEvent.command` after the leading slash is
+ * stripped) to a known catalog verb, or `undefined` for unknown
+ * commands. Case-insensitive. Used by the controller's
+ * `handleCommand` to decide whether to dispatch to a verb-specific
+ * handler or fall through to the help surface.
+ *
+ * Kept here (next to the catalog itself) rather than in the
+ * controller because future contributors looking at the catalog to
+ * understand the verb set should immediately see the matcher
+ * alongside.
+ */
+export function matchMessagingCommandVerb(
+  rawCommand: string,
+): MessagingCommandVerb | undefined {
+  // Trim FIRST (handles `"  /status  "`), then strip the leading
+  // slash, then lowercase for case-insensitive lookup. Reversing
+  // these steps would let leading whitespace mask the slash and
+  // accidentally treat the slash as part of the verb token.
+  const normalized = rawCommand.trim().replace(/^\/+/, "").toLowerCase();
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  for (const spec of MESSAGING_COMMAND_CATALOG) {
+    if (spec.verb === normalized) {
+      return spec.verb;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
@@ -1,3 +1,9 @@
+import {
+  capabilityProfilePageSize,
+  type MessagingCapabilityProfile,
+  type MessagingSurfaceAction,
+} from "@pwragent/messaging-interface";
+
 /**
  * Channel-neutral catalog of the canonical PwrAgent slash commands.
  *
@@ -139,4 +145,173 @@ export function matchMessagingCommandVerb(
     }
   }
   return undefined;
+}
+
+// -----------------------------------------------------------------
+// Help-surface action layout
+// -----------------------------------------------------------------
+
+/**
+ * Worst-case nav-button budget on a paginated help surface:
+ *   - Previous (only when page > 0)
+ *   - Next (only when more pages remain)
+ *   - Cancel (always rendered)
+ *
+ * Used by `helpPageSize` to reserve action slots from the capability
+ * profile so the navigation buttons always fit. We always reserve
+ * for the worst case (3) even on the first/last page where Prev or
+ * Next is hidden — keeps page-size constant across pages so users
+ * don't see the layout grow and shrink as they navigate.
+ */
+export const HELP_NAV_ACTION_COUNT = 3;
+
+/**
+ * Soft cap on how many command buttons we'll show per page even
+ * when the capability profile would allow more. Help is read,
+ * not skimmed — eight buttons on one screen is plenty.
+ */
+const HELP_PAGE_SIZE = 8;
+
+export type MessagingCommandHelpPage = {
+  pageIndex: number;
+  totalPages: number;
+  /**
+   * Capability-aware page size after subtracting nav reservation.
+   * Zero means the profile's action budget is fully consumed by
+   * navigation; the caller should fall back to text-only rendering
+   * (the help body already lists every verb in prose).
+   */
+  pageSize: number;
+  /**
+   * Subset of `MESSAGING_COMMAND_CATALOG` for this page, in catalog
+   * order. Empty when `pageSize === 0`.
+   */
+  commands: readonly MessagingCommandSpec[];
+};
+
+/**
+ * Compute how many command buttons to render per page given a
+ * capability profile. Defers to `capabilityProfilePageSize` so the
+ * nav-button reservation matches the resume browser's pattern.
+ *
+ * Returns 0 when the profile has fewer than `HELP_NAV_ACTION_COUNT`
+ * action slots — the caller falls back to text-only rendering.
+ */
+export function helpPageSize(
+  profile?: MessagingCapabilityProfile,
+): number {
+  if (!profile) {
+    return HELP_PAGE_SIZE;
+  }
+  return capabilityProfilePageSize(
+    profile,
+    HELP_NAV_ACTION_COUNT,
+    HELP_PAGE_SIZE,
+  );
+}
+
+/**
+ * Page the catalog for rendering as command buttons. Clamps
+ * `pageIndex` to a valid range and reports the resolved page so
+ * callers can render an accurate "Page X/Y" indicator. When the
+ * total catalog fits in one page (`totalPages === 1`), nav
+ * buttons should be omitted by the caller — see
+ * `buildHelpActions` for the canonical pattern.
+ */
+export function paginateHelpCatalog(params: {
+  catalog?: readonly MessagingCommandSpec[];
+  profile?: MessagingCapabilityProfile;
+  pageIndex?: number;
+}): MessagingCommandHelpPage {
+  const catalog = params.catalog ?? MESSAGING_COMMAND_CATALOG;
+  const pageSize = helpPageSize(params.profile);
+  if (pageSize <= 0) {
+    return { pageIndex: 0, totalPages: 0, pageSize: 0, commands: [] };
+  }
+  const totalPages = Math.max(1, Math.ceil(catalog.length / pageSize));
+  const clamped = Math.max(0, Math.min(totalPages - 1, params.pageIndex ?? 0));
+  const start = clamped * pageSize;
+  const commands = catalog.slice(start, start + pageSize);
+  return { pageIndex: clamped, totalPages, pageSize, commands };
+}
+
+/**
+ * Build the action array for the help surface — one command button
+ * per verb on the current page, plus navigation buttons (Prev /
+ * Next / Cancel) when the catalog overflows a single page. The
+ * navigation row is omitted entirely when everything fits in one
+ * page, so the help surface renders as a tight verb-button row in
+ * the steady state of today's small catalog.
+ *
+ * Action id conventions:
+ *   - `command:<verb>` — invoke the verb. Routes through
+ *     `readCommandAction` in the controller and dispatches to
+ *     `handleCommand`. The same actionId pattern is already in use
+ *     for the existing single Resume button on the help surface, so
+ *     this just expands the set.
+ *   - `help:page:next` / `help:page:prev` — navigation. The next
+ *     page index travels in `action.value.pageIndex` so the
+ *     callback handler can re-render without persistent session
+ *     state (help is stateless — the catalog is deterministic from
+ *     pageIndex alone).
+ *   - `help:cancel` — dismiss the surface. The controller's
+ *     callback handler updates the surface to remove the action
+ *     row and replaces the body with a brief "help dismissed"
+ *     line.
+ */
+export function buildHelpActions(params: {
+  page: MessagingCommandHelpPage;
+}): MessagingSurfaceAction[] {
+  const { page } = params;
+  if (page.pageSize <= 0 || page.commands.length === 0) {
+    return [];
+  }
+  const actions: MessagingSurfaceAction[] = [];
+  for (const spec of page.commands) {
+    actions.push({
+      id: `command:${spec.verb}`,
+      label: capitalize(spec.verb),
+      // `resume` stays primary so the button hierarchy matches the
+      // existing single-button help surface (where Resume is also
+      // the primary). Other verbs use the default neutral style.
+      style: spec.verb === "resume" ? "primary" : undefined,
+      fallbackText: `/${spec.verb}`,
+    });
+  }
+  // Nav row only when there's more than one page. Single-page
+  // rendering keeps the help surface compact.
+  if (page.totalPages > 1) {
+    if (page.pageIndex > 0) {
+      actions.push({
+        id: "help:page:prev",
+        label: "Previous",
+        style: "navigation",
+        fallbackText: "back",
+        value: { pageIndex: page.pageIndex - 1 },
+      });
+    }
+    if (page.pageIndex < page.totalPages - 1) {
+      actions.push({
+        id: "help:page:next",
+        label: "Next",
+        style: "navigation",
+        fallbackText: "next",
+        value: { pageIndex: page.pageIndex + 1 },
+      });
+    }
+    actions.push({
+      id: "help:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+    });
+  }
+  return actions;
+}
+
+function capitalize(text: string): string {
+  if (text.length === 0) {
+    return text;
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -597,14 +597,26 @@ export class MessagingController {
       await this.presentResumeBrowser(event);
       return;
     }
-
+    // `help` and any unrecognized command both fall through to the
+    // help surface — for unknown commands this serves as a "did you
+    // mean?" prompt with the canonical list. Keeping `Resume` as the
+    // primary action because it's the most common entry point and
+    // works as a button-driven shortcut for anyone who prefers
+    // tapping over typing.
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("help"),
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
-        title: "PwrAgent",
-        body: "Use /resume to choose a thread to control from this conversation.",
+        title: "PwrAgent commands",
+        body: [
+          "• `resume` — choose a thread to control from this conversation",
+          "• `status` — show the current binding and controls",
+          "• `detach` — detach this conversation from its thread",
+          "• `help` — show this message",
+          "",
+          "Invoke via the slash menu (`/<cmd>`) or by mentioning the bot (`@<bot> <cmd>`).",
+        ].join("\n"),
         actions: [
           {
             id: "command:resume",

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -35,6 +35,10 @@ import type {
   MessagingSurfaceRef,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
+import {
+  formatMessagingCommandHelpBody,
+  matchMessagingCommandVerb,
+} from "./messaging-command-catalog.js";
 import { buildMessagingConversationKey } from "./messaging-store.js";
 import type { MessagingStoreLike } from "../../state/messaging-store-sqlite";
 import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
@@ -584,39 +588,37 @@ export class MessagingController {
   }
 
   private async handleCommand(event: MessagingInboundCommandEvent): Promise<void> {
-    const command = event.command.replace(/^\//, "").toLowerCase();
-    if (command === "status") {
+    const verb = matchMessagingCommandVerb(event.command);
+    if (verb === "status") {
       await this.presentStatus(event);
       return;
     }
-    if (command === "detach") {
+    if (verb === "detach") {
       await this.detachBinding(event);
       return;
     }
-    if (command === "resume") {
+    if (verb === "resume") {
       await this.presentResumeBrowser(event);
       return;
     }
-    // `help` and any unrecognized command both fall through to the
-    // help surface — for unknown commands this serves as a "did you
-    // mean?" prompt with the canonical list. Keeping `Resume` as the
-    // primary action because it's the most common entry point and
-    // works as a button-driven shortcut for anyone who prefers
-    // tapping over typing.
+    // `verb === "help"` and any unrecognized command both fall
+    // through to the help surface. For unknown commands this serves
+    // as a "did you mean?" prompt with the canonical list — keeping
+    // `Resume` as the primary action because it's the most common
+    // entry point and works as a button-driven shortcut for anyone
+    // who prefers tapping over typing.
+    //
+    // Body content is derived from `MESSAGING_COMMAND_CATALOG` so
+    // adding a new verb stays in lock-step with the help text. See
+    // `messaging-command-catalog.ts` for the catalog definition and
+    // the routine that formats the body.
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("help"),
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
         title: "PwrAgent commands",
-        body: [
-          "• `resume` — choose a thread to control from this conversation",
-          "• `status` — show the current binding and controls",
-          "• `detach` — detach this conversation from its thread",
-          "• `help` — show this message",
-          "",
-          "Invoke via the slash menu (`/<cmd>`) or by mentioning the bot (`@<bot> <cmd>`).",
-        ].join("\n"),
+        body: formatMessagingCommandHelpBody(),
         actions: [
           {
             id: "command:resume",

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -36,8 +36,10 @@ import type {
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
+  buildHelpActions,
   formatMessagingCommandHelpBody,
   matchMessagingCommandVerb,
+  paginateHelpCatalog,
 } from "./messaging-command-catalog.js";
 import { buildMessagingConversationKey } from "./messaging-store.js";
 import type { MessagingStoreLike } from "../../state/messaging-store-sqlite";
@@ -603,30 +605,56 @@ export class MessagingController {
     }
     // `verb === "help"` and any unrecognized command both fall
     // through to the help surface. For unknown commands this serves
-    // as a "did you mean?" prompt with the canonical list — keeping
-    // `Resume` as the primary action because it's the most common
-    // entry point and works as a button-driven shortcut for anyone
-    // who prefers tapping over typing.
-    //
-    // Body content is derived from `MESSAGING_COMMAND_CATALOG` so
-    // adding a new verb stays in lock-step with the help text. See
-    // `messaging-command-catalog.ts` for the catalog definition and
-    // the routine that formats the body.
+    // as a "did you mean?" prompt with the canonical list.
+    await this.presentHelp(event);
+  }
+
+  /**
+   * Render the help surface. The body is the prose
+   * description-list (derived from `MESSAGING_COMMAND_CATALOG` so it
+   * never drifts from the verb set) and the action row is one
+   * `command:<verb>` button per catalog entry on the current page,
+   * plus Prev/Next/Cancel navigation when the catalog overflows a
+   * single page.
+   *
+   * Pagination is stateless: the next/previous page index travels in
+   * `action.value.pageIndex` and comes back through the
+   * `MessagingInboundCallbackEvent.value` field. Help has no
+   * persistent session record like the resume browser does — the
+   * page content is deterministic from the catalog plus the page
+   * index.
+   *
+   * Re-renders pass `targetSurface` from the originating callback's
+   * interaction state so we update the existing post in place
+   * instead of stacking new help posts on every Next click.
+   */
+  private async presentHelp(
+    event: MessagingInboundEvent,
+    options?: { pageIndex?: number; targetSurface?: MessagingSurfaceRef },
+  ): Promise<void> {
+    const page = paginateHelpCatalog({
+      profile: this.capabilityProfile,
+      pageIndex: options?.pageIndex,
+    });
+    const actions = buildHelpActions({ page });
+    const titleSuffix
+      = page.totalPages > 1
+        ? ` (page ${page.pageIndex + 1}/${page.totalPages})`
+        : "";
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("help"),
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
-        title: "PwrAgent commands",
+        title: `PwrAgent commands${titleSuffix}`,
         body: formatMessagingCommandHelpBody(),
-        actions: [
-          {
-            id: "command:resume",
-            label: "Resume",
-            style: "primary",
-            fallbackText: "/resume",
-          },
-        ],
+        actions,
+        ...(options?.targetSurface
+          ? {
+              targetSurface: options.targetSurface,
+              delivery: { mode: "update" as const, replaceMarkup: true },
+            }
+          : {}),
       }),
       undefined,
       event,
@@ -1211,6 +1239,12 @@ export class MessagingController {
       return;
     }
 
+    const helpAction = readHelpNavAction(event);
+    if (helpAction) {
+      await this.handleHelpNavCallback(event, helpAction);
+      return;
+    }
+
     const browseAction = readBrowseAction(event);
     if (browseAction) {
       await this.handleBrowseCallback(event, browseAction);
@@ -1716,6 +1750,53 @@ export class MessagingController {
   dispose(): void {
     this.turnAdmission.dispose();
     this.toolUpdatePolicy.dispose();
+  }
+
+  /**
+   * Handle navigation callbacks on the paginated help surface
+   * (Prev / Next / Cancel). The page index travels in
+   * `event.value.pageIndex` so help has no persistent session
+   * record — re-rendering is a function of catalog + page index.
+   *
+   * `targetSurface` is taken from the originating callback's
+   * interaction state so the help post is updated in place rather
+   * than stacking new posts on every Next click.
+   */
+  private async handleHelpNavCallback(
+    event: MessagingInboundCallbackEvent,
+    actionId: string,
+  ): Promise<void> {
+    const targetSurface: MessagingSurfaceRef | undefined = {
+      channel: event.interaction.channel,
+      id: event.interaction.id,
+      ...(event.interaction.state ? { state: event.interaction.state } : {}),
+    };
+    if (actionId === "help:cancel") {
+      // Replace the help body with a brief dismissal and strip the
+      // action row. Mirrors the resume browser's "Resume cancelled"
+      // pattern for consistent dismissed-surface UX across both
+      // paginated flows.
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("help-dismissed"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          title: "Help dismissed",
+          body: "Send `/help` or `@<bot> help` to see commands again.",
+          actions: [],
+          delivery: { mode: "update", replaceMarkup: true },
+          targetSurface,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+    const requestedPage = readHelpPageIndex(event);
+    await this.presentHelp(event, {
+      pageIndex: requestedPage,
+      targetSurface,
+    });
   }
 
   private async presentResumeBrowser(event: MessagingInboundCommandEvent): Promise<void> {
@@ -3625,6 +3706,36 @@ function readCommandAction(event: MessagingInboundCallbackEvent): string | undef
 function readBrowseAction(event: MessagingInboundCallbackEvent): string | undefined {
   const actionId = event.actionId ?? event.interaction.id;
   return actionId.startsWith("browse:") ? actionId : undefined;
+}
+
+function readHelpNavAction(event: MessagingInboundCallbackEvent): string | undefined {
+  const actionId = event.actionId ?? event.interaction.id;
+  if (
+    actionId === "help:page:next"
+    || actionId === "help:page:prev"
+    || actionId === "help:cancel"
+  ) {
+    return actionId;
+  }
+  return undefined;
+}
+
+/**
+ * Read the target page index from a help-nav callback's value
+ * payload. Returns 0 (first page) when the value is missing or
+ * malformed — clamping in `paginateHelpCatalog` will pin to the
+ * first/last page anyway, so an absent value never crashes the
+ * re-render.
+ */
+function readHelpPageIndex(event: MessagingInboundCallbackEvent): number {
+  const value = event.value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const candidate = (value as Record<string, unknown>).pageIndex;
+    if (typeof candidate === "number" && Number.isInteger(candidate) && candidate >= 0) {
+      return candidate;
+    }
+  }
+  return 0;
 }
 
 function readStatusAction(event: MessagingInboundCallbackEvent): string | undefined {

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -287,6 +287,25 @@ Providers receive persistent state only through opaque interfaces declared in `@
 
 This is enforced by package boundaries (`pnpm lint:boundaries`) and reinforced in [`packages/messaging/AGENTS.md`](../packages/messaging/AGENTS.md). The reason matters as much as the rule: providers come and go, the schema is shared, and a provider that owns its own table effectively owns a piece of the desktop migration plan it has no business owning. Keep the seam at the interface, not the database.
 
+## Canonical command catalog
+
+The slash-command surface every messaging provider exposes — `resume`, `status`, `detach`, `help` — is defined in a single channel-neutral catalog at [`apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`](../apps/desktop/src/main/messaging/core/messaging-command-catalog.ts).
+
+Three things consume the catalog:
+
+1. **The controller's `handleCommand` dispatch.** `matchMessagingCommandVerb` resolves an inbound `MessagingInboundCommandEvent.command` to a known verb (or `undefined` for unrecognized commands). Verbs in the catalog dispatch to typed handlers; everything else falls through to the help surface.
+2. **The user-facing `/help` body.** `formatMessagingCommandHelpBody` derives the bullet list from the catalog so adding or renaming a verb in one place updates the help text everywhere it's rendered.
+3. **Provider adapters that register native slash commands.** Today each adapter maintains its own list (`packages/messaging/providers/discord/src/discord-commands.ts`, `packages/messaging/providers/mattermost/src/mattermost-commands.ts`). A future refactor can collapse those onto the shared catalog so a new verb only requires touching one file. Until then, adapter-side lists must stay in sync with the catalog by convention.
+
+To add a new canonical verb:
+
+1. Add an entry to `MESSAGING_COMMAND_CATALOG` with a stable `verb` string and a one-line description.
+2. Bump the `MessagingCommandVerb` union type.
+3. Wire a handler branch in `MessagingController.handleCommand` that calls `matchMessagingCommandVerb` and dispatches.
+4. For each provider adapter that registers native slash commands, add the verb to its own canonical-bases array (Discord's `DISCORD_APPLICATION_COMMANDS`, Mattermost's `CANONICAL_COMMAND_BASES`, etc.).
+
+The help surface and unknown-command fallback automatically pick up the new verb from the catalog — no string-list to update separately.
+
 ## How to add a provider
 
 The full procedure is in [`docs/messaging-adapter-contract.md`](messaging-adapter-contract.md). At a high level:
@@ -310,6 +329,7 @@ The full procedure is in [`docs/messaging-adapter-contract.md`](messaging-adapte
 | `packages/messaging/providers/<channel>/src/<channel>-formatting.ts` | Pure formatters that turn intents into platform-native components/text. Reads the profile for layout caps. |
 | `apps/desktop/src/main/messaging/messaging-runtime.ts` | Constructs one controller per adapter, wires backend events |
 | `apps/desktop/src/main/messaging/core/messaging-controller.ts` | Workflow logic — turn admission, picker state, status card, handoff flow, audit |
+| `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` | Canonical command catalog (verb + description), `matchMessagingCommandVerb` for dispatch lookup, `formatMessagingCommandHelpBody` for `/help` body generation |
 | `apps/desktop/src/main/messaging/core/messaging-renderer.ts` | Producers for thread picker, confirmation, questionnaire, error |
 | `apps/desktop/src/main/messaging/core/messaging-status-card.ts` | Producers for status card, model picker, reasoning picker, handoff overview/branch-picker/confirmation |
 | `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` | Producer for resume browser (`/resume`) — picker pagination, project/thread filtering |

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -291,11 +291,12 @@ This is enforced by package boundaries (`pnpm lint:boundaries`) and reinforced i
 
 The slash-command surface every messaging provider exposes — `resume`, `status`, `detach`, `help` — is defined in a single channel-neutral catalog at [`apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`](../apps/desktop/src/main/messaging/core/messaging-command-catalog.ts).
 
-Three things consume the catalog:
+Four things consume the catalog:
 
 1. **The controller's `handleCommand` dispatch.** `matchMessagingCommandVerb` resolves an inbound `MessagingInboundCommandEvent.command` to a known verb (or `undefined` for unrecognized commands). Verbs in the catalog dispatch to typed handlers; everything else falls through to the help surface.
-2. **The user-facing `/help` body.** `formatMessagingCommandHelpBody` derives the bullet list from the catalog so adding or renaming a verb in one place updates the help text everywhere it's rendered.
-3. **Provider adapters that register native slash commands.** Today each adapter maintains its own list (`packages/messaging/providers/discord/src/discord-commands.ts`, `packages/messaging/providers/mattermost/src/mattermost-commands.ts`). A future refactor can collapse those onto the shared catalog so a new verb only requires touching one file. Until then, adapter-side lists must stay in sync with the catalog by convention.
+2. **The user-facing `/help` body.** `formatMessagingCommandHelpBody` derives the prose bullet list from the catalog so adding or renaming a verb in one place updates the help text everywhere it's rendered.
+3. **The `/help` action row.** `paginateHelpCatalog` + `buildHelpActions` render one `command:<verb>` button per catalog entry on the current page. Pages overflow with capability-aware Prev/Next/Cancel navigation when the catalog grows past the profile's action budget; for today's small catalog every button fits on one page and no nav row is rendered. The `Resume` button is styled primary to match the previous single-button shape; everything else is neutral. Pagination is **stateless** — the next/previous page index travels in `action.value.pageIndex` and comes back through `MessagingInboundCallbackEvent.value`, so the controller can re-render without persistent session state (unlike the resume browser which uses a `MessagingBrowseSessionRecord`).
+4. **Provider adapters that register native slash commands.** Today each adapter maintains its own list (`packages/messaging/providers/discord/src/discord-commands.ts`, `packages/messaging/providers/mattermost/src/mattermost-commands.ts`). A future refactor can collapse those onto the shared catalog so a new verb only requires touching one file. Until then, adapter-side lists must stay in sync with the catalog by convention.
 
 To add a new canonical verb:
 
@@ -329,7 +330,7 @@ The full procedure is in [`docs/messaging-adapter-contract.md`](messaging-adapte
 | `packages/messaging/providers/<channel>/src/<channel>-formatting.ts` | Pure formatters that turn intents into platform-native components/text. Reads the profile for layout caps. |
 | `apps/desktop/src/main/messaging/messaging-runtime.ts` | Constructs one controller per adapter, wires backend events |
 | `apps/desktop/src/main/messaging/core/messaging-controller.ts` | Workflow logic — turn admission, picker state, status card, handoff flow, audit |
-| `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` | Canonical command catalog (verb + description), `matchMessagingCommandVerb` for dispatch lookup, `formatMessagingCommandHelpBody` for `/help` body generation |
+| `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` | Canonical command catalog (verb + description), `matchMessagingCommandVerb` for dispatch lookup, `formatMessagingCommandHelpBody` for `/help` body generation, `paginateHelpCatalog` + `buildHelpActions` for the paginated command-button row |
 | `apps/desktop/src/main/messaging/core/messaging-renderer.ts` | Producers for thread picker, confirmation, questionnaire, error |
 | `apps/desktop/src/main/messaging/core/messaging-status-card.ts` | Producers for status card, model picker, reasoning picker, handoff overview/branch-picker/confirmation |
 | `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` | Producer for resume browser (`/resume`) — picker pagination, project/thread filtering |


### PR DESCRIPTION
## Summary

Replaces the existing "unknown command" fallback (a single line pointing at `/resume`) with a richer `/help` surface that lists every canonical verb and both invocation styles. Extracts the verb list into a single channel-neutral catalog so `/help` content is always in lockstep with the controller's dispatch routing.

The seed change (the body string) was cherry-picked from #199 (messaging-mattermost-adapter); this PR finishes it as standalone work — proper test coverage, single-source-of-truth refactor, architecture-doc update.

## Why

After #199 landed Mattermost slash-command namespacing (`/pwragent_resume` etc.), the existing fallback's body — `"Use /resume to choose a thread to control..."` — became increasingly inaccurate. The literal `/resume` doesn't exist on Mattermost. The original cherry-picked commit fixed the string but left the verb list duplicated in two places (the if/else routing in `handleCommand` and the bullet list in the help body). That's exactly the kind of double-bookkeeping that goes silently stale every time a verb is added or renamed.

## What changed

### `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` (new)

Single channel-neutral source of truth for the canonical verb list:

- `MessagingCommandVerb` — string-union type for the four canonical verbs (`resume`, `status`, `detach`, `help`). Provides static exhaustiveness for the controller's dispatch.
- `MESSAGING_COMMAND_CATALOG` — ordered list. Order is intentional: `resume` first (most common entry point), `help` last (meta-command). The `/help` body renders in this order.
- `matchMessagingCommandVerb(rawCommand)` — case-insensitive, whitespace-tolerant resolver from raw command string to a catalog verb (or `undefined` for unknown). Trims first, then strips the leading `/`, so `"  /status  "` resolves correctly.
- `formatMessagingCommandHelpBody({ catalog?, invocationFooter? })` — derives the bullet-list body from the catalog. Accepts a custom catalog (subset rendering) and a custom invocation footer (e.g., for a provider that wants namespaced trigger names). Defaults are provider-neutral (`/<cmd>` and `@<bot> <cmd>` both work).

### `apps/desktop/src/main/messaging/core/messaging-controller.ts`

Mechanical refactor of `handleCommand`:
- Replace four `command === "<verb>"` if/else clauses with `verb = matchMessagingCommandVerb(event.command)`.
- Replace the inline bullet-list strings in the help body with `formatMessagingCommandHelpBody()`.
- Help title renamed `"PwrAgent"` → `"PwrAgent commands"` to reflect the new content (originally in the cherry-picked seed commit).

`/help` and any unrecognized command both fall through to the help surface — the surface doubles as a "did you mean?" prompt for typos.

### Tests

15 new tests across two files (191 → **206** in the messaging slice):

**`apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts`** (12 tests, new file):
- Catalog declares the canonical verb set in the documented order
- Every verb has a non-empty description
- All verbs are lowercase (matches dispatch contract)
- `matchMessagingCommandVerb` recognizes every catalog verb, strips a leading slash, is case-insensitive, trims surrounding whitespace, returns `undefined` for unknown commands and for empty/whitespace/slash-only input
- `formatMessagingCommandHelpBody` renders one bullet per catalog entry in catalog order, appends the default invocation footer with both styles, accepts custom footers, accepts a custom catalog, separates the bullet list from the footer with a blank line

**`apps/desktop/src/main/__tests__/messaging-controller.test.ts`** (3 new tests + 1 fix):
- `/help` command renders the help surface with title `"PwrAgent commands"`
- Help body lists every canonical verb (`resume`, `status`, `detach`, `help`) and both invocation styles
- Help surface keeps the `Resume` action button as the primary tap-driven entry point
- Existing `/threads` (unknown command) test updated for the renamed title

### Docs

`docs/messaging-architecture.md` gains a new "Canonical command catalog" section that:
- Points readers at `messaging-command-catalog.ts` as the single source of truth
- Names the three consumers (controller dispatch, `/help` body generation, provider-side native slash-command registration)
- Spells out the four-step "how to add a verb" procedure
- File-map table updated with the new module

## Engineering details worth flagging

- **Bug found and fixed during catalog extraction**: the initial `matchMessagingCommandVerb` stripped `/` before trim, so `"  /status  "` failed to match. Reordered to trim → strip → lowercase. Test `trims surrounding whitespace` covers this case.
- **Provider adapters still maintain their own native-command lists** (Discord's `DISCORD_APPLICATION_COMMANDS`, Mattermost's `CANONICAL_COMMAND_BASES`). A future refactor can collapse those onto the shared catalog so a new verb only requires one file change. Until then, adapter-side lists must stay in sync with the catalog by convention. The architecture doc calls this out.
- **No E2E tests** — the desktop E2E harness uses Playwright and exercises the renderer; messaging slash-commands require a real Telegram/Discord/Mattermost server which isn't available in CI. Integration tests through `MessagingController.handleInboundEvent` (which we already have for every other command path) are the right level. Each provider's manual smoke-test checklist (in `docs/messaging-platform-integration.md`) covers `/help` end-to-end.

## Test plan

- [x] `pnpm typecheck` — full workspace clean
- [x] `pnpm lint:boundaries` — 0 violations across 956 modules
- [x] `pnpm test apps/desktop/src/main/__tests__/messaging` — 206/206 pass
- [x] `pnpm test` (full workspace) — 1189 pass / 3 skipped, no new failures
- [x] Manual smoke: invoke `/help` (or `/pwragent_help` on Mattermost) on a bound conversation; verify body lists all four verbs and the footer; tap `Resume` button; verify it opens the thread picker.

## Post-Deploy Monitoring & Validation

- **What to monitor**: `(pwragent:messaging)` log lines for `mattermost slash command received command=/pwragent_help` (or equivalent on Telegram/Discord). The handler dispatches to the help surface synchronously; no async failure path was introduced.
- **Expected healthy behavior**: `/help` invocations from any provider render a confirmation intent with title `"PwrAgent commands"` listing all four verbs. Unknown commands (e.g., `/threads`) render the same surface — fallback unchanged in behavior, just clearer in copy.
- **Failure signal**: messaging tests start failing with `expected "PwrAgent" got "PwrAgent commands"` (or vice-versa) — indicates the catalog and the test expectations have drifted. Update the catalog and the test in the same commit.
- **No additional operational monitoring required** — this is a copy and routing-internal refactor; no new network calls, no new persistence, no new IPC channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)