### PR TITLE
feat(messaging): @<bot> text-mention as a slash-command alternative for Discord and Telegram

### DIFF
--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -169,6 +169,104 @@ describe("TelegramAdapter", () => {
     });
   });
 
+  it("treats `@PwrAgentBot resume` as the /resume command", async () => {
+    const harness = await createControllerHarness();
+    await harness.adapter.start((event) => harness.controller.handleInboundEvent(event));
+    await harness.adapter.handleUpdate({
+      update_id: 1,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        date: 1,
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+          username: "mutable_username",
+        },
+        message_id: 100,
+        text: "@PwrAgentBot resume",
+      },
+    });
+
+    // Same outbound shape as /resume — the inbound mention path
+    // synthesizes a `MessagingInboundCommandEvent` with command =
+    // "resume" so the controller's existing dispatcher sees an
+    // identical event.
+    expect(harness.api.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat_id: 777,
+        reply_markup: {
+          inline_keyboard: expect.arrayContaining([
+            [
+              expect.objectContaining({ text: "1. Thread one" }),
+            ],
+          ]),
+        },
+      }),
+    );
+    const request = harness.api.sendMessage.mock.calls.at(-1)?.[0];
+    expect(request?.text).toContain("Choose a thread to resume");
+  });
+
+  it("treats `@PwrAgentBot help` as a command and a non-leading mention as text", async () => {
+    const harness = await createControllerHarness();
+    const events: MessagingInboundEvent[] = [];
+    await harness.adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await harness.adapter.handleUpdate({
+      update_id: 1,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        date: 1,
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+          username: "mutable_username",
+        },
+        message_id: 100,
+        text: "@PwrAgentBot help",
+      },
+    });
+    await harness.adapter.handleUpdate({
+      update_id: 2,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        date: 2,
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+          username: "mutable_username",
+        },
+        message_id: 101,
+        text: "hi there @PwrAgentBot",
+      },
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      kind: "command",
+      command: "help",
+      rawText: "/help",
+    });
+    expect(events[1]).toMatchObject({
+      kind: "text",
+      text: "hi there @PwrAgentBot",
+    });
+  });
+
   it("signals typing activity without rendering a visible Telegram message", async () => {
     const api = createApi();
     const adapter = new TelegramAdapter({
@@ -2211,6 +2309,7 @@ function createApi(overrides?: Partial<{
   deleteWebhook: ReturnType<typeof vi.fn>;
   editForumTopic: ReturnType<typeof vi.fn>;
   editMessageText: ReturnType<typeof vi.fn>;
+  getMe: ReturnType<typeof vi.fn>;
   getWebhookInfo: ReturnType<typeof vi.fn>;
   getFile: ReturnType<typeof vi.fn>;
   pinChatMessage: ReturnType<typeof vi.fn>;
@@ -2225,6 +2324,7 @@ function createApi(overrides?: Partial<{
   deleteWebhook: ReturnType<typeof vi.fn>;
   editForumTopic: ReturnType<typeof vi.fn>;
   editMessageText: ReturnType<typeof vi.fn>;
+  getMe: ReturnType<typeof vi.fn>;
   getWebhookInfo: ReturnType<typeof vi.fn>;
   getFile: ReturnType<typeof vi.fn>;
   pinChatMessage: ReturnType<typeof vi.fn>;
@@ -2246,6 +2346,7 @@ function createApi(overrides?: Partial<{
       },
       message_id: request.message_id,
     })),
+    getMe: vi.fn(async () => ({ id: 100, is_bot: true, username: "PwrAgentBot" })),
     getWebhookInfo: vi.fn(async () => ({ url: "" })),
     getFile: vi.fn(async () => ({ file_path: "documents/streaming-logs.txt" })),
     pinChatMessage: vi.fn(async (_request: TelegramPinChatMessageRequest) => true),

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -211,6 +211,47 @@ describe("TelegramAdapter", () => {
     expect(request?.text).toContain("Choose a thread to resume");
   });
 
+  it("treats a photo caption like `@PwrAgentBot resume` as a command, not media", async () => {
+    const harness = await createControllerHarness();
+    const events: MessagingInboundEvent[] = [];
+    await harness.adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await harness.adapter.handleUpdate({
+      update_id: 1,
+      message: {
+        caption: "@PwrAgentBot resume",
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        date: 1,
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+          username: "mutable_username",
+        },
+        message_id: 100,
+        photo: [
+          {
+            file_id: "AgADBA",
+            height: 480,
+            width: 640,
+          },
+        ],
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: "command",
+      command: "resume",
+      rawText: "/resume",
+    });
+  });
+
   it("treats `@PwrAgentBot help` as a command and a non-leading mention as text", async () => {
     const harness = await createControllerHarness();
     const events: MessagingInboundEvent[] = [];

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -20,6 +20,26 @@ Telegram registers these commands at startup with `setMyCommands`. Telegram
 clients can cache command menus, so if old OpenClaw commands still appear,
 restart or reopen the bot menu after starting PwrAgent.
 
+### `@<bot> <verb>` text-mention alternative
+
+On Telegram and Discord, the same verbs can be invoked by mentioning the bot
+followed by the verb — for example `@PwrAgent resume` or `@PwrAgent help`.
+The mention path is recognized before the slash-prefix path and dispatches the
+identical `MessagingInboundCommandEvent` the slash form produces, so workflow
+behavior is the same regardless of invocation style. This is useful from
+keyboards or topics where the slash menu isn't readily accessible. Notes:
+
+- Telegram requires the bot's `@username` and matches it case-insensitively
+  (Telegram usernames are case-insensitive); the adapter captures the
+  username via `getMe()` at startup. If `getMe()` fails, slash commands
+  still work, but mention parsing is disabled until the next start.
+- Discord ships raw user-id mention tokens (`<@USER_ID>` or the legacy
+  `<@!USER_ID>` nickname-alias form) in `message.content` even though the
+  client UI renders `@PwrAgent`. The adapter matches on the bot's user_id,
+  taken from the configured `applicationId` (which equals the bot user_id
+  for any modern Discord app). If `applicationId` is not set, mention
+  parsing is disabled.
+
 ## Button Layout
 
 Interactive actions can carry generic layout hints. Shared workflow code may
@@ -235,6 +255,7 @@ Telegram:
 1. Start PwrAgent with `pnpm dev:op`; if the bot has a webhook configured, PwrAgent clears it before long polling.
 2. Confirm `/resume`, `/threads`, `/status`, `/detach`, and `/bind` are registered in the Telegram command menu.
 3. Send `/resume` from an allowlisted Telegram user.
+3a. Repeat the previous step using `@<botusername> resume` instead of the slash command — the same thread picker should render. Confirm `@<botusername>` (no verb) is treated as plain text and not as a command.
 4. Use Projects, select a project, then select a thread.
 5. Verify a pinned status card appears and updates in place.
 6. Use status buttons to change Model, Reasoning, Fast mode, and Permissions.
@@ -274,6 +295,7 @@ Discord:
 
 1. In the Discord Developer Portal, confirm the bot has Gateway access, the privileged Message Content Intent enabled, and the bot was installed with the `applications.commands` scope.
 2. Send `/resume` from an allowlisted Discord user.
+2a. Repeat the previous step using `@PwrAgent resume` (a text mention) instead of the slash command — the same thread picker should render. Confirm `@PwrAgent` (no verb) is treated as plain text and not as a command. Mention parsing requires `applicationId` to be configured.
 3. Verify a numbered thread picker appears with components.
 4. Choose a thread by component, then repeat by replying `1`.
 5. For a bound Local thread with handoff branch metadata, choose Handoff from

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -39,6 +39,10 @@ keyboards or topics where the slash menu isn't readily accessible. Notes:
   taken from the configured `applicationId` (which equals the bot user_id
   for any modern Discord app). If `applicationId` is not set, mention
   parsing is disabled.
+- The mention parser also runs against attachment captions, so a photo or
+  file uploaded with caption `@<bot> resume` dispatches as the `resume`
+  command (the typed verb wins over the incidental upload). Bare or
+  unrecognized captions still route the attachment as media.
 
 ## Button Layout
 
@@ -255,7 +259,7 @@ Telegram:
 1. Start PwrAgent with `pnpm dev:op`; if the bot has a webhook configured, PwrAgent clears it before long polling.
 2. Confirm `/resume`, `/threads`, `/status`, `/detach`, and `/bind` are registered in the Telegram command menu.
 3. Send `/resume` from an allowlisted Telegram user.
-3a. Repeat the previous step using `@<botusername> resume` instead of the slash command — the same thread picker should render. Confirm `@<botusername>` (no verb) is treated as plain text and not as a command.
+   - Repeat using a text mention (`@` + your bot's username + ` resume`) instead of the slash command — the same thread picker should render. Confirm a bare mention with no verb is treated as plain text and not as a command.
 4. Use Projects, select a project, then select a thread.
 5. Verify a pinned status card appears and updates in place.
 6. Use status buttons to change Model, Reasoning, Fast mode, and Permissions.
@@ -295,7 +299,7 @@ Discord:
 
 1. In the Discord Developer Portal, confirm the bot has Gateway access, the privileged Message Content Intent enabled, and the bot was installed with the `applications.commands` scope.
 2. Send `/resume` from an allowlisted Discord user.
-2a. Repeat the previous step using `@PwrAgent resume` (a text mention) instead of the slash command — the same thread picker should render. Confirm `@PwrAgent` (no verb) is treated as plain text and not as a command. Mention parsing requires `applicationId` to be configured.
+   - Repeat using a text mention (type `@` and pick the bot from the autocomplete, then ` resume`) instead of the slash command — the same thread picker should render. Confirm a bare mention with no verb is treated as plain text and not as a command. Mention parsing requires `applicationId` to be configured.
 3. Verify a numbered thread picker appears with components.
 4. Choose a thread by component, then repeat by replying `1`.
 5. For a bound Local thread with handoff branch metadata, choose Handoff from

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1,8 +1,16 @@
-import type { MessagingAuditContext } from "@pwragent/messaging-interface";
+import type {
+  MessagingAuditContext,
+  MessagingInboundEvent,
+} from "@pwragent/messaging-interface";
 import { describe, expect, it, vi } from "vitest";
 import {
   DiscordAdapter,
+  stripDiscordBotMention,
   type DiscordApi,
+  type DiscordGatewayConnection,
+  type DiscordGatewayEvent,
+  type DiscordGatewayListener,
+  type DiscordMessageCreateDispatch,
 } from "../discord-adapter.ts";
 import type { DiscordApplicationCommand } from "../discord-commands.ts";
 
@@ -250,7 +258,204 @@ describe("discord adapter", () => {
       }),
     );
   });
+
+  describe("stripDiscordBotMention", () => {
+    const BOT_ID = "1480556454498009352";
+
+    it("strips a leading <@id> mention and returns the verb remainder", () => {
+      expect(stripDiscordBotMention(`<@${BOT_ID}> help`, BOT_ID)).toBe("help");
+    });
+
+    it("accepts the legacy <@!id> nickname-alias form", () => {
+      expect(stripDiscordBotMention(`<@!${BOT_ID}> resume`, BOT_ID)).toBe("resume");
+    });
+
+    it("preserves args after the verb", () => {
+      expect(stripDiscordBotMention(`<@${BOT_ID}> resume thread-42`, BOT_ID)).toBe(
+        "resume thread-42",
+      );
+    });
+
+    it("tolerates leading whitespace before the mention", () => {
+      expect(stripDiscordBotMention(`   <@${BOT_ID}> help`, BOT_ID)).toBe("help");
+    });
+
+    it("returns undefined when the mention is the entire message", () => {
+      expect(stripDiscordBotMention(`<@${BOT_ID}>`, BOT_ID)).toBeUndefined();
+      expect(stripDiscordBotMention(`<@${BOT_ID}>   `, BOT_ID)).toBeUndefined();
+    });
+
+    it("returns undefined when the message doesn't start with the mention", () => {
+      expect(stripDiscordBotMention(`hi <@${BOT_ID}> help`, BOT_ID)).toBeUndefined();
+      expect(stripDiscordBotMention("just text", BOT_ID)).toBeUndefined();
+    });
+
+    it("returns undefined when a different user is mentioned", () => {
+      expect(stripDiscordBotMention("<@9999999> help", BOT_ID)).toBeUndefined();
+    });
+
+    it("returns undefined when botUserId is unset", () => {
+      expect(stripDiscordBotMention(`<@${BOT_ID}> help`, undefined)).toBeUndefined();
+    });
+  });
+
+  describe("text mention dispatch", () => {
+    it("dispatches `<@bot> resume` as a command event", async () => {
+      const BOT_ID = "1480556454498009352";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: ["user-1"],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          authorBot: false,
+          content: `<@${BOT_ID}> resume`,
+          id: "msg-1",
+        }),
+      });
+      // Allow the async listener to run.
+
+      expect(events).toHaveLength(1);
+      const dispatched = events[0];
+      expect(dispatched).toMatchObject({
+        kind: "command",
+        command: "resume",
+        rawText: "/resume",
+      });
+      await adapter.stop();
+    });
+
+    it("dispatches `<@bot> help args` with args parsed from the remainder", async () => {
+      const BOT_ID = "1480556454498009352";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: ["user-1"],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          authorBot: false,
+          content: `<@${BOT_ID}> help foo bar`,
+          id: "msg-2",
+        }),
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        kind: "command",
+        command: "help",
+        args: ["foo", "bar"],
+        rawText: "/help foo bar",
+      });
+      await adapter.stop();
+    });
+
+    it("falls through to a text event when the mention isn't ours", async () => {
+      const BOT_ID = "1480556454498009352";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: ["user-1"],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          authorBot: false,
+          content: "hey <@9999999> what's up",
+          id: "msg-3",
+        }),
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        kind: "text",
+        text: "hey <@9999999> what's up",
+      });
+      await adapter.stop();
+    });
+  });
 });
+
+class TestDiscordGateway implements DiscordGatewayConnection {
+  private readonly listeners = new Set<DiscordGatewayListener>();
+
+  async start(): Promise<void> {}
+  async close(): Promise<void> {
+    this.listeners.clear();
+  }
+  onEvent(listener: DiscordGatewayListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+  async emit(event: DiscordGatewayEvent): Promise<void> {
+    await Promise.all([...this.listeners].map(async (listener) => listener(event)));
+  }
+}
+
+function messageDispatch(params: {
+  authorBot: boolean;
+  content: string;
+  id: string;
+}): DiscordMessageCreateDispatch {
+  return {
+    author: {
+      bot: params.authorBot,
+      id: "user-1",
+      username: "huntharo",
+    },
+    channel_id: "channel-1",
+    channel_type: 0,
+    content: params.content,
+    guild_id: "guild-1",
+    id: params.id,
+    is_thread: false,
+  };
+}
 
 function discordAudit(): MessagingAuditContext {
   return {

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -329,7 +329,6 @@ describe("discord adapter", () => {
           id: "msg-1",
         }),
       });
-      // Allow the async listener to run.
 
       expect(events).toHaveLength(1);
       const dispatched = events[0];
@@ -376,6 +375,97 @@ describe("discord adapter", () => {
         command: "help",
         args: ["foo", "bar"],
         rawText: "/help foo bar",
+      });
+      await adapter.stop();
+    });
+
+    it("routes a caption like `<@bot> resume` on an attachment to a command, not media", async () => {
+      const BOT_ID = "1480556454498009352";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: ["user-1"],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          attachments: [
+            {
+              filename: "screenshot.png",
+              id: "att-1",
+              size: 100,
+              url: "https://cdn.discordapp.com/.../screenshot.png",
+            },
+          ],
+          authorBot: false,
+          content: `<@${BOT_ID}> resume`,
+          id: "msg-cap-1",
+        }),
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        kind: "command",
+        command: "resume",
+        rawText: "/resume",
+      });
+      await adapter.stop();
+    });
+
+    it("preserves media dispatch when the caption isn't a recognized mention command", async () => {
+      const BOT_ID = "1480556454498009352";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi(),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: ["user-1"],
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: messageDispatch({
+          attachments: [
+            {
+              filename: "logs.txt",
+              id: "att-2",
+              size: 12,
+              url: "https://cdn.discordapp.com/.../logs.txt",
+            },
+          ],
+          authorBot: false,
+          content: "see the attached logs",
+          id: "msg-cap-2",
+        }),
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        kind: "media",
+        text: "see the attached logs",
       });
       await adapter.stop();
     });
@@ -438,11 +528,13 @@ class TestDiscordGateway implements DiscordGatewayConnection {
 }
 
 function messageDispatch(params: {
+  attachments?: DiscordMessageCreateDispatch["attachments"];
   authorBot: boolean;
   content: string;
   id: string;
 }): DiscordMessageCreateDispatch {
   return {
+    attachments: params.attachments,
     author: {
       bot: params.authorBot,
       id: "user-1",

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -677,6 +677,52 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       isThread: message.is_thread,
     });
 
+    // `<@botUserId> <verb>` text mention → command. Run BEFORE the
+    // attachment branch so captions like `@PwrAgent resume` on a
+    // file/image upload route to the command pathway too — the user
+    // typed a verb, that intent wins over the incidental attachment.
+    // Mirrors the Mattermost `@<bot> <verb>` path so users on Discord
+    // can invoke commands without remembering slash names. Discord
+    // ships raw `<@USER_ID>` (or legacy `<@!USER_ID>`) tokens in
+    // `message.content` even though the UI renders `@PwrAgent`, so we
+    // match on the id rather than the display name. The bot's user_id
+    // equals the configured applicationId for any modern Discord app
+    // (the application id and bot user id were unified for bots
+    // created since 2016).
+    if (message.content !== undefined) {
+      const mentionRemainder = stripDiscordBotMention(
+        message.content,
+        this.options.config.applicationId,
+      );
+      if (mentionRemainder !== undefined) {
+        // Synthesize the slash form so the controller sees the same
+        // `MessagingInboundCommandEvent` shape as a `/`-prefixed
+        // message. The slash regex below extracts verb + args. If
+        // the remainder doesn't form a valid verb (e.g. `@bot @bot
+        // help` strips one mention but leaves another, or `@bot 123`
+        // leads with a non-identifier char) we deliberately fall
+        // through to the standard attachment / slash / text paths
+        // below — the original `message.content` is dispatched as
+        // media or plain text rather than a half-recognized command.
+        const synthRaw = `/${mentionRemainder}`;
+        const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
+        if (mentionCommandMatch) {
+          await listener({
+            id: `discord:message:${message.id}`,
+            kind: "command",
+            actor: this.actorFromUser(message.author),
+            args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
+            channel,
+            command: mentionCommandMatch[1]?.toLowerCase() ?? "",
+            rawText: synthRaw,
+            receivedAt,
+            routingState,
+          });
+          return;
+        }
+      }
+    }
+
     if (message.attachments && message.attachments.length > 0) {
       const attachments = message.attachments.map((attachment) =>
         this.attachmentFromDiscord(attachment),
@@ -707,41 +753,6 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       throw new Error(
         "Discord message content is unavailable; enable the privileged message content intent.",
       );
-    }
-
-    // `<@botUserId> <verb>` text mention → command. Mirrors the
-    // Mattermost `@<bot> <verb>` path so users on Discord can invoke
-    // commands without remembering slash names. Discord ships raw
-    // `<@USER_ID>` (or legacy `<@!USER_ID>`) tokens in
-    // `message.content` even though the UI renders `@PwrAgent`, so
-    // we match on the id rather than the display name. The bot's
-    // user_id equals the configured applicationId for any modern
-    // Discord app (the application id and bot user id were unified
-    // for bots created since 2016).
-    const mentionRemainder = stripDiscordBotMention(
-      message.content,
-      this.options.config.applicationId,
-    );
-    if (mentionRemainder !== undefined) {
-      // Synthesize the slash form so the controller sees the same
-      // `MessagingInboundCommandEvent` shape as a `/`-prefixed
-      // message. The slash regex below extracts verb + args.
-      const synthRaw = `/${mentionRemainder}`;
-      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
-      if (mentionCommandMatch) {
-        await listener({
-          id: `discord:message:${message.id}`,
-          kind: "command",
-          actor: this.actorFromUser(message.author),
-          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
-          channel,
-          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
-          rawText: synthRaw,
-          receivedAt,
-          routingState,
-        });
-        return;
-      }
     }
 
     const commandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(message.content);
@@ -1704,13 +1715,20 @@ export function stripDiscordBotMention(
   // Match either `<@123>` or the legacy `<@!123>` form. Discord still
   // ships both in `message.content`; the `!` variant historically
   // signaled a server-nickname alias, but the user_id payload is the
-  // same regardless.
-  const mentionPattern = new RegExp(`^<@!?${botUserId}>`);
-  const match = mentionPattern.exec(trimmedStart);
-  if (!match) {
+  // same regardless. Use plain `startsWith` rather than building a
+  // RegExp — `botUserId` comes from config and we don't want a stray
+  // metacharacter to ever change matching semantics.
+  const direct = `<@${botUserId}>`;
+  const alias = `<@!${botUserId}>`;
+  const mention = trimmedStart.startsWith(direct)
+    ? direct
+    : trimmedStart.startsWith(alias)
+      ? alias
+      : undefined;
+  if (!mention) {
     return undefined;
   }
-  const remainder = trimmedStart.slice(match[0].length).trim();
+  const remainder = trimmedStart.slice(mention.length).trim();
   if (remainder.length === 0) {
     return undefined;
   }

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -709,6 +709,41 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       );
     }
 
+    // `<@botUserId> <verb>` text mention → command. Mirrors the
+    // Mattermost `@<bot> <verb>` path so users on Discord can invoke
+    // commands without remembering slash names. Discord ships raw
+    // `<@USER_ID>` (or legacy `<@!USER_ID>`) tokens in
+    // `message.content` even though the UI renders `@PwrAgent`, so
+    // we match on the id rather than the display name. The bot's
+    // user_id equals the configured applicationId for any modern
+    // Discord app (the application id and bot user id were unified
+    // for bots created since 2016).
+    const mentionRemainder = stripDiscordBotMention(
+      message.content,
+      this.options.config.applicationId,
+    );
+    if (mentionRemainder !== undefined) {
+      // Synthesize the slash form so the controller sees the same
+      // `MessagingInboundCommandEvent` shape as a `/`-prefixed
+      // message. The slash regex below extracts verb + args.
+      const synthRaw = `/${mentionRemainder}`;
+      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
+      if (mentionCommandMatch) {
+        await listener({
+          id: `discord:message:${message.id}`,
+          kind: "command",
+          actor: this.actorFromUser(message.author),
+          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
+          channel,
+          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
+          rawText: synthRaw,
+          receivedAt,
+          routingState,
+        });
+        return;
+      }
+    }
+
     const commandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(message.content);
     await listener({
       id: `discord:message:${message.id}`,
@@ -1639,6 +1674,47 @@ function defensiveAllowedMentions(): DiscordAllowedMentions {
     roles: [],
     users: [],
   };
+}
+
+/**
+ * If `text` starts with a Discord user-mention token for `botUserId`
+ * (`<@123>` or the legacy nickname-alias form `<@!123>`, with optional
+ * leading whitespace), return the rest of the message with that
+ * mention stripped and trimmed. Otherwise return `undefined`.
+ *
+ * Used to detect `@PwrAgent <verb>` text-mention commands so the
+ * adapter can dispatch them through the same command pathway as
+ * slash commands. Discord renders `@PwrAgent` in the UI but ships
+ * the raw `<@USER_ID>` token in `message.content` over the gateway,
+ * so we match on the id rather than the visible name.
+ *
+ * Returns `undefined` when:
+ *   - `botUserId` is unset (config didn't expose it)
+ *   - the message doesn't begin with the mention token
+ *   - the mention is the entire message (no command verb following)
+ */
+export function stripDiscordBotMention(
+  text: string,
+  botUserId: string | undefined,
+): string | undefined {
+  if (!botUserId) {
+    return undefined;
+  }
+  const trimmedStart = text.replace(/^\s+/, "");
+  // Match either `<@123>` or the legacy `<@!123>` form. Discord still
+  // ships both in `message.content`; the `!` variant historically
+  // signaled a server-nickname alias, but the user_id payload is the
+  // same regardless.
+  const mentionPattern = new RegExp(`^<@!?${botUserId}>`);
+  const match = mentionPattern.exec(trimmedStart);
+  if (!match) {
+    return undefined;
+  }
+  const remainder = trimmedStart.slice(match[0].length).trim();
+  if (remainder.length === 0) {
+    return undefined;
+  }
+  return remainder;
 }
 
 function messageToDispatch(message: Message): DiscordMessageCreateDispatch {

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -136,6 +136,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
     editForumTopic: ReturnType<typeof vi.fn>;
     editMessageText: ReturnType<typeof vi.fn>;
     getFile: ReturnType<typeof vi.fn>;
+    getMe: ReturnType<typeof vi.fn>;
     getWebhookInfo: ReturnType<typeof vi.fn>;
     pinChatMessage: ReturnType<typeof vi.fn>;
     sendChatAction: ReturnType<typeof vi.fn>;
@@ -169,6 +170,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
         }),
       ),
       getFile: vi.fn(async () => ({ file_path: "documents/file.txt" })),
+      getMe: vi.fn(async () => ({ id: 123, is_bot: true, username: "TestBot" })),
       getWebhookInfo: vi.fn(async () => ({ url: "" })),
       pinChatMessage: vi.fn(
         async (

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-mention.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-mention.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { stripTelegramBotMention } from "../telegram-adapter.ts";
+
+describe("stripTelegramBotMention", () => {
+  const USERNAME = "PwrAgentBot";
+
+  it("strips a leading @username mention and returns the verb remainder", () => {
+    expect(stripTelegramBotMention(`@${USERNAME} help`, USERNAME)).toBe("help");
+  });
+
+  it("preserves args after the verb", () => {
+    expect(stripTelegramBotMention(`@${USERNAME} resume thread-42`, USERNAME)).toBe(
+      "resume thread-42",
+    );
+  });
+
+  it("matches case-insensitively (Telegram usernames are case-insensitive)", () => {
+    expect(stripTelegramBotMention(`@${USERNAME.toLowerCase()} help`, USERNAME)).toBe(
+      "help",
+    );
+    expect(stripTelegramBotMention(`@${USERNAME.toUpperCase()} help`, USERNAME)).toBe(
+      "help",
+    );
+  });
+
+  it("tolerates leading whitespace before the mention", () => {
+    expect(stripTelegramBotMention(`   @${USERNAME} help`, USERNAME)).toBe("help");
+  });
+
+  it("returns undefined when the mention is the entire message", () => {
+    expect(stripTelegramBotMention(`@${USERNAME}`, USERNAME)).toBeUndefined();
+    expect(stripTelegramBotMention(`@${USERNAME}   `, USERNAME)).toBeUndefined();
+  });
+
+  it("returns undefined when the message doesn't start with the mention", () => {
+    expect(stripTelegramBotMention(`hi @${USERNAME} help`, USERNAME)).toBeUndefined();
+    expect(stripTelegramBotMention("just text", USERNAME)).toBeUndefined();
+  });
+
+  it("returns undefined when a longer username matches as a prefix", () => {
+    // `@PwrAgentBot2 help` must NOT match `PwrAgentBot` — it's a
+    // different bot. The word-boundary check guards this.
+    expect(stripTelegramBotMention(`@${USERNAME}2 help`, USERNAME)).toBeUndefined();
+  });
+
+  it("returns undefined when botUsername is unset", () => {
+    expect(stripTelegramBotMention(`@${USERNAME} help`, undefined)).toBeUndefined();
+  });
+});

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -232,6 +232,7 @@ export type TelegramBotApi = {
   deleteWebhook(params?: { drop_pending_updates?: boolean }): Promise<boolean>;
   editForumTopic(request: TelegramEditForumTopicRequest): Promise<boolean>;
   editMessageText(request: TelegramEditMessageTextRequest): Promise<TelegramSentMessage>;
+  getMe(): Promise<{ id: number; is_bot: boolean; username?: string }>;
   getWebhookInfo(): Promise<{ url: string }>;
   getFile(fileId: string): Promise<{ file_path?: string }>;
   pinChatMessage(request: TelegramPinChatMessageRequest): Promise<boolean>;
@@ -275,6 +276,7 @@ export type TelegramGrammyBotLike = {
       text: string,
       other?: Omit<TelegramEditMessageTextRequest, "chat_id" | "message_id" | "text">,
     ): Promise<TelegramSentMessage | boolean>;
+    getMe(): Promise<{ id: number; is_bot: boolean; username: string }>;
     getWebhookInfo(): Promise<{ url: string }>;
     getFile(fileId: string): Promise<{ file_path?: string }>;
     pinChatMessage(
@@ -372,6 +374,16 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   private callbackBindings = new Map<string, TelegramCallbackBinding>();
   private defaultBot?: TelegramBotLike;
+  /**
+   * The bot's `@username` as returned by `getMe()`, lower-cased once
+   * for case-insensitive prefix matching. Captured during `start()`.
+   * Telegram usernames are derived from the bot's profile (not from
+   * the bot token), so unlike `configuredBotId` this can't be
+   * computed offline. Undefined when the adapter hasn't started yet
+   * or `getMe()` failed at startup; in that case `@<bot> <verb>`
+   * mention parsing is skipped (slash commands still work).
+   */
+  private botUsername?: string;
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private streamRateLimits = new Map<string, TelegramStreamRateLimitState>();
   private streamSurfaces = new Map<string, TelegramDeliveryTarget>();
@@ -424,6 +436,25 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     const tokenDiagnostics = telegramBotTokenDiagnostics(this.options.config.botToken);
     this.options.logger?.debug("telegram startup token diagnostics", tokenDiagnostics);
+
+    // Capture the bot's `@username` so the inbound path can recognize
+    // `@<botusername> <verb>` text mentions. Telegram usernames live
+    // on the bot profile (not the token), so this requires an actual
+    // API call. Failure isn't fatal — slash commands still work; we
+    // just skip mention parsing.
+    try {
+      const me = await this.bot.api.getMe();
+      if (me.username) {
+        this.botUsername = me.username.toLowerCase();
+        this.options.logger?.debug(
+          `telegram captured bot username for mention parsing: @${this.botUsername}`,
+        );
+      }
+    } catch (error) {
+      this.options.logger?.warn?.("telegram getMe failed; @-mention commands disabled", {
+        error: errorMessage(error),
+      });
+    }
 
     let webhookInfo: { url: string };
     try {
@@ -478,6 +509,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     await this.startPromise?.catch(() => undefined);
     this.startPromise = undefined;
     this.listener = undefined;
+    this.botUsername = undefined;
   }
 
   async downloadAttachment(
@@ -976,6 +1008,35 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     if (!message.text) {
       return;
+    }
+
+    // `@<botusername> <verb>` text mention → command. Mirrors the
+    // Mattermost / Discord paths so users on Telegram can invoke
+    // commands without the slash menu (helpful when a phone keyboard
+    // doesn't surface custom commands or when typing into a topic
+    // the user hasn't sent a slash to before). Username matching is
+    // case-insensitive — Telegram usernames are case-insensitive.
+    const mentionRemainder = stripTelegramBotMention(message.text, this.botUsername);
+    if (mentionRemainder !== undefined) {
+      const synthRaw = `/${mentionRemainder}`;
+      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
+      if (mentionCommandMatch) {
+        this.options.logger?.debug(
+          `telegram inbound mention-command update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} command=${mentionCommandMatch[1]} preview="${compactPreview(message.text)}"`,
+        );
+        await listener({
+          id: `telegram:update:${updateId}:message:${message.message_id}`,
+          kind: "command",
+          actor: this.actorFromUser(message.from),
+          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
+          channel: this.channelFromMessage(message),
+          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
+          rawText: synthRaw,
+          receivedAt: this.messageReceivedAt(message),
+          routingState: this.routingStateFromMessage(message),
+        });
+        return;
+      }
     }
 
     const commandMatch = /^\/([A-Za-z0-9_]+)(?:@\S+)?(?:\s+(.*))?$/.exec(message.text);
@@ -1881,6 +1942,7 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
           request,
         );
       },
+      getMe: async () => await bot.api.getMe(),
       getWebhookInfo: async () => await bot.api.getWebhookInfo(),
       getFile: async (fileId) => await bot.api.getFile(fileId),
       pinChatMessage: async (request) => {
@@ -1949,6 +2011,54 @@ function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | unde
   return intent.kind === "thread_picker" || intent.kind === "project_picker"
     ? intent.browseSessionId
     : undefined;
+}
+
+/**
+ * If `text` starts with `@<botUsername>` (case-insensitive, optional
+ * leading whitespace), return the rest of the message with that
+ * prefix stripped and trimmed. Otherwise return `undefined`.
+ *
+ * Used to detect `@PwrAgent <verb>` text-mention commands so the
+ * adapter can dispatch them through the same command pathway as
+ * slash commands. Telegram usernames are case-insensitive (server
+ * normalizes), so we lower-case both sides before comparing.
+ *
+ * Returns `undefined` when:
+ *   - `botUsername` is unset (adapter hasn't `start()`'d yet, or
+ *     `getMe()` failed at startup)
+ *   - the message doesn't begin with the mention
+ *   - a longer username token follows `@<botUsername>` (so
+ *     `@pwragent2` doesn't match `@pwragent`)
+ *   - the mention is the entire message (no command verb following)
+ */
+export function stripTelegramBotMention(
+  text: string,
+  botUsername: string | undefined,
+): string | undefined {
+  if (!botUsername) {
+    return undefined;
+  }
+  const trimmedStart = text.replace(/^\s+/, "");
+  const mention = `@${botUsername}`;
+  if (trimmedStart.length < mention.length) {
+    return undefined;
+  }
+  if (trimmedStart.slice(0, mention.length).toLowerCase() !== mention.toLowerCase()) {
+    return undefined;
+  }
+  // Word-boundary check: anything after the mention prefix must be
+  // whitespace or end-of-string. Telegram usernames are
+  // [A-Za-z0-9_]{5,32}, so `@pwragent2` continuing with `2` would
+  // be a different bot — not us.
+  const after = trimmedStart.charAt(mention.length);
+  if (after !== "" && !/\s/.test(after)) {
+    return undefined;
+  }
+  const remainder = trimmedStart.slice(mention.length).trim();
+  if (remainder.length === 0) {
+    return undefined;
+  }
+  return remainder;
 }
 
 function sanitizeTelegramTopicName(title: string): string {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -276,7 +276,12 @@ export type TelegramGrammyBotLike = {
       text: string,
       other?: Omit<TelegramEditMessageTextRequest, "chat_id" | "message_id" | "text">,
     ): Promise<TelegramSentMessage | boolean>;
-    getMe(): Promise<{ id: number; is_bot: boolean; username: string }>;
+    // Telegram's `User` allows `username` to be absent (non-bot users
+    // can omit it). Grammy returns `UserFromGetMe` which always has
+    // it set for bot accounts, but we keep the type optional here to
+    // match `TelegramBotApi.getMe` and avoid a structural narrowing
+    // surprise if grammy ever loosens the type.
+    getMe(): Promise<{ id: number; is_bot: boolean; username?: string }>;
     getWebhookInfo(): Promise<{ url: string }>;
     getFile(fileId: string): Promise<{ file_path?: string }>;
     pinChatMessage(
@@ -978,6 +983,47 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       return;
     }
 
+    // `@<botusername> <verb>` text mention → command. Run BEFORE the
+    // attachment branch so captions like `@PwrAgentBot resume` on a
+    // photo/file/voice upload route to the command pathway too — the
+    // user typed a verb, that intent wins over the incidental
+    // attachment. Mirrors the Mattermost / Discord paths so users on
+    // Telegram can invoke commands without the slash menu (helpful
+    // when a phone keyboard doesn't surface custom commands or when
+    // typing into a topic the user hasn't sent a slash to before).
+    // Username matching is case-insensitive — Telegram usernames are
+    // case-insensitive.
+    const mentionCandidate = message.text ?? message.caption;
+    const mentionRemainder = mentionCandidate
+      ? stripTelegramBotMention(mentionCandidate, this.botUsername)
+      : undefined;
+    if (mentionRemainder !== undefined && mentionCandidate !== undefined) {
+      // If the remainder after the mention doesn't form a valid verb
+      // (e.g. a second mention, or a digit-leading token), we
+      // deliberately fall through to the attachment / slash / text
+      // paths below so the user's original message is dispatched as
+      // media or plain text rather than a half-recognized command.
+      const synthRaw = `/${mentionRemainder}`;
+      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
+      if (mentionCommandMatch) {
+        this.options.logger?.debug(
+          `telegram inbound mention-command update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} command=${mentionCommandMatch[1]} preview="${compactPreview(mentionCandidate)}"`,
+        );
+        await listener({
+          id: `telegram:update:${updateId}:message:${message.message_id}`,
+          kind: "command",
+          actor: this.actorFromUser(message.from),
+          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
+          channel: this.channelFromMessage(message),
+          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
+          rawText: synthRaw,
+          receivedAt: this.messageReceivedAt(message),
+          routingState: this.routingStateFromMessage(message),
+        });
+        return;
+      }
+    }
+
     const attachments = this.attachmentsFromMessage(message);
     if (attachments.length > 0) {
       await listener({
@@ -1008,35 +1054,6 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
     if (!message.text) {
       return;
-    }
-
-    // `@<botusername> <verb>` text mention → command. Mirrors the
-    // Mattermost / Discord paths so users on Telegram can invoke
-    // commands without the slash menu (helpful when a phone keyboard
-    // doesn't surface custom commands or when typing into a topic
-    // the user hasn't sent a slash to before). Username matching is
-    // case-insensitive — Telegram usernames are case-insensitive.
-    const mentionRemainder = stripTelegramBotMention(message.text, this.botUsername);
-    if (mentionRemainder !== undefined) {
-      const synthRaw = `/${mentionRemainder}`;
-      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
-      if (mentionCommandMatch) {
-        this.options.logger?.debug(
-          `telegram inbound mention-command update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} command=${mentionCommandMatch[1]} preview="${compactPreview(message.text)}"`,
-        );
-        await listener({
-          id: `telegram:update:${updateId}:message:${message.message_id}`,
-          kind: "command",
-          actor: this.actorFromUser(message.from),
-          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
-          channel: this.channelFromMessage(message),
-          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
-          rawText: synthRaw,
-          receivedAt: this.messageReceivedAt(message),
-          routingState: this.routingStateFromMessage(message),
-        });
-        return;
-      }
     }
 
     const commandMatch = /^\/([A-Za-z0-9_]+)(?:@\S+)?(?:\s+(.*))?$/.exec(message.text);


### PR DESCRIPTION
## Summary

Mirrors the Mattermost `35a46de8` pattern: users on **Discord** and **Telegram** can now invoke any canonical PwrAgent verb by mentioning the bot followed by the verb, in addition to the slash-command form. The mention path is recognized before the slash-prefix path and dispatches the identical `MessagingInboundCommandEvent` shape, so workflow code sees the same event regardless of invocation style.

- `@PwrAgent resume` → routes to `/resume` (thread picker)
- `@PwrAgent help` → routes to `/help` (catalog-driven help, when paired with PR #215)
- `@PwrAgent <any-canonical-verb>` → standard command dispatch
- Bare `@PwrAgent` (no verb) → plain text (no command synthesized)

## Why

In some Telegram clients (forum topics, third-party clients) and Discord contexts, the slash menu isn't always reachable. Text mentions give users a "just works" alternative — and on Mattermost the same path also sidesteps the v10.x `root_id` slash-command limitation entirely. This PR brings parity to Discord and Telegram so the invocation surface is consistent across all three channels.

## Implementation notes

**Discord** — `stripDiscordBotMention(text, botUserId)` matches `<@USER_ID>` and the legacy `<@!USER_ID>` nickname-alias form. Discord ships raw user-id tokens in `message.content` even though the UI renders `@PwrAgent`, so we match on id rather than display name. Bot user_id source is `applicationId` from config (which equals the bot user_id for any modern Discord app — unified since 2016). If `applicationId` isn't set, mention parsing is silently skipped; slash commands still work.

**Telegram** — `stripTelegramBotMention(text, botUsername)` matches `@<botusername>` case-insensitively (Telegram usernames are server-normalized) with a word-boundary check so `@PwrAgentBot2` doesn't match `@PwrAgentBot`. Bot username source is `bot.api.getMe()` at startup. Unlike the bot id (derivable from the token), the bot's `@username` lives on the profile and requires an API call. `getMe()` failure is logged but non-fatal.

Both helpers return undefined for: missing bot identity, message that doesn't start with the mention, mention with no verb following, or a different user mentioned.

## Tests

- **Discord package**: 8 unit tests for `stripDiscordBotMention` + 3 inbound-dispatch integration tests through a `TestDiscordGateway` harness (resume via mention, help with args parsed, fall-through to text when the mention isn't ours).
- **Telegram package**: 8 unit tests in a new `telegram-mention.test.ts` (parallel coverage to Discord, plus the longer-username word-boundary case).
- **Desktop**: 1 integration test driving `@PwrAgentBot resume` through the controller harness and verifying the same outbound thread picker the slash form produces; 1 test verifying non-leading mentions are dispatched as text rather than commands.
- All **1193 workspace tests pass**; typecheck and `lint:boundaries` clean (0 violations across 955 modules).

## Files

- `packages/messaging/providers/discord/src/discord-adapter.ts` — `stripDiscordBotMention` helper + `handleMessageCreate` mention branch
- `packages/messaging/providers/telegram/src/telegram-adapter.ts` — `stripTelegramBotMention` helper, `botUsername` field, `getMe()` capture in `start()`, `handleMessage` mention branch, `getMe` added to `TelegramBotApi` + grammy adapter
- `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts` — unit + integration tests
- `packages/messaging/providers/telegram/src/__tests__/telegram-mention.test.ts` — new file, unit tests
- `packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts` — added `getMe` to mock api
- `apps/desktop/src/main/__tests__/telegram-adapter.test.ts` — added `getMe` to mock api + 1 mention integration test
- `docs/messaging-platform-integration.md` — new "@<bot> text-mention alternative" section + smoke-checklist steps `3a` (Telegram) and `2a` (Discord)

## Scope

This PR does **not** register `/help` as a slash command on Discord or Telegram. That namespace is left clean for now (per direction, command names like `/help` likely need namespacing to stay out of the way of platform commands on various clients). `@<bot> help` still routes correctly once the controller-side help surface lands (PR #215).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:boundaries` — 0 violations
- [x] `pnpm test` — 1193 passed
- [x] Manual Discord smoke: send `@PwrAgent resume` from an allowlisted user; verify the same thread picker as `/resume` renders
- [x] Manual Discord smoke: send bare `@PwrAgent` (no verb); verify it's treated as text, not a command
- [x] Manual Telegram smoke: send `@<botusername> resume` from an allowlisted user; verify the same thread picker as `/resume` renders
- [x] Manual Telegram smoke: send bare `@<botusername>`; verify it's treated as text

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: search for `telegram captured bot username for mention parsing` at startup (confirms `getMe()` succeeded)
  - Logs: search for `telegram getMe failed; @-mention commands disabled` (signals startup degradation — slash commands still work)
  - Logs: `telegram inbound mention-command` (confirms a user invoked via mention)
- **Validation checks**
  - In a test channel, send `@<bot> resume` and confirm a thread picker appears.
  - Verify `applicationId` is set in the desktop Discord settings (mention parsing requires it).
- **Expected healthy behavior**
  - Mention path produces the same UI as the slash path.
  - Bare `@<bot>` falls through to text without synthesizing a command.
- **Failure signal / rollback trigger**
  - Mention dispatches that produce duplicate replies (would indicate the slash and mention paths both fired) → revert this commit.
- **Validation window & owner**
  - Window: through next manual smoke session.
  - Owner: @huntharo.
- **If no operational impact**
  - N/A — this is an additive inbound parsing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)