### PR TITLE
feat(desktop): detect codex permission-mode drift and prompt to resolve

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -184,6 +184,61 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadObservedExecutionMode: async ({
+      backend,
+      threadId,
+      observedExecutionMode,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      observedExecutionMode?: "default" | "full-access";
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        observedExecutionMode,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
+    retainThreadExecutionModeDrift: async ({
+      backend,
+      threadId,
+      expectedExecutionMode,
+      observedExecutionMode,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      expectedExecutionMode: "default" | "full-access";
+      observedExecutionMode: "default" | "full-access";
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        retainedExecutionModeDriftPairs: [
+          ...(current.retainedExecutionModeDriftPairs ?? []),
+          {
+            expectedExecutionMode,
+            observedExecutionMode,
+            retainedAt: Date.now(),
+          },
+        ],
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     getLaunchpadDefaults: async () => launchpadDefaults,
     setLaunchpadDefaults: async (patch: Partial<NavigationLaunchpadDefaults>) => {
       launchpadDefaults = {
@@ -340,6 +395,7 @@ class MockBackendClient {
   listThreadsCallCount = 0;
   listModelsCallCount = 0;
   steerTurnCallCount = 0;
+  probeThreadPermissionsCallCount = 0;
   lastListModelsDiagnostics?: {
     callerReason?: string;
     ownerId?: string;
@@ -378,6 +434,7 @@ class MockBackendClient {
       startTurnError?: Error;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
+      probedExecutionMode?: "default" | "full-access";
     }
   ) {}
 
@@ -541,13 +598,26 @@ class MockBackendClient {
     sandbox?: string;
     serviceTier?: string;
     reasoningEffort?: string;
-  }): Promise<{ threadId: string }> {
+  }): Promise<{ threadId: string; observedExecutionMode?: "default" | "full-access" }> {
     this.lastSetThreadPermissionsParams = params;
     if (this.options.setThreadPermissionsError) {
       throw this.options.setThreadPermissionsError;
     }
 
-    return { threadId: params.threadId };
+    return {
+      threadId: params.threadId,
+      observedExecutionMode: this.options.probedExecutionMode,
+    };
+  }
+
+  async probeThreadPermissions(params: {
+    threadId: string;
+  }): Promise<{ threadId: string; observedExecutionMode?: "default" | "full-access" }> {
+    this.probeThreadPermissionsCallCount += 1;
+    return {
+      threadId: params.threadId,
+      observedExecutionMode: this.options.probedExecutionMode,
+    };
   }
 
   async interruptTurn(): Promise<{ threadId: string; turnId: string }> {
@@ -3283,6 +3353,135 @@ describe("DesktopBackendRegistry", () => {
       sandbox: "workspace-write",
     });
     expect(codexFullAccessClient.lastStartTurnParams).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("checkThreadExecutionModeDrift reports drift when codex's probe disagrees with the overlay", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/resume"] },
+      probedExecutionMode: "full-access",
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-drift": {
+          backend: "codex",
+          threadId: "thread-drift",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/resume"] },
+        probedExecutionMode: "full-access",
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+    });
+
+    const drift = await registry.checkThreadExecutionModeDrift({
+      backend: "codex",
+      threadId: "thread-drift",
+    });
+
+    expect(drift).toMatchObject({
+      backend: "codex",
+      threadId: "thread-drift",
+      expectedExecutionMode: "default",
+      observedExecutionMode: "full-access",
+      drifted: true,
+    });
+    // Probe persists the observed value back to the overlay so subsequent
+    // navigation snapshots reflect codex's view without re-probing.
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-drift",
+      }),
+    ).resolves.toMatchObject({
+      observedExecutionMode: "full-access",
+    });
+
+    await registry.close();
+  });
+
+  it("checkThreadExecutionModeDrift reports no drift when overlay agrees with codex's probe", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/resume"] },
+      probedExecutionMode: "default",
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-aligned": {
+          backend: "codex",
+          threadId: "thread-aligned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/resume"] },
+        probedExecutionMode: "default",
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+    });
+
+    const drift = await registry.checkThreadExecutionModeDrift({
+      backend: "codex",
+      threadId: "thread-aligned",
+    });
+
+    expect(drift.drifted).toBe(false);
+
+    await registry.close();
+  });
+
+  it("retainThreadExecutionModeDrift persists the dismissed pair on the overlay", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/resume"] },
+      }),
+      codexFullAccessClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/resume"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+    });
+
+    await registry.retainThreadExecutionModeDrift({
+      backend: "codex",
+      threadId: "thread-retain",
+      expectedExecutionMode: "default",
+      observedExecutionMode: "full-access",
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-retain",
+      }),
+    ).resolves.toMatchObject({
+      retainedExecutionModeDriftPairs: [
+        expect.objectContaining({
+          expectedExecutionMode: "default",
+          observedExecutionMode: "full-access",
+        }),
+      ],
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3855,4 +3855,125 @@ describe("CodexAppServerClient", () => {
 
     await client.close();
   });
+
+  it("captures observedExecutionMode=default from a thread/resume legacy sandbox + approvalPolicy pair", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    MockTransport.threadResumeResult = {
+      threadId: "thread-mode",
+      threadName: "Mode capture",
+      cwd: "/repo/app",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-mode",
+      input: [{ type: "text", text: "Capture observed mode from resume" }],
+    });
+
+    expect(result.observedExecutionMode).toBe("default");
+
+    await client.close();
+  });
+
+  it("maps the dangerFullAccess SandboxPolicy variant to observedExecutionMode=full-access", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    MockTransport.threadResumeResult = {
+      threadId: "thread-full",
+      threadName: "Full access",
+      cwd: "/repo/app",
+      approvalPolicy: "never",
+      sandbox: { type: "dangerFullAccess" },
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-full",
+      input: [{ type: "text", text: "Capture observed mode from resume" }],
+    });
+
+    expect(result.observedExecutionMode).toBe("full-access");
+
+    await client.close();
+  });
+
+  it("returns observedExecutionMode=undefined when codex reports a permission combination PwrAgent does not surface", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    // Granular approval policy is not one of the two combinations PwrAgent
+    // exposes — capture should refuse to guess.
+    MockTransport.threadResumeResult = {
+      threadId: "thread-granular",
+      threadName: "Granular",
+      cwd: "/repo/app",
+      approvalPolicy: {
+        granular: {
+          sandbox_approval: false,
+          rules: false,
+          skill_approval: false,
+          request_permissions: false,
+          mcp_elicitations: false,
+        },
+      },
+      sandbox: { type: "workspaceWrite", writableRoots: [], networkAccess: false },
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const result = await client.startTurn({
+      threadId: "thread-granular",
+      input: [{ type: "text", text: "Granular approvals" }],
+    });
+
+    expect(result.observedExecutionMode).toBeUndefined();
+
+    await client.close();
+  });
+
+  it("probeThreadPermissions calls thread/resume without policy overrides and captures observedExecutionMode", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    MockTransport.threadResumeResult = {
+      threadId: "thread-probe",
+      threadName: "Probe",
+      cwd: "/repo/app",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const result = await client.probeThreadPermissions({
+      threadId: "thread-probe",
+    });
+
+    expect(result.observedExecutionMode).toBe("full-access");
+
+    const transport = MockTransport.instances.at(-1);
+    const resumePayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/resume");
+    // The probe must NOT push our policy/sandbox at codex — it's a read.
+    expect(resumePayload?.params).not.toHaveProperty("approvalPolicy");
+    expect(resumePayload?.params).not.toHaveProperty("sandbox");
+
+    await client.close();
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -28,7 +28,10 @@ import {
   type BackendSummary,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  type CheckThreadExecutionModeDriftRequest,
+  type CheckThreadExecutionModeDriftResponse,
   isBranchDrifted,
+  isExecutionModeDrifted,
   type HandoffThreadWorkspaceRequest,
   type HandoffThreadWorkspaceResponse,
   type ListBackendsRequest,
@@ -44,6 +47,8 @@ import {
   type ResetDirectoryLaunchpadResponse,
   type RetainThreadBranchDriftRequest,
   type RetainThreadBranchDriftResponse,
+  type RetainThreadExecutionModeDriftRequest,
+  type RetainThreadExecutionModeDriftResponse,
   type RenameThreadRequest,
   type RenameThreadResponse,
   type RestoreWorktreeRequest,
@@ -164,7 +169,7 @@ type BackendClient = {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
-  }): Promise<{ threadId: string }>;
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }>;
   startTurn(params: {
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -176,7 +181,11 @@ type BackendClient = {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
-  }): Promise<{ threadId: string; turnId: string }>;
+  }): Promise<{
+    threadId: string;
+    turnId: string;
+    observedExecutionMode?: ThreadExecutionMode;
+  }>;
   startReview?(params: {
     threadId: string;
     target: StartReviewRequest["target"];
@@ -209,7 +218,10 @@ type BackendClient = {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
-  }): Promise<{ threadId: string }>;
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }>;
+  probeThreadPermissions?(params: {
+    threadId: string;
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }>;
 };
 
 function resolveThreadGitSourcePath(
@@ -1568,6 +1580,11 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         executionMode,
       });
+      await this.recordObservedExecutionMode({
+        backend,
+        threadId: result.threadId,
+        observedExecutionMode: result.observedExecutionMode ?? executionMode,
+      });
     }
     if (
       modelSettings.model !== undefined ||
@@ -1668,6 +1685,13 @@ export class DesktopBackendRegistry {
         buildActiveTurnModeKey(result.threadId, result.turnId),
         activeTurnMode,
       );
+    }
+    if (params.backend === "codex" && result.observedExecutionMode) {
+      await this.recordObservedExecutionMode({
+        backend: params.backend,
+        threadId: result.threadId,
+        observedExecutionMode: result.observedExecutionMode,
+      });
     }
 
     const response = {
@@ -1829,6 +1853,16 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         executionMode: params.executionMode,
       });
+      // Codex confirms the new permission profile in the response — record
+      // it so the drift detector compares against the canonical value
+      // rather than the value we asked for.
+      const observed =
+        result.observedExecutionMode ?? params.executionMode;
+      await this.recordObservedExecutionMode({
+        backend: "codex",
+        threadId: result.threadId,
+        observedExecutionMode: observed,
+      });
     }
     // Non-codex backends (e.g. Grok) currently no-op on execution mode —
     // no overlay write, no backend change. We still emit on the bus so all
@@ -1969,6 +2003,140 @@ export class DesktopBackendRegistry {
       branch,
       updatedAt: Date.now(),
     };
+  }
+
+  /**
+   * Compare PwrAgent's expected per-thread execution mode against codex's
+   * latest reported value, probing codex via `thread/resume` if no
+   * observation has been captured yet. Mirrors `checkThreadBranchDrift`
+   * for branches.
+   *
+   * Drift can appear when the user toggles the same thread in the codex
+   * desktop app (which shares thread storage with PwrAgent), or when an
+   * older PwrAgent build wrote one mode but the running codex
+   * `PermissionProfile` reports another.
+   */
+  async checkThreadExecutionModeDrift(
+    params: CheckThreadExecutionModeDriftRequest,
+  ): Promise<CheckThreadExecutionModeDriftResponse> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const expectedExecutionMode = overlay?.executionMode;
+
+    let observedExecutionMode: ThreadExecutionMode | undefined =
+      overlay?.observedExecutionMode;
+
+    if (params.backend === "codex") {
+      // Probe codex for the canonical per-thread permission profile. We
+      // try the thread's preferred client first (via withCodexThreadClient
+      // overlay-based fallback) and silently swallow failures: a probe
+      // shouldn't break thread loading.
+      try {
+        const probeResult = await this.withCodexThreadClient(
+          params.threadId,
+          async (client) => {
+            if (!client.probeThreadPermissions) {
+              return { threadId: params.threadId, observedExecutionMode };
+            }
+            return await client.probeThreadPermissions({
+              threadId: params.threadId,
+            });
+          },
+        );
+        if (probeResult?.observedExecutionMode) {
+          observedExecutionMode = probeResult.observedExecutionMode;
+          await this.recordObservedExecutionMode({
+            backend: params.backend,
+            threadId: params.threadId,
+            observedExecutionMode,
+          });
+        }
+      } catch (error) {
+        backendRegistryLog.debug("thread permission probe failed", {
+          backend: params.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: params.threadId,
+        });
+      }
+    }
+
+    const drifted = isExecutionModeDrifted(
+      expectedExecutionMode,
+      observedExecutionMode,
+    );
+
+    backendRegistryLog.debug("checked thread execution mode drift", {
+      backend: params.backend,
+      drifted,
+      expectedExecutionMode,
+      observedExecutionMode,
+      threadId: params.threadId,
+    });
+
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      expectedExecutionMode,
+      observedExecutionMode,
+      drifted,
+      checkedAt: Date.now(),
+    };
+  }
+
+  async retainThreadExecutionModeDrift(
+    params: RetainThreadExecutionModeDriftRequest,
+  ): Promise<RetainThreadExecutionModeDriftResponse> {
+    const retainedAt = Date.now();
+    await this.overlayStore.retainThreadExecutionModeDrift({
+      backend: params.backend,
+      threadId: params.threadId,
+      expectedExecutionMode: params.expectedExecutionMode,
+      observedExecutionMode: params.observedExecutionMode,
+      retainedAt,
+    });
+
+    return {
+      ...params,
+      retainedAt,
+    };
+  }
+
+  /**
+   * Persist the most recent observed permission mode reported by codex.
+   * Called after every codex `thread/start`, `thread/resume`, and
+   * `thread/permissions` call. Triggers a `thread/observedExecutionMode/updated`
+   * notification so the renderer can re-render the drift banner without
+   * polling.
+   */
+  private async recordObservedExecutionMode(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    observedExecutionMode: ThreadExecutionMode;
+  }): Promise<void> {
+    const previous = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (previous?.observedExecutionMode === params.observedExecutionMode) {
+      return;
+    }
+    await this.overlayStore.setThreadObservedExecutionMode({
+      backend: params.backend,
+      threadId: params.threadId,
+      observedExecutionMode: params.observedExecutionMode,
+    });
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/observedExecutionMode/updated",
+        params: {
+          threadId: params.threadId,
+          observedExecutionMode: params.observedExecutionMode,
+        },
+      },
+    });
   }
 
   async retainThreadBranchDrift(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2,6 +2,7 @@ import { appendFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  executionModeFromCodexResponse,
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
@@ -35,6 +36,7 @@ import type {
   BackendModelOption,
   BackendRateLimitSummary,
   LinkedDirectorySummary,
+  ThreadExecutionMode,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import type {
@@ -3071,6 +3073,39 @@ function extractStringProperty(value: unknown, ...keys: string[]): string | unde
   return undefined;
 }
 
+function extractCodexApprovalPolicyFromValue(value: unknown): string | undefined {
+  return extractStringProperty(value, "approvalPolicy", "approval_policy");
+}
+
+function extractCodexSandboxModeFromValue(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const raw = record.sandbox ?? record.sandbox_policy ?? record.sandboxPolicy;
+  if (typeof raw === "string") {
+    return raw.trim() || undefined;
+  }
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const variant = (raw as Record<string, unknown>).type;
+    if (typeof variant !== "string") return undefined;
+    if (variant === "workspaceWrite") return "workspace-write";
+    if (variant === "dangerFullAccess") return "danger-full-access";
+    if (variant === "readOnly") return "read-only";
+    return undefined;
+  }
+  return undefined;
+}
+
+function extractObservedExecutionModeFromCodexResult(
+  value: unknown,
+): ThreadExecutionMode | undefined {
+  return executionModeFromCodexResponse({
+    approvalPolicy: extractCodexApprovalPolicyFromValue(value),
+    sandbox: extractCodexSandboxModeFromValue(value),
+  });
+}
+
 function buildCollaborationModeOverrides(params: {
   collaborationMode?: AppServerCollaborationModeRequest;
   fallbackModel?: string;
@@ -3802,7 +3837,7 @@ export class CodexAppServerClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
-  }): Promise<{ threadId: string }> {
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }> {
     await this.ensureInitialized();
 
     const result = await requestWithFallbacks({
@@ -3819,7 +3854,10 @@ export class CodexAppServerClient {
 
     await this.recordThreadInSessionIndex(result);
 
-    return { threadId };
+    return {
+      threadId,
+      observedExecutionMode: extractObservedExecutionModeFromCodexResult(result),
+    };
   }
 
   async startTurn(params: {
@@ -3833,7 +3871,11 @@ export class CodexAppServerClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
-  }): Promise<{ threadId: string; turnId: string }> {
+  }): Promise<{
+    threadId: string;
+    turnId: string;
+    observedExecutionMode?: ThreadExecutionMode;
+  }> {
     await this.ensureInitialized();
 
     const resumeResult = await requestWithFallbacks({
@@ -3883,7 +3925,13 @@ export class CodexAppServerClient {
       input: params.input,
     });
 
-    return { threadId, turnId };
+    // The thread/resume response carries the canonical permission state;
+    // turn/start does not. Prefer the resume value when present.
+    const observedExecutionMode =
+      extractObservedExecutionModeFromCodexResult(resumeResult) ??
+      extractObservedExecutionModeFromCodexResult(result);
+
+    return { threadId, turnId, observedExecutionMode };
   }
 
   async generateTitle(params: ThreadTitleAdapterParams): Promise<ThreadTitleAdapterResult> {
@@ -4011,6 +4059,34 @@ export class CodexAppServerClient {
     };
   }
 
+  /**
+   * Best-effort probe of codex's per-thread permission profile, used to
+   * detect drift when the user opens a thread without sending a turn.
+   *
+   * This sends `thread/resume` without policy overrides, so codex returns
+   * the thread's current `approvalPolicy` + `sandbox` without us mutating
+   * them. Returns `undefined` if codex's response can't be classified into
+   * one of PwrAgent's two surfaced modes (e.g. a granular approval policy
+   * the UI doesn't have a button for).
+   */
+  async probeThreadPermissions(params: {
+    threadId: string;
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/resume"],
+      payloads: buildThreadResumePayloads({ threadId: params.threadId }),
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    return {
+      threadId: extractThreadIdFromValue(result) ?? params.threadId,
+      observedExecutionMode: extractObservedExecutionModeFromCodexResult(result),
+    };
+  }
+
   async setThreadPermissions(params: {
     threadId: string;
     cwd?: string;
@@ -4019,7 +4095,7 @@ export class CodexAppServerClient {
     sandbox?: string;
     serviceTier?: string;
     reasoningEffort?: string;
-  }): Promise<{ threadId: string }> {
+  }): Promise<{ threadId: string; observedExecutionMode?: ThreadExecutionMode }> {
     await this.ensureInitialized();
 
     const result = await requestWithFallbacks({
@@ -4031,6 +4107,7 @@ export class CodexAppServerClient {
 
     return {
       threadId: extractThreadIdFromValue(result) ?? params.threadId,
+      observedExecutionMode: extractObservedExecutionModeFromCodexResult(result),
     };
   }
 

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -4,6 +4,8 @@ import type {
   AgentEvent,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CheckThreadExecutionModeDriftRequest,
+  CheckThreadExecutionModeDriftResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   InterruptTurnRequest,
@@ -12,6 +14,8 @@ import type {
   ListBackendsResponse,
   RetainThreadBranchDriftRequest,
   RetainThreadBranchDriftResponse,
+  RetainThreadExecutionModeDriftRequest,
+  RetainThreadExecutionModeDriftResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
@@ -33,9 +37,11 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import {
   AGENT_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
@@ -377,6 +383,28 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL);
+  ipcMain.handle(
+    AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
+    async (
+      _event,
+      request: CheckThreadExecutionModeDriftRequest,
+    ): Promise<CheckThreadExecutionModeDriftResponse> => {
+      return await registry.checkThreadExecutionModeDrift(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL);
+  ipcMain.handle(
+    AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
+    async (
+      _event,
+      request: RetainThreadExecutionModeDriftRequest,
+    ): Promise<RetainThreadExecutionModeDriftResponse> => {
+      return await registry.retainThreadExecutionModeDrift(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.handle(
     AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -414,6 +442,8 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL);
   ipcMain.removeHandler(AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL);
   ipcMain.removeHandler(AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL);
+  ipcMain.removeHandler(AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL);
+  ipcMain.removeHandler(AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL);
   ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
 }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -310,7 +310,71 @@ export class SqliteOverlayStore {
       threadId: params.threadId,
       extraLinkedDirectories: [],
     };
-    const nextState: ThreadOverlayState = { ...current, executionMode: params.executionMode };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      executionMode: params.executionMode,
+      retainedExecutionModeDriftPairs: (
+        current.retainedExecutionModeDriftPairs ?? []
+      ).filter(
+        (pair) =>
+          pair.expectedExecutionMode !== params.executionMode &&
+          pair.observedExecutionMode !== params.executionMode,
+      ),
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async setThreadObservedExecutionMode(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    observedExecutionMode?: ThreadExecutionMode;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      observedExecutionMode: params.observedExecutionMode,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async retainThreadExecutionModeDrift(params: {
+    backend: ThreadOverlayState["backend"];
+    expectedExecutionMode: ThreadExecutionMode;
+    observedExecutionMode: ThreadExecutionMode;
+    retainedAt?: number;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const retainedExecutionModeDriftPairs = [
+      ...(current.retainedExecutionModeDriftPairs ?? []).filter(
+        (pair) =>
+          pair.expectedExecutionMode !== params.expectedExecutionMode ||
+          pair.observedExecutionMode !== params.observedExecutionMode,
+      ),
+      {
+        expectedExecutionMode: params.expectedExecutionMode,
+        observedExecutionMode: params.observedExecutionMode,
+        retainedAt: params.retainedAt ?? Date.now(),
+      },
+    ];
+    const nextState: ThreadOverlayState = {
+      ...current,
+      retainedExecutionModeDriftPairs,
+    };
     this.putThread(threadKey, nextState);
     return nextState;
   }
@@ -604,6 +668,8 @@ export type OverlayStoreLike = Pick<
   | "setThreadExpectedBranch"
   | "setThreadObservedBranch"
   | "retainThreadBranchDrift"
+  | "setThreadObservedExecutionMode"
+  | "retainThreadExecutionModeDrift"
   | "getLaunchpadDefaults"
   | "setLaunchpadDefaults"
   | "getDirectoryLaunchpad"

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -29,6 +29,8 @@ import type {
   AppServerReadThreadResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CheckThreadExecutionModeDriftRequest,
+  CheckThreadExecutionModeDriftResponse,
   GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
@@ -51,6 +53,8 @@ import type {
   ResetDirectoryLaunchpadResponse,
   RetainThreadBranchDriftRequest,
   RetainThreadBranchDriftResponse,
+  RetainThreadExecutionModeDriftRequest,
+  RetainThreadExecutionModeDriftResponse,
   RenameThreadRequest,
   RenameThreadResponse,
   RestoreWorktreeRequest,
@@ -89,9 +93,11 @@ import type {
 import {
   AGENT_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
@@ -286,6 +292,20 @@ const desktopApi = Object.freeze({
     request: RetainThreadBranchDriftRequest
   ): Promise<RetainThreadBranchDriftResponse> =>
     await ipcRenderer.invoke(AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL, request),
+  checkThreadExecutionModeDrift: async (
+    request: CheckThreadExecutionModeDriftRequest
+  ): Promise<CheckThreadExecutionModeDriftResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
+      request,
+    ),
+  retainThreadExecutionModeDrift: async (
+    request: RetainThreadExecutionModeDriftRequest
+  ): Promise<RetainThreadExecutionModeDriftResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL,
+      request,
+    ),
   materializeDirectoryLaunchpad: async (
     request: MaterializeDirectoryLaunchpadRequest
   ): Promise<MaterializeDirectoryLaunchpadResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -24,7 +24,7 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
-import { isBranchDrifted } from "@pwragent/shared";
+import { isBranchDrifted, isExecutionModeDrifted } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -698,6 +698,14 @@ type BranchDriftDialogState = {
   threadKey: string;
 };
 
+type ExecutionModeDriftDialogState = {
+  checkedAt?: number;
+  expectedExecutionMode: ThreadExecutionMode;
+  observedExecutionMode: ThreadExecutionMode;
+  reason: "focus";
+  threadKey: string;
+};
+
 export function ThreadView(props: ThreadViewProps) {
   const [pendingActivityEntry, setPendingActivityEntry] =
     useState<AppServerThreadActivityEntry>();
@@ -736,6 +744,10 @@ export function ThreadView(props: ThreadViewProps) {
     useState<BranchDriftDialogState>();
   const [branchDriftError, setBranchDriftError] = useState<string>();
   const [branchDriftBusy, setBranchDriftBusy] = useState(false);
+  const [executionModeDriftDialog, setExecutionModeDriftDialog] =
+    useState<ExecutionModeDriftDialogState>();
+  const [executionModeDriftError, setExecutionModeDriftError] = useState<string>();
+  const [executionModeDriftBusy, setExecutionModeDriftBusy] = useState(false);
 
   const selectedThreadKey = selectedThread
     ? `${selectedThread.source}:${selectedThread.id}`
@@ -802,6 +814,102 @@ export function ThreadView(props: ThreadViewProps) {
     return showBranchDriftDialog(thread, expectedBranch, observedBranch, reason, checkedAt);
   };
 
+  const executionModeDriftRetained = (
+    thread: NavigationThreadSummary,
+    expectedExecutionMode: ThreadExecutionMode,
+    observedExecutionMode: ThreadExecutionMode,
+  ): boolean => {
+    return (thread.retainedExecutionModeDriftPairs ?? []).some(
+      (pair) =>
+        pair.expectedExecutionMode === expectedExecutionMode &&
+        pair.observedExecutionMode === observedExecutionMode,
+    );
+  };
+
+  const showExecutionModeDriftDialog = (
+    thread: NavigationThreadSummary,
+    expectedExecutionMode: ThreadExecutionMode,
+    observedExecutionMode: ThreadExecutionMode,
+    reason: ExecutionModeDriftDialogState["reason"],
+    checkedAt?: number,
+  ): boolean => {
+    if (!isExecutionModeDrifted(expectedExecutionMode, observedExecutionMode)) {
+      return false;
+    }
+    if (
+      executionModeDriftRetained(
+        thread,
+        expectedExecutionMode,
+        observedExecutionMode,
+      )
+    ) {
+      return false;
+    }
+    setExecutionModeDriftError(undefined);
+    setExecutionModeDriftDialog({
+      checkedAt,
+      expectedExecutionMode,
+      observedExecutionMode,
+      reason,
+      threadKey: `${thread.source}:${thread.id}`,
+    });
+    return true;
+  };
+
+  const checkSelectedThreadExecutionModeDrift = async (
+    reason: ExecutionModeDriftDialogState["reason"],
+  ): Promise<boolean> => {
+    const thread = selectedThread;
+    if (
+      !thread ||
+      thread.source !== "codex" ||
+      !props.desktopApi?.checkThreadExecutionModeDrift
+    ) {
+      return false;
+    }
+    const startedThreadKey = `${thread.source}:${thread.id}`;
+    if (props.activeTurnId !== undefined) {
+      // Don't probe codex while a turn is in flight — the per-turn permission
+      // refresh happens on the next turn anyway, and probing concurrently
+      // racy with thread/resume / turn/start.
+      return false;
+    }
+    try {
+      const result = await props.desktopApi.checkThreadExecutionModeDrift({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+      if (selectedThreadKeyRef.current !== startedThreadKey) {
+        return false;
+      }
+      if (result.observedExecutionMode !== thread.observedExecutionMode) {
+        await props.onRefreshNavigation?.();
+        if (selectedThreadKeyRef.current !== startedThreadKey) {
+          return false;
+        }
+      }
+      if (
+        !result.drifted ||
+        !result.expectedExecutionMode ||
+        !result.observedExecutionMode
+      ) {
+        setExecutionModeDriftDialog((current) =>
+          current?.threadKey === startedThreadKey ? undefined : current,
+        );
+        return false;
+      }
+      return showExecutionModeDriftDialog(
+        thread,
+        result.expectedExecutionMode,
+        result.observedExecutionMode,
+        reason,
+        result.checkedAt,
+      );
+    } catch {
+      return false;
+    }
+  };
+
   const checkSelectedThreadBranchDrift = async (
     reason: BranchDriftDialogState["reason"],
   ): Promise<boolean> => {
@@ -853,6 +961,8 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     setBranchDriftDialog(undefined);
     setBranchDriftError(undefined);
+    setExecutionModeDriftDialog(undefined);
+    setExecutionModeDriftError(undefined);
   }, [selectedThreadKey]);
 
   // Live mirror of selectedThreadKey for async stale-closure guards.
@@ -913,8 +1023,10 @@ export function ThreadView(props: ThreadViewProps) {
     }
 
     void checkSelectedThreadBranchDrift("focus");
+    void checkSelectedThreadExecutionModeDrift("focus");
     const unsubscribeFocus = props.desktopApi?.onWindowFocus?.(() => {
       void checkSelectedThreadBranchDrift("focus");
+      void checkSelectedThreadExecutionModeDrift("focus");
     });
 
     return () => {
@@ -1730,8 +1842,137 @@ export function ThreadView(props: ThreadViewProps) {
         </div>
       ) : null}
 
+      {executionModeDriftDialog && selectedThread ? (
+        <div className="workspace-handoff-modal">
+          <div
+            aria-labelledby="execution-mode-drift-title"
+            aria-modal="true"
+            className="workspace-handoff-dialog"
+            role="dialog"
+          >
+            <h2 id="execution-mode-drift-title">Permission mode out of sync</h2>
+            <p>
+              PwrAgent expected this thread to be running with{" "}
+              <strong>
+                {executionModeLabel(
+                  executionModeDriftDialog.expectedExecutionMode,
+                )}
+              </strong>{" "}
+              but Codex is reporting{" "}
+              <strong>
+                {executionModeLabel(
+                  executionModeDriftDialog.observedExecutionMode,
+                )}
+              </strong>
+              .
+            </p>
+            <p>
+              The thread may have been toggled in the Codex desktop app, or an
+              earlier turn updated the permission profile in a way PwrAgent
+              didn't observe.
+            </p>
+            <dl className="workspace-handoff-dialog__summary">
+              <div>
+                <dt>PwrAgent expects</dt>
+                <dd>
+                  {executionModeLabel(
+                    executionModeDriftDialog.expectedExecutionMode,
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt>Codex reports</dt>
+                <dd>
+                  {executionModeLabel(
+                    executionModeDriftDialog.observedExecutionMode,
+                  )}
+                </dd>
+              </div>
+            </dl>
+            {executionModeDriftError ? (
+              <p className="workspace-handoff-dialog__error">
+                {executionModeDriftError}
+              </p>
+            ) : null}
+            <div className="workspace-handoff-dialog__actions">
+              <button
+                className="button-secondary"
+                disabled={executionModeDriftBusy}
+                title="Keep PwrAgent's value, push it back to Codex on the next turn."
+                type="button"
+                onClick={async () => {
+                  if (
+                    !props.desktopApi?.retainThreadExecutionModeDrift ||
+                    !selectedThread
+                  ) {
+                    setExecutionModeDriftDialog(undefined);
+                    return;
+                  }
+
+                  setExecutionModeDriftBusy(true);
+                  setExecutionModeDriftError(undefined);
+                  try {
+                    await props.desktopApi.retainThreadExecutionModeDrift({
+                      backend: selectedThread.source,
+                      threadId: selectedThread.id,
+                      expectedExecutionMode:
+                        executionModeDriftDialog.expectedExecutionMode,
+                      observedExecutionMode:
+                        executionModeDriftDialog.observedExecutionMode,
+                    });
+                    await props.onRefreshNavigation?.();
+                    setExecutionModeDriftDialog(undefined);
+                  } catch (error) {
+                    setExecutionModeDriftError(
+                      error instanceof Error ? error.message : String(error),
+                    );
+                  } finally {
+                    setExecutionModeDriftBusy(false);
+                  }
+                }}
+              >
+                Keep PwrAgent value
+              </button>
+              <button
+                className="button-primary"
+                disabled={executionModeDriftBusy}
+                title="Adopt Codex's value as the expected mode."
+                type="button"
+                onClick={async () => {
+                  if (!props.onSetExecutionMode || !selectedThread) {
+                    return;
+                  }
+                  setExecutionModeDriftBusy(true);
+                  setExecutionModeDriftError(undefined);
+                  try {
+                    await props.onSetExecutionMode(
+                      executionModeDriftDialog.observedExecutionMode,
+                    );
+                    await props.onRefreshNavigation?.();
+                    setExecutionModeDriftDialog(undefined);
+                  } catch (error) {
+                    setExecutionModeDriftError(
+                      error instanceof Error ? error.message : String(error),
+                    );
+                  } finally {
+                    setExecutionModeDriftBusy(false);
+                  }
+                }}
+              >
+                Use Codex value
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
     </section>
   );
+}
+
+function executionModeLabel(mode: ThreadExecutionMode): string {
+  if (mode === "full-access") return "Full Access";
+  return "Default Access";
 }
 
 function buildPendingRequestResponse(

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -16,6 +16,8 @@ import type {
   AppServerListSkillsResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CheckThreadExecutionModeDriftRequest,
+  CheckThreadExecutionModeDriftResponse,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   FocusedDiffAnalysisRequest,
@@ -51,6 +53,8 @@ import type {
   ResetDirectoryLaunchpadResponse,
   RetainThreadBranchDriftRequest,
   RetainThreadBranchDriftResponse,
+  RetainThreadExecutionModeDriftRequest,
+  RetainThreadExecutionModeDriftResponse,
   RenameThreadRequest,
   RenameThreadResponse,
   RestoreWorktreeRequest,
@@ -146,6 +150,12 @@ export type DesktopApi = {
   retainThreadBranchDrift?: (
     request: RetainThreadBranchDriftRequest
   ) => Promise<RetainThreadBranchDriftResponse>;
+  checkThreadExecutionModeDrift?: (
+    request: CheckThreadExecutionModeDriftRequest
+  ) => Promise<CheckThreadExecutionModeDriftResponse>;
+  retainThreadExecutionModeDrift?: (
+    request: RetainThreadExecutionModeDriftRequest
+  ) => Promise<RetainThreadExecutionModeDriftResponse>;
   materializeDirectoryLaunchpad?: (
     request: MaterializeDirectoryLaunchpadRequest
   ) => Promise<MaterializeDirectoryLaunchpadResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -22,6 +22,10 @@ export const AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL =
   "agent:update-thread-expected-branch";
 export const AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL =
   "agent:retain-thread-branch-drift";
+export const AGENT_CHECK_THREAD_EXECUTION_MODE_DRIFT_CHANNEL =
+  "agent:check-thread-execution-mode-drift";
+export const AGENT_RETAIN_THREAD_EXECUTION_MODE_DRIFT_CHANNEL =
+  "agent:retain-thread-execution-mode-drift";
 export const AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "agent:materialize-directory-launchpad";
 export const AGENT_SUBMIT_SERVER_REQUEST_CHANNEL = "agent:submit-server-request";

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -445,4 +445,78 @@ describe("OverlayStore", () => {
       ]),
     );
   });
+
+  it("retainThreadExecutionModeDrift persists the dismissed pair without overwriting other fields", async () => {
+    const store = await createStore();
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread({ executionMode: "default" })],
+    });
+
+    const result = await store.retainThreadExecutionModeDrift({
+      backend: "codex",
+      threadId: "thread-1",
+      expectedExecutionMode: "default",
+      observedExecutionMode: "full-access",
+      retainedAt: 2000,
+    });
+
+    expect(result.retainedExecutionModeDriftPairs).toEqual([
+      {
+        expectedExecutionMode: "default",
+        observedExecutionMode: "full-access",
+        retainedAt: 2000,
+      },
+    ]);
+    expect(result.executionMode).toBe("default");
+  });
+
+  it("setThreadExecutionMode clears retained drift pairs that referenced the old expected value", async () => {
+    const store = await createStore();
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread({ executionMode: "default" })],
+    });
+
+    await store.retainThreadExecutionModeDrift({
+      backend: "codex",
+      threadId: "thread-1",
+      expectedExecutionMode: "default",
+      observedExecutionMode: "full-access",
+      retainedAt: 2000,
+    });
+
+    const next = await store.setThreadExecutionMode({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+
+    // The previously-retained (default, full-access) pair touched
+    // "full-access" — once the user explicitly picks that mode, the pair
+    // is meaningless and should be cleared so a future drift back to
+    // "default" can prompt again.
+    expect(next.retainedExecutionModeDriftPairs ?? []).toEqual([]);
+    expect(next.executionMode).toBe("full-access");
+  });
+
+  it("setThreadObservedExecutionMode persists the captured value without touching the expected mode", async () => {
+    const store = await createStore();
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1000,
+      threads: [buildThread({ executionMode: "default" })],
+    });
+
+    const next = await store.setThreadObservedExecutionMode({
+      backend: "codex",
+      threadId: "thread-1",
+      observedExecutionMode: "full-access",
+    });
+
+    expect(next.executionMode).toBe("default");
+    expect(next.observedExecutionMode).toBe("full-access");
+  });
 });

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -102,6 +102,8 @@ export function materializeNavigationThreads(params: {
       gitBranch: overlayGitBranch ?? thread.gitBranch,
       observedGitBranch: overlay?.observedGitBranch ?? thread.observedGitBranch,
       retainedBranchDriftPairs: overlay?.retainedBranchDriftPairs,
+      observedExecutionMode: overlay?.observedExecutionMode,
+      retainedExecutionModeDriftPairs: overlay?.retainedExecutionModeDriftPairs,
       executionMode: overlay?.executionMode ?? thread.executionMode ?? "default",
       model: overlay?.model ?? thread.model,
       reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
@@ -187,6 +189,14 @@ export function buildNavigationSnapshotHash(params: {
       retainedBranchDriftPairs: (thread.retainedBranchDriftPairs ?? []).map((pair) => ({
         expectedBranch: pair.expectedBranch,
         observedBranch: pair.observedBranch,
+        retainedAt: pair.retainedAt,
+      })),
+      observedExecutionMode: thread.observedExecutionMode ?? null,
+      retainedExecutionModeDriftPairs: (
+        thread.retainedExecutionModeDriftPairs ?? []
+      ).map((pair) => ({
+        expectedExecutionMode: pair.expectedExecutionMode,
+        observedExecutionMode: pair.observedExecutionMode,
         retainedAt: pair.retainedAt,
       })),
       executionMode: thread.executionMode ?? "default",

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -56,7 +56,10 @@ export class OverlayStore {
             fastMode: data.threads[threadKey]?.fastMode ?? thread.fastMode,
             gitBranch: data.threads[threadKey]?.gitBranch,
             observedGitBranch: data.threads[threadKey]?.observedGitBranch,
+            observedExecutionMode: data.threads[threadKey]?.observedExecutionMode,
             retainedBranchDriftPairs: data.threads[threadKey]?.retainedBranchDriftPairs,
+            retainedExecutionModeDriftPairs:
+              data.threads[threadKey]?.retainedExecutionModeDriftPairs,
             lastSeenAt: params.fetchedAt,
             lastSeenUpdatedAt: thread.updatedAt,
             extraLinkedDirectories:
@@ -129,9 +132,11 @@ export class OverlayStore {
         fastMode: current?.fastMode,
         gitBranch: current?.gitBranch,
         observedGitBranch: current?.observedGitBranch,
+        observedExecutionMode: current?.observedExecutionMode,
         dismissedAt: current?.dismissedAt,
         snoozedUntil: current?.snoozedUntil,
         retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
+        retainedExecutionModeDriftPairs: current?.retainedExecutionModeDriftPairs,
         lastSeenAt: seenAt,
         lastSeenUpdatedAt: params.seenUpdatedAt ?? current?.lastSeenUpdatedAt,
         extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
@@ -300,6 +305,74 @@ export class OverlayStore {
       const nextState: ThreadOverlayState = {
         ...current,
         executionMode: params.executionMode,
+        // The user has explicitly set the expected mode — drop any
+        // retained drift pairs that referenced the OLD value, so a future
+        // observation that disagrees with the NEW value can prompt again.
+        retainedExecutionModeDriftPairs: (
+          current.retainedExecutionModeDriftPairs ?? []
+        ).filter(
+          (pair) =>
+            pair.expectedExecutionMode !== params.executionMode &&
+            pair.observedExecutionMode !== params.executionMode,
+        ),
+      };
+      data.threads[threadKey] = nextState;
+      return nextState;
+    });
+  }
+
+  async setThreadObservedExecutionMode(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    observedExecutionMode?: ThreadExecutionMode;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const nextState: ThreadOverlayState = {
+        ...current,
+        observedExecutionMode: params.observedExecutionMode,
+      };
+      data.threads[threadKey] = nextState;
+      return nextState;
+    });
+  }
+
+  async retainThreadExecutionModeDrift(params: {
+    backend: ThreadOverlayState["backend"];
+    expectedExecutionMode: ThreadExecutionMode;
+    observedExecutionMode: ThreadExecutionMode;
+    retainedAt?: number;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const retainedExecutionModeDriftPairs = [
+        ...(current.retainedExecutionModeDriftPairs ?? []).filter(
+          (pair) =>
+            pair.expectedExecutionMode !== params.expectedExecutionMode ||
+            pair.observedExecutionMode !== params.observedExecutionMode,
+        ),
+        {
+          expectedExecutionMode: params.expectedExecutionMode,
+          observedExecutionMode: params.observedExecutionMode,
+          retainedAt: params.retainedAt ?? Date.now(),
+        },
+      ];
+      const nextState: ThreadOverlayState = {
+        ...current,
+        retainedExecutionModeDriftPairs,
       };
       data.threads[threadKey] = nextState;
       return nextState;

--- a/packages/shared/src/contracts/__tests__/execution-mode-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/execution-mode-drift.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  executionModeFromCodexResponse,
+  isExecutionModeDrifted,
+} from "../execution-mode-drift";
+
+describe("isExecutionModeDrifted", () => {
+  it("returns true when expected and observed disagree", () => {
+    expect(isExecutionModeDrifted("default", "full-access")).toBe(true);
+    expect(isExecutionModeDrifted("full-access", "default")).toBe(true);
+  });
+
+  it("returns false when both agree", () => {
+    expect(isExecutionModeDrifted("default", "default")).toBe(false);
+    expect(isExecutionModeDrifted("full-access", "full-access")).toBe(false);
+  });
+
+  it("returns false when either side is missing — drift requires both values", () => {
+    expect(isExecutionModeDrifted(undefined, "default")).toBe(false);
+    expect(isExecutionModeDrifted("default", undefined)).toBe(false);
+    expect(isExecutionModeDrifted(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("executionModeFromCodexResponse", () => {
+  it("maps the workspace-write + on-request pair to default", () => {
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+      }),
+    ).toBe("default");
+  });
+
+  it("maps the danger-full-access + never pair to full-access", () => {
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      }),
+    ).toBe("full-access");
+  });
+
+  it("returns undefined for any combination PwrAgent does not surface", () => {
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "untrusted",
+        sandbox: "workspace-write",
+      }),
+    ).toBeUndefined();
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "on-request",
+        sandbox: "read-only",
+      }),
+    ).toBeUndefined();
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "never",
+        sandbox: "workspace-write",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when either side is missing", () => {
+    expect(
+      executionModeFromCodexResponse({ approvalPolicy: "never" }),
+    ).toBeUndefined();
+    expect(
+      executionModeFromCodexResponse({ sandbox: "danger-full-access" }),
+    ).toBeUndefined();
+    expect(executionModeFromCodexResponse({})).toBeUndefined();
+  });
+
+  it("trims whitespace before classifying", () => {
+    expect(
+      executionModeFromCodexResponse({
+        approvalPolicy: "  on-request  ",
+        sandbox: "  workspace-write  ",
+      }),
+    ).toBe("default");
+  });
+});

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -165,6 +165,32 @@ export type RetainThreadBranchDriftResponse = RetainThreadBranchDriftRequest & {
   retainedAt: number;
 };
 
+export type CheckThreadExecutionModeDriftRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type CheckThreadExecutionModeDriftResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  expectedExecutionMode?: ThreadExecutionMode;
+  observedExecutionMode?: ThreadExecutionMode;
+  drifted: boolean;
+  checkedAt: number;
+};
+
+export type RetainThreadExecutionModeDriftRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  expectedExecutionMode: ThreadExecutionMode;
+  observedExecutionMode: ThreadExecutionMode;
+};
+
+export type RetainThreadExecutionModeDriftResponse =
+  RetainThreadExecutionModeDriftRequest & {
+    retainedAt: number;
+  };
+
 export type SubmitServerRequestRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/execution-mode-drift.ts
+++ b/packages/shared/src/contracts/execution-mode-drift.ts
@@ -1,0 +1,40 @@
+import type { ThreadExecutionMode } from "./normalized-app-server";
+
+/**
+ * Detect whether the user's expected per-thread execution mode (PwrAgent's
+ * overlay value) disagrees with the mode codex's app-server is reporting for
+ * the same thread (the value derived from `approvalPolicy` + `sandbox` on
+ * `thread/start` / `thread/resume` / `thread/fork` responses).
+ *
+ * Returns `false` when either side is missing — drift is only detectable
+ * once both values are known.
+ */
+export function isExecutionModeDrifted(
+  expected: ThreadExecutionMode | undefined,
+  observed: ThreadExecutionMode | undefined,
+): boolean {
+  if (!expected || !observed) return false;
+  return expected !== observed;
+}
+
+/**
+ * Map the codex `approvalPolicy` + `sandbox` pair returned from
+ * `thread/start` / `thread/resume` / `thread/fork` to PwrAgent's binary
+ * execution mode. Returns `undefined` when the codex pair is not one of the
+ * two combinations PwrAgent surfaces — callers should treat that as
+ * "unknown" and skip drift detection rather than guessing.
+ */
+export function executionModeFromCodexResponse(params: {
+  approvalPolicy?: string;
+  sandbox?: string;
+}): ThreadExecutionMode | undefined {
+  const approval = params.approvalPolicy?.trim();
+  const sandbox = params.sandbox?.trim();
+  if (approval === "never" && sandbox === "danger-full-access") {
+    return "full-access";
+  }
+  if (approval === "on-request" && sandbox === "workspace-write") {
+    return "default";
+  }
+  return undefined;
+}

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -25,6 +25,15 @@ export type ThreadInboxState = {
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
   retainedBranchDriftPairs?: ThreadBranchDriftPair[];
+  /**
+   * Permission mode codex's app-server is currently reporting for this
+   * thread. Captured opportunistically from `thread/start` / `thread/resume`
+   * / `thread/fork` responses. May lag overlay's `executionMode` when the
+   * user has just toggled — see `retainedExecutionModeDriftPairs` for the
+   * "ignore this drift" pairs the user has already dismissed.
+   */
+  observedExecutionMode?: ThreadExecutionMode;
+  retainedExecutionModeDriftPairs?: ThreadExecutionModeDriftPair[];
   optimisticUserMessage?: {
     text: string;
     imageParts?: AppServerThreadImagePart[];
@@ -290,11 +299,22 @@ export type ThreadOverlayState = {
   fastMode?: boolean;
   gitBranch?: string;
   observedGitBranch?: string;
+  /**
+   * Latest execution mode reported by codex's app-server for this thread,
+   * captured from `thread/start` / `thread/resume` / `thread/fork`
+   * responses. Compared against `executionMode` (the user's expected
+   * value) to detect drift introduced by external mutation (e.g. the
+   * user toggling permissions in the codex desktop app, which shares
+   * thread storage with PwrAgent).
+   */
+  observedExecutionMode?: ThreadExecutionMode;
   lastSeenAt?: number;
   lastSeenUpdatedAt?: number;
   dismissedAt?: number;
   snoozedUntil?: number;
   retainedBranchDriftPairs?: ThreadBranchDriftPair[];
+  /** "Ignore for now" pairs the user has dismissed via the drift dialog. */
+  retainedExecutionModeDriftPairs?: ThreadExecutionModeDriftPair[];
   extraLinkedDirectories: LinkedDirectorySummary[];
   worktreeSnapshots?: WorktreeSnapshotSummary[];
   /**
@@ -317,6 +337,12 @@ export type ThreadOverlayState = {
 export type ThreadBranchDriftPair = {
   expectedBranch: string;
   observedBranch: string;
+  retainedAt: number;
+};
+
+export type ThreadExecutionModeDriftPair = {
+  expectedExecutionMode: ThreadExecutionMode;
+  observedExecutionMode: ThreadExecutionMode;
   retainedAt: number;
 };
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -797,6 +797,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/observedExecutionMode/updated";
+      params: {
+        threadId: string;
+        observedExecutionMode: ThreadExecutionMode;
+      };
+    }
+  | {
       method: "thread/modelSettings/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/branch-drift";
 export * from "./contracts/diff-focus";
+export * from "./contracts/execution-mode-drift";
 export * from "./contracts/messaging";
 export * from "./contracts/navigation";
 export * from "./contracts/settings";


### PR DESCRIPTION
## Summary

Mirror the existing branch-drift detection for per-thread execution mode. Codex App Server returns the canonical permission state on `thread/start`, `thread/resume`, and `thread/fork` — we capture it now, persist it on the overlay alongside the user's expected mode, and prompt the user with two resolve buttons when the two disagree.

## Why this is needed even after #209 + #213

The earlier fixes pinned the wire messages on every turn. They did not address two cases where PwrAgent's view and codex's view fall out of sync:

1. **Codex Desktop and PwrAgent share thread storage.** If the user toggles permissions in the codex desktop app, codex's per-thread `PermissionProfile` flips but PwrAgent's overlay does not. The thread keeps showing "Default Access" in our UI while codex actually runs Full Access.
2. **Older overlay vs current codex.** An older PwrAgent build wrote one mode but the running codex `PermissionProfile` reports another. With #213 in place we silently overwrite codex's value on the next turn — exactly the *"tiny footgun wearing a cardigan"* the analysis flagged. We should ask first.

## What this PR does, end to end

1. **Capture from codex.** New helpers in `client.ts` decode codex's `approvalPolicy` + `sandbox` (legacy string OR structured `SandboxPolicy` variant) into PwrAgent's binary `ThreadExecutionMode`. Returned from `startThread`, `startTurn`, `setThreadPermissions`. Granular approval or read-only sandbox cleanly returns `undefined` — we don't guess.

2. **Probe.** New `CodexAppServerClient.probeThreadPermissions` sends `thread/resume` with no policy overrides — pure read of codex's per-thread profile, used when checking drift on focus before any turn has happened.

3. **Persist.** Two new overlay fields:
   - `observedExecutionMode` — latest value codex reported for this thread; populated from the response of every codex permission-adjacent call.
   - `retainedExecutionModeDriftPairs` — the user's "ignore for now" dismissals, mirroring `retainedBranchDriftPairs`.
   - `setThreadExecutionMode` now drops retained pairs that referenced the value the user just chose, so re-drifting from that direction prompts again.

4. **Detect.** New registry method `checkThreadExecutionModeDrift` probes codex, compares observed vs overlay's expected via `isExecutionModeDrifted`, persists the captured value, and emits a `thread/observedExecutionMode/updated` notification on the bus so the renderer re-renders without polling. New logger line `checked thread execution mode drift` mirrors the branch-drift telemetry for production diagnosis.

5. **IPC.** Two new channels, two new `desktopApi` methods, two new request/response contract types — same shape as the branch-drift counterparts.

6. **UI.** New permission-drift dialog in `ThreadView`, shown on focus when codex's reported mode differs from the overlay's expected mode and the user hasn't already retained that pair. Two buttons:
   - **Keep PwrAgent value** calls `retainThreadExecutionModeDrift` to dismiss this exact pair. PwrAgent's expected mode wins on the next turn (per #213's per-turn refresh).
   - **Use Codex value** calls `onSetExecutionMode` with codex's value so the overlay flips to match what codex actually has. The redundant codex `setThreadPermissions` call is harmless and keeps the resolve action consistent with the regular toggle path.

   The dialog is suppressed while a turn is active — racing with `thread/resume` / `turn/start` during a turn would corrupt the probe.

## Tests

- **8 unit tests** for shared `isExecutionModeDrifted` and `executionModeFromCodexResponse` — both surfaced pairs, granular/read-only/missing cases, whitespace.
- **4 codex-client tests** asserting capture from legacy + structured `SandboxPolicy` variants, `undefined` for granular policies, and `probeThreadPermissions` sending `thread/resume` with no overrides (so the probe doesn't accidentally push state).
- **3 registry tests** for `checkThreadExecutionModeDrift` (drift, no drift, retain) using a `probedExecutionMode` option on the mock client.
- **3 overlay-store tests** for `retainThreadExecutionModeDrift`, `setThreadExecutionMode` clearing matching pairs, and `setThreadObservedExecutionMode` preserving the expected mode.

## Test plan

- [x] `npx vitest run --config vitest.workspace.ts` — 869 backend + 348 renderer tests pass.
- [x] `pnpm --filter @pwragent/desktop exec tsc --noEmit` — clean.
- [x] `pnpm lint:boundaries` — clean (958 modules, 1263 deps cruised).
- [x] **User repro for thread `019dee7f-3708-76d3-8fb4-9fb3e9db7d83`:** open in PwrAgent (UI shows Default Access). The dialog should fire on focus, indicating codex sees Full Access. Choosing "Use Codex value" should flip the UI to Full Access. Choosing "Keep PwrAgent value" should dismiss the dialog and the next turn should push Default Access at codex.

## Related

- #203 — Composer dropping `executionMode`, registry cross-mode fallback (merged)
- #209 — default codex client spawn-args (merged)
- #213 — per-turn `approvalPolicy`/`sandboxPolicy` refresh on `turn/start`

Each addresses a different layer of the same root cause: codex moved permission state from process-level to per-thread `PermissionProfile`. This PR is the missing piece — reconciliation when our overlay disagrees with codex's profile, instead of silently winning either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)