### PR TITLE
feat(messaging): flip Telegram status pill to errored on fatal poll-loop crash

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -673,6 +673,91 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("flips health to errored when an adapter signals a runtime error after start", async () => {
+    await prepareRuntimeStore();
+    let fireRuntimeError: ((reason: string) => void) | undefined;
+    const adapter = createAdapter("telegram", {
+      onRuntimeError: (listener: (reason: string) => void) => {
+        fireRuntimeError = listener;
+        return () => {
+          fireRuntimeError = undefined;
+        };
+      },
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+
+    await runtime.start();
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    fireRuntimeError?.(
+      "Call to 'getUpdates' failed! (409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running)",
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "errored",
+        reason: expect.stringContaining("409"),
+      }),
+    );
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "errored",
+        reason: expect.stringContaining("409"),
+      }),
+    ]);
+  });
+
+  it("detaches adapter runtime-error listeners on stop so a graceful shutdown does not flip to errored", async () => {
+    await prepareRuntimeStore();
+    let fireRuntimeError: ((reason: string) => void) | undefined;
+    const adapter = createAdapter("telegram", {
+      onRuntimeError: (listener: (reason: string) => void) => {
+        fireRuntimeError = listener;
+        return () => {
+          fireRuntimeError = undefined;
+        };
+      },
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.stop();
+
+    expect(fireRuntimeError).toBeUndefined();
+  });
+
   it("emits an activity event when an inbound message arrives", async () => {
     const { runtime, adapter } = await createRuntimeHarness();
     await runtime.start();

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -83,6 +83,94 @@ describe("TelegramAdapter", () => {
     });
   });
 
+  it("fans out a runtime-error event when the polling loop rejects after start", async () => {
+    const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    let rejectStart: ((error: Error) => void) | undefined;
+    const startPromise = new Promise<void>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const bot: TelegramBotLike = {
+      api: api as unknown as TelegramBotApi,
+      catch: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => startPromise),
+      stop: vi.fn(),
+    };
+    const adapter = new TelegramAdapter({
+      bot,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: ["42"],
+      },
+      logger,
+      now: () => 1000,
+    });
+    const reasons: string[] = [];
+    adapter.onRuntimeError((reason) => reasons.push(reason));
+
+    await adapter.start(async () => {});
+    rejectStart?.(
+      new Error(
+        "Call to 'getUpdates' failed! (409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running)",
+      ),
+    );
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("409");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "telegram polling loop exited with error",
+      expect.objectContaining({
+        error: expect.stringContaining("409"),
+      }),
+    );
+  });
+
+  it("does not fire a runtime-error event when the polling loop unwinds during stop()", async () => {
+    const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    let rejectStart: ((error: Error) => void) | undefined;
+    const startPromise = new Promise<void>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const bot: TelegramBotLike = {
+      api: api as unknown as TelegramBotApi,
+      catch: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => startPromise),
+      stop: vi.fn(() => {
+        rejectStart?.(new Error("polling stopped"));
+      }),
+    };
+    const adapter = new TelegramAdapter({
+      bot,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: ["42"],
+      },
+      logger,
+      now: () => 1000,
+    });
+    const reasons: string[] = [];
+    adapter.onRuntimeError((reason) => reasons.push(reason));
+
+    await adapter.start(async () => {});
+    await adapter.stop();
+
+    expect(reasons).toHaveLength(0);
+  });
+
   it("normalizes /resume and renders a thread picker with inline keyboard handles", async () => {
     const harness = await createControllerHarness();
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -40,6 +40,15 @@ export type DesktopMessagingAdapter = {
   channel: MessagingChannelKind;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
+  /**
+   * Optional subscription for fatal runtime errors that took the
+   * adapter offline after a successful start (e.g. Telegram's 409
+   * Conflict when a second bot instance starts polling). The runtime
+   * subscribes after `start()` and flips the platform health to
+   * `errored` so the renderer status pill turns red. Adapters that
+   * cannot detect post-start failures may simply omit the method.
+   */
+  onRuntimeError?(listener: (reason: string) => void): () => void;
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -122,6 +131,11 @@ export class DesktopMessagingRuntime {
   private adapters: DesktopMessagingAdapter[] = [];
   private controllers: MessagingController[] = [];
   private unsubscribeBackendEvents?: () => void;
+  /**
+   * One unsubscribe per running adapter that exposed `onRuntimeError`.
+   * Held so `stop()` can detach before adapters are torn down.
+   */
+  private adapterRuntimeErrorUnsubscribes: Array<() => void> = [];
   private started = false;
   /**
    * Per-platform health snapshot. Keyed by `MessagingChannelKind`. Updated
@@ -241,6 +255,17 @@ export class DesktopMessagingRuntime {
       this.adapters.push(adapter);
       this.controllers.push(controller);
       this.setPlatformHealth(adapter.channel, "enabled");
+
+      const unsubscribeRuntimeError = adapter.onRuntimeError?.((reason) => {
+        messagingLog.warn(`${adapter.channel}: adapter runtime error`, {
+          channel: adapter.channel,
+          reason,
+        });
+        this.setPlatformHealth(adapter.channel, "errored", { reason });
+      });
+      if (unsubscribeRuntimeError) {
+        this.adapterRuntimeErrorUnsubscribes.push(unsubscribeRuntimeError);
+      }
     }
 
     this.unsubscribeBackendEvents = this.options.backendBridge.onEvent?.(async (event) => {
@@ -287,6 +312,16 @@ export class DesktopMessagingRuntime {
 
     this.unsubscribeBackendEvents?.();
     this.unsubscribeBackendEvents = undefined;
+    for (const unsubscribe of this.adapterRuntimeErrorUnsubscribes) {
+      try {
+        unsubscribe();
+      } catch (error) {
+        messagingLog.warn("messaging adapter runtime-error unsubscribe threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    this.adapterRuntimeErrorUnsubscribes = [];
     this.controllers.forEach((controller) => controller.dispose());
     const stoppedChannels = this.adapters.map((adapter) => adapter.channel);
     await Promise.all(this.adapters.map(async (adapter) => adapter.stop?.()));

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -333,6 +333,15 @@ export type TelegramProviderAdapter = {
   downloadAttachment?(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
+  /**
+   * Subscribe to fatal runtime errors that took the adapter offline
+   * after a successful start — e.g. the long-poll loop exited because
+   * Telegram returned a 409 Conflict (another bot instance is running).
+   * Fired at most once per `start()` lifecycle and never on graceful
+   * `stop()`. The host is expected to surface this to the user (e.g.
+   * flip the platform status pill from green to red).
+   */
+  onRuntimeError?(listener: (reason: string) => void): () => void;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -422,6 +431,13 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     store?: MessagingCallbackHandleStore;
   };
   private startPromise?: Promise<void>;
+  /**
+   * `true` once `stop()` has been called; suppresses the runtime-error
+   * fan-out for the polling-loop rejection that grammy raises as part
+   * of normal shutdown.
+   */
+  private stopping = false;
+  private readonly runtimeErrorListeners = new Set<(reason: string) => void>();
   private typingSignalSequence = 0;
   private typingSignals = new Map<string, TelegramTypingSignal>();
 
@@ -499,22 +515,54 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         allowed_updates: [...TELEGRAM_ALLOWED_UPDATES],
       });
       // Eagerly handle rejection so it doesn't become unhandled if the
-      // process exits before stop() can await startPromise.
+      // process exits before stop() can await startPromise. A rejection
+      // after startup is a fatal runtime error (most often Telegram's
+      // 409 Conflict when a second bot instance starts polling and
+      // kicks ours off) — fan it out to runtime-error listeners so the
+      // host can flip the platform status indicator. Suppress the
+      // fan-out when we're in the middle of `stop()` because grammy
+      // resolves/rejects the start promise as part of normal shutdown.
       this.startPromise?.catch((error) => {
+        const reason = errorMessage(error);
         this.options.logger?.warn?.("telegram polling loop exited with error", {
-          error: errorMessage(error),
+          error: reason,
         });
+        if (!this.stopping) {
+          this.emitRuntimeError(reason);
+        }
       });
     }
   }
 
+  onRuntimeError(listener: (reason: string) => void): () => void {
+    this.runtimeErrorListeners.add(listener);
+    return () => {
+      this.runtimeErrorListeners.delete(listener);
+    };
+  }
+
+  private emitRuntimeError(reason: string): void {
+    for (const listener of this.runtimeErrorListeners) {
+      try {
+        listener(reason);
+      } catch (error) {
+        this.options.logger?.warn?.("telegram runtime-error listener threw", {
+          error: errorMessage(error),
+        });
+      }
+    }
+  }
+
   async stop(): Promise<void> {
+    this.stopping = true;
     this.stopTypingSignals();
     await this.bot.stop?.();
     await this.startPromise?.catch(() => undefined);
     this.startPromise = undefined;
     this.listener = undefined;
     this.botUsername = undefined;
+    this.runtimeErrorListeners.clear();
+    this.stopping = false;
   }
 
   async downloadAttachment(


### PR DESCRIPTION
## Summary

- When a second PwrAgent instance starts, Telegram returns `409 Conflict` and grammy's long-poll loop rejects on the first instance. The error was logged but the platform-status pill stayed green, so users had no visible signal that Telegram had gone offline.
- Add a generic `onRuntimeError(listener)` subscription on the adapter contract. `TelegramAdapter` fires it from the existing post-start rejection path, suppressed during graceful `stop()` via a `stopping` guard.
- The runtime subscribes after `setPlatformHealth(..., "enabled")` and routes the error to `setPlatformHealth(..., "errored", { reason })`, which already feeds the renderer's red-dot status pill via the existing `MessagingPlatformStatusEvent` channel.
- Discord is intentionally untouched — `onRuntimeError` is optional, so `DiscordAdapter` can wire its own gateway error events later without any runtime-side plumbing changes.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint:boundaries` clean
- [x] `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts` (new: poll-rejection fan-out + stop()-suppression)
- [x] `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts` (new: runtime flips to `errored` on adapter signal; listener detached on stop)
- [x] Manual: start two PwrAgent instances against the same bot token; confirm the Telegram pill turns red on the loser within ~1s and the tooltip shows the 409 reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)