### PR TITLE
fix(desktop): tiebreak transcript merge ordering with renderer sequence

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -6,6 +6,20 @@ import type {
   AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
 
+export const RENDERER_SEQUENCE_KEY = "__rendererSequence" as const;
+
+export function readRendererSequence(entry: object | undefined): number | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  const value = (entry as Record<string, unknown>)[RENDERER_SEQUENCE_KEY];
+  return typeof value === "number" ? value : undefined;
+}
+
+export function withRendererSequence<T extends object>(entry: T, sequence: number): T {
+  return { ...entry, [RENDERER_SEQUENCE_KEY]: sequence } as T;
+}
+
 export function getNotificationItem(
   params: Record<string, unknown>
 ): Record<string, unknown> | undefined {
@@ -515,6 +529,7 @@ export function buildLiveActivityEntry(params: {
   id: string;
   createdAt?: number;
   details: AppServerThreadActivityDetail[];
+  rendererSequence?: number;
   turn?: AppServerThreadTurnMetadata;
 }): AppServerThreadActivityEntry {
   return {
@@ -525,5 +540,8 @@ export function buildLiveActivityEntry(params: {
     status: summarizeActivityStatus(params.details),
     details: params.details,
     ...(params.turn ? { turn: params.turn } : {}),
+    ...(typeof params.rendererSequence === "number"
+      ? { [RENDERER_SEQUENCE_KEY]: params.rendererSequence }
+      : {}),
   };
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -891,6 +891,169 @@ describe("useThreadSessionState", () => {
     ).toEqual(["commentary", "commentary", "final"]);
   });
 
+  it("preserves live receipt order when consecutive events share a wall-clock millisecond", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(50_000);
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "inProgress" },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-1",
+            phase: "final",
+            delta: "First commentary.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-1",
+              type: "commandExecution",
+              command: "rg first src",
+              commandActions: [{ type: "search", path: "src" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-2",
+            phase: "final",
+            delta: "Second commentary.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-2",
+              type: "commandExecution",
+              command: "rg second src",
+              commandActions: [{ type: "search", path: "src" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-3",
+            delta: "Third commentary.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: { id: "turn-1", status: "completed", durationMs: 70_000 },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message"
+          ? `message:${entry.text}`
+          : entry.type === "activity"
+            ? `activity:${entry.summary}`
+            : entry.type
+      )
+    ).toEqual([
+      "message:First commentary.",
+      "activity:Explored 1 item",
+      "message:Second commentary.",
+      "activity:Explored 1 item",
+      "message:Third commentary.",
+    ]);
+  });
+
   it("keeps live activity between assistant messages after coarse hydration", async () => {
     let now = 30_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -34,8 +34,10 @@ import {
   buildMcpProgressDetail,
   getNotificationItem,
   mergeActivityDetails,
+  readRendererSequence,
   summarizeActivityStatus,
   summarizeLiveActivity,
+  withRendererSequence,
 } from "../features/thread-detail/live-transcript-activity";
 
 const MAX_VIEW_ONLY_THREADS = 10;
@@ -194,15 +196,29 @@ function mergeTranscriptEntries(
       typeof optimisticEntry.createdAt === "number"
         ? optimisticEntry.createdAt
         : undefined;
+    const optimisticSequence = readRendererSequence(optimisticEntry);
     const timedIndex =
       optimisticTurnId && typeof optimisticCreatedAt === "number"
         ? merged.findIndex((entry) => {
             const entryCreatedAt =
               typeof entry.createdAt === "number" ? entry.createdAt : undefined;
+            if (
+              entry.turn?.id !== optimisticTurnId ||
+              typeof entryCreatedAt !== "number"
+            ) {
+              return false;
+            }
+            if (entryCreatedAt > optimisticCreatedAt) {
+              return true;
+            }
+            if (entryCreatedAt < optimisticCreatedAt) {
+              return false;
+            }
+            const entrySequence = readRendererSequence(entry);
             return (
-              entry.turn?.id === optimisticTurnId &&
-              typeof entryCreatedAt === "number" &&
-              entryCreatedAt > optimisticCreatedAt
+              typeof entrySequence === "number" &&
+              typeof optimisticSequence === "number" &&
+              entrySequence > optimisticSequence
             );
           })
         : -1;
@@ -1101,6 +1117,7 @@ function upsertLiveActivityEntry(
         id,
         createdAt: params.now,
         details: params.details,
+        rendererSequence: flushed.nextLiveEntrySequence,
         turn: params.turn,
       }),
     ],
@@ -2041,26 +2058,40 @@ export function useThreadSessionState(params: {
                 optimisticMessageEntries(current.optimisticEntries),
                 current.pendingAssistantMessage
               );
+          const carriedSequence = isSamePendingMessage
+            ? readRendererSequence(current.pendingAssistantMessage)
+            : undefined;
+          const allocatedSequence =
+            carriedSequence ?? current.nextLiveEntrySequence;
+          const nextEntrySequence = isSamePendingMessage
+            ? current.nextLiveEntrySequence
+            : current.nextLiveEntrySequence + 1;
+
+          const nextPendingAssistantMessage: AppServerThreadMessageEntry = {
+            type: "message",
+            id: itemId,
+            role: "assistant",
+            phase,
+            createdAt: isSamePendingMessage
+              ? current.pendingAssistantMessage?.createdAt
+              : Date.now(),
+            ...(turn ? { turn } : {}),
+            text:
+              isSamePendingMessage
+                ? `${pendingText}${delta}`
+                : delta,
+          };
 
           return {
             ...current,
             expectOwnUpdate: true,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
-            pendingAssistantMessage: {
-              type: "message",
-              id: itemId,
-              role: "assistant",
-              phase,
-              createdAt: isSamePendingMessage
-                ? current.pendingAssistantMessage?.createdAt
-                : Date.now(),
-              ...(turn ? { turn } : {}),
-              text:
-                isSamePendingMessage
-                  ? `${pendingText}${delta}`
-                  : delta,
-            },
+            nextLiveEntrySequence: nextEntrySequence,
+            pendingAssistantMessage: withRendererSequence(
+              nextPendingAssistantMessage,
+              allocatedSequence
+            ),
             response: flushedResponse,
           };
         }
@@ -2312,16 +2343,22 @@ export function useThreadSessionState(params: {
               : []),
           ];
 
+          const syntheticFinalSequence = current.nextLiveEntrySequence;
           if (shouldAppendFinalMessage && completedText) {
-            nextEntries.push({
-              type: "message",
-              id: `${event.notification.params.turnId}:assistant`,
-              role: "assistant",
-              phase: "final",
-              ...(completedTurn ? { turn: completedTurn } : {}),
-              text: completedText,
-              createdAt: Date.now(),
-            });
+            nextEntries.push(
+              withRendererSequence(
+                {
+                  type: "message",
+                  id: `${event.notification.params.turnId}:assistant`,
+                  role: "assistant",
+                  phase: "final",
+                  ...(completedTurn ? { turn: completedTurn } : {}),
+                  text: completedText,
+                  createdAt: Date.now(),
+                },
+                syntheticFinalSequence
+              )
+            );
           }
 
           const responseWithCompletedTurn = withCompletedResponseTurnMetadata(
@@ -2376,6 +2413,10 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion:
               !completedText || shouldHydrateUnknownPhaseAssistant,
+            nextLiveEntrySequence:
+              shouldAppendFinalMessage && completedText
+                ? current.nextLiveEntrySequence + 1
+                : current.nextLiveEntrySequence,
             optimisticEntries: remainingOptimisticEntries,
             pendingAssistantMessage: undefined,
             pendingMcpInteraction: undefined,


### PR DESCRIPTION
## Summary

- Fixes the `transcript-temporal-order` E2E flake on CI by adding a renderer-internal monotonic sequence as a `(createdAt, sequence)` tiebreaker in `mergeTranscriptEntries`.
- Root cause: when two consecutive renderer events fired within the same `Date.now()` millisecond, an optimistic activity could end up appended to the end of the merged list instead of slotted before the next message — because the merge used strict `>` on `createdAt` and there was no secondary sort key.
- Failure mode on CI: the second tool-search activity rendered after the third assistant message, breaking `assertOrdered(["...", "More work", "I added the controller hook..."])`.

## What changed

- `live-transcript-activity.ts`: exports `RENDERER_SEQUENCE_KEY`, `readRendererSequence`, `withRendererSequence` helpers; `buildLiveActivityEntry` accepts an optional `rendererSequence`.
- `useThreadSessionState.ts`:
  - Reuses the existing `nextLiveEntrySequence` counter on `ThreadSessionEntry`.
  - Stamps the sequence onto locally-created entries: optimistic activities, pending assistant messages, and the synthetic turn-completion message. Bumps the counter for each new pending message and synthetic completion message (already bumped for new activities).
  - `mergeTranscriptEntries.timedIndex` lookup now falls back to sequence comparison only when `createdAt` is exactly equal. Strict-greater createdAt remains primary.
- Object-spread paths through `appendMessageEntries` / `withTurnMetadataAndPhase` preserve the property naturally.

## Why a sequence and not monotonic timestamps

Wall-clock `createdAt` stays honest. A separate sequence is a clean tiebreaker that only matters when timestamps actually collide, and it never affects the user-visible time semantics.

## Test plan

- [x] New regression test in `useThreadSessionState.test.tsx`: `"preserves live receipt order when consecutive events share a wall-clock millisecond"` pins `Date.now()` to a constant and replays the alternating message/activity sequence. Verified it fails on the pre-fix code (`activity:Explored` lands at end twice) and passes after.
- [x] All 40 hook tests pass; transcript-render-items + transcript-list tests pass (58/58).
- [x] `pnpm lint:boundaries` clean (967 modules, 1295 dependencies).
- [x] `transcript-temporal-order` Playwright spec ran 5/5 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)