### PR TITLE
fix(desktop): preserve unknown TOML sections + stop env-leak on settings save

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { desktopSettingsPatchToEdits } from "../settings/desktop-config";
+
+describe("desktopSettingsPatchToEdits — Mattermost", () => {
+  it("emits one set op per defined Mattermost field with the correct snake_case key", () => {
+    const edits = desktopSettingsPatchToEdits({
+      messaging: {
+        mattermost: {
+          enabled: true,
+          streamingResponses: false,
+          serverUrl: "https://chat.example.com",
+          callbackBaseUrl: "https://callbacks.example.com",
+          slashCommandPrefix: "pwragent_",
+          registerSlashCommands: true,
+          authorizedUserIds: ["abc", "def"],
+        },
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "enabled"],
+        value: true,
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "streaming_responses"],
+        value: false,
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "server_url"],
+        value: "https://chat.example.com",
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "callback_base_url"],
+        value: "https://callbacks.example.com",
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "slash_command_prefix"],
+        value: "pwragent_",
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "register_slash_commands"],
+        value: true,
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+        value: ["abc", "def"],
+      },
+    ]);
+  });
+
+  it("emits no ops when the Mattermost patch is empty", () => {
+    expect(
+      desktopSettingsPatchToEdits({ messaging: { mattermost: {} } }),
+    ).toEqual([]);
+  });
+
+  it("emits ops only for the fields that are defined", () => {
+    const edits = desktopSettingsPatchToEdits({
+      messaging: {
+        mattermost: {
+          serverUrl: "https://chat.example.com",
+        },
+      },
+    });
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "server_url"],
+        value: "https://chat.example.com",
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -603,4 +603,111 @@ describe("DesktopSettingsService", () => {
     // enabled stays true because the patch only updated model
     expect(reverted.experimental.diffCondensation.enabled.value).toBe(true);
   });
+
+  it("preserves unknown sections written by other builds when saving a patch", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const original = [
+      "# config edited by hand — comments must survive",
+      "[messaging.telegram]",
+      "enabled = true",
+      "",
+      "# Mattermost block written by a future build the current code doesn't know about",
+      "[messaging.mattermost]",
+      'server_url = "https://chat.example.com"',
+      'callback_base_url = "https://callbacks.example.com"',
+      'authorized_user_ids = ["abc-123", "def-456"]',
+      "",
+      "[unknown.future.section]",
+      'opaque_field = "preserve me"',
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, original, "utf8");
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 0,
+    });
+
+    await service.writeConfigPatch({
+      messaging: {
+        telegram: { enabled: false },
+      },
+    });
+
+    const after = fs.readFileSync(configPath, "utf8");
+    expect(after).toContain("# config edited by hand — comments must survive");
+    expect(after).toContain("[messaging.mattermost]");
+    expect(after).toContain('server_url = "https://chat.example.com"');
+    expect(after).toContain('callback_base_url = "https://callbacks.example.com"');
+    expect(after).toContain('authorized_user_ids = ["abc-123", "def-456"]');
+    expect(after).toContain("[unknown.future.section]");
+    expect(after).toContain('opaque_field = "preserve me"');
+    expect(after).toContain("enabled = false");
+  });
+
+  it("reads a config that contains inline-table-array values in unknown sections without erroring", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "",
+        "# Future schema (unknown to current code) — must parse, not throw.",
+        "[messaging.mattermost]",
+        'server_url = "https://chat.example.com"',
+        "authorized_users = [",
+        '  { id = "-1001234567890", label = "Mom\'s group" },',
+        '  { id = "-1009876543210", label = "Work team" },',
+        "]",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 0,
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.configError).toBeUndefined();
+    expect(snapshot.messaging.telegram.enabled.value).toBe(true);
+  });
+
+  it("leaves the file byte-identical when a patch sets values that already match", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const original = [
+      "[messaging.telegram]",
+      "enabled = true",
+      "streaming_responses = false",
+      "",
+    ].join("\n");
+    fs.writeFileSync(configPath, original, "utf8");
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 0,
+    });
+
+    await service.writeConfigPatch({
+      messaging: {
+        telegram: {
+          enabled: true,
+          streamingResponses: false,
+        },
+      },
+    });
+
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+  });
 });

--- a/apps/desktop/src/main/__tests__/toml-editor.test.ts
+++ b/apps/desktop/src/main/__tests__/toml-editor.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import { applyTomlEdits } from "../settings/toml-editor";
+
+describe("applyTomlEdits", () => {
+  it("returns the source unchanged when there are no edits", () => {
+    const source = "[messaging.telegram]\nenabled = true\n";
+    expect(applyTomlEdits(source, [])).toBe(source);
+  });
+
+  it("preserves the file byte-identical when set value already matches", () => {
+    const source = "[messaging.telegram]\nenabled = true\n";
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["messaging", "telegram", "enabled"], value: true },
+    ]);
+    expect(result).toBe(source);
+  });
+
+  it("preserves an unknown section when editing a known key", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      "",
+      "# Mattermost was configured by a future build of the app.",
+      "[messaging.mattermost]",
+      'server_url = "https://chat.example.com"',
+      'authorized_user_ids = ["abc", "def"]',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["messaging", "telegram", "enabled"], value: false },
+    ]);
+
+    expect(result).toContain(
+      "# Mattermost was configured by a future build of the app.",
+    );
+    expect(result).toContain("[messaging.mattermost]");
+    expect(result).toContain('server_url = "https://chat.example.com"');
+    expect(result).toContain('authorized_user_ids = ["abc", "def"]');
+    expect(result).toContain("enabled = false");
+  });
+
+  it("preserves comments above and between keys when editing a key", () => {
+    const source = [
+      "# top comment",
+      "[messaging.telegram]",
+      "# inline comment above key",
+      "enabled = true",
+      "# trailing key comment",
+      'authorized_user_ids = ["111"]',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["messaging", "telegram", "enabled"], value: false },
+    ]);
+
+    expect(result).toContain("# top comment");
+    expect(result).toContain("# inline comment above key");
+    expect(result).toContain("# trailing key comment");
+    expect(result).toContain("enabled = false");
+    expect(result).toContain('authorized_user_ids = ["111"]');
+  });
+
+  it("preserves blank lines between sections", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      "",
+      "",
+      "[messaging.discord]",
+      "enabled = false",
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["messaging", "telegram", "enabled"], value: false },
+    ]);
+
+    expect(result).toContain("enabled = false\n\n\n[messaging.discord]");
+  });
+
+  it("replaces an existing scalar value in place without touching other lines", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      'authorized_user_ids = ["111"]',
+      "streaming_responses = true",
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "set",
+        path: ["messaging", "telegram", "streaming_responses"],
+        value: false,
+      },
+    ]);
+
+    expect(result).toBe(
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        'authorized_user_ids = ["111"]',
+        "streaming_responses = false",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("replaces an existing array value in place", () => {
+    const source = [
+      "[messaging.telegram]",
+      'authorized_user_ids = ["111", "222"]',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "set",
+        path: ["messaging", "telegram", "authorized_user_ids"],
+        value: ["333"],
+      },
+    ]);
+
+    expect(result).toContain('authorized_user_ids = ["333"]');
+    expect(result).not.toContain('"111"');
+    expect(result).not.toContain('"222"');
+  });
+
+  it("appends a new key to an existing section before trailing blank lines", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "set",
+        path: ["messaging", "telegram", "streaming_responses"],
+        value: true,
+      },
+    ]);
+
+    expect(result).toBe(
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "streaming_responses = true",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("creates a new section at end of file when missing", () => {
+    const source = ["[messaging.telegram]", "enabled = true", ""].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "set",
+        path: ["messaging", "discord", "enabled"],
+        value: true,
+      },
+    ]);
+
+    expect(result).toContain("[messaging.telegram]");
+    expect(result).toContain("[messaging.discord]");
+    expect(result.indexOf("[messaging.discord]")).toBeGreaterThan(
+      result.indexOf("[messaging.telegram]"),
+    );
+    expect(result).toMatch(/\[messaging\.discord\]\nenabled = true\n?$/);
+  });
+
+  it("creates the file from scratch when source is empty", () => {
+    const result = applyTomlEdits("", [
+      {
+        op: "set",
+        path: ["messaging", "telegram", "enabled"],
+        value: true,
+      },
+    ]);
+
+    expect(result).toBe("[messaging.telegram]\nenabled = true\n");
+  });
+
+  it("deletes a key by removing its line", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      'authorized_user_ids = ["111"]',
+      "streaming_responses = true",
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "delete", path: ["messaging", "telegram", "streaming_responses"] },
+    ]);
+
+    expect(result).not.toContain("streaming_responses");
+    expect(result).toContain("enabled = true");
+    expect(result).toContain('authorized_user_ids = ["111"]');
+  });
+
+  it("emits an inline-table-array as one entry per line", () => {
+    const result = applyTomlEdits("[messaging.mattermost]\n", [
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "authorized_users"],
+        value: [
+          { id: "-100100", label: "Mom group" },
+          { id: "-100200", label: "Work team" },
+        ],
+      },
+    ]);
+
+    expect(result).toContain("[messaging.mattermost]");
+    expect(result).toContain("authorized_users = [");
+    expect(result).toContain('{ id = "-100100", label = "Mom group" },');
+    expect(result).toContain('{ id = "-100200", label = "Work team" },');
+    expect(result).toMatch(/]\n?$/);
+  });
+
+  it("replaces a multi-line inline-table-array value across lines", () => {
+    const source = [
+      "[messaging.mattermost]",
+      "authorized_users = [",
+      '  { id = "-100100", label = "Mom" },',
+      '  { id = "-100200", label = "Work" },',
+      "]",
+      'server_url = "https://chat.example.com"',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "authorized_users"],
+        value: [{ id: "-100300", label: "New" }],
+      },
+    ]);
+
+    expect(result).toContain('{ id = "-100300", label = "New" }');
+    expect(result).not.toContain('"-100100"');
+    expect(result).not.toContain('"-100200"');
+    expect(result).toContain('server_url = "https://chat.example.com"');
+  });
+
+  it("escapes special characters in string values on write", () => {
+    const result = applyTomlEdits("[s]\n", [
+      {
+        op: "set",
+        path: ["s", "k"],
+        value: 'has "quotes" and \\backslash and\nnewline',
+      },
+    ]);
+    expect(result).toContain(
+      'k = "has \\"quotes\\" and \\\\backslash and\\nnewline"',
+    );
+  });
+
+  it("preserves an empty string array as []", () => {
+    const result = applyTomlEdits("[s]\n", [
+      { op: "set", path: ["s", "list"], value: [] as readonly string[] },
+    ]);
+    expect(result).toContain("list = []");
+  });
+
+  it("treats path with single element as a top-level key", () => {
+    const source = "key = 1\n";
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["key"], value: 2 },
+    ]);
+    expect(result).toBe("key = 2\n");
+  });
+
+  it("ignores a delete for a key that does not exist", () => {
+    const source = "[s]\nx = 1\n";
+    const result = applyTomlEdits(source, [
+      { op: "delete", path: ["s", "y"] },
+    ]);
+    expect(result).toBe(source);
+  });
+
+  it("applies multiple edits in order", () => {
+    const source = [
+      "[messaging.telegram]",
+      "enabled = true",
+      'authorized_user_ids = ["111"]',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["messaging", "telegram", "enabled"], value: false },
+      {
+        op: "set",
+        path: ["messaging", "telegram", "authorized_user_ids"],
+        value: ["222"],
+      },
+      {
+        op: "set",
+        path: ["messaging", "discord", "enabled"],
+        value: true,
+      },
+    ]);
+
+    expect(result).toContain("enabled = false");
+    expect(result).toContain('authorized_user_ids = ["222"]');
+    expect(result).toContain("[messaging.discord]");
+  });
+});

--- a/apps/desktop/src/main/__tests__/toml-editor.test.ts
+++ b/apps/desktop/src/main/__tests__/toml-editor.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { applyTomlEdits } from "../settings/toml-editor";
+import { describe, expect, it, vi } from "vitest";
+import { applyTomlEdits, parseTomlTables } from "../settings/toml-editor";
 
 describe("applyTomlEdits", () => {
   it("returns the source unchanged when there are no edits", () => {
@@ -282,6 +282,66 @@ describe("applyTomlEdits", () => {
     expect(result).toBe(source);
   });
 
+  it("preserves a source with no trailing newline", () => {
+    const source = "[s]\nx = 1";
+    expect(applyTomlEdits(source, [])).toBe(source);
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["s", "x"], value: 2 },
+    ]);
+    expect(result).toBe("[s]\nx = 2");
+  });
+
+  it("preserves a source with a trailing newline", () => {
+    const source = "[s]\nx = 1\n";
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["s", "x"], value: 2 },
+    ]);
+    expect(result).toBe("[s]\nx = 2\n");
+  });
+
+  it("writes a float value", () => {
+    const result = applyTomlEdits("[s]\n", [
+      { op: "set", path: ["s", "ratio"], value: 1.5 },
+    ]);
+    expect(result).toContain("ratio = 1.5");
+  });
+
+  it("coalesces multiple edits to a missing section into a single new section", () => {
+    const source = "[a]\nx = 1\n";
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["b", "p"], value: 1 },
+      { op: "set", path: ["b", "q"], value: 2 },
+    ]);
+    expect(result).toBe("[a]\nx = 1\n\n[b]\np = 1\nq = 2\n");
+  });
+
+  it("applies multiple edits to the same section in original order", () => {
+    const source = "[s]\nexisting = 1\n";
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["s", "a"], value: 1 },
+      { op: "set", path: ["s", "b"], value: 2 },
+    ]);
+    expect(result).toBe("[s]\nexisting = 1\na = 1\nb = 2\n");
+  });
+
+  it("parses sources only once regardless of edit count (single-pass)", () => {
+    // Spy via a side channel: count regex.exec invocations on a hot path
+    // would be too invasive. Instead, this is a behavior smoke check —
+    // 50 edits to a small section produce a stable result quickly.
+    const lines = ["[s]", "x = 0"];
+    const source = lines.join("\n") + "\n";
+    const edits = Array.from({ length: 50 }, (_, i) => ({
+      op: "set" as const,
+      path: ["s", `k${i}`],
+      value: i,
+    }));
+    const result = applyTomlEdits(source, edits);
+    for (let i = 0; i < 50; i += 1) {
+      expect(result).toContain(`k${i} = ${i}`);
+    }
+  });
+
   it("applies multiple edits in order", () => {
     const source = [
       "[messaging.telegram]",
@@ -307,5 +367,82 @@ describe("applyTomlEdits", () => {
     expect(result).toContain("enabled = false");
     expect(result).toContain('authorized_user_ids = ["222"]');
     expect(result).toContain("[messaging.discord]");
+  });
+});
+
+describe("parseTomlTables", () => {
+  it("parses float values", () => {
+    const tables = parseTomlTables('[s]\nratio = 1.5\nneg = -2.25\n', "/x");
+    expect(tables.s.ratio).toBe(1.5);
+    expect(tables.s.neg).toBe(-2.25);
+  });
+
+  it("parses scientific-notation floats", () => {
+    const tables = parseTomlTables("[s]\na = 1.5e3\nb = -2E-2\n", "/x");
+    expect(tables.s.a).toBe(1500);
+    expect(tables.s.b).toBe(-0.02);
+  });
+
+  it("does not throw when an unknown value kind appears in any section", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      // 2026-05-15T00:00:00Z is a TOML datetime. Our parser doesn't yet
+      // understand datetimes, but a future build will. The current parser
+      // must skip the line, not blow up the entire snapshot read.
+      const tables = parseTomlTables(
+        "[s]\nwhen = 2026-05-15T00:00:00Z\nx = 1\n",
+        "/x",
+      );
+      expect(tables.s.x).toBe(1);
+      expect(tables.s.when).toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns and uses the first occurrence when a section appears twice", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const tables = parseTomlTables(
+        "[s]\nx = 1\n\n[s]\ny = 2\n",
+        "/x",
+      );
+      expect(tables.s.x).toBe(1);
+      expect(tables.s.y).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Duplicate section [s]"),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("still throws on malformed TOML lines", () => {
+    expect(() => parseTomlTables("[s]\nbroken line no equals\n", "/x")).toThrow(
+      /Invalid TOML line/,
+    );
+  });
+});
+
+describe("applyTomlEdits with duplicate sections", () => {
+  it("edits the first occurrence and leaves the second untouched", () => {
+    const source = [
+      "[s]",
+      "x = 1",
+      "",
+      "[s]",
+      "y = 2",
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      { op: "set", path: ["s", "x"], value: 99 },
+    ]);
+
+    // First section's x updated.
+    expect(result).toContain("x = 99");
+    // Second section preserved verbatim.
+    expect(result).toContain("[s]\ny = 2");
   });
 });

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -4,11 +4,18 @@ import path from "node:path";
 import type {
   DesktopChatReplyComposer,
   DesktopMessagingImageProfile,
+  DesktopSettingsConfigPatch,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
 import { isDesktopWorktreeStorageLocation } from "@pwragent/shared";
 import { resolveActiveProfilePath } from "../profile";
+import {
+  applyTomlEdits,
+  parseTomlTables,
+  type TomlEdit,
+  type TomlValue,
+} from "./toml-editor";
 
 type DesktopConfigPathOptions = {
   env?: NodeJS.ProcessEnv;
@@ -74,7 +81,7 @@ export type DesktopSettingsConfig = {
   };
 };
 
-type TomlScalar = string | number | boolean | string[];
+type TomlScalar = TomlValue;
 
 export function defaultDesktopConfigDir(
   options?: DesktopConfigPathOptions,
@@ -107,294 +114,175 @@ export function readDesktopSettingsConfig(
   return parseDesktopSettingsToml(fs.readFileSync(configPath, "utf8"), configPath);
 }
 
-export function writeDesktopSettingsConfig(
+/**
+ * Apply a settings patch to the on-disk config by editing only the keys named
+ * in the patch. Sections, comments, blank lines, and unknown keys outside the
+ * patch are preserved byte-for-byte. The file is never round-tripped through
+ * a typed config, so unknown sections written by other builds survive a save.
+ */
+export function applyDesktopSettingsPatch(
   configPath: string,
-  config: DesktopSettingsConfig,
+  patch: DesktopSettingsConfigPatch,
 ): void {
+  const edits = desktopSettingsPatchToEdits(patch);
+  if (edits.length === 0) {
+    return;
+  }
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  const source = fs.existsSync(configPath)
+    ? fs.readFileSync(configPath, "utf8")
+    : "";
+  const next = applyTomlEdits(source, edits);
+  if (next === source) {
+    return;
+  }
   const temporaryPath = `${configPath}.${process.pid}.tmp`;
-  fs.writeFileSync(temporaryPath, stringifyDesktopSettingsToml(config), "utf8");
+  fs.writeFileSync(temporaryPath, next, "utf8");
   fs.renameSync(temporaryPath, configPath);
 }
 
-export function mergeDesktopSettingsConfig(
-  current: DesktopSettingsConfig,
-  patch: DesktopSettingsConfig,
-): DesktopSettingsConfig {
-  return pruneEmptyConfig({
-    experimental: {
-      ...current.experimental,
-      ...patch.experimental,
-      diffCondensation: {
-        ...current.experimental?.diffCondensation,
-        ...patch.experimental?.diffCondensation,
-      },
-    },
-    messaging: {
-      inputDebounceMs:
-        patch.messaging?.inputDebounceMs ?? current.messaging?.inputDebounceMs,
-      toolUpdateMode:
-        patch.messaging?.toolUpdateMode ?? current.messaging?.toolUpdateMode,
-      attachments: {
-        ...current.messaging?.attachments,
-        ...patch.messaging?.attachments,
-      },
-      telegram: {
-        ...current.messaging?.telegram,
-        ...patch.messaging?.telegram,
-      },
-      discord: {
-        ...current.messaging?.discord,
-        ...patch.messaging?.discord,
-      },
-      mattermost: {
-        ...current.messaging?.mattermost,
-        ...patch.messaging?.mattermost,
-      },
-    },
-    models: {
-      codex: {
-        ...current.models?.codex,
-        ...patch.models?.codex,
-      },
-    },
-    applications: {
-      editor: {
-        ...current.applications?.editor,
-        ...patch.applications?.editor,
-      },
-      terminal: {
-        ...current.applications?.terminal,
-        ...patch.applications?.terminal,
-      },
-    },
-    worktrees: {
-      ...current.worktrees,
-      ...patch.worktrees,
-    },
-  });
+export function desktopSettingsPatchToEdits(
+  patch: DesktopSettingsConfigPatch,
+): TomlEdit[] {
+  const edits: TomlEdit[] = [];
+
+  const set = (
+    pathSegments: readonly string[],
+    value: string | number | boolean | readonly string[] | undefined,
+  ): void => {
+    if (value === undefined) return;
+    edits.push({ op: "set", path: pathSegments, value });
+  };
+
+  if (patch.experimental?.chatReplyComposer !== undefined) {
+    set(["experimental", "chat_reply_composer"], patch.experimental.chatReplyComposer);
+  }
+  if (patch.experimental?.diffCondensation?.enabled !== undefined) {
+    set(
+      ["experimental", "diff_condensation", "enabled"],
+      patch.experimental.diffCondensation.enabled,
+    );
+  }
+  if (patch.experimental?.diffCondensation?.model !== undefined) {
+    set(
+      ["experimental", "diff_condensation", "model"],
+      patch.experimental.diffCondensation.model,
+    );
+  }
+
+  if (patch.messaging?.inputDebounceMs !== undefined) {
+    set(["messaging", "input_debounce_ms"], patch.messaging.inputDebounceMs);
+  }
+  if (patch.messaging?.toolUpdateMode !== undefined) {
+    set(["messaging", "tool_update_mode"], patch.messaging.toolUpdateMode);
+  }
+
+  const attachments = patch.messaging?.attachments;
+  if (attachments?.imageProfile !== undefined) {
+    set(["messaging", "attachments", "image_profile"], attachments.imageProfile);
+  }
+  if (attachments?.maxAttachmentBytes !== undefined) {
+    set(["messaging", "attachments", "max_attachment_bytes"], attachments.maxAttachmentBytes);
+  }
+  if (attachments?.maxAttachmentCount !== undefined) {
+    set(["messaging", "attachments", "max_attachment_count"], attachments.maxAttachmentCount);
+  }
+
+  const telegram = patch.messaging?.telegram;
+  if (telegram?.enabled !== undefined) {
+    set(["messaging", "telegram", "enabled"], telegram.enabled);
+  }
+  if (telegram?.streamingResponses !== undefined) {
+    set(["messaging", "telegram", "streaming_responses"], telegram.streamingResponses);
+  }
+  if (telegram?.authorizedUserIds !== undefined) {
+    set(["messaging", "telegram", "authorized_user_ids"], telegram.authorizedUserIds);
+  }
+  if (telegram?.authorizedSupergroups !== undefined) {
+    set(
+      ["messaging", "telegram", "authorized_supergroups"],
+      telegram.authorizedSupergroups,
+    );
+  }
+
+  const discord = patch.messaging?.discord;
+  if (discord?.enabled !== undefined) {
+    set(["messaging", "discord", "enabled"], discord.enabled);
+  }
+  if (discord?.streamingResponses !== undefined) {
+    set(["messaging", "discord", "streaming_responses"], discord.streamingResponses);
+  }
+  if (discord?.applicationId !== undefined) {
+    set(["messaging", "discord", "application_id"], discord.applicationId);
+  }
+  if (discord?.authorizedUserIds !== undefined) {
+    set(["messaging", "discord", "authorized_user_ids"], discord.authorizedUserIds);
+  }
+  if (discord?.authorizedGuilds !== undefined) {
+    set(["messaging", "discord", "authorized_guilds"], discord.authorizedGuilds);
+  }
+
+  const mattermost = patch.messaging?.mattermost;
+  if (mattermost?.enabled !== undefined) {
+    set(["messaging", "mattermost", "enabled"], mattermost.enabled);
+  }
+  if (mattermost?.streamingResponses !== undefined) {
+    set(
+      ["messaging", "mattermost", "streaming_responses"],
+      mattermost.streamingResponses,
+    );
+  }
+  if (mattermost?.serverUrl !== undefined) {
+    set(["messaging", "mattermost", "server_url"], mattermost.serverUrl);
+  }
+  if (mattermost?.callbackBaseUrl !== undefined) {
+    set(
+      ["messaging", "mattermost", "callback_base_url"],
+      mattermost.callbackBaseUrl,
+    );
+  }
+  if (mattermost?.slashCommandPrefix !== undefined) {
+    set(
+      ["messaging", "mattermost", "slash_command_prefix"],
+      mattermost.slashCommandPrefix,
+    );
+  }
+  if (mattermost?.registerSlashCommands !== undefined) {
+    set(
+      ["messaging", "mattermost", "register_slash_commands"],
+      mattermost.registerSlashCommands,
+    );
+  }
+  if (mattermost?.authorizedUserIds !== undefined) {
+    set(
+      ["messaging", "mattermost", "authorized_user_ids"],
+      mattermost.authorizedUserIds,
+    );
+  }
+
+  if (patch.models?.codex?.path !== undefined) {
+    set(["models", "codex", "path"], patch.models.codex.path);
+  }
+
+  if (patch.applications?.editor?.preferredId !== undefined) {
+    set(["applications", "editor", "preferred_id"], patch.applications.editor.preferredId);
+  }
+  if (patch.applications?.terminal?.preferredId !== undefined) {
+    set(["applications", "terminal", "preferred_id"], patch.applications.terminal.preferredId);
+  }
+
+  if (patch.worktrees?.storage !== undefined) {
+    set(["worktrees", "storage"], patch.worktrees.storage);
+  }
+
+  return edits;
 }
 
 export function parseDesktopSettingsToml(
   contents: string,
   filePath: string,
 ): DesktopSettingsConfig {
-  const tables: Record<string, Record<string, TomlScalar>> = {};
-  let currentTable = "";
-
-  for (const [index, rawLine] of contents.split(/\r?\n/).entries()) {
-    const line = stripInlineComment(rawLine).trim();
-    if (!line) {
-      continue;
-    }
-
-    if (line.startsWith("[") && line.endsWith("]")) {
-      currentTable = line.slice(1, -1).trim();
-      if (!currentTable) {
-        throw new Error(`Invalid TOML table on line ${index + 1} in ${filePath}`);
-      }
-      tables[currentTable] ??= {};
-      continue;
-    }
-
-    const separatorIndex = line.indexOf("=");
-    if (separatorIndex < 1) {
-      throw new Error(`Invalid TOML line ${index + 1} in ${filePath}`);
-    }
-
-    const key = line.slice(0, separatorIndex).trim();
-    const rawValue = line.slice(separatorIndex + 1).trim();
-    if (!key) {
-      throw new Error(`Invalid TOML key on line ${index + 1} in ${filePath}`);
-    }
-
-    tables[currentTable] ??= {};
-    tables[currentTable][key] = parseTomlValue(rawValue, filePath, index + 1);
-  }
-
-  return normalizeDesktopConfig(tables);
-}
-
-export function stringifyDesktopSettingsToml(
-  config: DesktopSettingsConfig,
-): string {
-  const sections: string[] = [];
-
-  if (config.experimental?.chatReplyComposer) {
-    sections.push(
-      [
-        "[experimental]",
-        `chat_reply_composer = ${formatTomlValue(
-          config.experimental.chatReplyComposer,
-        )}`,
-      ].join("\n"),
-    );
-  }
-
-  const diffCondensation = config.experimental?.diffCondensation;
-  if (
-    diffCondensation
-    && (diffCondensation.enabled !== undefined || diffCondensation.model !== undefined)
-  ) {
-    sections.push(
-      [
-        "[experimental.diff_condensation]",
-        formatOptionalTomlEntry("enabled", diffCondensation.enabled),
-        formatOptionalTomlEntry("model", diffCondensation.model),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  if (
-    config.messaging?.toolUpdateMode
-    || config.messaging?.inputDebounceMs !== undefined
-  ) {
-    sections.push(
-      [
-        "[messaging]",
-        formatOptionalTomlEntry(
-          "input_debounce_ms",
-          config.messaging.inputDebounceMs,
-        ),
-        formatOptionalTomlEntry("tool_update_mode", config.messaging.toolUpdateMode),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  const attachments = config.messaging?.attachments;
-  if (attachments && hasDefinedValue(attachments)) {
-    sections.push(
-      [
-        "[messaging.attachments]",
-        formatOptionalTomlEntry("image_profile", attachments.imageProfile),
-        formatOptionalTomlEntry("max_attachment_bytes", attachments.maxAttachmentBytes),
-        formatOptionalTomlEntry("max_attachment_count", attachments.maxAttachmentCount),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  const telegram = config.messaging?.telegram;
-  if (telegram && hasDefinedValue(telegram)) {
-    sections.push(
-      [
-        "[messaging.telegram]",
-        formatOptionalTomlEntry("enabled", telegram.enabled),
-        formatOptionalTomlEntry(
-          "streaming_responses",
-          telegram.streamingResponses,
-        ),
-        formatOptionalTomlEntry(
-          "authorized_user_ids",
-          telegram.authorizedUserIds,
-        ),
-        formatOptionalTomlEntry(
-          "authorized_supergroups",
-          telegram.authorizedSupergroups,
-        ),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  const discord = config.messaging?.discord;
-  if (discord && hasDefinedValue(discord)) {
-    sections.push(
-      [
-        "[messaging.discord]",
-        formatOptionalTomlEntry("enabled", discord.enabled),
-        formatOptionalTomlEntry(
-          "streaming_responses",
-          discord.streamingResponses,
-        ),
-        formatOptionalTomlEntry("application_id", discord.applicationId),
-        formatOptionalTomlEntry(
-          "authorized_user_ids",
-          discord.authorizedUserIds,
-        ),
-        formatOptionalTomlEntry("authorized_guilds", discord.authorizedGuilds),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  const mattermost = config.messaging?.mattermost;
-  if (mattermost && hasDefinedValue(mattermost)) {
-    sections.push(
-      [
-        "[messaging.mattermost]",
-        formatOptionalTomlEntry("enabled", mattermost.enabled),
-        formatOptionalTomlEntry(
-          "streaming_responses",
-          mattermost.streamingResponses,
-        ),
-        formatOptionalTomlEntry("server_url", mattermost.serverUrl),
-        formatOptionalTomlEntry(
-          "callback_base_url",
-          mattermost.callbackBaseUrl,
-        ),
-        formatOptionalTomlEntry(
-          "slash_command_prefix",
-          mattermost.slashCommandPrefix,
-        ),
-        formatOptionalTomlEntry(
-          "register_slash_commands",
-          mattermost.registerSlashCommands,
-        ),
-        formatOptionalTomlEntry(
-          "authorized_user_ids",
-          mattermost.authorizedUserIds,
-        ),
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-
-  const codex = config.models?.codex;
-  if (codex?.path !== undefined) {
-    sections.push(
-      ["[models.codex]", `path = ${formatTomlValue(codex.path)}`].join("\n"),
-    );
-  }
-
-  const editor = config.applications?.editor;
-  if (editor?.preferredId !== undefined) {
-    sections.push(
-      [
-        "[applications.editor]",
-        `preferred_id = ${formatTomlValue(editor.preferredId)}`,
-      ].join("\n"),
-    );
-  }
-
-  const terminal = config.applications?.terminal;
-  if (terminal?.preferredId !== undefined) {
-    sections.push(
-      [
-        "[applications.terminal]",
-        `preferred_id = ${formatTomlValue(terminal.preferredId)}`,
-      ].join("\n"),
-    );
-  }
-
-  const worktrees = config.worktrees;
-  if (worktrees?.storage !== undefined) {
-    sections.push(
-      ["[worktrees]", `storage = ${formatTomlValue(worktrees.storage)}`].join(
-        "\n",
-      ),
-    );
-  }
-
-  return sections.join("\n\n").concat(sections.length ? "\n" : "");
+  return normalizeDesktopConfig(parseTomlTables(contents, filePath));
 }
 
 function normalizeDesktopConfig(
@@ -590,7 +478,11 @@ function readString(value: TomlScalar | undefined): string | undefined {
 }
 
 function readStringArray(value: TomlScalar | undefined): string[] | undefined {
-  return Array.isArray(value) ? value.map((item) => item.trim()).filter(Boolean) : undefined;
+  if (!Array.isArray(value)) return undefined;
+  if (!value.every((item): item is string => typeof item === "string")) {
+    return undefined;
+  }
+  return value.map((item) => item.trim()).filter(Boolean);
 }
 
 function readNumber(value: TomlScalar | undefined): number | undefined {
@@ -619,175 +511,3 @@ function readWorktreeStorage(
     : undefined;
 }
 
-function parseTomlValue(
-  value: string,
-  filePath: string,
-  lineNumber: number,
-): TomlScalar {
-  if (value === "true") {
-    return true;
-  }
-  if (value === "false") {
-    return false;
-  }
-  if (value.startsWith("[") && value.endsWith("]")) {
-    return parseStringArray(value, filePath, lineNumber);
-  }
-  if (value.startsWith("\"") && value.endsWith("\"")) {
-    return unescapeQuotedString(value.slice(1, -1), filePath, lineNumber);
-  }
-  if (/^-?\d+$/.test(value)) {
-    return Number(value);
-  }
-  throw new Error(`Unsupported TOML value on line ${lineNumber} in ${filePath}`);
-}
-
-function parseStringArray(
-  value: string,
-  filePath: string,
-  lineNumber: number,
-): string[] {
-  const inner = value.slice(1, -1).trim();
-  if (!inner) {
-    return [];
-  }
-
-  const values: string[] = [];
-  let current = "";
-  let inQuotedString = false;
-  let escaped = false;
-
-  for (let index = 0; index < inner.length; index += 1) {
-    const character = inner[index];
-    if (escaped) {
-      current += `\\${character}`;
-      escaped = false;
-      continue;
-    }
-    if (character === "\\") {
-      escaped = inQuotedString;
-      if (!inQuotedString) {
-        throw new Error(`Invalid TOML array on line ${lineNumber} in ${filePath}`);
-      }
-      continue;
-    }
-    if (character === "\"") {
-      inQuotedString = !inQuotedString;
-      current += character;
-      continue;
-    }
-    if (character === "," && !inQuotedString) {
-      values.push(parseStringArrayItem(current.trim(), filePath, lineNumber));
-      current = "";
-      continue;
-    }
-    current += character;
-  }
-
-  if (inQuotedString) {
-    throw new Error(`Unterminated TOML string on line ${lineNumber} in ${filePath}`);
-  }
-
-  values.push(parseStringArrayItem(current.trim(), filePath, lineNumber));
-  return values;
-}
-
-function parseStringArrayItem(
-  value: string,
-  filePath: string,
-  lineNumber: number,
-): string {
-  const parsed = parseTomlValue(value, filePath, lineNumber);
-  if (typeof parsed !== "string") {
-    throw new Error(`Expected TOML string array on line ${lineNumber} in ${filePath}`);
-  }
-  return parsed;
-}
-
-function stripInlineComment(line: string): string {
-  let inQuotedString = false;
-  let escaped = false;
-
-  for (let index = 0; index < line.length; index += 1) {
-    const character = line[index];
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (character === "\\") {
-      escaped = inQuotedString;
-      continue;
-    }
-    if (character === "\"") {
-      inQuotedString = !inQuotedString;
-      continue;
-    }
-    if (character === "#" && !inQuotedString) {
-      return line.slice(0, index);
-    }
-  }
-
-  return line;
-}
-
-function unescapeQuotedString(
-  value: string,
-  filePath: string,
-  lineNumber: number,
-): string {
-  let result = "";
-
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value[index];
-    if (character !== "\\") {
-      result += character;
-      continue;
-    }
-
-    index += 1;
-    const escape = value[index];
-    if (escape === undefined) {
-      throw new Error(`Invalid TOML escape on line ${lineNumber} in ${filePath}`);
-    }
-    if (escape === "\\" || escape === "\"") {
-      result += escape;
-      continue;
-    }
-    if (escape === "n") {
-      result += "\n";
-      continue;
-    }
-    if (escape === "t") {
-      result += "\t";
-      continue;
-    }
-    throw new Error(`Unsupported TOML escape \\${escape} on line ${lineNumber} in ${filePath}`);
-  }
-
-  return result;
-}
-
-function formatOptionalTomlEntry(
-  key: string,
-  value: string | number | boolean | string[] | undefined,
-): string | undefined {
-  return value === undefined ? undefined : `${key} = ${formatTomlValue(value)}`;
-}
-
-function formatTomlValue(value: string | number | boolean | string[]): string {
-  if (typeof value === "boolean") {
-    return String(value);
-  }
-  if (typeof value === "number") {
-    return String(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => formatTomlValue(item)).join(", ")}]`;
-  }
-
-  return `"${value
-    .replace(/\\/g, "\\\\")
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, "\\t")
-    .replace(/"/g, '\\"')}"`;
-}

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -14,11 +14,10 @@ import {
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
 } from "@pwragent/shared";
 import {
-  mergeDesktopSettingsConfig,
+  applyDesktopSettingsPatch,
   readDesktopSettingsConfig,
   resolveDesktopConfigPath,
   userHomeWorktreesRoot,
-  writeDesktopSettingsConfig,
   type DesktopSettingsConfig,
 } from "./desktop-config";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
@@ -307,10 +306,7 @@ export class DesktopSettingsService {
         `Cannot save settings because ${this.configPath} could not be parsed: ${current.error}`,
       );
     }
-    writeDesktopSettingsConfig(
-      this.configPath,
-      mergeDesktopSettingsConfig(current.config, patch),
-    );
+    applyDesktopSettingsPatch(this.configPath, patch);
     return this.readSettings();
   }
 

--- a/apps/desktop/src/main/settings/toml-editor.ts
+++ b/apps/desktop/src/main/settings/toml-editor.ts
@@ -10,16 +10,28 @@
  * Supported value kinds (read and write):
  *   - string       e.g. `"value"`
  *   - integer      e.g. `123`
+ *   - float        e.g. `1.5`, `-2.25`, `1.5e3`
  *   - boolean      e.g. `true` / `false`
  *   - string array e.g. `["a", "b"]`
  *   - inline-table array, with scalar fields per entry, e.g.
  *     `[{ id = "-1", label = "Mom" }, { id = "-2", label = "Work" }]`
  *
  * Read-side: tolerates multi-line array formatting, inline comments, and
- * `[[array.of.tables]]` / dotted-key forms it doesn't actively use.
+ * `[[array.of.tables]]` headers. Unknown TOML value kinds (datetimes, hex
+ * ints, multi-line strings) are skipped with a console warning rather than
+ * throwing — a future build introducing them in a section the current build
+ * doesn't know about must not kill the entire snapshot read.
  *
  * Write-side: emits a canonical, deterministic format. Values that match
  * the parsed existing value are skipped (the file stays byte-identical).
+ *
+ * Duplicate section headers (e.g. `[s]` twice in one file) follow
+ * **first-wins** semantics: the reader takes only the first occurrence's
+ * keys and warns; the editor edits keys in the first occurrence and leaves
+ * subsequent duplicates untouched.
+ *
+ * Trailing newline: preserved from the source. Empty source plus content
+ * defaults to having a trailing newline (POSIX convention).
  */
 
 export type TomlEditScalar = string | number | boolean;
@@ -47,6 +59,7 @@ export type TomlTables = Record<string, Record<string, TomlValue>>;
 type ParsedValue =
   | { kind: "string"; value: string }
   | { kind: "integer"; value: number }
+  | { kind: "float"; value: number }
   | { kind: "boolean"; value: boolean }
   | { kind: "string-array"; value: string[] }
   | { kind: "inline-table-array"; value: Record<string, TomlEditScalar>[] };
@@ -61,6 +74,7 @@ type SectionLocation = {
   name: string; // dotted; "" for the implicit top-level section
   headerLine: number; // -1 for the implicit top-level section
   keys: KeyLocation[];
+  duplicate: boolean; // true if this is the 2nd+ occurrence of the name
 };
 
 type SourceModel = {
@@ -72,21 +86,27 @@ type SourceModel = {
 const KEY_LINE = /^(\s*)([A-Za-z_][A-Za-z0-9_\-]*)\s*=\s*/;
 const SECTION_HEADER = /^\s*\[\s*([^\[\]]+?)\s*\]\s*(#.*)?$/;
 const ARRAY_OF_TABLES_HEADER = /^\s*\[\[\s*([^\[\]]+?)\s*\]\]\s*(#.*)?$/;
+const INTEGER_LITERAL = /^-?\d+$/;
+const FLOAT_LITERAL = /^-?(?:\d+\.\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)$/;
 
 /**
  * Parse a TOML source into a flat `tables[sectionName][key] = value` map.
  *
- * Strict: throws on invalid TOML, unsupported value kinds, or malformed
- * section headers, so callers can surface a config error to the user.
+ * Strict on syntax (throws on malformed lines or empty section headers) but
+ * lenient on value kinds — values our value parser doesn't recognize log a
+ * warning and the key is dropped from the table. The schema-aware
+ * normalization layer treats missing keys as defaults, so an exotic value
+ * in an unknown section can't kill a config read.
  *
- * Tolerant of multi-line `[ ... ]` arrays, multi-line inline-table arrays,
- * comments (line and trailing), and `[[array.of.tables]]` headers (each
- * occurrence overwrites the prior accumulator under the same name).
+ * Duplicate section headers: first occurrence wins. Subsequent occurrences
+ * log a warning and their keys are ignored.
  */
 export function parseTomlTables(source: string, filePath: string): TomlTables {
   const lines = source.split(/\r?\n/);
   const tables: TomlTables = {};
+  const seenSections = new Set<string>();
   let currentTable = "";
+  let skipSection = false;
 
   let i = 0;
   while (i < lines.length) {
@@ -100,11 +120,21 @@ export function parseTomlTables(source: string, filePath: string): TomlTables {
     const arrayHeader = ARRAY_OF_TABLES_HEADER.exec(line);
     const sectionMatch = arrayHeader ?? SECTION_HEADER.exec(line);
     if (sectionMatch) {
-      currentTable = sectionMatch[1].trim();
-      if (!currentTable) {
+      const name = sectionMatch[1].trim();
+      if (!name) {
         throw new Error(`Invalid TOML table on line ${i + 1} in ${filePath}`);
       }
-      tables[currentTable] ??= {};
+      if (seenSections.has(name)) {
+        console.warn(
+          `Duplicate section [${name}] on line ${i + 1} in ${filePath} — using the first occurrence; subsequent keys are ignored.`,
+        );
+        skipSection = true;
+      } else {
+        seenSections.add(name);
+        currentTable = name;
+        tables[currentTable] ??= {};
+        skipSection = false;
+      }
       i += 1;
       continue;
     }
@@ -116,10 +146,20 @@ export function parseTomlTables(source: string, filePath: string): TomlTables {
     const key = keyMatch[2];
     const valueStartCol = keyMatch[0].length;
     const endLine = findValueEndLine(lines, i, valueStartCol);
+
+    if (skipSection) {
+      i = endLine + 1;
+      continue;
+    }
+
     const valueText = sliceValueText(lines, i, valueStartCol, endLine);
     const parsed = tryParseValue(valueText);
     if (!parsed) {
-      throw new Error(`Unsupported TOML value on line ${i + 1} in ${filePath}`);
+      console.warn(
+        `Skipping unsupported TOML value for key '${key}' on line ${i + 1} in ${filePath}.`,
+      );
+      i = endLine + 1;
+      continue;
     }
 
     tables[currentTable] ??= {};
@@ -139,30 +179,29 @@ export function applyTomlEdits(
   }
 
   const model = parseSource(source);
-  let lines = model.lines.slice();
-
-  for (const edit of edits) {
-    lines = applyEdit(lines, parseSource(joinLines(lines, model.trailingNewline)), edit);
+  const plan = planEdits(model, edits);
+  if (plan.lineOps.length === 0 && plan.newSections.length === 0) {
+    return source;
   }
-
-  return joinLines(lines, model.trailingNewline);
+  const newLines = executePlan(model, plan);
+  return joinLines(newLines, model.trailingNewline);
 }
 
-function joinLines(lines: string[], _trailingNewline: boolean): string {
-  if (lines.length === 0) {
-    return "";
-  }
-  return lines.join("\n") + "\n";
-}
+// =============================================================================
+// Source parsing (used by the editor; lenient where parseTomlTables is strict)
+// =============================================================================
 
 function parseSource(source: string): SourceModel {
-  const trailingNewline = source.endsWith("\n");
-  const body = trailingNewline ? source.slice(0, -1) : source;
+  // Treat empty source as "should end with \n once we add content".
+  const hadTrailingNewline = source.endsWith("\n");
+  const trailingNewline = hadTrailingNewline || source.length === 0;
+  const body = hadTrailingNewline ? source.slice(0, -1) : source;
   const lines = body.length === 0 ? [] : body.split("\n");
 
   const sections: SectionLocation[] = [
-    { name: "", headerLine: -1, keys: [] },
+    { name: "", headerLine: -1, keys: [], duplicate: false },
   ];
+  const seenNames = new Set<string>();
 
   let i = 0;
   while (i < lines.length) {
@@ -175,23 +214,12 @@ function parseSource(source: string): SourceModel {
     }
 
     const arrayHeader = ARRAY_OF_TABLES_HEADER.exec(line);
-    if (arrayHeader) {
-      sections.push({
-        name: arrayHeader[1].trim(),
-        headerLine: i,
-        keys: [],
-      });
-      i += 1;
-      continue;
-    }
-
-    const header = SECTION_HEADER.exec(line);
-    if (header) {
-      sections.push({
-        name: header[1].trim(),
-        headerLine: i,
-        keys: [],
-      });
+    const sectionMatch = arrayHeader ?? SECTION_HEADER.exec(line);
+    if (sectionMatch) {
+      const name = sectionMatch[1].trim();
+      const duplicate = seenNames.has(name);
+      if (!duplicate) seenNames.add(name);
+      sections.push({ name, headerLine: i, keys: [], duplicate });
       i += 1;
       continue;
     }
@@ -203,57 +231,192 @@ function parseSource(source: string): SourceModel {
       continue;
     }
 
-    const key = keyMatch[2];
     const valueStartCol = keyMatch[0].length;
     const endLine = findValueEndLine(lines, i, valueStartCol);
     const currentSection = sections[sections.length - 1];
-    currentSection.keys.push({ name: key, startLine: i, endLine });
+    // Skip recording keys in duplicate sections so edits never target them.
+    if (!currentSection.duplicate) {
+      currentSection.keys.push({
+        name: keyMatch[2],
+        startLine: i,
+        endLine,
+      });
+    }
     i = endLine + 1;
   }
 
-  return { lines, trailingNewline: trailingNewline || lines.length > 0, sections };
+  return { lines, trailingNewline, sections };
 }
 
-function applyEdit(
-  lines: string[],
-  model: SourceModel,
-  edit: TomlEdit,
-): string[] {
-  const { tableName, keyName } = splitPath(edit.path);
-  const section = findSection(model, tableName);
+function joinLines(lines: string[], trailingNewline: boolean): string {
+  if (lines.length === 0) {
+    return "";
+  }
+  return lines.join("\n") + (trailingNewline ? "\n" : "");
+}
 
-  if (edit.op === "delete") {
+// =============================================================================
+// Edit planning: turn a list of TomlEdits into concrete line operations,
+// computed against the original model (no re-parsing per edit).
+// =============================================================================
+
+type LineOp =
+  | {
+      kind: "replace";
+      startLine: number;
+      endLine: number;
+      newLines: readonly string[];
+    }
+  | { kind: "insert"; insertionLine: number; newLines: readonly string[] };
+
+type NewSectionPlan = {
+  tableName: string;
+  keyLines: string[]; // already formatted, including any multi-line entries
+};
+
+type EditPlan = {
+  lineOps: LineOp[];
+  newSections: NewSectionPlan[];
+};
+
+function planEdits(model: SourceModel, edits: readonly TomlEdit[]): EditPlan {
+  const lineOps: LineOp[] = [];
+  // Insertion order is preserved by Map iteration, so all keys destined for
+  // the same nonexistent section land in one new section in the order they
+  // were requested.
+  const newSections = new Map<string, string[]>();
+
+  for (const edit of edits) {
+    const { tableName, keyName } = splitPath(edit.path);
+    const section = findSection(model, tableName);
+
+    if (edit.op === "delete") {
+      if (!section) continue;
+      const key = section.keys.find((k) => k.name === keyName);
+      if (!key) continue;
+      lineOps.push({
+        kind: "replace",
+        startLine: key.startLine,
+        endLine: key.endLine,
+        newLines: [],
+      });
+      continue;
+    }
+
+    // op: set
     if (!section) {
-      return lines;
+      const formatted = formatKeyValue(keyName, edit.value, "");
+      let bucket = newSections.get(tableName);
+      if (!bucket) {
+        bucket = [];
+        newSections.set(tableName, bucket);
+      }
+      bucket.push(...formatted);
+      continue;
     }
-    const key = section.keys.find((k) => k.name === keyName);
-    if (!key) {
-      return lines;
+
+    const existingKey = section.keys.find((k) => k.name === keyName);
+    if (existingKey) {
+      const existingValue = parseExistingValue(model.lines, existingKey);
+      if (existingValue && valuesEqual(existingValue, edit.value)) {
+        continue; // no-op set
+      }
+      lineOps.push({
+        kind: "replace",
+        startLine: existingKey.startLine,
+        endLine: existingKey.endLine,
+        newLines: formatKeyValue(keyName, edit.value, ""),
+      });
+      continue;
     }
-    return removeLines(lines, key.startLine, key.endLine);
+
+    lineOps.push({
+      kind: "insert",
+      insertionLine: computeKeyInsertionLine(model, section),
+      newLines: formatKeyValue(keyName, edit.value, ""),
+    });
   }
 
-  // op: set
-  if (!section) {
-    return appendNewSection(lines, tableName, keyName, edit.value);
+  const newSectionPlans: NewSectionPlan[] = [];
+  for (const [tableName, keyLines] of newSections) {
+    newSectionPlans.push({ tableName, keyLines });
   }
 
-  const existingKey = section.keys.find((k) => k.name === keyName);
-  if (existingKey) {
-    const existingValue = parseExistingValue(lines, existingKey);
-    if (existingValue && valuesEqual(existingValue, edit.value)) {
-      return lines;
-    }
-    return replaceLines(
-      lines,
-      existingKey.startLine,
-      existingKey.endLine,
-      formatKeyValue(keyName, edit.value, /* indent */ ""),
-    );
-  }
-
-  return appendKeyToSection(lines, model, section, keyName, edit.value);
+  return { lineOps, newSections: newSectionPlans };
 }
+
+function executePlan(model: SourceModel, plan: EditPlan): string[] {
+  // Bucket line ops by line. Each line index can have:
+  //   - at most one "replace" (since edits don't overlap on existing keys)
+  //   - any number of "insert" blocks (preserved in arrival order)
+  const replaceAt = new Map<
+    number,
+    { endLine: number; newLines: readonly string[] }
+  >();
+  const insertsAt = new Map<number, string[][]>();
+
+  for (const op of plan.lineOps) {
+    if (op.kind === "replace") {
+      replaceAt.set(op.startLine, {
+        endLine: op.endLine,
+        newLines: op.newLines,
+      });
+    } else {
+      let bucket = insertsAt.get(op.insertionLine);
+      if (!bucket) {
+        bucket = [];
+        insertsAt.set(op.insertionLine, bucket);
+      }
+      bucket.push([...op.newLines]);
+    }
+  }
+
+  // Walk the original lines once, emitting a new array.
+  const result: string[] = [];
+  let i = 0;
+  while (i < model.lines.length) {
+    const inserts = insertsAt.get(i);
+    if (inserts) {
+      for (const block of inserts) {
+        for (const ln of block) result.push(ln);
+      }
+    }
+
+    const replace = replaceAt.get(i);
+    if (replace) {
+      for (const ln of replace.newLines) result.push(ln);
+      i = replace.endLine + 1;
+      continue;
+    }
+
+    result.push(model.lines[i]);
+    i += 1;
+  }
+  // Inserts targeted at one-past-the-last line:
+  const eofInserts = insertsAt.get(model.lines.length);
+  if (eofInserts) {
+    for (const block of eofInserts) {
+      for (const ln of block) result.push(ln);
+    }
+  }
+
+  // Append new sections at end of file, separated by a blank line each.
+  for (const section of plan.newSections) {
+    if (result.length > 0 && result[result.length - 1].trim().length !== 0) {
+      result.push("");
+    }
+    if (section.tableName.length > 0) {
+      result.push(`[${section.tableName}]`);
+    }
+    for (const ln of section.keyLines) result.push(ln);
+  }
+
+  return result;
+}
+
+// =============================================================================
+// Section / key location helpers
+// =============================================================================
 
 function splitPath(path: readonly string[]): {
   tableName: string;
@@ -275,48 +438,15 @@ function findSection(
   model: SourceModel,
   name: string,
 ): SectionLocation | undefined {
-  // Last definition wins for repeated headers, but for our config format we
-  // expect each section to appear once. Search from the end so a redeclared
-  // section wins.
-  for (let i = model.sections.length - 1; i >= 0; i -= 1) {
-    if (model.sections[i].name === name) {
-      return model.sections[i];
+  // First-wins: scan from the start so duplicate section headers are inert
+  // for editing purposes (the duplicate-detection in parseSource also skips
+  // recording keys for them on read).
+  for (const section of model.sections) {
+    if (section.name === name && !section.duplicate) {
+      return section;
     }
   }
   return undefined;
-}
-
-function appendNewSection(
-  lines: string[],
-  tableName: string,
-  keyName: string,
-  value: TomlEditValue,
-): string[] {
-  const additions: string[] = [];
-  // Separate from preceding content with a blank line, but only if there's
-  // content and it doesn't already end with one.
-  if (lines.length > 0 && lines[lines.length - 1].trim().length !== 0) {
-    additions.push("");
-  }
-  if (tableName.length > 0) {
-    additions.push(`[${tableName}]`);
-  }
-  for (const formatted of formatKeyValue(keyName, value, "")) {
-    additions.push(formatted);
-  }
-  return [...lines, ...additions];
-}
-
-function appendKeyToSection(
-  lines: string[],
-  model: SourceModel,
-  section: SectionLocation,
-  keyName: string,
-  value: TomlEditValue,
-): string[] {
-  const insertionLine = computeKeyInsertionLine(model, section);
-  const additions = formatKeyValue(keyName, value, "");
-  return [...lines.slice(0, insertionLine), ...additions, ...lines.slice(insertionLine)];
 }
 
 function computeKeyInsertionLine(
@@ -330,16 +460,10 @@ function computeKeyInsertionLine(
   const sectionEnd =
     nextSection !== undefined ? nextSection.headerLine : model.lines.length;
 
-  // The last "owned" line of this section is the line of its last key (or the
-  // header line if no keys).
   let cursor = sectionEnd - 1;
   const lastKey = section.keys[section.keys.length - 1];
-  const lastOwnedLine = lastKey
-    ? lastKey.endLine
-    : section.headerLine; // -1 for top-level implicit section
+  const lastOwnedLine = lastKey ? lastKey.endLine : section.headerLine;
 
-  // Walk back over trailing blank lines that would be visually attached to the
-  // *next* section (or to nothing, for the trailing-blank-at-EOF case).
   while (cursor > lastOwnedLine && model.lines[cursor].trim().length === 0) {
     cursor -= 1;
   }
@@ -347,37 +471,17 @@ function computeKeyInsertionLine(
   return cursor + 1;
 }
 
-function removeLines(
-  lines: string[],
-  startLine: number,
-  endLine: number,
-): string[] {
-  return [...lines.slice(0, startLine), ...lines.slice(endLine + 1)];
-}
-
-function replaceLines(
-  lines: string[],
-  startLine: number,
-  endLine: number,
-  replacement: string[],
-): string[] {
-  return [
-    ...lines.slice(0, startLine),
-    ...replacement,
-    ...lines.slice(endLine + 1),
-  ];
-}
+// =============================================================================
+// Value parsing (read-side)
+// =============================================================================
 
 function parseExistingValue(
   lines: string[],
   key: KeyLocation,
 ): ParsedValue | undefined {
-  // Reconstruct the value text from the key line and any continuation lines.
   const firstLine = lines[key.startLine];
   const match = KEY_LINE.exec(firstLine);
-  if (!match) {
-    return undefined;
-  }
+  if (!match) return undefined;
   const valueText = sliceValueText(
     lines,
     key.startLine,
@@ -405,19 +509,18 @@ function sliceValueText(
 
 function tryParseValue(rawText: string): ParsedValue | undefined {
   const text = stripValueTrailingComment(rawText).trim();
-  if (text.length === 0) {
-    return undefined;
-  }
+  if (text.length === 0) return undefined;
 
-  if (text === "true") {
-    return { kind: "boolean", value: true };
-  }
-  if (text === "false") {
-    return { kind: "boolean", value: false };
-  }
-  if (/^-?\d+$/.test(text)) {
+  if (text === "true") return { kind: "boolean", value: true };
+  if (text === "false") return { kind: "boolean", value: false };
+
+  if (INTEGER_LITERAL.test(text)) {
     const value = Number(text);
     return Number.isFinite(value) ? { kind: "integer", value } : undefined;
+  }
+  if (FLOAT_LITERAL.test(text)) {
+    const value = Number(text);
+    return Number.isFinite(value) ? { kind: "float", value } : undefined;
   }
   if (text.startsWith('"')) {
     const result = scanQuotedString(text, 0);
@@ -433,20 +536,12 @@ function tryParseValue(rawText: string): ParsedValue | undefined {
 }
 
 function parseArrayLiteral(text: string): ParsedValue | undefined {
-  // text starts with `[` and (we hope) ends with `]`.
   const last = findArrayClose(text, 0);
-  if (last === -1 || last !== text.length - 1) {
-    return undefined;
-  }
+  if (last === -1 || last !== text.length - 1) return undefined;
   const inner = text.slice(1, last);
   const elements = splitTopLevel(inner, ",");
-  if (elements.length === 1 && elements[0].trim().length === 0) {
-    // Empty array — could be either kind; pick string-array as the canonical
-    // empty form.
-    return { kind: "string-array", value: [] };
-  }
-
   const trimmed = elements.map((e) => e.trim()).filter((e) => e.length > 0);
+
   if (trimmed.length === 0) {
     return { kind: "string-array", value: [] };
   }
@@ -474,8 +569,9 @@ function parseArrayLiteral(text: string): ParsedValue | undefined {
   return undefined;
 }
 
-function parseInlineTable(text: string): Record<string, TomlEditScalar> | undefined {
-  // text is `{ ... }` (possibly with newlines/whitespace inside).
+function parseInlineTable(
+  text: string,
+): Record<string, TomlEditScalar> | undefined {
   if (!text.startsWith("{") || !text.endsWith("}")) return undefined;
   const inner = text.slice(1, -1);
   const fields = splitTopLevel(inner, ",");
@@ -493,6 +589,7 @@ function parseInlineTable(text: string): Record<string, TomlEditScalar> | undefi
     if (
       parsed.kind === "string"
       || parsed.kind === "integer"
+      || parsed.kind === "float"
       || parsed.kind === "boolean"
     ) {
       out[key] = parsed.value;
@@ -525,7 +622,6 @@ function findArrayClose(text: string, openIndex: number): number {
         depth -= 1;
         if (depth === 0) return i;
       } else if (ch === "#") {
-        // Skip rest of line.
         const nl = text.indexOf("\n", i);
         if (nl === -1) return -1;
         i = nl;
@@ -537,14 +633,16 @@ function findArrayClose(text: string, openIndex: number): number {
 }
 
 function splitTopLevel(text: string, sep: string): string[] {
+  // Strip line comments first so we don't have to track them inside the loop.
+  const cleaned = stripCommentsAcrossLines(text);
   const parts: string[] = [];
   let depth = 0;
   let inDQ = false;
   let inSQ = false;
   let escaped = false;
   let start = 0;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
+  for (let i = 0; i < cleaned.length; i += 1) {
+    const ch = cleaned[i];
     if (inDQ) {
       if (escaped) escaped = false;
       else if (ch === "\\") escaped = true;
@@ -571,23 +669,20 @@ function splitTopLevel(text: string, sep: string): string[] {
       depth -= 1;
       continue;
     }
-    if (ch === "#") {
-      const nl = text.indexOf("\n", i);
-      if (nl === -1) {
-        // Treat rest as comment — drop.
-        text = text.slice(0, i);
-        break;
-      }
-      text = text.slice(0, i) + text.slice(nl);
-      continue;
-    }
     if (ch === sep && depth === 0) {
-      parts.push(text.slice(start, i));
+      parts.push(cleaned.slice(start, i));
       start = i + 1;
     }
   }
-  parts.push(text.slice(start));
+  parts.push(cleaned.slice(start));
   return parts;
+}
+
+function stripCommentsAcrossLines(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => stripComment(line))
+    .join("\n");
 }
 
 function scanQuotedString(
@@ -621,12 +716,9 @@ function scanQuotedString(
 }
 
 function stripValueTrailingComment(text: string): string {
-  // Strip a trailing `# ...` comment that's not inside a string. Multi-line
-  // safe: only consider comments on the final line.
   const lines = text.split("\n");
   const lastLine = lines[lines.length - 1];
-  const stripped = stripComment(lastLine);
-  lines[lines.length - 1] = stripped;
+  lines[lines.length - 1] = stripComment(lastLine);
   return lines.join("\n");
 }
 
@@ -669,12 +761,9 @@ function findValueEndLine(
   const first = lines[startLine];
   let i = valueStartCol;
   while (i < first.length && /\s/.test(first[i])) i += 1;
-  if (i >= first.length) {
-    return startLine;
-  }
+  if (i >= first.length) return startLine;
   const ch = first[i];
   if (ch !== "[" && ch !== "{") {
-    // Single-line scalar / string.
     return startLine;
   }
 
@@ -709,7 +798,6 @@ function findValueEndLine(
     }
     if (depth === 0) return l;
   }
-  // Unterminated; best effort.
   return lines.length - 1;
 }
 
@@ -717,7 +805,10 @@ function valuesEqual(parsed: ParsedValue, requested: TomlEditValue): boolean {
   if (parsed.kind === "boolean" && typeof requested === "boolean") {
     return parsed.value === requested;
   }
-  if (parsed.kind === "integer" && typeof requested === "number") {
+  if (
+    (parsed.kind === "integer" || parsed.kind === "float")
+    && typeof requested === "number"
+  ) {
     return parsed.value === requested;
   }
   if (parsed.kind === "string" && typeof requested === "string") {
@@ -744,6 +835,10 @@ function valuesEqual(parsed: ParsedValue, requested: TomlEditValue): boolean {
   return false;
 }
 
+// =============================================================================
+// Value formatting (write-side)
+// =============================================================================
+
 function formatKeyValue(
   key: string,
   value: TomlEditValue,
@@ -757,7 +852,6 @@ function formatKeyValue(
       const items = (value as readonly string[]).map(formatString);
       return [`${indent}${key} = [${items.join(", ")}]`];
     }
-    // inline-table array — multi-line, one entry per line
     const lines: string[] = [`${indent}${key} = [`];
     for (const entry of value as readonly Record<string, TomlEditScalar>[]) {
       lines.push(`${indent}  ${formatInlineTable(entry)},`);
@@ -770,8 +864,16 @@ function formatKeyValue(
 
 function formatScalar(value: TomlEditScalar): string {
   if (typeof value === "boolean") return value ? "true" : "false";
-  if (typeof value === "number") return String(value);
+  if (typeof value === "number") return formatNumber(value);
   return formatString(value);
+}
+
+function formatNumber(value: number): string {
+  // Integer values that happen to be whole numbers still emit without a
+  // decimal point — matches how the editor parses them back as integers.
+  // For non-integer numbers, JS's default String() produces a TOML-valid
+  // float literal.
+  return String(value);
 }
 
 function formatString(value: string): string {

--- a/apps/desktop/src/main/settings/toml-editor.ts
+++ b/apps/desktop/src/main/settings/toml-editor.ts
@@ -1,0 +1,791 @@
+/**
+ * Diff-style TOML editor.
+ *
+ * Reads an existing TOML source as text, applies a list of `set`/`delete`
+ * operations to the keys we know about, and returns the updated text. Lines,
+ * whitespace, comments, and unknown sections that aren't touched by an edit
+ * are preserved byte-for-byte. The point is to avoid round-trip data loss
+ * when a build that doesn't recognize a section saves the file.
+ *
+ * Supported value kinds (read and write):
+ *   - string       e.g. `"value"`
+ *   - integer      e.g. `123`
+ *   - boolean      e.g. `true` / `false`
+ *   - string array e.g. `["a", "b"]`
+ *   - inline-table array, with scalar fields per entry, e.g.
+ *     `[{ id = "-1", label = "Mom" }, { id = "-2", label = "Work" }]`
+ *
+ * Read-side: tolerates multi-line array formatting, inline comments, and
+ * `[[array.of.tables]]` / dotted-key forms it doesn't actively use.
+ *
+ * Write-side: emits a canonical, deterministic format. Values that match
+ * the parsed existing value are skipped (the file stays byte-identical).
+ */
+
+export type TomlEditScalar = string | number | boolean;
+
+export type TomlEditValue =
+  | TomlEditScalar
+  | readonly string[]
+  | readonly Record<string, TomlEditScalar>[];
+
+export type TomlEdit =
+  | { op: "set"; path: readonly string[]; value: TomlEditValue }
+  | { op: "delete"; path: readonly string[] };
+
+/** Parsed value type for the read-side parser. */
+export type TomlValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | Record<string, TomlEditScalar>[];
+
+/** Map of section name (dotted, "" for top-level) to key→value map. */
+export type TomlTables = Record<string, Record<string, TomlValue>>;
+
+type ParsedValue =
+  | { kind: "string"; value: string }
+  | { kind: "integer"; value: number }
+  | { kind: "boolean"; value: boolean }
+  | { kind: "string-array"; value: string[] }
+  | { kind: "inline-table-array"; value: Record<string, TomlEditScalar>[] };
+
+type KeyLocation = {
+  name: string;
+  startLine: number;
+  endLine: number; // inclusive
+};
+
+type SectionLocation = {
+  name: string; // dotted; "" for the implicit top-level section
+  headerLine: number; // -1 for the implicit top-level section
+  keys: KeyLocation[];
+};
+
+type SourceModel = {
+  lines: string[];
+  trailingNewline: boolean;
+  sections: SectionLocation[];
+};
+
+const KEY_LINE = /^(\s*)([A-Za-z_][A-Za-z0-9_\-]*)\s*=\s*/;
+const SECTION_HEADER = /^\s*\[\s*([^\[\]]+?)\s*\]\s*(#.*)?$/;
+const ARRAY_OF_TABLES_HEADER = /^\s*\[\[\s*([^\[\]]+?)\s*\]\]\s*(#.*)?$/;
+
+/**
+ * Parse a TOML source into a flat `tables[sectionName][key] = value` map.
+ *
+ * Strict: throws on invalid TOML, unsupported value kinds, or malformed
+ * section headers, so callers can surface a config error to the user.
+ *
+ * Tolerant of multi-line `[ ... ]` arrays, multi-line inline-table arrays,
+ * comments (line and trailing), and `[[array.of.tables]]` headers (each
+ * occurrence overwrites the prior accumulator under the same name).
+ */
+export function parseTomlTables(source: string, filePath: string): TomlTables {
+  const lines = source.split(/\r?\n/);
+  const tables: TomlTables = {};
+  let currentTable = "";
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = stripComment(line).trim();
+    if (trimmed.length === 0) {
+      i += 1;
+      continue;
+    }
+
+    const arrayHeader = ARRAY_OF_TABLES_HEADER.exec(line);
+    const sectionMatch = arrayHeader ?? SECTION_HEADER.exec(line);
+    if (sectionMatch) {
+      currentTable = sectionMatch[1].trim();
+      if (!currentTable) {
+        throw new Error(`Invalid TOML table on line ${i + 1} in ${filePath}`);
+      }
+      tables[currentTable] ??= {};
+      i += 1;
+      continue;
+    }
+
+    const keyMatch = KEY_LINE.exec(line);
+    if (!keyMatch) {
+      throw new Error(`Invalid TOML line ${i + 1} in ${filePath}`);
+    }
+    const key = keyMatch[2];
+    const valueStartCol = keyMatch[0].length;
+    const endLine = findValueEndLine(lines, i, valueStartCol);
+    const valueText = sliceValueText(lines, i, valueStartCol, endLine);
+    const parsed = tryParseValue(valueText);
+    if (!parsed) {
+      throw new Error(`Unsupported TOML value on line ${i + 1} in ${filePath}`);
+    }
+
+    tables[currentTable] ??= {};
+    tables[currentTable][key] = parsed.value;
+    i = endLine + 1;
+  }
+
+  return tables;
+}
+
+export function applyTomlEdits(
+  source: string,
+  edits: readonly TomlEdit[],
+): string {
+  if (edits.length === 0) {
+    return source;
+  }
+
+  const model = parseSource(source);
+  let lines = model.lines.slice();
+
+  for (const edit of edits) {
+    lines = applyEdit(lines, parseSource(joinLines(lines, model.trailingNewline)), edit);
+  }
+
+  return joinLines(lines, model.trailingNewline);
+}
+
+function joinLines(lines: string[], _trailingNewline: boolean): string {
+  if (lines.length === 0) {
+    return "";
+  }
+  return lines.join("\n") + "\n";
+}
+
+function parseSource(source: string): SourceModel {
+  const trailingNewline = source.endsWith("\n");
+  const body = trailingNewline ? source.slice(0, -1) : source;
+  const lines = body.length === 0 ? [] : body.split("\n");
+
+  const sections: SectionLocation[] = [
+    { name: "", headerLine: -1, keys: [] },
+  ];
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = stripComment(line).trim();
+
+    if (trimmed.length === 0) {
+      i += 1;
+      continue;
+    }
+
+    const arrayHeader = ARRAY_OF_TABLES_HEADER.exec(line);
+    if (arrayHeader) {
+      sections.push({
+        name: arrayHeader[1].trim(),
+        headerLine: i,
+        keys: [],
+      });
+      i += 1;
+      continue;
+    }
+
+    const header = SECTION_HEADER.exec(line);
+    if (header) {
+      sections.push({
+        name: header[1].trim(),
+        headerLine: i,
+        keys: [],
+      });
+      i += 1;
+      continue;
+    }
+
+    const keyMatch = KEY_LINE.exec(line);
+    if (!keyMatch) {
+      // Unknown line shape — leave it alone.
+      i += 1;
+      continue;
+    }
+
+    const key = keyMatch[2];
+    const valueStartCol = keyMatch[0].length;
+    const endLine = findValueEndLine(lines, i, valueStartCol);
+    const currentSection = sections[sections.length - 1];
+    currentSection.keys.push({ name: key, startLine: i, endLine });
+    i = endLine + 1;
+  }
+
+  return { lines, trailingNewline: trailingNewline || lines.length > 0, sections };
+}
+
+function applyEdit(
+  lines: string[],
+  model: SourceModel,
+  edit: TomlEdit,
+): string[] {
+  const { tableName, keyName } = splitPath(edit.path);
+  const section = findSection(model, tableName);
+
+  if (edit.op === "delete") {
+    if (!section) {
+      return lines;
+    }
+    const key = section.keys.find((k) => k.name === keyName);
+    if (!key) {
+      return lines;
+    }
+    return removeLines(lines, key.startLine, key.endLine);
+  }
+
+  // op: set
+  if (!section) {
+    return appendNewSection(lines, tableName, keyName, edit.value);
+  }
+
+  const existingKey = section.keys.find((k) => k.name === keyName);
+  if (existingKey) {
+    const existingValue = parseExistingValue(lines, existingKey);
+    if (existingValue && valuesEqual(existingValue, edit.value)) {
+      return lines;
+    }
+    return replaceLines(
+      lines,
+      existingKey.startLine,
+      existingKey.endLine,
+      formatKeyValue(keyName, edit.value, /* indent */ ""),
+    );
+  }
+
+  return appendKeyToSection(lines, model, section, keyName, edit.value);
+}
+
+function splitPath(path: readonly string[]): {
+  tableName: string;
+  keyName: string;
+} {
+  if (path.length === 0) {
+    throw new Error("TomlEdit path must have at least one segment");
+  }
+  if (path.length === 1) {
+    return { tableName: "", keyName: path[0] };
+  }
+  return {
+    tableName: path.slice(0, -1).join("."),
+    keyName: path[path.length - 1],
+  };
+}
+
+function findSection(
+  model: SourceModel,
+  name: string,
+): SectionLocation | undefined {
+  // Last definition wins for repeated headers, but for our config format we
+  // expect each section to appear once. Search from the end so a redeclared
+  // section wins.
+  for (let i = model.sections.length - 1; i >= 0; i -= 1) {
+    if (model.sections[i].name === name) {
+      return model.sections[i];
+    }
+  }
+  return undefined;
+}
+
+function appendNewSection(
+  lines: string[],
+  tableName: string,
+  keyName: string,
+  value: TomlEditValue,
+): string[] {
+  const additions: string[] = [];
+  // Separate from preceding content with a blank line, but only if there's
+  // content and it doesn't already end with one.
+  if (lines.length > 0 && lines[lines.length - 1].trim().length !== 0) {
+    additions.push("");
+  }
+  if (tableName.length > 0) {
+    additions.push(`[${tableName}]`);
+  }
+  for (const formatted of formatKeyValue(keyName, value, "")) {
+    additions.push(formatted);
+  }
+  return [...lines, ...additions];
+}
+
+function appendKeyToSection(
+  lines: string[],
+  model: SourceModel,
+  section: SectionLocation,
+  keyName: string,
+  value: TomlEditValue,
+): string[] {
+  const insertionLine = computeKeyInsertionLine(model, section);
+  const additions = formatKeyValue(keyName, value, "");
+  return [...lines.slice(0, insertionLine), ...additions, ...lines.slice(insertionLine)];
+}
+
+function computeKeyInsertionLine(
+  model: SourceModel,
+  section: SectionLocation,
+): number {
+  // Insert at the end of the section's content, before any trailing blank
+  // lines that separate this section from the next.
+  const sectionIndex = model.sections.indexOf(section);
+  const nextSection = model.sections[sectionIndex + 1];
+  const sectionEnd =
+    nextSection !== undefined ? nextSection.headerLine : model.lines.length;
+
+  // The last "owned" line of this section is the line of its last key (or the
+  // header line if no keys).
+  let cursor = sectionEnd - 1;
+  const lastKey = section.keys[section.keys.length - 1];
+  const lastOwnedLine = lastKey
+    ? lastKey.endLine
+    : section.headerLine; // -1 for top-level implicit section
+
+  // Walk back over trailing blank lines that would be visually attached to the
+  // *next* section (or to nothing, for the trailing-blank-at-EOF case).
+  while (cursor > lastOwnedLine && model.lines[cursor].trim().length === 0) {
+    cursor -= 1;
+  }
+
+  return cursor + 1;
+}
+
+function removeLines(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+): string[] {
+  return [...lines.slice(0, startLine), ...lines.slice(endLine + 1)];
+}
+
+function replaceLines(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  replacement: string[],
+): string[] {
+  return [
+    ...lines.slice(0, startLine),
+    ...replacement,
+    ...lines.slice(endLine + 1),
+  ];
+}
+
+function parseExistingValue(
+  lines: string[],
+  key: KeyLocation,
+): ParsedValue | undefined {
+  // Reconstruct the value text from the key line and any continuation lines.
+  const firstLine = lines[key.startLine];
+  const match = KEY_LINE.exec(firstLine);
+  if (!match) {
+    return undefined;
+  }
+  const valueText = sliceValueText(
+    lines,
+    key.startLine,
+    match[0].length,
+    key.endLine,
+  );
+  return tryParseValue(valueText);
+}
+
+function sliceValueText(
+  lines: string[],
+  startLine: number,
+  startCol: number,
+  endLine: number,
+): string {
+  if (startLine === endLine) {
+    return lines[startLine].slice(startCol);
+  }
+  const parts: string[] = [lines[startLine].slice(startCol)];
+  for (let l = startLine + 1; l <= endLine; l += 1) {
+    parts.push(lines[l]);
+  }
+  return parts.join("\n");
+}
+
+function tryParseValue(rawText: string): ParsedValue | undefined {
+  const text = stripValueTrailingComment(rawText).trim();
+  if (text.length === 0) {
+    return undefined;
+  }
+
+  if (text === "true") {
+    return { kind: "boolean", value: true };
+  }
+  if (text === "false") {
+    return { kind: "boolean", value: false };
+  }
+  if (/^-?\d+$/.test(text)) {
+    const value = Number(text);
+    return Number.isFinite(value) ? { kind: "integer", value } : undefined;
+  }
+  if (text.startsWith('"')) {
+    const result = scanQuotedString(text, 0);
+    if (result && result.endIndex === text.length - 1) {
+      return { kind: "string", value: result.value };
+    }
+    return undefined;
+  }
+  if (text.startsWith("[")) {
+    return parseArrayLiteral(text);
+  }
+  return undefined;
+}
+
+function parseArrayLiteral(text: string): ParsedValue | undefined {
+  // text starts with `[` and (we hope) ends with `]`.
+  const last = findArrayClose(text, 0);
+  if (last === -1 || last !== text.length - 1) {
+    return undefined;
+  }
+  const inner = text.slice(1, last);
+  const elements = splitTopLevel(inner, ",");
+  if (elements.length === 1 && elements[0].trim().length === 0) {
+    // Empty array — could be either kind; pick string-array as the canonical
+    // empty form.
+    return { kind: "string-array", value: [] };
+  }
+
+  const trimmed = elements.map((e) => e.trim()).filter((e) => e.length > 0);
+  if (trimmed.length === 0) {
+    return { kind: "string-array", value: [] };
+  }
+
+  if (trimmed.every((e) => e.startsWith("{") && e.endsWith("}"))) {
+    const tables: Record<string, TomlEditScalar>[] = [];
+    for (const entry of trimmed) {
+      const table = parseInlineTable(entry);
+      if (!table) return undefined;
+      tables.push(table);
+    }
+    return { kind: "inline-table-array", value: tables };
+  }
+
+  if (trimmed.every((e) => e.startsWith('"'))) {
+    const strings: string[] = [];
+    for (const entry of trimmed) {
+      const parsed = scanQuotedString(entry, 0);
+      if (!parsed || parsed.endIndex !== entry.length - 1) return undefined;
+      strings.push(parsed.value);
+    }
+    return { kind: "string-array", value: strings };
+  }
+
+  return undefined;
+}
+
+function parseInlineTable(text: string): Record<string, TomlEditScalar> | undefined {
+  // text is `{ ... }` (possibly with newlines/whitespace inside).
+  if (!text.startsWith("{") || !text.endsWith("}")) return undefined;
+  const inner = text.slice(1, -1);
+  const fields = splitTopLevel(inner, ",");
+  const out: Record<string, TomlEditScalar> = {};
+  for (const raw of fields) {
+    const field = raw.trim();
+    if (field.length === 0) continue;
+    const eq = field.indexOf("=");
+    if (eq === -1) return undefined;
+    const key = field.slice(0, eq).trim();
+    const valueText = field.slice(eq + 1).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_\-]*$/.test(key)) return undefined;
+    const parsed = tryParseValue(valueText);
+    if (!parsed) return undefined;
+    if (
+      parsed.kind === "string"
+      || parsed.kind === "integer"
+      || parsed.kind === "boolean"
+    ) {
+      out[key] = parsed.value;
+    } else {
+      return undefined;
+    }
+  }
+  return out;
+}
+
+function findArrayClose(text: string, openIndex: number): number {
+  let depth = 0;
+  let i = openIndex;
+  let inDQ = false;
+  let inSQ = false;
+  let escaped = false;
+  while (i < text.length) {
+    const ch = text[i];
+    if (inDQ) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inDQ = false;
+    } else if (inSQ) {
+      if (ch === "'") inSQ = false;
+    } else {
+      if (ch === '"') inDQ = true;
+      else if (ch === "'") inSQ = true;
+      else if (ch === "[" || ch === "{") depth += 1;
+      else if (ch === "]" || ch === "}") {
+        depth -= 1;
+        if (depth === 0) return i;
+      } else if (ch === "#") {
+        // Skip rest of line.
+        const nl = text.indexOf("\n", i);
+        if (nl === -1) return -1;
+        i = nl;
+      }
+    }
+    i += 1;
+  }
+  return -1;
+}
+
+function splitTopLevel(text: string, sep: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inDQ = false;
+  let inSQ = false;
+  let escaped = false;
+  let start = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inDQ) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inDQ = false;
+      continue;
+    }
+    if (inSQ) {
+      if (ch === "'") inSQ = false;
+      continue;
+    }
+    if (ch === '"') {
+      inDQ = true;
+      continue;
+    }
+    if (ch === "'") {
+      inSQ = true;
+      continue;
+    }
+    if (ch === "[" || ch === "{") {
+      depth += 1;
+      continue;
+    }
+    if (ch === "]" || ch === "}") {
+      depth -= 1;
+      continue;
+    }
+    if (ch === "#") {
+      const nl = text.indexOf("\n", i);
+      if (nl === -1) {
+        // Treat rest as comment — drop.
+        text = text.slice(0, i);
+        break;
+      }
+      text = text.slice(0, i) + text.slice(nl);
+      continue;
+    }
+    if (ch === sep && depth === 0) {
+      parts.push(text.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(text.slice(start));
+  return parts;
+}
+
+function scanQuotedString(
+  text: string,
+  startIndex: number,
+): { value: string; endIndex: number } | undefined {
+  if (text[startIndex] !== '"') return undefined;
+  let value = "";
+  let i = startIndex + 1;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "\\") {
+      const escape = text[i + 1];
+      if (escape === undefined) return undefined;
+      if (escape === "\\") value += "\\";
+      else if (escape === '"') value += '"';
+      else if (escape === "n") value += "\n";
+      else if (escape === "t") value += "\t";
+      else if (escape === "r") value += "\r";
+      else return undefined;
+      i += 2;
+      continue;
+    }
+    if (ch === '"') {
+      return { value, endIndex: i };
+    }
+    value += ch;
+    i += 1;
+  }
+  return undefined;
+}
+
+function stripValueTrailingComment(text: string): string {
+  // Strip a trailing `# ...` comment that's not inside a string. Multi-line
+  // safe: only consider comments on the final line.
+  const lines = text.split("\n");
+  const lastLine = lines[lines.length - 1];
+  const stripped = stripComment(lastLine);
+  lines[lines.length - 1] = stripped;
+  return lines.join("\n");
+}
+
+function stripComment(line: string): string {
+  let inDQ = false;
+  let inSQ = false;
+  let escaped = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inDQ) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inDQ = false;
+      continue;
+    }
+    if (inSQ) {
+      if (ch === "'") inSQ = false;
+      continue;
+    }
+    if (ch === '"') {
+      inDQ = true;
+      continue;
+    }
+    if (ch === "'") {
+      inSQ = true;
+      continue;
+    }
+    if (ch === "#") {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+function findValueEndLine(
+  lines: string[],
+  startLine: number,
+  valueStartCol: number,
+): number {
+  const first = lines[startLine];
+  let i = valueStartCol;
+  while (i < first.length && /\s/.test(first[i])) i += 1;
+  if (i >= first.length) {
+    return startLine;
+  }
+  const ch = first[i];
+  if (ch !== "[" && ch !== "{") {
+    // Single-line scalar / string.
+    return startLine;
+  }
+
+  let depth = 0;
+  let inDQ = false;
+  let inSQ = false;
+  let escaped = false;
+  for (let l = startLine; l < lines.length; l += 1) {
+    const startCol = l === startLine ? i : 0;
+    const line = lines[l];
+    let c = startCol;
+    while (c < line.length) {
+      const cur = line[c];
+      if (inDQ) {
+        if (escaped) escaped = false;
+        else if (cur === "\\") escaped = true;
+        else if (cur === '"') inDQ = false;
+      } else if (inSQ) {
+        if (cur === "'") inSQ = false;
+      } else {
+        if (cur === '"') inDQ = true;
+        else if (cur === "'") inSQ = true;
+        else if (cur === "[" || cur === "{") depth += 1;
+        else if (cur === "]" || cur === "}") {
+          depth -= 1;
+          if (depth === 0) return l;
+        } else if (cur === "#") {
+          break; // comment to end of line
+        }
+      }
+      c += 1;
+    }
+    if (depth === 0) return l;
+  }
+  // Unterminated; best effort.
+  return lines.length - 1;
+}
+
+function valuesEqual(parsed: ParsedValue, requested: TomlEditValue): boolean {
+  if (parsed.kind === "boolean" && typeof requested === "boolean") {
+    return parsed.value === requested;
+  }
+  if (parsed.kind === "integer" && typeof requested === "number") {
+    return parsed.value === requested;
+  }
+  if (parsed.kind === "string" && typeof requested === "string") {
+    return parsed.value === requested;
+  }
+  if (parsed.kind === "string-array" && Array.isArray(requested)) {
+    if (requested.length === 0) return parsed.value.length === 0;
+    if (typeof requested[0] !== "string") return false;
+    if (parsed.value.length !== requested.length) return false;
+    return parsed.value.every((v, i) => v === requested[i]);
+  }
+  if (parsed.kind === "inline-table-array" && Array.isArray(requested)) {
+    if (requested.length === 0) return parsed.value.length === 0;
+    if (typeof requested[0] !== "object") return false;
+    if (parsed.value.length !== requested.length) return false;
+    return parsed.value.every((entry, i) => {
+      const other = requested[i] as Record<string, TomlEditScalar>;
+      const entryKeys = Object.keys(entry);
+      const otherKeys = Object.keys(other);
+      if (entryKeys.length !== otherKeys.length) return false;
+      return entryKeys.every((k) => entry[k] === other[k]);
+    });
+  }
+  return false;
+}
+
+function formatKeyValue(
+  key: string,
+  value: TomlEditValue,
+  indent: string,
+): string[] {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return [`${indent}${key} = []`];
+    }
+    if (typeof value[0] === "string") {
+      const items = (value as readonly string[]).map(formatString);
+      return [`${indent}${key} = [${items.join(", ")}]`];
+    }
+    // inline-table array — multi-line, one entry per line
+    const lines: string[] = [`${indent}${key} = [`];
+    for (const entry of value as readonly Record<string, TomlEditScalar>[]) {
+      lines.push(`${indent}  ${formatInlineTable(entry)},`);
+    }
+    lines.push(`${indent}]`);
+    return lines;
+  }
+  return [`${indent}${key} = ${formatScalar(value as TomlEditScalar)}`];
+}
+
+function formatScalar(value: TomlEditScalar): string {
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  return formatString(value);
+}
+
+function formatString(value: string): string {
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\r/g, "\\r")}"`;
+}
+
+function formatInlineTable(entry: Record<string, TomlEditScalar>): string {
+  const fields = Object.entries(entry)
+    .map(([k, v]) => `${k} = ${formatScalar(v)}`)
+    .join(", ");
+  return `{ ${fields} }`;
+}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -12,6 +12,11 @@ import { ModelsSettings } from "./ModelsSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { WorktreesSettings } from "./WorktreesSettings";
+import {
+  buildDiscordPatchDelta,
+  buildMattermostPatchDelta,
+  buildTelegramPatchDelta,
+} from "./settings-patch-delta";
 import { useCallback, useEffect, useState } from "react";
 
 export type SettingsSection =
@@ -247,43 +252,33 @@ function SettingsSectionBody(props: {
           });
         }}
         onSaveDiscord={async (discord) => {
+          const delta = buildDiscordPatchDelta(
+            props.snapshot.messaging.discord,
+            discord,
+          );
+          if (delta === undefined) return;
           await props.settings.writeConfig({
-            messaging: {
-              discord: {
-                applicationId: discord.applicationId.value,
-                authorizedGuilds: discord.authorizedGuilds.value,
-                authorizedUserIds: discord.authorizedUserIds.value,
-                enabled: discord.enabled.value,
-                streamingResponses: discord.streamingResponses.value,
-              },
-            },
+            messaging: { discord: delta },
           });
         }}
         onSaveTelegram={async (telegram) => {
+          const delta = buildTelegramPatchDelta(
+            props.snapshot.messaging.telegram,
+            telegram,
+          );
+          if (delta === undefined) return;
           await props.settings.writeConfig({
-            messaging: {
-              telegram: {
-                authorizedSupergroups: telegram.authorizedSupergroups.value,
-                authorizedUserIds: telegram.authorizedUserIds.value,
-                enabled: telegram.enabled.value,
-                streamingResponses: telegram.streamingResponses.value,
-              },
-            },
+            messaging: { telegram: delta },
           });
         }}
         onSaveMattermost={async (mattermost) => {
+          const delta = buildMattermostPatchDelta(
+            props.snapshot.messaging.mattermost,
+            mattermost,
+          );
+          if (delta === undefined) return;
           await props.settings.writeConfig({
-            messaging: {
-              mattermost: {
-                authorizedUserIds: mattermost.authorizedUserIds.value,
-                callbackBaseUrl: mattermost.callbackBaseUrl.value,
-                enabled: mattermost.enabled.value,
-                registerSlashCommands: mattermost.registerSlashCommands.value,
-                serverUrl: mattermost.serverUrl.value,
-                slashCommandPrefix: mattermost.slashCommandPrefix.value,
-                streamingResponses: mattermost.streamingResponses.value,
-              },
-            },
+            messaging: { mattermost: delta },
           });
         }}
       />

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import {
+  buildDiscordPatchDelta,
+  buildTelegramPatchDelta,
+} from "../settings-patch-delta";
+
+type Telegram = DesktopSettingsSnapshot["messaging"]["telegram"];
+type Discord = DesktopSettingsSnapshot["messaging"]["discord"];
+
+function telegramSnapshot(overrides: Partial<Telegram> = {}): Telegram {
+  return {
+    enabled: { value: false, source: "default" },
+    streamingResponses: { value: false, source: "default" },
+    botToken: { configured: false, source: "unset", writable: true },
+    authorizedUserIds: { value: [], source: "default" },
+    authorizedSupergroups: { value: [], source: "default" },
+    ...overrides,
+  };
+}
+
+function discordSnapshot(overrides: Partial<Discord> = {}): Discord {
+  return {
+    enabled: { value: false, source: "default" },
+    streamingResponses: { value: false, source: "default" },
+    botToken: { configured: false, source: "unset", writable: true },
+    applicationId: { value: "", source: "default" },
+    authorizedUserIds: { value: [], source: "default" },
+    authorizedGuilds: { value: [], source: "default" },
+    ...overrides,
+  };
+}
+
+describe("buildTelegramPatchDelta", () => {
+  it("returns undefined when nothing changed", () => {
+    const snapshot = telegramSnapshot();
+    expect(buildTelegramPatchDelta(snapshot, snapshot)).toBeUndefined();
+  });
+
+  it("emits only the field the user changed", () => {
+    const snapshot = telegramSnapshot();
+    const candidate: Telegram = {
+      ...snapshot,
+      streamingResponses: { ...snapshot.streamingResponses, value: true },
+    };
+    expect(buildTelegramPatchDelta(snapshot, candidate)).toEqual({
+      streamingResponses: true,
+    });
+  });
+
+  it("does not leak env-overridden values the user did not touch", () => {
+    // Env says enabled=true; user toggles streaming, leaves enabled alone.
+    const snapshot = telegramSnapshot({
+      enabled: { value: true, source: "env", overriddenByEnv: true },
+    });
+    const candidate: Telegram = {
+      ...snapshot,
+      streamingResponses: { ...snapshot.streamingResponses, value: true },
+    };
+    const delta = buildTelegramPatchDelta(snapshot, candidate);
+    expect(delta).toEqual({ streamingResponses: true });
+    expect(delta).not.toHaveProperty("enabled");
+  });
+
+  it("writes a new value when the user actively overrides an env-sourced field", () => {
+    // Env says enabled=true; user explicitly toggles to false.
+    const snapshot = telegramSnapshot({
+      enabled: { value: true, source: "env", overriddenByEnv: true },
+    });
+    const candidate: Telegram = {
+      ...snapshot,
+      enabled: { ...snapshot.enabled, value: false },
+    };
+    expect(buildTelegramPatchDelta(snapshot, candidate)).toEqual({
+      enabled: false,
+    });
+  });
+
+  it("compares string arrays element-wise", () => {
+    const snapshot = telegramSnapshot({
+      authorizedUserIds: { value: ["111", "222"], source: "config" },
+    });
+    const same: Telegram = {
+      ...snapshot,
+      authorizedUserIds: { ...snapshot.authorizedUserIds, value: ["111", "222"] },
+    };
+    expect(buildTelegramPatchDelta(snapshot, same)).toBeUndefined();
+
+    const different: Telegram = {
+      ...snapshot,
+      authorizedUserIds: { ...snapshot.authorizedUserIds, value: ["333"] },
+    };
+    expect(buildTelegramPatchDelta(snapshot, different)).toEqual({
+      authorizedUserIds: ["333"],
+    });
+  });
+});
+
+describe("buildDiscordPatchDelta", () => {
+  it("returns undefined when nothing changed", () => {
+    const snapshot = discordSnapshot();
+    expect(buildDiscordPatchDelta(snapshot, snapshot)).toBeUndefined();
+  });
+
+  it("emits applicationId only when changed", () => {
+    const snapshot = discordSnapshot({
+      applicationId: { value: "old-id", source: "config" },
+    });
+    const same: Discord = {
+      ...snapshot,
+      applicationId: { ...snapshot.applicationId, value: "old-id" },
+    };
+    expect(buildDiscordPatchDelta(snapshot, same)).toBeUndefined();
+
+    const different: Discord = {
+      ...snapshot,
+      applicationId: { ...snapshot.applicationId, value: "new-id" },
+    };
+    expect(buildDiscordPatchDelta(snapshot, different)).toEqual({
+      applicationId: "new-id",
+    });
+  });
+
+  it("does not leak env-sourced applicationId when other fields change", () => {
+    const snapshot = discordSnapshot({
+      applicationId: { value: "env-app", source: "env", overriddenByEnv: true },
+    });
+    const candidate: Discord = {
+      ...snapshot,
+      enabled: { ...snapshot.enabled, value: true },
+    };
+    const delta = buildDiscordPatchDelta(snapshot, candidate);
+    expect(delta).toEqual({ enabled: true });
+    expect(delta).not.toHaveProperty("applicationId");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -236,9 +236,6 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           telegram: {
-            authorizedSupergroups: [],
-            authorizedUserIds: [],
-            enabled: false,
             streamingResponses: true,
           },
         },
@@ -333,13 +330,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           mattermost: {
-            authorizedUserIds: [],
-            callbackBaseUrl: "",
-            enabled: false,
-            registerSlashCommands: false,
             serverUrl: "https://chat.example.com",
-            slashCommandPrefix: "pwragent_",
-            streamingResponses: false,
           },
         },
       });
@@ -352,13 +343,7 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           mattermost: {
-            authorizedUserIds: [],
-            callbackBaseUrl: "",
-            enabled: false,
             registerSlashCommands: true,
-            serverUrl: "",
-            slashCommandPrefix: "pwragent_",
-            streamingResponses: false,
           },
         },
       });

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -1,0 +1,140 @@
+import type {
+  DesktopSettingsConfigPatch,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+
+/**
+ * Compute a config patch for a Telegram/Discord save action that includes
+ * ONLY the fields whose new value differs from the snapshot the user opened.
+ *
+ * The Settings UI builds candidate objects shaped like the snapshot (each
+ * field has a `.value`). Without this filter, every save would emit every
+ * field — including env-resolved ones the user never touched — which leaks
+ * environment overrides into the config file.
+ *
+ * Rules:
+ *   - A field is included only when its new `.value` is not equal to the
+ *     snapshot's `.value`.
+ *   - Env-overridden fields whose value the user did not change are dropped.
+ *   - If the user did change an env-overridden field, the new value is
+ *     written to the config file (env still wins on read until the env var
+ *     is unset, but the user's intent is recorded).
+ */
+export function buildTelegramPatchDelta(
+  snapshot: DesktopSettingsSnapshot["messaging"]["telegram"],
+  candidate: DesktopSettingsSnapshot["messaging"]["telegram"],
+): NonNullable<NonNullable<DesktopSettingsConfigPatch["messaging"]>["telegram"]> | undefined {
+  const patch: NonNullable<
+    NonNullable<DesktopSettingsConfigPatch["messaging"]>["telegram"]
+  > = {};
+
+  if (snapshot.enabled.value !== candidate.enabled.value) {
+    patch.enabled = candidate.enabled.value;
+  }
+  if (snapshot.streamingResponses.value !== candidate.streamingResponses.value) {
+    patch.streamingResponses = candidate.streamingResponses.value;
+  }
+  if (
+    !stringArrayEqual(
+      snapshot.authorizedUserIds.value,
+      candidate.authorizedUserIds.value,
+    )
+  ) {
+    patch.authorizedUserIds = candidate.authorizedUserIds.value;
+  }
+  if (
+    !stringArrayEqual(
+      snapshot.authorizedSupergroups.value,
+      candidate.authorizedSupergroups.value,
+    )
+  ) {
+    patch.authorizedSupergroups = candidate.authorizedSupergroups.value;
+  }
+
+  return Object.keys(patch).length === 0 ? undefined : patch;
+}
+
+export function buildDiscordPatchDelta(
+  snapshot: DesktopSettingsSnapshot["messaging"]["discord"],
+  candidate: DesktopSettingsSnapshot["messaging"]["discord"],
+): NonNullable<NonNullable<DesktopSettingsConfigPatch["messaging"]>["discord"]> | undefined {
+  const patch: NonNullable<
+    NonNullable<DesktopSettingsConfigPatch["messaging"]>["discord"]
+  > = {};
+
+  if (snapshot.enabled.value !== candidate.enabled.value) {
+    patch.enabled = candidate.enabled.value;
+  }
+  if (snapshot.streamingResponses.value !== candidate.streamingResponses.value) {
+    patch.streamingResponses = candidate.streamingResponses.value;
+  }
+  if (snapshot.applicationId.value !== candidate.applicationId.value) {
+    patch.applicationId = candidate.applicationId.value;
+  }
+  if (
+    !stringArrayEqual(
+      snapshot.authorizedUserIds.value,
+      candidate.authorizedUserIds.value,
+    )
+  ) {
+    patch.authorizedUserIds = candidate.authorizedUserIds.value;
+  }
+  if (
+    !stringArrayEqual(
+      snapshot.authorizedGuilds.value,
+      candidate.authorizedGuilds.value,
+    )
+  ) {
+    patch.authorizedGuilds = candidate.authorizedGuilds.value;
+  }
+
+  return Object.keys(patch).length === 0 ? undefined : patch;
+}
+
+export function buildMattermostPatchDelta(
+  snapshot: DesktopSettingsSnapshot["messaging"]["mattermost"],
+  candidate: DesktopSettingsSnapshot["messaging"]["mattermost"],
+): NonNullable<NonNullable<DesktopSettingsConfigPatch["messaging"]>["mattermost"]> | undefined {
+  const patch: NonNullable<
+    NonNullable<DesktopSettingsConfigPatch["messaging"]>["mattermost"]
+  > = {};
+
+  if (snapshot.enabled.value !== candidate.enabled.value) {
+    patch.enabled = candidate.enabled.value;
+  }
+  if (snapshot.streamingResponses.value !== candidate.streamingResponses.value) {
+    patch.streamingResponses = candidate.streamingResponses.value;
+  }
+  if (snapshot.serverUrl.value !== candidate.serverUrl.value) {
+    patch.serverUrl = candidate.serverUrl.value;
+  }
+  if (snapshot.callbackBaseUrl.value !== candidate.callbackBaseUrl.value) {
+    patch.callbackBaseUrl = candidate.callbackBaseUrl.value;
+  }
+  if (snapshot.slashCommandPrefix.value !== candidate.slashCommandPrefix.value) {
+    patch.slashCommandPrefix = candidate.slashCommandPrefix.value;
+  }
+  if (
+    snapshot.registerSlashCommands.value !== candidate.registerSlashCommands.value
+  ) {
+    patch.registerSlashCommands = candidate.registerSlashCommands.value;
+  }
+  if (
+    !stringArrayEqual(
+      snapshot.authorizedUserIds.value,
+      candidate.authorizedUserIds.value,
+    )
+  ) {
+    patch.authorizedUserIds = candidate.authorizedUserIds.value;
+  }
+
+  return Object.keys(patch).length === 0 ? undefined : patch;
+}
+
+function stringArrayEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- Replace the read-merge-stringify settings write pipeline with a diff-style TOML editor that only mutates the keys named in the patch. Sections, comments, blank lines, and unknown keys outside the patch survive byte-for-byte.
- Stop env-overridden values from leaking into the config file when the user saves an unrelated toggle: renderer-side delta builders emit only fields whose new value differs from the snapshot the user opened.
- Replace the old line-based read parser with a multi-line / inline-table-array tolerant one, so a future `[messaging.mattermost]` schema with `authorized_users = [{ id = \"…\", label = \"…\" }, …]` can land without a parser rewrite — and so configs that already contain such blocks stop throwing today.

## Why

Today's pipeline is destructive by design. If you ever save anything (even an unrelated toggle) while running a build that doesn't recognize a section, that whole section is silently erased on the next save — comments and whitespace go too. A user lost a hand-configured `[messaging.mattermost]` block this way after a cross-branch save. Same parse-typed-stringify shape also leaks env-resolved snapshot values into the file via the renderer's full-section save handlers.

## What changed

### Diff-style writer (main process)
- New [`toml-editor.ts`](apps/desktop/src/main/settings/toml-editor.ts): `applyTomlEdits(source, edits)` — reads existing text, applies `set`/`delete` ops, returns updated text. Handles scalars, string arrays, and inline-table arrays. No-op `set` (value already matches parsed existing value) leaves the file byte-identical.
- New `parseTomlTables(source, filePath)` — strict whole-file parser. Replaces the old per-line parser; tolerates multi-line `[ … ]` arrays, inline-table arrays, and `[[array.of.tables]]` headers.
- New `applyDesktopSettingsPatch(configPath, patch)` in [`desktop-config.ts`](apps/desktop/src/main/settings/desktop-config.ts) wires it into the service. `writeConfigPatch` now goes through the editor.
- Removed ~280 lines of dead code: `writeDesktopSettingsConfig`, `mergeDesktopSettingsConfig`, `stringifyDesktopSettingsToml`, the per-line value parser, and helpers.

### Env-leak fix (renderer)
- New [`settings-patch-delta.ts`](apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts): `buildTelegramPatchDelta` / `buildDiscordPatchDelta` compare each field of the candidate against the snapshot and emit only changed fields.
- [`SettingsScreen.tsx`](apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx) `onSaveTelegram` / `onSaveDiscord` use the delta builders. If the resulting delta is empty, no IPC call is made.

### Behavior contract
- ✅ Unknown TOML sections + their comments survive a save.
- ✅ Save with no real change is byte-identical (no temp-file rename, no IPC echo).
- ✅ Env-overridden fields the user did not touch are not written.
- ✅ Env-overridden fields the user actively changed are written (env still wins on read until the env var is unset, but the user's intent is recorded in the file).
- ✅ Inline-table-array values in unknown sections parse cleanly instead of throwing a config error.

## Test plan

- [x] `pnpm test` — 1336 passed / 3 skipped
- [x] `pnpm --filter @pwragent/desktop typecheck`
- [x] `pnpm lint:boundaries` (depcruise) — no violations
- [x] New tests cover: unknown-section survival, byte-identical no-op save, env-leak suppression, env-override-then-user-change, inline-table-array read tolerance, multi-line array reformat on edit
- [x] Manual smoke: open Settings, toggle Telegram Streaming Responses on/off, confirm the on-disk `config.toml` only contains `streaming_responses = true` change and other fields/sections are unchanged

## Reviewer notes

- The patch→edits translator [`desktopSettingsPatchToEdits`](apps/desktop/src/main/settings/desktop-config.ts) is intentionally an explicit field-by-field mapping rather than a recursive walker. It mirrors what the schema is, makes adding new keys obvious, and avoids surprises with `undefined` vs missing.
- The editor's canonical write format for inline-table arrays is one entry per line. We emit canonically when we touch a value; values the user never touched stay byte-identical, including custom hand-formatted arrays.
- One known lossy case (documented in [`toml-editor.ts`](apps/desktop/src/main/settings/toml-editor.ts:1) and discussed in design): comments _inside_ a value the user changes through the UI are dropped. Comments outside (above the key, between keys, between sections) survive untouched. Preserving inside-value comments would require an AST-preserving TOML parser; the JS ecosystem doesn't have a good one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)