### PR TITLE
feat(desktop): project-directory picker with add-new affordance

### DIFF
--- a/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  EnsureDirectoryLaunchpadResponse,
+  NavigationLaunchpadDefaults,
+  NavigationLaunchpadDraft,
+} from "@pwragent/shared";
+import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
+
+// Tests for the project-directory picker registration path (issue #223).
+// We stub the filesystem and `git` invocations so the suite stays fast
+// and deterministic — the integration with `git-directory-service` is
+// covered by `git-directory-service.test.ts`. Each test asserts on the
+// structured pass/fail shape the renderer's `ProjectPicker` consumes.
+
+const sampleLaunchpad: NavigationLaunchpadDraft = {
+  directoryKey: "directory:/tmp/sample",
+  directoryKind: "directory",
+  directoryLabel: "sample",
+  directoryPath: "/tmp/sample",
+  backend: "codex",
+  executionMode: "default",
+  prompt: "",
+  workMode: "local",
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const sampleDefaults: NavigationLaunchpadDefaults = {
+  backend: "codex",
+  executionMode: "default",
+};
+
+function buildEnsureSpy() {
+  return vi.fn<
+    (request: {
+      directoryKey: string;
+      directoryKind: "directory";
+      directoryLabel: string;
+      directoryPath: string;
+      currentBranch?: string;
+    }) => Promise<EnsureDirectoryLaunchpadResponse>
+  >(async (request) => {
+    return {
+      launchpad: {
+        ...sampleLaunchpad,
+        directoryKey: request.directoryKey,
+        directoryLabel: request.directoryLabel,
+        directoryPath: request.directoryPath,
+        branchName: request.currentBranch,
+      },
+      defaults: sampleDefaults,
+    };
+  });
+}
+
+function statDir(): Promise<{ isDirectory: () => boolean }> {
+  return Promise.resolve({ isDirectory: () => true });
+}
+
+function statFile(): Promise<{ isDirectory: () => boolean }> {
+  return Promise.resolve({ isDirectory: () => false });
+}
+
+describe("registerDirectoryFromDisk", () => {
+  it("seeds a launchpad and returns canonical metadata for a git repo", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn<
+      (cwd: string, args: string[]) => Promise<string>
+    >(async (_cwd, args) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return "/Users/huntharo/code/PwrAgent";
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return "main";
+      }
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    });
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/Users/huntharo/code/PwrAgent" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.directoryPath).toBe("/Users/huntharo/code/PwrAgent");
+    expect(result.directoryKey).toBe("directory:/Users/huntharo/code/PwrAgent");
+    expect(result.directoryLabel).toBe("PwrAgent");
+    expect(result.currentBranch).toBe("main");
+    expect(ensure).toHaveBeenCalledExactlyOnceWith({
+      directoryKey: "directory:/Users/huntharo/code/PwrAgent",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/code/PwrAgent",
+      currentBranch: "main",
+      preferredBackend: undefined,
+    });
+  });
+
+  it("normalizes symlinked roots via `git rev-parse --show-toplevel`", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return "/Users/me/repos/canonical-name";
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return "main";
+      }
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    });
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/Users/me/symlink-to-repo" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.directoryPath).toBe("/Users/me/repos/canonical-name");
+    expect(result.directoryKey).toBe(
+      "directory:/Users/me/repos/canonical-name",
+    );
+  });
+
+  it("returns not-a-git-repo when `git rev-parse` fails", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async () => {
+      throw new Error("fatal: not a git repository");
+    });
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/tmp/not-a-repo" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("not-a-git-repo");
+    expect(result.message).toContain("/tmp/not-a-repo");
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("returns not-a-directory when the chosen path is a file", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async () => "");
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/tmp/just-a-file.txt" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statFile,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("not-a-directory");
+    expect(ensure).not.toHaveBeenCalled();
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it("returns inaccessible when stat throws", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async () => "");
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/tmp/missing" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: () => Promise.reject(new Error("ENOENT")),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("inaccessible");
+    expect(ensure).not.toHaveBeenCalled();
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it("returns inaccessible when path is empty", async () => {
+    const ensure = buildEnsureSpy();
+    const result = await registerDirectoryFromDisk(
+      { path: "   " },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit: vi.fn(),
+        statPath: statDir,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("inaccessible");
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("leaves currentBranch undefined for detached HEAD repos", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return "/tmp/repo";
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return "HEAD";
+      }
+      return "";
+    });
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/tmp/repo" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.currentBranch).toBeUndefined();
+    expect(ensure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ currentBranch: undefined }),
+    );
+  });
+
+  it("propagates preferredBackend through to ensureDirectoryLaunchpad", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return "/tmp/repo";
+      }
+      return "main";
+    });
+
+    await registerDirectoryFromDisk(
+      { path: "/tmp/repo", preferredBackend: "grok" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    expect(ensure).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ preferredBackend: "grok" }),
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
@@ -3,8 +3,38 @@ import type {
   EnsureDirectoryLaunchpadResponse,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
+  RegisterDirectoryFromDiskResponse,
 } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
+
+/**
+ * Narrowing helpers that THROW on the wrong branch. The previous
+ * `expect(result.ok).toBe(true); if (!result.ok) return;` pattern
+ * relies on `expect` running first to fail the test — fine when
+ * authored together, but easy to copy-paste without the `expect` and
+ * end up with a silent no-op. These helpers make the negative branch
+ * fail loudly even on its own, and TypeScript narrows the return value
+ * for the rest of the test body.
+ */
+function assertOk(
+  result: RegisterDirectoryFromDiskResponse,
+): asserts result is Extract<RegisterDirectoryFromDiskResponse, { ok: true }> {
+  if (!result.ok) {
+    throw new Error(
+      `Expected ok result, got failure: ${result.reason} — ${result.message}`,
+    );
+  }
+}
+
+function assertFailed(
+  result: RegisterDirectoryFromDiskResponse,
+): asserts result is Extract<RegisterDirectoryFromDiskResponse, { ok: false }> {
+  if (result.ok) {
+    throw new Error(
+      `Expected failure result, got ok: ${result.directoryKey}`,
+    );
+  }
+}
 
 // Tests for the project-directory picker registration path (issue #223).
 // We stub the filesystem and `git` invocations so the suite stays fast
@@ -85,8 +115,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    assertOk(result);
     expect(result.directoryPath).toBe("/Users/huntharo/code/PwrAgent");
     expect(result.directoryKey).toBe("directory:/Users/huntharo/code/PwrAgent");
     expect(result.directoryLabel).toBe("PwrAgent");
@@ -122,8 +151,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    assertOk(result);
     expect(result.directoryPath).toBe("/Users/me/repos/canonical-name");
     expect(result.directoryKey).toBe(
       "directory:/Users/me/repos/canonical-name",
@@ -145,8 +173,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
+    assertFailed(result);
     expect(result.reason).toBe("not-a-git-repo");
     expect(result.message).toContain("/tmp/not-a-repo");
     expect(ensure).not.toHaveBeenCalled();
@@ -165,8 +192,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
+    assertFailed(result);
     expect(result.reason).toBe("not-a-directory");
     expect(ensure).not.toHaveBeenCalled();
     expect(runGit).not.toHaveBeenCalled();
@@ -185,8 +211,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
+    assertFailed(result);
     expect(result.reason).toBe("inaccessible");
     expect(ensure).not.toHaveBeenCalled();
     expect(runGit).not.toHaveBeenCalled();
@@ -203,8 +228,7 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
+    assertFailed(result);
     expect(result.reason).toBe("inaccessible");
     expect(ensure).not.toHaveBeenCalled();
   });
@@ -230,12 +254,43 @@ describe("registerDirectoryFromDisk", () => {
       },
     );
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
+    assertOk(result);
     expect(result.currentBranch).toBeUndefined();
     expect(ensure).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ currentBranch: undefined }),
     );
+  });
+
+  it("canonicalizes pwragent-managed worktree paths back to the parent repo", async () => {
+    // When the user picks a directory inside `<repo>/.worktrees/<hash>/<project>`,
+    // `git rev-parse --show-toplevel` reports the worktree path. We
+    // canonicalize back to `<repo>` so the directoryKey dedupes against
+    // the existing canonical-repo entry rather than producing a duplicate
+    // "PwrAgent" pinned at the worktree path.
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--show-toplevel") {
+        return "/Users/me/code/PwrAgent/.worktrees/abc123/PwrAgent";
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return "feat/x";
+      }
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    });
+
+    const result = await registerDirectoryFromDisk(
+      { path: "/Users/me/code/PwrAgent/.worktrees/abc123/PwrAgent" },
+      {
+        ensureDirectoryLaunchpad: ensure,
+        runGit,
+        statPath: statDir,
+      },
+    );
+
+    assertOk(result);
+    expect(result.directoryPath).toBe("/Users/me/code/PwrAgent");
+    expect(result.directoryKey).toBe("directory:/Users/me/code/PwrAgent");
+    expect(result.directoryLabel).toBe("PwrAgent");
   });
 
   it("propagates preferredBackend through to ensureDirectoryLaunchpad", async () => {

--- a/apps/desktop/src/main/app-server/directory-registration-service.ts
+++ b/apps/desktop/src/main/app-server/directory-registration-service.ts
@@ -1,0 +1,158 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { stat as fsStat } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type {
+  AppServerBackendKind,
+  EnsureDirectoryLaunchpadResponse,
+  RegisterDirectoryFromDiskFailureReason,
+  RegisterDirectoryFromDiskResponse,
+} from "@pwragent/shared";
+
+const execFile = promisify(execFileCallback);
+
+/**
+ * Validate `path` and seed a launchpad for the project-directory
+ * picker (issue #223 — "add a new directory" affordance in the new-thread
+ * composer). The renderer hands us a path coming straight out of the
+ * system "choose folder" dialog; we owe the renderer a structured
+ * pass/fail result so the picker can render an inline error rather than
+ * crashing or silently no-op'ing.
+ *
+ * Validation steps in order:
+ *
+ *   1. The path exists and is reachable. Failure → `inaccessible` (the
+ *      OS dialog can in theory return paths we cannot stat, e.g. a stale
+ *      bookmark or a permissions-blocked folder).
+ *   2. The path resolves to a directory, not a file. Failure →
+ *      `not-a-directory`.
+ *   3. `git rev-parse --show-toplevel` succeeds inside the path. Per
+ *      issue #223 acceptance criteria the picker registers git repos
+ *      only — a non-repo errors with `not-a-git-repo`.
+ *
+ * On success we call `ensureDirectoryLaunchpad` so the directory is
+ * known to the launchpad layer immediately. The repo's canonical root
+ * (rev-parse output) is what we persist — symlinked roots normalize so
+ * the same repo accessed via two paths still maps to one launchpad.
+ */
+export type DirectoryRegistrationDeps = {
+  ensureDirectoryLaunchpad: (request: {
+    directoryKey: string;
+    directoryKind: "directory";
+    directoryLabel: string;
+    directoryPath: string;
+    currentBranch?: string;
+    preferredBackend?: AppServerBackendKind;
+  }) => Promise<EnsureDirectoryLaunchpadResponse>;
+  /** Test seam — defaults to a real `git` execFile invocation. */
+  runGit?: (cwd: string, args: string[]) => Promise<string>;
+  /** Test seam — defaults to `node:fs` `stat`. */
+  statPath?: (target: string) => Promise<{ isDirectory: () => boolean }>;
+};
+
+async function defaultRunGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFile("git", ["-C", cwd, ...args], {
+    env: process.env,
+  });
+  return stdout.trim();
+}
+
+async function defaultStat(
+  target: string,
+): Promise<{ isDirectory: () => boolean }> {
+  return await fsStat(target);
+}
+
+function failed(
+  reason: RegisterDirectoryFromDiskFailureReason,
+  message: string,
+): RegisterDirectoryFromDiskResponse {
+  return { ok: false, reason, message };
+}
+
+export async function registerDirectoryFromDisk(
+  request: { path: string; preferredBackend?: AppServerBackendKind },
+  deps: DirectoryRegistrationDeps,
+): Promise<RegisterDirectoryFromDiskResponse> {
+  const candidate = request.path?.trim();
+  if (!candidate) {
+    return failed("inaccessible", "Pick a folder to add it as a directory.");
+  }
+
+  const runGit = deps.runGit ?? defaultRunGit;
+  const statPath = deps.statPath ?? defaultStat;
+
+  try {
+    const info = await statPath(candidate);
+    if (!info.isDirectory()) {
+      return failed(
+        "not-a-directory",
+        `${candidate} is not a folder.`,
+      );
+    }
+  } catch (error) {
+    return failed(
+      "inaccessible",
+      `Couldn't open ${candidate}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  let repoRoot: string;
+  try {
+    repoRoot = (await runGit(candidate, ["rev-parse", "--show-toplevel"])).trim();
+    if (!repoRoot) {
+      return failed(
+        "not-a-git-repo",
+        `${candidate} is not inside a git repository.`,
+      );
+    }
+  } catch {
+    // `git rev-parse --show-toplevel` exits non-zero (with a message on
+    // stderr) for any path that isn't tracked. We treat all such
+    // failures as "not a git repo" rather than surfacing the raw stderr,
+    // which is implementation-y and not useful in the picker UI.
+    return failed(
+      "not-a-git-repo",
+      `${candidate} is not inside a git repository.`,
+    );
+  }
+
+  // Resolve the current branch (best effort — detached HEADs return an
+  // empty string and we just leave `currentBranch` unset).
+  let currentBranch: string | undefined;
+  try {
+    const head = (await runGit(repoRoot, [
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ])).trim();
+    if (head && head !== "HEAD") {
+      currentBranch = head;
+    }
+  } catch {
+    // Brand-new repo with no commits — leave currentBranch undefined.
+  }
+
+  const directoryKey = `directory:${repoRoot}`;
+  const directoryLabel = path.basename(repoRoot) || repoRoot;
+  const ensured = await deps.ensureDirectoryLaunchpad({
+    directoryKey,
+    directoryKind: "directory",
+    directoryLabel,
+    directoryPath: repoRoot,
+    currentBranch,
+    preferredBackend: request.preferredBackend,
+  });
+
+  return {
+    ok: true,
+    directoryPath: repoRoot,
+    directoryKey,
+    directoryLabel,
+    currentBranch,
+    launchpad: ensured.launchpad,
+    defaults: ensured.defaults,
+  };
+}

--- a/apps/desktop/src/main/app-server/directory-registration-service.ts
+++ b/apps/desktop/src/main/app-server/directory-registration-service.ts
@@ -70,6 +70,30 @@ function failed(
   return { ok: false, reason, message };
 }
 
+/**
+ * If `target` lives inside `<repo>/.worktrees/<hash>/<project>` —
+ * pwragent's own auxiliary-worktree convention — return `<repo>` so
+ * the picker's directoryKey matches the canonical-repo entry that
+ * already exists in the navigation snapshot.
+ *
+ * Without this, picking a path under `.worktrees/<hash>/<project>`
+ * generates `directory:/repo/.worktrees/<hash>/<project>` while the
+ * rest of the system uses `directory:/repo`, producing a duplicate
+ * entry in the picker's "Recent directories" list. This mirrors the
+ * `repoWorktreeMatch` branch in
+ * `packages/agent-core/src/domain/directory-navigation.ts:88`, which
+ * is the read-side of the same normalization. We deliberately do NOT
+ * canonicalize `.codex/worktrees/...` paths — those are intentionally
+ * tracked as their own directory entries by the directory-navigation
+ * builder.
+ */
+function canonicalizeRepoWorktreePath(target: string): string {
+  const match = target.match(
+    /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/][^\\/]+)?(?:[\\/].*)?$/,
+  );
+  return match ? match[1] : target;
+}
+
 export async function registerDirectoryFromDisk(
   request: { path: string; preferredBackend?: AppServerBackendKind },
   deps: DirectoryRegistrationDeps,
@@ -101,13 +125,20 @@ export async function registerDirectoryFromDisk(
 
   let repoRoot: string;
   try {
-    repoRoot = (await runGit(candidate, ["rev-parse", "--show-toplevel"])).trim();
-    if (!repoRoot) {
+    const toplevel = (await runGit(candidate, [
+      "rev-parse",
+      "--show-toplevel",
+    ])).trim();
+    if (!toplevel) {
       return failed(
         "not-a-git-repo",
         `${candidate} is not inside a git repository.`,
       );
     }
+    // If the toplevel is itself a pwragent-managed worktree, walk back
+    // to the parent repo so the directoryKey dedupes against the
+    // already-tracked directory entry. See `canonicalizeRepoWorktreePath`.
+    repoRoot = canonicalizeRepoWorktreePath(toplevel);
   } catch {
     // `git rev-parse --show-toplevel` exits non-zero (with a message on
     // stderr) for any path that isn't tracked. We treat all such

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, dialog, ipcMain } from "electron";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import type {
   AppServerBackendScope,
@@ -21,8 +21,11 @@ import type {
   HandoffThreadWorkspaceResponse,
   GetGhStatusRequest,
   GhStatus,
+  PickDirectoryFromDiskResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
+  RegisterDirectoryFromDiskRequest,
+  RegisterDirectoryFromDiskResponse,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   NavigationSnapshot,
@@ -39,6 +42,7 @@ import type {
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
+import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
   getDesktopBackendRegistry,
@@ -60,6 +64,8 @@ import {
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
+  NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -523,6 +529,42 @@ class DesktopAppServerService {
     return await getDesktopBackendRegistry().resetDirectoryLaunchpad(request);
   }
 
+  async pickDirectoryFromDisk(
+    parentWindow?: BrowserWindow,
+  ): Promise<PickDirectoryFromDiskResponse> {
+    // Anchor the dialog to whichever window dispatched the IPC so it
+    // appears as a sheet on macOS (the renderer's expectation) instead
+    // of floating free. `dialog.showOpenDialog` accepts an optional
+    // `BrowserWindow` first arg for exactly this; if the caller didn't
+    // pass one we fall back to the focused window.
+    const window =
+      parentWindow ?? BrowserWindow.getFocusedWindow() ?? undefined;
+    const result = window
+      ? await dialog.showOpenDialog(window, {
+          title: "Add directory",
+          buttonLabel: "Add directory",
+          properties: ["openDirectory", "createDirectory"],
+        })
+      : await dialog.showOpenDialog({
+          title: "Add directory",
+          buttonLabel: "Add directory",
+          properties: ["openDirectory", "createDirectory"],
+        });
+    if (result.canceled || result.filePaths.length === 0) {
+      return { canceled: true };
+    }
+    return { canceled: false, path: result.filePaths[0] };
+  }
+
+  async registerDirectoryFromDisk(
+    request: RegisterDirectoryFromDiskRequest,
+  ): Promise<RegisterDirectoryFromDiskResponse> {
+    const registry = getDesktopBackendRegistry();
+    return await registerDirectoryFromDisk(request, {
+      ensureDirectoryLaunchpad: (req) => registry.ensureDirectoryLaunchpad(req),
+    });
+  }
+
   async analyzeFocusedDiff(
     request: FocusedDiffAnalysisRequest
   ): Promise<FocusedDiffAnalysisResponse> {
@@ -799,6 +841,29 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.resetDirectoryLaunchpad(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
+    async (event): Promise<PickDirectoryFromDiskResponse> => {
+      // Find the window that dispatched the IPC so the system "Choose
+      // folder" dialog anchors to it as a sheet on macOS. Falls back to
+      // the focused window inside `pickDirectoryFromDisk`.
+      const senderWindow = BrowserWindow.fromWebContents(event.sender);
+      return await appServerService.pickDirectoryFromDisk(
+        senderWindow ?? undefined,
+      );
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
+    async (
+      _event,
+      request: RegisterDirectoryFromDiskRequest,
+    ): Promise<RegisterDirectoryFromDiskResponse> => {
+      return await appServerService.registerDirectoryFromDisk(request);
+    },
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
@@ -820,6 +885,8 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,9 @@ import type {
   ListMessagingActivityResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  PickDirectoryFromDiskResponse,
+  RegisterDirectoryFromDiskRequest,
+  RegisterDirectoryFromDiskResponse,
   UnbindMessagingThreadRequest,
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
@@ -133,7 +136,9 @@ import {
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
+  NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
+  NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -357,6 +362,15 @@ const desktopApi = Object.freeze({
     request: ResetDirectoryLaunchpadRequest,
   ): Promise<ResetDirectoryLaunchpadResponse> =>
     await ipcRenderer.invoke(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  pickDirectoryFromDisk: async (): Promise<PickDirectoryFromDiskResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL),
+  registerDirectoryFromDisk: async (
+    request: RegisterDirectoryFromDiskRequest,
+  ): Promise<RegisterDirectoryFromDiskResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
+      request,
+    ),
   reportRendererError: async (report: RendererErrorReport): Promise<void> => {
     await ipcRenderer.invoke(RENDERER_ERROR_REPORT_CHANNEL, report);
   },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -194,6 +194,16 @@ function DesktopAppShell(props: {
           selectedDirectory={navigation.selectedDirectory}
           selectedLaunchpad={navigation.selectedLaunchpad}
           selectedThread={navigation.selectedThread}
+          directories={navigation.directories}
+          pickDirectoryError={navigation.pickDirectoryError}
+          pickingDirectory={navigation.pickingDirectory}
+          onSelectDirectoryFromPicker={(directory) => {
+            void navigation.openDirectoryLaunchpad(directory);
+          }}
+          onPickAndRegisterDirectory={() => {
+            void navigation.pickAndRegisterDirectory();
+          }}
+          onClearPickDirectoryError={navigation.clearPickDirectoryError}
           setExecutionModeError={navigation.setThreadExecutionModeError}
           setThreadModelSettingsError={navigation.setThreadModelSettingsError}
           skillError={skills.error}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -52,6 +52,7 @@ import {
 } from "./ComposerRichInput";
 import { ComposerTextareaInput } from "./ComposerTextareaInput";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
+import { ProjectPicker } from "./ProjectPicker";
 import {
   useComposerDraftStore,
   type ComposerDraftSnapshot,
@@ -69,6 +70,13 @@ type ComposerProps = {
   applications?: DesktopApplicationsSnapshot;
   desktopApi?: DesktopApi;
   directory?: NavigationDirectorySummary;
+  /**
+   * Full set of currently-tracked directories from the navigation
+   * snapshot. Used by the project picker (issue #223) to render the
+   * "recent directories" list. Optional so tests / threads-only
+   * surfaces don't have to provide it.
+   */
+  directories?: NavigationDirectorySummary[];
   disabled?: boolean;
   contextWindow?: ThreadContextWindowState;
   composerImplementation?: DesktopChatReplyComposer;
@@ -110,6 +118,16 @@ type ComposerProps = {
     options?: { stickySettingsChanged?: boolean }
   ) => Promise<void>;
   removeOptimisticMessage?: (id: string) => void;
+  /**
+   * Project-directory picker plumbing (issue #223). Optional — surfaces
+   * that don't render a launchpad (read-only thread views) won't pass
+   * these through and the picker won't render.
+   */
+  onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
+  onPickAndRegisterDirectory?: () => void;
+  onClearPickDirectoryError?: () => void;
+  pickDirectoryError?: string;
+  pickingDirectory?: boolean;
   setExecutionModeError?: string;
   skillError?: string;
   skillLoading?: boolean;
@@ -3621,6 +3639,35 @@ export function Composer(props: ComposerProps) {
                 ) {
                   void props.onSetExecutionMode?.(executionMode);
                 }
+              }}
+            />
+          ) : null}
+
+          {props.launchpad &&
+          (props.onSelectDirectoryFromPicker || props.onPickAndRegisterDirectory) ? (
+            // Project picker (issue #223). Only render in the launchpad
+            // surface — once a thread exists, the directory binding is
+            // immutable. The current directory shows as the trigger
+            // value when the launchpad is anchored to an actual
+            // directory; the synthesized "workspace:new-thread"
+            // launchpad reads as "No selected project" instead.
+            <ProjectPicker
+              value={
+                props.directory && props.directory.kind === "directory"
+                  ? props.directory
+                  : undefined
+              }
+              directories={props.directories ?? []}
+              disabled={launchpadSubmitting}
+              pickError={props.pickDirectoryError}
+              picking={props.pickingDirectory}
+              onSelect={(directory) => {
+                props.onClearPickDirectoryError?.();
+                props.onSelectDirectoryFromPicker?.(directory);
+              }}
+              onPickFromDisk={() => {
+                props.onClearPickDirectoryError?.();
+                props.onPickAndRegisterDirectory?.();
               }}
             />
           ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState, type ReactElement } from "react";
 import type { NavigationDirectorySummary } from "@pwragent/shared";
+import { FolderIcon } from "../../icons";
 
 /**
  * Project-directory picker for the new-thread composer (issue #223).
@@ -114,6 +115,12 @@ export function ProjectPicker(props: ProjectPickerProps): ReactElement {
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
+        // When the most-recent register attempt failed, point screen
+        // readers at the inline error so it's announced when focus
+        // returns to the trigger. `aria-describedby` is wider-supported
+        // than `aria-errormessage`, and the message is short enough to
+        // read fluently as a description.
+        aria-describedby={props.pickError ? errorId : undefined}
         aria-label={
           props.value ? `Project: ${buttonLabel}` : "Choose a project"
         }
@@ -123,19 +130,7 @@ export function ProjectPicker(props: ProjectPickerProps): ReactElement {
         disabled={props.disabled}
         onClick={() => setOpen((current) => !current)}
       >
-        <svg
-          aria-hidden="true"
-          width="11"
-          height="11"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-        </svg>
+        <FolderIcon size={11} />
         <span className="project-picker__label">{buttonLabel}</span>
         <span className="project-picker__chevron" aria-hidden="true">
           ⌄

--- a/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useId, useMemo, useRef, useState, type ReactElement } from "react";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+
+/**
+ * Project-directory picker for the new-thread composer (issue #223).
+ *
+ * Behavior:
+ *   - The button reads "No selected project" (dashed border) when no
+ *     directory is selected, or shows the current directory's label
+ *     otherwise.
+ *   - Opening the popover lists tracked directories (workspace + plain
+ *     directory entries) sorted by `latestUpdatedAt` desc, capped at 10.
+ *     A search input filters by label or path.
+ *   - The "+ Add directory…" action at the bottom triggers the system
+ *     "Choose folder" dialog via the desktop bridge. Validation lives in
+ *     the main process — the picker just surfaces the inline error
+ *     string when registration fails (e.g. "not a git repo").
+ *
+ * The picker is presentation-only; the parent is responsible for
+ * wiring `onSelect` (existing directory) and `onPickFromDisk`
+ * (system dialog → register flow). Errors come back through the
+ * `pickError` prop so we don't keep transient async state inside this
+ * component — that lives in the parent's hook.
+ */
+export type ProjectPickerProps = {
+  /** Currently-selected directory, if any. */
+  value?: NavigationDirectorySummary;
+  /** All tracked directories from the navigation snapshot. */
+  directories: NavigationDirectorySummary[];
+  /** Disabled while a thread is being materialized, etc. */
+  disabled?: boolean;
+  /** Inline error string from the most-recent register attempt. */
+  pickError?: string;
+  /** Whether the system dialog is currently open / register in flight. */
+  picking?: boolean;
+  onSelect: (directory: NavigationDirectorySummary) => void;
+  onPickFromDisk: () => void;
+};
+
+const RECENTS_LIMIT = 10;
+
+function formatLabel(directory: NavigationDirectorySummary): string {
+  return directory.label || directory.path || directory.key;
+}
+
+function formatPath(directory: NavigationDirectorySummary): string {
+  return directory.path ?? "—";
+}
+
+function isPickable(directory: NavigationDirectorySummary): boolean {
+  // The "unlinked" pseudo-directory and our internal scratch
+  // workspace-collector entry are not pickable from the project picker
+  // — they don't correspond to a folder the user picked.
+  return directory.kind !== "unlinked";
+}
+
+export function ProjectPicker(props: ProjectPickerProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const listboxId = useId();
+  const errorId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const sorted = useMemo(() => {
+    const pickable = props.directories.filter(isPickable);
+    const ordered = [...pickable].sort(
+      (left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0),
+    );
+    const top = ordered.slice(0, RECENTS_LIMIT);
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) {
+      return top;
+    }
+    return top.filter((directory) => {
+      const label = formatLabel(directory).toLowerCase();
+      const path = (directory.path ?? "").toLowerCase();
+      return label.includes(trimmed) || path.includes(trimmed);
+    });
+  }, [props.directories, query]);
+
+  const buttonLabel = props.value ? formatLabel(props.value) : "No selected project";
+  const isEmpty = !props.value;
+
+  return (
+    <span
+      ref={containerRef}
+      className="project-picker"
+      data-state={open ? "open" : "closed"}
+    >
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-label={
+          props.value ? `Project: ${buttonLabel}` : "Choose a project"
+        }
+        className={`project-picker__trigger${
+          isEmpty ? " is-empty" : " is-active"
+        }`}
+        disabled={props.disabled}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <svg
+          aria-hidden="true"
+          width="11"
+          height="11"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+        </svg>
+        <span className="project-picker__label">{buttonLabel}</span>
+        <span className="project-picker__chevron" aria-hidden="true">
+          ⌄
+        </span>
+      </button>
+
+      {open ? (
+        <div className="project-picker__pop" role="dialog" aria-label="Project picker">
+          <div className="project-picker__search">
+            <input
+              type="text"
+              autoFocus
+              placeholder="Search directories"
+              className="project-picker__search-input"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+
+          <div className="project-picker__section">Recent directories</div>
+          <ul
+            className="project-picker__list"
+            id={listboxId}
+            role="listbox"
+            aria-label="Tracked directories"
+          >
+            {sorted.length === 0 ? (
+              <li className="project-picker__empty">
+                {query ? "No matches." : "No tracked directories yet."}
+              </li>
+            ) : (
+              sorted.map((directory) => {
+                const active =
+                  props.value && props.value.key === directory.key;
+                return (
+                  <li key={directory.key}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={Boolean(active)}
+                      className={`project-picker__row${
+                        active ? " is-active" : ""
+                      }`}
+                      onClick={() => {
+                        setOpen(false);
+                        props.onSelect(directory);
+                      }}
+                    >
+                      <span className="project-picker__row-name">
+                        {formatLabel(directory)}
+                      </span>
+                      <span className="project-picker__row-path">
+                        {formatPath(directory)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+
+          <div className="project-picker__separator" />
+
+          <button
+            type="button"
+            className="project-picker__row project-picker__row--action"
+            disabled={props.picking}
+            onClick={() => {
+              setOpen(false);
+              props.onPickFromDisk();
+            }}
+          >
+            <span aria-hidden="true" className="project-picker__plus">
+              +
+            </span>
+            <span className="project-picker__row-name">
+              {props.picking ? "Picking…" : "Add directory…"}
+            </span>
+          </button>
+
+          {props.pickError ? (
+            <p
+              id={errorId}
+              role="alert"
+              className="project-picker__error"
+            >
+              {props.pickError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
@@ -1,0 +1,236 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProjectPicker } from "../ProjectPicker";
+
+afterEach(() => {
+  cleanup();
+});
+
+const dirA: NavigationDirectorySummary = {
+  key: "directory:/Users/me/code/PwrAgent",
+  kind: "directory",
+  label: "PwrAgent",
+  path: "/Users/me/code/PwrAgent",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 1_000,
+};
+
+const dirB: NavigationDirectorySummary = {
+  key: "directory:/Users/me/code/PwrSnap",
+  kind: "directory",
+  label: "PwrSnap",
+  path: "/Users/me/code/PwrSnap",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 2_000,
+};
+
+const workspace: NavigationDirectorySummary = {
+  key: "workspace:scratch",
+  kind: "workspace",
+  label: "Workspaces",
+  path: "/Users/me/.pwragent/projects",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 500,
+};
+
+const unlinked: NavigationDirectorySummary = {
+  key: "unlinked",
+  kind: "unlinked",
+  label: "No linked directory",
+  threadKeys: [],
+  needsAttentionCount: 0,
+};
+
+describe("ProjectPicker", () => {
+  it("reads 'No selected project' with a dashed trigger when no value is set", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /choose a project/i });
+    expect(trigger).toHaveTextContent("No selected project");
+    expect(trigger.className).toContain("is-empty");
+  });
+
+  it("shows the current directory's label when a value is set", () => {
+    render(
+      <ProjectPicker
+        value={dirA}
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /project: pwragent/i }),
+    ).toHaveTextContent("PwrAgent");
+  });
+
+  it("opens a popover with tracked directories sorted by latestUpdatedAt desc", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA, dirB, workspace]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+
+    const list = screen.getByRole("listbox", { name: /tracked directories/i });
+    const rows = within(list).getAllByRole("option");
+    // Workspace + dirB (most recent) + dirA. Workspace IS pickable
+    // (kind "workspace") so it surfaces in the picker — only "unlinked"
+    // is filtered out.
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent("PwrSnap");
+    expect(rows[1]).toHaveTextContent("PwrAgent");
+    expect(rows[2]).toHaveTextContent("Workspaces");
+  });
+
+  it("filters out the 'unlinked' pseudo-directory", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA, unlinked]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    const list = screen.getByRole("listbox", { name: /tracked directories/i });
+    const rows = within(list).getAllByRole("option");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("PwrAgent");
+  });
+
+  it("filters by query against label or path", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA, dirB]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    const search = screen.getByPlaceholderText("Search directories");
+    fireEvent.change(search, { target: { value: "snap" } });
+
+    const list = screen.getByRole("listbox", { name: /tracked directories/i });
+    const rows = within(list).getAllByRole("option");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("PwrSnap");
+  });
+
+  it("invokes onSelect when an existing directory is clicked", () => {
+    const onSelect = vi.fn();
+    render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={onSelect}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    fireEvent.click(screen.getByRole("option", { name: /pwragent/i }));
+
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(dirA);
+  });
+
+  it("invokes onPickFromDisk when 'Add directory…' is clicked", () => {
+    const onPickFromDisk = vi.fn();
+    render(
+      <ProjectPicker
+        directories={[]}
+        onSelect={() => undefined}
+        onPickFromDisk={onPickFromDisk}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add directory/i }));
+
+    expect(onPickFromDisk).toHaveBeenCalledOnce();
+  });
+
+  it("disables the Add directory… row while picking is in flight", () => {
+    render(
+      <ProjectPicker
+        directories={[]}
+        picking
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    expect(screen.getByRole("button", { name: /picking/i })).toBeDisabled();
+  });
+
+  it("renders the inline pickError as an alert", () => {
+    render(
+      <ProjectPicker
+        directories={[]}
+        pickError="That folder isn't a git repository."
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /isn't a git repository/i,
+    );
+  });
+
+  it("shows an empty-state message when no directories match", () => {
+    render(
+      <ProjectPicker
+        directories={[]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    expect(screen.getByText(/no tracked directories yet/i)).toBeInTheDocument();
+  });
+
+  it("closes the popover when Escape is pressed", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    expect(
+      screen.getByRole("listbox", { name: /tracked directories/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.queryByRole("listbox", { name: /tracked directories/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -603,6 +603,17 @@ type ThreadViewProps = {
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
+  /**
+   * Project-directory picker (issue #223) — surfaced in the launchpad
+   * composer when no thread is selected yet. Rendering happens inside
+   * `Composer.tsx`; we just plumb the data and callbacks through.
+   */
+  directories?: NavigationDirectorySummary[];
+  pickDirectoryError?: string;
+  pickingDirectory?: boolean;
+  onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
+  onPickAndRegisterDirectory?: () => void;
+  onClearPickDirectoryError?: () => void;
   setExecutionModeError?: string;
   setThreadModelSettingsError?: string;
   worktreeArchiveError?: string;
@@ -1482,12 +1493,18 @@ export function ThreadView(props: ThreadViewProps) {
               composerImplementation={props.composerImplementation}
               draftStore={props.composerDraftStore}
               directory={props.selectedDirectory}
+              directories={props.directories}
               disabled={!launchpadBackend?.available}
               launchpad={selectedLaunchpad}
               launchpadError={props.launchpadError}
               onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
               onMaterializeLaunchpad={handleMaterializeLaunchpad}
               onUpdateLaunchpad={props.onUpdateLaunchpad}
+              onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
+              onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
+              onClearPickDirectoryError={props.onClearPickDirectoryError}
+              pickDirectoryError={props.pickDirectoryError}
+              pickingDirectory={props.pickingDirectory}
               skillError={props.skillError}
               skillLoading={props.skillLoading}
               skills={props.skills}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1653,4 +1653,133 @@ describe("useThreadNavigation", () => {
       result.current.selectedThread?.messagingBindings?.[0]?.platform,
     ).toBe("discord");
   });
+
+  describe("pickAndRegisterDirectory (issue #223)", () => {
+    function buildBaseDesktopApi(
+      overrides: Partial<DesktopApi> = {},
+    ): DesktopApi {
+      return {
+        getNavigationSnapshot: vi.fn(async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        })),
+        onAgentEvent: () => () => undefined,
+        ...overrides,
+      };
+    }
+
+    it("seeds the launchpad and focuses it on a successful pick", async () => {
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/Users/me/repos/PwrAgent",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: true as const,
+        directoryPath: "/Users/me/repos/PwrAgent",
+        directoryKey: "directory:/Users/me/repos/PwrAgent",
+        directoryLabel: "PwrAgent",
+        currentBranch: "main",
+        launchpad: {
+          directoryKey: "directory:/Users/me/repos/PwrAgent",
+          directoryKind: "directory" as const,
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/me/repos/PwrAgent",
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        defaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      }));
+
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.pickAndRegisterDirectory();
+      });
+
+      expect(pickDirectoryFromDisk).toHaveBeenCalledOnce();
+      expect(registerDirectoryFromDisk).toHaveBeenCalledExactlyOnceWith({
+        path: "/Users/me/repos/PwrAgent",
+        preferredBackend: undefined,
+      });
+      expect(result.current.pickDirectoryError).toBeUndefined();
+      expect(result.current.pickingDirectory).toBe(false);
+      expect(result.current.selectedItemKey).toBe(
+        "launchpad:directory:/Users/me/repos/PwrAgent",
+      );
+    });
+
+    it("is silent when the user cancels the OS dialog", async () => {
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: true as const,
+      }));
+      const registerDirectoryFromDisk = vi.fn();
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.pickAndRegisterDirectory();
+      });
+
+      expect(registerDirectoryFromDisk).not.toHaveBeenCalled();
+      expect(result.current.pickDirectoryError).toBeUndefined();
+    });
+
+    it("surfaces an inline error when the chosen path is not a git repo", async () => {
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/tmp/not-a-repo",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: false as const,
+        reason: "not-a-git-repo" as const,
+        message: "/tmp/not-a-repo is not inside a git repository.",
+      }));
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.pickAndRegisterDirectory();
+      });
+
+      expect(result.current.pickDirectoryError).toContain("not inside a git");
+      expect(result.current.selectedItemKey).toBeUndefined();
+
+      // clearPickDirectoryError resets the inline error state.
+      act(() => {
+        result.current.clearPickDirectoryError();
+      });
+      expect(result.current.pickDirectoryError).toBeUndefined();
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -42,6 +42,9 @@ import type {
   ListMessagingActivityResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  PickDirectoryFromDiskResponse,
+  RegisterDirectoryFromDiskRequest,
+  RegisterDirectoryFromDiskResponse,
   UnbindMessagingThreadRequest,
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
@@ -221,6 +224,18 @@ export type DesktopApi = {
   resetDirectoryLaunchpad?: (
     request: ResetDirectoryLaunchpadRequest
   ) => Promise<ResetDirectoryLaunchpadResponse>;
+  /**
+   * Project-directory picker (issue #223): two-step flow so the renderer
+   * can show inline validation errors. `pickDirectoryFromDisk` opens the
+   * OS dialog and returns the chosen path (or `canceled: true` if the
+   * user dismissed). The renderer then calls `registerDirectoryFromDisk`
+   * with the path so the main process can validate it's a git repo and
+   * seed a launchpad in one round-trip.
+   */
+  pickDirectoryFromDisk?: () => Promise<PickDirectoryFromDiskResponse>;
+  registerDirectoryFromDisk?: (
+    request: RegisterDirectoryFromDiskRequest,
+  ) => Promise<RegisterDirectoryFromDiskResponse>;
   normalizeImageForUpload?: (
     request: ImageUploadFallbackRequest
   ) => Promise<ImageUploadFallbackResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -948,6 +948,13 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
+  /** Project-directory picker (issue #223): OS dialog → validate → seed launchpad → focus it. */
+  pickAndRegisterDirectory: (
+    preferredBackend?: AppServerBackendKind,
+  ) => Promise<void>;
+  pickDirectoryError?: string;
+  pickingDirectory: boolean;
+  clearPickDirectoryError: () => void;
   resetDirectoryLaunchpad: (directoryKey: string) => Promise<void>;
   selectedDirectory?: NavigationDirectorySummary;
   selectedItemKey?: string;
@@ -1034,6 +1041,13 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     useState<string>();
   const [setThreadModelSettingsError, setSetThreadModelSettingsError] =
     useState<string>();
+  // Project-directory picker (issue #223). `pickAndRegisterDirectory`
+  // bridges the OS dialog → register flow; while it's in flight we
+  // disable the picker's "Add directory…" row, and any validation
+  // failure surfaces inline via `pickDirectoryError`. Both reset on the
+  // next attempt rather than persisting between renders.
+  const [pickDirectoryError, setPickDirectoryError] = useState<string>();
+  const [pickingDirectory, setPickingDirectory] = useState(false);
   const [state, setState] = useState<NavigationState>({
     loading: true,
     refreshing: false,
@@ -1785,6 +1799,65 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     [desktopApi]
   );
 
+  const pickAndRegisterDirectory = useCallback(
+    async (preferredBackend?: AppServerBackendKind): Promise<void> => {
+      // Two-step OS-dialog → register-as-launchpad flow (issue #223).
+      // We separate the cancel path (silent — the user closed the
+      // dialog) from the validation-failure path (loud — we surface
+      // the inline error so the picker can render it). The success
+      // path navigates to the new directory's launchpad immediately
+      // so the composer focuses the just-added directory without an
+      // extra click.
+      if (
+        !desktopApi?.pickDirectoryFromDisk ||
+        !desktopApi?.registerDirectoryFromDisk
+      ) {
+        setPickDirectoryError(
+          "Desktop bridge is missing the directory picker.",
+        );
+        return;
+      }
+
+      setPickDirectoryError(undefined);
+      setPickingDirectory(true);
+
+      try {
+        const pick = await desktopApi.pickDirectoryFromDisk();
+        if (pick.canceled) {
+          return;
+        }
+        const result = await desktopApi.registerDirectoryFromDisk({
+          path: pick.path,
+          preferredBackend,
+        });
+        if (!result.ok) {
+          setPickDirectoryError(result.message);
+          return;
+        }
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdate(
+            current.response,
+            result.launchpad,
+            result.defaults,
+          ),
+        }));
+        setSelectedItemKey(buildLaunchpadSelectionKey(result.directoryKey));
+      } catch (error) {
+        setPickDirectoryError(
+          error instanceof Error ? error.message : String(error),
+        );
+      } finally {
+        setPickingDirectory(false);
+      }
+    },
+    [desktopApi],
+  );
+
+  const clearPickDirectoryError = useCallback((): void => {
+    setPickDirectoryError(undefined);
+  }, []);
+
   const updateDirectoryLaunchpad = useCallback(
     async (
       directoryKey: string,
@@ -2372,6 +2445,10 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     refresh: async () => await refresh(),
     materializeDirectoryLaunchpad,
     openDirectoryLaunchpad,
+    pickAndRegisterDirectory,
+    pickDirectoryError,
+    pickingDirectory,
+    clearPickDirectoryError,
     resetDirectoryLaunchpad,
     selectedDirectory,
     selectedItemKey,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5758,6 +5758,213 @@ textarea,
   background: var(--border-subtle);
 }
 
+/* ===========================================================
+   Project picker (issue #223)
+   ===========================================================
+   Shares the visual language of `.composer-dropdown` so the
+   project pill reads as a peer of the workspace / model / branch
+   pickers in the launchpad row. The dashed border on the empty
+   state mirrors `pa-pick--proj.is-empty` from the v2 design
+   prototype (`docs/design/pwragent-v2/project/newthread.css`).
+*/
+
+.project-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.project-picker__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  max-width: 240px;
+}
+
+.project-picker__trigger:hover:not(:disabled),
+.project-picker__trigger:focus-visible:not(:disabled) {
+  border-color: var(--accent-border);
+  outline: none;
+}
+
+.project-picker__trigger:disabled {
+  color: var(--text-secondary);
+  cursor: default;
+}
+
+.project-picker__trigger.is-empty {
+  border-style: dashed;
+  color: var(--text-muted);
+}
+
+.project-picker__trigger.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.project-picker__label {
+  min-width: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-picker__chevron {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.project-picker__pop {
+  position: absolute;
+  z-index: 30;
+  bottom: calc(100% + 8px);
+  left: 0;
+  min-width: 360px;
+  max-width: min(440px, calc(100vw - 32px));
+  max-height: min(420px, calc(100dvh - 128px));
+  padding: 6px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.project-picker__search {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.project-picker__search-input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  padding: 4px 0;
+}
+
+.project-picker__search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.project-picker__section {
+  padding: 6px 10px 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.project-picker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.project-picker__row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.project-picker__row:hover:not(:disabled),
+.project-picker__row:focus-visible:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.project-picker__row.is-active {
+  color: var(--accent-bright);
+}
+
+.project-picker__row:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.project-picker__row-name {
+  flex: 0 0 auto;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.project-picker__row-path {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.project-picker__row--action {
+  color: var(--accent-bright);
+}
+
+.project-picker__plus {
+  display: inline-flex;
+  width: 14px;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.project-picker__separator {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border-subtle);
+}
+
+.project-picker__empty {
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.project-picker__error {
+  margin: 4px 8px 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: var(--errored-soft, rgba(255, 90, 90, 0.08));
+  color: var(--errored, var(--accent-bright));
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .workspace-handoff-modal {
   position: fixed;
   z-index: 100;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5981,8 +5981,11 @@ textarea,
   margin: 4px 8px 6px;
   padding: 6px 8px;
   border-radius: 6px;
-  background: var(--errored-soft, rgba(255, 90, 90, 0.08));
-  color: var(--errored, var(--accent-bright));
+  /* Canonical danger pair — same tokens used by .settings-panel--error
+     and .messaging-status-chip--errored. Don't introduce a new error
+     token name (UI-THEME.md). */
+  background: var(--danger-soft);
+  color: var(--danger-text);
   font-size: 12px;
   line-height: 1.35;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5825,17 +5825,24 @@ textarea,
   line-height: 1;
 }
 
+/* The popover itself is a fixed-size flex column. The search row +
+   section header are pinned to the top, the "Add directory…" row + any
+   inline error are pinned to the bottom, and only the directories list
+   in the middle scrolls. Critically, the popover height does NOT shrink
+   when the user filters down to fewer matches — the list region just
+   leaves blank space. Resizing the popover on every keystroke shifts
+   the action row vertically and is hard to use. */
 .project-picker__pop {
   position: absolute;
   z-index: 30;
   bottom: calc(100% + 8px);
   left: 0;
-  min-width: 360px;
-  max-width: min(440px, calc(100vw - 32px));
-  max-height: min(420px, calc(100dvh - 128px));
+  width: 440px;
+  max-width: calc(100vw - 32px);
+  height: 420px;
+  max-height: calc(100dvh - 128px);
   padding: 6px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  overflow: hidden;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
@@ -5846,6 +5853,7 @@ textarea,
 }
 
 .project-picker__search {
+  flex: 0 0 auto;
   padding: 4px 6px;
   border-bottom: 1px solid var(--border-subtle);
 }
@@ -5866,6 +5874,7 @@ textarea,
 }
 
 .project-picker__section {
+  flex: 0 0 auto;
   padding: 6px 10px 4px;
   font-size: 11px;
   color: var(--text-muted);
@@ -5874,6 +5883,13 @@ textarea,
 }
 
 .project-picker__list {
+  flex: 1 1 0;
+  /* `min-height: 0` is required for a flex child whose content overflows
+     to actually scroll — without it the list grows past its parent and
+     the popover scroll is taken over by the wrong region. */
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -5933,6 +5949,10 @@ textarea,
 }
 
 .project-picker__row--action {
+  /* Pinned to the bottom of the popover — the directories list above
+     is the only flex-grow child, so this row sits at the bottom edge
+     regardless of how short the (filtered) list becomes. */
+  flex: 0 0 auto;
   color: var(--accent-bright);
 }
 
@@ -5944,6 +5964,7 @@ textarea,
 }
 
 .project-picker__separator {
+  flex: 0 0 auto;
   height: 1px;
   margin: 4px 2px;
   background: var(--border-subtle);
@@ -5956,6 +5977,7 @@ textarea,
 }
 
 .project-picker__error {
+  flex: 0 0 auto;
   margin: 4px 8px 6px;
   padding: 6px 8px;
   border-radius: 6px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -91,6 +91,18 @@ export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:update-directory-launchpad";
 export const NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:reset-directory-launchpad";
+/**
+ * IPC channels backing the project-directory picker (issue #223). The
+ * renderer first asks the main process to open the OS dialog (`pick`)
+ * and, on a confirmed pick, follows up with `register` so the main
+ * process can validate the path and seed a launchpad in one round-trip.
+ * Splitting them keeps the dialog itself uncancelable from the renderer
+ * while letting the picker surface validation errors inline.
+ */
+export const NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL =
+  "navigation:pick-directory-from-disk";
+export const NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL =
+  "navigation:register-directory-from-disk";
 export const RENDERER_ERROR_REPORT_CHANNEL = "renderer:error-report";
 export const IMAGE_UPLOAD_FALLBACK_CHANNEL = "image-upload:fallback";
 export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =

--- a/docs/design/pwragent-v2/project/PwrAgnt v2.html
+++ b/docs/design/pwragent-v2/project/PwrAgnt v2.html
@@ -5,6 +5,7 @@
 <title>PwrAgent — Threads</title>
 <link rel="stylesheet" href="lib/colors_and_type.css">
 <link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="newthread.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
@@ -17,6 +18,7 @@
 <script type="text/babel" src="sidebar.jsx"></script>
 <script type="text/babel" src="threadview.jsx"></script>
 <script type="text/babel" src="rightrail.jsx"></script>
+<script type="text/babel" src="newthread.jsx"></script>
 <script type="text/babel" src="settings.jsx"></script>
 <script type="text/babel" src="activity.jsx"></script>
 <script type="text/babel" src="tweaks-panel.jsx"></script>
@@ -101,7 +103,7 @@ const PLATFORMS = [
 
 /* -------- defaults / tweaks -------- */
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
-  "lens": "Inbox",
+  "lens": "Directories",
   "messagingOn": true,
   "blinkTelegram": false,
   "showRail": false,
@@ -113,10 +115,19 @@ function App() {
   const I = window.PA.Icon;
   const [tweaks, setTweak] = window.useTweaks(TWEAK_DEFAULTS);
 
-  const [screen, setScreen] = useState("main"); // main | settings | activity
+  const [screen, setScreen] = useState("main"); // main | settings | activity | newthread
   const [settingsSection, setSettingsSection] = useState("messaging");
   const [selectedId, setSelectedId] = useState("t1");
   const [data, setData] = useState(SEED);
+  const [recents, setRecents] = useState(() => SEED.map((g, i) => ({
+    dir: g.dir,
+    branch: g.branch,
+    path: `/Users/huntharo/github/${g.dir}`,
+    isRepo: true,
+    threadCount: g.threads.length,
+    lastUsed: Date.now() - i * 60000,
+  })));
+  const [preselectProject, setPreselectProject] = useState(null);
   const [lens, setLens] = useState(tweaks.lens || "Inbox");
   const [messagingOn, setMessagingOn] = useState(!!tweaks.messagingOn);
   const [showRail, setShowRail] = useState(!!tweaks.showRail);
@@ -141,6 +152,9 @@ function App() {
     }
     if (screen === "activity") {
       return [{ label: "Messaging", eyebrow: "Live" }, { label: "Activity" }];
+    }
+    if (screen === "newthread") {
+      return [{ label: "PwrAgent", eyebrow: "App" }, { label: "New thread" }];
     }
     return [
       { label: selected?.dir || "—", eyebrow: "Folder" },
@@ -226,6 +240,7 @@ function App() {
         onOpenActivity={() => setScreen("activity")}
         onOpenSettings={() => setScreen("settings")}
         onToggleRail={() => { const v = !showRail; setShowRail(v); setTweak("showRail", v); }}
+        onNewThread={() => { setPreselectProject(null); setScreen("newthread"); }}
       />
 
       {!messagingOn && (
@@ -238,23 +253,64 @@ function App() {
         </div>
       )}
 
-      {screen === "main" && (
-        <div className={`pa-window ${showRail ? "" : "no-rail"}`}>
+      {(screen === "main" || screen === "newthread") && (
+        <div className={`pa-window ${showRail && screen === "main" ? "" : "no-rail"}`}>
           <window.PA.Sidebar
             showDevContext={tweaks.showDevContext}
             data={data}
-            selectedId={selectedId}
-            onSelect={setSelectedId}
+            selectedId={screen === "newthread" ? null : selectedId}
+            onSelect={(id) => { setSelectedId(id); setScreen("main"); }}
             lens={lens}
             setLens={(v) => { setLens(v); setTweak("lens", v); }}
             contextDir={ctxDir}
             contextBranch={ctxBranch}
+            newThreadActive={screen === "newthread"}
             onAddReaction={addReaction}
             onUnbindPlatform={unbindPlatform}
-            onNewThread={() => alert("New thread")}
+            onNewThread={() => { setPreselectProject(null); setScreen("newthread"); }}
+            onNewThreadInDir={(group) => {
+              const r = recents.find((x) => x.dir === group.dir);
+              setPreselectProject(r || { dir: group.dir, branch: group.branch, path: `/Users/huntharo/github/${group.dir}`, isRepo: true, lastUsed: Date.now() });
+              setScreen("newthread");
+            }}
           />
-          {threadForView && <window.PA.ThreadView thread={threadForView} onSend={sendMessage} />}
-          {showRail && (
+          {screen === "main" && threadForView && <window.PA.ThreadView thread={threadForView} onSend={sendMessage} />}
+          {screen === "newthread" && (
+            <window.PA.NewThread
+              recents={recents}
+              initialProject={preselectProject}
+              onCancel={() => setScreen("main")}
+              onStart={({ project, text, worktreeMode }) => {
+                const now = Date.now();
+                const newThreadObj = {
+                  id: `nt-${now}`,
+                  title: text.length > 60 ? text.slice(0, 60) + "\u2026" : text,
+                  time: "now",
+                  platforms: [],
+                  chips: [{ label: "OpenAI" }, { label: worktreeMode === "worktree" ? "Worktree" : "Local" }],
+                  branch: project.branch || "main",
+                  working: true,
+                };
+                setData((d) => {
+                  const idx = d.findIndex((g) => g.dir === project.dir);
+                  if (idx === -1) return [{ dir: project.dir, branch: project.branch || "main", threads: [newThreadObj] }, ...d];
+                  const next = [...d];
+                  next[idx] = { ...next[idx], threads: [newThreadObj, ...next[idx].threads] };
+                  return next;
+                });
+                setRecents((rs) => {
+                  const idx = rs.findIndex((r) => r.dir === project.dir);
+                  if (idx === -1) return [{ ...project, isNew: false, lastUsed: now, threadCount: 1 }, ...rs];
+                  const next = [...rs];
+                  next[idx] = { ...next[idx], lastUsed: now, threadCount: (next[idx].threadCount || 0) + 1 };
+                  return next;
+                });
+                setSelectedId(newThreadObj.id);
+                setScreen("main");
+              }}
+            />
+          )}
+          {showRail && screen === "main" && (
             <window.PA.RightRail
               thread={selected}
               platforms={PLATFORMS}

--- a/docs/design/pwragent-v2/project/newthread.css
+++ b/docs/design/pwragent-v2/project/newthread.css
@@ -1,0 +1,414 @@
+/* ============================================================
+   NEW THREAD SCREEN
+   ============================================================ */
+.pa-newthread {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-thread, var(--bg-panel));
+}
+.pa-newthread__inner {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 32px 18px;
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* ---- Header ---- */
+.pa-newthread__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+.pa-newthread__eyebrow-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pa-newthread__eyebrow {
+  font: 700 10px/1 var(--font-sans);
+  color: var(--accent);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-right: 2px;
+}
+.pa-pill2 {
+  display: inline-flex; align-items: center;
+  height: 22px; padding: 0 8px;
+  border-radius: 11px;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font: 500 11px/1 var(--font-sans);
+}
+.pa-newthread__spacer { flex: 1; }
+.pa-newthread__meta {
+  display: flex;
+  gap: 36px;
+}
+.pa-newthread__meta-col { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.pa-newthread__meta-label {
+  font: 500 10px/1 var(--font-sans);
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.pa-newthread__meta-value {
+  font: 600 13px/1.2 var(--font-sans);
+  color: var(--text-primary);
+}
+.pa-newthread__title {
+  font: 700 30px/1.05 var(--font-sans);
+  color: var(--text-primary);
+  margin: 4px 0 0;
+  letter-spacing: -0.01em;
+}
+
+/* ---- Project info card ---- */
+.pa-newthread__card {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px 48px;
+  padding: 18px 22px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--bg-panel) 60%, transparent);
+}
+.pa-newthread__card-col {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+.pa-newthread__card-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.pa-newthread__field-label {
+  font: 500 10px/1 var(--font-sans);
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.pa-newthread__field-value {
+  font: 500 14px/1.25 var(--font-sans);
+  color: var(--text-secondary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.pa-newthread__field-value--strong {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 16px;
+}
+.pa-newthread__field-value--mono {
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.pa-newthread__card--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-style: dashed;
+  border-color: color-mix(in oklab, var(--border-subtle) 70%, transparent);
+  background: transparent;
+  padding: 36px 22px;
+  grid-template-columns: none;
+}
+.pa-newthread__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  text-align: center;
+}
+.pa-newthread__empty-title {
+  font: 600 14px/1.2 var(--font-sans);
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+.pa-newthread__empty-sub {
+  font: 400 12px/1.4 var(--font-sans);
+  color: var(--text-muted);
+  max-width: 360px;
+}
+
+.pa-newthread__filler { flex: 1; min-height: 18px; }
+
+/* ---- Composer adjustments inside new thread ---- */
+.pa-newthread__compose-input {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+.pa-newthread__textarea { min-height: 84px; padding-top: 30px; }
+.pa-slash {
+  position: absolute;
+  top: 4px; left: 0;
+  display: inline-flex; align-items: center;
+  height: 22px; padding: 0 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  color: var(--accent-bright);
+  font: 600 11px/1 var(--font-mono);
+}
+
+.pa-newthread__addnote {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 24px; padding: 0 9px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent-bright);
+  font: 500 11px/1 var(--font-sans);
+}
+.pa-newthread__addnote strong { color: var(--accent-bright); font-weight: 700; }
+
+.pa-newthread__cancel {
+  height: 28px; padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 12px/1 var(--font-sans);
+  cursor: pointer;
+}
+.pa-newthread__cancel:hover { border-color: var(--accent-border); color: var(--text-primary); }
+
+.pa-sb__newthread.is-active {
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ---- Project picker ---- */
+.pa-pick--proj {
+  max-width: 240px;
+}
+.pa-pick--proj.is-empty {
+  color: var(--text-muted);
+  border-style: dashed;
+}
+.pa-pick--proj.is-active {
+  border-color: var(--accent-border);
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  color: var(--text-primary);
+}
+.pa-pick__txt {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 160px;
+}
+
+.pa-projpop {
+  position: absolute;
+  min-width: 360px;
+  max-width: 440px;
+  padding: 6px;
+  z-index: 30;
+}
+.pa-projpop__head {
+  display: flex; align-items: center; gap: 7px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 4px;
+  color: var(--text-muted);
+}
+.pa-projpop__search {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--text-primary);
+  font: 500 12px/1 var(--font-sans);
+}
+.pa-projpop__search::placeholder { color: var(--text-muted); }
+.pa-projpop__section {
+  padding: 6px 10px 4px;
+  font: 600 10px/1 var(--font-sans);
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.pa-projpop__row {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border-radius: 6px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 12px/1 var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+}
+.pa-projpop__row:hover { background: var(--bg-row-hover, color-mix(in oklab, var(--accent) 10%, transparent)); color: var(--text-primary); }
+.pa-projpop__row.is-active { color: var(--accent-bright); }
+.pa-projpop__name { color: var(--text-primary); flex: 0 0 auto; max-width: 130px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pa-projpop__path {
+  flex: 1;
+  font: 400 11px/1 var(--font-mono);
+  color: var(--text-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  text-align: right;
+}
+.pa-projpop__hint {
+  font: 500 10px/1 var(--font-mono);
+  color: var(--text-muted);
+}
+.pa-projpop__sep {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 4px 4px;
+}
+.pa-projpop__row--action { color: var(--accent-bright); }
+.pa-projpop__row--action .pa-projpop__name { color: var(--accent-bright); }
+.pa-projpop__empty {
+  padding: 10px 12px;
+  color: var(--text-muted);
+  font: 400 12px/1.4 var(--font-sans);
+}
+
+/* ---- File browser modal ---- */
+.pa-fb__scrim {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in oklab, #000 55%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  backdrop-filter: blur(2px);
+}
+.pa-fb {
+  width: 560px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+  overflow: hidden;
+}
+.pa-fb__head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.pa-fb__nav, .pa-fb__close {
+  width: 24px; height: 24px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 5px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.pa-fb__nav:disabled { opacity: 0.4; cursor: not-allowed; }
+.pa-fb__nav:hover:not(:disabled), .pa-fb__close:hover { border-color: var(--accent-border); color: var(--text-primary); }
+.pa-fb__crumbs {
+  flex: 1;
+  display: flex; align-items: center; gap: 4px;
+  font: 500 12px/1 var(--font-mono);
+  color: var(--text-secondary);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.pa-fb__crumb {
+  background: transparent;
+  border: 0;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font: 500 12px/1 var(--font-mono);
+  cursor: pointer;
+}
+.pa-fb__crumb:hover { background: var(--bg-row-hover, color-mix(in oklab, var(--accent) 8%, transparent)); color: var(--text-primary); }
+.pa-fb__crumb-sep { color: var(--text-muted); }
+.pa-fb__body {
+  flex: 1;
+  min-height: 240px;
+  overflow-y: auto;
+  padding: 6px;
+}
+.pa-fb__empty {
+  padding: 22px;
+  text-align: center;
+  color: var(--text-muted);
+  font: 400 12px/1.4 var(--font-sans);
+}
+.pa-fb__row {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 5px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 12px/1 var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+}
+.pa-fb__row:hover { background: var(--bg-row-hover, color-mix(in oklab, var(--accent) 8%, transparent)); color: var(--text-primary); }
+.pa-fb__row.is-selected {
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+  color: var(--accent-bright);
+}
+.pa-fb__name { flex: 1; }
+.pa-fb__badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  height: 18px; padding: 0 7px;
+  border-radius: 9px;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font: 500 10px/1 var(--font-mono);
+}
+.pa-fb__foot {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+.pa-fb__path {
+  flex: 1;
+  font: 400 11px/1.3 var(--font-mono);
+  color: var(--text-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.pa-fb__cancel, .pa-fb__choose {
+  height: 28px; padding: 0 14px;
+  border-radius: 6px;
+  font: 500 12px/1 var(--font-sans);
+  cursor: pointer;
+}
+.pa-fb__cancel {
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+}
+.pa-fb__cancel:hover { border-color: var(--accent-border); color: var(--text-primary); }
+.pa-fb__choose {
+  border: 1px solid var(--accent-border);
+  background: var(--accent);
+  color: var(--button-text-on-accent, #1a1a1a);
+  font-weight: 600;
+}
+.pa-fb__choose:hover:not(:disabled) { background: var(--accent-strong, var(--accent)); }
+.pa-fb__choose:disabled { opacity: 0.5; cursor: not-allowed; }
+.pa-fb__hint {
+  padding: 8px 14px 10px;
+  font: 400 11px/1.4 var(--font-sans);
+  color: var(--text-muted);
+  background: color-mix(in oklab, var(--accent) 4%, transparent);
+}

--- a/docs/design/pwragent-v2/project/newthread.jsx
+++ b/docs/design/pwragent-v2/project/newthread.jsx
@@ -1,0 +1,454 @@
+/* eslint-disable */
+const { useState: useStateNT, useRef: useRefNT, useEffect: useEffectNT, useMemo: useMemoNT } = React;
+
+/* ----------------------------------------------------------------
+   Project picker — sits next to the Worktree picker in the composer.
+   Default is "No selected project". Opening it shows recent dirs
+   (sorted by lastUsed, capped at 10) plus a "Pick directory…" action
+   that simulates a native folder browser.
+---------------------------------------------------------------- */
+function ProjectPicker({ value, recents, onChange, onPickFromDisk }) {
+  const I = window.PA.Icon;
+  const [open, setOpen] = useStateNT(false);
+  const [query, setQuery] = useStateNT("");
+  const ref = useRefNT(null);
+
+  useEffectNT(() => {
+    if (!open) return;
+    const onDoc = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const sorted = useMemoNT(() => {
+    const arr = [...(recents || [])];
+    arr.sort((a, b) => (b.lastUsed || 0) - (a.lastUsed || 0));
+    const top10 = arr.slice(0, 10);
+    if (!query.trim()) return top10;
+    const q = query.trim().toLowerCase();
+    return top10.filter((d) => d.dir.toLowerCase().includes(q) || (d.path || "").toLowerCase().includes(q));
+  }, [recents, query]);
+
+  const isEmpty = !value;
+  const labelClass = `pa-pick pa-pick--proj ${isEmpty ? "is-empty" : "is-active"}`;
+
+  return (
+    <span ref={ref} style={{ position: "relative", display: "inline-flex" }}>
+      <button
+        className={labelClass}
+        onClick={(e) => { e.stopPropagation(); setOpen(!open); }}
+        title={value ? `Project: ${value.dir}` : "Choose a project for this thread"}
+        type="button"
+      >
+        <I.Folder size={11} />
+        <span className="pa-pick__txt">{value ? value.dir : "No selected project"}</span>
+        <span className="pa-pick__chev">▾</span>
+      </button>
+
+      {open && (
+        <div className="pa-pop pa-projpop" style={{ bottom: "calc(100% + 6px)", left: 0 }}>
+          <div className="pa-projpop__head">
+            <I.Search size={12} />
+            <input
+              className="pa-projpop__search"
+              placeholder="Search directories"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="pa-projpop__section">Recent directories</div>
+
+          {sorted.length === 0 && (
+            <div className="pa-projpop__empty">
+              {query ? "No matches." : "No directories yet — pick one below."}
+            </div>
+          )}
+
+          {sorted.map((d) => {
+            const active = value && value.dir === d.dir;
+            return (
+              <button
+                key={d.dir}
+                className={`pa-projpop__row ${active ? "is-active" : ""}`}
+                onClick={() => { onChange(d); setOpen(false); }}
+                type="button"
+              >
+                <I.Folder size={13} />
+                <span className="pa-projpop__name">{d.dir}</span>
+                <span className="pa-projpop__path">{d.path || "—"}</span>
+                {active && <I.Check size={12} />}
+              </button>
+            );
+          })}
+
+          <div className="pa-projpop__sep" />
+
+          <button
+            className="pa-projpop__row pa-projpop__row--action"
+            onClick={() => { setOpen(false); onPickFromDisk(); }}
+            type="button"
+          >
+            <I.Plus size={13} />
+            <span className="pa-projpop__name">Pick directory…</span>
+            <span className="pa-projpop__hint">⌘O</span>
+          </button>
+        </div>
+      )}
+    </span>
+  );
+}
+
+/* ----------------------------------------------------------------
+   File-browser modal — stand-in for the native Open dialog.
+   Lets the user "navigate" a fake filesystem and pick a folder.
+---------------------------------------------------------------- */
+const FAKE_FS = {
+  "/Users/huntharo": [
+    { name: "github", kind: "dir" },
+    { name: "Documents", kind: "dir" },
+    { name: "Downloads", kind: "dir" },
+    { name: "code", kind: "dir" },
+    { name: "Desktop", kind: "dir" },
+  ],
+  "/Users/huntharo/github": [
+    { name: "PwrSnap", kind: "dir", repo: true, branch: "main" },
+    { name: "drvr-billing", kind: "dir", repo: true, branch: "release/2026.05" },
+    { name: "site-marketing", kind: "dir", repo: true, branch: "main" },
+    { name: "telemetry-pipe", kind: "dir", repo: true, branch: "main" },
+    { name: "internal-docs", kind: "dir" },
+  ],
+  "/Users/huntharo/code": [
+    { name: "scratch", kind: "dir" },
+    { name: "experiments", kind: "dir", repo: true, branch: "wip" },
+  ],
+  "/Users/huntharo/Documents": [
+    { name: "notes", kind: "dir" },
+  ],
+  "/Users/huntharo/Downloads": [],
+  "/Users/huntharo/Desktop": [],
+};
+
+function FileBrowser({ initialPath, onCancel, onPick }) {
+  const I = window.PA.Icon;
+  const [path, setPath] = useStateNT(initialPath || "/Users/huntharo/github");
+  const [selected, setSelected] = useStateNT(null);
+
+  const entries = FAKE_FS[path] || [];
+  const segs = path.split("/").filter(Boolean);
+
+  const goUp = () => {
+    if (segs.length <= 1) return;
+    const next = "/" + segs.slice(0, -1).join("/");
+    setPath(next);
+    setSelected(null);
+  };
+
+  const open = (entry) => {
+    const next = path === "/" ? `/${entry.name}` : `${path}/${entry.name}`;
+    if (FAKE_FS[next]) { setPath(next); setSelected(null); }
+    else setSelected(entry);
+  };
+
+  const choose = () => {
+    const target = selected
+      ? { name: selected.name, fullPath: `${path}/${selected.name}`, repo: !!selected.repo, branch: selected.branch || "main" }
+      : { name: segs[segs.length - 1], fullPath: path, repo: entries.some(e => e.name === ".git"), branch: "main" };
+    onPick(target);
+  };
+
+  return (
+    <div className="pa-fb__scrim" onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}>
+      <div className="pa-fb">
+        <div className="pa-fb__head">
+          <button className="pa-fb__nav" onClick={goUp} disabled={segs.length <= 1} title="Parent folder">
+            <I.ChevronLeft size={13} />
+          </button>
+          <div className="pa-fb__crumbs">
+            {segs.map((s, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <span className="pa-fb__crumb-sep">/</span>}
+                <button
+                  className="pa-fb__crumb"
+                  onClick={() => { setPath("/" + segs.slice(0, i + 1).join("/")); setSelected(null); }}
+                >{s}</button>
+              </React.Fragment>
+            ))}
+          </div>
+          <button className="pa-fb__close" onClick={onCancel} title="Close">
+            <I.X size={13} />
+          </button>
+        </div>
+
+        <div className="pa-fb__body">
+          {entries.length === 0 && <div className="pa-fb__empty">Empty folder</div>}
+          {entries.map((e) => {
+            const active = selected && selected.name === e.name;
+            return (
+              <button
+                key={e.name}
+                className={`pa-fb__row ${active ? "is-selected" : ""}`}
+                onClick={() => setSelected(e)}
+                onDoubleClick={() => open(e)}
+              >
+                <I.Folder size={14} />
+                <span className="pa-fb__name">{e.name}</span>
+                {e.repo && (
+                  <span className="pa-fb__badge" title={`git · ${e.branch}`}>
+                    <I.Branch size={10} />{e.branch}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="pa-fb__foot">
+          <div className="pa-fb__path">
+            {selected ? `${path}/${selected.name}` : path}
+          </div>
+          <button className="pa-fb__cancel" onClick={onCancel}>Cancel</button>
+          <button
+            className="pa-fb__choose"
+            onClick={choose}
+            disabled={!selected || (selected && !selected.repo && !FAKE_FS[`${path}/${selected.name}`])}
+          >
+            Choose
+          </button>
+        </div>
+        <div className="pa-fb__hint">
+          Double-click a folder to open it. Pick any directory — git repos start as worktrees, others start local.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------------------------------------------
+   New thread screen
+---------------------------------------------------------------- */
+function NewThread({ recents, initialProject, onCancel, onStart }) {
+  const I = window.PA.Icon;
+  const [project, setProject] = useStateNT(initialProject || null);
+  const [text, setText] = useStateNT("");
+  const [fast, setFast] = useStateNT(false);
+  const [plan, setPlan] = useStateNT(false);
+  const [browser, setBrowser] = useStateNT(false);
+  const [worktreeMode, setWorktreeMode] = useStateNT(initialProject && !initialProject.isRepo ? "local" : "worktree"); // worktree | local
+
+  const canStart = !!project && text.trim().length > 0;
+
+  const start = () => {
+    if (!canStart) return;
+    onStart({
+      project,
+      text,
+      worktreeMode,
+      fast,
+      plan,
+    });
+  };
+
+  const onPickFromDisk = () => setBrowser(true);
+  const onChosenFromDisk = (target) => {
+    setBrowser(false);
+    // Synthesize a directory entry; mark it as "new" so it gets added on start.
+    setProject({
+      dir: target.name,
+      path: target.fullPath,
+      branch: target.branch,
+      isRepo: target.repo,
+      isNew: true,
+      lastUsed: Date.now(),
+    });
+    // If it's not a repo, default to local rather than worktree.
+    if (!target.repo) setWorktreeMode("local");
+  };
+
+  return (
+    <main className="pa-newthread">
+      {browser && (
+        <FileBrowser
+          initialPath="/Users/huntharo/github"
+          onCancel={() => setBrowser(false)}
+          onPick={onChosenFromDisk}
+        />
+      )}
+
+      <div className="pa-newthread__inner">
+        <header className="pa-newthread__header">
+          <div className="pa-newthread__eyebrow-row">
+            <span className="pa-newthread__eyebrow">NEW THREAD</span>
+            <span className="pa-pill2">OpenAI</span>
+            <span className="pa-pill2">Full Access</span>
+            <span className="pa-newthread__spacer" />
+            <div className="pa-newthread__meta">
+              <div className="pa-newthread__meta-col">
+                <div className="pa-newthread__meta-label">Workspace</div>
+                <div className="pa-newthread__meta-value">
+                  {project
+                    ? (worktreeMode === "worktree" && project.isRepo ? "New worktree" : "Local")
+                    : "—"}
+                </div>
+              </div>
+              <div className="pa-newthread__meta-col">
+                <div className="pa-newthread__meta-label">Branch</div>
+                <div className="pa-newthread__meta-value">{project?.branch || "—"}</div>
+              </div>
+            </div>
+          </div>
+          <h1 className="pa-newthread__title">
+            {project ? project.dir : "Untitled"}
+          </h1>
+        </header>
+
+        {project ? (
+          <section className="pa-newthread__card">
+            <div className="pa-newthread__card-col">
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Project</div>
+                <div className="pa-newthread__field-value">{project.dir}</div>
+              </div>
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Threads</div>
+                <div className="pa-newthread__field-value pa-newthread__field-value--strong">
+                  {project.isNew ? "0 threads (new)" : `${project.threadCount ?? 0} threads`}
+                </div>
+              </div>
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Status</div>
+                <div className="pa-newthread__field-value">
+                  {project.isNew ? "Not yet tracked" : "Up to date"}
+                </div>
+              </div>
+            </div>
+            <div className="pa-newthread__card-col">
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Path</div>
+                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                  {project.path || "—"}
+                </div>
+              </div>
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Upstream</div>
+                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                  {project.isRepo ? `origin/${project.branch || "main"}` : "—"}
+                </div>
+              </div>
+              <div className="pa-newthread__card-row">
+                <div className="pa-newthread__field-label">Current branch</div>
+                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                  {project.branch || "—"}
+                </div>
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section className="pa-newthread__card pa-newthread__card--empty">
+            <div className="pa-newthread__empty">
+              <I.Folder size={22} />
+              <div className="pa-newthread__empty-title">No project selected</div>
+              <div className="pa-newthread__empty-sub">
+                Pick a directory below to start the thread in. We'll add it to your Directories list.
+              </div>
+            </div>
+          </section>
+        )}
+
+        <div className="pa-newthread__filler" />
+
+        {/* ---- Composer ---- */}
+        <div className="pa-composer">
+          <div className="pa-composer__eyebrow">New thread</div>
+          <div className="pa-newthread__compose-input">
+            <span className="pa-slash">$ce:plan</span>
+            <textarea
+              className="pa-composer__textarea pa-newthread__textarea"
+              placeholder="Describe what you want to do…"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) start(); }}
+              autoFocus
+            />
+          </div>
+
+          <div className="pa-composer__row">
+            <button className="pa-pick">OpenAI<span className="pa-pick__chev">▾</span></button>
+            <button className="pa-pick"><span>Full Access</span><span className="pa-pick__chev">▾</span></button>
+
+            {/* NEW: Project picker, sits before Worktree */}
+            <ProjectPicker
+              value={project}
+              recents={recents}
+              onChange={(d) => {
+                setProject({ ...d, isNew: false, lastUsed: Date.now() });
+                if (!d.isRepo) setWorktreeMode("local");
+                else setWorktreeMode("worktree");
+              }}
+              onPickFromDisk={onPickFromDisk}
+            />
+
+            <button
+              className={`pa-pick ${project && project.isRepo ? "is-active" : ""}`}
+              onClick={() => {
+                if (!project) return;
+                setWorktreeMode((m) => m === "worktree" ? "local" : (project.isRepo ? "worktree" : "local"));
+              }}
+              disabled={!project}
+              title={project?.isRepo ? "Toggle worktree / local" : "Local only — not a git repo"}
+            >
+              <I.Worktree size={11} />
+              <span>{worktreeMode === "worktree" && project?.isRepo ? "New worktree" : "Local"}</span>
+              <span className="pa-pick__chev">▾</span>
+            </button>
+
+            <button className="pa-pick" disabled={!project}>
+              <I.Branch size={11} />
+              <span>{project?.branch || "main"}</span>
+              <span className="pa-pick__chev">▾</span>
+            </button>
+
+            <button className="pa-pick"><span>GPT-5.5</span><span className="pa-pick__chev">▾</span></button>
+            <button className="pa-pick"><span>high</span><span className="pa-pick__chev">▾</span></button>
+
+            <span className="pa-composer__spacer" />
+
+            <button className={`pa-toggle2 ${fast ? "is-on" : ""}`} onClick={() => setFast(!fast)}>
+              <span className="pa-toggle__box">{fast && <I.Check size={9} />}</span>
+              Fast mode
+            </button>
+            <button className={`pa-toggle2 ${plan ? "is-on" : ""}`} onClick={() => setPlan(!plan)}>
+              <span className="pa-toggle__box">{plan && <I.Check size={9} />}</span>
+              Plan mode
+            </button>
+          </div>
+
+          <div className="pa-composer__row">
+            <button className="pa-applaunch" disabled={!project}>
+              <I.VSCodeGlyph size={16} />VS Code
+            </button>
+            <button className="pa-applaunch" disabled={!project}>
+              <I.GhosttyGlyph size={16} />Ghostty
+            </button>
+            <span className="pa-composer__spacer" />
+            {project?.isNew && (
+              <span className="pa-newthread__addnote">
+                <I.Plus size={11} />
+                Adds <strong>{project.dir}</strong> to Directories
+              </span>
+            )}
+            <button className="pa-newthread__cancel" onClick={onCancel}>Cancel</button>
+            <button className="pa-send" onClick={start} disabled={!canStart} title={!project ? "Pick a project first" : !text.trim() ? "Type a prompt" : "Start thread"}>
+              <I.Send size={12} />
+              Start thread
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+window.PA = window.PA || {};
+window.PA.NewThread = NewThread;

--- a/docs/design/pwragent-v2/project/sidebar.jsx
+++ b/docs/design/pwragent-v2/project/sidebar.jsx
@@ -149,7 +149,7 @@ function LensSwitch({ value, onChange }) {
   );
 }
 
-function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPlatform }) {
+function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPlatform, onNewThreadInDir }) {
   const I = window.PA.Icon;
   return (
     <div className="pa-dir-section">
@@ -157,7 +157,13 @@ function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPl
         <span className="pa-dir-sticky__icon"><I.Folder size={14} /></span>
         <span className="pa-dir-sticky__title">{group.dir}</span>
         <span className="pa-dir-sticky__count">{group.threads.length}</span>
-        <button className="pa-dir-sticky__action" title="New thread in this folder"><I.Plus size={13} /></button>
+        <button
+          className="pa-dir-sticky__action"
+          title="New thread in this folder"
+          onClick={(e) => { e.stopPropagation(); onNewThreadInDir?.(group); }}
+        >
+          <I.Plus size={13} />
+        </button>
         <button className="pa-dir-sticky__action" title="Collapse"><I.ChevronDown size={13} /></button>
       </div>
       {group.threads.map((t) => (
@@ -174,7 +180,7 @@ function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPl
   );
 }
 
-function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contextBranch, showDevContext, onAddReaction, onUnbindPlatform, onNewThread }) {
+function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contextBranch, showDevContext, newThreadActive, onAddReaction, onUnbindPlatform, onNewThread, onNewThreadInDir }) {
   const I = window.PA.Icon;
   const flat = data.flatMap((g) => g.threads);
   return (
@@ -198,7 +204,7 @@ function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contex
       )}
 
       <div className="pa-sb__newthread-row">
-        <button className="pa-sb__newthread" type="button" onClick={onNewThread}>
+        <button className={`pa-sb__newthread ${newThreadActive ? "is-active" : ""}`} type="button" onClick={onNewThread}>
           <I.PlusSquare size={14} />
           <span>New thread</span>
           <span className="pa-sb__newthread-kbd">⌘N</span>
@@ -226,6 +232,7 @@ function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contex
             onSelect={onSelect}
             onAddReaction={onAddReaction}
             onUnbindPlatform={onUnbindPlatform}
+            onNewThreadInDir={onNewThreadInDir}
           />
         ))}
       </div>

--- a/docs/design/pwragent-v2/project/titlebar.jsx
+++ b/docs/design/pwragent-v2/project/titlebar.jsx
@@ -90,13 +90,12 @@ function MessagingBar({ messagingOn, platforms, blinkPlatforms, onToggleMessagin
 }
 
 function TitleBar(props) {
-  const { Icon, screen, breadcrumb, messagingOn, platforms, blinkPlatforms,
-          onToggleMessaging, onOpenActivity, onOpenSettings, onToggleRail, railOpen } = props;
+  const { screen, breadcrumb, messagingOn, platforms, blinkPlatforms,
+          onToggleMessaging, onOpenActivity, onOpenSettings, onToggleRail, railOpen, onNewThread } = props;
   const I = window.PA.Icon;
 
   return (
     <div className="pa-tb">
-      {/* Sidebar zone — aligns with the 320px sidebar gutter */}
       <div className="pa-tb__sb-zone">
         <div className="pa-tb__lights">
           <span className="pa-tb__light r" />
@@ -104,12 +103,16 @@ function TitleBar(props) {
           <span className="pa-tb__light g" />
         </div>
         <I.PwrAgntLogo size={22} />
+        <span style={{ flex: 1 }} />
+        {onNewThread && (
+          <button className="pa-tb__btn" title="New thread (\u2318N)" onClick={onNewThread}>
+            <I.PlusSquare size={15} />
+          </button>
+        )}
       </div>
 
-      {/* Vertical rule lining up with the sidebar/thread split */}
       <div className="pa-tb__divider" />
 
-      {/* Main zone — sits above the thread pane */}
       <div className="pa-tb__main-zone">
         <div className="pa-tb__crumbs">
           {breadcrumb.map((c, i) => (

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -280,6 +280,57 @@ export type MaterializeDirectoryLaunchpadResponse = {
   workMode: LaunchpadWorkMode;
 };
 
+/**
+ * Ask the main process to open the system "choose folder" dialog. The
+ * renderer never sees the path until the user confirms — `canceled: true`
+ * signals the user dismissed the dialog and the renderer should treat it
+ * as a no-op (no error). The returned `path` is whatever the OS dialog
+ * yielded; validation (is-this-a-git-repo, accessibility) happens in the
+ * follow-up `registerDirectoryFromDisk` call so the picker can show a
+ * useful error inline rather than blocking inside the dialog.
+ */
+export type PickDirectoryFromDiskResponse =
+  | { canceled: true }
+  | { canceled: false; path: string };
+
+export type RegisterDirectoryFromDiskRequest = {
+  /** Absolute path the user picked from the system dialog. */
+  path: string;
+  /**
+   * Backend the new directory's launchpad should default to. The launchpad
+   * defaults are otherwise loaded from the overlay store.
+   */
+  preferredBackend?: AppServerBackendKind;
+};
+
+/** Why a registration attempt failed — drives the inline error copy. */
+export type RegisterDirectoryFromDiskFailureReason =
+  | "inaccessible"
+  | "not-a-directory"
+  | "not-a-git-repo";
+
+export type RegisterDirectoryFromDiskResponse =
+  | {
+      ok: true;
+      /**
+       * Canonical filesystem path (resolved via `git rev-parse
+       * --show-toplevel` so symlinked roots normalize). The directoryKey
+       * is derived from this path with the `directory:` prefix.
+       */
+      directoryPath: string;
+      directoryKey: string;
+      directoryLabel: string;
+      currentBranch?: string;
+      launchpad: NavigationLaunchpadDraft;
+      defaults: NavigationLaunchpadDefaults;
+    }
+  | {
+      ok: false;
+      reason: RegisterDirectoryFromDiskFailureReason;
+      /** Human-readable reason for surfacing in the picker UI. */
+      message: string;
+    };
+
 export type AgentEvent = {
   backend: AppServerBackendKind;
   notification: AppServerNotification;


### PR DESCRIPTION
Closes #223.

## Summary
- Adds a project-directory picker to the new-thread launchpad composer between the access-mode and workspace-mode pickers.
- Picker popover lists tracked directories from the navigation snapshot (sorted by `latestUpdatedAt`, capped at 10, with search filter) plus an "Add directory…" action that opens the OS "Choose folder" dialog.
- Validation happens in the main process via `registerDirectoryFromDisk`: normalizes the path through `git rev-parse --show-toplevel`, then seeds a launchpad via the existing `ensureDirectoryLaunchpad` path. Errors (`inaccessible`, `not-a-directory`, `not-a-git-repo`) come back as structured rejections the picker renders inline.

## What was built
- **Contracts** (`@pwragent/shared`): `PickDirectoryFromDiskResponse`, `RegisterDirectoryFromDiskRequest`, `RegisterDirectoryFromDiskResponse`, `RegisterDirectoryFromDiskFailureReason`.
- **Main process**: `directory-registration-service.ts` (validates path → repo root → launchpad seed). New IPC channels `navigation:pick-directory-from-disk` and `navigation:register-directory-from-disk` wired through `app-server.ts`.
- **Preload + renderer bridge**: `pickDirectoryFromDisk()` + `registerDirectoryFromDisk(request)`.
- **`useThreadNavigation` hook**: `pickAndRegisterDirectory`, `pickDirectoryError`, `pickingDirectory`, `clearPickDirectoryError`. Two-step flow handles the cancel branch silently and surfaces the validation-failure branch inline.
- **`ProjectPicker.tsx`**: presentation-only popover component matching the v2 design language (`docs/design/pwragent-v2/project/newthread.{jsx,css}`).
- **Composer integration**: `ProjectPicker` mounts in the launchpad row, scoped to the launchpad surface (a thread's directory binding is immutable once it exists).
- **Styles**: new `.project-picker__*` tokens in `app.css` reusing existing accent / border / popover variables.

## Acceptance criteria from #223
- [x] Pull design from `docs/design/pwragent-v2/project/newthread.{jsx,css}` — built against that spec.
- [x] Picker shows tracked directories with label + path.
- [x] "Add directory…" affordance opens the system dialog, validates the chosen path is a git repo, and registers it via the existing launchpad path.
- [x] Reachable from the launchpad composer (the surface the design specifies).
- [x] Renderer ↔ main routes through the existing directory-service paths via IPC.
- [x] Tests covering: pick existing, add-and-pick new, cancel, error path (not a git repo).

## Out of scope (per issue)
- Worktree creation / handoff flows already exist; this PR plugs into them via `ensureDirectoryLaunchpad`.

## Test plan
- [x] `pnpm test apps/desktop/src/main/__tests__/directory-registration-service.test.ts` (8 tests)
- [x] `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx` (11 tests)
- [x] `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (22 tests, including 3 new for the picker flow)
- [x] Full `pnpm test apps/desktop/src/{main,renderer}` passes (1090 tests)
- [x] `pnpm lint:boundaries` clean (990 modules, 0 violations)
- [x] Manual: launch `pnpm --filter @pwragent/desktop dev:no-messaging`, click sidebar "+ New thread", confirm the picker renders before the workspace-mode dropdown, pick from existing directories, pick from disk via "Add directory…", verify a non-repo folder shows the inline error.

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: main-process logs for any `registerDirectoryFromDisk` exceptions; renderer console for `pickDirectoryError` propagation.
- **Expected healthy behavior**
  - Picker opens, lists tracked directories, system dialog opens on "Add directory…" click, valid git repos register and the launchpad focuses immediately.
- **Failure signal(s) / rollback trigger**
  - Renderer crash on picker open → revert. Dialog hangs (Electron ipc deadlock) → revert.
- **Validation window & owner**
  - Window: first internal-tester session post-merge. Owner: @huntharo.
- No data-store migrations or persistence schema changes.

🤖 Generated with [Claude Opus 4.7](https://claude.com/claude-code) (1M context, extended thinking)