### PR TITLE
feat(settings): add collapsible section headers

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
@@ -4,7 +4,11 @@ import type {
   AppUpdateCheckResult,
 } from "../../../../shared/app-metadata";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { SettingsPanelHead, SettingsSection } from "./SettingsLayout";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
 
 export function AboutSettings(props: { desktopApi?: DesktopApi }) {
   const [metadata, setMetadata] = useState<AppMetadata | undefined>(undefined);
@@ -58,7 +62,7 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
 
   if (error) {
     return (
-      <section className="settings-stack" aria-label="About PwrAgent">
+      <SettingsSectionStack paneId="about" aria-label="About PwrAgent">
         <SettingsPanelHead
           eyebrow="About"
           title="PwrAgent"
@@ -67,13 +71,13 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
         <div className="settings-panel" role="alert">
           <p className="settings-row__error">Could not load app info: {error}</p>
         </div>
-      </section>
+      </SettingsSectionStack>
     );
   }
 
   if (!metadata) {
     return (
-      <section className="settings-stack" aria-label="About PwrAgent">
+      <SettingsSectionStack paneId="about" aria-label="About PwrAgent">
         <SettingsPanelHead
           eyebrow="About"
           title="PwrAgent"
@@ -82,12 +86,12 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
         <div className="settings-panel">
           <p className="settings-empty">Loading…</p>
         </div>
-      </section>
+      </SettingsSectionStack>
     );
   }
 
   return (
-    <section className="settings-stack" aria-label="About PwrAgent">
+    <SettingsSectionStack paneId="about" aria-label="About PwrAgent">
       <SettingsPanelHead
         eyebrow="About"
         title={metadata.applicationName}
@@ -142,7 +146,7 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
       </SettingsSection>
 
       {updateResult ? <UpdateResultStatus result={updateResult} /> : null}
-    </section>
+    </SettingsSectionStack>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ApplicationsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ApplicationsSettings.tsx
@@ -6,7 +6,11 @@ import type {
   GhStatus,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { SettingsPanelHead, SettingsSection } from "./SettingsLayout";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
 import {
   SettingsPathRow,
   type SettingsPathRowChip,
@@ -22,7 +26,7 @@ export function ApplicationsSettings(props: {
   ) => Promise<void>;
 }) {
   return (
-    <section className="settings-stack" aria-label="Application settings">
+    <SettingsSectionStack paneId="applications" aria-label="Application settings">
       <SettingsPanelHead
         eyebrow="Applications"
         title="Editor & terminal"
@@ -48,7 +52,7 @@ export function ApplicationsSettings(props: {
         onPreferredApplicationChange={props.onPreferredApplicationChange}
       />
       <GhStatusPanel desktopApi={props.desktopApi} />
-    </section>
+    </SettingsSectionStack>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -4,6 +4,7 @@ import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
+  SettingsSectionStack,
 } from "./SettingsLayout";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { sourceBadge } from "./settings-fields";
@@ -69,7 +70,7 @@ export function ExperimentalSettings(props: {
   );
 
   return (
-    <section className="settings-stack" aria-label="Experimental settings">
+    <SettingsSectionStack paneId="experimental" aria-label="Experimental settings">
       <SettingsPanelHead
         eyebrow="Experimental"
         title="Experimental features"
@@ -172,6 +173,6 @@ export function ExperimentalSettings(props: {
           />
         </div>
       </SettingsSection>
-    </section>
+    </SettingsSectionStack>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -10,6 +10,7 @@ import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
+  SettingsSectionStack,
   type SettingsChipTone,
 } from "./SettingsLayout";
 import { SettingsSwitch } from "./SettingsSwitch";
@@ -52,7 +53,7 @@ export function MessagingSettings(props: {
   const runtimeMessaging = props.snapshot.runtime.messaging;
 
   return (
-    <section className="settings-stack" aria-label="Messaging settings">
+    <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
       <SettingsPanelHead
         eyebrow="Messaging"
         title="Connected chat platforms"
@@ -480,7 +481,7 @@ export function MessagingSettings(props: {
           />
         </div>
       </SettingsSection>
-    </section>
+    </SettingsSectionStack>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -9,6 +9,7 @@ import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
+  SettingsSectionStack,
 } from "./SettingsLayout";
 import {
   SettingsPathRow,
@@ -61,7 +62,7 @@ export function ModelsSettings(props: {
   };
 
   return (
-    <section className="settings-stack" aria-label="Model settings">
+    <SettingsSectionStack paneId="models" aria-label="Model settings">
       <SettingsPanelHead
         eyebrow="Models"
         title="Backends & credentials"
@@ -243,7 +244,7 @@ export function ModelsSettings(props: {
           />
         </div>
       </SettingsSection>
-    </section>
+    </SettingsSectionStack>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -1,4 +1,16 @@
-import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 
 /**
  * Layout primitives for settings screens. Compose `SettingsPanelHead`,
@@ -29,6 +41,190 @@ import type { ReactNode } from "react";
  */
 export type SettingsChipTone = "default" | "muted" | "ok" | "err" | "warn";
 
+type SettingsSectionRegistration = {
+  element: HTMLElement;
+  id: string;
+  title: string;
+};
+
+type SettingsSectionPaneContextValue = {
+  allCollapsed: boolean;
+  allExpanded: boolean;
+  collapseAll: () => void;
+  collapsedSections: Record<string, boolean>;
+  expandAll: () => void;
+  paneId: string;
+  registerSection: (section: SettingsSectionRegistration) => () => void;
+  registeredSections: SettingsSectionRegistration[];
+  rememberSectionVisit: (sectionId: string) => void;
+  toggleSection: (sectionId: string) => void;
+};
+
+const SettingsSectionPaneContext =
+  createContext<SettingsSectionPaneContextValue | null>(null);
+
+const savedCollapsedSectionsByPane = new Map<string, Record<string, boolean>>();
+const savedVisitedSectionByPane = new Map<string, string>();
+
+function slugForSettingsId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function SettingsSectionStack(props: {
+  "aria-label": string;
+  children: ReactNode;
+  paneId: string;
+}) {
+  const [registeredSections, setRegisteredSections] = useState<
+    SettingsSectionRegistration[]
+  >([]);
+  const [collapsedSections, setCollapsedSections] = useState<
+    Record<string, boolean>
+  >(() => savedCollapsedSectionsByPane.get(props.paneId) ?? {});
+  const didRestoreFocusRef = useRef(false);
+
+  const updateCollapsedSections = useCallback(
+    (
+      updater: (
+        current: Record<string, boolean>,
+      ) => Record<string, boolean>,
+    ) => {
+      setCollapsedSections((current) => {
+        const next = updater(current);
+        savedCollapsedSectionsByPane.set(props.paneId, next);
+        return next;
+      });
+    },
+    [props.paneId],
+  );
+
+  const registerSection = useCallback(
+    (section: SettingsSectionRegistration) => {
+      setRegisteredSections((current) => {
+        const existingIndex = current.findIndex(
+          (entry) => entry.id === section.id,
+        );
+        if (existingIndex === -1) {
+          return [...current, section];
+        }
+        const next = [...current];
+        next[existingIndex] = section;
+        return next;
+      });
+
+      return () => {
+        setRegisteredSections((current) =>
+          current.filter((entry) => entry.id !== section.id),
+        );
+      };
+    },
+    [],
+  );
+
+  const rememberSectionVisit = useCallback(
+    (sectionId: string) => {
+      savedVisitedSectionByPane.set(props.paneId, sectionId);
+    },
+    [props.paneId],
+  );
+
+  const toggleSection = useCallback(
+    (sectionId: string) => {
+      updateCollapsedSections((current) => {
+        const nextCollapsed = current[sectionId] !== true;
+        if (!nextCollapsed) {
+          savedVisitedSectionByPane.set(props.paneId, sectionId);
+        }
+        return {
+          ...current,
+          [sectionId]: nextCollapsed,
+        };
+      });
+    },
+    [props.paneId, updateCollapsedSections],
+  );
+
+  const collapseAll = useCallback(() => {
+    updateCollapsedSections((current) => {
+      const next = { ...current };
+      for (const section of registeredSections) {
+        next[section.id] = true;
+      }
+      return next;
+    });
+  }, [registeredSections, updateCollapsedSections]);
+
+  const expandAll = useCallback(() => {
+    updateCollapsedSections((current) => {
+      const next = { ...current };
+      for (const section of registeredSections) {
+        next[section.id] = false;
+      }
+      return next;
+    });
+  }, [registeredSections, updateCollapsedSections]);
+
+  const allCollapsed =
+    registeredSections.length > 0 &&
+    registeredSections.every((section) => collapsedSections[section.id] === true);
+  const allExpanded =
+    registeredSections.length > 0 &&
+    registeredSections.every((section) => collapsedSections[section.id] !== true);
+
+  useEffect(() => {
+    if (didRestoreFocusRef.current || registeredSections.length === 0) {
+      return;
+    }
+    didRestoreFocusRef.current = true;
+    const visitedSectionId = savedVisitedSectionByPane.get(props.paneId);
+    if (!visitedSectionId) {
+      return;
+    }
+    const visitedSection = registeredSections.find(
+      (section) => section.id === visitedSectionId,
+    );
+    visitedSection?.element.focus();
+  }, [props.paneId, registeredSections]);
+
+  const value = useMemo<SettingsSectionPaneContextValue>(
+    () => ({
+      allCollapsed,
+      allExpanded,
+      collapseAll,
+      collapsedSections,
+      expandAll,
+      paneId: props.paneId,
+      registerSection,
+      registeredSections,
+      rememberSectionVisit,
+      toggleSection,
+    }),
+    [
+      allCollapsed,
+      allExpanded,
+      collapseAll,
+      collapsedSections,
+      expandAll,
+      props.paneId,
+      registerSection,
+      registeredSections,
+      rememberSectionVisit,
+      toggleSection,
+    ],
+  );
+
+  return (
+    <SettingsSectionPaneContext.Provider value={value}>
+      <section className="settings-stack" aria-label={props["aria-label"]}>
+        {props.children}
+      </section>
+    </SettingsSectionPaneContext.Provider>
+  );
+}
+
 export function SettingsPanelHead(props: {
   eyebrow: string;
   title: ReactNode;
@@ -36,6 +232,11 @@ export function SettingsPanelHead(props: {
   /** Optional right-side action (e.g. "Check for updates" button). */
   action?: ReactNode;
 }) {
+  const pane = useContext(SettingsSectionPaneContext);
+  const bulkControls = pane?.registeredSections.length ? (
+    <SettingsSectionBulkControls />
+  ) : null;
+
   return (
     <header className="settings-head">
       <div className="settings-head__text">
@@ -45,10 +246,41 @@ export function SettingsPanelHead(props: {
           <p className="settings-head__help">{props.help}</p>
         ) : null}
       </div>
-      {props.action ? (
-        <div className="settings-head__action">{props.action}</div>
+      {props.action || bulkControls ? (
+        <div className="settings-head__action">
+          {bulkControls}
+          {props.action}
+        </div>
       ) : null}
     </header>
+  );
+}
+
+function SettingsSectionBulkControls() {
+  const pane = useContext(SettingsSectionPaneContext);
+  if (!pane || pane.registeredSections.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="settings-section-controls" aria-label="Section controls">
+      <button
+        className="button button--ghost settings-section-controls__button"
+        disabled={pane.allCollapsed}
+        type="button"
+        onClick={pane.collapseAll}
+      >
+        Collapse all
+      </button>
+      <button
+        className="button button--ghost settings-section-controls__button"
+        disabled={pane.allExpanded}
+        type="button"
+        onClick={pane.expandAll}
+      >
+        Expand all
+      </button>
+    </div>
   );
 }
 
@@ -61,34 +293,128 @@ export function SettingsSection(props: {
   chip?: ReactNode;
   chipKind?: SettingsChipTone;
   "aria-label"?: string;
+  sectionId?: string;
 }) {
-  const headingId = `settings-section-${props.title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")}`;
+  const generatedId = useId();
+  const pane = useContext(SettingsSectionPaneContext);
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const slug = slugForSettingsId(props.sectionId ?? props.title);
+  const sectionId = `${pane?.paneId ?? "global"}-${slug || generatedId}`;
+  const registerSection = pane?.registerSection;
+  const headingId = `settings-section-${sectionId}-heading`;
+  const bodyId = `settings-section-${sectionId}-body`;
+  const collapsed = pane?.collapsedSections[sectionId] === true;
 
   const chipClass =
     props.chipKind && props.chipKind !== "default" && props.chipKind !== "muted"
       ? `settings-card__chip settings-card__chip--${props.chipKind}`
       : "settings-card__chip";
 
+  useLayoutEffect(() => {
+    const element = headerRef.current;
+    if (!registerSection || !element) {
+      return;
+    }
+    return registerSection({
+      element,
+      id: sectionId,
+      title: props.title,
+    });
+  }, [props.title, registerSection, sectionId]);
+
+  const focusSiblingHeader = (direction: "next" | "previous" | "first" | "last") => {
+    if (!pane) return;
+    const sections = pane.registeredSections;
+    const currentIndex = sections.findIndex((section) => section.id === sectionId);
+    if (currentIndex === -1) return;
+
+    let nextIndex = currentIndex;
+    if (direction === "next") {
+      nextIndex = Math.min(sections.length - 1, currentIndex + 1);
+    } else if (direction === "previous") {
+      nextIndex = Math.max(0, currentIndex - 1);
+    } else if (direction === "first") {
+      nextIndex = 0;
+    } else {
+      nextIndex = sections.length - 1;
+    }
+
+    const nextSection = sections[nextIndex];
+    nextSection?.element.focus();
+    if (nextSection) {
+      pane.rememberSectionVisit(nextSection.id);
+    }
+  };
+
+  const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!pane) return;
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      pane.toggleSection(sectionId);
+      pane.rememberSectionVisit(sectionId);
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusSiblingHeader("next");
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusSiblingHeader("previous");
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      focusSiblingHeader("first");
+    } else if (event.key === "End") {
+      event.preventDefault();
+      focusSiblingHeader("last");
+    }
+  };
+
+  const handleHeaderClick = () => {
+    pane?.toggleSection(sectionId);
+    pane?.rememberSectionVisit(sectionId);
+  };
+
   return (
     <section
       aria-labelledby={headingId}
       aria-label={props["aria-label"]}
-      className="settings-panel settings-panel--has-body"
+      className={`settings-panel settings-panel--has-body settings-panel--collapsible${
+        collapsed ? " settings-panel--is-collapsed" : ""
+      }`}
     >
-      <div className="settings-panel__header">
-        <div>
+      <div
+        ref={headerRef}
+        aria-controls={bodyId}
+        aria-expanded={!collapsed}
+        aria-label={props.title}
+        className="settings-panel__header settings-section__header-button"
+        role="button"
+        tabIndex={0}
+        onClick={handleHeaderClick}
+        onKeyDown={handleHeaderKeyDown}
+      >
+        <div className="settings-section__header-main">
           {props.eyebrow ? <p className="eyebrow">{props.eyebrow}</p> : null}
           <h2 id={headingId}>{props.title}</h2>
           {props.description ? (
             <p className="settings-section__description">{props.description}</p>
           ) : null}
         </div>
-        {props.chip ? <span className={chipClass}>{props.chip}</span> : null}
+        <span className="settings-section__header-actions">
+          {props.chip ? <span className={chipClass}>{props.chip}</span> : null}
+          <span className="settings-section__chevron" aria-hidden="true" />
+        </span>
       </div>
-      <div className="settings-section__body">{props.children}</div>
+      <div
+        id={bodyId}
+        aria-hidden={collapsed}
+        className="settings-section__body-clip"
+        inert={collapsed ? true : undefined}
+      >
+        <div className="settings-section__body">{props.children}</div>
+      </div>
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/WorktreesSettings.tsx
@@ -6,6 +6,7 @@ import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
+  SettingsSectionStack,
 } from "./SettingsLayout";
 import { sourceBadge } from "./settings-fields";
 
@@ -40,7 +41,7 @@ export function WorktreesSettings(props: {
   );
 
   return (
-    <section className="settings-stack" aria-label="Worktree settings">
+    <SettingsSectionStack paneId="worktrees" aria-label="Worktree settings">
       <SettingsPanelHead
         eyebrow="Worktrees"
         title="Storage & cleanup"
@@ -104,6 +105,6 @@ export function WorktreesSettings(props: {
           />
         </div>
       </SettingsSection>
-    </section>
+    </SettingsSectionStack>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-layout.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-layout.test.tsx
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "../SettingsLayout";
+
+afterEach(() => {
+  cleanup();
+});
+
+let paneIndex = 0;
+
+function renderSectionStack(paneId = `test-pane-${paneIndex++}`) {
+  return render(
+    <SettingsSectionStack paneId={paneId} aria-label="Test settings">
+      <SettingsPanelHead
+        eyebrow="Test"
+        title="Settings"
+        help="A compact test pane."
+      />
+      <SettingsSection eyebrow="Test" title="Alpha">
+        <button type="button">Alpha action</button>
+      </SettingsSection>
+      <SettingsSection eyebrow="Test" title="Beta">
+        <button type="button">Beta action</button>
+      </SettingsSection>
+    </SettingsSectionStack>,
+  );
+}
+
+describe("SettingsLayout", () => {
+  it("collapses and expands sections from the header", async () => {
+    renderSectionStack("collapse-pane");
+
+    const alpha = screen.getByRole("button", { name: "Alpha" });
+    expect(alpha).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "Alpha action" })).toBeEnabled();
+
+    fireEvent.click(alpha);
+
+    expect(alpha).toHaveAttribute("aria-expanded", "false");
+    const body = document.querySelector("#settings-section-collapse-pane-alpha-body");
+    expect(body).toHaveAttribute("aria-hidden", "true");
+    expect(body).toHaveAttribute("inert");
+
+    fireEvent.click(alpha);
+
+    expect(alpha).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => {
+      expect(body).toHaveAttribute("aria-hidden", "false");
+    });
+    expect(body).not.toHaveAttribute("inert");
+  });
+
+  it("supports collapse all and expand all at the pane top", async () => {
+    renderSectionStack();
+
+    const collapseAll = await screen.findByRole("button", {
+      name: "Collapse all",
+    });
+    const expandAll = screen.getByRole("button", { name: "Expand all" });
+
+    expect(collapseAll).toBeEnabled();
+    expect(expandAll).toBeDisabled();
+
+    fireEvent.click(collapseAll);
+
+    expect(screen.getByRole("button", { name: "Alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Beta" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(collapseAll).toBeDisabled();
+    expect(expandAll).toBeEnabled();
+
+    fireEvent.click(expandAll);
+
+    expect(screen.getByRole("button", { name: "Alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Beta" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("handles keyboard activation and section-header focus movement", () => {
+    renderSectionStack();
+
+    const alpha = screen.getByRole("button", { name: "Alpha" });
+    const beta = screen.getByRole("button", { name: "Beta" });
+
+    alpha.focus();
+    fireEvent.keyDown(alpha, { key: " " });
+    expect(alpha).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.keyDown(alpha, { key: "Enter" });
+    expect(alpha).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.keyDown(alpha, { key: "ArrowDown" });
+    expect(beta).toHaveFocus();
+
+    fireEvent.keyDown(beta, { key: "ArrowUp" });
+    expect(alpha).toHaveFocus();
+
+    fireEvent.keyDown(alpha, { key: "End" });
+    expect(beta).toHaveFocus();
+
+    fireEvent.keyDown(beta, { key: "Home" });
+    expect(alpha).toHaveFocus();
+  });
+
+  it("persists collapsed state and restores focus within the session", async () => {
+    const paneId = `persistent-pane-${paneIndex++}`;
+    const firstRender = renderSectionStack(paneId);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Collapse all" }));
+    fireEvent.click(screen.getByRole("button", { name: "Beta" }));
+
+    expect(screen.getByRole("button", { name: "Alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Beta" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    firstRender.unmount();
+    renderSectionStack(paneId);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Beta" })).toHaveFocus();
+    });
+    expect(screen.getByRole("button", { name: "Alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Beta" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2103,6 +2103,10 @@ textarea,
 .settings-content {
   min-height: 0;
   overflow: auto;
+  /* Section headers stick inside this scroll container, which already
+     starts below `.settings-titlebar`; a zero offset pins them to the
+     titlebar's bottom edge rather than the absolute window top. */
+  --settings-section-sticky-top: 0px;
   /* More generous interior padding now that the card chrome around
      the layout is gone — the panels need breathing room from the
      window edges and from the nav's right border. */
@@ -2165,6 +2169,11 @@ textarea,
 }
 
 .settings-head__action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
   flex: 0 0 auto;
 }
 
@@ -2174,6 +2183,10 @@ textarea,
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel);
+}
+
+.settings-panel--collapsible {
+  overflow: visible;
 }
 
 .settings-panel--error {
@@ -2201,6 +2214,98 @@ textarea,
 
 .settings-panel--has-body .settings-panel__header {
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-section-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-section-controls__button {
+  min-height: 26px;
+  padding: 0 9px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.settings-section__header-button {
+  position: sticky;
+  z-index: 3;
+  top: var(--settings-section-sticky-top, 0);
+  width: 100%;
+  border: 0;
+  border-radius: 8px 8px 0 0;
+  background: var(--bg-panel-elevated);
+  box-shadow:
+    0 1px 0 var(--border-subtle),
+    0 8px 18px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.settings-section__header-button:hover,
+.settings-section__header-button:focus-visible {
+  background: var(--bg-panel-hover);
+}
+
+.settings-section__header-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.settings-panel--is-collapsed .settings-section__header-button {
+  border-radius: 8px;
+  box-shadow: 0 1px 0 var(--border-subtle);
+}
+
+.settings-section__header-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-section__header-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-section__chevron {
+  position: relative;
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition:
+    color 120ms ease,
+    transform 120ms ease;
+}
+
+.settings-section__chevron::before {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  content: "";
+  transform: translateY(-1px) rotate(45deg);
+  transition: transform 120ms ease;
+}
+
+.settings-panel--is-collapsed .settings-section__chevron::before {
+  transform: translateX(-2px) rotate(-45deg);
+}
+
+.settings-section__header-button:hover .settings-section__chevron,
+.settings-section__header-button:focus-visible .settings-section__chevron {
+  color: var(--text-secondary);
 }
 
 .settings-panel__header .eyebrow {
@@ -2321,6 +2426,22 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 0;
+  min-height: 0;
+}
+
+.settings-section__body-clip {
+  display: grid;
+  overflow: hidden;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transition:
+    grid-template-rows 120ms ease,
+    opacity 120ms ease;
+}
+
+.settings-panel--is-collapsed .settings-section__body-clip {
+  grid-template-rows: 0fr;
+  opacity: 0;
 }
 
 .settings-source {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2104,9 +2104,10 @@ textarea,
   min-height: 0;
   overflow: auto;
   /* Section headers stick inside this scroll container, which already
-     starts below `.settings-titlebar`; a zero offset pins them to the
-     titlebar's bottom edge rather than the absolute window top. */
-  --settings-section-sticky-top: 0px;
+     starts below `.settings-titlebar`. The content has 20px top
+     padding for the pane head, so the sticky offset cancels that
+     padding when a section header pins. */
+  --settings-section-sticky-top: -20px;
   /* More generous interior padding now that the card chrome around
      the layout is gone — the panels need breathing room from the
      window edges and from the nav's right border. */


### PR DESCRIPTION
## Summary

- Add sticky, keyboard-focusable Settings section headers with collapse / expand behavior.
- Add per-pane Collapse all / Expand all controls and session-scoped collapsed-state restoration.
- Apply the shared section stack across Settings panes and cover the interaction contract with renderer tests.

Closes #229.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-layout.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
