### PR TITLE
fix(desktop): preserve thread reactions on refresh

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { AppServerThreadSummary } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
@@ -19,6 +20,35 @@ afterEach(() => {
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
+
+function buildThreadSummary(
+  overrides: Partial<AppServerThreadSummary> = {},
+): AppServerThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Thread 1",
+    titleSource: "explicit",
+    linkedDirectories: [],
+    source: "codex",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+async function addTestReactions(target: SqliteOverlayStore, threadId = "thread-1") {
+  await target.setThreadReaction({
+    backend: "codex",
+    threadId,
+    emoji: "👀",
+    present: true,
+  });
+  await target.setThreadReaction({
+    backend: "codex",
+    threadId,
+    emoji: "✅",
+    present: true,
+  });
+}
 
 describe("SqliteOverlayStore — thread reactions", () => {
   it("starts with no reactions on a thread that has never been touched", async () => {
@@ -181,5 +211,51 @@ describe("SqliteOverlayStore — thread reactions", () => {
     // Re-open the original handle so afterEach's close doesn't double-close.
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
+  });
+
+  it("preserves reactions when a single instance refreshes thread metadata", async () => {
+    await addTestReactions(store);
+
+    await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [
+        buildThreadSummary({
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+          fastMode: true,
+          updatedAt: 1500,
+        }),
+      ],
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.reactions).toEqual(["👀", "✅"]);
+  });
+
+  it("preserves reactions when another sqlite handle performs an unrelated overlay write", async () => {
+    await addTestReactions(store);
+
+    const secondDb = StateDb.open(path.join(tempDir, "state.db"));
+    const secondStore = new SqliteOverlayStore(secondDb);
+    try {
+      await secondStore.markThreadSeen({
+        backend: "codex",
+        threadId: "thread-1",
+        seenAt: 2500,
+        seenUpdatedAt: 2000,
+      });
+    } finally {
+      secondDb.close();
+    }
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.reactions).toEqual(["👀", "✅"]);
   });
 });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -61,6 +61,7 @@ export class SqliteOverlayStore {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const current = this.getThread(threadKey);
         this.putThread(threadKey, {
+          ...(current ?? {}),
           backend: thread.source,
           threadId: thread.id,
           executionMode: current?.executionMode ?? thread.executionMode ?? "default",
@@ -154,22 +155,13 @@ export class SqliteOverlayStore {
     const seenAt = params.seenAt ?? Date.now();
 
     this.putThread(threadKey, {
+      ...(current ?? {}),
       backend: params.backend,
       threadId: params.threadId,
       executionMode: current?.executionMode ?? "default",
-      model: current?.model,
-      reasoningEffort: current?.reasoningEffort,
-      serviceTier: current?.serviceTier,
-      fastMode: current?.fastMode,
-      gitBranch: current?.gitBranch,
-      observedGitBranch: current?.observedGitBranch,
-      dismissedAt: current?.dismissedAt,
-      snoozedUntil: current?.snoozedUntil,
-      retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
       lastSeenAt: seenAt,
       lastSeenUpdatedAt: params.seenUpdatedAt ?? current?.lastSeenUpdatedAt,
       extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
-      worktreeSnapshots: current?.worktreeSnapshots ?? [],
     });
 
     return {


### PR DESCRIPTION
## Summary

I fixed the desktop overlay store path that could drop thread-list emoji reactions during refresh-style writes.

- Added regression coverage for single-instance metadata refresh preserving reactions.
- Added regression coverage for a second sqlite/WAL handle marking a thread seen after another handle adds reactions.
- Updated `reconcileNavigationSnapshot` and `markThreadSeen` to merge from the existing overlay payload before writing the fields they own.

Fixes #239

## Verification

I verified the focused reaction spec passes:

```bash
pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts
```

I also verified the neighboring overlay persistence specs pass:

```bash
pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts apps/desktop/src/main/__tests__/overlay-store-prs.test.ts apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
```
