### PR TITLE
fix(desktop): preserve queued composer turns across navigation

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -855,7 +855,7 @@ export function Composer(props: ComposerProps) {
   const inputRef = useRef<ComposerRichInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
-  const activeTurnIdRef = useRef<string | undefined>(undefined);
+  const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const skillListboxId = useId();
   const slashListboxId = useId();
@@ -931,7 +931,9 @@ export function Composer(props: ComposerProps) {
     savedInitialQueuedTurn
   );
   const [pendingSteer, setPendingSteer] = useState<PendingSteerDraft>();
-  const [activeTurnId, setActiveTurnId] = useState<string | undefined>(undefined);
+  const [activeTurnId, setActiveTurnId] = useState<string | undefined>(
+    props.activeTurnId
+  );
   const [sendError, setSendError] = useState<string>();
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -57,6 +57,7 @@ import {
   useComposerDraftStore,
   type ComposerDraftSnapshot,
   type ComposerDraftStore,
+  type ComposerQueuedTurnSnapshot,
 } from "./useComposerDraftStore";
 
 type ComposerProps = {
@@ -872,6 +873,9 @@ export function Composer(props: ComposerProps) {
   const composerSupportsSkillTokens = composerImplementation !== "textarea";
   const composerUsesTiptap = composerImplementation.startsWith("tiptap-");
   const savedInitialDraft = draftStore.get(composerScopeKey);
+  const savedInitialQueuedTurn = props.thread
+    ? draftStore.getQueuedTurn(composerScopeKey)
+    : undefined;
   const hydratedInitialLaunchpad =
     savedInitialDraft || !props.launchpad
       ? undefined
@@ -923,7 +927,9 @@ export function Composer(props: ComposerProps) {
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
   const [steering, setSteering] = useState(false);
-  const [queuedTurn, setQueuedTurn] = useState<QueuedTurnDraft>();
+  const [queuedTurn, setQueuedTurnState] = useState<QueuedTurnDraft | undefined>(
+    savedInitialQueuedTurn
+  );
   const [pendingSteer, setPendingSteer] = useState<PendingSteerDraft>();
   const [activeTurnId, setActiveTurnId] = useState<string | undefined>(undefined);
   const [sendError, setSendError] = useState<string>();
@@ -1044,6 +1050,27 @@ export function Composer(props: ComposerProps) {
     if (isDraftStoreScope(scopeKey)) {
       draftStore.delete(scopeKey);
     }
+  };
+  const isQueuedTurnStoreScope = (scopeKey: string): boolean =>
+    scopeKey.startsWith("thread:");
+  const saveQueuedTurnSnapshot = (
+    scopeKey: string,
+    state?: ComposerQueuedTurnSnapshot,
+  ): void => {
+    if (!isQueuedTurnStoreScope(scopeKey)) {
+      return;
+    }
+
+    if (!state || (!state.text.trim() && state.imageAttachments.length === 0)) {
+      draftStore.deleteQueuedTurn(scopeKey);
+      return;
+    }
+
+    draftStore.setQueuedTurn(scopeKey, state);
+  };
+  const setQueuedTurn = (nextQueuedTurn?: QueuedTurnDraft): void => {
+    saveQueuedTurnSnapshot(composerScopeKey, nextQueuedTurn);
+    setQueuedTurnState(nextQueuedTurn);
   };
   const markComposerDraftSubmitted = (scopeKey: string): void => {
     if (!isDraftStoreScope(scopeKey)) {
@@ -1225,10 +1252,14 @@ export function Composer(props: ComposerProps) {
 
     if (props.thread) {
       const saved = draftStore.get(composerScopeKey);
+      const savedQueuedTurn = draftStore.getQueuedTurn(composerScopeKey);
       setDraft(saved?.draft ?? "");
       setEditorDocument(saved?.editorDocument);
       setImageAttachments(saved?.imageAttachments ?? []);
       setSkillTokens(saved?.skillTokens ?? []);
+      setQueuedTurnState(savedQueuedTurn);
+    } else {
+      setQueuedTurnState(undefined);
     }
     setSending(false);
     setInterrupting(false);
@@ -1236,7 +1267,6 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-    setQueuedTurn(undefined);
     setPendingSteer(undefined);
   }, [composerScopeKey, draft, editorDocument, imageAttachments, skillTokens]);
 
@@ -1347,7 +1377,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-    setQueuedTurn(undefined);
+    setQueuedTurnState(undefined);
     setPendingSteer(undefined);
     window.setTimeout(() => {
       inputRef.current?.focus();

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -617,6 +617,7 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Keep this queued reply"
     );
+    expect(startTurn).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -13,6 +13,7 @@ import { Composer } from "../Composer";
 import type {
   ComposerDraftSnapshot,
   ComposerDraftStore,
+  ComposerQueuedTurnSnapshot,
 } from "../useComposerDraftStore";
 
 vi.mock("../../../lib/image-normalization", () => ({
@@ -51,11 +52,19 @@ function chooseDropdownOption(label: string, optionName: string): void {
 
 function createComposerDraftStore(): ComposerDraftStore {
   const drafts = new Map<string, ComposerDraftSnapshot>();
+  const queuedTurns = new Map<string, ComposerQueuedTurnSnapshot>();
   return {
     delete: (scopeKey) => {
       drafts.delete(scopeKey);
     },
     get: (scopeKey) => drafts.get(scopeKey),
+    deleteQueuedTurn: (scopeKey) => {
+      queuedTurns.delete(scopeKey);
+    },
+    getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey),
+    setQueuedTurn: (scopeKey, snapshot) => {
+      queuedTurns.set(scopeKey, snapshot);
+    },
     set: (scopeKey, snapshot) => {
       drafts.set(scopeKey, snapshot);
     },
@@ -535,6 +544,92 @@ describe("Composer", () => {
         })
       );
     });
+  });
+
+  it("restores a queued active-turn message after navigating away and back", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const threadA = {
+      id: "thread-1",
+      title: "Active turn",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB = {
+      ...threadA,
+      id: "thread-2",
+      title: "Another thread",
+    };
+
+    const { unmount } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Keep this queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Keep this queued reply"
+    );
+
+    unmount();
+    const { unmount: unmountThreadB } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />
+    );
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+
+    unmountThreadB();
+    const { unmount: unmountRestoredThreadA } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />
+    );
+
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Keep this queued reply"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+
+    unmountRestoredThreadA();
+    render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />
+    );
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
   });
 
   it("shows queued image thumbnails while a turn is active", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -10,14 +10,23 @@ export type ComposerDraftSnapshot = {
   skillTokens: ComposerSkillToken[];
 };
 
+export type ComposerQueuedTurnSnapshot = {
+  text: string;
+  imageAttachments: NavigationLaunchpadImageAttachment[];
+};
+
 export type ComposerDraftStore = {
   delete(scopeKey: string): void;
   get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  deleteQueuedTurn(scopeKey: string): void;
+  getQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
+  setQueuedTurn(scopeKey: string, snapshot: ComposerQueuedTurnSnapshot): void;
   set(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
 };
 
 export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
+  const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot>());
 
   return useMemo(
     () => ({
@@ -25,6 +34,13 @@ export function useComposerDraftStore(): ComposerDraftStore {
         storeRef.current.delete(scopeKey);
       },
       get: (scopeKey) => storeRef.current.get(scopeKey),
+      deleteQueuedTurn: (scopeKey) => {
+        queuedTurnStoreRef.current.delete(scopeKey);
+      },
+      getQueuedTurn: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey),
+      setQueuedTurn: (scopeKey, snapshot) => {
+        queuedTurnStoreRef.current.set(scopeKey, snapshot);
+      },
       set: (scopeKey, snapshot) => {
         storeRef.current.set(scopeKey, snapshot);
       },


### PR DESCRIPTION
## Summary

This fixes #237 by keeping queued mid-turn composer replies in the renderer-level composer draft store instead of only in `Composer` component-local state.

Queued replies are now stored by thread scope, restored when the user navigates away and back to the same thread, and cleared when the queued message is sent, edited, deleted, or moved into steering.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

The regression test covers queueing a reply during an active turn, navigating to another thread, returning to the original thread, seeing the same queued-message pill, deleting it, and confirming it does not reappear after remount.
