### PR TITLE
docs(messaging): warn about streaming response tradeoffs

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -150,6 +150,7 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Streaming Responses"
             sub="Send partial assistant tokens as Telegram message edits."
+            help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(telegram.streamingResponses)}
             onChange={(streamingResponses) => {
               void props.onSaveTelegram({
@@ -243,6 +244,7 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Streaming Responses"
             sub="Send partial assistant tokens as Discord message edits."
+            help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(discord.streamingResponses)}
             onChange={(streamingResponses) => {
               void props.onSaveDiscord({
@@ -374,6 +376,7 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Streaming Responses"
             sub="Send partial assistant tokens as Mattermost message edits."
+            help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(mattermost.streamingResponses)}
             onChange={(streamingResponses) => {
               void props.onSaveMattermost({
@@ -496,6 +499,9 @@ const TOOL_UPDATE_MODE_OPTIONS: Array<{
   { label: "Show All", value: "show_all" },
 ];
 
+const STREAMING_RESPONSES_WARNING =
+  "Leave this off unless you know you need live edits. Voice readers may speak each partial edit as a separate incomplete reply, and frequent edits can quickly hit platform rate limits.";
+
 function chipLabelForBotToken(
   botToken: DesktopSettingsSnapshot["messaging"]["telegram"]["botToken"],
 ): ReactNode {
@@ -558,6 +564,7 @@ function ToggleField(props: {
   disabled?: boolean;
   label: string;
   sub?: ReactNode;
+  help?: ReactNode;
   source: string;
   onChange: (value: boolean) => void;
 }) {
@@ -565,6 +572,7 @@ function ToggleField(props: {
     <SettingsField
       label={props.label}
       sub={props.sub}
+      help={props.help}
       source={props.source}
       control={
         <SettingsSwitch

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -231,6 +231,8 @@ describe("SettingsScreen", () => {
     });
     expect(screen.getByRole("heading", { name: "Telegram" })).toBeInTheDocument();
     expect(screen.getByText("Authorized SuperGroups")).toBeInTheDocument();
+    expect(screen.getAllByText(/Voice readers may speak each partial edit/)).toHaveLength(3);
+    expect(screen.getAllByText(/quickly hit platform rate limits/)).toHaveLength(3);
     fireEvent.click(screen.getAllByRole("switch", { name: "Streaming Responses" })[0]!);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

I updated the Settings -> Messaging streaming-response toggles to make the trade-offs explicit before users turn them on.

The new help text warns that streaming should stay off unless live edits are specifically needed because voice readers can speak each partial edit as a separate incomplete reply, and frequent edits can quickly hit messaging-platform rate limits.

## Validation

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

Refs #218
