### PR TITLE
feat(messaging): validate platform IDs in settings

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -11,6 +11,8 @@ import type {
   MessagingChannelKind,
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingInboundRejectedListener,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
@@ -825,6 +827,86 @@ describe("DesktopMessagingRuntime", () => {
       expect.objectContaining({
         kind: "activity",
         platform: "telegram",
+      }),
+    );
+  });
+
+  it("logs adapter-level rejected inbound IDs before provider dispatch", async () => {
+    await prepareRuntimeStore();
+    let rejectedListener: MessagingInboundRejectedListener | undefined;
+    const adapter = createAdapter("discord", {
+      onInboundRejected: (listener: MessagingInboundRejectedListener) => {
+        rejectedListener = listener;
+        return () => {
+          rejectedListener = undefined;
+        };
+      },
+    });
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: bridge,
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: ["user-1"],
+        },
+      },
+    });
+
+    await runtime.start();
+    const rejectedEvent: MessagingRejectedInboundEvent = {
+      id: "discord:message:msg-1:rejected",
+      kind: "command",
+      actor: {
+        platformUserId: "1177378744822943744",
+        displayName: "Other User",
+        username: "other",
+      },
+      channel: {
+        channel: "discord",
+        conversation: {
+          id: "1480554271907905000",
+          kind: "channel",
+          parentId: "1480554271907905731",
+        },
+      },
+      receivedAt: 1234,
+      reason: "unauthorized-conversation",
+    };
+    await rejectedListener?.(rejectedEvent);
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const row = getAppStateDb().raw
+      .prepare(
+        `SELECT actor_id, conversation_id, payload
+         FROM messaging_activity_log
+         WHERE kind = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .get("inbound-rejected") as
+        | { actor_id: string; conversation_id: string; payload: string }
+        | undefined;
+
+    expect(row).toMatchObject({
+      actor_id: "1177378744822943744",
+      conversation_id: "1480554271907905000",
+    });
+    expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
+      conversationParentId: "1480554271907905731",
+      rejectionReason: "unauthorized-conversation",
+    });
+    expect(messagingLog.warn).toHaveBeenCalledWith(
+      "messaging event rejected before dispatch",
+      expect.objectContaining({
+        actorId: "1177378744822943744",
+        conversationId: "1480554271907905000",
+        reason: "unauthorized-conversation",
       }),
     );
   });

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -20,6 +20,8 @@ import type {
   MessagingCredentialValidationResult,
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingInboundRejectedListener,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import { getMainLogger } from "../log";
@@ -49,6 +51,7 @@ export type DesktopMessagingAdapter = {
    * cannot detect post-start failures may simply omit the method.
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
+  onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -140,6 +143,7 @@ export class DesktopMessagingRuntime {
    * Held so `stop()` can detach before adapters are torn down.
    */
   private adapterRuntimeErrorUnsubscribes: Array<() => void> = [];
+  private adapterInboundRejectedUnsubscribes: Array<() => void> = [];
   private started = false;
   /**
    * Per-platform health snapshot. Keyed by `MessagingChannelKind`. Updated
@@ -203,6 +207,25 @@ export class DesktopMessagingRuntime {
       });
 
       try {
+        const unsubscribeInboundRejected = adapter.onInboundRejected?.((event) => {
+          this.emitPlatformActivity(adapter.channel);
+          this.recordActivityFromRejected(adapter.channel, event);
+          messagingLog.warn("messaging event rejected before dispatch", {
+            actorDisplayName: event.actor.displayName,
+            actorId: event.actor.platformUserId,
+            actorIsBot: event.actor.isBot,
+            actorUsername: event.actor.username,
+            channel: adapter.channel,
+            conversationId: event.channel.conversation.id,
+            conversationKind: event.channel.conversation.kind,
+            eventId: event.id,
+            eventKind: event.kind,
+            reason: event.reason,
+          });
+        });
+        if (unsubscribeInboundRejected) {
+          this.adapterInboundRejectedUnsubscribes.push(unsubscribeInboundRejected);
+        }
         await adapter.start?.(async (event) => {
           // Activity ping fires on every inbound, *before* authorization
           // checks — the platform is active even when the message is
@@ -326,6 +349,16 @@ export class DesktopMessagingRuntime {
       }
     }
     this.adapterRuntimeErrorUnsubscribes = [];
+    for (const unsubscribe of this.adapterInboundRejectedUnsubscribes) {
+      try {
+        unsubscribe();
+      } catch (error) {
+        messagingLog.warn("messaging adapter inbound-rejected unsubscribe threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    this.adapterInboundRejectedUnsubscribes = [];
     this.controllers.forEach((controller) => controller.dispose());
     const stoppedChannels = this.adapters.map((adapter) => adapter.channel);
     await Promise.all(this.adapters.map(async (adapter) => adapter.stop?.()));
@@ -640,6 +673,39 @@ export class DesktopMessagingRuntime {
       });
     } catch (error) {
       messagingLog.warn("messaging activity log write failed", {
+        platform,
+        eventId: event.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private recordActivityFromRejected(
+    platform: MessagingChannelKind,
+    event: MessagingRejectedInboundEvent,
+  ): void {
+    try {
+      const conversation = event.channel.conversation;
+      getDesktopMessagingActivityLog().record({
+        platform,
+        kind: "inbound-rejected",
+        conversationId: conversation.id,
+        conversationTitle: conversation.title,
+        actorId: event.actor.platformUserId,
+        actorDisplayName: event.actor.displayName,
+        summary: `Rejected inbound from ${event.actor.displayName ?? event.actor.platformUserId}`,
+        payload: {
+          eventId: event.id,
+          eventKind: event.kind,
+          conversationKind: conversation.kind,
+          conversationParentId: conversation.parentId,
+          actorUsername: event.actor.username,
+          actorIsBot: event.actor.isBot,
+          rejectionReason: event.reason,
+        },
+      });
+    } catch (error) {
+      messagingLog.warn("messaging rejected activity log write failed", {
         platform,
         eventId: event.id,
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -633,6 +633,7 @@ export class DesktopMessagingRuntime {
           eventId: event.id,
           eventKind: event.kind,
           conversationKind: conversation.kind,
+          conversationParentId: conversation.parentId,
           actorUsername: event.actor.username,
           actorIsBot: event.actor.isBot,
         },

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -4,6 +4,7 @@ import type {
   MessagingActivityKind,
 } from "@pwragent/shared";
 import { DiscordIcon, MattermostIcon, TelegramIcon } from "../../icons";
+import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
 const REFRESH_INTERVAL_MS = 5_000;
@@ -148,6 +149,8 @@ function ActivitySection(props: {
 function ActivityRow(props: { entry: MessagingActivityEntry }) {
   const { entry } = props;
   const tone = KIND_TONE[entry.kind];
+  const [copiedKey, setCopiedKey] = useState<string | undefined>(undefined);
+  const copyFields = copyFieldsForEntry(entry);
   return (
     <li className="messaging-activity-row">
       <span className={`messaging-activity-row__icon messaging-activity-row__icon--${tone}`}>
@@ -173,9 +176,104 @@ function ActivityRow(props: { entry: MessagingActivityEntry }) {
           {" · "}
           {formatRelative(entry.createdAt)}
         </div>
+        {copyFields.length > 0 ? (
+          <div className="messaging-activity-row__ids" aria-label="Copy identifiers">
+            {copyFields.map((field) => (
+              <button
+                key={field.key}
+                className="messaging-activity-row__copy"
+                type="button"
+                onClick={() => {
+                  void copyText(field.value).then(() => {
+                    setCopiedKey(field.key);
+                    window.setTimeout(() => {
+                      setCopiedKey((current) =>
+                        current === field.key ? undefined : current,
+                      );
+                    }, 1200);
+                  });
+                }}
+              >
+                <span>{field.label}</span>
+                <code>{field.value}</code>
+                <span className="messaging-activity-row__copy-state">
+                  {copiedKey === field.key ? "Copied" : "Copy"}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
     </li>
   );
+}
+
+function copyFieldsForEntry(
+  entry: MessagingActivityEntry,
+): Array<{ key: string; label: string; value: string }> {
+  const fields: Array<{ key: string; label: string; value: string }> = [];
+  if (entry.actorId) {
+    fields.push({
+      key: "actor",
+      label: userIdLabel(entry.platform),
+      value: entry.actorId,
+    });
+  }
+
+  const conversationKind =
+    typeof entry.payload?.conversationKind === "string"
+      ? entry.payload.conversationKind
+      : undefined;
+  const parentId =
+    typeof entry.payload?.conversationParentId === "string"
+      ? entry.payload.conversationParentId
+      : undefined;
+
+  if (parentId) {
+    fields.push({
+      key: "parent",
+      label: parentIdLabel(entry.platform, conversationKind),
+      value: parentId,
+    });
+  }
+  if (entry.conversationId) {
+    fields.push({
+      key: "conversation",
+      label: conversationIdLabel(entry.platform, conversationKind),
+      value: entry.conversationId,
+    });
+  }
+
+  return fields;
+}
+
+function userIdLabel(platform: MessagingActivityEntry["platform"]): string {
+  if (platform === "telegram") return "Peer ID";
+  if (platform === "discord") return "User ID";
+  if (platform === "mattermost") return "User ID";
+  return "Actor ID";
+}
+
+function parentIdLabel(
+  platform: MessagingActivityEntry["platform"],
+  conversationKind?: string,
+): string {
+  if (platform === "telegram") return "Supergroup ID";
+  if (platform === "discord") return "Guild ID";
+  if (platform === "mattermost" && conversationKind === "thread") return "Root ID";
+  return "Parent ID";
+}
+
+function conversationIdLabel(
+  platform: MessagingActivityEntry["platform"],
+  conversationKind?: string,
+): string {
+  if (platform === "telegram" && conversationKind !== "dm") {
+    return conversationKind === "topic" ? "Topic ID" : "Supergroup ID";
+  }
+  if (platform === "discord" && conversationKind !== "dm") return "Channel ID";
+  if (platform === "mattermost" && conversationKind !== "dm") return "Channel ID";
+  return "Conversation ID";
 }
 
 function groupByKind(

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessagingActivityScreen } from "../MessagingActivityScreen";
+import type { DesktopApi } from "../../../lib/desktop-api";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MessagingActivityScreen", () => {
+  it("shows rejected actor and guild IDs as copyable controls", async () => {
+    const desktopApi = {
+      listMessagingActivity: vi.fn(async () => ({
+        entries: [
+          {
+            id: 1,
+            platform: "discord",
+            kind: "inbound-rejected",
+            conversationId: "1480554271907905000",
+            conversationTitle: "ops",
+            actorId: "1177378744822943744",
+            actorDisplayName: "Harold",
+            summary: "Rejected inbound from Harold",
+            createdAt: Date.now(),
+            payload: {
+              conversationKind: "channel",
+              conversationParentId: "1480554271907905731",
+            },
+          },
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<MessagingActivityScreen desktopApi={desktopApi} />);
+
+    await waitFor(() => {
+      expect(desktopApi.listMessagingActivity).toHaveBeenCalledWith({ limit: 200 });
+    });
+    expect((await screen.findByText("1177378744822943744")).closest("button"))
+      .toHaveTextContent("User ID");
+    expect(screen.getByText("1480554271907905731").closest("button"))
+      .toHaveTextContent("Guild ID");
+    expect(screen.getByText("1480554271907905000").closest("button"))
+      .toHaveTextContent("Channel ID");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1,8 +1,13 @@
-import { useState, type ReactNode } from "react";
-import type {
-  DesktopSettingsSecretName,
-  DesktopSettingsSnapshot,
-  MessagingToolUpdateMode,
+import { useId, useState, type ReactNode } from "react";
+import {
+  validateDiscordSnowflake,
+  validateMattermostId,
+  validateTelegramPositiveId,
+  validateTelegramSupergroupId,
+  type IdentifierValidationResult,
+  type DesktopSettingsSecretName,
+  type DesktopSettingsSnapshot,
+  type MessagingToolUpdateMode,
 } from "@pwragent/shared";
 import { DiscordIcon, MattermostIcon, TelegramIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -57,7 +62,7 @@ export function MessagingSettings(props: {
       <SettingsPanelHead
         eyebrow="Messaging"
         title="Connected chat platforms"
-        help="Bridge PwrAgent threads to messaging platforms so you can drive runs from your phone. Tokens are stored in the system keychain. Each platform's enabled switch is independent of the global messaging switch."
+        help="Bridge PwrAgent threads to messaging platforms so you can drive runs from your phone. Tokens are stored in the system keychain. Authorization defaults closed: if no allowed IDs are configured, nothing can use that entry. Check the Messaging Activity window for rejected IDs to add here."
       />
 
       {runtimeMessaging.disabled ? (
@@ -166,7 +171,9 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Authorized User IDs"
             sub="Comma-separated Telegram user IDs that can DM the bot."
+            help="Numeric peer ID, e.g. 8460800771. Rejected Telegram DMs show the peer ID in Messaging Activity; use the numeric form, not @username."
             source={optionalListSourceBadge(telegram.authorizedUserIds)}
+            validateEntry={validateTelegramUserIdEntry}
             value={telegram.authorizedUserIds.value}
             onSave={(authorizedUserIds) => {
               void props.onSaveTelegram({
@@ -182,7 +189,9 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Authorized SuperGroups"
             sub="Comma-separated Telegram supergroup IDs that may host bound threads."
+            help="Negative ID starting with -100, e.g. -1003841603622. Rejected group messages show the supergroup ID in Messaging Activity."
             source={optionalListSourceBadge(telegram.authorizedSupergroups)}
+            validateEntry={validateTelegramSupergroupEntry}
             value={telegram.authorizedSupergroups.value}
             onSave={(authorizedSupergroups) => {
               void props.onSaveTelegram({
@@ -276,7 +285,9 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Authorized User IDs"
             sub="Comma-separated Discord user IDs that can DM the bot."
+            help="Snowflake (17-19 digit number), e.g. 1177378744822943744. Rejected Discord messages show the user ID in Messaging Activity."
             source={optionalListSourceBadge(discord.authorizedUserIds)}
+            validateEntry={validateDiscordUserIdEntry}
             value={discord.authorizedUserIds.value}
             onSave={(authorizedUserIds) => {
               void props.onSaveDiscord({
@@ -292,7 +303,9 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Authorized Guilds"
             sub="Comma-separated Discord guild (server) IDs that may host bound threads."
+            help="Snowflake (17-19 digit number), e.g. 1480554271907905731. Rejected server messages show the guild ID in Messaging Activity."
             source={optionalListSourceBadge(discord.authorizedGuilds)}
+            validateEntry={validateDiscordGuildIdEntry}
             value={discord.authorizedGuilds.value}
             onSave={(authorizedGuilds) => {
               void props.onSaveDiscord({
@@ -470,7 +483,9 @@ export function MessagingSettings(props: {
             disabled={props.saving}
             label="Authorized User IDs"
             sub="Comma-separated Mattermost user IDs that can DM the bot."
+            help="26-character lowercase a-z0-9 ID. Rejected Mattermost messages show the user ID in Messaging Activity."
             source={optionalListSourceBadge(mattermost.authorizedUserIds)}
+            validateEntry={validateMattermostUserIdEntry}
             value={mattermost.authorizedUserIds.value}
             onSave={(authorizedUserIds) => {
               void props.onSaveMattermost({
@@ -676,31 +691,172 @@ function NumberField(props: {
 
 function ListField(props: {
   disabled?: boolean;
+  help?: ReactNode;
   label: string;
   sub?: ReactNode;
   source: string;
+  validateEntry?: (value: string) => string | undefined;
   value: string[];
   onSave: (value: string[]) => void;
 }) {
+  const inputId = useId();
+  const descriptionId = `${inputId}-validation`;
   const [value, setValue] = useState(joinListValue(props.value));
+  const entries = parseListValue(value);
+  const invalidEntries = props.validateEntry
+    ? entries
+        .map((entry, index) => ({
+          entry,
+          index,
+          message: props.validateEntry?.(entry),
+        }))
+        .filter(
+          (result): result is { entry: string; index: number; message: string } =>
+            Boolean(result.message),
+        )
+    : [];
+  const hasInvalidEntries = invalidEntries.length > 0;
+
+  const removeEntry = (indexToRemove: number) => {
+    const nextEntries = entries.filter((_, index) => index !== indexToRemove);
+    const nextValue = joinListValue(nextEntries);
+    setValue(nextValue);
+    if (!props.validateEntry || nextEntries.every((entry) => !props.validateEntry!(entry))) {
+      props.onSave(nextEntries);
+    }
+  };
 
   return (
     <SettingsField
       label={props.label}
       sub={props.sub}
+      help={props.help}
       source={props.source}
+      error={
+        hasInvalidEntries
+          ? "Fix or remove invalid IDs before saving this setting."
+          : undefined
+      }
       control={
-        <input
-          aria-label={props.label}
-          className="settings-input"
-          disabled={props.disabled}
-          value={value}
-          onBlur={() => props.onSave(parseListValue(value))}
-          onChange={(event) => setValue(event.currentTarget.value)}
-        />
+        <>
+          <input
+            aria-describedby={hasInvalidEntries ? descriptionId : undefined}
+            aria-invalid={hasInvalidEntries ? "true" : undefined}
+            aria-label={props.label}
+            className={`settings-input${hasInvalidEntries ? " settings-input--invalid" : ""}`}
+            disabled={props.disabled}
+            value={value}
+            onBlur={() => {
+              const nextEntries = parseListValue(value);
+              if (
+                props.validateEntry &&
+                nextEntries.some((entry) => props.validateEntry?.(entry))
+              ) {
+                return;
+              }
+              props.onSave(nextEntries);
+            }}
+            onChange={(event) => setValue(event.currentTarget.value)}
+          />
+          {hasInvalidEntries ? (
+            <div
+              id={descriptionId}
+              className="settings-list-validation"
+              role="status"
+            >
+              {invalidEntries.map((invalid) => (
+                <div
+                  key={`${invalid.index}-${invalid.entry}`}
+                  className="settings-list-validation__item"
+                >
+                  <span className="settings-list-validation__message">
+                    <code>{invalid.entry}</code>
+                    {" — "}
+                    {invalid.message}
+                  </span>
+                  <button
+                    className="button button--ghost settings-list-validation__remove"
+                    disabled={props.disabled}
+                    type="button"
+                    onClick={() => removeEntry(invalid.index)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </>
       }
     />
   );
+}
+
+function validateTelegramUserIdEntry(value: string): string | undefined {
+  return validationMessage(
+    validateTelegramPositiveId(value),
+    "Telegram user ID",
+    {
+      format:
+        value.startsWith("@") || /^[A-Za-z][A-Za-z0-9_]*$/.test(value)
+          ? "That looks like a Telegram username, not a peer ID. Use the numeric form (e.g. 8460800771)."
+          : "Use a positive numeric Telegram peer ID, e.g. 8460800771.",
+      length: "Telegram peer IDs must fit the decimal numeric ID form.",
+      range: "Use a positive Telegram peer ID, e.g. 8460800771.",
+    },
+  );
+}
+
+function validateTelegramSupergroupEntry(value: string): string | undefined {
+  return validationMessage(
+    validateTelegramSupergroupId(value),
+    "Telegram supergroup ID",
+    {
+      format:
+        "Use the negative supergroup ID starting with -100, e.g. -1003841603622.",
+      length: "Telegram supergroup IDs must fit the decimal numeric ID form.",
+      range:
+        "Use the negative supergroup ID starting with -100, e.g. -1003841603622.",
+    },
+  );
+}
+
+function validateDiscordUserIdEntry(value: string): string | undefined {
+  return validationMessage(validateDiscordSnowflake(value), "Discord user ID", {
+    format: "Use the numeric Discord snowflake, e.g. 1177378744822943744.",
+    future: "That snowflake timestamp is in the future. Copy the user ID from Messaging Activity.",
+    length: "Discord IDs are snowflakes: 17-19 digits.",
+    range: "Use a positive Discord snowflake, e.g. 1177378744822943744.",
+  });
+}
+
+function validateDiscordGuildIdEntry(value: string): string | undefined {
+  return validationMessage(validateDiscordSnowflake(value), "Discord guild ID", {
+    format: "Use the numeric Discord guild snowflake, e.g. 1480554271907905731.",
+    future: "That snowflake timestamp is in the future. Copy the guild ID from Messaging Activity.",
+    length: "Discord guild IDs are snowflakes: 17-19 digits.",
+    range: "Use a positive Discord guild snowflake, e.g. 1480554271907905731.",
+  });
+}
+
+function validateMattermostUserIdEntry(value: string): string | undefined {
+  return validationMessage(validateMattermostId(value), "Mattermost user ID", {
+    format: "Use the 26-character lowercase a-z0-9 Mattermost user ID.",
+    length: "Mattermost user IDs are exactly 26 lowercase a-z0-9 characters.",
+  });
+}
+
+function validationMessage(
+  result: IdentifierValidationResult,
+  label: string,
+  messages: Partial<
+    Record<Exclude<IdentifierValidationResult, { ok: true }>["reason"], string>
+  >,
+): string | undefined {
+  if (result.ok) return undefined;
+  if (result.reason === "empty") return `${label} cannot be blank.`;
+  if (result.reason === "type") return `${label} must be a string.`;
+  return messages[result.reason] ?? `${label} has the wrong format.`;
 }
 
 function SecretField(props: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -352,6 +352,84 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("validates messaging authorized IDs inline and refuses invalid saves", async () => {
+    const settings = createSettingsState();
+    render(
+      <SettingsScreen
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText(/Authorization defaults closed/)).toBeInTheDocument();
+    expect(screen.getByText(/Rejected Telegram DMs show the peer ID/)).toBeInTheDocument();
+
+    const telegramUserIds = screen.getAllByLabelText("Authorized User IDs")[0]!;
+    fireEvent.change(telegramUserIds, { target: { value: "@huntharo" } });
+    fireEvent.blur(telegramUserIds);
+
+    expect(
+      await screen.findByText(/That looks like a Telegram username/),
+    ).toBeInTheDocument();
+    expect(telegramUserIds).toHaveAttribute("aria-invalid", "true");
+    expect(settings.writeConfig).not.toHaveBeenCalledWith({
+      messaging: { telegram: { authorizedUserIds: ["@huntharo"] } },
+    });
+
+    fireEvent.change(telegramUserIds, { target: { value: "8460800771" } });
+    fireEvent.blur(telegramUserIds);
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            authorizedUserIds: ["8460800771"],
+          },
+        },
+      });
+    });
+  });
+
+  it("surfaces invalid persisted messaging IDs with a Remove action", async () => {
+    const snapshot = createSnapshot();
+    const settings = createSettingsState({
+      ...snapshot,
+      messaging: {
+        ...snapshot.messaging,
+        telegram: {
+          ...snapshot.messaging.telegram,
+          authorizedUserIds: {
+            value: ["@huntharo", "8460800771"],
+            source: "config",
+          },
+        },
+      },
+    });
+
+    render(
+      <SettingsScreen
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("@huntharo")).toBeInTheDocument();
+    expect(screen.getByText(/That looks like a Telegram username/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            authorizedUserIds: ["8460800771"],
+          },
+        },
+      });
+    });
+  });
+
   it("returns to the previous app surface", () => {
     const onClose = vi.fn();
     render(<SettingsScreen settings={createSettingsState()} onClose={onClose} />);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -551,7 +551,7 @@ textarea,
 .messaging-activity-row__body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -573,6 +573,55 @@ textarea,
   font-size: 11px;
   color: var(--text-muted);
   font-family: var(--font-mono);
+}
+
+.messaging-activity-row__ids {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.messaging-activity-row__copy {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  max-width: 100%;
+  gap: 6px;
+  min-height: 26px;
+  padding: 4px 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.messaging-activity-row__copy:hover {
+  border-color: var(--accent-border);
+  color: var(--text-secondary);
+}
+
+.messaging-activity-row__copy:focus-visible {
+  border-color: var(--accent-border);
+  outline: none;
+  box-shadow: 0 0 0 1px var(--accent-shadow);
+}
+
+.messaging-activity-row__copy code {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.messaging-activity-row__copy-state {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
 }
 
 .sidebar__icon-button {
@@ -2542,6 +2591,45 @@ textarea,
   border-color: var(--accent-border);
   outline: none;
   box-shadow: 0 0 0 1px var(--accent-shadow);
+}
+
+.settings-input--invalid {
+  border-color: var(--danger-border);
+  box-shadow: 0 0 0 1px rgba(196, 90, 58, 0.22);
+}
+
+.settings-list-validation {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-list-validation__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 8px;
+  border: 1px solid var(--danger-border);
+  border-radius: 6px;
+  background: var(--danger-soft);
+}
+
+.settings-list-validation__message {
+  min-width: 0;
+  color: var(--danger-text);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.settings-list-validation__message code {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.settings-list-validation__remove {
+  flex: 0 0 auto;
 }
 
 /* Segmented control — chip-pill chiclets that fit the design's

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -14,6 +14,13 @@ import type {
 // import path without seeing two parallel declarations.
 export {
   MESSAGING_TOOL_UPDATE_MODES,
+  validateDiscordSnowflake,
+  validateMattermostId,
+  validateTelegramChatId,
+  validateTelegramPositiveId,
+  validateTelegramSupergroupId,
+  type IdentifierValidationReason,
+  type IdentifierValidationResult,
   type MessagingToolUpdateMode,
 } from "@pwragent/shared";
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -595,6 +595,24 @@ export type MessagingInboundBaseEvent = {
   routingState?: MessagingAdapterState;
 };
 
+export type MessagingInboundRejectionReason =
+  | "unauthorized-actor"
+  | "unauthorized-conversation";
+
+export type MessagingRejectedInboundEvent = {
+  id: string;
+  kind: MessagingInboundEventKind;
+  actor: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  receivedAt: number;
+  reason: MessagingInboundRejectionReason;
+  routingState?: MessagingAdapterState;
+};
+
+export type MessagingInboundRejectedListener = (
+  event: MessagingRejectedInboundEvent,
+) => Promise<void> | void;
+
 export type MessagingInboundTextEvent = MessagingInboundBaseEvent & {
   kind: "text";
   text: string;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -1,6 +1,7 @@
 import type {
   MessagingAuditContext,
   MessagingInboundEvent,
+  MessagingRejectedInboundEvent,
 } from "@pwragent/messaging-interface";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -306,6 +307,7 @@ describe("discord adapter", () => {
   describe("text mention dispatch", () => {
     it("drops messages from unauthorized guilds before listener dispatch", async () => {
       const events: MessagingInboundEvent[] = [];
+      const rejectedEvents: MessagingRejectedInboundEvent[] = [];
       const gateway = new TestDiscordGateway();
       const logger = { debug: vi.fn(), warn: vi.fn() };
       const adapter = new DiscordAdapter({
@@ -324,6 +326,9 @@ describe("discord adapter", () => {
       await adapter.start(async (event) => {
         events.push(event);
       });
+      adapter.onInboundRejected((event) => {
+        rejectedEvents.push(event);
+      });
       await gateway.emit({
         op: 0,
         t: "MESSAGE_CREATE",
@@ -335,6 +340,19 @@ describe("discord adapter", () => {
       });
 
       expect(events).toHaveLength(0);
+      expect(rejectedEvents).toEqual([
+        expect.objectContaining({
+          actor: expect.objectContaining({ platformUserId: TEST_USER_ID }),
+          channel: expect.objectContaining({
+            conversation: expect.objectContaining({
+              id: TEST_CHANNEL_ID,
+              parentId: TEST_GUILD_ID,
+            }),
+          }),
+          kind: "command",
+          reason: "unauthorized-conversation",
+        }),
+      ]);
       expect(logger.warn).toHaveBeenCalledWith(
         "discord inbound ignored unauthorized guild",
         expect.objectContaining({ guildId: TEST_GUILD_ID }),
@@ -396,6 +414,7 @@ describe("discord adapter", () => {
 
     it("acknowledges valid component interactions from unauthorized guilds before dropping them", async () => {
       const events: MessagingInboundEvent[] = [];
+      const rejectedEvents: MessagingRejectedInboundEvent[] = [];
       const createInteractionResponse = vi.fn(async () => {});
       const gateway = new TestDiscordGateway();
       const logger = { debug: vi.fn(), warn: vi.fn() };
@@ -415,6 +434,9 @@ describe("discord adapter", () => {
 
       await adapter.start(async (event) => {
         events.push(event);
+      });
+      adapter.onInboundRejected((event) => {
+        rejectedEvents.push(event);
       });
       await gateway.emit({
         op: 0,
@@ -439,6 +461,19 @@ describe("discord adapter", () => {
         type: 6,
       });
       expect(events).toHaveLength(0);
+      expect(rejectedEvents).toEqual([
+        expect.objectContaining({
+          actor: expect.objectContaining({ platformUserId: TEST_USER_ID }),
+          channel: expect.objectContaining({
+            conversation: expect.objectContaining({
+              id: TEST_CHANNEL_ID,
+              parentId: TEST_GUILD_ID,
+            }),
+          }),
+          kind: "callback",
+          reason: "unauthorized-conversation",
+        }),
+      ]);
       expect(logger.warn).toHaveBeenCalledWith(
         "discord inbound ignored unauthorized guild",
         expect.objectContaining({ guildId: TEST_GUILD_ID, surface: "interaction" }),

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -23,7 +23,9 @@ import type {
   MessagingDeliveryResult,
   MessagingFilePart,
   MessagingInboundEvent,
+  MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -246,6 +248,7 @@ export type DiscordProviderAdapter = {
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
+  onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };
@@ -307,6 +310,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private readonly channelCache = new Map<string, DiscordChannelInfo>();
   private readonly guildCache = new Map<string, DiscordGuildInfo>();
   private readonly unauthorizedGuildLogKeys = new Set<string>();
+  private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private readonly options: DiscordAdapterOptions;
   private streamSurfaces = new Map<string, string>();
@@ -320,6 +324,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
 
   get authorizedActorIds(): readonly string[] {
     return this.options.config.authorizedActorIds;
+  }
+
+  onInboundRejected(listener: MessagingInboundRejectedListener): () => void {
+    this.inboundRejectedListeners.add(listener);
+    return () => {
+      this.inboundRejectedListeners.delete(listener);
+    };
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
@@ -1011,6 +1022,12 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     options: { actionable: boolean },
   ): boolean {
     if (!this.isAuthorizedGuild(message.guild_id, "message")) {
+      if (options.actionable) {
+        this.emitInboundRejected(this.rejectedEventFromMessage(message, {
+          kind: "command",
+          reason: "unauthorized-conversation",
+        }));
+      }
       return false;
     }
     if (!this.authorizedActorIds.includes(message.author.id)) {
@@ -1021,6 +1038,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           guildId: message.guild_id,
           actionable: options.actionable,
         });
+        this.emitInboundRejected(this.rejectedEventFromMessage(message, {
+          kind: options.actionable ? "command" : "text",
+          reason: "unauthorized-actor",
+        }));
       }
       return false;
     }
@@ -1032,6 +1053,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     actor: DiscordUser,
   ): boolean {
     if (!this.isAuthorizedGuild(interaction.guild_id, "interaction")) {
+      this.emitInboundRejected(this.rejectedEventFromInteraction(interaction, actor, {
+        reason: "unauthorized-conversation",
+      }));
       return false;
     }
     if (!this.authorizedActorIds.includes(actor.id)) {
@@ -1041,6 +1065,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         guildId: interaction.guild_id,
         interactionKind: interaction.data?.custom_id ? "component" : "command",
       });
+      this.emitInboundRejected(this.rejectedEventFromInteraction(interaction, actor, {
+        reason: "unauthorized-actor",
+      }));
       return false;
     }
     return true;
@@ -1464,6 +1491,77 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       isBot: user.bot,
       username: user.username,
     };
+  }
+
+  private rejectedEventFromMessage(
+    message: DiscordMessageCreateDispatch,
+    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason">,
+  ): MessagingRejectedInboundEvent {
+    return {
+      id: `discord:message:${message.id}:rejected`,
+      kind: options.kind,
+      actor: this.actorFromUser(message.author),
+      channel: this.basicChannelRef(
+        message.channel_id,
+        message.guild_id,
+        message.guild_id ? "channel" : "dm",
+      ),
+      receivedAt: this.now(),
+      reason: options.reason,
+      routingState: this.routingStateFromDiscord(message.channel_id, message.guild_id, {
+        channelType: message.channel_type,
+        isThread: message.is_thread,
+      }),
+    };
+  }
+
+  private rejectedEventFromInteraction(
+    interaction: DiscordInteractionCreateDispatch,
+    actor: DiscordUser,
+    options: Pick<MessagingRejectedInboundEvent, "reason">,
+  ): MessagingRejectedInboundEvent {
+    const kind = interaction.data?.custom_id ? "callback" : "command";
+    return {
+      id: `discord:interaction:${interaction.id}:rejected`,
+      kind,
+      actor: this.actorFromUser(actor, interaction.member?.nick ?? undefined),
+      channel: this.basicChannelRef(
+        interaction.channel_id,
+        interaction.guild_id,
+        interaction.guild_id ? "channel" : "dm",
+      ),
+      receivedAt: this.now(),
+      reason: options.reason,
+      routingState: this.routingStateFromDiscord(
+        interaction.channel_id,
+        interaction.guild_id,
+        {
+          channelType: interaction.channel_type,
+          isThread: interaction.is_thread,
+        },
+      ),
+    };
+  }
+
+  private basicChannelRef(
+    channelId: string,
+    guildId: string | undefined,
+    kind: "dm" | "channel",
+  ): MessagingInboundEvent["channel"] {
+    return {
+      channel: this.channel,
+      conversation: {
+        id: channelId,
+        kind,
+        ...(guildId ? { parentId: guildId } : {}),
+      },
+    };
+  }
+
+  private emitInboundRejected(event: MessagingRejectedInboundEvent): void {
+    for (const listener of this.inboundRejectedListeners) {
+      void listener(event);
+    }
   }
 
   private routingStateFromDiscord(

--- a/packages/messaging/providers/discord/src/validate-ids.ts
+++ b/packages/messaging/providers/discord/src/validate-ids.ts
@@ -1,4 +1,9 @@
 import { createHash } from "node:crypto";
+import {
+  validateDiscordSnowflake,
+  type IdentifierValidationReason,
+  type IdentifierValidationResult,
+} from "@pwragent/messaging-interface";
 
 export type DiscordIdentifierField =
   | "application_id"
@@ -12,26 +17,10 @@ export type DiscordIdentifierField =
   | "message.id"
   | "user.id";
 
-export type IdentifierValidationReason =
-  | "empty"
-  | "format"
-  | "future"
-  | "length"
-  | "range"
-  | "type";
-
-export type IdentifierValidationResult =
-  | { ok: true }
-  | { ok: false; reason: IdentifierValidationReason };
-
 export type IdentifierRejectionLogger = {
   warn?(message: string, data?: Record<string, unknown>): void;
 };
 
-const DISCORD_EPOCH_MS = 1_420_070_400_000n;
-const DISCORD_MAX_SNOWFLAKE_LENGTH = 19;
-const DISCORD_MIN_SNOWFLAKE_LENGTH = 17;
-const DISCORD_MAX_FUTURE_MS = 24n * 60n * 60n * 1000n;
 const DISCORD_MAX_TOKEN_LENGTH = 256;
 const DISCORD_MAX_CUSTOM_ID_BYTES = 100;
 const DISCORD_MAX_ATTACHMENT_URL_LENGTH = 2048;
@@ -40,34 +29,8 @@ const DISCORD_ATTACHMENT_HOSTS = new Set([
   "media.discordapp.net",
 ]);
 
-export function validateDiscordSnowflake(value: unknown): IdentifierValidationResult {
-  if (typeof value !== "string") {
-    return { ok: false, reason: "type" };
-  }
-  if (value.length === 0) {
-    return { ok: false, reason: "empty" };
-  }
-  if (
-    value.length < DISCORD_MIN_SNOWFLAKE_LENGTH ||
-    value.length > DISCORD_MAX_SNOWFLAKE_LENGTH
-  ) {
-    return { ok: false, reason: "length" };
-  }
-  for (let index = 0; index < value.length; index += 1) {
-    if (!isAsciiDigit(value.charCodeAt(index))) {
-      return { ok: false, reason: "format" };
-    }
-  }
-  const parsed = BigInt(value);
-  if (parsed <= 0n) {
-    return { ok: false, reason: "range" };
-  }
-  const timestampMs = (parsed >> 22n) + DISCORD_EPOCH_MS;
-  if (timestampMs > BigInt(Date.now()) + DISCORD_MAX_FUTURE_MS) {
-    return { ok: false, reason: "future" };
-  }
-  return { ok: true };
-}
+export type { IdentifierValidationReason, IdentifierValidationResult };
+export { validateDiscordSnowflake };
 
 export function validateDiscordInteractionToken(
   value: unknown,

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -4,6 +4,7 @@ import type {
   MessagingCallbackHandleRecord,
   MessagingCallbackHandleStore,
   MessagingChannelRef,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import type { Client4, WebSocketClient } from "@mattermost/client";
@@ -171,6 +172,64 @@ describe("MattermostAdapter — capability profile", () => {
       websocketClient: fakeWebSocketClient(),
     });
     expect(adapter.channel).toBe("mattermost");
+  });
+
+  it("emits rejected activity for unauthorized actionable posts", async () => {
+    const wsHooks: WebSocketHooks = {
+      fireMessage: () => {},
+      fireClose: () => {},
+    };
+    const rejectedEvents: MessagingRejectedInboundEvent[] = [];
+    const adapter = new MattermostAdapter({
+      callbackHandleStore: fakeStore,
+      client: fakeClient4({
+        createdPosts: [],
+        patchedPosts: [],
+      }),
+      config: baseConfig,
+      logger: silentLogger,
+      websocketClient: fakeWebSocketClient(undefined, wsHooks),
+      callbackServer: {
+        start: async () => {},
+        stop: async () => {},
+        signContext: () => ({ hmac: "x", issuedAt: 0 }),
+      } as never,
+      now: () => 1_700_000_000_000,
+    });
+    adapter.onInboundRejected((event) => {
+      rejectedEvents.push(event);
+    });
+    await adapter.start(async () => {});
+
+    wsHooks.fireMessage({
+      event: "posted",
+      data: {
+        channel_type: "O",
+        channel_display_name: "Development",
+        sender_name: "mallory",
+        post: JSON.stringify({
+          id: "postpostabcdefghijklmn1234",
+          channel_id: "channelabcdefghijklmn12345",
+          user_id: "otheruserabcdefghijklmn123",
+          message: "/status",
+        }),
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(rejectedEvents).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({ platformUserId: "otheruserabcdefghijklmn123" }),
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "channelabcdefghijklmn12345",
+            kind: "channel",
+          }),
+        }),
+        kind: "command",
+        reason: "unauthorized-actor",
+      }),
+    ]);
   });
 });
 

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -24,7 +24,9 @@ import type {
   MessagingConversationKind,
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
   MessagingSurfaceRef,
@@ -140,6 +142,7 @@ export type MattermostProviderAdapter = {
    * `<img>` icon, which is structurally insulated from `currentColor`).
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
+  onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle?(request: {
     actor?: MessagingActorIdentity;
     channel: MessagingChannelRef;
@@ -324,6 +327,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
    */
   private readonly responseUrlPostIds = new Set<string>();
   private readonly unauthorizedConversationLogKeys = new Set<string>();
+  private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   /**
    * Last reconciliation result per team, kept for diagnostics + future
    * re-reconcile passes (e.g. on team-membership change).
@@ -598,6 +602,13 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     };
   }
 
+  onInboundRejected(listener: MessagingInboundRejectedListener): () => void {
+    this.inboundRejectedListeners.add(listener);
+    return () => {
+      this.inboundRejectedListeners.delete(listener);
+    };
+  }
+
   async setConversationTitle(request: {
     actor?: MessagingActorIdentity;
     channel: MessagingChannelRef;
@@ -862,6 +873,8 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     post: NonNullable<ReturnType<typeof parseEmbeddedPost>>,
     data: {
       channel_type?: string;
+      sender_name?: string;
+      channel_display_name?: string;
     },
   ): void {
     const messageText = post.message ?? "";
@@ -883,6 +896,19 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       eventId: post.id,
       actionable,
       conversationKind: isDm ? "dm" : "channel",
+    });
+    this.emitInboundRejected({
+      id: `mattermost:post:${post.id}:rejected`,
+      kind: actionable ? "command" : "text",
+      actor: {
+        platformUserId: post.user_id,
+        displayName: data.sender_name,
+        username: data.sender_name,
+        isBot: false,
+      },
+      channel: this.channelRefForPost(post, data),
+      receivedAt: this.now(),
+      reason: "unauthorized-actor",
     });
   }
 
@@ -914,6 +940,26 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       this.logger.warn("mattermost ignored unauthorized callback actor", {
         actorId: body.user_id,
         channelId: body.channel_id,
+      });
+      this.emitInboundRejected({
+        id: this.newEventId("callback-rejected"),
+        kind: "callback",
+        actor: {
+          platformUserId: body.user_id,
+          displayName: body.user_name,
+          username: body.user_name,
+          isBot: false,
+        },
+        channel: {
+          channel: this.channel,
+          conversation: {
+            id: body.channel_id,
+            kind: "channel",
+            ...(body.channel_name ? { title: body.channel_name } : {}),
+          },
+        },
+        receivedAt: this.now(),
+        reason: "unauthorized-actor",
       });
       return;
     }
@@ -1196,6 +1242,27 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         actorId: body.user_id,
         command: body.command,
         channelId: body.channel_id,
+      });
+      this.emitInboundRejected({
+        id: this.newEventId("slashcmd-rejected"),
+        kind: "command",
+        actor: {
+          platformUserId: body.user_id,
+          displayName: body.user_name,
+          username: body.user_name,
+          isBot: false,
+        },
+        channel: {
+          channel: this.channel,
+          conversation: {
+            id: body.channel_id,
+            kind: body.root_id ? "thread" : "channel",
+            ...(body.root_id ? { parentId: body.root_id } : {}),
+            ...(body.channel_name ? { title: body.channel_name } : {}),
+          },
+        },
+        receivedAt: this.now(),
+        reason: "unauthorized-actor",
       });
       return undefined;
     }
@@ -2159,6 +2226,12 @@ export class MattermostAdapter implements MattermostProviderAdapter {
 
   private newEventId(prefix: string): string {
     return `mattermost-${prefix}-${this.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  private emitInboundRejected(event: MessagingRejectedInboundEvent): void {
+    for (const listener of this.inboundRejectedListeners) {
+      void listener(event);
+    }
   }
 }
 

--- a/packages/messaging/providers/mattermost/src/validate-ids.ts
+++ b/packages/messaging/providers/mattermost/src/validate-ids.ts
@@ -1,4 +1,9 @@
 import { createHash } from "node:crypto";
+import {
+  validateMattermostId,
+  type IdentifierValidationReason,
+  type IdentifierValidationResult,
+} from "@pwragent/messaging-interface";
 
 export type MattermostIdentifierField =
   | "callback.context.handle"
@@ -12,42 +17,15 @@ export type MattermostIdentifierField =
   | "trigger_id"
   | "user_id";
 
-export type IdentifierValidationReason =
-  | "empty"
-  | "format"
-  | "length"
-  | "type";
-
-export type IdentifierValidationResult =
-  | { ok: true }
-  | { ok: false; reason: IdentifierValidationReason };
-
 export type IdentifierRejectionLogger = {
   warn?(message: string, data?: Record<string, unknown>): void;
 };
 
-const MATTERMOST_ID_LENGTH = 26;
 const MATTERMOST_MAX_TOKEN_LENGTH = 256;
 const MATTERMOST_MAX_RESPONSE_URL_LENGTH = 2048;
 
-export function validateMattermostId(value: unknown): IdentifierValidationResult {
-  if (typeof value !== "string") {
-    return { ok: false, reason: "type" };
-  }
-  if (value.length === 0) {
-    return { ok: false, reason: "empty" };
-  }
-  if (value.length !== MATTERMOST_ID_LENGTH) {
-    return { ok: false, reason: "length" };
-  }
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    if (!isLowercaseAlphaNumeric(code)) {
-      return { ok: false, reason: "format" };
-    }
-  }
-  return { ok: true };
-}
+export type { IdentifierValidationReason, IdentifierValidationResult };
+export { validateMattermostId };
 
 export function validateMattermostCallbackHandle(
   value: unknown,
@@ -131,13 +109,6 @@ export function logMattermostInvalidIdentifier(params: {
     length: identifierLength(params.value),
     first8_hash: identifierHash(params.value),
   });
-}
-
-function isLowercaseAlphaNumeric(code: number): boolean {
-  return (
-    (code >= 0x30 && code <= 0x39) ||
-    (code >= 0x61 && code <= 0x7a)
-  );
 }
 
 function isBase64UrlChar(code: number): boolean {

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { TelegramAdapter, type TelegramBotLike } from "../telegram-adapter.ts";
+import type { MessagingRejectedInboundEvent } from "@pwragent/messaging-interface";
 
 describe("TelegramAdapter inbound security boundary", () => {
   it("drops authorized actors in unauthorized supergroups before listener dispatch", async () => {
@@ -15,6 +16,10 @@ describe("TelegramAdapter inbound security boundary", () => {
       },
       logger,
       pollOnStart: false,
+    });
+    const rejectedEvents: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejectedEvents.push(event);
     });
     await adapter.start(listener);
 
@@ -36,6 +41,19 @@ describe("TelegramAdapter inbound security boundary", () => {
     });
 
     expect(listener).not.toHaveBeenCalled();
+    expect(rejectedEvents).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({ platformUserId: "42" }),
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "-1009999999999",
+            kind: "channel",
+          }),
+        }),
+        kind: "command",
+        reason: "unauthorized-conversation",
+      }),
+    ]);
     expect(logger.warn).toHaveBeenCalledWith(
       "telegram inbound ignored unauthorized conversation",
       expect.objectContaining({
@@ -109,6 +127,10 @@ describe("TelegramAdapter inbound security boundary", () => {
       logger,
       pollOnStart: false,
     });
+    const rejectedEvents: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejectedEvents.push(event);
+    });
     await adapter.start(listener);
 
     await adapter.handleUpdate({
@@ -139,6 +161,19 @@ describe("TelegramAdapter inbound security boundary", () => {
       callback_query_id: "callback-1",
     });
     expect(listener).not.toHaveBeenCalled();
+    expect(rejectedEvents).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({ platformUserId: "99" }),
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "99",
+            kind: "dm",
+          }),
+        }),
+        kind: "callback",
+        reason: "unauthorized-actor",
+      }),
+    ]);
     expect(logger.warn).toHaveBeenCalledWith(
       "telegram callback ignored unauthorized actor",
       expect.objectContaining({

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -12,7 +12,9 @@ import type {
   MessagingDeliveryResult,
   MessagingFilePart,
   MessagingInboundEvent,
+  MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -351,6 +353,7 @@ export type TelegramProviderAdapter = {
    * flip the platform status pill from green to red).
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
+  onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
@@ -430,6 +433,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private static readonly TOPIC_NAME_CACHE_CAP = 500;
   private readonly topicNameCache = new Map<string, string>();
   private readonly unauthorizedConversationLogKeys = new Set<string>();
+  private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   private readonly options: {
     api?: TelegramBotApi;
     bot?: TelegramBotLike;
@@ -457,6 +461,13 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   get authorizedActorIds(): readonly string[] {
     return this.options.config.authorizedActorIds;
+  }
+
+  onInboundRejected(listener: MessagingInboundRejectedListener): () => void {
+    this.inboundRejectedListeners.add(listener);
+    return () => {
+      this.inboundRejectedListeners.delete(listener);
+    };
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
@@ -1302,12 +1313,20 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           chatType: message.chat.type,
           actionable: options.actionable,
         });
+        this.emitInboundRejected(this.rejectedEventFromMessage(message, {
+          kind: options.actionable ? "command" : "text",
+          reason: "unauthorized-actor",
+        }));
       }
       return false;
     }
 
     if (!this.isAuthorizedTelegramConversation(message.chat)) {
       this.logUnauthorizedConversationOnce("message", message.chat);
+      this.emitInboundRejected(this.rejectedEventFromMessage(message, {
+        kind: options.actionable ? "command" : "text",
+        reason: "unauthorized-conversation",
+      }));
       return false;
     }
     return true;
@@ -1321,10 +1340,18 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         actorId,
         chatId: chat ? String(chat.id) : undefined,
       });
+      if (chat) {
+        this.emitInboundRejected(this.rejectedEventFromCallback(callbackQuery, {
+          reason: "unauthorized-actor",
+        }));
+      }
       return false;
     }
     if (chat && !this.isAuthorizedTelegramConversation(chat)) {
       this.logUnauthorizedConversationOnce("callback", chat);
+      this.emitInboundRejected(this.rejectedEventFromCallback(callbackQuery, {
+        reason: "unauthorized-conversation",
+      }));
       return false;
     }
     return true;
@@ -1964,6 +1991,51 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       isBot: user?.is_bot,
       username: user?.username,
     };
+  }
+
+  private rejectedEventFromMessage(
+    message: TelegramMessage,
+    options: Pick<MessagingRejectedInboundEvent, "kind" | "reason">,
+  ): MessagingRejectedInboundEvent {
+    return {
+      id: `telegram:message:${message.message_id}:rejected`,
+      kind: options.kind,
+      actor: this.actorFromUser(message.from),
+      channel: this.channelFromMessage(message),
+      receivedAt: this.messageReceivedAt(message),
+      reason: options.reason,
+      routingState: this.routingStateFromMessage(message),
+    };
+  }
+
+  private rejectedEventFromCallback(
+    callbackQuery: TelegramCallbackQuery,
+    options: Pick<MessagingRejectedInboundEvent, "reason">,
+  ): MessagingRejectedInboundEvent {
+    const message = callbackQuery.message;
+    return {
+      id: `telegram:callback:${callbackQuery.id}:rejected`,
+      kind: "callback",
+      actor: this.actorFromUser(callbackQuery.from),
+      channel: message
+        ? this.channelFromMessage(message)
+        : {
+            channel: this.channel,
+            conversation: {
+              id: String(callbackQuery.from.id),
+              kind: "dm",
+            },
+          },
+      receivedAt: this.now(),
+      reason: options.reason,
+      ...(message ? { routingState: this.routingStateFromMessage(message) } : {}),
+    };
+  }
+
+  private emitInboundRejected(event: MessagingRejectedInboundEvent): void {
+    for (const listener of this.inboundRejectedListeners) {
+      void listener(event);
+    }
   }
 
   private isOwnBotUser(user: TelegramMessage["from"]): boolean {

--- a/packages/messaging/providers/telegram/src/validate-ids.ts
+++ b/packages/messaging/providers/telegram/src/validate-ids.ts
@@ -1,4 +1,10 @@
 import { createHash } from "node:crypto";
+import {
+  validateTelegramChatId,
+  validateTelegramPositiveId,
+  type IdentifierValidationReason,
+  type IdentifierValidationResult,
+} from "@pwragent/messaging-interface";
 
 export type TelegramIdentifierField =
   | "callback_query.id"
@@ -10,34 +16,16 @@ export type TelegramIdentifierField =
   | "update.update_id"
   | "user.id";
 
-export type IdentifierValidationReason =
-  | "empty"
-  | "format"
-  | "length"
-  | "range"
-  | "type";
-
-export type IdentifierValidationResult =
-  | { ok: true }
-  | { ok: false; reason: IdentifierValidationReason };
-
 export type IdentifierRejectionLogger = {
   warn?(message: string, data?: Record<string, unknown>): void;
 };
 
-const TELEGRAM_MAX_SAFE_ID = Number.MAX_SAFE_INTEGER;
-const TELEGRAM_MAX_SIGNED_ID_LENGTH = 17; // Number.MAX_SAFE_INTEGER is 16 digits plus '-'.
 const TELEGRAM_MAX_FILE_ID_LENGTH = 512;
 const TELEGRAM_MAX_CALLBACK_QUERY_ID_LENGTH = 128;
 const TELEGRAM_CALLBACK_DATA_LIMIT_BYTES = 64;
 
-export function validateTelegramChatId(value: unknown): IdentifierValidationResult {
-  return validateTelegramIntegerId(value, { allowNegative: true });
-}
-
-export function validateTelegramPositiveId(value: unknown): IdentifierValidationResult {
-  return validateTelegramIntegerId(value, { allowNegative: false });
-}
+export type { IdentifierValidationReason, IdentifierValidationResult };
+export { validateTelegramChatId, validateTelegramPositiveId };
 
 export function validateTelegramCallbackQueryId(
   value: unknown,
@@ -99,55 +87,6 @@ export function logTelegramInvalidIdentifier(params: {
     length: identifierLength(params.value),
     first8_hash: identifierHash(params.value),
   });
-}
-
-function validateTelegramIntegerId(
-  value: unknown,
-  options: { allowNegative: boolean },
-): IdentifierValidationResult {
-  if (typeof value === "number") {
-    if (!Number.isSafeInteger(value)) {
-      return { ok: false, reason: "type" };
-    }
-    if (!options.allowNegative && value <= 0) {
-      return { ok: false, reason: "range" };
-    }
-    if (value > TELEGRAM_MAX_SAFE_ID || value < -TELEGRAM_MAX_SAFE_ID) {
-      return { ok: false, reason: "range" };
-    }
-    return { ok: true };
-  }
-
-  if (typeof value !== "string") {
-    return { ok: false, reason: "type" };
-  }
-  if (value.length === 0) {
-    return { ok: false, reason: "empty" };
-  }
-  if (value.length > TELEGRAM_MAX_SIGNED_ID_LENGTH) {
-    return { ok: false, reason: "length" };
-  }
-
-  let start = 0;
-  if (value[0] === "-") {
-    if (!options.allowNegative || value.length === 1) {
-      return { ok: false, reason: "format" };
-    }
-    start = 1;
-  }
-  for (let index = start; index < value.length; index += 1) {
-    if (!isAsciiDigit(value.charCodeAt(index))) {
-      return { ok: false, reason: "format" };
-    }
-  }
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) {
-    return { ok: false, reason: "range" };
-  }
-  if (!options.allowNegative && parsed <= 0) {
-    return { ok: false, reason: "range" };
-  }
-  return { ok: true };
 }
 
 function validateBoundedVisibleAscii(

--- a/packages/shared/src/__tests__/messaging-id-validation.test.ts
+++ b/packages/shared/src/__tests__/messaging-id-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateDiscordSnowflake,
+  validateMattermostId,
+  validateTelegramPositiveId,
+  validateTelegramSupergroupId,
+} from "../messaging-id-validation";
+
+describe("messaging ID validators", () => {
+  it("accepts known-good settings identifiers", () => {
+    expect(validateTelegramPositiveId("8460800771")).toEqual({ ok: true });
+    expect(validateTelegramSupergroupId("-1003841603622")).toEqual({ ok: true });
+    expect(validateDiscordSnowflake("1177378744822943744")).toEqual({
+      ok: true,
+    });
+    expect(validateDiscordSnowflake("1480554271907905731")).toEqual({
+      ok: true,
+    });
+    expect(validateMattermostId("abcdefghijklmnopqrstu12345")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("rejects username confusions and mixed-shape values", () => {
+    for (const value of ["@huntharo", "huntharo", " 8460800771", "8460800771 "]) {
+      expect(validateTelegramPositiveId(value).ok).toBe(false);
+    }
+    expect(validateTelegramSupergroupId("8460800771").ok).toBe(false);
+    expect(validateTelegramSupergroupId("-3841603622").ok).toBe(false);
+    expect(validateDiscordSnowflake("@huntharo").ok).toBe(false);
+    expect(validateDiscordSnowflake("8460800771").ok).toBe(false);
+    expect(validateMattermostId("UserName").ok).toBe(false);
+    expect(validateMattermostId("abcdefghijklmnopqrstu1234").ok).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,4 +6,5 @@ export * from "./contracts/diff-focus";
 export * from "./contracts/messaging";
 export * from "./contracts/navigation";
 export * from "./contracts/settings";
+export * from "./messaging-id-validation";
 export * from "./thread-titles";

--- a/packages/shared/src/messaging-id-validation.ts
+++ b/packages/shared/src/messaging-id-validation.ts
@@ -1,0 +1,147 @@
+export type IdentifierValidationReason =
+  | "empty"
+  | "format"
+  | "future"
+  | "length"
+  | "range"
+  | "type";
+
+export type IdentifierValidationResult =
+  | { ok: true }
+  | { ok: false; reason: IdentifierValidationReason };
+
+const TELEGRAM_MAX_SAFE_ID = Number.MAX_SAFE_INTEGER;
+const TELEGRAM_MAX_SIGNED_ID_LENGTH = 17; // Number.MAX_SAFE_INTEGER is 16 digits plus "-".
+const DISCORD_EPOCH_MS = 1_420_070_400_000n;
+const DISCORD_MAX_SNOWFLAKE_LENGTH = 19;
+const DISCORD_MIN_SNOWFLAKE_LENGTH = 17;
+const DISCORD_MAX_FUTURE_MS = 24n * 60n * 60n * 1000n;
+const MATTERMOST_ID_LENGTH = 26;
+
+export function validateTelegramChatId(value: unknown): IdentifierValidationResult {
+  return validateTelegramIntegerId(value, { allowNegative: true });
+}
+
+export function validateTelegramPositiveId(value: unknown): IdentifierValidationResult {
+  return validateTelegramIntegerId(value, { allowNegative: false });
+}
+
+export function validateTelegramSupergroupId(
+  value: unknown,
+): IdentifierValidationResult {
+  const result = validateTelegramIntegerId(value, { allowNegative: true });
+  if (!result.ok) return result;
+  const normalized = typeof value === "number" ? String(value) : value;
+  if (typeof normalized !== "string" || !normalized.startsWith("-100")) {
+    return { ok: false, reason: "format" };
+  }
+  return { ok: true };
+}
+
+export function validateDiscordSnowflake(value: unknown): IdentifierValidationResult {
+  if (typeof value !== "string") {
+    return { ok: false, reason: "type" };
+  }
+  if (value.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+  if (
+    value.length < DISCORD_MIN_SNOWFLAKE_LENGTH ||
+    value.length > DISCORD_MAX_SNOWFLAKE_LENGTH
+  ) {
+    return { ok: false, reason: "length" };
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (!isAsciiDigit(value.charCodeAt(index))) {
+      return { ok: false, reason: "format" };
+    }
+  }
+  const parsed = BigInt(value);
+  if (parsed <= 0n) {
+    return { ok: false, reason: "range" };
+  }
+  const timestampMs = (parsed >> 22n) + DISCORD_EPOCH_MS;
+  if (timestampMs > BigInt(Date.now()) + DISCORD_MAX_FUTURE_MS) {
+    return { ok: false, reason: "future" };
+  }
+  return { ok: true };
+}
+
+export function validateMattermostId(value: unknown): IdentifierValidationResult {
+  if (typeof value !== "string") {
+    return { ok: false, reason: "type" };
+  }
+  if (value.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+  if (value.length !== MATTERMOST_ID_LENGTH) {
+    return { ok: false, reason: "length" };
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (!isLowercaseAlphaNumeric(code)) {
+      return { ok: false, reason: "format" };
+    }
+  }
+  return { ok: true };
+}
+
+function validateTelegramIntegerId(
+  value: unknown,
+  options: { allowNegative: boolean },
+): IdentifierValidationResult {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      return { ok: false, reason: "type" };
+    }
+    if (!options.allowNegative && value <= 0) {
+      return { ok: false, reason: "range" };
+    }
+    if (value > TELEGRAM_MAX_SAFE_ID || value < -TELEGRAM_MAX_SAFE_ID) {
+      return { ok: false, reason: "range" };
+    }
+    return { ok: true };
+  }
+
+  if (typeof value !== "string") {
+    return { ok: false, reason: "type" };
+  }
+  if (value.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+  if (value.length > TELEGRAM_MAX_SIGNED_ID_LENGTH) {
+    return { ok: false, reason: "length" };
+  }
+
+  let start = 0;
+  if (value[0] === "-") {
+    if (!options.allowNegative || value.length === 1) {
+      return { ok: false, reason: "format" };
+    }
+    start = 1;
+  }
+  for (let index = start; index < value.length; index += 1) {
+    if (!isAsciiDigit(value.charCodeAt(index))) {
+      return { ok: false, reason: "format" };
+    }
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    return { ok: false, reason: "range" };
+  }
+  if (!options.allowNegative && parsed <= 0) {
+    return { ok: false, reason: "range" };
+  }
+  return { ok: true };
+}
+
+function isAsciiDigit(code: number): boolean {
+  return code >= 0x30 && code <= 0x39;
+}
+
+function isLowercaseAlphaNumeric(code: number): boolean {
+  return (
+    (code >= 0x30 && code <= 0x39) ||
+    (code >= 0x61 && code <= 0x7a)
+  );
+}


### PR DESCRIPTION
## Summary

- Add shared messaging ID validators and inline Settings validation for Telegram, Discord, and Mattermost authorization fields.
- Document default-closed messaging authorization and point operators to Messaging Activity for rejected IDs.
- Log provider-level rejected inbound IDs before runtime dispatch and expose copyable actor/conversation IDs in Messaging Activity.

Closes #248

## Why

The Settings UI could accept malformed values like usernames, which made authorization failures hard to diagnose. The first implementation also documented Messaging Activity as the place to find IDs, but provider adapters rejected unauthorized messages before the runtime listener could record those rows.

This adds a provider-to-runtime rejected-inbound event path so rejected peer IDs, supergroup IDs, guild IDs, channel IDs, and user IDs are recorded in Activity and can be copied into Settings.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx packages/shared/src/__tests__/messaging-id-validation.test.ts packages/messaging/providers/telegram/src/__tests__/validate-ids.test.ts packages/messaging/providers/discord/src/__tests__/validate-ids.test.ts packages/messaging/providers/mattermost/src/__tests__/validate-ids.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm --filter @pwragent/messaging-interface typecheck`
- `pnpm --filter @pwragent/messaging-provider-telegram typecheck`
- `pnpm --filter @pwragent/messaging-provider-discord typecheck`
- `pnpm --filter @pwragent/messaging-provider-mattermost typecheck`
- `pnpm lint:boundaries`
