### PR TITLE
fix(desktop): stop PR refresh loop

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -51,14 +51,17 @@ describe("SqliteOverlayStore — thread PRs", () => {
       backend: "codex",
       threadId: "thread-1",
       prs: [prPassing],
+      refreshKey: "codex:thread-1:feat/pr-chip:/repo",
     });
     expect(next.prs).toEqual([prPassing]);
+    expect(next.prsRefreshKey).toBe("codex:thread-1:feat/pr-chip:/repo");
 
     const overlay = await store.getThreadOverlayState({
       backend: "codex",
       threadId: "thread-1",
     });
     expect(overlay?.prs).toEqual([prPassing]);
+    expect(overlay?.prsRefreshKey).toBe("codex:thread-1:feat/pr-chip:/repo");
   });
 
   it("replaces prs (last write wins) so state transitions land", async () => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, dialog, ipcMain } from "electron";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import type {
+  AppServerBackendKind,
   AppServerBackendScope,
   ArchiveWorktreeRequest,
   ArchiveWorktreeResponse,
@@ -78,6 +79,7 @@ import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
+const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const appServerLog = getMainLogger("pwragent:app-server");
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -117,6 +119,18 @@ function getNavigationSnapshotRequestKey(
   });
 }
 
+function getThreadPullRequestsRequestKey(
+  backend: AppServerBackendKind,
+  request: RefreshThreadPullRequestsRequest,
+): string {
+  return JSON.stringify({
+    backend,
+    threadId: request.threadId,
+    branch: request.branch.trim(),
+    directoryPaths: request.directoryPaths,
+  });
+}
+
 class DesktopAppServerService {
   private focusedDiffService: FocusedDiffService | null = null;
   private focusedDiffServiceApiKey: string | undefined;
@@ -125,6 +139,10 @@ class DesktopAppServerService {
   private readonly pendingNavigationSnapshots = new Map<
     string,
     Promise<NavigationSnapshot>
+  >();
+  private readonly pendingThreadPullRequestRefreshes = new Map<
+    string,
+    Promise<RefreshThreadPullRequestsResponse>
   >();
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
@@ -395,6 +413,30 @@ class DesktopAppServerService {
     request: RefreshThreadPullRequestsRequest,
   ): Promise<RefreshThreadPullRequestsResponse> {
     const backend = request.backend ?? "codex";
+    const requestKey = getThreadPullRequestsRequestKey(backend, request);
+    const pending = this.pendingThreadPullRequestRefreshes.get(requestKey);
+    if (pending) {
+      return await pending;
+    }
+
+    const refreshPromise = this.refreshThreadPullRequestsUncached(
+      backend,
+      request,
+      requestKey,
+    );
+    this.pendingThreadPullRequestRefreshes.set(requestKey, refreshPromise);
+    try {
+      return await refreshPromise;
+    } finally {
+      this.pendingThreadPullRequestRefreshes.delete(requestKey);
+    }
+  }
+
+  private async refreshThreadPullRequestsUncached(
+    backend: AppServerBackendKind,
+    request: RefreshThreadPullRequestsRequest,
+    requestKey: string,
+  ): Promise<RefreshThreadPullRequestsResponse> {
     const fetcher = this.getPrFetcher();
     const ghAvailable = await fetcher.isGhAvailable();
     if (!ghAvailable) {
@@ -446,6 +488,20 @@ class DesktopAppServerService {
       };
     }
 
+    const lastFetchedAt = existing?.prsFetchedAt;
+    if (
+      typeof lastFetchedAt === "number" &&
+      Date.now() - lastFetchedAt < THREAD_PR_REFRESH_MIN_INTERVAL_MS &&
+      existing?.prsRefreshKey === requestKey
+    ) {
+      return {
+        backend,
+        threadId: request.threadId,
+        prs: existingPrs,
+        ghAvailable: true,
+      };
+    }
+
     const prs = await detectPullRequestsForThread({
       fetcher,
       branch,
@@ -460,6 +516,7 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
       prs,
+      refreshKey: requestKey,
     });
 
     logDebug("refreshThreadPullRequests", {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -273,6 +273,7 @@ export class SqliteOverlayStore {
     threadId: string;
     prs: PrSummary[];
     fetchedAt?: number;
+    refreshKey?: string;
   }): Promise<ThreadOverlayState> {
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
     const current = this.getThread(threadKey) ?? {
@@ -285,6 +286,7 @@ export class SqliteOverlayStore {
       ...current,
       prs: params.prs,
       prsFetchedAt: params.fetchedAt ?? Date.now(),
+      prsRefreshKey: params.refreshKey,
     };
     this.putThread(threadKey, nextState);
     return nextState;

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -101,4 +101,75 @@ describe("usePullRequestRefresh", () => {
     });
     expect(onRefreshNavigation).not.toHaveBeenCalled();
   });
+
+  it("does not refresh again when the selected thread object is replaced", async () => {
+    const response = buildResponse({ prs: [] });
+    const refreshThreadPullRequests = vi.fn(async () => response);
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { rerender } = renderHook(
+      ({ selectedThread }: { selectedThread: NavigationThreadSummary }) =>
+        usePullRequestRefresh({
+          desktopApi,
+          selectedThread,
+        }),
+      {
+        initialProps: {
+          selectedThread: buildThread({ prs: [] }),
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+    });
+
+    rerender({
+      selectedThread: buildThread({ prs: [], updatedAt: 99 }),
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 20));
+    expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes again when the selected thread PR request changes", async () => {
+    const response = buildResponse({ prs: [] });
+    const refreshThreadPullRequests = vi.fn(async () => response);
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { rerender } = renderHook(
+      ({ selectedThread }: { selectedThread: NavigationThreadSummary }) =>
+        usePullRequestRefresh({
+          desktopApi,
+          selectedThread,
+        }),
+      {
+        initialProps: {
+          selectedThread: buildThread({ prs: [] }),
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+    });
+
+    rerender({
+      selectedThread: buildThread({ gitBranch: "feat/next", prs: [] }),
+    });
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledTimes(2);
+    });
+    expect(refreshThreadPullRequests).toHaveBeenLastCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/next",
+      directoryPaths: ["/repo"],
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import { resolveFetchableDirectoryPaths } from "./resolveFetchableDirectoryPaths";
@@ -57,24 +57,38 @@ export function usePullRequestRefresh(params: {
   );
 
   const selected = params.selectedThread;
-  const selectedKey = selected
-    ? buildThreadIdentityKey(selected.source, selected.id)
-    : undefined;
+  const selectedRef = useRef<NavigationThreadSummary | undefined>(selected);
+  const selectedRefreshKey = useMemo(
+    () => selected ? buildRefreshRequestKey(selected) : undefined,
+    [selected],
+  );
+
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
 
   // Selection trigger + 60s ticker: collapse into a single effect keyed on
-  // the selected thread's identity. Re-running on every snapshot would
-  // burn fetches needlessly — the snapshot mutates on inbox refresh even
-  // when the selected thread is unchanged.
+  // the selected thread's fetchable PR request. Re-running on every
+  // snapshot would burn fetches needlessly — the snapshot mutates during
+  // live agent activity even when the selected thread's branch and
+  // directories are unchanged.
   useEffect(() => {
-    if (!selected) return;
-    refresh(selected);
+    if (!selectedRefreshKey) return;
+    const refreshSelected = (): void => {
+      const currentSelected = selectedRef.current;
+      if (!currentSelected) return;
+      if (buildRefreshRequestKey(currentSelected) !== selectedRefreshKey) return;
+      refresh(currentSelected);
+    };
+
+    refreshSelected();
     const intervalId = window.setInterval(() => {
-      refresh(selected);
+      refreshSelected();
     }, SELECTED_REFRESH_INTERVAL_MS);
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [selected, selectedKey, refresh]);
+  }, [selectedRefreshKey, refresh]);
 
   // Hover prefetch: dedupe so a flood of mouseenter events for the same
   // thread doesn't trigger a flood of gh subprocesses.
@@ -99,6 +113,20 @@ export function usePullRequestRefresh(params: {
   );
 
   return { prefetch };
+}
+
+function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undefined {
+  const branch = thread.gitBranch?.trim();
+  if (!branch) return undefined;
+
+  const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
+  if (directoryPaths.length === 0) return undefined;
+
+  return JSON.stringify({
+    threadKey: buildThreadIdentityKey(thread.source, thread.id),
+    branch,
+    directoryPaths,
+  });
 }
 
 function prSummariesEqual(

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -428,6 +428,7 @@ export class OverlayStore {
     threadId: string;
     prs: PrSummary[];
     fetchedAt?: number;
+    refreshKey?: string;
   }): Promise<ThreadOverlayState> {
     return await this.withData(async (data) => {
       const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
@@ -441,6 +442,7 @@ export class OverlayStore {
         ...current,
         prs: params.prs,
         prsFetchedAt: params.fetchedAt ?? Date.now(),
+        prsRefreshKey: params.refreshKey,
       };
       data.threads[threadKey] = nextState;
       return nextState;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -335,6 +335,12 @@ export type ThreadOverlayState = {
   /** Wall-clock ms when `prs` was last refreshed via gh. */
   prsFetchedAt?: number;
   /**
+   * Stable key for the branch + directory inputs used by the last PR
+   * refresh. Main only reuses a recent `prs` result when the current
+   * request matches this key.
+   */
+  prsRefreshKey?: string;
+  /**
    * Pending permission mode change waiting for the active turn to end.
    * Lives in registry memory only — the overlay store does NOT serialize
    * these two fields across app restart. Surfaced on the navigation


### PR DESCRIPTION
## Summary

I fixed the repeated PR-refresh loop that showed up during live Codex turns.

- Key the selected-thread PR refresh effect by the actual refresh request instead of the selected thread object reference.
- Coalesce identical in-flight backend PR refreshes.
- Reuse fresh persisted PR refresh results for 60 seconds only when branch and directory inputs exactly match the last fetch, including empty results.
- Add renderer hook regression coverage for selected-thread object replacement.

## Verification

I verified this in `/Users/huntharo/.codex/worktrees/mox5ghr5/PwrAgnt`:

- `pnpm test apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
