### PR TITLE
feat(settings): label authorized contact lists with friendly display names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - Override the root with `PWRAGENT_HOME=/path/to/root` for isolated E2E or dev-profile use.
 - Select a named profile with `PWRAGENT_PROFILE=<name>` (defaults to `default`).
 - Per-profile layout: `~/.pwragent/profiles/<name>/config.toml` (settings), `~/.pwragent/profiles/<name>/state/state.db` (sqlite).
+- Before making a backwards-incompatible TOML config shape change, read [docs/config-file-evolution.md](docs/config-file-evolution.md) and follow its read-fallback, lazy-conversion, legacy-comment, and dual-write rules.
 - Grok app-server config lives at `~/.config/grok-app-server/config.toml` (legacy path, still read).
 - Runtime config keys in the grok config: `xai_api_key`, `grok_model`, `xai_base_url`, `state_root`.
 - Environment variables (`XAI_API_KEY`, `GROK_MODEL`, `XAI_BASE_URL`) still override the toml config.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -48,6 +48,14 @@ pnpm --filter @pwragent/desktop dev:no-messaging
 - The `dev` script (without `no-messaging`) also works but will attempt to connect messaging providers.
 - If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
 
+## Config File Evolution
+
+Before changing `config.toml` keys in a backwards-incompatible way, read
+[../../docs/config-file-evolution.md](../../docs/config-file-evolution.md).
+The desktop config writer must preserve recognized legacy shapes when possible,
+mark them with the `pwragent-legacy-settings` comment, lazily convert on save,
+and avoid whole-file rewrites that discard user comments.
+
 ## Thread-State Update Bus
 
 When mutating persistent thread state (model, reasoning effort, fast mode,

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { desktopSettingsPatchToEdits } from "../settings/desktop-config";
+import { parseTomlTables } from "../settings/toml-editor";
 
 describe("desktopSettingsPatchToEdits — Mattermost", () => {
   it("emits one set op per defined Mattermost field with the correct snake_case key", () => {
@@ -53,7 +54,11 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
       },
       {
         op: "delete",
-        path: ["messaging", "mattermost", "authorized_user_ids"],
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
       },
       {
         op: "delete",
@@ -64,12 +69,66 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
         path: ["messaging", "mattermost", "authorized_users"],
       },
       {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+      },
+      {
         op: "setTableArray",
-        path: ["messaging", "mattermost", "authorized_users"],
+        path: ["messaging", "mattermost", "authorized_user_ids"],
         value: [
           { id: "abc", display_name: "Alice" },
           { id: "def", display_name: "Dev Team" },
         ],
+      },
+    ]);
+  });
+
+  it("keeps a legacy scalar mirror when the current config already has one", () => {
+    const tables = parseTomlTables(
+      "[messaging.mattermost]\nauthorized_user_ids = [\"old\"]\n",
+      "/tmp/config.toml",
+    );
+
+    const edits = desktopSettingsPatchToEdits(
+      {
+        messaging: {
+          mattermost: {
+            authorizedUserIds: [{ id: "abc", displayName: "Alice" }],
+          },
+        },
+      },
+      tables,
+    );
+
+    expect(edits).toEqual([
+      {
+        op: "delete",
+        path: ["messaging", "mattermost", "authorized_users"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_users"],
+      },
+      {
+        op: "ensureCommentBefore",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+        marker: "pwragent-legacy-settings",
+        comment:
+          "# pwragent-legacy-settings key=authorized_user_ids shape=string-array used_through=1.0.0-alpha.9 kept_for_older_clients",
+      },
+      {
+        op: "set",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+        value: ["abc"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+      },
+      {
+        op: "setTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+        value: [{ id: "abc", display_name: "Alice" }],
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -12,7 +12,10 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
           callbackBaseUrl: "https://callbacks.example.com",
           slashCommandPrefix: "pwragent_",
           registerSlashCommands: true,
-          authorizedUserIds: ["abc", "def"],
+          authorizedUserIds: [
+            { id: "abc", displayName: "Alice" },
+            { id: "def", displayName: "Dev Team" },
+          ],
         },
       },
     });
@@ -49,9 +52,24 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
         value: true,
       },
       {
-        op: "set",
+        op: "delete",
         path: ["messaging", "mattermost", "authorized_user_ids"],
-        value: ["abc", "def"],
+      },
+      {
+        op: "delete",
+        path: ["messaging", "mattermost", "authorized_users"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_users"],
+      },
+      {
+        op: "setTableArray",
+        path: ["messaging", "mattermost", "authorized_users"],
+        value: [
+          { id: "abc", display_name: "Alice" },
+          { id: "def", display_name: "Dev Team" },
+        ],
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -54,6 +54,22 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
       },
       {
         op: "delete",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids"],
+      },
+      {
+        op: "delete",
+        path: ["messaging", "mattermost", "authorized_users_list"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_users_list"],
+      },
+      {
+        op: "delete",
         path: ["messaging", "mattermost", "authorized_user_ids_list"],
       },
       {
@@ -69,12 +85,8 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
         path: ["messaging", "mattermost", "authorized_users"],
       },
       {
-        op: "deleteTableArray",
-        path: ["messaging", "mattermost", "authorized_user_ids"],
-      },
-      {
         op: "setTableArray",
-        path: ["messaging", "mattermost", "authorized_user_ids"],
+        path: ["messaging", "mattermost", "authorized_users"],
         value: [
           { id: "abc", display_name: "Alice" },
           { id: "def", display_name: "Dev Team" },
@@ -103,11 +115,19 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
     expect(edits).toEqual([
       {
         op: "delete",
-        path: ["messaging", "mattermost", "authorized_users"],
+        path: ["messaging", "mattermost", "authorized_users_list"],
       },
       {
         op: "deleteTableArray",
-        path: ["messaging", "mattermost", "authorized_users"],
+        path: ["messaging", "mattermost", "authorized_users_list"],
+      },
+      {
+        op: "delete",
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+      },
+      {
+        op: "deleteTableArray",
+        path: ["messaging", "mattermost", "authorized_user_ids_list"],
       },
       {
         op: "ensureCommentBefore",
@@ -122,12 +142,16 @@ describe("desktopSettingsPatchToEdits — Mattermost", () => {
         value: ["abc"],
       },
       {
+        op: "delete",
+        path: ["messaging", "mattermost", "authorized_users"],
+      },
+      {
         op: "deleteTableArray",
-        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+        path: ["messaging", "mattermost", "authorized_users"],
       },
       {
         op: "setTableArray",
-        path: ["messaging", "mattermost", "authorized_user_ids_list"],
+        path: ["messaging", "mattermost", "authorized_users"],
         value: [{ id: "abc", display_name: "Alice" }],
       },
     ]);

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -165,6 +165,33 @@ describe("DesktopSettingsService", () => {
     ]);
   });
 
+  it("sanitizes authorized contact display names read from config", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const unsafeDisplayName = "<script>alert(1)</script>Harold\u202e";
+    fs.writeFileSync(
+      configPath,
+      [
+        "[[messaging.telegram.authorized_users]]",
+        'id = "111111111"',
+        `display_name = "${unsafeDisplayName}"`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
+      { id: "111111111", displayName: "Harold" },
+    ]);
+  });
+
   it("migrates legacy authorized user arrays when the list is next saved", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -138,7 +138,7 @@ describe("DesktopSettingsService", () => {
         "[messaging.telegram]",
         "enabled = true",
         "",
-        "[[messaging.telegram.authorized_users]]",
+        "[[messaging.telegram.authorized_user_ids]]",
         'id = "111111111"',
         'display_name = "Harold"',
         "",
@@ -200,11 +200,19 @@ describe("DesktopSettingsService", () => {
     });
 
     const contents = fs.readFileSync(configPath, "utf8");
-    expect(contents).not.toContain("authorized_user_ids");
-    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).toContain(
+      "# pwragent-legacy-settings key=authorized_user_ids shape=string-array used_through=1.0.0-alpha.9 kept_for_older_clients",
+    );
+    expect(contents).toContain('authorized_user_ids = ["111111111"]');
+    expect(contents).toContain("[[messaging.telegram.authorized_user_ids_list]]");
     expect(contents).toContain('id = "111111111"');
     expect(contents).toContain('display_name = "Harold"');
     expect(contents).toContain("streaming_responses = true");
+
+    const after = await service.readSettings();
+    expect(after.messaging.telegram.authorizedUserIds.value).toEqual([
+      { id: "111111111", displayName: "Harold" },
+    ]);
   });
 
   it("loads the worktree storage location from TOML and exposes the effective path", async () => {
@@ -408,8 +416,8 @@ describe("DesktopSettingsService", () => {
     expect(contents).toContain("input_debounce_ms = 1250");
     expect(contents).toContain('tool_update_mode = "show_less"');
     expect(contents).toContain("streaming_responses = true");
-    expect(contents).not.toContain("authorized_user_ids");
-    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).not.toContain("authorized_user_ids =");
+    expect(contents).toContain("[[messaging.telegram.authorized_user_ids]]");
     expect(contents).toContain('id = "111111111"');
     expect(contents).toContain('display_name = "Harold"');
     expect(contents).toContain("[applications.terminal]");
@@ -540,8 +548,8 @@ describe("DesktopSettingsService", () => {
     expect(contents).toContain("register_slash_commands = true");
     expect(contents).not.toContain("callback_port");
     expect(contents).toContain('slash_command_prefix = "agent_"');
-    expect(contents).not.toContain("authorized_user_ids");
-    expect(contents).toContain("[[messaging.mattermost.authorized_users]]");
+    expect(contents).not.toContain("authorized_user_ids =");
+    expect(contents).toContain("[[messaging.mattermost.authorized_user_ids]]");
     expect(contents).toContain('id = "userA"');
     expect(contents).toContain('display_name = "Alice"');
     // Bot token + HMAC secret never written to TOML

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -90,8 +90,8 @@ describe("DesktopSettingsService", () => {
       source: "config",
     });
     expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
-      "111111111",
-      "222222222",
+      { id: "111111111", displayName: "" },
+      { id: "222222222", displayName: "" },
     ]);
     expect(snapshot.messaging.telegram.authorizedSupergroups.value).toEqual([]);
     expect(snapshot.messaging.discord.applicationId.value).toBe(
@@ -102,7 +102,7 @@ describe("DesktopSettingsService", () => {
       source: "config",
     });
     expect(snapshot.messaging.discord.authorizedGuilds.value).toEqual([
-      "guild-one",
+      { id: "guild-one", displayName: "" },
     ]);
     expect(snapshot.models.codex.path).toEqual({
       value: "codex-beta",
@@ -127,6 +127,84 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.worktrees.effectivePath).toMatch(
       /\.pwragent\/worktrees$/,
     );
+  });
+
+  it("reads authorized contacts from TOML array-of-tables", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "",
+        "[[messaging.telegram.authorized_users]]",
+        'id = "111111111"',
+        'display_name = "Harold"',
+        "",
+        "[[messaging.telegram.authorized_supergroups]]",
+        'id = "-1003841603622"',
+        'display_name = "PwrAgent ops"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
+      { id: "111111111", displayName: "Harold" },
+    ]);
+    expect(snapshot.messaging.telegram.authorizedSupergroups.value).toEqual([
+      { id: "-1003841603622", displayName: "PwrAgent ops" },
+    ]);
+  });
+
+  it("migrates legacy authorized user arrays when the list is next saved", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        'authorized_user_ids = ["111111111"]',
+        "streaming_responses = true",
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const before = await service.readSettings();
+    expect(before.messaging.telegram.authorizedUserIds.value).toEqual([
+      { id: "111111111", displayName: "" },
+    ]);
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      'authorized_user_ids = ["111111111"]',
+    );
+
+    await service.writeConfigPatch({
+      messaging: {
+        telegram: {
+          authorizedUserIds: [{ id: "111111111", displayName: "Harold" }],
+        },
+      },
+    });
+
+    const contents = fs.readFileSync(configPath, "utf8");
+    expect(contents).not.toContain("authorized_user_ids");
+    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).toContain('id = "111111111"');
+    expect(contents).toContain('display_name = "Harold"');
+    expect(contents).toContain("streaming_responses = true");
   });
 
   it("loads the worktree storage location from TOML and exposes the effective path", async () => {
@@ -259,7 +337,10 @@ describe("DesktopSettingsService", () => {
       overriddenByEnv: false,
     });
     expect(snapshot.messaging.telegram.authorizedUserIds).toMatchObject({
-      value: ["222222222", "333333333"],
+      value: [
+        { id: "222222222", displayName: "" },
+        { id: "333333333", displayName: "" },
+      ],
       source: "env",
       overriddenByEnv: true,
     });
@@ -299,7 +380,7 @@ describe("DesktopSettingsService", () => {
         telegram: {
           enabled: true,
           streamingResponses: true,
-          authorizedUserIds: ["111111111"],
+          authorizedUserIds: [{ id: "111111111", displayName: "Harold" }],
           authorizedSupergroups: [],
         },
       },
@@ -327,7 +408,10 @@ describe("DesktopSettingsService", () => {
     expect(contents).toContain("input_debounce_ms = 1250");
     expect(contents).toContain('tool_update_mode = "show_less"');
     expect(contents).toContain("streaming_responses = true");
-    expect(contents).toContain('authorized_user_ids = ["111111111"]');
+    expect(contents).not.toContain("authorized_user_ids");
+    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).toContain('id = "111111111"');
+    expect(contents).toContain('display_name = "Harold"');
     expect(contents).toContain("[applications.terminal]");
     expect(contents).toContain('preferred_id = "ghostty"');
     expect(contents).toContain("[applications.gh]");
@@ -439,7 +523,10 @@ describe("DesktopSettingsService", () => {
           callbackBaseUrl: "https://tunnel.example.com/mm",
           slashCommandPrefix: "agent_",
           registerSlashCommands: true,
-          authorizedUserIds: ["userA", "userB"],
+          authorizedUserIds: [
+            { id: "userA", displayName: "Alice" },
+            { id: "userB", displayName: "Bob" },
+          ],
         },
       },
     });
@@ -453,7 +540,10 @@ describe("DesktopSettingsService", () => {
     expect(contents).toContain("register_slash_commands = true");
     expect(contents).not.toContain("callback_port");
     expect(contents).toContain('slash_command_prefix = "agent_"');
-    expect(contents).toContain('authorized_user_ids = ["userA", "userB"]');
+    expect(contents).not.toContain("authorized_user_ids");
+    expect(contents).toContain("[[messaging.mattermost.authorized_users]]");
+    expect(contents).toContain('id = "userA"');
+    expect(contents).toContain('display_name = "Alice"');
     // Bot token + HMAC secret never written to TOML
     expect(contents).not.toContain("token-abc");
     expect(contents).not.toContain("hmac-secret");
@@ -480,8 +570,8 @@ describe("DesktopSettingsService", () => {
       true,
     );
     expect(snapshot.messaging.mattermost.authorizedUserIds.value).toEqual([
-      "userA",
-      "userB",
+      { id: "userA", displayName: "Alice" },
+      { id: "userB", displayName: "Bob" },
     ]);
     expect(snapshot.messaging.mattermost.botToken).toMatchObject({
       configured: true,

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -138,7 +138,7 @@ describe("DesktopSettingsService", () => {
         "[messaging.telegram]",
         "enabled = true",
         "",
-        "[[messaging.telegram.authorized_user_ids]]",
+        "[[messaging.telegram.authorized_users]]",
         'id = "111111111"',
         'display_name = "Harold"',
         "",
@@ -204,7 +204,8 @@ describe("DesktopSettingsService", () => {
       "# pwragent-legacy-settings key=authorized_user_ids shape=string-array used_through=1.0.0-alpha.9 kept_for_older_clients",
     );
     expect(contents).toContain('authorized_user_ids = ["111111111"]');
-    expect(contents).toContain("[[messaging.telegram.authorized_user_ids_list]]");
+    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).not.toContain("[[messaging.telegram.authorized_user_ids_list]]");
     expect(contents).toContain('id = "111111111"');
     expect(contents).toContain('display_name = "Harold"');
     expect(contents).toContain("streaming_responses = true");
@@ -213,6 +214,49 @@ describe("DesktopSettingsService", () => {
     expect(after.messaging.telegram.authorizedUserIds.value).toEqual([
       { id: "111111111", displayName: "Harold" },
     ]);
+  });
+
+  it("migrates interim authorized user list tables to the canonical name", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        "streaming_responses = true",
+        "",
+        "[[messaging.telegram.authorized_user_ids_list]]",
+        'id = "111111111"',
+        'display_name = "Harold"',
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const before = await service.readSettings();
+    expect(before.messaging.telegram.authorizedUserIds.value).toEqual([
+      { id: "111111111", displayName: "Harold" },
+    ]);
+
+    await service.writeConfigPatch({
+      messaging: {
+        telegram: {
+          authorizedUserIds: [{ id: "111111111", displayName: "Harold" }],
+        },
+      },
+    });
+
+    const contents = fs.readFileSync(configPath, "utf8");
+    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
+    expect(contents).not.toContain(
+      "[[messaging.telegram.authorized_user_ids_list]]",
+    );
+    expect(contents).not.toContain("authorized_user_ids =");
+    expect(contents).toContain("streaming_responses = true");
   });
 
   it("loads the worktree storage location from TOML and exposes the effective path", async () => {
@@ -417,7 +461,7 @@ describe("DesktopSettingsService", () => {
     expect(contents).toContain('tool_update_mode = "show_less"');
     expect(contents).toContain("streaming_responses = true");
     expect(contents).not.toContain("authorized_user_ids =");
-    expect(contents).toContain("[[messaging.telegram.authorized_user_ids]]");
+    expect(contents).toContain("[[messaging.telegram.authorized_users]]");
     expect(contents).toContain('id = "111111111"');
     expect(contents).toContain('display_name = "Harold"');
     expect(contents).toContain("[applications.terminal]");
@@ -549,7 +593,7 @@ describe("DesktopSettingsService", () => {
     expect(contents).not.toContain("callback_port");
     expect(contents).toContain('slash_command_prefix = "agent_"');
     expect(contents).not.toContain("authorized_user_ids =");
-    expect(contents).toContain("[[messaging.mattermost.authorized_user_ids]]");
+    expect(contents).toContain("[[messaging.mattermost.authorized_users]]");
     expect(contents).toContain('id = "userA"');
     expect(contents).toContain('display_name = "Alice"');
     // Bot token + HMAC secret never written to TOML

--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -75,7 +75,7 @@ describe("DiscordAdapter", () => {
         applicationId: DISCORD_APP_ID,
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
     });
@@ -111,7 +111,7 @@ describe("DiscordAdapter", () => {
         applicationId: DISCORD_APP_ID,
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
     });
@@ -143,7 +143,7 @@ describe("DiscordAdapter", () => {
         applicationId: DISCORD_APP_ID,
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
     });
@@ -170,7 +170,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway,
       now: () => 1000,
@@ -348,7 +348,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
       now: () => 1000,
@@ -396,7 +396,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
         streamingResponses: true,
       },
       gateway: createGateway(),
@@ -631,7 +631,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
       now: () => 1000,
@@ -693,7 +693,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway: createGateway(),
       now: () => 1000,
@@ -759,7 +759,7 @@ describe("DiscordAdapter", () => {
         config: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: [DISCORD_USER_ID],
+          authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
         },
         gateway: createGateway(),
         now: () => 1000,
@@ -829,7 +829,7 @@ describe("DiscordAdapter", () => {
         config: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: [DISCORD_USER_ID],
+          authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
         },
         gateway: createGateway(),
         now: () => 1000,
@@ -1027,7 +1027,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway,
     });
@@ -1081,7 +1081,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       gateway,
     });
@@ -1115,7 +1115,7 @@ describe("DiscordAdapter", () => {
       config: {
         channel: "discord",
         botToken: "discord-token",
-        authorizedActorIds: [DISCORD_USER_ID],
+        authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
       },
       now: () => 1000,
     });
@@ -1203,7 +1203,7 @@ async function createControllerHarness(options: {
       applicationId: options.applicationId,
       channel: "discord",
       botToken: "discord-token",
-      authorizedActorIds: [DISCORD_USER_ID],
+      authorizedActorIds: [{ id: DISCORD_USER_ID, displayName: "" }],
     },
     gateway,
     now: () => 1000,

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -43,7 +43,10 @@ describe("desktop messaging config", () => {
         enabled: true,
         botToken: "tg-token",
         streamingResponses: false,
-        authorizedActorIds: ["user-1", "user-2"],
+        authorizedActorIds: [
+          { id: "user-1", displayName: "" },
+          { id: "user-2", displayName: "" },
+        ],
         authorizedSupergroupIds: [],
       },
     });
@@ -62,13 +65,16 @@ describe("desktop messaging config", () => {
       telegram: {
         botToken: "legacy-tg-token",
         streamingResponses: false,
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       discord: {
         applicationId: "discord-app",
         botToken: "legacy-discord-token",
         streamingResponses: false,
-        authorizedActorIds: ["100", "200"],
+        authorizedActorIds: [
+          { id: "100", displayName: "" },
+          { id: "200", displayName: "" },
+        ],
       },
     });
   });
@@ -116,7 +122,7 @@ describe("desktop messaging config", () => {
         enabled: true,
         botToken: "settings-telegram-token",
         streamingResponses: true,
-        authorizedActorIds: ["111111111"],
+        authorizedActorIds: [{ id: "111111111", displayName: "" }],
         authorizedSupergroupIds: [],
       },
       discord: {
@@ -125,7 +131,7 @@ describe("desktop messaging config", () => {
         applicationId: "discord-app",
         botToken: "settings-discord-token",
         streamingResponses: true,
-        authorizedActorIds: ["222222222"],
+        authorizedActorIds: [{ id: "222222222", displayName: "" }],
         authorizedGuildIds: [],
       },
     });
@@ -146,7 +152,7 @@ describe("desktop messaging config", () => {
     expect(config.telegram).toMatchObject({
       botToken: "env-telegram-token",
       streamingResponses: false,
-      authorizedActorIds: ["42"],
+      authorizedActorIds: [{ id: "42", displayName: "" }],
     });
   });
 
@@ -174,14 +180,17 @@ describe("desktop messaging config", () => {
         channel: "telegram",
         botToken: "secret-token",
         streamingResponses: true,
-        authorizedActorIds: ["1", "2"],
+        authorizedActorIds: [
+          { id: "1", displayName: "" },
+          { id: "2", displayName: "" },
+        ],
       },
       discord: {
         channel: "discord",
         applicationId: "app-id",
         botToken: "discord-secret",
         streamingResponses: false,
-        authorizedActorIds: ["3"],
+        authorizedActorIds: [{ id: "3", displayName: "" }],
       },
     });
 

--- a/apps/desktop/src/main/__tests__/messaging-provider-loader.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-provider-loader.test.ts
@@ -49,13 +49,13 @@ describe("messaging provider loader", () => {
     const store = createStore();
     const config: DesktopMessagingConfig = {
       discord: {
-        authorizedActorIds: ["discord-user"],
+        authorizedActorIds: [{ id: "discord-user", displayName: "" }],
         botToken: "discord-token",
         channel: "discord",
         enabled: false,
       },
       telegram: {
-        authorizedActorIds: ["telegram-user"],
+        authorizedActorIds: [{ id: "telegram-user", displayName: "" }],
         botToken: "telegram-token",
         channel: "telegram",
       },
@@ -85,12 +85,12 @@ describe("messaging provider loader", () => {
     });
     const config: DesktopMessagingConfig = {
       discord: {
-        authorizedActorIds: ["discord-user"],
+        authorizedActorIds: [{ id: "discord-user", displayName: "" }],
         botToken: "discord-token",
         channel: "discord",
       },
       telegram: {
-        authorizedActorIds: ["telegram-user"],
+        authorizedActorIds: [{ id: "telegram-user", displayName: "" }],
         botToken: "telegram-token",
         channel: "telegram",
       },

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -132,7 +132,7 @@ describe("DesktopMessagingRuntime", () => {
       telegram: {
         channel: "telegram" as const,
         botToken: "telegram-token",
-        authorizedActorIds: ["user-1"],
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
       },
     }));
     const bridge = createBackendBridge();
@@ -333,12 +333,12 @@ describe("DesktopMessagingRuntime", () => {
         discord: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -389,12 +389,12 @@ describe("DesktopMessagingRuntime", () => {
         discord: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -556,12 +556,12 @@ describe("DesktopMessagingRuntime", () => {
         discord: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -613,12 +613,12 @@ describe("DesktopMessagingRuntime", () => {
         discord: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -711,7 +711,7 @@ describe("DesktopMessagingRuntime", () => {
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -752,7 +752,7 @@ describe("DesktopMessagingRuntime", () => {
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -804,7 +804,7 @@ describe("DesktopMessagingRuntime", () => {
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -853,7 +853,7 @@ describe("DesktopMessagingRuntime", () => {
         discord: {
           channel: "discord",
           botToken: "discord-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -1040,13 +1040,13 @@ describe("DesktopMessagingRuntime", () => {
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
         discord: {
           channel: "discord",
           botToken: "discord-token",
           applicationId: "app-1",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -1101,7 +1101,7 @@ describe("DesktopMessagingRuntime", () => {
         telegram: {
           channel: "telegram",
           botToken: "telegram-token",
-          authorizedActorIds: ["user-1"],
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
         },
       },
     });
@@ -1136,7 +1136,7 @@ async function createRuntimeHarness(): Promise<{
       telegram: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["user-1"],
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
       },
     },
   });

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -186,7 +186,8 @@ describe("settings ipc", () => {
     providerMocks.resolveTelegramContact.mockResolvedValue({
       status: "ok",
       id: "8460800771",
-      displayName: "Harold (@huntharo)",
+      displayName: "<script>alert(1)</script>Harold\u202e",
+      handle: "@hunt<haro>",
     });
 
     registerSettingsIpcHandlers(service);
@@ -202,7 +203,8 @@ describe("settings ipc", () => {
       ),
     ).resolves.toMatchObject({
       status: "ok",
-      displayName: "Harold (@huntharo)",
+      displayName: "Harold",
+      handle: "@hunt",
     });
     expect(providerMocks.resolveTelegramContact).toHaveBeenCalledExactlyOnceWith(
       { botToken: "telegram-token" },

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -8,6 +8,11 @@ import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const tempRoots: string[] = [];
 const disposeDesktopBackendRegistryMock = vi.fn(async () => undefined);
+const providerMocks = vi.hoisted(() => ({
+  resolveTelegramContact: vi.fn(),
+  resolveDiscordContact: vi.fn(),
+  resolveMattermostContact: vi.fn(),
+}));
 
 vi.mock("electron", () => ({
   ipcMain: {
@@ -29,6 +34,18 @@ vi.mock("../app-server/backend-registry", () => ({
   disposeDesktopBackendRegistry: disposeDesktopBackendRegistryMock,
 }));
 
+vi.mock("@pwragent/messaging-provider-telegram", () => ({
+  resolveContact: providerMocks.resolveTelegramContact,
+}));
+
+vi.mock("@pwragent/messaging-provider-discord", () => ({
+  resolveContact: providerMocks.resolveDiscordContact,
+}));
+
+vi.mock("@pwragent/messaging-provider-mattermost", () => ({
+  resolveContact: providerMocks.resolveMattermostContact,
+}));
+
 describe("settings ipc", () => {
   afterEach(() => {
     for (const root of tempRoots.splice(0)) {
@@ -39,6 +56,9 @@ describe("settings ipc", () => {
   beforeEach(() => {
     handlers.clear();
     disposeDesktopBackendRegistryMock.mockClear();
+    providerMocks.resolveTelegramContact.mockReset();
+    providerMocks.resolveDiscordContact.mockReset();
+    providerMocks.resolveMattermostContact.mockReset();
   });
 
   it("registers redacted read and write handlers", async () => {
@@ -146,5 +166,47 @@ describe("settings ipc", () => {
     );
 
     expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves messaging contacts through provider packages", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-settings-ipc-"));
+    tempRoots.push(tempRoot);
+    const secretStore = new MemoryDesktopSecretStore();
+    await secretStore.setSecret("telegramBotToken", "telegram-token");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore,
+      now: () => 20,
+    });
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const {
+      SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
+    } = await import("../../shared/ipc");
+    providerMocks.resolveTelegramContact.mockResolvedValue({
+      status: "ok",
+      id: "8460800771",
+      displayName: "Harold (@huntharo)",
+    });
+
+    registerSettingsIpcHandlers(service);
+
+    await expect(
+      handlers.get(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL)?.(
+        {},
+        {
+          platform: "telegram",
+          kind: "user",
+          id: "8460800771",
+        },
+      ),
+    ).resolves.toMatchObject({
+      status: "ok",
+      displayName: "Harold (@huntharo)",
+    });
+    expect(providerMocks.resolveTelegramContact).toHaveBeenCalledExactlyOnceWith(
+      { botToken: "telegram-token" },
+      { id: "8460800771", kind: "user" },
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -65,7 +65,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       now: () => 1000,
@@ -105,7 +105,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       now: () => 1000,
@@ -157,7 +157,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       now: () => 1000,
@@ -403,7 +403,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
     });
@@ -474,7 +474,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       now: () => 1000,
@@ -521,7 +521,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
     });
@@ -569,7 +569,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => 1000,
@@ -656,7 +656,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => 1000,
@@ -726,7 +726,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => now,
@@ -798,7 +798,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => now,
@@ -918,7 +918,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => now,
@@ -1007,7 +1007,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         streamingResponses: true,
       },
       now: () => now,
@@ -1069,7 +1069,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "12345:test-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
     });
@@ -1122,7 +1122,7 @@ describe("TelegramAdapter", () => {
         config: {
           channel: "telegram",
           botToken: "12345:test-token",
-          authorizedActorIds: ["42"],
+          authorizedActorIds: [{ id: "42", displayName: "" }],
         },
         now: () => 1000,
       });
@@ -1193,7 +1193,7 @@ describe("TelegramAdapter", () => {
         config: {
           channel: "telegram",
           botToken: "12345:test-token",
-          authorizedActorIds: ["42"],
+          authorizedActorIds: [{ id: "42", displayName: "" }],
         },
         now: () => 1000,
       });
@@ -1345,7 +1345,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -1364,7 +1364,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -1400,7 +1400,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: " 12345:test-token ",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       pollOnStart: false,
@@ -1442,7 +1442,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "bad token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       logger,
       pollOnStart: false,
@@ -1477,7 +1477,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -1542,7 +1542,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
     });
@@ -1605,7 +1605,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -1668,7 +1668,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -1879,7 +1879,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -2001,7 +2001,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -2054,7 +2054,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -2102,7 +2102,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -2142,7 +2142,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "8378950683:telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -2179,7 +2179,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "8378950683:telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       pollOnStart: false,
     });
@@ -2215,7 +2215,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -2267,7 +2267,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -2320,7 +2320,7 @@ describe("TelegramAdapter", () => {
       config: {
         channel: "telegram",
         botToken: "telegram-token",
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
       },
       now: () => 1000,
       pollOnStart: false,
@@ -2395,7 +2395,7 @@ async function createControllerHarness(): Promise<{
     config: {
       channel: "telegram",
       botToken: "telegram-token",
-      authorizedActorIds: ["42"],
+      authorizedActorIds: [{ id: "42", displayName: "" }],
     },
     now: () => 1000,
     pollOnStart: false,

--- a/apps/desktop/src/main/__tests__/toml-editor.test.ts
+++ b/apps/desktop/src/main/__tests__/toml-editor.test.ts
@@ -221,6 +221,25 @@ describe("applyTomlEdits", () => {
     expect(result).toMatch(/]\n?$/);
   });
 
+  it("emits array-of-tables blocks", () => {
+    const result = applyTomlEdits("[messaging.telegram]\n", [
+      {
+        op: "setTableArray",
+        path: ["messaging", "telegram", "authorized_users"],
+        value: [
+          { id: "8460800771", display_name: "Harold" },
+          { id: "1234567890", display_name: "" },
+        ],
+      },
+    ]);
+
+    expect(result).toContain("[messaging.telegram]");
+    expect(result).toContain("[[messaging.telegram.authorized_users]]");
+    expect(result).toContain('id = "8460800771"');
+    expect(result).toContain('display_name = "Harold"');
+    expect(result).toContain('id = "1234567890"');
+  });
+
   it("replaces a multi-line inline-table-array value across lines", () => {
     const source = [
       "[messaging.mattermost]",
@@ -416,6 +435,29 @@ describe("parseTomlTables", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("parses array-of-tables into the parent table key", () => {
+    const tables = parseTomlTables(
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "",
+        "[[messaging.telegram.authorized_users]]",
+        'id = "8460800771"',
+        'display_name = "Harold"',
+        "",
+        "[[messaging.telegram.authorized_users]]",
+        'id = "1234567890"',
+        'display_name = ""',
+      ].join("\n"),
+      "/x",
+    );
+
+    expect(tables["messaging.telegram"].authorized_users).toEqual([
+      { id: "8460800771", display_name: "Harold" },
+      { id: "1234567890", display_name: "" },
+    ]);
   });
 
   it("still throws on malformed TOML lines", () => {

--- a/apps/desktop/src/main/__tests__/toml-editor.test.ts
+++ b/apps/desktop/src/main/__tests__/toml-editor.test.ts
@@ -202,6 +202,40 @@ describe("applyTomlEdits", () => {
     expect(result).toContain('authorized_user_ids = ["111"]');
   });
 
+  it("inserts a marker comment before a key once", () => {
+    const source = [
+      "[messaging.telegram]",
+      'authorized_user_ids = ["111"]',
+      "",
+    ].join("\n");
+
+    const result = applyTomlEdits(source, [
+      {
+        op: "ensureCommentBefore",
+        path: ["messaging", "telegram", "authorized_user_ids"],
+        marker: "pwragent-legacy-settings",
+        comment: "# pwragent-legacy-settings used_through=1.0.0-alpha.9",
+      },
+    ]);
+
+    expect(result).toContain(
+      [
+        "# pwragent-legacy-settings used_through=1.0.0-alpha.9",
+        'authorized_user_ids = ["111"]',
+      ].join("\n"),
+    );
+    expect(
+      applyTomlEdits(result, [
+        {
+          op: "ensureCommentBefore",
+          path: ["messaging", "telegram", "authorized_user_ids"],
+          marker: "pwragent-legacy-settings",
+          comment: "# pwragent-legacy-settings used_through=1.0.0-alpha.9",
+        },
+      ]),
+    ).toBe(result);
+  });
+
   it("emits an inline-table-array as one entry per line", () => {
     const result = applyTomlEdits("[messaging.mattermost]\n", [
       {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, dialog, ipcMain } from "electron";
 import type {
   ClearDesktopSettingsSecretRequest,
+  DesktopMessagingContactLookupRequest,
+  DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
@@ -19,6 +21,7 @@ import {
   SETTINGS_READ_CHANNEL,
   SETTINGS_REFRESH_CODEX_DISCOVERY_CHANNEL,
   SETTINGS_REPLACE_SECRET_CHANNEL,
+  SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
   SETTINGS_TEST_CREDENTIALS_CHANNEL,
   SETTINGS_WRITE_CONFIG_CHANNEL,
 } from "../../shared/ipc";
@@ -40,6 +43,70 @@ async function refreshModelBackendsIfNeeded(params: {
   if (params.patch?.models?.codex?.path !== undefined || params.secret === "grokApiKey") {
     await disposeDesktopBackendRegistry();
   }
+}
+
+async function resolveMessagingContact(
+  service: DesktopSettingsService,
+  request: DesktopMessagingContactLookupRequest,
+): Promise<DesktopMessagingContactLookupResponse> {
+  const id = request.id.trim();
+  if (!id) {
+    return {
+      status: "failed",
+      id,
+      errorMessage: "ID is required.",
+    };
+  }
+
+  switch (request.platform) {
+    case "telegram": {
+      if (request.kind !== "user" && request.kind !== "supergroup") {
+        return unsupportedLookup(request);
+      }
+      const botToken = service.resolveTelegramBotTokenSync();
+      if (!botToken) return { status: "unset", id };
+      const provider = await import("@pwragent/messaging-provider-telegram");
+      return provider.resolveContact(
+        { botToken },
+        { id, kind: request.kind },
+      );
+    }
+    case "discord": {
+      if (request.kind !== "user" && request.kind !== "guild") {
+        return unsupportedLookup(request);
+      }
+      const botToken = service.resolveDiscordBotTokenSync();
+      if (!botToken) return { status: "unset", id };
+      const provider = await import("@pwragent/messaging-provider-discord");
+      return provider.resolveContact(
+        { botToken },
+        { id, kind: request.kind },
+      );
+    }
+    case "mattermost": {
+      if (request.kind !== "user") {
+        return unsupportedLookup(request);
+      }
+      const botToken = service.resolveMattermostBotTokenSync();
+      const serverUrl = service.resolveMattermostServerUrlSync();
+      if (!botToken || !serverUrl) return { status: "unset", id };
+      const provider = await import("@pwragent/messaging-provider-mattermost");
+      return provider.resolveContact(
+        { botToken, serverUrl },
+        { id, kind: request.kind },
+      );
+    }
+  }
+}
+
+function unsupportedLookup(
+  request: DesktopMessagingContactLookupRequest,
+): DesktopMessagingContactLookupResponse {
+  return {
+    status: "unsupported",
+    id: request.id.trim(),
+    errorMessage: `${request.platform} cannot resolve ${request.kind} contacts.`,
+  };
 }
 
 /**
@@ -231,6 +298,16 @@ export function registerSettingsIpcHandlers(
       return tester.lastResult(request.kind);
     },
   );
+
+  ipcMain.removeHandler(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL);
+  ipcMain.handle(
+    SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
+    async (
+      _event,
+      request: DesktopMessagingContactLookupRequest,
+    ): Promise<DesktopMessagingContactLookupResponse> =>
+      await resolveMessagingContact(getService(service), request),
+  );
 }
 
 export function disposeSettingsIpcHandlers(): void {
@@ -242,5 +319,6 @@ export function disposeSettingsIpcHandlers(): void {
   ipcMain.removeHandler(SETTINGS_PICK_GH_COMMAND_CHANNEL);
   ipcMain.removeHandler(SETTINGS_TEST_CREDENTIALS_CHANNEL);
   ipcMain.removeHandler(SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL);
+  ipcMain.removeHandler(SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL);
   disposeCredentialTester();
 }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -15,6 +15,10 @@ import type {
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
 import {
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
+} from "@pwragent/shared";
+import {
   SETTINGS_CLEAR_SECRET_CHANNEL,
   SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL,
   SETTINGS_PICK_GH_COMMAND_CHANNEL,
@@ -66,9 +70,11 @@ async function resolveMessagingContact(
       const botToken = service.resolveTelegramBotTokenSync();
       if (!botToken) return { status: "unset", id };
       const provider = await import("@pwragent/messaging-provider-telegram");
-      return provider.resolveContact(
-        { botToken },
-        { id, kind: request.kind },
+      return sanitizeMessagingContactLookupResponse(
+        await provider.resolveContact(
+          { botToken },
+          { id, kind: request.kind },
+        ),
       );
     }
     case "discord": {
@@ -78,9 +84,11 @@ async function resolveMessagingContact(
       const botToken = service.resolveDiscordBotTokenSync();
       if (!botToken) return { status: "unset", id };
       const provider = await import("@pwragent/messaging-provider-discord");
-      return provider.resolveContact(
-        { botToken },
-        { id, kind: request.kind },
+      return sanitizeMessagingContactLookupResponse(
+        await provider.resolveContact(
+          { botToken },
+          { id, kind: request.kind },
+        ),
       );
     }
     case "mattermost": {
@@ -91,12 +99,26 @@ async function resolveMessagingContact(
       const serverUrl = service.resolveMattermostServerUrlSync();
       if (!botToken || !serverUrl) return { status: "unset", id };
       const provider = await import("@pwragent/messaging-provider-mattermost");
-      return provider.resolveContact(
-        { botToken, serverUrl },
-        { id, kind: request.kind },
+      return sanitizeMessagingContactLookupResponse(
+        await provider.resolveContact(
+          { botToken, serverUrl },
+          { id, kind: request.kind },
+        ),
       );
     }
   }
+}
+
+function sanitizeMessagingContactLookupResponse(
+  response: DesktopMessagingContactLookupResponse,
+): DesktopMessagingContactLookupResponse {
+  const displayName = sanitizeMessagingContactLabel(response.displayName);
+  const handle = sanitizeMessagingContactHandle(response.handle);
+  return {
+    ...response,
+    displayName: displayName || undefined,
+    handle: handle ? `@${handle}` : undefined,
+  };
 }
 
 function unsupportedLookup(

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -88,17 +88,17 @@ export function loadDesktopMessagingConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): DesktopMessagingConfig {
   const telegramBotToken = readEnv(env, TELEGRAM_BOT_TOKEN_ENV, "TELEGRAM_BOT_TOKEN");
-  const telegramAuthorizedActorIds = parseList(env[TELEGRAM_AUTHORIZED_USER_IDS_ENV]);
-  const telegramAuthorizedSupergroupIds = parseList(
+  const telegramAuthorizedActorIds = parseContactList(env[TELEGRAM_AUTHORIZED_USER_IDS_ENV]);
+  const telegramAuthorizedSupergroupIds = parseContactList(
     env[TELEGRAM_AUTHORIZED_SUPERGROUPS_ENV],
   );
   const discordBotToken = readEnv(env, DISCORD_BOT_TOKEN_ENV, "DISCORD_BOT_TOKEN");
-  const discordAuthorizedActorIds = parseList(env[DISCORD_AUTHORIZED_USER_IDS_ENV]);
-  const discordAuthorizedGuildIds = parseList(env[DISCORD_AUTHORIZED_GUILDS_ENV]);
+  const discordAuthorizedActorIds = parseContactList(env[DISCORD_AUTHORIZED_USER_IDS_ENV]);
+  const discordAuthorizedGuildIds = parseContactList(env[DISCORD_AUTHORIZED_GUILDS_ENV]);
   const mattermostBotToken = readEnv(env, MATTERMOST_BOT_TOKEN_ENV);
   const mattermostServerUrl = readEnv(env, MATTERMOST_SERVER_URL_ENV);
   const mattermostCallbackBaseUrl = readEnv(env, MATTERMOST_CALLBACK_BASE_URL_ENV);
-  const mattermostAuthorizedActorIds = parseList(
+  const mattermostAuthorizedActorIds = parseContactList(
     env[MATTERMOST_AUTHORIZED_USER_IDS_ENV],
   );
   const mattermostCallbackHmacSecret = readEnv(
@@ -462,7 +462,10 @@ function readEnv(
   return env[primary]?.trim() || (fallback ? env[fallback]?.trim() : undefined);
 }
 
-function parseList(value: string | undefined): string[] {
+function parseContactList(value: string | undefined): Array<{
+  id: string;
+  displayName: string;
+}> {
   return [
     ...new Set(
       (value ?? "")
@@ -470,7 +473,7 @@ function parseList(value: string | undefined): string[] {
         .map((item) => item.trim())
         .filter(Boolean),
     ),
-  ];
+  ].map((id) => ({ id, displayName: "" }));
 }
 
 function readAttachmentPolicyFromEnv(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -15,6 +15,7 @@ import {
   applyTomlEdits,
   parseTomlTables,
   type TomlEdit,
+  type TomlTables,
   type TomlValue,
 } from "./toml-editor";
 
@@ -90,6 +91,8 @@ export type DesktopSettingsConfig = {
 type TomlScalar = TomlValue;
 
 const AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH = 64;
+const LEGACY_AUTHORIZED_CONTACT_LAST_VERSION = "1.0.0-alpha.9";
+const LEGACY_AUTHORIZED_CONTACT_MARKER = "pwragent-legacy-settings";
 
 export function defaultDesktopConfigDir(
   options?: DesktopConfigPathOptions,
@@ -132,14 +135,17 @@ export function applyDesktopSettingsPatch(
   configPath: string,
   patch: DesktopSettingsConfigPatch,
 ): void {
-  const edits = desktopSettingsPatchToEdits(patch);
-  if (edits.length === 0) {
-    return;
-  }
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   const source = fs.existsSync(configPath)
     ? fs.readFileSync(configPath, "utf8")
     : "";
+  const edits = desktopSettingsPatchToEdits(
+    patch,
+    parseTomlTables(source, configPath),
+  );
+  if (edits.length === 0) {
+    return;
+  }
   const next = applyTomlEdits(source, edits);
   if (next === source) {
     return;
@@ -151,6 +157,7 @@ export function applyDesktopSettingsPatch(
 
 export function desktopSettingsPatchToEdits(
   patch: DesktopSettingsConfigPatch,
+  currentTables: TomlTables = {},
 ): TomlEdit[] {
   const edits: TomlEdit[] = [];
 
@@ -164,19 +171,42 @@ export function desktopSettingsPatchToEdits(
   const setAuthorizedContacts = (
     tablePath: readonly string[],
     legacyKey: string,
-    tableArrayKey: string,
     value: readonly DesktopAuthorizedContact[] | undefined,
+    oldTableArrayKeys: readonly string[] = [],
   ): void => {
     if (value === undefined) return;
+    const tableName = tablePath.join(".");
+    const listKey = `${legacyKey}_list`;
+    const table = currentTables[tableName];
+    const hasLegacyScalar = readStringArray(table?.[legacyKey]) !== undefined;
+    const hasListTable = readAuthorizedContactArray(table?.[listKey]) !== undefined;
+    const tableArrayKey = hasLegacyScalar || hasListTable ? listKey : legacyKey;
     const tableArrayPath = [...tablePath, tableArrayKey];
-    edits.push({ op: "delete", path: [...tablePath, legacyKey] });
-    if (legacyKey !== tableArrayKey) {
-      edits.push({ op: "delete", path: tableArrayPath });
-    }
-    edits.push({ op: "deleteTableArray", path: tableArrayPath });
     const normalizedContacts = normalizeAuthorizedContacts(value);
+
+    for (const staleKey of [legacyKey, listKey, ...oldTableArrayKeys]) {
+      if (staleKey === tableArrayKey) continue;
+      if (staleKey === legacyKey && hasLegacyScalar) continue;
+      edits.push({ op: "delete", path: [...tablePath, staleKey] });
+      edits.push({ op: "deleteTableArray", path: [...tablePath, staleKey] });
+    }
+
+    if (hasLegacyScalar) {
+      edits.push({
+        op: "ensureCommentBefore",
+        path: [...tablePath, legacyKey],
+        marker: LEGACY_AUTHORIZED_CONTACT_MARKER,
+        comment: legacyAuthorizedContactComment(legacyKey),
+      });
+      edits.push({
+        op: "set",
+        path: [...tablePath, legacyKey],
+        value: normalizedContacts.map((contact) => contact.id),
+      });
+    }
+
+    edits.push({ op: "deleteTableArray", path: tableArrayPath });
     if (normalizedContacts.length === 0) {
-      edits.push({ op: "set", path: tableArrayPath, value: [] });
       return;
     }
     edits.push({
@@ -234,14 +264,13 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "telegram"],
       "authorized_user_ids",
-      "authorized_users",
       telegram.authorizedUserIds,
+      ["authorized_users"],
     );
   }
   if (telegram?.authorizedSupergroups !== undefined) {
     setAuthorizedContacts(
       ["messaging", "telegram"],
-      "authorized_supergroups",
       "authorized_supergroups",
       telegram.authorizedSupergroups,
     );
@@ -261,14 +290,13 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "discord"],
       "authorized_user_ids",
-      "authorized_users",
       discord.authorizedUserIds,
+      ["authorized_users"],
     );
   }
   if (discord?.authorizedGuilds !== undefined) {
     setAuthorizedContacts(
       ["messaging", "discord"],
-      "authorized_guilds",
       "authorized_guilds",
       discord.authorizedGuilds,
     );
@@ -309,8 +337,8 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "mattermost"],
       "authorized_user_ids",
-      "authorized_users",
       mattermost.authorizedUserIds,
+      ["authorized_users"],
     );
   }
 
@@ -378,10 +406,12 @@ function normalizeDesktopConfig(
         enabled: readBoolean(telegram?.enabled),
         streamingResponses: readBoolean(telegram?.streaming_responses),
         authorizedUserIds: readAuthorizedContacts(
-          telegram?.authorized_users,
+          telegram?.authorized_user_ids_list,
           telegram?.authorized_user_ids,
+          telegram?.authorized_users,
         ),
         authorizedSupergroups: readAuthorizedContacts(
+          telegram?.authorized_supergroups_list,
           telegram?.authorized_supergroups,
         ),
       },
@@ -390,10 +420,14 @@ function normalizeDesktopConfig(
         streamingResponses: readBoolean(discord?.streaming_responses),
         applicationId: readString(discord?.application_id),
         authorizedUserIds: readAuthorizedContacts(
-          discord?.authorized_users,
+          discord?.authorized_user_ids_list,
           discord?.authorized_user_ids,
+          discord?.authorized_users,
         ),
-        authorizedGuilds: readAuthorizedContacts(discord?.authorized_guilds),
+        authorizedGuilds: readAuthorizedContacts(
+          discord?.authorized_guilds_list,
+          discord?.authorized_guilds,
+        ),
       },
       mattermost: {
         enabled: readBoolean(mattermost?.enabled),
@@ -403,8 +437,9 @@ function normalizeDesktopConfig(
         slashCommandPrefix: readString(mattermost?.slash_command_prefix),
         registerSlashCommands: readBoolean(mattermost?.register_slash_commands),
         authorizedUserIds: readAuthorizedContacts(
-          mattermost?.authorized_users,
+          mattermost?.authorized_user_ids_list,
           mattermost?.authorized_user_ids,
+          mattermost?.authorized_users,
         ),
       },
     },
@@ -563,16 +598,19 @@ function readStringArray(value: TomlScalar | undefined): string[] | undefined {
 }
 
 function readAuthorizedContacts(
-  value: TomlScalar | undefined,
-  legacyValue?: TomlScalar | undefined,
+  ...values: Array<TomlScalar | undefined>
 ): DesktopAuthorizedContact[] | undefined {
-  const contacts = readAuthorizedContactArray(value);
-  if (contacts !== undefined) {
-    return contacts;
+  for (const value of values) {
+    const contacts = readAuthorizedContactArray(value);
+    if (contacts !== undefined) {
+      return contacts;
+    }
   }
-  const legacy = readStringArray(value) ?? readStringArray(legacyValue);
-  if (legacy !== undefined) {
-    return legacy.map((id) => ({ id, displayName: "" }));
+  for (const value of values) {
+    const legacy = readStringArray(value);
+    if (legacy !== undefined) {
+      return legacy.map((id) => ({ id, displayName: "" }));
+    }
   }
   return undefined;
 }
@@ -620,6 +658,17 @@ function sanitizeAuthorizedContactDisplayName(value: string): string {
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH);
+}
+
+function legacyAuthorizedContactComment(key: string): string {
+  return [
+    "#",
+    LEGACY_AUTHORIZED_CONTACT_MARKER,
+    `key=${key}`,
+    "shape=string-array",
+    `used_through=${LEGACY_AUTHORIZED_CONTACT_LAST_VERSION}`,
+    "kept_for_older_clients",
+  ].join(" ");
 }
 
 function readNumber(value: TomlScalar | undefined): number | undefined {

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -9,7 +9,10 @@ import type {
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
-import { isDesktopWorktreeStorageLocation } from "@pwragent/shared";
+import {
+  isDesktopWorktreeStorageLocation,
+  sanitizeMessagingContactLabel,
+} from "@pwragent/shared";
 import { resolveActiveProfilePath } from "../profile";
 import {
   applyTomlEdits,
@@ -90,7 +93,6 @@ export type DesktopSettingsConfig = {
 
 type TomlScalar = TomlValue;
 
-const AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH = 64;
 const LEGACY_AUTHORIZED_CONTACT_LAST_VERSION = "1.0.0-alpha.9";
 const LEGACY_AUTHORIZED_CONTACT_MARKER = "pwragent-legacy-settings";
 
@@ -657,17 +659,9 @@ function normalizeAuthorizedContacts(
   return contacts
     .map((contact) => ({
       id: contact.id.trim(),
-      displayName: sanitizeAuthorizedContactDisplayName(contact.displayName),
+      displayName: sanitizeMessagingContactLabel(contact.displayName),
     }))
     .filter((contact) => contact.id.length > 0);
-}
-
-function sanitizeAuthorizedContactDisplayName(value: string): string {
-  return value
-    .replace(/[\u0000-\u001f\u007f]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH);
 }
 
 function legacyAuthorizedContactComment(key: string): string {

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -171,16 +171,20 @@ export function desktopSettingsPatchToEdits(
   const setAuthorizedContacts = (
     tablePath: readonly string[],
     legacyKey: string,
+    canonicalKey: string,
     value: readonly DesktopAuthorizedContact[] | undefined,
     oldTableArrayKeys: readonly string[] = [],
   ): void => {
     if (value === undefined) return;
     const tableName = tablePath.join(".");
-    const listKey = `${legacyKey}_list`;
+    const listKey = `${canonicalKey}_list`;
     const table = currentTables[tableName];
     const hasLegacyScalar = readStringArray(table?.[legacyKey]) !== undefined;
     const hasListTable = readAuthorizedContactArray(table?.[listKey]) !== undefined;
-    const tableArrayKey = hasLegacyScalar || hasListTable ? listKey : legacyKey;
+    const tableArrayKey =
+      (hasLegacyScalar && canonicalKey === legacyKey) || hasListTable
+        ? listKey
+        : canonicalKey;
     const tableArrayPath = [...tablePath, tableArrayKey];
     const normalizedContacts = normalizeAuthorizedContacts(value);
 
@@ -205,6 +209,7 @@ export function desktopSettingsPatchToEdits(
       });
     }
 
+    edits.push({ op: "delete", path: tableArrayPath });
     edits.push({ op: "deleteTableArray", path: tableArrayPath });
     if (normalizedContacts.length === 0) {
       return;
@@ -264,13 +269,15 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "telegram"],
       "authorized_user_ids",
+      "authorized_users",
       telegram.authorizedUserIds,
-      ["authorized_users"],
+      ["authorized_user_ids_list"],
     );
   }
   if (telegram?.authorizedSupergroups !== undefined) {
     setAuthorizedContacts(
       ["messaging", "telegram"],
+      "authorized_supergroups",
       "authorized_supergroups",
       telegram.authorizedSupergroups,
     );
@@ -290,13 +297,15 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "discord"],
       "authorized_user_ids",
+      "authorized_users",
       discord.authorizedUserIds,
-      ["authorized_users"],
+      ["authorized_user_ids_list"],
     );
   }
   if (discord?.authorizedGuilds !== undefined) {
     setAuthorizedContacts(
       ["messaging", "discord"],
+      "authorized_guilds",
       "authorized_guilds",
       discord.authorizedGuilds,
     );
@@ -337,8 +346,9 @@ export function desktopSettingsPatchToEdits(
     setAuthorizedContacts(
       ["messaging", "mattermost"],
       "authorized_user_ids",
+      "authorized_users",
       mattermost.authorizedUserIds,
-      ["authorized_users"],
+      ["authorized_user_ids_list"],
     );
   }
 
@@ -406,9 +416,9 @@ function normalizeDesktopConfig(
         enabled: readBoolean(telegram?.enabled),
         streamingResponses: readBoolean(telegram?.streaming_responses),
         authorizedUserIds: readAuthorizedContacts(
+          telegram?.authorized_users,
           telegram?.authorized_user_ids_list,
           telegram?.authorized_user_ids,
-          telegram?.authorized_users,
         ),
         authorizedSupergroups: readAuthorizedContacts(
           telegram?.authorized_supergroups_list,
@@ -420,9 +430,9 @@ function normalizeDesktopConfig(
         streamingResponses: readBoolean(discord?.streaming_responses),
         applicationId: readString(discord?.application_id),
         authorizedUserIds: readAuthorizedContacts(
+          discord?.authorized_users,
           discord?.authorized_user_ids_list,
           discord?.authorized_user_ids,
-          discord?.authorized_users,
         ),
         authorizedGuilds: readAuthorizedContacts(
           discord?.authorized_guilds_list,
@@ -437,9 +447,9 @@ function normalizeDesktopConfig(
         slashCommandPrefix: readString(mattermost?.slash_command_prefix),
         registerSlashCommands: readBoolean(mattermost?.register_slash_commands),
         authorizedUserIds: readAuthorizedContacts(
+          mattermost?.authorized_users,
           mattermost?.authorized_user_ids_list,
           mattermost?.authorized_user_ids,
-          mattermost?.authorized_users,
         ),
       },
     },

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type {
   DesktopChatReplyComposer,
+  DesktopAuthorizedContact,
   DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
   DesktopWorktreeStorageLocation,
@@ -24,6 +25,8 @@ type DesktopConfigPathOptions = {
   cliProfile?: string;
 };
 
+type AuthorizedContactConfig = DesktopAuthorizedContact;
+
 export type DesktopSettingsConfig = {
   experimental?: {
     chatReplyComposer?: DesktopChatReplyComposer;
@@ -43,15 +46,15 @@ export type DesktopSettingsConfig = {
     telegram?: {
       enabled?: boolean;
       streamingResponses?: boolean;
-      authorizedUserIds?: string[];
-      authorizedSupergroups?: string[];
+      authorizedUserIds?: AuthorizedContactConfig[];
+      authorizedSupergroups?: AuthorizedContactConfig[];
     };
     discord?: {
       enabled?: boolean;
       streamingResponses?: boolean;
       applicationId?: string;
-      authorizedUserIds?: string[];
-      authorizedGuilds?: string[];
+      authorizedUserIds?: AuthorizedContactConfig[];
+      authorizedGuilds?: AuthorizedContactConfig[];
     };
     mattermost?: {
       enabled?: boolean;
@@ -60,7 +63,7 @@ export type DesktopSettingsConfig = {
       callbackBaseUrl?: string;
       slashCommandPrefix?: string;
       registerSlashCommands?: boolean;
-      authorizedUserIds?: string[];
+      authorizedUserIds?: AuthorizedContactConfig[];
     };
   };
   models?: {
@@ -85,6 +88,8 @@ export type DesktopSettingsConfig = {
 };
 
 type TomlScalar = TomlValue;
+
+const AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH = 64;
 
 export function defaultDesktopConfigDir(
   options?: DesktopConfigPathOptions,
@@ -156,6 +161,33 @@ export function desktopSettingsPatchToEdits(
     if (value === undefined) return;
     edits.push({ op: "set", path: pathSegments, value });
   };
+  const setAuthorizedContacts = (
+    tablePath: readonly string[],
+    legacyKey: string,
+    tableArrayKey: string,
+    value: readonly DesktopAuthorizedContact[] | undefined,
+  ): void => {
+    if (value === undefined) return;
+    const tableArrayPath = [...tablePath, tableArrayKey];
+    edits.push({ op: "delete", path: [...tablePath, legacyKey] });
+    if (legacyKey !== tableArrayKey) {
+      edits.push({ op: "delete", path: tableArrayPath });
+    }
+    edits.push({ op: "deleteTableArray", path: tableArrayPath });
+    const normalizedContacts = normalizeAuthorizedContacts(value);
+    if (normalizedContacts.length === 0) {
+      edits.push({ op: "set", path: tableArrayPath, value: [] });
+      return;
+    }
+    edits.push({
+      op: "setTableArray",
+      path: tableArrayPath,
+      value: normalizedContacts.map((contact) => ({
+        id: contact.id,
+        display_name: contact.displayName,
+      })),
+    });
+  };
 
   if (patch.experimental?.chatReplyComposer !== undefined) {
     set(["experimental", "chat_reply_composer"], patch.experimental.chatReplyComposer);
@@ -199,11 +231,18 @@ export function desktopSettingsPatchToEdits(
     set(["messaging", "telegram", "streaming_responses"], telegram.streamingResponses);
   }
   if (telegram?.authorizedUserIds !== undefined) {
-    set(["messaging", "telegram", "authorized_user_ids"], telegram.authorizedUserIds);
+    setAuthorizedContacts(
+      ["messaging", "telegram"],
+      "authorized_user_ids",
+      "authorized_users",
+      telegram.authorizedUserIds,
+    );
   }
   if (telegram?.authorizedSupergroups !== undefined) {
-    set(
-      ["messaging", "telegram", "authorized_supergroups"],
+    setAuthorizedContacts(
+      ["messaging", "telegram"],
+      "authorized_supergroups",
+      "authorized_supergroups",
       telegram.authorizedSupergroups,
     );
   }
@@ -219,10 +258,20 @@ export function desktopSettingsPatchToEdits(
     set(["messaging", "discord", "application_id"], discord.applicationId);
   }
   if (discord?.authorizedUserIds !== undefined) {
-    set(["messaging", "discord", "authorized_user_ids"], discord.authorizedUserIds);
+    setAuthorizedContacts(
+      ["messaging", "discord"],
+      "authorized_user_ids",
+      "authorized_users",
+      discord.authorizedUserIds,
+    );
   }
   if (discord?.authorizedGuilds !== undefined) {
-    set(["messaging", "discord", "authorized_guilds"], discord.authorizedGuilds);
+    setAuthorizedContacts(
+      ["messaging", "discord"],
+      "authorized_guilds",
+      "authorized_guilds",
+      discord.authorizedGuilds,
+    );
   }
 
   const mattermost = patch.messaging?.mattermost;
@@ -257,8 +306,10 @@ export function desktopSettingsPatchToEdits(
     );
   }
   if (mattermost?.authorizedUserIds !== undefined) {
-    set(
-      ["messaging", "mattermost", "authorized_user_ids"],
+    setAuthorizedContacts(
+      ["messaging", "mattermost"],
+      "authorized_user_ids",
+      "authorized_users",
       mattermost.authorizedUserIds,
     );
   }
@@ -326,15 +377,23 @@ function normalizeDesktopConfig(
       telegram: {
         enabled: readBoolean(telegram?.enabled),
         streamingResponses: readBoolean(telegram?.streaming_responses),
-        authorizedUserIds: readStringArray(telegram?.authorized_user_ids),
-        authorizedSupergroups: readStringArray(telegram?.authorized_supergroups),
+        authorizedUserIds: readAuthorizedContacts(
+          telegram?.authorized_users,
+          telegram?.authorized_user_ids,
+        ),
+        authorizedSupergroups: readAuthorizedContacts(
+          telegram?.authorized_supergroups,
+        ),
       },
       discord: {
         enabled: readBoolean(discord?.enabled),
         streamingResponses: readBoolean(discord?.streaming_responses),
         applicationId: readString(discord?.application_id),
-        authorizedUserIds: readStringArray(discord?.authorized_user_ids),
-        authorizedGuilds: readStringArray(discord?.authorized_guilds),
+        authorizedUserIds: readAuthorizedContacts(
+          discord?.authorized_users,
+          discord?.authorized_user_ids,
+        ),
+        authorizedGuilds: readAuthorizedContacts(discord?.authorized_guilds),
       },
       mattermost: {
         enabled: readBoolean(mattermost?.enabled),
@@ -343,7 +402,10 @@ function normalizeDesktopConfig(
         callbackBaseUrl: readString(mattermost?.callback_base_url),
         slashCommandPrefix: readString(mattermost?.slash_command_prefix),
         registerSlashCommands: readBoolean(mattermost?.register_slash_commands),
-        authorizedUserIds: readStringArray(mattermost?.authorized_user_ids),
+        authorizedUserIds: readAuthorizedContacts(
+          mattermost?.authorized_users,
+          mattermost?.authorized_user_ids,
+        ),
       },
     },
     models: {
@@ -498,6 +560,66 @@ function readStringArray(value: TomlScalar | undefined): string[] | undefined {
     return undefined;
   }
   return value.map((item) => item.trim()).filter(Boolean);
+}
+
+function readAuthorizedContacts(
+  value: TomlScalar | undefined,
+  legacyValue?: TomlScalar | undefined,
+): DesktopAuthorizedContact[] | undefined {
+  const contacts = readAuthorizedContactArray(value);
+  if (contacts !== undefined) {
+    return contacts;
+  }
+  const legacy = readStringArray(value) ?? readStringArray(legacyValue);
+  if (legacy !== undefined) {
+    return legacy.map((id) => ({ id, displayName: "" }));
+  }
+  return undefined;
+}
+
+function readAuthorizedContactArray(
+  value: TomlScalar | undefined,
+): DesktopAuthorizedContact[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  if (value.length === 0) return [];
+  if (
+    !value.every(
+      (item): item is Record<string, string | number | boolean> =>
+        typeof item === "object" && item !== null && !Array.isArray(item),
+    )
+  ) {
+    return undefined;
+  }
+  return normalizeAuthorizedContacts(
+    value.map((entry) => ({
+      id: typeof entry.id === "string" ? entry.id : "",
+      displayName:
+        typeof entry.display_name === "string"
+          ? entry.display_name
+          : typeof entry.displayName === "string"
+            ? entry.displayName
+            : "",
+    })),
+  );
+}
+
+function normalizeAuthorizedContacts(
+  contacts: readonly DesktopAuthorizedContact[],
+): DesktopAuthorizedContact[] {
+  return contacts
+    .map((contact) => ({
+      id: contact.id.trim(),
+      displayName: sanitizeAuthorizedContactDisplayName(contact.displayName),
+    }))
+    .filter((contact) => contact.id.length > 0);
+}
+
+function sanitizeAuthorizedContactDisplayName(value: string): string {
+  return value
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, AUTHORIZED_CONTACT_DISPLAY_NAME_MAX_LENGTH);
 }
 
 function readNumber(value: TomlScalar | undefined): number | undefined {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,5 +1,6 @@
 import type {
   DesktopChatReplyComposer,
+  DesktopAuthorizedContact,
   DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
   DesktopSettingsSecretName,
@@ -609,13 +610,13 @@ export class DesktopSettingsService {
   }
 
   private resolveList(
-    configValue: string[] | undefined,
+    configValue: DesktopAuthorizedContact[] | undefined,
     envKey: string,
-  ): DesktopSettingsValue<string[]> {
+  ): DesktopSettingsValue<DesktopAuthorizedContact[]> {
     const envValue = readEnvList(this.env, envKey);
     if (envValue !== undefined) {
       return {
-        value: envValue,
+        value: envValue.map((id) => ({ id, displayName: "" })),
         source: "env",
         overriddenByEnv: configValue !== undefined,
       };

--- a/apps/desktop/src/main/settings/toml-editor.ts
+++ b/apps/desktop/src/main/settings/toml-editor.ts
@@ -45,6 +45,12 @@ export type TomlEdit =
   | { op: "set"; path: readonly string[]; value: TomlEditValue }
   | { op: "delete"; path: readonly string[] }
   | {
+      op: "ensureCommentBefore";
+      path: readonly string[];
+      comment: string;
+      marker: string;
+    }
+  | {
       op: "setTableArray";
       path: readonly string[];
       value: readonly Record<string, TomlEditScalar>[];
@@ -359,6 +365,20 @@ function planEdits(model: SourceModel, edits: readonly TomlEdit[]): EditPlan {
     const { tableName, keyName } = splitPath(edit.path);
     const section = findSection(model, tableName);
 
+    if (edit.op === "ensureCommentBefore") {
+      if (!section) continue;
+      const key = section.keys.find((k) => k.name === keyName);
+      if (!key || markerPrecedesKey(model.lines, key, edit.marker)) {
+        continue;
+      }
+      lineOps.push({
+        kind: "insert",
+        insertionLine: key.startLine,
+        newLines: [edit.comment],
+      });
+      continue;
+    }
+
     if (edit.op === "delete") {
       if (!section) continue;
       const key = section.keys.find((k) => k.name === keyName);
@@ -580,6 +600,29 @@ function sectionLineRange(
     startLine: section.headerLine,
     endLine: Math.max(section.headerLine, sectionEnd - 1),
   };
+}
+
+function markerPrecedesKey(
+  lines: readonly string[],
+  key: KeyLocation,
+  marker: string,
+): boolean {
+  let cursor = key.startLine - 1;
+  while (cursor >= 0) {
+    const trimmed = lines[cursor].trim();
+    if (trimmed.length === 0) {
+      cursor -= 1;
+      continue;
+    }
+    if (!trimmed.startsWith("#")) {
+      return false;
+    }
+    if (trimmed.includes(marker)) {
+      return true;
+    }
+    cursor -= 1;
+  }
+  return false;
 }
 
 function computeKeyInsertionLine(

--- a/apps/desktop/src/main/settings/toml-editor.ts
+++ b/apps/desktop/src/main/settings/toml-editor.ts
@@ -43,7 +43,13 @@ export type TomlEditValue =
 
 export type TomlEdit =
   | { op: "set"; path: readonly string[]; value: TomlEditValue }
-  | { op: "delete"; path: readonly string[] };
+  | { op: "delete"; path: readonly string[] }
+  | {
+      op: "setTableArray";
+      path: readonly string[];
+      value: readonly Record<string, TomlEditScalar>[];
+    }
+  | { op: "deleteTableArray"; path: readonly string[] };
 
 /** Parsed value type for the read-side parser. */
 export type TomlValue =
@@ -75,6 +81,7 @@ type SectionLocation = {
   headerLine: number; // -1 for the implicit top-level section
   keys: KeyLocation[];
   duplicate: boolean; // true if this is the 2nd+ occurrence of the name
+  arrayOfTables: boolean;
 };
 
 type SourceModel = {
@@ -106,6 +113,7 @@ export function parseTomlTables(source: string, filePath: string): TomlTables {
   const tables: TomlTables = {};
   const seenSections = new Set<string>();
   let currentTable = "";
+  let currentTarget: Record<string, TomlValue> | undefined;
   let skipSection = false;
 
   let i = 0;
@@ -124,15 +132,30 @@ export function parseTomlTables(source: string, filePath: string): TomlTables {
       if (!name) {
         throw new Error(`Invalid TOML table on line ${i + 1} in ${filePath}`);
       }
-      if (seenSections.has(name)) {
+      if (arrayHeader) {
+        const { parentTable, keyName } = splitArrayTableName(name);
+        const parent = (tables[parentTable] ??= {});
+        const existing = parent[keyName];
+        const entries =
+          Array.isArray(existing) && isInlineTableArray(existing)
+            ? existing
+            : [];
+        const entry: Record<string, TomlEditScalar> = {};
+        entries.push(entry);
+        parent[keyName] = entries;
+        currentTable = name;
+        currentTarget = entry;
+        skipSection = false;
+      } else if (seenSections.has(name)) {
         console.warn(
           `Duplicate section [${name}] on line ${i + 1} in ${filePath} — using the first occurrence; subsequent keys are ignored.`,
         );
         skipSection = true;
+        currentTarget = undefined;
       } else {
         seenSections.add(name);
         currentTable = name;
-        tables[currentTable] ??= {};
+        currentTarget = tables[currentTable] ??= {};
         skipSection = false;
       }
       i += 1;
@@ -162,8 +185,12 @@ export function parseTomlTables(source: string, filePath: string): TomlTables {
       continue;
     }
 
-    tables[currentTable] ??= {};
-    tables[currentTable][key] = parsed.value;
+    if (currentTarget) {
+      currentTarget[key] = parsed.value;
+    } else {
+      tables[currentTable] ??= {};
+      tables[currentTable][key] = parsed.value;
+    }
     i = endLine + 1;
   }
 
@@ -180,7 +207,11 @@ export function applyTomlEdits(
 
   const model = parseSource(source);
   const plan = planEdits(model, edits);
-  if (plan.lineOps.length === 0 && plan.newSections.length === 0) {
+  if (
+    plan.lineOps.length === 0
+    && plan.newSections.length === 0
+    && plan.newTableArrays.length === 0
+  ) {
     return source;
   }
   const newLines = executePlan(model, plan);
@@ -199,7 +230,13 @@ function parseSource(source: string): SourceModel {
   const lines = body.length === 0 ? [] : body.split("\n");
 
   const sections: SectionLocation[] = [
-    { name: "", headerLine: -1, keys: [], duplicate: false },
+    {
+      name: "",
+      headerLine: -1,
+      keys: [],
+      duplicate: false,
+      arrayOfTables: false,
+    },
   ];
   const seenNames = new Set<string>();
 
@@ -217,9 +254,15 @@ function parseSource(source: string): SourceModel {
     const sectionMatch = arrayHeader ?? SECTION_HEADER.exec(line);
     if (sectionMatch) {
       const name = sectionMatch[1].trim();
-      const duplicate = seenNames.has(name);
-      if (!duplicate) seenNames.add(name);
-      sections.push({ name, headerLine: i, keys: [], duplicate });
+      const duplicate = !arrayHeader && seenNames.has(name);
+      if (!duplicate && !arrayHeader) seenNames.add(name);
+      sections.push({
+        name,
+        headerLine: i,
+        keys: [],
+        duplicate,
+        arrayOfTables: Boolean(arrayHeader),
+      });
       i += 1;
       continue;
     }
@@ -274,9 +317,15 @@ type NewSectionPlan = {
   keyLines: string[]; // already formatted, including any multi-line entries
 };
 
+type NewTableArrayPlan = {
+  tableName: string;
+  entries: readonly Record<string, TomlEditScalar>[];
+};
+
 type EditPlan = {
   lineOps: LineOp[];
   newSections: NewSectionPlan[];
+  newTableArrays: NewTableArrayPlan[];
 };
 
 function planEdits(model: SourceModel, edits: readonly TomlEdit[]): EditPlan {
@@ -285,8 +334,28 @@ function planEdits(model: SourceModel, edits: readonly TomlEdit[]): EditPlan {
   // the same nonexistent section land in one new section in the order they
   // were requested.
   const newSections = new Map<string, string[]>();
+  const newTableArrays: NewTableArrayPlan[] = [];
 
   for (const edit of edits) {
+    if (edit.op === "deleteTableArray" || edit.op === "setTableArray") {
+      for (const section of findTableArraySections(model, edit.path.join("."))) {
+        const { startLine, endLine } = sectionLineRange(model, section);
+        lineOps.push({
+          kind: "replace",
+          startLine,
+          endLine,
+          newLines: [],
+        });
+      }
+      if (edit.op === "setTableArray" && edit.value.length > 0) {
+        newTableArrays.push({
+          tableName: edit.path.join("."),
+          entries: edit.value,
+        });
+      }
+      continue;
+    }
+
     const { tableName, keyName } = splitPath(edit.path);
     const section = findSection(model, tableName);
 
@@ -342,7 +411,7 @@ function planEdits(model: SourceModel, edits: readonly TomlEdit[]): EditPlan {
     newSectionPlans.push({ tableName, keyLines });
   }
 
-  return { lineOps, newSections: newSectionPlans };
+  return { lineOps, newSections: newSectionPlans, newTableArrays };
 }
 
 function executePlan(model: SourceModel, plan: EditPlan): string[] {
@@ -411,6 +480,18 @@ function executePlan(model: SourceModel, plan: EditPlan): string[] {
     for (const ln of section.keyLines) result.push(ln);
   }
 
+  for (const tableArray of plan.newTableArrays) {
+    for (const entry of tableArray.entries) {
+      if (result.length > 0 && result[result.length - 1].trim().length !== 0) {
+        result.push("");
+      }
+      result.push(`[[${tableArray.tableName}]]`);
+      for (const [key, value] of Object.entries(entry)) {
+        result.push(...formatKeyValue(key, value, ""));
+      }
+    }
+  }
+
   return result;
 }
 
@@ -434,6 +515,35 @@ function splitPath(path: readonly string[]): {
   };
 }
 
+function splitArrayTableName(name: string): {
+  parentTable: string;
+  keyName: string;
+} {
+  const segments = name.split(".");
+  const keyName = segments.pop();
+  if (!keyName) {
+    throw new Error(`Invalid TOML array table name '${name}'`);
+  }
+  return {
+    parentTable: segments.join("."),
+    keyName,
+  };
+}
+
+function isInlineTableArray(
+  value: unknown,
+): value is Record<string, TomlEditScalar>[] {
+  return (
+    Array.isArray(value)
+    && value.every(
+      (entry) =>
+        typeof entry === "object"
+        && entry !== null
+        && !Array.isArray(entry),
+    )
+  );
+}
+
 function findSection(
   model: SourceModel,
   name: string,
@@ -442,11 +552,34 @@ function findSection(
   // for editing purposes (the duplicate-detection in parseSource also skips
   // recording keys for them on read).
   for (const section of model.sections) {
-    if (section.name === name && !section.duplicate) {
+    if (section.name === name && !section.duplicate && !section.arrayOfTables) {
       return section;
     }
   }
   return undefined;
+}
+
+function findTableArraySections(
+  model: SourceModel,
+  name: string,
+): SectionLocation[] {
+  return model.sections.filter(
+    (section) => section.name === name && section.arrayOfTables,
+  );
+}
+
+function sectionLineRange(
+  model: SourceModel,
+  section: SectionLocation,
+): { startLine: number; endLine: number } {
+  const sectionIndex = model.sections.indexOf(section);
+  const nextSection = model.sections[sectionIndex + 1];
+  const sectionEnd =
+    nextSection !== undefined ? nextSection.headerLine : model.lines.length;
+  return {
+    startLine: section.headerLine,
+    endLine: Math.max(section.headerLine, sectionEnd - 1),
+  };
 }
 
 function computeKeyInsertionLine(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -74,6 +74,8 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ClearDesktopSettingsSecretRequest,
+  DesktopMessagingContactLookupRequest,
+  DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
@@ -154,6 +156,7 @@ import {
   SETTINGS_READ_CHANNEL,
   SETTINGS_REFRESH_CODEX_DISCOVERY_CHANNEL,
   SETTINGS_REPLACE_SECRET_CHANNEL,
+  SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
   SETTINGS_TEST_CREDENTIALS_CHANNEL,
   SETTINGS_WRITE_CONFIG_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
@@ -238,6 +241,13 @@ const desktopApi = Object.freeze({
     request: { kind: SettingsCredentialTestKind },
   ): Promise<SettingsCredentialTestResult | undefined> =>
     await ipcRenderer.invoke(SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL, request),
+  resolveMessagingContact: async (
+    request: DesktopMessagingContactLookupRequest,
+  ): Promise<DesktopMessagingContactLookupResponse> =>
+    await ipcRenderer.invoke(
+      SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL,
+      request,
+    ),
   openApplication: async (
     request: OpenDesktopApplicationRequest,
   ): Promise<OpenDesktopApplicationResponse> =>

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -5,6 +5,9 @@ import {
   validateTelegramPositiveId,
   validateTelegramSupergroupId,
   type DesktopAuthorizedContact,
+  type DesktopMessagingContactLookupKind,
+  type DesktopMessagingContactLookupPlatform,
+  type DesktopMessagingContactLookupResponse,
   type IdentifierValidationResult,
   type DesktopSettingsSecretName,
   type DesktopSettingsSnapshot,
@@ -168,6 +171,11 @@ export function MessagingSettings(props: {
           />
           <AuthorizedListField
             disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "telegram",
+              "user",
+            )}
             label="Authorized User IDs"
             sub="Telegram user IDs that can DM the bot."
             help="Numeric peer ID, e.g. 8460800771. Rejected Telegram DMs show the peer ID in Messaging Activity; use the numeric form, not @username."
@@ -186,6 +194,11 @@ export function MessagingSettings(props: {
           />
           <AuthorizedListField
             disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "telegram",
+              "supergroup",
+            )}
             label="Authorized SuperGroups"
             sub="Telegram supergroup IDs that may host bound threads."
             help="Negative ID starting with -100, e.g. -1003841603622. Rejected group messages show the supergroup ID in Messaging Activity."
@@ -282,6 +295,11 @@ export function MessagingSettings(props: {
           />
           <AuthorizedListField
             disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "discord",
+              "user",
+            )}
             label="Authorized User IDs"
             sub="Discord user IDs that can DM the bot."
             help="Snowflake (17-19 digit number), e.g. 1177378744822943744. Rejected Discord messages show the user ID in Messaging Activity."
@@ -300,6 +318,11 @@ export function MessagingSettings(props: {
           />
           <AuthorizedListField
             disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "discord",
+              "guild",
+            )}
             label="Authorized Guilds"
             sub="Discord guild (server) IDs that may host bound threads."
             help="Snowflake (17-19 digit number), e.g. 1480554271907905731. Rejected server messages show the guild ID in Messaging Activity."
@@ -480,6 +503,11 @@ export function MessagingSettings(props: {
           />
           <AuthorizedListField
             disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "mattermost",
+              "user",
+            )}
             label="Authorized User IDs"
             sub="Mattermost user IDs that can DM the bot."
             help="26-character lowercase a-z0-9 ID. Rejected Mattermost messages show the user ID in Messaging Activity."
@@ -692,6 +720,7 @@ function AuthorizedListField(props: {
   disabled?: boolean;
   help?: ReactNode;
   label: string;
+  lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
   sub?: ReactNode;
   source: string;
   validateEntry?: (value: string) => string | undefined;
@@ -701,6 +730,9 @@ function AuthorizedListField(props: {
   const inputId = useId();
   const descriptionId = `${inputId}-validation`;
   const [rows, setRows] = useState<DesktopAuthorizedContact[]>(props.value);
+  const [lookupState, setLookupState] = useState<
+    Record<number, { loading?: boolean; message?: string }>
+  >({});
   const normalizedRows = rows.map(normalizeAuthorizedContactRow);
   const invalidEntries = props.validateEntry
     ? normalizedRows
@@ -740,6 +772,10 @@ function AuthorizedListField(props: {
     indexToUpdate: number,
     patch: Partial<DesktopAuthorizedContact>,
   ) => {
+    setLookupState((current) => {
+      const { [indexToUpdate]: _discard, ...rest } = current;
+      return rest;
+    });
     setRows((current) =>
       current.map((row, index) =>
         index === indexToUpdate ? { ...row, ...patch } : row,
@@ -751,6 +787,55 @@ function AuthorizedListField(props: {
     const nextRows = rows.filter((_, index) => index !== indexToRemove);
     setRows(nextRows);
     saveIfValid(nextRows);
+  };
+
+  const lookupRow = async (
+    indexToLookup: number,
+    candidateRows: DesktopAuthorizedContact[],
+  ) => {
+    const lookup = props.lookup;
+    if (!lookup) return;
+    const row = normalizeAuthorizedContactRow(candidateRows[indexToLookup] ?? {
+      id: "",
+      displayName: "",
+    });
+    if (!row.id || props.validateEntry?.(row.id)) return;
+
+    setLookupState((current) => ({
+      ...current,
+      [indexToLookup]: { loading: true },
+    }));
+    let result: DesktopMessagingContactLookupResponse;
+    try {
+      result = await lookup(row.id);
+    } catch (error) {
+      result = {
+        status: "failed",
+        id: row.id,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (result.status === "ok" && result.displayName) {
+      const nextRows = candidateRows.map((current, rowIndex) =>
+        rowIndex === indexToLookup
+          ? { id: row.id, displayName: result.displayName ?? "" }
+          : current,
+      );
+      setRows(nextRows);
+      setLookupState((current) => {
+        const { [indexToLookup]: _discard, ...rest } = current;
+        return rest;
+      });
+      saveIfValid(nextRows);
+      return;
+    }
+
+    setLookupState((current) => ({
+      ...current,
+      [indexToLookup]: {
+        message: lookupFailureMessage(result),
+      },
+    }));
   };
 
   return (
@@ -775,6 +860,13 @@ function AuthorizedListField(props: {
               const invalid = invalidEntries.find(
                 (entry) => entry.index === index,
               );
+              const lookup = lookupState[index];
+              const canLookup =
+                Boolean(props.lookup)
+                && normalized.id.length > 0
+                && !invalid
+                && !props.disabled
+                && !lookup?.loading;
               return (
                 <div
                   key={index}
@@ -796,6 +888,9 @@ function AuthorizedListField(props: {
                       );
                       setRows(nextRows);
                       saveIfValid(nextRows);
+                      if (normalized.displayName.length === 0) {
+                        void lookupRow(index, nextRows);
+                      }
                     }}
                     onChange={(event) =>
                       updateRow(index, { id: event.currentTarget.value })
@@ -822,6 +917,17 @@ function AuthorizedListField(props: {
                     }
                   />
                   <button
+                    aria-label={`Lookup ${props.label} row ${index + 1}`}
+                    className="button button--ghost settings-authorized-list__lookup"
+                    disabled={!canLookup}
+                    type="button"
+                    onClick={() => {
+                      void lookupRow(index, rows);
+                    }}
+                  >
+                    {lookup?.loading ? "Looking..." : "Lookup"}
+                  </button>
+                  <button
                     aria-label={`Remove ${props.label} row ${index + 1}`}
                     className="button button--ghost settings-authorized-list__remove"
                     disabled={props.disabled}
@@ -847,6 +953,22 @@ function AuthorizedListField(props: {
               Add
             </button>
           </div>
+          {Object.entries(lookupState).some(([, state]) => state.message) ? (
+            <div className="settings-list-validation" role="status">
+              {Object.entries(lookupState)
+                .filter(([, state]) => state.message)
+                .map(([index, state]) => (
+                  <div
+                    key={`lookup-${index}`}
+                    className="settings-list-validation__item"
+                  >
+                    <span className="settings-list-validation__message">
+                      {state.message}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          ) : null}
           {hasInvalidEntries ? (
             <div
               id={descriptionId}
@@ -879,6 +1001,40 @@ function AuthorizedListField(props: {
       }
     />
   );
+}
+
+function contactLookup(
+  desktopApi: DesktopApi | undefined,
+  platform: DesktopMessagingContactLookupPlatform,
+  kind: DesktopMessagingContactLookupKind,
+): ((id: string) => Promise<DesktopMessagingContactLookupResponse>) | undefined {
+  const lookup = desktopApi?.resolveMessagingContact;
+  if (!lookup) {
+    return undefined;
+  }
+  return async (id: string) =>
+    await lookup({
+      platform,
+      kind,
+      id,
+    });
+}
+
+function lookupFailureMessage(
+  result: DesktopMessagingContactLookupResponse,
+): string {
+  switch (result.status) {
+    case "unset":
+      return "Configure the platform token before looking up names.";
+    case "not_found":
+      return result.errorMessage ?? "No matching platform identity was found.";
+    case "unsupported":
+      return result.errorMessage ?? "Lookup is not supported for this row.";
+    case "ok":
+      return "No display name was returned for this ID.";
+    case "failed":
+      return result.errorMessage ?? "Lookup failed.";
+  }
 }
 
 function normalizeAuthorizedContactRow(

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -4,6 +4,7 @@ import {
   validateMattermostId,
   validateTelegramPositiveId,
   validateTelegramSupergroupId,
+  type DesktopAuthorizedContact,
   type IdentifierValidationResult,
   type DesktopSettingsSecretName,
   type DesktopSettingsSnapshot,
@@ -22,10 +23,8 @@ import { SettingsSwitch } from "./SettingsSwitch";
 import { SettingsTestBlock } from "./SettingsTestBlock";
 import {
   formatSourceLabel,
-  joinListValue,
   optionalListSourceBadge,
   optionalStringSourceBadge,
-  parseListValue,
   sourceBadge,
 } from "./settings-fields";
 
@@ -167,10 +166,10 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          <ListField
+          <AuthorizedListField
             disabled={props.saving}
             label="Authorized User IDs"
-            sub="Comma-separated Telegram user IDs that can DM the bot."
+            sub="Telegram user IDs that can DM the bot."
             help="Numeric peer ID, e.g. 8460800771. Rejected Telegram DMs show the peer ID in Messaging Activity; use the numeric form, not @username."
             source={optionalListSourceBadge(telegram.authorizedUserIds)}
             validateEntry={validateTelegramUserIdEntry}
@@ -185,10 +184,10 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          <ListField
+          <AuthorizedListField
             disabled={props.saving}
             label="Authorized SuperGroups"
-            sub="Comma-separated Telegram supergroup IDs that may host bound threads."
+            sub="Telegram supergroup IDs that may host bound threads."
             help="Negative ID starting with -100, e.g. -1003841603622. Rejected group messages show the supergroup ID in Messaging Activity."
             source={optionalListSourceBadge(telegram.authorizedSupergroups)}
             validateEntry={validateTelegramSupergroupEntry}
@@ -281,10 +280,10 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          <ListField
+          <AuthorizedListField
             disabled={props.saving}
             label="Authorized User IDs"
-            sub="Comma-separated Discord user IDs that can DM the bot."
+            sub="Discord user IDs that can DM the bot."
             help="Snowflake (17-19 digit number), e.g. 1177378744822943744. Rejected Discord messages show the user ID in Messaging Activity."
             source={optionalListSourceBadge(discord.authorizedUserIds)}
             validateEntry={validateDiscordUserIdEntry}
@@ -299,10 +298,10 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          <ListField
+          <AuthorizedListField
             disabled={props.saving}
             label="Authorized Guilds"
-            sub="Comma-separated Discord guild (server) IDs that may host bound threads."
+            sub="Discord guild (server) IDs that may host bound threads."
             help="Snowflake (17-19 digit number), e.g. 1480554271907905731. Rejected server messages show the guild ID in Messaging Activity."
             source={optionalListSourceBadge(discord.authorizedGuilds)}
             validateEntry={validateDiscordGuildIdEntry}
@@ -479,10 +478,10 @@ export function MessagingSettings(props: {
               });
             }}
           />
-          <ListField
+          <AuthorizedListField
             disabled={props.saving}
             label="Authorized User IDs"
-            sub="Comma-separated Mattermost user IDs that can DM the bot."
+            sub="Mattermost user IDs that can DM the bot."
             help="26-character lowercase a-z0-9 ID. Rejected Mattermost messages show the user ID in Messaging Activity."
             source={optionalListSourceBadge(mattermost.authorizedUserIds)}
             validateEntry={validateMattermostUserIdEntry}
@@ -689,26 +688,31 @@ function NumberField(props: {
   );
 }
 
-function ListField(props: {
+function AuthorizedListField(props: {
   disabled?: boolean;
   help?: ReactNode;
   label: string;
   sub?: ReactNode;
   source: string;
   validateEntry?: (value: string) => string | undefined;
-  value: string[];
-  onSave: (value: string[]) => void;
+  value: DesktopAuthorizedContact[];
+  onSave: (value: DesktopAuthorizedContact[]) => void;
 }) {
   const inputId = useId();
   const descriptionId = `${inputId}-validation`;
-  const [value, setValue] = useState(joinListValue(props.value));
-  const entries = parseListValue(value);
+  const [rows, setRows] = useState<DesktopAuthorizedContact[]>(props.value);
+  const normalizedRows = rows.map(normalizeAuthorizedContactRow);
   const invalidEntries = props.validateEntry
-    ? entries
-        .map((entry, index) => ({
-          entry,
+    ? normalizedRows
+        .map((row, index) => ({
+          entry: row.id,
           index,
-          message: props.validateEntry?.(entry),
+          message:
+            row.id.length > 0
+              ? props.validateEntry?.(row.id)
+              : row.displayName.length > 0
+                ? "ID cannot be blank when a display name is set."
+                : undefined,
         }))
         .filter(
           (result): result is { entry: string; index: number; message: string } =>
@@ -717,13 +721,36 @@ function ListField(props: {
     : [];
   const hasInvalidEntries = invalidEntries.length > 0;
 
-  const removeEntry = (indexToRemove: number) => {
-    const nextEntries = entries.filter((_, index) => index !== indexToRemove);
-    const nextValue = joinListValue(nextEntries);
-    setValue(nextValue);
-    if (!props.validateEntry || nextEntries.every((entry) => !props.validateEntry!(entry))) {
-      props.onSave(nextEntries);
+  const saveIfValid = (nextRows: DesktopAuthorizedContact[]) => {
+    const normalized = nextRows.map(normalizeAuthorizedContactRow);
+    if (
+      props.validateEntry &&
+      normalized.some(
+        (row) =>
+          (row.id.length > 0 && props.validateEntry?.(row.id))
+          || (row.id.length === 0 && row.displayName.length > 0),
+      )
+    ) {
+      return;
     }
+    props.onSave(normalized.filter((row) => row.id.length > 0));
+  };
+
+  const updateRow = (
+    indexToUpdate: number,
+    patch: Partial<DesktopAuthorizedContact>,
+  ) => {
+    setRows((current) =>
+      current.map((row, index) =>
+        index === indexToUpdate ? { ...row, ...patch } : row,
+      ),
+    );
+  };
+
+  const removeEntry = (indexToRemove: number) => {
+    const nextRows = rows.filter((_, index) => index !== indexToRemove);
+    setRows(nextRows);
+    saveIfValid(nextRows);
   };
 
   return (
@@ -739,25 +766,87 @@ function ListField(props: {
       }
       control={
         <>
-          <input
-            aria-describedby={hasInvalidEntries ? descriptionId : undefined}
-            aria-invalid={hasInvalidEntries ? "true" : undefined}
-            aria-label={props.label}
-            className={`settings-input${hasInvalidEntries ? " settings-input--invalid" : ""}`}
-            disabled={props.disabled}
-            value={value}
-            onBlur={() => {
-              const nextEntries = parseListValue(value);
-              if (
-                props.validateEntry &&
-                nextEntries.some((entry) => props.validateEntry?.(entry))
-              ) {
-                return;
+          <div className="settings-authorized-list">
+            {rows.map((row, index) => {
+              const normalized = normalizedRows[index] ?? {
+                id: "",
+                displayName: "",
+              };
+              const invalid = invalidEntries.find(
+                (entry) => entry.index === index,
+              );
+              return (
+                <div
+                  key={index}
+                  className="settings-authorized-list__row"
+                >
+                  <input
+                    aria-describedby={invalid ? descriptionId : undefined}
+                    aria-invalid={invalid ? "true" : undefined}
+                    aria-label={`${props.label} ID ${index + 1}`}
+                    className={`settings-input settings-authorized-list__id${
+                      invalid ? " settings-input--invalid" : ""
+                    }`}
+                    disabled={props.disabled}
+                    placeholder="ID"
+                    value={row.id}
+                    onBlur={() => {
+                      const nextRows = rows.map((current, rowIndex) =>
+                        rowIndex === index ? normalized : current,
+                      );
+                      setRows(nextRows);
+                      saveIfValid(nextRows);
+                    }}
+                    onChange={(event) =>
+                      updateRow(index, { id: event.currentTarget.value })
+                    }
+                  />
+                  <input
+                    aria-label={`${props.label} display name ${index + 1}`}
+                    className="settings-input settings-authorized-list__name"
+                    disabled={props.disabled}
+                    maxLength={64}
+                    placeholder="Display name"
+                    value={row.displayName}
+                    onBlur={() => {
+                      const nextRows = rows.map((current, rowIndex) =>
+                        rowIndex === index ? normalized : current,
+                      );
+                      setRows(nextRows);
+                      saveIfValid(nextRows);
+                    }}
+                    onChange={(event) =>
+                      updateRow(index, {
+                        displayName: event.currentTarget.value,
+                      })
+                    }
+                  />
+                  <button
+                    aria-label={`Remove ${props.label} row ${index + 1}`}
+                    className="button button--ghost settings-authorized-list__remove"
+                    disabled={props.disabled}
+                    type="button"
+                    onClick={() => removeEntry(index)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              );
+            })}
+            <button
+              className="button button--secondary settings-authorized-list__add"
+              disabled={props.disabled}
+              type="button"
+              onClick={() =>
+                setRows((current) => [
+                  ...current,
+                  { id: "", displayName: "" },
+                ])
               }
-              props.onSave(nextEntries);
-            }}
-            onChange={(event) => setValue(event.currentTarget.value)}
-          />
+            >
+              Add
+            </button>
+          </div>
           {hasInvalidEntries ? (
             <div
               id={descriptionId}
@@ -770,7 +859,7 @@ function ListField(props: {
                   className="settings-list-validation__item"
                 >
                   <span className="settings-list-validation__message">
-                    <code>{invalid.entry}</code>
+                    <code>{invalid.entry || "(blank)"}</code>
                     {" — "}
                     {invalid.message}
                   </span>
@@ -790,6 +879,19 @@ function ListField(props: {
       }
     />
   );
+}
+
+function normalizeAuthorizedContactRow(
+  contact: DesktopAuthorizedContact,
+): DesktopAuthorizedContact {
+  return {
+    id: contact.id.trim(),
+    displayName: contact.displayName
+      .replace(/[\u0000-\u001f\u007f]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 64),
+  };
 }
 
 function validateTelegramUserIdEntry(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1,4 +1,10 @@
-import { useId, useState, type ReactNode } from "react";
+import {
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
 import {
   validateDiscordSnowflake,
   validateMattermostId,
@@ -729,7 +735,8 @@ function AuthorizedListField(props: {
 }) {
   const inputId = useId();
   const descriptionId = `${inputId}-validation`;
-  const [rows, setRows] = useState<DesktopAuthorizedContact[]>(props.value);
+  const [rows, setRowsState] = useState<DesktopAuthorizedContact[]>(props.value);
+  const rowsRef = useRef<DesktopAuthorizedContact[]>(props.value);
   const [lookupState, setLookupState] = useState<
     Record<number, { loading?: boolean; message?: string }>
   >({});
@@ -752,6 +759,16 @@ function AuthorizedListField(props: {
         )
     : [];
   const hasInvalidEntries = invalidEntries.length > 0;
+  const setRows = (
+    nextRowsOrUpdater: SetStateAction<DesktopAuthorizedContact[]>,
+  ) => {
+    const nextRows =
+      typeof nextRowsOrUpdater === "function"
+        ? nextRowsOrUpdater(rowsRef.current)
+        : nextRowsOrUpdater;
+    rowsRef.current = nextRows;
+    setRowsState(nextRows);
+  };
 
   const saveIfValid = (nextRows: DesktopAuthorizedContact[]) => {
     const normalized = nextRows.map(normalizeAuthorizedContactRow);
@@ -816,7 +833,19 @@ function AuthorizedListField(props: {
       };
     }
     if (result.status === "ok" && result.displayName) {
-      const nextRows = candidateRows.map((current, rowIndex) =>
+      const latestRows = rowsRef.current;
+      const latestRow = normalizeAuthorizedContactRow(
+        latestRows[indexToLookup] ?? { id: "", displayName: "" },
+      );
+      if (latestRow.id !== row.id) {
+        setLookupState((current) => {
+          const { [indexToLookup]: _discard, ...rest } = current;
+          return rest;
+        });
+        return;
+      }
+
+      const nextRows = latestRows.map((current, rowIndex) =>
         rowIndex === indexToLookup
           ? { id: row.id, displayName: result.displayName ?? "" }
           : current,

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -8,6 +8,7 @@ import {
 import {
   validateDiscordSnowflake,
   validateMattermostId,
+  sanitizeMessagingContactLabel,
   validateTelegramPositiveId,
   validateTelegramSupergroupId,
   type DesktopAuthorizedContact,
@@ -1071,11 +1072,7 @@ function normalizeAuthorizedContactRow(
 ): DesktopAuthorizedContact {
   return {
     id: contact.id.trim(),
-    displayName: contact.displayName
-      .replace(/[\u0000-\u001f\u007f]/g, " ")
-      .replace(/\s+/g, " ")
-      .trim()
-      .slice(0, 64),
+    displayName: sanitizeMessagingContactLabel(contact.displayName),
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
@@ -78,20 +78,35 @@ describe("buildTelegramPatchDelta", () => {
 
   it("compares string arrays element-wise", () => {
     const snapshot = telegramSnapshot({
-      authorizedUserIds: { value: ["111", "222"], source: "config" },
+      authorizedUserIds: {
+        value: [
+          { id: "111", displayName: "" },
+          { id: "222", displayName: "Harold" },
+        ],
+        source: "config",
+      },
     });
     const same: Telegram = {
       ...snapshot,
-      authorizedUserIds: { ...snapshot.authorizedUserIds, value: ["111", "222"] },
+      authorizedUserIds: {
+        ...snapshot.authorizedUserIds,
+        value: [
+          { id: "111", displayName: "" },
+          { id: "222", displayName: "Harold" },
+        ],
+      },
     };
     expect(buildTelegramPatchDelta(snapshot, same)).toBeUndefined();
 
     const different: Telegram = {
       ...snapshot,
-      authorizedUserIds: { ...snapshot.authorizedUserIds, value: ["333"] },
+      authorizedUserIds: {
+        ...snapshot.authorizedUserIds,
+        value: [{ id: "333", displayName: "" }],
+      },
     };
     expect(buildTelegramPatchDelta(snapshot, different)).toEqual({
-      authorizedUserIds: ["333"],
+      authorizedUserIds: [{ id: "333", displayName: "" }],
     });
   });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -528,6 +528,44 @@ describe("SettingsScreen", () => {
     ).toHaveValue("Harold (@huntharo)");
   });
 
+  it("sanitizes manually entered messaging display names before saving", async () => {
+    const settings = createSettingsState();
+
+    render(
+      <SettingsScreen
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]!);
+    fireEvent.change(screen.getByLabelText("Authorized User IDs ID 1"), {
+      target: { value: "8460800771" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Authorized User IDs display name 1"),
+      {
+        target: {
+          value: "<script>alert(1)</script>Harold\u202e",
+        },
+      },
+    );
+    fireEvent.blur(screen.getByLabelText("Authorized User IDs display name 1"));
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            authorizedUserIds: [
+              { id: "8460800771", displayName: "Harold" },
+            ],
+          },
+        },
+      });
+    });
+  });
+
   it("ignores stale lookup results after an authorized ID is removed", async () => {
     const snapshot = createSnapshot();
     const settings = createSettingsState({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -471,6 +471,55 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("looks up blank messaging display names from the settings screen", async () => {
+    const settings = createSettingsState();
+    const resolveMessagingContact = vi.fn(async () => ({
+      status: "ok" as const,
+      id: "8460800771",
+      displayName: "Harold (@huntharo)",
+      handle: "@huntharo",
+    }));
+    const desktopApi = {
+      resolveMessagingContact,
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]!);
+    const telegramUserIds = screen.getByLabelText("Authorized User IDs ID 1");
+    fireEvent.change(telegramUserIds, { target: { value: "8460800771" } });
+    fireEvent.blur(telegramUserIds);
+
+    await waitFor(() => {
+      expect(resolveMessagingContact).toHaveBeenCalledWith({
+        platform: "telegram",
+        kind: "user",
+        id: "8460800771",
+      });
+    });
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            authorizedUserIds: [
+              { id: "8460800771", displayName: "Harold (@huntharo)" },
+            ],
+          },
+        },
+      });
+    });
+    expect(
+      screen.getByLabelText("Authorized User IDs display name 1"),
+    ).toHaveValue("Harold (@huntharo)");
+  });
+
   it("surfaces invalid persisted messaging IDs with a Remove action", async () => {
     const snapshot = createSnapshot();
     const settings = createSettingsState({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1,5 +1,13 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopSettingsSnapshot } from "@pwragent/shared";
 import { SettingsScreen } from "../SettingsScreen";
@@ -518,6 +526,101 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByLabelText("Authorized User IDs display name 1"),
     ).toHaveValue("Harold (@huntharo)");
+  });
+
+  it("ignores stale lookup results after an authorized ID is removed", async () => {
+    const snapshot = createSnapshot();
+    const settings = createSettingsState({
+      ...snapshot,
+      messaging: {
+        ...snapshot.messaging,
+        telegram: {
+          ...snapshot.messaging.telegram,
+          authorizedUserIds: {
+            value: [{ id: "8460800771", displayName: "" }],
+            source: "config",
+          },
+        },
+      },
+    });
+    let resolveLookup:
+      | ((value: {
+          status: "ok";
+          id: string;
+          displayName: string;
+        }) => void)
+      | undefined;
+    const resolveMessagingContact = vi.fn(
+      () =>
+        new Promise<{
+          status: "ok";
+          id: string;
+          displayName: string;
+        }>((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+    const desktopApi = {
+      resolveMessagingContact,
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Lookup Authorized User IDs row 1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(resolveMessagingContact).toHaveBeenCalledWith({
+        platform: "telegram",
+        kind: "user",
+        id: "8460800771",
+      });
+    });
+    const removeButton = await screen.findByRole("button", {
+      name: "Remove Authorized User IDs row 1",
+    });
+    expect(removeButton).toBeEnabled();
+    fireEvent.click(removeButton);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          telegram: {
+            authorizedUserIds: [],
+          },
+        },
+      });
+    });
+
+    const writeConfig = settings.writeConfig as ReturnType<typeof vi.fn>;
+    const callsBeforeLookupResolution = writeConfig.mock.calls.length;
+    await act(async () => {
+      resolveLookup?.({
+        status: "ok",
+        id: "8460800771",
+        displayName: "Harold (@huntharo)",
+      });
+    });
+
+    expect(writeConfig).toHaveBeenCalledTimes(callsBeforeLookupResolution);
+    expect(writeConfig).not.toHaveBeenCalledWith({
+      messaging: {
+        telegram: {
+          authorizedUserIds: [
+            { id: "8460800771", displayName: "Harold (@huntharo)" },
+          ],
+        },
+      },
+    });
   });
 
   it("surfaces invalid persisted messaging IDs with a Remove action", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -434,7 +434,8 @@ describe("SettingsScreen", () => {
     expect(screen.getByText(/Authorization defaults closed/)).toBeInTheDocument();
     expect(screen.getByText(/Rejected Telegram DMs show the peer ID/)).toBeInTheDocument();
 
-    const telegramUserIds = screen.getAllByLabelText("Authorized User IDs")[0]!;
+    fireEvent.click(screen.getAllByRole("button", { name: "Add" })[0]!);
+    const telegramUserIds = screen.getByLabelText("Authorized User IDs ID 1");
     fireEvent.change(telegramUserIds, { target: { value: "@huntharo" } });
     fireEvent.blur(telegramUserIds);
 
@@ -443,17 +444,27 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
     expect(telegramUserIds).toHaveAttribute("aria-invalid", "true");
     expect(settings.writeConfig).not.toHaveBeenCalledWith({
-      messaging: { telegram: { authorizedUserIds: ["@huntharo"] } },
+      messaging: {
+        telegram: {
+          authorizedUserIds: [{ id: "@huntharo", displayName: "" }],
+        },
+      },
     });
 
     fireEvent.change(telegramUserIds, { target: { value: "8460800771" } });
+    fireEvent.change(
+      screen.getByLabelText("Authorized User IDs display name 1"),
+      { target: { value: "Harold (@huntharo)" } },
+    );
     fireEvent.blur(telegramUserIds);
 
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           telegram: {
-            authorizedUserIds: ["8460800771"],
+            authorizedUserIds: [
+              { id: "8460800771", displayName: "Harold (@huntharo)" },
+            ],
           },
         },
       });
@@ -469,7 +480,10 @@ describe("SettingsScreen", () => {
         telegram: {
           ...snapshot.messaging.telegram,
           authorizedUserIds: {
-            value: ["@huntharo", "8460800771"],
+            value: [
+              { id: "@huntharo", displayName: "Wrong person" },
+              { id: "8460800771", displayName: "Harold" },
+            ],
             source: "config",
           },
         },
@@ -486,13 +500,17 @@ describe("SettingsScreen", () => {
 
     expect(screen.getByText("@huntharo")).toBeInTheDocument();
     expect(screen.getByText(/That looks like a Telegram username/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove Authorized User IDs row 1",
+      }),
+    );
 
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           telegram: {
-            authorizedUserIds: ["8460800771"],
+            authorizedUserIds: [{ id: "8460800771", displayName: "Harold" }],
           },
         },
       });

--- a/apps/desktop/src/renderer/src/features/settings/settings-fields.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-fields.ts
@@ -1,4 +1,7 @@
-import type { DesktopSettingsValue } from "@pwragent/shared";
+import type {
+  DesktopAuthorizedContact,
+  DesktopSettingsValue,
+} from "@pwragent/shared";
 
 export function formatSourceLabel(source: string, overriddenByEnv?: boolean): string {
   if (source === "env") {
@@ -39,7 +42,7 @@ export function optionalStringSourceBadge(
 }
 
 export function optionalListSourceBadge(
-  setting: DesktopSettingsValue<string[]>,
+  setting: DesktopSettingsValue<string[] | DesktopAuthorizedContact[]>,
 ): string {
   if (setting.source === "default" && setting.value.length === 0) {
     return "unset";

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -1,4 +1,5 @@
 import type {
+  DesktopAuthorizedContact,
   DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
@@ -35,7 +36,7 @@ export function buildTelegramPatchDelta(
     patch.streamingResponses = candidate.streamingResponses.value;
   }
   if (
-    !stringArrayEqual(
+    !authorizedContactArrayEqual(
       snapshot.authorizedUserIds.value,
       candidate.authorizedUserIds.value,
     )
@@ -43,7 +44,7 @@ export function buildTelegramPatchDelta(
     patch.authorizedUserIds = candidate.authorizedUserIds.value;
   }
   if (
-    !stringArrayEqual(
+    !authorizedContactArrayEqual(
       snapshot.authorizedSupergroups.value,
       candidate.authorizedSupergroups.value,
     )
@@ -72,7 +73,7 @@ export function buildDiscordPatchDelta(
     patch.applicationId = candidate.applicationId.value;
   }
   if (
-    !stringArrayEqual(
+    !authorizedContactArrayEqual(
       snapshot.authorizedUserIds.value,
       candidate.authorizedUserIds.value,
     )
@@ -80,7 +81,7 @@ export function buildDiscordPatchDelta(
     patch.authorizedUserIds = candidate.authorizedUserIds.value;
   }
   if (
-    !stringArrayEqual(
+    !authorizedContactArrayEqual(
       snapshot.authorizedGuilds.value,
       candidate.authorizedGuilds.value,
     )
@@ -120,7 +121,7 @@ export function buildMattermostPatchDelta(
     patch.registerSlashCommands = candidate.registerSlashCommands.value;
   }
   if (
-    !stringArrayEqual(
+    !authorizedContactArrayEqual(
       snapshot.authorizedUserIds.value,
       candidate.authorizedUserIds.value,
     )
@@ -131,10 +132,15 @@ export function buildMattermostPatchDelta(
   return Object.keys(patch).length === 0 ? undefined : patch;
 }
 
-function stringArrayEqual(a: readonly string[], b: readonly string[]): boolean {
+function authorizedContactArrayEqual(
+  a: readonly DesktopAuthorizedContact[],
+  b: readonly DesktopAuthorizedContact[],
+): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
+    if (a[i]?.id !== b[i]?.id || a[i]?.displayName !== b[i]?.displayName) {
+      return false;
+    }
   }
   return true;
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -79,6 +79,8 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ClearDesktopSettingsSecretRequest,
+  DesktopMessagingContactLookupRequest,
+  DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
@@ -203,6 +205,9 @@ export type DesktopApi = {
   readLastSettingsCredentialTest?: (
     request: { kind: SettingsCredentialTestKind },
   ) => Promise<SettingsCredentialTestResult | undefined>;
+  resolveMessagingContact?: (
+    request: DesktopMessagingContactLookupRequest,
+  ) => Promise<DesktopMessagingContactLookupResponse>;
   openApplication?: (
     request: OpenDesktopApplicationRequest
   ) => Promise<OpenDesktopApplicationResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2632,6 +2632,39 @@ textarea,
   flex: 0 0 auto;
 }
 
+.settings-authorized-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-authorized-list__row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(150px, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-authorized-list__id,
+.settings-authorized-list__name {
+  min-width: 0;
+}
+
+.settings-authorized-list__remove,
+.settings-authorized-list__add {
+  width: max-content;
+}
+
+.settings-authorized-list__add {
+  align-self: flex-start;
+}
+
+@media (max-width: 760px) {
+  .settings-authorized-list__row {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Segmented control — chip-pill chiclets that fit the design's
    restrained register. Buttons keep `role="radio"` (existing test
    contract). */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2640,7 +2640,7 @@ textarea,
 
 .settings-authorized-list__row {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) minmax(150px, 1fr) auto;
+  grid-template-columns: minmax(150px, 1fr) minmax(150px, 1fr) auto auto;
   gap: 8px;
   align-items: center;
 }
@@ -2651,6 +2651,7 @@ textarea,
 }
 
 .settings-authorized-list__remove,
+.settings-authorized-list__lookup,
 .settings-authorized-list__add {
   width: max-content;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -72,6 +72,8 @@ export const SETTINGS_TEST_CREDENTIALS_CHANNEL =
  */
 export const SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL =
   "settings:last-credential-test";
+export const SETTINGS_RESOLVE_MESSAGING_CONTACT_CHANNEL =
+  "settings:resolve-messaging-contact";
 /**
  * Fired main → renderer whenever the messaging store has had bindings
  * created, revoked, or had their conversation metadata change. The

--- a/docs/config-file-evolution.md
+++ b/docs/config-file-evolution.md
@@ -1,0 +1,149 @@
+# Config File Evolution
+
+PwrAgent's desktop config is a user-editable TOML file at
+`~/.pwragent/profiles/<profile>/config.toml`. Treat it differently from sqlite
+state: there is no schema table, users may hand-edit it, and older app versions
+may be opened against the same file after a downgrade.
+
+Use this pattern whenever a config key changes in a way that older clients
+cannot read, such as scalar to table-array, renamed fields, or values that need
+additional per-entry metadata.
+
+## Goals
+
+- New clients read the newest valid shape they understand.
+- Existing users do not lose values when a shape changes.
+- Older clients keep working when we can preserve their existing field.
+- New config files use the best current names and shapes.
+- Conversion is lazy and localized to the setting being saved, not a whole-file
+  rewrite on read.
+
+## Reader Pattern
+
+For each evolved setting, keep a small ordered catalog of recognized shapes.
+Newest supported shapes should be checked first, then older fallbacks.
+
+The reader should use the first candidate that matches a shape it can parse.
+If a candidate key exists but has the wrong shape, ignore that candidate and
+try the next recognized shape. Do not throw away the whole section because one
+candidate is malformed.
+
+For authorized contact lists, the current reader follows this shape order:
+
+1. Canonical table-array shape, for example
+   `[[messaging.telegram.authorized_users]]` with `id` and `display_name`.
+2. Interim disambiguated table-array shape when it exists, for example
+   `[[messaging.telegram.authorized_user_ids_list]]`.
+3. Legacy scalar string-array shape, for example
+   `authorized_user_ids = ["111111111"]`.
+
+When a list entry is parsed from an older scalar array, normalize it into the
+current in-memory shape with blank metadata fields rather than preserving a
+parallel runtime type.
+
+## Writer Pattern
+
+When saving a setting whose shape changed:
+
+1. Normalize and sanitize the new in-memory value before writing.
+2. If the legacy scalar field exists and still has the recognized legacy shape,
+   keep it and update the subset of data it can represent.
+3. Add a marker comment above the legacy key if one is not already present.
+4. Write the current shape using the canonical key unless the canonical key
+   collides with the legacy scalar key.
+5. If the canonical table-array key would collide with a legacy scalar key,
+   write the current shape to `<key>_list`.
+6. If an existing config already uses an interim `_list` key, continue writing
+   that key until a later explicit cleanup. Do not silently move users between
+   equivalent shapes on unrelated saves.
+7. Delete stale intermediate keys only when they are superseded by the selected
+   current key and are not the preserved legacy scalar.
+
+This is why `authorized_user_ids` now writes new data to
+`authorized_users`, while `authorized_supergroups` writes to
+`authorized_supergroups_list` only when the old scalar
+`authorized_supergroups = [...]` already exists.
+
+For a blank or newly-created config, write only the current canonical shape.
+There is no older field to preserve, and users of a new config are not expected
+to downgrade to clients that predate the new setting shape.
+
+## Legacy Comments
+
+Legacy fields preserved for downgrade compatibility must be marked with a
+single-line comment immediately above the key:
+
+```toml
+# pwragent-legacy-settings key=authorized_user_ids shape=string-array used_through=1.0.0-alpha.9 kept_for_older_clients
+authorized_user_ids = ["111111111"]
+```
+
+The marker is `pwragent-legacy-settings`. The comment must include:
+
+- `key=<toml_key>`
+- `shape=<recognized_shape_name>`
+- `used_through=<last_version_that_used_this_shape>`
+- `kept_for_older_clients`
+
+Keep the version and shape data as code constants next to the reader/writer
+logic, not only in comments. Comments help humans and tooling inspect a file;
+code constants are the catalog the app actually trusts.
+
+If the marker already exists, preserve it rather than inserting duplicates.
+Do not rely on the marker to decide whether a shape is readable. Always inspect
+the actual TOML value shape.
+
+## Naming
+
+Use clear current names even if the old key name was too narrow. Do not carry a
+bad name forward just for continuity.
+
+- Prefer `authorized_users` over `authorized_user_ids` once entries contain more
+  than IDs.
+- Use `_list` only to disambiguate an evolved array/table-array from an existing
+  scalar key with the same TOML name.
+- Do not invent stilted names like `authorized_user_id_objects` when the domain
+  name can describe the entity.
+
+## Conversion Safety
+
+Config conversion should happen through the normal config writer for the setting
+being changed. Avoid eager whole-file migrations on startup unless a future
+change truly cannot be represented side-by-side.
+
+Preserve user comments and unrelated keys. Edits should be path-based TOML edits
+against the relevant key or table-array, not a parse-and-reprint of the whole
+file.
+
+If a current client updates the new field, older preserved fields may receive a
+lossy projection of the new value. For example, `authorized_users` entries keep
+`display_name`, while the old `authorized_user_ids` array stores only `id`.
+The reverse direction is intentionally not guaranteed: changes made by old
+clients to legacy fields may not be reflected in a newer field that already
+exists.
+
+## Tests Required
+
+For every backwards-incompatible config shape change, add or update tests that
+cover:
+
+- Reading the new canonical shape.
+- Reading each recognized legacy shape.
+- Falling back when an earlier candidate key exists but has the wrong shape.
+- Saving a legacy config preserves and updates the old field.
+- Saving a legacy config inserts the legacy marker comment exactly once.
+- Saving a blank config writes only the current canonical shape.
+- Saving does not delete unrelated comments or unrelated keys in the section.
+- `_list` is used only when the canonical key collides with an existing legacy
+  scalar key, or when an existing supported `_list` shape is already present.
+
+## Current Implementation References
+
+- Config parser/writer:
+  `apps/desktop/src/main/settings/desktop-config.ts`
+- Settings service tests:
+  `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+- TOML edit helper:
+  `apps/desktop/src/main/settings/toml-editor.ts`
+- Runtime/state layout:
+  `docs/state-layout.md`

--- a/packages/messaging/AGENTS.md
+++ b/packages/messaging/AGENTS.md
@@ -4,6 +4,12 @@ This tree defines the generic messaging contract and the provider adapters that 
 
 For a layered architecture overview with diagrams, data-flow sequences, the capability-profile system, and a file map, see [`docs/messaging-architecture.md`](../../docs/messaging-architecture.md). For the technical contract every adapter must satisfy, see [`docs/messaging-adapter-contract.md`](../../docs/messaging-adapter-contract.md).
 
+Messaging settings are persisted in the desktop `config.toml`. Before adding or
+changing messaging config fields in a backwards-incompatible shape, read
+[`docs/config-file-evolution.md`](../../docs/config-file-evolution.md). Preserve
+recognized legacy fields and project new values back into them when possible so
+older clients can keep reading existing configs.
+
 ## Package Boundaries
 
 - `packages/messaging/interface` is the only generic messaging contract. It may define channel-neutral types, capabilities, delivery policies, opaque adapter state, callback handles, and rendering primitives.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -13,7 +13,10 @@ import type {
 // Re-export shared messaging primitives so consumers can pick either
 // import path without seeing two parallel declarations.
 export {
+  MESSAGING_CONTACT_LABEL_MAX_LENGTH,
   MESSAGING_TOOL_UPDATE_MODES,
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
   validateDiscordSnowflake,
   validateMattermostId,
   validateTelegramChatId,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1074,6 +1074,44 @@ export type MattermostCredentialValidationConfig = {
   serverUrl: string;
 };
 
+/* -----------------------------------------------------------------
+ * Contact identity lookup (Settings → authorized contact rows)
+ * -----------------------------------------------------------------
+ *
+ * Each provider package may export a top-level
+ * `resolveContact(config, request) -> MessagingContactLookupResult`
+ * function. The desktop main process dispatches to the right provider
+ * via dynamic import, keeping provider SDKs out of the renderer and
+ * desktop orchestration layer.
+ *
+ * The lookup is best-effort and read-only. Platform APIs can only
+ * resolve identities the bot is allowed to see: Telegram Bot API
+ * `getChat`, Discord REST `GET /users/{id}` / `GET /guilds/{id}`,
+ * and Mattermost REST `GET /api/v4/users/{id}`.
+ */
+export type MessagingContactLookupKind = "user" | "supergroup" | "guild";
+
+export type MessagingContactLookupRequest = {
+  id: string;
+  kind: MessagingContactLookupKind;
+};
+
+export type MessagingContactLookupStatus =
+  | "ok"
+  | "failed"
+  | "not_found"
+  | "unset"
+  | "unsupported";
+
+export type MessagingContactLookupResult = {
+  status: MessagingContactLookupStatus;
+  id: string;
+  displayName?: string;
+  handle?: string;
+  detail?: string;
+  errorMessage?: string;
+};
+
 /**
  * Helper providers can use to clip an error message to the contract
  * limit. Trims whitespace, replaces a tail with an ellipsis when over

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -29,7 +29,7 @@ describe("discord adapter", () => {
         createMessage: vi.fn().mockRejectedValue(unknownChannelError),
       }),
       config: {
-        authorizedActorIds: [TEST_USER_ID],
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
         botToken: "token",
         channel: "discord",
       },
@@ -64,7 +64,7 @@ describe("discord adapter", () => {
         updateMessage: vi.fn().mockRejectedValue(unknownChannelError),
       }),
       config: {
-        authorizedActorIds: [TEST_USER_ID],
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
         botToken: "token",
         channel: "discord",
       },
@@ -108,7 +108,7 @@ describe("discord adapter", () => {
     const adapter = new DiscordAdapter({
       api: createApi({ updateChannelName }),
       config: {
-        authorizedActorIds: [TEST_USER_ID],
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
         botToken: "token",
         channel: "discord",
       },
@@ -167,7 +167,7 @@ describe("discord adapter", () => {
     const adapter = new DiscordAdapter({
       api: createApi({ createMessage }),
       config: {
-        authorizedActorIds: [TEST_USER_ID],
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
         botToken: "token",
         channel: "discord",
       },
@@ -224,7 +224,7 @@ describe("discord adapter", () => {
     const adapter = new DiscordAdapter({
       api: createApi({ createMessage }),
       config: {
-        authorizedActorIds: [TEST_USER_ID],
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
         botToken: "token",
         channel: "discord",
       },
@@ -313,8 +313,8 @@ describe("discord adapter", () => {
       const adapter = new DiscordAdapter({
         api: createApi(),
         config: {
-          authorizedActorIds: [TEST_USER_ID],
-          authorizedGuildIds: ["1480556454498009999"],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: [{ id: "1480556454498009999", displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -369,7 +369,7 @@ describe("discord adapter", () => {
         api: createApi({ createInteractionResponse }),
         config: {
           applicationId: TEST_CHANNEL_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -422,8 +422,8 @@ describe("discord adapter", () => {
         api: createApi({ createInteractionResponse }),
         config: {
           applicationId: TEST_CHANNEL_ID,
-          authorizedActorIds: [TEST_USER_ID],
-          authorizedGuildIds: ["1480556454498009999"],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: [{ id: "1480556454498009999", displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -490,7 +490,7 @@ describe("discord adapter", () => {
         api: createApi({ createInteractionResponse }),
         config: {
           applicationId: TEST_CHANNEL_ID,
-          authorizedActorIds: ["1480556454498009999"],
+          authorizedActorIds: [{ id: "1480556454498009999", displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -543,7 +543,7 @@ describe("discord adapter", () => {
         api: createApi(),
         config: {
           applicationId: BOT_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -583,7 +583,7 @@ describe("discord adapter", () => {
         api: createApi(),
         config: {
           applicationId: BOT_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -622,7 +622,7 @@ describe("discord adapter", () => {
         api: createApi(),
         config: {
           applicationId: BOT_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -668,7 +668,7 @@ describe("discord adapter", () => {
         api: createApi(),
         config: {
           applicationId: BOT_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },
@@ -713,7 +713,7 @@ describe("discord adapter", () => {
         api: createApi(),
         config: {
           applicationId: BOT_ID,
-          authorizedActorIds: [TEST_USER_ID],
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
           botToken: "token",
           channel: "discord",
         },

--- a/packages/messaging/providers/discord/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/resolve-contact.test.ts
@@ -76,4 +76,24 @@ describe("Discord resolveContact", () => {
       "/guilds/1480554271907905731",
     );
   });
+
+  it("sanitizes provider-controlled user names from the REST API", async () => {
+    getMock.mockResolvedValue({
+      id: "1177378744822943744",
+      username: "hun<tharo>",
+      global_name: "<img src=x onerror=alert(1)>Harold\u202e",
+      discriminator: "0",
+    });
+
+    const result = await resolveContact(
+      { botToken: "BotTokenABC" },
+      { id: "1177378744822943744", kind: "user" },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      displayName: "Harold (@hun)",
+      handle: "@hun",
+    });
+  });
 });

--- a/packages/messaging/providers/discord/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/resolve-contact.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.fn();
+const setTokenMock = vi.fn();
+
+vi.mock("discord.js", () => {
+  class MockREST {
+    setToken(token: string) {
+      setTokenMock(token);
+      return this;
+    }
+    get(route: string) {
+      return getMock(route);
+    }
+  }
+  return {
+    REST: MockREST,
+    Routes: {
+      guild: (id: string) => `/guilds/${id}`,
+      user: (id: string) => `/users/${id}`,
+    },
+  };
+});
+
+import { resolveContact } from "../resolve-contact.ts";
+
+beforeEach(() => {
+  getMock.mockReset();
+  setTokenMock.mockReset();
+});
+
+describe("Discord resolveContact", () => {
+  it("formats user names from the REST API", async () => {
+    getMock.mockResolvedValue({
+      id: "1177378744822943744",
+      username: "huntharo",
+      global_name: "Harold",
+      discriminator: "0",
+    });
+
+    const result = await resolveContact(
+      { botToken: "BotTokenABC" },
+      { id: "1177378744822943744", kind: "user" },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      id: "1177378744822943744",
+      displayName: "Harold (@huntharo)",
+      handle: "@huntharo",
+      detail: "user",
+    });
+    expect(setTokenMock).toHaveBeenCalledExactlyOnceWith("BotTokenABC");
+    expect(getMock).toHaveBeenCalledExactlyOnceWith(
+      "/users/1177378744822943744",
+    );
+  });
+
+  it("resolves guild names from the REST API", async () => {
+    getMock.mockResolvedValue({
+      id: "1480554271907905731",
+      name: "PwrAgent Ops",
+    });
+
+    const result = await resolveContact(
+      { botToken: "BotTokenABC" },
+      { id: "1480554271907905731", kind: "guild" },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      displayName: "PwrAgent Ops",
+      detail: "guild",
+    });
+    expect(getMock).toHaveBeenCalledExactlyOnceWith(
+      "/guilds/1480554271907905731",
+    );
+  });
+});

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -323,7 +323,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   }
 
   get authorizedActorIds(): readonly string[] {
-    return this.options.config.authorizedActorIds;
+    return this.options.config.authorizedActorIds.map((contact) => contact.id);
   }
 
   onInboundRejected(listener: MessagingInboundRejectedListener): () => void {
@@ -1030,7 +1030,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       }
       return false;
     }
-    if (!this.authorizedActorIds.includes(message.author.id)) {
+    if (!this.isAuthorizedActor(message.author.id)) {
       if (!message.guild_id || options.actionable) {
         this.options.logger?.warn?.("discord inbound ignored unauthorized actor", {
           actorId: message.author.id,
@@ -1058,7 +1058,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       }));
       return false;
     }
-    if (!this.authorizedActorIds.includes(actor.id)) {
+    if (!this.isAuthorizedActor(actor.id)) {
       this.options.logger?.warn?.("discord interaction ignored unauthorized actor", {
         actorId: actor.id,
         channelId: interaction.channel_id,
@@ -1073,6 +1073,12 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     return true;
   }
 
+  private isAuthorizedActor(actorId: string): boolean {
+    return this.options.config.authorizedActorIds.some(
+      (contact) => contact.id === actorId,
+    );
+  }
+
   private isAuthorizedGuild(
     guildId: string | undefined,
     surface: "interaction" | "message",
@@ -1081,7 +1087,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       return true;
     }
     const authorized = this.options.config.authorizedGuildIds ?? [];
-    if (authorized.length === 0 || authorized.includes(guildId)) {
+    if (
+      authorized.length === 0
+      || authorized.some((contact) => contact.id === guildId)
+    ) {
       return true;
     }
     if (!this.unauthorizedGuildLogKeys.has(guildId)) {

--- a/packages/messaging/providers/discord/src/discord-config.ts
+++ b/packages/messaging/providers/discord/src/discord-config.ts
@@ -1,7 +1,12 @@
+export type DiscordAuthorizedContact = {
+  id: string;
+  displayName: string;
+};
+
 export type DiscordMessagingConfig = {
   applicationId?: string;
-  authorizedActorIds: string[];
-  authorizedGuildIds?: string[];
+  authorizedActorIds: DiscordAuthorizedContact[];
+  authorizedGuildIds?: DiscordAuthorizedContact[];
   botToken: string;
   channel: "discord";
   enabled?: boolean;

--- a/packages/messaging/providers/discord/src/index.ts
+++ b/packages/messaging/providers/discord/src/index.ts
@@ -13,6 +13,7 @@ export type {
   DiscordApplicationCommandBody,
 } from "./discord-commands.ts";
 export { DiscordAdapter, createDiscordAdapter } from "./discord-adapter.ts";
+export { resolveContact } from "./resolve-contact.ts";
 export {
   DISCORD_COMPONENT_CUSTOM_ID_LIMIT_BYTES,
   actionsForDiscordIntent,

--- a/packages/messaging/providers/discord/src/resolve-contact.ts
+++ b/packages/messaging/providers/discord/src/resolve-contact.ts
@@ -1,0 +1,83 @@
+import { REST, Routes } from "discord.js";
+import {
+  clipMessagingValidationError,
+  type MessagingContactLookupRequest,
+  type MessagingContactLookupResult,
+} from "@pwragent/messaging-interface";
+import type { DiscordMessagingConfig } from "./discord-config.ts";
+
+type DiscordLookupUser = {
+  discriminator?: string;
+  global_name?: string | null;
+  id?: string;
+  username?: string;
+};
+
+type DiscordLookupGuild = {
+  id?: string;
+  name?: string;
+};
+
+export async function resolveContact(
+  config: Pick<DiscordMessagingConfig, "botToken">,
+  request: MessagingContactLookupRequest,
+): Promise<MessagingContactLookupResult> {
+  if (!config.botToken) {
+    return { status: "unset", id: request.id };
+  }
+  if (request.kind !== "user" && request.kind !== "guild") {
+    return {
+      status: "unsupported",
+      id: request.id,
+      errorMessage: `Discord cannot resolve ${request.kind} contacts.`,
+    };
+  }
+
+  try {
+    const rest = new REST({ version: "10" }).setToken(config.botToken);
+    if (request.kind === "guild") {
+      const guild = (await rest.get(Routes.guild(request.id))) as DiscordLookupGuild;
+      return {
+        status: "ok",
+        id: request.id,
+        displayName: guild.name ?? guild.id ?? request.id,
+        detail: "guild",
+      };
+    }
+
+    const user = (await rest.get(Routes.user(request.id))) as DiscordLookupUser;
+    return {
+      status: "ok",
+      id: request.id,
+      displayName: formatDiscordUserDisplayName(user),
+      handle: user.username ? `@${user.username}` : undefined,
+      detail: "user",
+    };
+  } catch (error) {
+    return lookupFailure(request.id, error);
+  }
+}
+
+function formatDiscordUserDisplayName(
+  user: DiscordLookupUser,
+): string | undefined {
+  const username = user.discriminator && user.discriminator !== "0"
+    ? `${user.username ?? "unknown"}#${user.discriminator}`
+    : user.username;
+  const handle = user.username ? `@${user.username}` : undefined;
+  const display = user.global_name ?? undefined;
+  if (display && handle && display !== user.username) return `${display} (${handle})`;
+  return display ?? username ?? handle;
+}
+
+function lookupFailure(id: string, error: unknown): MessagingContactLookupResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = /\b(403|404|10013|10004)\b|unknown user|unknown guild|missing access/i.test(message)
+    ? "not_found"
+    : "failed";
+  return {
+    status,
+    id,
+    errorMessage: clipMessagingValidationError(message),
+  };
+}

--- a/packages/messaging/providers/discord/src/resolve-contact.ts
+++ b/packages/messaging/providers/discord/src/resolve-contact.ts
@@ -1,6 +1,8 @@
 import { REST, Routes } from "discord.js";
 import {
   clipMessagingValidationError,
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
   type MessagingContactLookupRequest,
   type MessagingContactLookupResult,
 } from "@pwragent/messaging-interface";
@@ -40,17 +42,20 @@ export async function resolveContact(
       return {
         status: "ok",
         id: request.id,
-        displayName: guild.name ?? guild.id ?? request.id,
+        displayName: sanitizeOptionalContactLabel(guild.name)
+          ?? sanitizeOptionalContactLabel(guild.id)
+          ?? request.id,
         detail: "guild",
       };
     }
 
     const user = (await rest.get(Routes.user(request.id))) as DiscordLookupUser;
+    const handle = formatContactHandle(user.username);
     return {
       status: "ok",
       id: request.id,
       displayName: formatDiscordUserDisplayName(user),
-      handle: user.username ? `@${user.username}` : undefined,
+      handle,
       detail: "user",
     };
   } catch (error) {
@@ -61,13 +66,25 @@ export async function resolveContact(
 function formatDiscordUserDisplayName(
   user: DiscordLookupUser,
 ): string | undefined {
-  const username = user.discriminator && user.discriminator !== "0"
-    ? `${user.username ?? "unknown"}#${user.discriminator}`
-    : user.username;
-  const handle = user.username ? `@${user.username}` : undefined;
-  const display = user.global_name ?? undefined;
-  if (display && handle && display !== user.username) return `${display} (${handle})`;
-  return display ?? username ?? handle;
+  const username = sanitizeOptionalContactLabel(user.username);
+  const discriminator = sanitizeOptionalContactLabel(user.discriminator);
+  const legacyUsername = discriminator && discriminator !== "0"
+    ? sanitizeOptionalContactLabel(`${username ?? "unknown"} ${discriminator}`)
+    : username;
+  const handle = formatContactHandle(user.username);
+  const display = sanitizeOptionalContactLabel(user.global_name ?? undefined);
+  if (display && handle && display !== username) return `${display} (${handle})`;
+  return display ?? legacyUsername ?? handle;
+}
+
+function sanitizeOptionalContactLabel(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactLabel(value);
+  return sanitized || undefined;
+}
+
+function formatContactHandle(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactHandle(value);
+  return sanitized ? `@${sanitized}` : undefined;
 }
 
 function lookupFailure(id: string, error: unknown): MessagingContactLookupResult {

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -26,7 +26,7 @@ const baseConfig = {
   serverUrl: "https://chat.example.com",
   callbackBaseUrl: "https://callback.example.com/cb",
   callbackHmacSecret: "test-secret",
-  authorizedActorIds: ["user-1"],
+  authorizedActorIds: [{ id: "user-1", displayName: "" }],
 };
 
 /**
@@ -157,7 +157,7 @@ describe("MattermostAdapter — capability profile", () => {
   it("exposes the configured authorized actor IDs", () => {
     const adapter = new MattermostAdapter({
       callbackHandleStore: fakeStore,
-      config: { ...baseConfig, authorizedActorIds: ["alice", "bob"] },
+      config: { ...baseConfig, authorizedActorIds: [{ id: "alice", displayName: "" }, { id: "bob", displayName: "" }] },
       logger: silentLogger,
       websocketClient: fakeWebSocketClient(),
     });
@@ -524,7 +524,7 @@ describe("MattermostAdapter — slash command response_url", () => {
       const adapter = new MattermostAdapter({
         callbackHandleStore: fakeStore,
         client: fakeClient4(spies),
-        config: { ...baseConfig, authorizedActorIds: ["harold-user-id"] },
+        config: { ...baseConfig, authorizedActorIds: [{ id: "harold-user-id", displayName: "" }] },
         logger: silentLogger,
         websocketClient: fakeWebSocketClient(),
         callbackServer: { start: async () => {}, stop: async () => {}, signContext: () => ({ hmac: "x", issuedAt: 0 }) } as never,
@@ -746,7 +746,7 @@ describe("MattermostAdapter — response_url echo dedup", () => {
       const adapter = new MattermostAdapter({
         callbackHandleStore: fakeStore,
         client: fakeClient4(spies),
-        config: { ...baseConfig, authorizedActorIds: ["harold-user-id"] },
+        config: { ...baseConfig, authorizedActorIds: [{ id: "harold-user-id", displayName: "" }] },
         logger: silentLogger,
         websocketClient: fakeWebSocketClient(undefined, wsHooks),
         callbackServer: {

--- a/packages/messaging/providers/mattermost/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/resolve-contact.test.ts
@@ -42,6 +42,34 @@ describe("Mattermost resolveContact", () => {
     expect(init.headers.Authorization).toBe("Bearer token");
   });
 
+  it("sanitizes provider-controlled names from the REST API", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "user-1",
+          username: "hun<tharo>",
+          nickname: "<img src=x onerror=alert(1)>Harold\u202e",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await resolveContact(
+      {
+        botToken: "token",
+        serverUrl: "https://chat.example.com",
+      },
+      { id: "user-1", kind: "user" },
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      displayName: "Harold (@hun)",
+      handle: "@hun",
+    });
+  });
+
   it("returns unset without complete connection settings", async () => {
     const result = await resolveContact(
       { botToken: "", serverUrl: "https://chat.example.com" },

--- a/packages/messaging/providers/mattermost/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/resolve-contact.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveContact } from "../resolve-contact.ts";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+});
+
+describe("Mattermost resolveContact", () => {
+  it("formats user names from the REST API", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "user-1",
+          username: "huntharo",
+          first_name: "Harold",
+          last_name: "Hunt",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await resolveContact(
+      {
+        botToken: "token",
+        serverUrl: "https://chat.example.com",
+      },
+      { id: "user-1", kind: "user" },
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      id: "user-1",
+      displayName: "Harold Hunt (@huntharo)",
+      handle: "@huntharo",
+      detail: "user",
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://chat.example.com/api/v4/users/user-1");
+    expect(init.headers.Authorization).toBe("Bearer token");
+  });
+
+  it("returns unset without complete connection settings", async () => {
+    const result = await resolveContact(
+      { botToken: "", serverUrl: "https://chat.example.com" },
+      { id: "user-1", kind: "user" },
+      { fetch: fetchMock as unknown as typeof fetch },
+    );
+
+    expect(result).toEqual({ status: "unset", id: "user-1" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/messaging/providers/mattermost/src/index.ts
+++ b/packages/messaging/providers/mattermost/src/index.ts
@@ -1,5 +1,6 @@
 export type { MattermostMessagingConfig } from "./mattermost-config.ts";
 export { validateCredentials } from "./validate-credentials.ts";
+export { resolveContact } from "./resolve-contact.ts";
 export type {
   MattermostProviderAdapter,
   MattermostProviderLogger,

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -336,7 +336,9 @@ export class MattermostAdapter implements MattermostProviderAdapter {
 
   constructor(options: MattermostAdapterOptions) {
     this.config = options.config;
-    this.authorizedActorIds = [...options.config.authorizedActorIds];
+    this.authorizedActorIds = options.config.authorizedActorIds.map(
+      (contact) => contact.id,
+    );
     this.callbackHandleStore = options.callbackHandleStore;
     this.logger = options.logger;
     this.now = options.now ?? Date.now;

--- a/packages/messaging/providers/mattermost/src/mattermost-config.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-config.ts
@@ -1,5 +1,10 @@
+export type MattermostAuthorizedContact = {
+  id: string;
+  displayName: string;
+};
+
 export type MattermostMessagingConfig = {
-  authorizedActorIds: string[];
+  authorizedActorIds: MattermostAuthorizedContact[];
   /**
    * Bot access token from Mattermost (System Console → Integrations → Bot Accounts).
    * Personal access tokens also work but a bot account is the canonical identity.

--- a/packages/messaging/providers/mattermost/src/resolve-contact.ts
+++ b/packages/messaging/providers/mattermost/src/resolve-contact.ts
@@ -1,5 +1,7 @@
 import {
   clipMessagingValidationError,
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
   type MessagingContactLookupRequest,
   type MessagingContactLookupResult,
 } from "@pwragent/messaging-interface";
@@ -74,11 +76,12 @@ export async function resolveContact(
       };
     }
     const user = (await response.json()) as MattermostLookupUser;
+    const handle = formatContactHandle(user.username);
     return {
       status: "ok",
       id: request.id,
       displayName: formatMattermostDisplayName(user),
-      handle: user.username ? `@${user.username}` : undefined,
+      handle,
       detail: "user",
     };
   } catch (error) {
@@ -107,11 +110,27 @@ function buildUserUrl(serverUrl: string, userId: string): string | undefined {
 function formatMattermostDisplayName(
   user: MattermostLookupUser,
 ): string | undefined {
-  const fullName = [user.first_name, user.last_name].filter(Boolean).join(" ");
-  const name = user.nickname || fullName || undefined;
-  const handle = user.username ? `@${user.username}` : undefined;
-  if (name && handle && name !== user.username) return `${name} (${handle})`;
-  return name ?? handle ?? user.id;
+  const fullName = [
+    sanitizeOptionalContactLabel(user.first_name),
+    sanitizeOptionalContactLabel(user.last_name),
+  ].filter(Boolean).join(" ");
+  const name = sanitizeOptionalContactLabel(user.nickname)
+    || fullName
+    || undefined;
+  const username = sanitizeOptionalContactLabel(user.username);
+  const handle = formatContactHandle(user.username);
+  if (name && handle && name !== username) return `${name} (${handle})`;
+  return name ?? handle ?? sanitizeOptionalContactLabel(user.id);
+}
+
+function sanitizeOptionalContactLabel(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactLabel(value);
+  return sanitized || undefined;
+}
+
+function formatContactHandle(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactHandle(value);
+  return sanitized ? `@${sanitized}` : undefined;
 }
 
 async function safeReadText(response: Response): Promise<string> {

--- a/packages/messaging/providers/mattermost/src/resolve-contact.ts
+++ b/packages/messaging/providers/mattermost/src/resolve-contact.ts
@@ -1,0 +1,124 @@
+import {
+  clipMessagingValidationError,
+  type MessagingContactLookupRequest,
+  type MessagingContactLookupResult,
+} from "@pwragent/messaging-interface";
+import type { MattermostMessagingConfig } from "./mattermost-config.ts";
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+type MattermostLookupUser = {
+  first_name?: string;
+  id?: string;
+  last_name?: string;
+  nickname?: string;
+  username?: string;
+};
+
+export type MattermostResolveContactOptions = {
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+};
+
+export async function resolveContact(
+  config: Pick<MattermostMessagingConfig, "botToken" | "serverUrl">,
+  request: MessagingContactLookupRequest,
+  options: MattermostResolveContactOptions = {},
+): Promise<MessagingContactLookupResult> {
+  if (!config.botToken || !config.serverUrl) {
+    return { status: "unset", id: request.id };
+  }
+  if (request.kind !== "user") {
+    return {
+      status: "unsupported",
+      id: request.id,
+      errorMessage: `Mattermost cannot resolve ${request.kind} contacts.`,
+    };
+  }
+
+  const url = buildUserUrl(config.serverUrl, request.id);
+  if (!url) {
+    return {
+      status: "failed",
+      id: request.id,
+      errorMessage: clipMessagingValidationError(
+        `Invalid Mattermost server URL: ${config.serverUrl}`,
+      ),
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  try {
+    const response = await (options.fetch ?? globalThis.fetch)(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${config.botToken}`,
+        Accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const body = await safeReadText(response);
+      return {
+        status: response.status === 403 || response.status === 404
+          ? "not_found"
+          : "failed",
+        id: request.id,
+        errorMessage: clipMessagingValidationError(
+          `HTTP ${response.status} ${response.statusText || ""} ${body}`.trim(),
+        ),
+      };
+    }
+    const user = (await response.json()) as MattermostLookupUser;
+    return {
+      status: "ok",
+      id: request.id,
+      displayName: formatMattermostDisplayName(user),
+      handle: user.username ? `@${user.username}` : undefined,
+      detail: "user",
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      id: request.id,
+      errorMessage: clipMessagingValidationError(
+        error instanceof Error ? error.message : String(error),
+      ),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildUserUrl(serverUrl: string, userId: string): string | undefined {
+  try {
+    const base = new URL(serverUrl);
+    return new URL(`/api/v4/users/${encodeURIComponent(userId)}`, base)
+      .toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function formatMattermostDisplayName(
+  user: MattermostLookupUser,
+): string | undefined {
+  const fullName = [user.first_name, user.last_name].filter(Boolean).join(" ");
+  const name = user.nickname || fullName || undefined;
+  const handle = user.username ? `@${user.username}` : undefined;
+  if (name && handle && name !== user.username) return `${name} (${handle})`;
+  return name ?? handle ?? user.id;
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 200);
+  } catch {
+    return "";
+  }
+}

--- a/packages/messaging/providers/telegram/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/resolve-contact.test.ts
@@ -30,6 +30,31 @@ describe("Telegram resolveContact", () => {
     expect(bot.api.getChat).toHaveBeenCalledExactlyOnceWith("8460800771");
   });
 
+  it("sanitizes provider-controlled names from getChat", async () => {
+    const bot = {
+      api: {
+        getChat: vi.fn(async () => ({
+          first_name: "<script>alert(1)</script>Harold",
+          last_name: "Hunt\u202e",
+          type: "private",
+          username: "hunt<haro>",
+        })),
+      },
+    };
+
+    const result = await resolveContact(
+      { botToken: "12345:abcdef" },
+      { id: "8460800771", kind: "user" },
+      { bot },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      displayName: "Harold Hunt (@hunt)",
+      handle: "@hunt",
+    });
+  });
+
   it("returns unset without a bot token", async () => {
     const result = await resolveContact(
       { botToken: "" },

--- a/packages/messaging/providers/telegram/src/__tests__/resolve-contact.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/resolve-contact.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveContact } from "../resolve-contact.ts";
+
+describe("Telegram resolveContact", () => {
+  it("formats user names from getChat", async () => {
+    const bot = {
+      api: {
+        getChat: vi.fn(async () => ({
+          first_name: "Harold",
+          last_name: "Hunt",
+          type: "private",
+          username: "huntharo",
+        })),
+      },
+    };
+
+    const result = await resolveContact(
+      { botToken: "12345:abcdef" },
+      { id: "8460800771", kind: "user" },
+      { bot },
+    );
+
+    expect(result).toMatchObject({
+      status: "ok",
+      id: "8460800771",
+      displayName: "Harold Hunt (@huntharo)",
+      handle: "@huntharo",
+      detail: "private",
+    });
+    expect(bot.api.getChat).toHaveBeenCalledExactlyOnceWith("8460800771");
+  });
+
+  it("returns unset without a bot token", async () => {
+    const result = await resolveContact(
+      { botToken: "" },
+      { id: "8460800771", kind: "user" },
+    );
+
+    expect(result).toEqual({ status: "unset", id: "8460800771" });
+  });
+});

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
@@ -9,8 +9,8 @@ describe("TelegramAdapter inbound security boundary", () => {
     const adapter = new TelegramAdapter({
       bot: fakeBot(),
       config: {
-        authorizedActorIds: ["42"],
-        authorizedSupergroupIds: ["-1001234567890"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+        authorizedSupergroupIds: [{ id: "-1001234567890", displayName: "" }],
         botToken: "token",
         channel: "telegram",
       },
@@ -69,7 +69,7 @@ describe("TelegramAdapter inbound security boundary", () => {
     const adapter = new TelegramAdapter({
       bot,
       config: {
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         botToken: "token",
         channel: "telegram",
       },
@@ -120,7 +120,7 @@ describe("TelegramAdapter inbound security boundary", () => {
     const adapter = new TelegramAdapter({
       bot,
       config: {
-        authorizedActorIds: ["42"],
+        authorizedActorIds: [{ id: "42", displayName: "" }],
         botToken: "token",
         channel: "telegram",
       },

--- a/packages/messaging/providers/telegram/src/index.ts
+++ b/packages/messaging/providers/telegram/src/index.ts
@@ -28,3 +28,4 @@ export {
 } from "./telegram-formatting.ts";
 export type { TelegramMessagingConfig } from "./telegram-config.ts";
 export { validateCredentials } from "./validate-credentials.ts";
+export { resolveContact } from "./resolve-contact.ts";

--- a/packages/messaging/providers/telegram/src/resolve-contact.ts
+++ b/packages/messaging/providers/telegram/src/resolve-contact.ts
@@ -1,6 +1,8 @@
 import { Bot } from "grammy";
 import {
   clipMessagingValidationError,
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
   type MessagingContactLookupRequest,
   type MessagingContactLookupResult,
 } from "@pwragent/messaging-interface";
@@ -43,11 +45,12 @@ export async function resolveContact(
   try {
     const bot = options.bot ?? new Bot(config.botToken);
     const chat = await bot.api.getChat(request.id);
+    const handle = formatContactHandle(chat.username);
     return {
       status: "ok",
       id: request.id,
       displayName: formatTelegramDisplayName(chat),
-      handle: chat.username ? `@${chat.username}` : undefined,
+      handle,
       detail: chat.type,
     };
   } catch (error) {
@@ -56,13 +59,26 @@ export async function resolveContact(
 }
 
 function formatTelegramDisplayName(chat: TelegramLookupChat): string | undefined {
+  const handle = formatContactHandle(chat.username);
   const name =
-    [chat.first_name, chat.last_name].filter(Boolean).join(" ")
-    || chat.title
+    [
+      sanitizeOptionalContactLabel(chat.first_name),
+      sanitizeOptionalContactLabel(chat.last_name),
+    ].filter(Boolean).join(" ")
+    || sanitizeOptionalContactLabel(chat.title)
     || undefined;
-  const handle = chat.username ? `@${chat.username}` : undefined;
   if (name && handle) return `${name} (${handle})`;
   return name ?? handle;
+}
+
+function sanitizeOptionalContactLabel(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactLabel(value);
+  return sanitized || undefined;
+}
+
+function formatContactHandle(value: string | undefined): string | undefined {
+  const sanitized = sanitizeMessagingContactHandle(value);
+  return sanitized ? `@${sanitized}` : undefined;
 }
 
 function lookupFailure(id: string, error: unknown): MessagingContactLookupResult {

--- a/packages/messaging/providers/telegram/src/resolve-contact.ts
+++ b/packages/messaging/providers/telegram/src/resolve-contact.ts
@@ -1,0 +1,78 @@
+import { Bot } from "grammy";
+import {
+  clipMessagingValidationError,
+  type MessagingContactLookupRequest,
+  type MessagingContactLookupResult,
+} from "@pwragent/messaging-interface";
+import type { TelegramMessagingConfig } from "./telegram-config.ts";
+
+type TelegramLookupBotLike = {
+  api: {
+    getChat(chatId: number | string): Promise<TelegramLookupChat>;
+  };
+};
+
+type TelegramLookupChat = {
+  first_name?: string;
+  last_name?: string;
+  title?: string;
+  type?: string;
+  username?: string;
+};
+
+export type TelegramResolveContactOptions = {
+  bot?: TelegramLookupBotLike;
+};
+
+export async function resolveContact(
+  config: Pick<TelegramMessagingConfig, "botToken">,
+  request: MessagingContactLookupRequest,
+  options: TelegramResolveContactOptions = {},
+): Promise<MessagingContactLookupResult> {
+  if (!config.botToken) {
+    return { status: "unset", id: request.id };
+  }
+  if (request.kind !== "user" && request.kind !== "supergroup") {
+    return {
+      status: "unsupported",
+      id: request.id,
+      errorMessage: `Telegram cannot resolve ${request.kind} contacts.`,
+    };
+  }
+
+  try {
+    const bot = options.bot ?? new Bot(config.botToken);
+    const chat = await bot.api.getChat(request.id);
+    return {
+      status: "ok",
+      id: request.id,
+      displayName: formatTelegramDisplayName(chat),
+      handle: chat.username ? `@${chat.username}` : undefined,
+      detail: chat.type,
+    };
+  } catch (error) {
+    return lookupFailure(request.id, error);
+  }
+}
+
+function formatTelegramDisplayName(chat: TelegramLookupChat): string | undefined {
+  const name =
+    [chat.first_name, chat.last_name].filter(Boolean).join(" ")
+    || chat.title
+    || undefined;
+  const handle = chat.username ? `@${chat.username}` : undefined;
+  if (name && handle) return `${name} (${handle})`;
+  return name ?? handle;
+}
+
+function lookupFailure(id: string, error: unknown): MessagingContactLookupResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = /\b(400|403|404)\b|not found|chat not found/i.test(message)
+    ? "not_found"
+    : "failed";
+  return {
+    status,
+    id,
+    errorMessage: clipMessagingValidationError(message),
+  };
+}

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -460,7 +460,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   get authorizedActorIds(): readonly string[] {
-    return this.options.config.authorizedActorIds;
+    return this.options.config.authorizedActorIds.map((contact) => contact.id);
   }
 
   onInboundRejected(listener: MessagingInboundRejectedListener): () => void {
@@ -1305,7 +1305,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     options: { actionable: boolean },
   ): boolean {
     const actorId = String(message.from?.id ?? "");
-    if (!this.authorizedActorIds.includes(actorId)) {
+    if (!this.isAuthorizedActor(actorId)) {
       if (message.chat.type === "private" || options.actionable) {
         this.options.logger?.warn?.("telegram inbound ignored unauthorized actor", {
           actorId,
@@ -1335,7 +1335,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private isAuthorizedCallbackSource(callbackQuery: TelegramCallbackQuery): boolean {
     const actorId = String(callbackQuery.from.id);
     const chat = callbackQuery.message?.chat;
-    if (!this.authorizedActorIds.includes(actorId)) {
+    if (!this.isAuthorizedActor(actorId)) {
       this.options.logger?.warn?.("telegram callback ignored unauthorized actor", {
         actorId,
         chatId: chat ? String(chat.id) : undefined,
@@ -1357,12 +1357,21 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return true;
   }
 
+  private isAuthorizedActor(actorId: string): boolean {
+    return this.options.config.authorizedActorIds.some(
+      (contact) => contact.id === actorId,
+    );
+  }
+
   private isAuthorizedTelegramConversation(chat: TelegramChat): boolean {
     if (chat.type !== "supergroup" && chat.type !== "group") {
       return true;
     }
     const authorized = this.options.config.authorizedSupergroupIds ?? [];
-    return authorized.length === 0 || authorized.includes(String(chat.id));
+    return (
+      authorized.length === 0
+      || authorized.some((contact) => contact.id === String(chat.id))
+    );
   }
 
   private logUnauthorizedConversationOnce(

--- a/packages/messaging/providers/telegram/src/telegram-config.ts
+++ b/packages/messaging/providers/telegram/src/telegram-config.ts
@@ -1,6 +1,11 @@
+export type TelegramAuthorizedContact = {
+  id: string;
+  displayName: string;
+};
+
 export type TelegramMessagingConfig = {
-  authorizedActorIds: string[];
-  authorizedSupergroupIds?: string[];
+  authorizedActorIds: TelegramAuthorizedContact[];
+  authorizedSupergroupIds?: TelegramAuthorizedContact[];
   botToken: string;
   channel: "telegram";
   enabled?: boolean;

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -2,6 +2,13 @@
 
 This package contains types, contracts, and utility functions shared across the monorepo. It is the lowest-level internal package.
 
+When changing shared settings/config contracts in a way that changes the TOML
+shape persisted by the desktop app, read
+[../../docs/config-file-evolution.md](../../docs/config-file-evolution.md)
+before editing types. The reader/writer migration behavior lives in the desktop
+app, but the shared contract should still be shaped to support recognized
+legacy config values and current canonical values cleanly.
+
 ## Dependency Boundary Enforcement
 
 **DO NOT, under any circumstances, loosen the dependency boundary rules.**

--- a/packages/shared/src/__tests__/messaging-contact-labels.test.ts
+++ b/packages/shared/src/__tests__/messaging-contact-labels.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  MESSAGING_CONTACT_LABEL_MAX_LENGTH,
+  sanitizeMessagingContactHandle,
+  sanitizeMessagingContactLabel,
+} from "../messaging-contact-labels";
+
+describe("messaging contact label sanitization", () => {
+  it("keeps recognizable plain contact labels", () => {
+    expect(sanitizeMessagingContactLabel("Harold Hunt (@huntharo)")).toBe(
+      "Harold Hunt (@huntharo)",
+    );
+  });
+
+  it("keeps non-latin names and normalizes whitespace", () => {
+    expect(sanitizeMessagingContactLabel("  山田   太郎  ")).toBe("山田 太郎");
+  });
+
+  it("removes markup, controls, bidi controls, and injection punctuation", () => {
+    const sanitized = sanitizeMessagingContactLabel(
+      "<img src=x onerror=alert(1)> Robert'); DROP TABLE users;-- \u202eevil",
+    );
+
+    expect(sanitized).toBe("Robert) DROP TABLE users- evil");
+    expect(sanitized).not.toMatch(/[<>"'`;=\\/\u202e]/u);
+  });
+
+  it("strips script bodies instead of retaining executable text", () => {
+    expect(
+      sanitizeMessagingContactLabel("Alice <script>alert(1)</script> Bob"),
+    ).toBe("Alice Bob");
+  });
+
+  it("caps labels before persisting them", () => {
+    expect(sanitizeMessagingContactLabel("a".repeat(200))).toHaveLength(
+      MESSAGING_CONTACT_LABEL_MAX_LENGTH,
+    );
+  });
+
+  it("sanitizes handles without adding an at-sign", () => {
+    expect(sanitizeMessagingContactHandle("@hun<tharo> user")).toBe(
+      "hunuser",
+    );
+  });
+});

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -51,7 +51,10 @@ describe("desktop settings contracts", () => {
             writable: true,
           },
           authorizedUserIds: {
-            value: ["111111111", "222222222"],
+            value: [
+              { id: "111111111", displayName: "" },
+              { id: "222222222", displayName: "Harold" },
+            ],
             source: "config",
           },
           authorizedSupergroups: {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -42,6 +42,38 @@ export type DesktopAuthorizedContact = {
   displayName: string;
 };
 
+export type DesktopMessagingContactLookupPlatform =
+  | "telegram"
+  | "discord"
+  | "mattermost";
+
+export type DesktopMessagingContactLookupKind =
+  | "user"
+  | "supergroup"
+  | "guild";
+
+export type DesktopMessagingContactLookupRequest = {
+  platform: DesktopMessagingContactLookupPlatform;
+  kind: DesktopMessagingContactLookupKind;
+  id: string;
+};
+
+export type DesktopMessagingContactLookupStatus =
+  | "ok"
+  | "failed"
+  | "not_found"
+  | "unset"
+  | "unsupported";
+
+export type DesktopMessagingContactLookupResponse = {
+  status: DesktopMessagingContactLookupStatus;
+  id: string;
+  displayName?: string;
+  handle?: string;
+  detail?: string;
+  errorMessage?: string;
+};
+
 export type DesktopSettingsSecretName =
   | "telegramBotToken"
   | "discordBotToken"

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -37,6 +37,11 @@ export type DesktopSettingsValue<T> = {
   error?: string;
 };
 
+export type DesktopAuthorizedContact = {
+  id: string;
+  displayName: string;
+};
+
 export type DesktopSettingsSecretName =
   | "telegramBotToken"
   | "discordBotToken"
@@ -180,16 +185,16 @@ export type DesktopSettingsSnapshot = {
       enabled: DesktopSettingsValue<boolean>;
       streamingResponses: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
-      authorizedUserIds: DesktopSettingsValue<string[]>;
-      authorizedSupergroups: DesktopSettingsValue<string[]>;
+      authorizedUserIds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
+      authorizedSupergroups: DesktopSettingsValue<DesktopAuthorizedContact[]>;
     };
     discord: {
       enabled: DesktopSettingsValue<boolean>;
       streamingResponses: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
       applicationId: DesktopSettingsValue<string>;
-      authorizedUserIds: DesktopSettingsValue<string[]>;
-      authorizedGuilds: DesktopSettingsValue<string[]>;
+      authorizedUserIds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
+      authorizedGuilds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
     };
     mattermost: {
       enabled: DesktopSettingsValue<boolean>;
@@ -200,7 +205,7 @@ export type DesktopSettingsSnapshot = {
       callbackBaseUrl: DesktopSettingsValue<string>;
       slashCommandPrefix: DesktopSettingsValue<string>;
       registerSlashCommands: DesktopSettingsValue<boolean>;
-      authorizedUserIds: DesktopSettingsValue<string[]>;
+      authorizedUserIds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
     };
   };
   models: {
@@ -239,15 +244,15 @@ export type DesktopSettingsConfigPatch = {
     telegram?: {
       enabled?: boolean;
       streamingResponses?: boolean;
-      authorizedUserIds?: string[];
-      authorizedSupergroups?: string[];
+      authorizedUserIds?: DesktopAuthorizedContact[];
+      authorizedSupergroups?: DesktopAuthorizedContact[];
     };
     discord?: {
       enabled?: boolean;
       streamingResponses?: boolean;
       applicationId?: string;
-      authorizedUserIds?: string[];
-      authorizedGuilds?: string[];
+      authorizedUserIds?: DesktopAuthorizedContact[];
+      authorizedGuilds?: DesktopAuthorizedContact[];
     };
     mattermost?: {
       enabled?: boolean;
@@ -256,7 +261,7 @@ export type DesktopSettingsConfigPatch = {
       callbackBaseUrl?: string;
       slashCommandPrefix?: string;
       registerSlashCommands?: boolean;
-      authorizedUserIds?: string[];
+      authorizedUserIds?: DesktopAuthorizedContact[];
     };
   };
   models?: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,5 +6,6 @@ export * from "./contracts/diff-focus";
 export * from "./contracts/messaging";
 export * from "./contracts/navigation";
 export * from "./contracts/settings";
+export * from "./messaging-contact-labels";
 export * from "./messaging-id-validation";
 export * from "./thread-titles";

--- a/packages/shared/src/messaging-contact-labels.ts
+++ b/packages/shared/src/messaging-contact-labels.ts
@@ -1,0 +1,99 @@
+export const MESSAGING_CONTACT_LABEL_MAX_LENGTH = 64;
+
+const RAW_CONTACT_LABEL_MAX_LENGTH = 512;
+const SAFE_CONTACT_LABEL_PUNCTUATION = new Set([
+  " ",
+  ".",
+  "_",
+  "-",
+  "+",
+  "@",
+  "(",
+  ")",
+]);
+const BLOCKED_FORMAT_CHARS = new Set([
+  "\u061c",
+  "\u200b",
+  "\u200c",
+  "\u200d",
+  "\u200e",
+  "\u200f",
+  "\u202a",
+  "\u202b",
+  "\u202c",
+  "\u202d",
+  "\u202e",
+  "\u2060",
+  "\u2066",
+  "\u2067",
+  "\u2068",
+  "\u2069",
+  "\ufeff",
+]);
+
+/**
+ * Contact labels are provider/user-controlled data. Store only plain text that
+ * is safe to render as text and safe to carry through config/database layers.
+ */
+export function sanitizeMessagingContactLabel(value: unknown): string {
+  if (typeof value !== "string") return "";
+
+  const normalized = stripHtmlLikeMarkup(
+    value.slice(0, RAW_CONTACT_LABEL_MAX_LENGTH),
+  ).normalize("NFKC");
+  const result: string[] = [];
+  let lastWasSpace = false;
+
+  for (const char of normalized) {
+    if (result.length >= MESSAGING_CONTACT_LABEL_MAX_LENGTH) break;
+
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (
+      isBlockedContactLabelCodePoint(codePoint)
+      || BLOCKED_FORMAT_CHARS.has(char)
+      || !isAllowedContactLabelChar(char)
+    ) {
+      continue;
+    }
+
+    if (char === " ") {
+      if (!lastWasSpace && result.length > 0) {
+        result.push(char);
+      }
+      lastWasSpace = true;
+      continue;
+    }
+
+    result.push(char);
+    lastWasSpace = false;
+  }
+
+  return result.join("").replace(/-{2,}/g, "-").trim();
+}
+
+export function sanitizeMessagingContactHandle(value: unknown): string {
+  return sanitizeMessagingContactLabel(value)
+    .replace(/^@+/, "")
+    .replace(/\s+/g, "");
+}
+
+function stripHtmlLikeMarkup(value: string): string {
+  return value
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]*>/g, " ");
+}
+
+function isAllowedContactLabelChar(char: string): boolean {
+  return /^[\p{L}\p{N}\p{M}]$/u.test(char)
+    || SAFE_CONTACT_LABEL_PUNCTUATION.has(char);
+}
+
+function isBlockedContactLabelCodePoint(codePoint: number): boolean {
+  return codePoint <= 0x1f
+    || (codePoint >= 0x7f && codePoint <= 0x9f)
+    || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    || (codePoint >= 0xe000 && codePoint <= 0xf8ff)
+    || (codePoint >= 0xf0000 && codePoint <= 0xffffd)
+    || (codePoint >= 0x100000 && codePoint <= 0x10fffd);
+}


### PR DESCRIPTION
## Summary

This adds friendly labels for authorized messaging contacts while preserving the existing ID-based authorization behavior.

- Change authorized user/supergroup/guild settings from plain ID arrays to contact rows with `id` and `display_name`.
- Keep provider authorization checks ID-only so labels are only for operator clarity in Settings.
- Read legacy scalar arrays and one-time migrate them when the new client saves.
- Preserve and update legacy scalar mirrors when they already exist, with a marker comment for older clients.
- Use `authorized_users` as the canonical object-list key instead of carrying forward `authorized_user_ids`.
- Resolve blank display names from Settings via provider-owned lookups: Telegram `getChat`, Discord REST user/guild fetches, and Mattermost `/api/v4/users/{id}`.

Closes #228

## Validation

- `pnpm test apps/desktop/src/main/__tests__/toml-editor.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check origin/main..HEAD`
