### PR TITLE
fix(desktop): keep thread reactions in sync

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1264,6 +1264,78 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("refreshes the selected thread when only reactions change", async () => {
+    const listeners = new Set<(event: any) => void>();
+    let navigationCallCount = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      navigationCallCount += 1;
+      return {
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [
+          {
+            id: "019e0755-ac96-7be2-a94d-78a6912eccb6",
+            title: "Emoji sync regression",
+            titleSource: "explicit" as const,
+            summary: "The thread whose reactions were disappearing.",
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+            reactions: navigationCallCount === 1 ? [] : ["👀", "🚀"],
+            updatedAt: 1_000,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe(
+        "019e0755-ac96-7be2-a94d-78a6912eccb6"
+      );
+    });
+    expect(result.current.selectedThread?.reactions).toEqual([]);
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "019e0755-ac96-7be2-a94d-78a6912eccb6",
+              turnId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.reactions).toEqual(["👀", "🚀"]);
+    });
+  });
+
   it("restores backend state and surfaces errors when rename fails", async () => {
     const renameThread = vi.fn(async () => {
       throw new Error("rename failed");

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -21,6 +21,7 @@ export type BrowseMode = "inbox" | "recents" | "directories";
 
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
+const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
 
 type NavigationState = {
   loading: boolean;
@@ -168,6 +169,21 @@ function prSummariesEqual(
   });
 }
 
+function reactionsEqual(
+  left: NavigationThreadSummary["reactions"],
+  right: NavigationThreadSummary["reactions"]
+): boolean {
+  const leftReactions = left ?? [];
+  const rightReactions = right ?? [];
+  if (leftReactions.length !== rightReactions.length) {
+    return false;
+  }
+
+  return leftReactions.every(
+    (reaction, index) => rightReactions[index] === reaction
+  );
+}
+
 function threadSummariesEqual(
   left: NavigationThreadSummary,
   right: NavigationThreadSummary
@@ -197,12 +213,14 @@ function threadSummariesEqual(
     threadInboxEqual(left.inbox, right.inbox) &&
     // Bindings and PRs mutate independently of `updatedAt`: the messaging
     // store revokes a binding row without touching the thread row, and
-    // GitHub PR detection runs on its own cadence. Without these checks
-    // the reconciler reuses the previous thread reference whenever
-    // nothing else changed and chips on the row stay stale until
-    // something else triggers a re-render.
+    // GitHub PR detection runs on its own cadence. Reactions can also be
+    // changed by another app instance while the backend thread record is
+    // otherwise unchanged. Without these checks the reconciler reuses the
+    // previous thread reference whenever nothing else changed and chips on
+    // the row stay stale until something else triggers a re-render.
     messagingBindingsEqual(left.messagingBindings, right.messagingBindings) &&
-    prSummariesEqual(left.prs, right.prs)
+    prSummariesEqual(left.prs, right.prs) &&
+    reactionsEqual(left.reactions, right.reactions)
   );
 }
 
@@ -1279,6 +1297,30 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    if (!desktopApi?.getNavigationSnapshot) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      scheduleRefresh();
+    }, NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [desktopApi?.getNavigationSnapshot, scheduleRefresh]);
+
+  useEffect(() => {
+    if (!desktopApi?.onWindowFocus) {
+      return;
+    }
+
+    return desktopApi.onWindowFocus(() => {
+      scheduleRefresh();
+    });
+  }, [desktopApi, scheduleRefresh]);
 
   useEffect(() => {
     if (!desktopApi?.onAgentEvent) {

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -68,6 +68,36 @@ describe("OverlayStore", () => {
     });
   });
 
+  it("preserves reactions when seen state is written later", async () => {
+    const store = await createStore();
+
+    await store.setThreadReaction({
+      backend: "codex",
+      threadId: "thread-1",
+      emoji: "👀",
+      present: true,
+    });
+    await store.setThreadReaction({
+      backend: "codex",
+      threadId: "thread-1",
+      emoji: "🚀",
+      present: true,
+    });
+
+    await store.markThreadSeen({
+      backend: "codex",
+      threadId: "thread-1",
+      seenAt: 2000,
+      seenUpdatedAt: 1000,
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.reactions).toEqual(["👀", "🚀"]);
+  });
+
   it("stores extra linked directories for desktop-only multi-project overlays", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -161,6 +161,19 @@ function migratePermissionTransitionLog(
   return entries.length > 0 ? entries : undefined;
 }
 
+function migrateThreadReactions(
+  value: unknown,
+): ThreadOverlayState["reactions"] {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const reactions = value.filter(
+    (item): item is string => typeof item === "string" && item.length > 0,
+  );
+  return reactions.length > 0 ? Array.from(new Set(reactions)) : undefined;
+}
+
 function migrateRetainedBranchDriftPairs(
   value: unknown,
 ): ThreadOverlayState["retainedBranchDriftPairs"] {
@@ -373,6 +386,7 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
             permissionTransitionLog: migratePermissionTransitionLog(
               threadRecord.permissionTransitionLog,
             ),
+            reactions: migrateThreadReactions(threadRecord.reactions),
           } satisfies ThreadOverlayState,
         ];
       }),

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -48,24 +48,25 @@ export class OverlayStore {
       if (firstSnapshot) {
         for (const thread of params.threads) {
           const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+          const current = data.threads[threadKey];
           data.threads[threadKey] = {
+            ...(current ?? {}),
             backend: thread.source,
             threadId: thread.id,
             executionMode:
-              data.threads[threadKey]?.executionMode ?? thread.executionMode ?? "default",
-            model: data.threads[threadKey]?.model ?? thread.model,
+              current?.executionMode ?? thread.executionMode ?? "default",
+            model: current?.model ?? thread.model,
             reasoningEffort:
-              data.threads[threadKey]?.reasoningEffort ?? thread.reasoningEffort,
-            serviceTier: data.threads[threadKey]?.serviceTier ?? thread.serviceTier,
-            fastMode: data.threads[threadKey]?.fastMode ?? thread.fastMode,
-            gitBranch: data.threads[threadKey]?.gitBranch,
-            observedGitBranch: data.threads[threadKey]?.observedGitBranch,
-            retainedBranchDriftPairs: data.threads[threadKey]?.retainedBranchDriftPairs,
+              current?.reasoningEffort ?? thread.reasoningEffort,
+            serviceTier: current?.serviceTier ?? thread.serviceTier,
+            fastMode: current?.fastMode ?? thread.fastMode,
+            gitBranch: current?.gitBranch,
+            observedGitBranch: current?.observedGitBranch,
+            retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
             lastSeenAt: params.fetchedAt,
             lastSeenUpdatedAt: thread.updatedAt,
-            extraLinkedDirectories:
-              data.threads[threadKey]?.extraLinkedDirectories ?? [],
-            worktreeSnapshots: data.threads[threadKey]?.worktreeSnapshots ?? [],
+            extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
+            worktreeSnapshots: current?.worktreeSnapshots ?? [],
           };
         }
       }
@@ -124,6 +125,7 @@ export class OverlayStore {
       const seenAt = params.seenAt ?? Date.now();
 
       data.threads[threadKey] = {
+        ...(current ?? {}),
         backend: params.backend,
         threadId: params.threadId,
         executionMode: current?.executionMode ?? "default",


### PR DESCRIPTION
## Summary

- I fixed reaction-only navigation refreshes so thread rows update when another app instance adds or removes emojis without changing the backend thread timestamp.
- I added a periodic navigation refresh and refresh-on-window-focus so multiple open desktop instances converge on the persisted reaction set.
- I preserved reactions in the legacy file-backed overlay store migration/read path and guarded later seen-state writes from dropping them.

## Root Cause

The renderer snapshot reconciler compared messaging bindings and PR chips, but not thread reactions. A refreshed snapshot could contain `👀` and `🚀` while the reconciler reused the old thread object, leaving the row stale. The legacy file-backed overlay normalizer also omitted `reactions`, so any path still using that store could erase them during read/write cycles.

## Validation

- I verified the new renderer regression failed before the fix with `[]` instead of `["👀", "🚀"]`.
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/overlay-store-reactions.test.ts`
- `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts`
- `pnpm --filter @pwragent/agent-core typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
