### PR TITLE
fix(desktop): block workspace handoff during active turns

### DIFF
--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -122,6 +122,160 @@ async function createActiveTurnThinkingFixture(): Promise<{
   };
 }
 
+async function createActiveTurnWorkspaceFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-active-turn-workspace-"));
+  const fixturePath = path.join(rootDir, "active-turn-workspace.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "active-turn-workspace",
+          threadId: "thread-active-workspace",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-active-workspace",
+                title: "Active workspace handoff replay",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "feature/active",
+                linkedDirectories: [
+                  {
+                    id: "directory:/repo/pwragent",
+                    kind: "local",
+                    label: "PwrAgent",
+                    path: "/repo/pwragent",
+                  },
+                ],
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-idle-workspace",
+                title: "Idle workspace handoff replay",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "feature/idle",
+                linkedDirectories: [
+                  {
+                    id: "directory:/repo/pwragent",
+                    kind: "local",
+                    label: "PwrAgent",
+                    path: "/repo/pwragent",
+                  },
+                ],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-active",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "active-message-1",
+                  role: "assistant",
+                  text: "Active workspace baseline.",
+                },
+              ],
+              messages: [
+                {
+                  id: "active-message-1",
+                  role: "assistant",
+                  text: "Active workspace baseline.",
+                },
+              ],
+              lastAssistantMessage: "Active workspace baseline.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "turn-started-active",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-active-workspace",
+                turnId: "turn-active-workspace-1",
+                turn: {
+                  id: "turn-active-workspace-1",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "thread-read-idle",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "idle-message-1",
+                  role: "assistant",
+                  text: "Idle workspace baseline.",
+                },
+              ],
+              messages: [
+                {
+                  id: "idle-message-1",
+                  role: "assistant",
+                  text: "Idle workspace baseline.",
+                },
+              ],
+              lastAssistantMessage: "Idle workspace baseline.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
 test("keeps transient turn UI through metadata and premature idle notifications", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
@@ -215,6 +369,45 @@ test("keeps transient turn UI through metadata and premature idle notifications"
     ).toBeVisible();
   } finally {
     await app.close();
+  }
+});
+
+test("disables workspace handoff on the focused thread while its turn is active", async () => {
+  const fixture = await createActiveTurnWorkspaceFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Active workspace handoff replay/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Active workspace handoff replay",
+      })
+    ).toBeVisible();
+
+    await expect(app.window.getByLabel("Workspace mode")).toBeEnabled();
+    await app.advance({ stepId: "turn-started-active" });
+    await expect(app.window.getByLabel("Workspace mode")).toBeDisabled();
+
+    await app.window
+      .getByRole("button", { name: /Idle workspace handoff replay/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Idle workspace handoff replay",
+      })
+    ).toBeVisible();
+    await expect(app.window.getByLabel("Workspace mode")).toBeEnabled();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
   }
 });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2635,6 +2635,185 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("rejects workspace handoff while the thread has an active turn", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Move me later",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "feature/handoff",
+      updatedAt: 2,
+    };
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      direction: "local-to-worktree" as const,
+      workMode: "worktree" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:thread-1",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+        kind: "worktree" as const,
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [thread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      codexSessionMetadataService: {
+        updateThreadCwd: vi.fn(async () => ({ updated: true })),
+      } as never,
+      gitDirectoryService: {
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "keep working" }],
+    });
+
+    await expect(
+      registry.handoffThreadWorkspace({
+        backend: "codex",
+        threadId: "thread-1",
+        direction: "local-to-worktree",
+      }),
+    ).rejects.toThrow(
+      "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.",
+    );
+    expect(handoff).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("rejects workspace handoff for active turns learned from backend notifications", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Notification active turn",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "feature/handoff",
+      updatedAt: 2,
+    };
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      direction: "local-to-worktree" as const,
+      workMode: "worktree" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:thread-1",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+        kind: "worktree" as const,
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [thread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      codexSessionMetadataService: {
+        updateThreadCwd: vi.fn(async () => ({ updated: true })),
+      } as never,
+      gitDirectoryService: {
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+
+    await codexClient.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-from-notification",
+        turn: {
+          id: "turn-from-notification",
+          status: "inProgress",
+        },
+      },
+    });
+
+    await expect(
+      registry.handoffThreadWorkspace({
+        backend: "codex",
+        threadId: "thread-1",
+        direction: "local-to-worktree",
+      }),
+    ).rejects.toThrow(
+      "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.",
+    );
+
+    await codexClient.emit({
+      method: "turn/failed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-from-notification",
+        turn: {
+          id: "turn-from-notification",
+          status: "failed",
+          error: {
+            message: "boom",
+          },
+        },
+      },
+    });
+
+    await registry.handoffThreadWorkspace({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+    });
+    expect(handoff).toHaveBeenCalledTimes(1);
+
+    await registry.close();
+  });
+
   it("records detached handoff results as HEAD immediately", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3843,6 +3843,62 @@ describe("MessagingController", () => {
     });
   });
 
+  it("rejects handoff confirmations while a turn is active", async () => {
+    const harness = await createHarness();
+    harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: toWorktree.id,
+        value: toWorktree.value,
+      }),
+    );
+    const leaveMain = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: leaveMain.id,
+        value: leaveMain.value,
+      }),
+    );
+    const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "inProgress",
+          },
+        },
+      },
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: confirm.id,
+        value: confirm.value,
+      }),
+    );
+
+    expect(harness.handoffThreadWorkspace).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Handoff unavailable",
+      body: expect.stringContaining(
+        "Worktree/local migration is not available while a turn is in progress",
+      ),
+    });
+  });
+
   it("reports handoff as unavailable when the backend bridge does not expose it", async () => {
     const harness = await createHarness({ handoff: false });
     harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -116,6 +116,8 @@ type InitializeResult = {
 const isDevelopment = process.env.NODE_ENV !== "production";
 const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
 const THREAD_LIST_REUSE_WINDOW_MS = 750;
+const ACTIVE_TURN_HANDOFF_ERROR =
+  "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 /**
  * Number of consecutive queued-execution-mode flush failures tolerated
  * before the queue is auto-cancelled and an explanatory `cancelled`
@@ -569,6 +571,19 @@ function readTurnStatus(value: unknown): string | undefined {
 
   const status = value.status;
   return typeof status === "string" ? status : undefined;
+}
+
+function turnIdFromStartedNotification(
+  notification: {
+    params: {
+      turnId?: string;
+      turn: {
+        id: string;
+      };
+    };
+  },
+): string {
+  return notification.params.turnId ?? notification.params.turn.id;
 }
 
 function logBackendLifecycleNotification(
@@ -1408,6 +1423,10 @@ export class DesktopBackendRegistry {
   async handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse> {
+    if (request.backend === "codex" && this.threadHasActiveTurn(request.threadId)) {
+      throw new Error(ACTIVE_TURN_HANDOFF_ERROR);
+    }
+
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: request.backend,
       threadId: request.threadId,
@@ -2175,6 +2194,16 @@ export class DesktopBackendRegistry {
       }
     }
     return false;
+  }
+
+  private async resolveCodexThreadExecutionModeForActiveTurn(
+    threadId: string,
+  ): Promise<ThreadExecutionMode> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId,
+    });
+    return overlay?.executionMode ?? "default";
   }
 
   /**
@@ -3650,20 +3679,55 @@ export class DesktopBackendRegistry {
   private async emit(event: AgentEvent): Promise<void> {
     if (
       event.backend === "codex" &&
-      event.notification.method === "turn/completed" &&
-      event.notification.params.turnId
+      event.notification.method === "turn/started"
     ) {
+      const notification = event.notification as {
+        params: {
+          threadId: string;
+          turnId?: string;
+          turn: {
+            id: string;
+          };
+        };
+      };
+      const turnId = turnIdFromStartedNotification(notification);
+      const key = buildActiveTurnModeKey(
+        notification.params.threadId,
+        turnId,
+      );
+      if (!this.activeCodexTurnModes.has(key)) {
+        this.activeCodexTurnModes.set(
+          key,
+          await this.resolveCodexThreadExecutionModeForActiveTurn(
+            notification.params.threadId,
+          ),
+        );
+      }
+    }
+
+    if (
+      event.backend === "codex" &&
+      (event.notification.method === "turn/completed" ||
+        event.notification.method === "turn/failed" ||
+        event.notification.method === "turn/cancelled")
+    ) {
+      const notification = event.notification as {
+        params: {
+          threadId: string;
+          turnId: string;
+        };
+      };
       this.activeCodexTurnModes.delete(
         buildActiveTurnModeKey(
-          event.notification.params.threadId,
-          event.notification.params.turnId,
+          notification.params.threadId,
+          notification.params.turnId,
         ),
       );
       // Turn-end is the resume boundary — flush any queued mode change
       // now. Fire-and-forget; failures are logged + retried inside
       // flushQueuedExecutionModeIfPresent.
       void this.flushQueuedExecutionModeIfPresent(
-        event.notification.params.threadId,
+        notification.params.threadId,
       );
     }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -105,6 +105,8 @@ const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
 const TYPING_ACTIVITY_REFRESH_MS = 10_000;
 const DEFAULT_INPUT_DEBOUNCE_MS = 500;
+const ACTIVE_TURN_HANDOFF_ERROR =
+  "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 // Provider adapters own stricter platform pacing; the generic layer only
 // coalesces noisy token deltas into human-visible refreshes.
 const STREAM_UPDATE_REFRESH_MS = 1_000;
@@ -2582,6 +2584,11 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    if (this.handoffBlockedByActiveTurn(binding)) {
+      await this.deliverHandoffUnavailable(binding, event, ACTIVE_TURN_HANDOFF_ERROR);
+      return;
+    }
+
     if (!this.options.backend.handoffThreadWorkspace) {
       await this.deliverHandoffUnavailable(binding, event, "This runtime does not expose workspace handoff through messaging.");
       return;
@@ -2615,6 +2622,11 @@ export class MessagingController {
     event: MessagingInboundEvent,
     pageIndex = 0,
   ): Promise<void> {
+    if (this.handoffBlockedByActiveTurn(binding)) {
+      await this.deliverHandoffUnavailable(binding, event, ACTIVE_TURN_HANDOFF_ERROR);
+      return;
+    }
+
     const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
     const context = handoffContextForBinding(binding, navigation);
     if (!context || context.workspaceKind !== "local") {
@@ -2647,6 +2659,11 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundCallbackEvent,
   ): Promise<void> {
+    if (this.handoffBlockedByActiveTurn(binding)) {
+      await this.deliverHandoffUnavailable(binding, event, ACTIVE_TURN_HANDOFF_ERROR);
+      return;
+    }
+
     const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
     const context = handoffContextForBinding(binding, navigation);
     const request = handoffRequestFromValue(event.value);
@@ -2686,6 +2703,11 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundCallbackEvent,
   ): Promise<void> {
+    if (this.handoffBlockedByActiveTurn(binding)) {
+      await this.deliverHandoffUnavailable(binding, event, ACTIVE_TURN_HANDOFF_ERROR);
+      return;
+    }
+
     if (!this.options.backend.handoffThreadWorkspace) {
       await this.deliverHandoffUnavailable(binding, event, "This runtime does not expose workspace handoff through messaging.");
       return;
@@ -2831,6 +2853,11 @@ export class MessagingController {
     if (pendingIntent && pendingIntent.intent.id.includes("handoff")) {
       await this.options.store.deletePendingIntent(pendingIntent.id);
     }
+  }
+
+  private handoffBlockedByActiveTurn(binding: MessagingBindingRecord): boolean {
+    const activeTurn = this.getActiveTurn(binding);
+    return Boolean(activeTurn && ["working", "waiting"].includes(activeTurn.status));
   }
 
   private async deliverHandoffUnavailable(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2418,6 +2418,12 @@ export function Composer(props: ComposerProps) {
       !handoffSubmitting
   );
 
+  useEffect(() => {
+    if (activeTurnId) {
+      setWorkspaceMenuOpen(false);
+    }
+  }, [activeTurnId]);
+
   const openHandoffDialog = (
     direction: HandoffThreadWorkspaceRequest["direction"]
   ): void => {
@@ -3731,7 +3737,7 @@ export function Composer(props: ComposerProps) {
                 aria-haspopup="menu"
                 aria-label="Workspace mode"
                 className="composer-dropdown__button"
-                disabled={!props.onHandoffThreadWorkspace}
+                disabled={!canHandoffThreadWorkspace}
                 type="button"
                 value={threadWorkspace.mode}
                 onClick={() => setWorkspaceMenuOpen((open) => !open)}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1761,6 +1761,53 @@ describe("Composer", () => {
     });
   });
 
+  it("disables existing thread workspace handoff while a turn is active", () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+    const thread = {
+      id: "thread-1",
+      title: "Build Codex client",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      gitBranch: "feature/handoff",
+      linkedDirectories: [
+        {
+          id: "dir-1",
+          label: "PwrAgent",
+          path: "/repo",
+          kind: "local" as const,
+        },
+      ],
+      inbox: { inInbox: false },
+    };
+
+    const { rerender } = render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    expect(screen.getByLabelText("Workspace mode")).toBeDisabled();
+
+    rerender(
+      <Composer
+        activeTurnId={undefined}
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    expect(screen.getByLabelText("Workspace mode")).toBeEnabled();
+  });
+
   it("lets the desktop handoff dialog move the current branch instead", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
 


### PR DESCRIPTION
## Summary

Fixes pwrdrvr/PwrAgent#263 by blocking workspace handoff while a thread has an active turn. The guard now applies at the desktop UI, messaging callbacks, and the backend registry, including active turns learned from backend lifecycle notifications rather than only turns started locally.

## Changes

- Disable the desktop workspace mode handoff dropdown while the focused thread has an active turn, and re-enable it when focus moves to an idle thread.
- Reject messaging handoff flows with a clear retry-after-completion error when a bound turn is working or waiting.
- Track Codex `turn/started` notifications in the registry active-turn map and clear that state on terminal turn notifications before allowing workspace migration.
- Add unit and replay E2E coverage for desktop, messaging, and backend guard paths.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/turn-lifecycle.spec.ts`
