### PR TITLE
feat(messaging): hot-apply runtime toggles

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -534,6 +534,7 @@ describe("DesktopSettingsService", () => {
 
     expect(snapshot.runtime.messaging).toEqual({
       disabled: true,
+      overrideActive: true,
       disabledReason: "--disable-messaging was provided at startup",
     });
   });

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -169,6 +169,21 @@ describe("desktop messaging config", () => {
       inputDebounceMs: 500,
     });
     expect(config.telegram).toBeUndefined();
+
+    const sessionConfig = await loadDesktopMessagingConfigFromSettings(
+      service,
+      {},
+      { messagingEnabledOverride: true },
+    );
+
+    expect(sessionConfig).toMatchObject({
+      enabled: true,
+      telegram: {
+        channel: "telegram",
+        botToken: "settings-telegram-token",
+        authorizedActorIds: [{ id: "111111111", displayName: "" }],
+      },
+    });
   });
 
   it("keeps env-only messaging config fallback enabled for tests", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -36,6 +36,7 @@ describe("desktop messaging config", () => {
     });
 
     expect(config).toEqual({
+      enabled: true,
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
       telegram: {
@@ -110,6 +111,7 @@ describe("desktop messaging config", () => {
     const config = await loadDesktopMessagingConfigFromSettings(service, {});
 
     expect(config).toEqual({
+      enabled: true,
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
       attachmentPolicy: {
@@ -135,6 +137,38 @@ describe("desktop messaging config", () => {
         authorizedGuildIds: [],
       },
     });
+  });
+
+  it("honors the persisted master messaging switch before building providers", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging]",
+        "enabled = false",
+        "",
+        "[messaging.telegram]",
+        "enabled = true",
+        'authorized_user_ids = ["111111111"]',
+      ].join("\n"),
+      "utf8",
+    );
+    const secretStore = new MemoryDesktopSecretStore();
+    await secretStore.setSecret("telegramBotToken", "settings-telegram-token");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore,
+    });
+
+    const config = await loadDesktopMessagingConfigFromSettings(service, {});
+
+    expect(config).toMatchObject({
+      enabled: false,
+      inputDebounceMs: 500,
+    });
+    expect(config.telegram).toBeUndefined();
   });
 
   it("keeps env-only messaging config fallback enabled for tests", async () => {
@@ -196,6 +230,7 @@ describe("desktop messaging config", () => {
 
     expect(JSON.stringify(redacted)).not.toContain("secret");
     expect(redacted).toEqual({
+      enabled: true,
       telegram: {
         channel: "telegram",
         enabled: true,

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1215,6 +1215,59 @@ describe("DesktopMessagingRuntime", () => {
       }),
     ]);
   });
+
+  it("preserves errored health when a hot restart replacement fails", async () => {
+    await prepareRuntimeStore();
+    const firstTelegramAdapter = createAdapter("telegram");
+    const failingTelegramAdapter = createAdapter("telegram", {
+      start: vi.fn(async () => {
+        throw new Error("new token rejected");
+      }),
+    });
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => {
+      if (!config.telegram) return [];
+      return [
+        config.telegram.botToken === "telegram-token-2"
+          ? failingTelegramAdapter
+          : firstTelegramAdapter,
+      ];
+    });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        inputDebounceMs: 0,
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token-1",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token-2",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+
+    expect(firstTelegramAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(failingTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "errored",
+        reason: "new token rejected",
+      }),
+    ]);
+  });
 });
 
 async function createRuntimeHarness(): Promise<{

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -576,7 +576,7 @@ describe("DesktopMessagingRuntime", () => {
       }),
     );
     expect(messagingLog.info).toHaveBeenCalledWith(
-      "messaging runtime started",
+      "messaging runtime config applied",
       expect.objectContaining({
         started: ["discord"],
         failed: ["telegram"],
@@ -1111,6 +1111,109 @@ describe("DesktopMessagingRuntime", () => {
 
     expect(factory).toHaveBeenCalledTimes(1);
     expect(adapter.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("hot-applies config by leaving unchanged adapters alone and starting new channels", async () => {
+    await prepareRuntimeStore();
+    const telegramAdapter = createAdapter("telegram");
+    const discordAdapter = createAdapter("discord");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => [
+      ...(config.telegram ? [telegramAdapter] : []),
+      ...(config.discord ? [discordAdapter] : []),
+    ]);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        inputDebounceMs: 0,
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+      discord: {
+        channel: "discord",
+        botToken: "discord-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+
+    expect(telegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(telegramAdapter.stop).not.toHaveBeenCalled();
+    expect(discordAdapter.start).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ platform: "telegram", health: "enabled" }),
+        expect.objectContaining({ platform: "discord", health: "enabled" }),
+      ]),
+    );
+  });
+
+  it("hot-applies config by stopping disabled channels and restarting changed credentials", async () => {
+    await prepareRuntimeStore();
+    const firstTelegramAdapter = createAdapter("telegram");
+    const secondTelegramAdapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => {
+      if (!config.telegram) return [];
+      return [
+        config.telegram.botToken === "telegram-token-2"
+          ? secondTelegramAdapter
+          : firstTelegramAdapter,
+      ];
+    });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        inputDebounceMs: 0,
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token-1",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await runtime.start();
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token-2",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+    await runtime.applyConfig({
+      inputDebounceMs: 0,
+      enabled: false,
+    });
+
+    expect(firstTelegramAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(secondTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(secondTelegramAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "suspended",
+      }),
+    ]);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -13,6 +13,11 @@ const providerMocks = vi.hoisted(() => ({
   resolveDiscordContact: vi.fn(),
   resolveMattermostContact: vi.fn(),
 }));
+const runtimeMock = vi.hoisted(() => ({
+  applyConfig: vi.fn(async () => undefined),
+  isEnabled: vi.fn(() => false),
+  requestCredentialValidation: vi.fn(),
+}));
 
 vi.mock("electron", () => ({
   ipcMain: {
@@ -34,6 +39,10 @@ vi.mock("../app-server/backend-registry", () => ({
   disposeDesktopBackendRegistry: disposeDesktopBackendRegistryMock,
 }));
 
+vi.mock("../messaging/messaging-runtime", () => ({
+  getDesktopMessagingRuntime: vi.fn(() => runtimeMock),
+}));
+
 vi.mock("@pwragent/messaging-provider-telegram", () => ({
   resolveContact: providerMocks.resolveTelegramContact,
 }));
@@ -51,6 +60,7 @@ describe("settings ipc", () => {
     for (const root of tempRoots.splice(0)) {
       fs.rmSync(root, { recursive: true, force: true });
     }
+    vi.unstubAllEnvs();
   });
 
   beforeEach(() => {
@@ -59,6 +69,9 @@ describe("settings ipc", () => {
     providerMocks.resolveTelegramContact.mockReset();
     providerMocks.resolveDiscordContact.mockReset();
     providerMocks.resolveMattermostContact.mockReset();
+    runtimeMock.applyConfig.mockClear();
+    runtimeMock.isEnabled.mockClear();
+    runtimeMock.requestCredentialValidation.mockReset();
   });
 
   it("registers redacted read and write handlers", async () => {
@@ -166,6 +179,41 @@ describe("settings ipc", () => {
     );
 
     expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("hot-applies messaging config writes without defeating a launch disable override", async () => {
+    vi.stubEnv("PWRAGENT_DISABLE_MESSAGING", "1");
+    runtimeMock.isEnabled.mockReturnValue(false);
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-settings-ipc-"));
+    tempRoots.push(tempRoot);
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { SETTINGS_WRITE_CONFIG_CHANNEL } = await import("../../shared/ipc");
+
+    registerSettingsIpcHandlers(service);
+
+    await handlers.get(SETTINGS_WRITE_CONFIG_CHANNEL)?.(
+      {},
+      {
+        patch: {
+          messaging: {
+            telegram: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    );
+
+    expect(runtimeMock.applyConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+      { allowStart: false },
+    );
   });
 
   it("resolves messaging contacts through provider packages", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -110,19 +110,20 @@ export function bootstrapApp(): void {
     if (isDevelopment) {
       registerRuntimeIdentityIpcHandlers();
     }
+    const messagingRuntime = getDesktopMessagingRuntime((options) =>
+      loadDesktopMessagingConfigFromSettings(
+        getDesktopSettingsService(),
+        process.env,
+        options,
+      ),
+    );
     const messagingOverride = resolveRuntimeMessagingOverride();
     if (messagingOverride.disabled) {
       mainLog.info("messaging runtime disabled for this app instance", {
         reason: messagingOverride.reason,
       });
     } else {
-      await getDesktopMessagingRuntime((options) =>
-        loadDesktopMessagingConfigFromSettings(
-          getDesktopSettingsService(),
-          process.env,
-          options,
-        ),
-      ).start();
+      await messagingRuntime.start();
     }
     // Register status IPC after the runtime is constructed so the
     // initial subscriber attaches before the renderer asks for the

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -4,13 +4,18 @@ import type {
   ListMessagingActivityResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
   UnbindMessagingThreadRequest,
   UnbindMessagingThreadResponse,
 } from "@pwragent/shared";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-config";
 import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
 import { getMainLogger } from "../log";
 import { showMessagingActivityWindow } from "../messaging-activity-window";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { resolveRuntimeMessagingOverride } from "../runtime-flags";
 import { subscribersForChannel } from "../window-channels";
 import {
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
@@ -18,6 +23,7 @@ import {
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_SET_ENABLED_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
 } from "../../shared/ipc";
 
@@ -107,6 +113,34 @@ export function registerMessagingStatusIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(MESSAGING_SET_ENABLED_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_SET_ENABLED_CHANNEL,
+    async (
+      _event,
+      request: SetMessagingEnabledRequest,
+    ): Promise<SetMessagingEnabledResponse> => {
+      if (request.enabled) {
+        await runtime.applyConfig(
+          await loadDesktopMessagingConfigFromSettings(
+            getDesktopSettingsService(),
+            process.env,
+          ),
+          { allowStart: true },
+        );
+      } else {
+        await runtime.stop();
+      }
+
+      const override = resolveRuntimeMessagingOverride();
+      return {
+        enabled: runtime.isEnabled(),
+        overridden: override.disabled,
+        ...(override.reason ? { overrideReason: override.reason } : {}),
+      };
+    },
+  );
+
   ipcMain.removeHandler(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL);
   ipcMain.handle(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL, async (): Promise<void> => {
     showMessagingActivityWindow();
@@ -121,5 +155,6 @@ export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
   ipcMain.removeHandler(MESSAGING_LIST_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_SET_ENABLED_CHANNEL);
   ipcMain.removeHandler(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -125,6 +125,7 @@ export function registerMessagingStatusIpcHandlers(): void {
           await loadDesktopMessagingConfigFromSettings(
             getDesktopSettingsService(),
             process.env,
+            { messagingEnabledOverride: true },
           ),
           { allowStart: true },
         );

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -3,7 +3,10 @@ import type {
   ClearDesktopSettingsSecretRequest,
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
+  DesktopSettingsConfigPatch,
+  DesktopSettingsSecretName,
   DesktopSettingsWriteResponse,
+  DesktopSettingsSnapshot,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   PickGhCommandResponse,
@@ -34,6 +37,8 @@ import { getDesktopSettingsService } from "../settings/desktop-settings-singleto
 import { disposeDesktopBackendRegistry } from "../app-server/backend-registry";
 import { CredentialTester } from "../credential-tester/credential-tester";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
+import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-config";
+import { resolveRuntimeMessagingOverride } from "../runtime-flags";
 import { validateGhCommand } from "../settings/gh-discovery";
 
 function getService(service?: DesktopSettingsService): DesktopSettingsService {
@@ -47,6 +52,55 @@ async function refreshModelBackendsIfNeeded(params: {
   if (params.patch?.models?.codex?.path !== undefined || params.secret === "grokApiKey") {
     await disposeDesktopBackendRegistry();
   }
+}
+
+function messagingPatchTouchesRuntime(
+  patch: DesktopSettingsConfigPatch | undefined,
+): boolean {
+  return patch?.messaging !== undefined;
+}
+
+function messagingSecretTouchesRuntime(
+  secret: DesktopSettingsSecretName,
+): boolean {
+  return secret === "telegramBotToken"
+    || secret === "discordBotToken"
+    || secret === "mattermostBotToken"
+    || secret === "mattermostHmacSecret";
+}
+
+async function applyLatestMessagingRuntimeConfig(
+  service: DesktopSettingsService,
+): Promise<void> {
+  const runtime = getDesktopMessagingRuntime();
+  const runtimeOverride = resolveRuntimeMessagingOverride();
+  await runtime.applyConfig(
+    await loadDesktopMessagingConfigFromSettings(service, process.env),
+    {
+      allowStart: !runtimeOverride.disabled || runtime.isEnabled(),
+    },
+  );
+}
+
+function applyRuntimeMessagingSnapshot(
+  snapshot: DesktopSettingsSnapshot,
+): DesktopSettingsSnapshot {
+  const overrideActive = snapshot.runtime.messaging.overrideActive === true;
+  const runtimeEnabled = overrideActive
+    ? getDesktopMessagingRuntime().isEnabled()
+    : snapshot.messaging.enabled.value;
+  return {
+    ...snapshot,
+    runtime: {
+      ...snapshot.runtime,
+      messaging: {
+        ...snapshot.runtime.messaging,
+        disabled: overrideActive
+          ? !runtimeEnabled
+          : snapshot.messaging.enabled.value === false,
+      },
+    },
+  };
 }
 
 async function resolveMessagingContact(
@@ -195,7 +249,9 @@ export function registerSettingsIpcHandlers(
       _event,
       _request?: ReadDesktopSettingsRequest,
     ): Promise<ReadDesktopSettingsResponse> => ({
-      snapshot: await getService(service).readSettings(),
+      snapshot: applyRuntimeMessagingSnapshot(
+        await getService(service).readSettings(),
+      ),
     }),
   );
 
@@ -206,9 +262,13 @@ export function registerSettingsIpcHandlers(
       _event,
       request: WriteDesktopSettingsConfigRequest,
     ): Promise<DesktopSettingsWriteResponse> => {
-      const snapshot = await getService(service).writeConfigPatch(request.patch);
+      const activeService = getService(service);
+      const snapshot = await activeService.writeConfigPatch(request.patch);
       await refreshModelBackendsIfNeeded({ patch: request.patch });
-      return { snapshot };
+      if (messagingPatchTouchesRuntime(request.patch)) {
+        await applyLatestMessagingRuntimeConfig(activeService);
+      }
+      return { snapshot: applyRuntimeMessagingSnapshot(snapshot) };
     },
   );
 
@@ -219,12 +279,16 @@ export function registerSettingsIpcHandlers(
       _event,
       request: ReplaceDesktopSettingsSecretRequest,
     ): Promise<DesktopSettingsWriteResponse> => {
-      const snapshot = await getService(service).replaceSecret(
+      const activeService = getService(service);
+      const snapshot = await activeService.replaceSecret(
         request.secret,
         request.value,
       );
       await refreshModelBackendsIfNeeded({ secret: request.secret });
-      return { snapshot };
+      if (messagingSecretTouchesRuntime(request.secret)) {
+        await applyLatestMessagingRuntimeConfig(activeService);
+      }
+      return { snapshot: applyRuntimeMessagingSnapshot(snapshot) };
     },
   );
 
@@ -235,9 +299,13 @@ export function registerSettingsIpcHandlers(
       _event,
       request: ClearDesktopSettingsSecretRequest,
     ): Promise<DesktopSettingsWriteResponse> => {
-      const snapshot = await getService(service).clearSecret(request.secret);
+      const activeService = getService(service);
+      const snapshot = await activeService.clearSecret(request.secret);
       await refreshModelBackendsIfNeeded({ secret: request.secret });
-      return { snapshot };
+      if (messagingSecretTouchesRuntime(request.secret)) {
+        await applyLatestMessagingRuntimeConfig(activeService);
+      }
+      return { snapshot: applyRuntimeMessagingSnapshot(snapshot) };
     },
   );
 
@@ -248,7 +316,9 @@ export function registerSettingsIpcHandlers(
       _event,
       _request?: RefreshDesktopCodexDiscoveryRequest,
     ): Promise<ReadDesktopSettingsResponse> => ({
-      snapshot: await getService(service).readSettings(),
+      snapshot: applyRuntimeMessagingSnapshot(
+        await getService(service).readSettings(),
+      ),
     }),
   );
 

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -65,6 +65,7 @@ export {
 export type DesktopMessagingConfig = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   discord?: DiscordMessagingConfig;
+  enabled?: boolean;
   inputDebounceMs?: number;
   mattermost?: MattermostMessagingConfig;
   telegram?: TelegramMessagingConfig;
@@ -116,6 +117,7 @@ export function loadDesktopMessagingConfig(
   const attachmentPolicy = readAttachmentPolicyFromEnv(env);
 
   return {
+    enabled: true,
     inputDebounceMs: readInputDebounceMsFromEnv(env) ?? 500,
     toolUpdateDefaultMode: "show_some",
     ...(attachmentPolicy ? { attachmentPolicy } : {}),
@@ -242,6 +244,7 @@ export async function loadDesktopMessagingConfigFromSettings(
     maxAttachmentBytes: snapshot.messaging.attachments.maxAttachmentBytes.value,
     maxAttachmentCount: snapshot.messaging.attachments.maxAttachmentCount.value,
   };
+  const messagingEnabled = snapshot.messaging.enabled.value;
 
   // Resolve per-platform enablement and log the decision for each
   const telegramEnabled = shouldEnableSettingsChannel(
@@ -263,7 +266,7 @@ export async function loadDesktopMessagingConfigFromSettings(
     MATTERMOST_ENABLED_ENV,
   );
 
-  const telegramConfig = buildChannelConfig({
+  const telegramConfig = messagingEnabled && buildChannelConfig({
     log,
     channel: "telegram",
     enabled: telegramEnabled,
@@ -283,7 +286,7 @@ export async function loadDesktopMessagingConfigFromSettings(
       }
     : {};
 
-  const discordConfig = buildChannelConfig({
+  const discordConfig = messagingEnabled && buildChannelConfig({
     log,
     channel: "discord",
     enabled: discordEnabled,
@@ -308,7 +311,8 @@ export async function loadDesktopMessagingConfigFromSettings(
     : {};
 
   const mattermostConfig =
-    buildChannelConfig({
+    messagingEnabled
+    && buildChannelConfig({
       log,
       channel: "mattermost",
       enabled: mattermostEnabled,
@@ -340,6 +344,7 @@ export async function loadDesktopMessagingConfigFromSettings(
       : {};
 
   return {
+    enabled: messagingEnabled,
     inputDebounceMs: snapshot.messaging.inputDebounceMs.value,
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
     attachmentPolicy,
@@ -416,6 +421,7 @@ export function redactDesktopMessagingConfig(
           authorizedActorCount: config.telegram.authorizedActorIds.length,
         }
       : undefined,
+    enabled: config.enabled !== false,
     toolUpdateDefaultMode: config.toolUpdateDefaultMode ?? "show_some",
     inputDebounceMs: config.inputDebounceMs ?? 500,
     discord: config.discord

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -83,6 +83,7 @@ export type DesktopMessagingSettingsSource = Pick<
 
 export type DesktopMessagingConfigLoadOptions = {
   logStartupEligibility?: boolean;
+  messagingEnabledOverride?: boolean;
 };
 
 export function loadDesktopMessagingConfig(
@@ -244,7 +245,8 @@ export async function loadDesktopMessagingConfigFromSettings(
     maxAttachmentBytes: snapshot.messaging.attachments.maxAttachmentBytes.value,
     maxAttachmentCount: snapshot.messaging.attachments.maxAttachmentCount.value,
   };
-  const messagingEnabled = snapshot.messaging.enabled.value;
+  const messagingEnabled =
+    options.messagingEnabledOverride ?? snapshot.messaging.enabled.value;
 
   // Resolve per-platform enablement and log the decision for each
   const telegramEnabled = shouldEnableSettingsChannel(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -273,8 +273,9 @@ export class DesktopMessagingRuntime {
 
     this.syncRunningAdapterLists();
 
+    const failedChannelSet = new Set<MessagingChannelKind>(failedChannels);
     for (const channel of stoppedChannels) {
-      if (!this.runningAdapters.has(channel)) {
+      if (!this.runningAdapters.has(channel) && !failedChannelSet.has(channel)) {
         this.setPlatformHealth(channel, "suspended");
       }
     }

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -70,6 +70,14 @@ export type DesktopMessagingConfigLoader = (
   | DesktopMessagingConfig
   | Promise<DesktopMessagingConfig>;
 
+type RunningMessagingAdapter = {
+  adapter: DesktopMessagingAdapter;
+  controller: MessagingController;
+  fingerprint: string;
+  unsubscribeInboundRejected?: () => void;
+  unsubscribeRuntimeError?: () => void;
+};
+
 const messagingLog = getMainLogger("pwragent:messaging");
 
 /**
@@ -137,13 +145,11 @@ export type CredentialValidationRequest =
 export class DesktopMessagingRuntime {
   private adapters: DesktopMessagingAdapter[] = [];
   private controllers: MessagingController[] = [];
+  private readonly runningAdapters = new Map<
+    MessagingChannelKind,
+    RunningMessagingAdapter
+  >();
   private unsubscribeBackendEvents?: () => void;
-  /**
-   * One unsubscribe per running adapter that exposed `onRuntimeError`.
-   * Held so `stop()` can detach before adapters are torn down.
-   */
-  private adapterRuntimeErrorUnsubscribes: Array<() => void> = [];
-  private adapterInboundRejectedUnsubscribes: Array<() => void> = [];
   private started = false;
   /**
    * Per-platform health snapshot. Keyed by `MessagingChannelKind`. Updated
@@ -177,158 +183,8 @@ export class DesktopMessagingRuntime {
   ) {}
 
   async start(): Promise<void> {
-    if (this.started) {
-      return;
-    }
-    this.started = true;
-
-    const store = getDesktopMessagingStore();
     const config = await this.loadConfig({ logStartupEligibility: true });
-    const configuredAdapters = await this.options.adapterFactory({
-      config,
-      store,
-    });
-
-    const failedChannels: string[] = [];
-    for (const adapter of configuredAdapters) {
-      const authorizedActorIds = [...adapter.authorizedActorIds];
-      const authorizedActorIdSet = new Set(authorizedActorIds);
-      const controller = new MessagingController({
-        adapter,
-        attachmentPolicy: config.attachmentPolicy,
-        authorizedActorIds,
-        backend: this.options.backendBridge,
-        channel: adapter.channel,
-        inputDebounceMs: config.inputDebounceMs,
-        store,
-        toolUpdateDefaultMode: async () =>
-          (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
-        onBindingChanged: () => this.broadcastBindingsChanged(),
-      });
-
-      try {
-        const unsubscribeInboundRejected = adapter.onInboundRejected?.((event) => {
-          this.emitPlatformActivity(adapter.channel);
-          this.recordActivityFromRejected(adapter.channel, event);
-          messagingLog.warn("messaging event rejected before dispatch", {
-            actorDisplayName: event.actor.displayName,
-            actorId: event.actor.platformUserId,
-            actorIsBot: event.actor.isBot,
-            actorUsername: event.actor.username,
-            channel: adapter.channel,
-            conversationId: event.channel.conversation.id,
-            conversationKind: event.channel.conversation.kind,
-            eventId: event.id,
-            eventKind: event.kind,
-            reason: event.reason,
-          });
-        });
-        if (unsubscribeInboundRejected) {
-          this.adapterInboundRejectedUnsubscribes.push(unsubscribeInboundRejected);
-        }
-        await adapter.start?.(async (event) => {
-          // Activity ping fires on every inbound, *before* authorization
-          // checks — the platform is active even when the message is
-          // rejected, and the user wants the dot to reflect that.
-          this.emitPlatformActivity(adapter.channel);
-          const authorized = authorizedActorIdSet.has(
-            event.actor.platformUserId,
-          );
-          this.recordActivityFromInbound(adapter.channel, event, authorized);
-          try {
-            if (!authorized) {
-              messagingLog.warn("messaging event rejected by authorization", {
-                actorDisplayName: event.actor.displayName,
-                actorId: event.actor.platformUserId,
-                actorIsBot: event.actor.isBot,
-                actorUsername: event.actor.username,
-                authorizedActorCount: authorizedActorIds.length,
-                channel: adapter.channel,
-                conversationId: event.channel.conversation.id,
-                conversationKind: event.channel.conversation.kind,
-                eventId: event.id,
-                eventKind: event.kind,
-              });
-            }
-            await controller.handleInboundEvent(event);
-          } catch (error) {
-            messagingLog.error("messaging controller failed to handle inbound event", {
-              actorDisplayName: event.actor.displayName,
-              actorId: event.actor.platformUserId,
-              channel: adapter.channel,
-              conversationId: event.channel.conversation.id,
-              conversationKind: event.channel.conversation.kind,
-              error,
-              eventId: event.id,
-              eventKind: event.kind,
-            });
-          }
-        });
-      } catch (error) {
-        messagingLog.error(`${adapter.channel}: failed to start adapter`, {
-          channel: adapter.channel,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        failedChannels.push(adapter.channel);
-        this.setPlatformHealth(adapter.channel, "errored", {
-          reason: error instanceof Error ? error.message : String(error),
-        });
-        continue;
-      }
-
-      messagingLog.info(`${adapter.channel}: adapter started successfully`, {
-        channel: adapter.channel,
-      });
-      this.adapters.push(adapter);
-      this.controllers.push(controller);
-      this.setPlatformHealth(adapter.channel, "enabled");
-
-      const unsubscribeRuntimeError = adapter.onRuntimeError?.((reason) => {
-        messagingLog.warn(`${adapter.channel}: adapter runtime error`, {
-          channel: adapter.channel,
-          reason,
-        });
-        this.setPlatformHealth(adapter.channel, "errored", { reason });
-      });
-      if (unsubscribeRuntimeError) {
-        this.adapterRuntimeErrorUnsubscribes.push(unsubscribeRuntimeError);
-      }
-    }
-
-    this.unsubscribeBackendEvents = this.options.backendBridge.onEvent?.(async (event) => {
-      await Promise.all(
-        this.controllers.map(async (controller) => {
-          try {
-            if (isMessagingPendingRequest(event.notification)) {
-              await controller.handleBackendPendingRequest(
-                event.backend,
-                event.notification,
-              );
-            } else {
-              await controller.handleBackendEvent(event);
-            }
-          } catch (error) {
-            messagingLog.error("messaging controller failed to handle backend event", {
-              backend: event.backend,
-              error,
-              method: event.notification.method,
-            });
-          }
-        }),
-      );
-    });
-
-    const startedChannels = this.adapters.map((adapter) => adapter.channel);
-    if (startedChannels.length > 0 || failedChannels.length > 0) {
-      messagingLog.info("messaging runtime started", {
-        started: startedChannels,
-        failed: failedChannels.length > 0 ? failedChannels : undefined,
-      });
-    } else {
-      messagingLog.info(
-        "messaging runtime started with no adapters — no platforms configured",
-      );
-    }
+    await this.applyConfig(config);
   }
 
   async stop(): Promise<void> {
@@ -339,29 +195,13 @@ export class DesktopMessagingRuntime {
 
     this.unsubscribeBackendEvents?.();
     this.unsubscribeBackendEvents = undefined;
-    for (const unsubscribe of this.adapterRuntimeErrorUnsubscribes) {
-      try {
-        unsubscribe();
-      } catch (error) {
-        messagingLog.warn("messaging adapter runtime-error unsubscribe threw", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-    this.adapterRuntimeErrorUnsubscribes = [];
-    for (const unsubscribe of this.adapterInboundRejectedUnsubscribes) {
-      try {
-        unsubscribe();
-      } catch (error) {
-        messagingLog.warn("messaging adapter inbound-rejected unsubscribe threw", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-    this.adapterInboundRejectedUnsubscribes = [];
-    this.controllers.forEach((controller) => controller.dispose());
-    const stoppedChannels = this.adapters.map((adapter) => adapter.channel);
-    await Promise.all(this.adapters.map(async (adapter) => adapter.stop?.()));
+    const stoppedChannels = [...this.runningAdapters.keys()];
+    await Promise.all(
+      [...this.runningAdapters.values()].map(async (running) =>
+        this.stopRunningAdapter(running)
+      ),
+    );
+    this.runningAdapters.clear();
     this.adapters = [];
     this.controllers = [];
     // Mark each previously-running platform as suspended (not removed),
@@ -370,6 +210,100 @@ export class DesktopMessagingRuntime {
     for (const channel of stoppedChannels) {
       this.setPlatformHealth(channel, "suspended");
     }
+  }
+
+  async applyConfig(
+    config: DesktopMessagingConfig,
+    options: { allowStart?: boolean } = {},
+  ): Promise<void> {
+    if (config.enabled === false) {
+      await this.stop();
+      return;
+    }
+
+    if (!this.started) {
+      if (options.allowStart === false) {
+        return;
+      }
+      this.started = true;
+      this.subscribeBackendEvents();
+    }
+
+    const store = getDesktopMessagingStore();
+    const configuredAdapters = await this.options.adapterFactory({
+      config,
+      store,
+    });
+    const nextAdapters = new Map<MessagingChannelKind, DesktopMessagingAdapter>();
+    for (const adapter of configuredAdapters) {
+      nextAdapters.set(adapter.channel, adapter);
+    }
+
+    const stoppedChannels: MessagingChannelKind[] = [];
+    for (const [channel, running] of [...this.runningAdapters.entries()]) {
+      const next = nextAdapters.get(channel);
+      const nextFingerprint = next
+        ? messagingAdapterConfigFingerprint(config, channel)
+        : undefined;
+      if (!next || running.fingerprint !== nextFingerprint) {
+        await this.stopRunningAdapter(running);
+        this.runningAdapters.delete(channel);
+        stoppedChannels.push(channel);
+      }
+    }
+
+    const startedChannels: MessagingChannelKind[] = [];
+    const failedChannels: MessagingChannelKind[] = [];
+    for (const [channel, adapter] of nextAdapters.entries()) {
+      if (this.runningAdapters.has(channel)) {
+        continue;
+      }
+
+      const started = await this.startRunningAdapter({
+        adapter,
+        config,
+        store,
+      });
+      if (started) {
+        startedChannels.push(channel);
+      } else {
+        failedChannels.push(channel);
+      }
+    }
+
+    this.syncRunningAdapterLists();
+
+    for (const channel of stoppedChannels) {
+      if (!this.runningAdapters.has(channel)) {
+        this.setPlatformHealth(channel, "suspended");
+      }
+    }
+
+    if (
+      startedChannels.length > 0
+      || stoppedChannels.length > 0
+      || failedChannels.length > 0
+    ) {
+      messagingLog.info("messaging runtime config applied", {
+        started: startedChannels.length > 0 ? startedChannels : undefined,
+        stopped: stoppedChannels.length > 0 ? stoppedChannels : undefined,
+        failed: failedChannels.length > 0 ? failedChannels : undefined,
+      });
+    } else if (this.runningAdapters.size === 0) {
+      messagingLog.info(
+        "messaging runtime started with no adapters — no platforms configured",
+      );
+    }
+  }
+
+  async applyLatestConfig(
+    options: { allowStart?: boolean } = {},
+  ): Promise<void> {
+    await this.applyConfig(await this.loadConfig(), options);
+  }
+
+  isEnabled(): boolean {
+    return this.started;
   }
 
   /**
@@ -566,6 +500,180 @@ export class DesktopMessagingRuntime {
         );
       }
     }
+  }
+
+  private async startRunningAdapter(params: {
+    adapter: DesktopMessagingAdapter;
+    config: DesktopMessagingConfig;
+    store: MessagingStoreLike;
+  }): Promise<boolean> {
+    const { adapter, config, store } = params;
+    const authorizedActorIds = [...adapter.authorizedActorIds];
+    const authorizedActorIdSet = new Set(authorizedActorIds);
+    const controller = new MessagingController({
+      adapter,
+      attachmentPolicy: config.attachmentPolicy,
+      authorizedActorIds,
+      backend: this.options.backendBridge,
+      channel: adapter.channel,
+      inputDebounceMs: config.inputDebounceMs,
+      store,
+      toolUpdateDefaultMode: async () =>
+        (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
+      onBindingChanged: () => this.broadcastBindingsChanged(),
+    });
+
+    let unsubscribeInboundRejected: (() => void) | undefined;
+    try {
+      unsubscribeInboundRejected = adapter.onInboundRejected?.((event) => {
+        this.emitPlatformActivity(adapter.channel);
+        this.recordActivityFromRejected(adapter.channel, event);
+        messagingLog.warn("messaging event rejected before dispatch", {
+          actorDisplayName: event.actor.displayName,
+          actorId: event.actor.platformUserId,
+          actorIsBot: event.actor.isBot,
+          actorUsername: event.actor.username,
+          channel: adapter.channel,
+          conversationId: event.channel.conversation.id,
+          conversationKind: event.channel.conversation.kind,
+          eventId: event.id,
+          eventKind: event.kind,
+          reason: event.reason,
+        });
+      });
+      await adapter.start?.(async (event) => {
+        // Activity ping fires on every inbound, before authorization checks.
+        this.emitPlatformActivity(adapter.channel);
+        const authorized = authorizedActorIdSet.has(event.actor.platformUserId);
+        this.recordActivityFromInbound(adapter.channel, event, authorized);
+        try {
+          if (!authorized) {
+            messagingLog.warn("messaging event rejected by authorization", {
+              actorDisplayName: event.actor.displayName,
+              actorId: event.actor.platformUserId,
+              actorIsBot: event.actor.isBot,
+              actorUsername: event.actor.username,
+              authorizedActorCount: authorizedActorIds.length,
+              channel: adapter.channel,
+              conversationId: event.channel.conversation.id,
+              conversationKind: event.channel.conversation.kind,
+              eventId: event.id,
+              eventKind: event.kind,
+            });
+          }
+          await controller.handleInboundEvent(event);
+        } catch (error) {
+          messagingLog.error("messaging controller failed to handle inbound event", {
+            actorDisplayName: event.actor.displayName,
+            actorId: event.actor.platformUserId,
+            channel: adapter.channel,
+            conversationId: event.channel.conversation.id,
+            conversationKind: event.channel.conversation.kind,
+            error,
+            eventId: event.id,
+            eventKind: event.kind,
+          });
+        }
+      });
+    } catch (error) {
+      try {
+        unsubscribeInboundRejected?.();
+      } catch {
+        // Best effort cleanup after startup failure.
+      }
+      controller.dispose();
+      try {
+        await adapter.stop?.();
+      } catch (stopError) {
+        messagingLog.warn(`${adapter.channel}: adapter stop after failed start threw`, {
+          channel: adapter.channel,
+          error: stopError instanceof Error ? stopError.message : String(stopError),
+        });
+      }
+      messagingLog.error(`${adapter.channel}: failed to start adapter`, {
+        channel: adapter.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.setPlatformHealth(adapter.channel, "errored", {
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+
+    const unsubscribeRuntimeError = adapter.onRuntimeError?.((reason) => {
+      messagingLog.warn(`${adapter.channel}: adapter runtime error`, {
+        channel: adapter.channel,
+        reason,
+      });
+      this.setPlatformHealth(adapter.channel, "errored", { reason });
+    });
+
+    this.runningAdapters.set(adapter.channel, {
+      adapter,
+      controller,
+      fingerprint: messagingAdapterConfigFingerprint(config, adapter.channel),
+      unsubscribeInboundRejected,
+      unsubscribeRuntimeError,
+    });
+    this.setPlatformHealth(adapter.channel, "enabled");
+    messagingLog.info(`${adapter.channel}: adapter started successfully`, {
+      channel: adapter.channel,
+    });
+    return true;
+  }
+
+  private async stopRunningAdapter(running: RunningMessagingAdapter): Promise<void> {
+    try {
+      running.unsubscribeRuntimeError?.();
+    } catch (error) {
+      messagingLog.warn("messaging adapter runtime-error unsubscribe threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    try {
+      running.unsubscribeInboundRejected?.();
+    } catch (error) {
+      messagingLog.warn("messaging adapter inbound-rejected unsubscribe threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    running.controller.dispose();
+    await running.adapter.stop?.();
+  }
+
+  private subscribeBackendEvents(): void {
+    if (this.unsubscribeBackendEvents) {
+      return;
+    }
+
+    this.unsubscribeBackendEvents = this.options.backendBridge.onEvent?.(async (event) => {
+      await Promise.all(
+        this.controllers.map(async (controller) => {
+          try {
+            if (isMessagingPendingRequest(event.notification)) {
+              await controller.handleBackendPendingRequest(
+                event.backend,
+                event.notification,
+              );
+            } else {
+              await controller.handleBackendEvent(event);
+            }
+          } catch (error) {
+            messagingLog.error("messaging controller failed to handle backend event", {
+              backend: event.backend,
+              error,
+              method: event.notification.method,
+            });
+          }
+        }),
+      );
+    });
+  }
+
+  private syncRunningAdapterLists(): void {
+    const running = [...this.runningAdapters.values()];
+    this.adapters = running.map((record) => record.adapter);
+    this.controllers = running.map((record) => record.controller);
   }
 
   private async dispatchRevokeToControllers(
@@ -771,6 +879,41 @@ function createConfiguredAdapters(params: {
   store: MessagingStoreLike;
 }): Promise<DesktopMessagingAdapter[]> {
   return loadConfiguredMessagingAdapters(params);
+}
+
+function messagingAdapterConfigFingerprint(
+  config: DesktopMessagingConfig,
+  channel: MessagingChannelKind,
+): string {
+  const channelConfig =
+    channel === "telegram"
+      ? config.telegram
+      : channel === "discord"
+        ? config.discord
+        : channel === "mattermost"
+          ? config.mattermost
+          : undefined;
+
+  return stableStringify({
+    attachmentPolicy: config.attachmentPolicy,
+    channelConfig,
+    inputDebounceMs: config.inputDebounceMs,
+  });
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }
 
 function isMessagingPendingRequest(

--- a/apps/desktop/src/main/messaging/provider-loader.ts
+++ b/apps/desktop/src/main/messaging/provider-loader.ts
@@ -63,6 +63,10 @@ export async function loadConfiguredMessagingAdapters(params: {
 export function configuredMessagingProviderIds(
   config: DesktopMessagingConfig,
 ): DesktopMessagingProviderId[] {
+  if (config.enabled === false) {
+    return [];
+  }
+
   return [
     ...(config.telegram && config.telegram.enabled !== false
       ? (["telegram"] as const)

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -40,6 +40,7 @@ export type DesktopSettingsConfig = {
     };
   };
   messaging?: {
+    enabled?: boolean;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
     attachments?: {
@@ -245,6 +246,9 @@ export function desktopSettingsPatchToEdits(
   if (patch.messaging?.inputDebounceMs !== undefined) {
     set(["messaging", "input_debounce_ms"], patch.messaging.inputDebounceMs);
   }
+  if (patch.messaging?.enabled !== undefined) {
+    set(["messaging", "enabled"], patch.messaging.enabled);
+  }
   if (patch.messaging?.toolUpdateMode !== undefined) {
     set(["messaging", "tool_update_mode"], patch.messaging.toolUpdateMode);
   }
@@ -407,6 +411,7 @@ function normalizeDesktopConfig(
       },
     },
     messaging: {
+      enabled: readBoolean(messaging?.enabled),
       inputDebounceMs: readNumber(messaging?.input_debounce_ms),
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
       attachments: {
@@ -489,8 +494,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const discord = config.messaging?.discord;
   const mattermost = config.messaging?.mattermost;
   const inputDebounceMs = config.messaging?.inputDebounceMs;
+  const enabled = config.messaging?.enabled;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
   if (
+    enabled !== undefined ||
     inputDebounceMs !== undefined ||
     toolUpdateMode !== undefined ||
     (attachments && hasDefinedValue(attachments))
@@ -499,6 +506,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     || (mattermost && hasDefinedValue(mattermost))
   ) {
     pruned.messaging = {};
+    if (enabled !== undefined) {
+      pruned.messaging.enabled = enabled;
+    }
     if (inputDebounceMs !== undefined) {
       pruned.messaging.inputDebounceMs = inputDebounceMs;
     }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -154,6 +154,7 @@ export class DesktopSettingsService {
       runtime: {
         messaging: {
           disabled: messagingOverride.disabled,
+          overrideActive: messagingOverride.disabled,
           ...(messagingOverride.reason
             ? { disabledReason: messagingOverride.reason }
             : {}),
@@ -174,6 +175,7 @@ export class DesktopSettingsService {
         },
       },
       messaging: {
+        enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
         inputDebounceMs: this.resolveClampedNumber(
           config.messaging?.inputDebounceMs,
           DEFAULT_MESSAGING_INPUT_DEBOUNCE_MS,
@@ -459,6 +461,16 @@ export class DesktopSettingsService {
       value: configValue ?? defaultValue,
       source: configValue === undefined ? "default" : "config",
       error: envValue.error,
+    };
+  }
+
+  private resolveConfigBoolean(
+    configValue: boolean | undefined,
+    defaultValue: boolean,
+  ): DesktopSettingsValue<boolean> {
+    return {
+      value: configValue ?? defaultValue,
+      source: configValue === undefined ? "default" : "config",
     };
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,8 @@ import type {
   ListMessagingActivityResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
   PickGhCommandResponse,
   RegisterDirectoryFromDiskRequest,
@@ -137,6 +139,7 @@ import {
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
+  MESSAGING_SET_ENABLED_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
@@ -419,6 +422,10 @@ const desktopApi = Object.freeze({
   },
   getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
     await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+  setMessagingEnabled: async (
+    request: SetMessagingEnabledRequest,
+  ): Promise<SetMessagingEnabledResponse> =>
+    await ipcRenderer.invoke(MESSAGING_SET_ENABLED_CHANNEL, request),
   unbindMessagingThread: async (
     request: UnbindMessagingThreadRequest,
   ): Promise<UnbindMessagingThreadResponse> =>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -63,6 +63,7 @@ describe("App", () => {
         },
       },
       messaging: {
+        enabled: { value: true, source: "default" },
         inputDebounceMs: { value: 500, source: "default" },
         toolUpdateMode: { value: "show_some", source: "default" },
         telegram: {

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -49,6 +49,7 @@ export function MessagingSettings(props: {
   ) => Promise<boolean>;
   onToolUpdateModeChange: (mode: MessagingToolUpdateMode) => Promise<void>;
   onInputDebounceMsChange: (value: number) => Promise<void>;
+  onMessagingEnabledChange: (enabled: boolean) => Promise<void>;
   onSaveDiscord: (
     patch: NonNullable<DesktopSettingsSnapshot["messaging"]["discord"]>,
   ) => Promise<void>;
@@ -62,9 +63,14 @@ export function MessagingSettings(props: {
   const telegram = props.snapshot.messaging.telegram;
   const discord = props.snapshot.messaging.discord;
   const mattermost = props.snapshot.messaging.mattermost;
+  const messagingEnabled = props.snapshot.messaging.enabled;
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
   const runtimeMessaging = props.snapshot.runtime.messaging;
+  const masterEnabled = runtimeMessaging.overrideActive
+    ? !runtimeMessaging.disabled
+    : messagingEnabled.value;
+  const platformControlsDisabled = props.saving || !masterEnabled;
 
   return (
     <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
@@ -74,7 +80,7 @@ export function MessagingSettings(props: {
         help="Bridge PwrAgent threads to messaging platforms so you can drive runs from your phone. Tokens are stored in the system keychain. Authorization defaults closed: if no allowed IDs are configured, nothing can use that entry. Check the Messaging Activity window for rejected IDs to add here."
       />
 
-      {runtimeMessaging.disabled ? (
+      {runtimeMessaging.overrideActive && runtimeMessaging.disabled ? (
         <section className="settings-panel settings-panel--warning" role="status">
           <div className="settings-panel__header">
             <div>
@@ -83,14 +89,39 @@ export function MessagingSettings(props: {
             </div>
           </div>
           <p className="settings-row__description">
-            {runtimeMessaging.disabledReason
-              ?? "Messaging startup was disabled by a launch override."}
+            Messaging is off because the app was launched with the no-messaging
+            flag. You can override this for the current session by flipping the
+            master toggle below, but make sure messaging is off in any other
+            PwrAgent instances first. The override applies to this session only;
+            the saved default is unchanged.
           </p>
         </section>
       ) : null}
 
       <SettingsSection eyebrow="Messaging" title="General">
         <div className="settings-fields">
+          <ToggleField
+            checked={masterEnabled}
+            disabled={
+              props.saving
+              || (runtimeMessaging.overrideActive
+                && !props.desktopApi?.setMessagingEnabled)
+            }
+            label="Messaging"
+            sub={
+              runtimeMessaging.overrideActive
+                ? "Session-only master switch. The saved default is unchanged while the launch override is active."
+                : "Master switch for all messaging adapters."
+            }
+            source={
+              runtimeMessaging.overrideActive
+                ? "session"
+                : sourceBadge(messagingEnabled)
+            }
+            onChange={(enabled) => {
+              void props.onMessagingEnabledChange(enabled);
+            }}
+          />
           <SegmentedField
             disabled={props.saving}
             label="Tool usage notifications"
@@ -126,7 +157,7 @@ export function MessagingSettings(props: {
         <div className="settings-fields">
           <ToggleField
             checked={telegram.enabled.value}
-            disabled={props.saving}
+            disabled={platformControlsDisabled}
             label="Enabled"
             sub="Turn the Telegram adapter on or off independently of the global messaging switch."
             source={sourceBadge(telegram.enabled)}
@@ -234,7 +265,7 @@ export function MessagingSettings(props: {
         <div className="settings-fields">
           <ToggleField
             checked={discord.enabled.value}
-            disabled={props.saving}
+            disabled={platformControlsDisabled}
             label="Enabled"
             sub="Turn the Discord adapter on or off independently of the global messaging switch."
             source={sourceBadge(discord.enabled)}
@@ -358,7 +389,7 @@ export function MessagingSettings(props: {
         <div className="settings-fields">
           <ToggleField
             checked={mattermost.enabled.value}
-            disabled={props.saving}
+            disabled={platformControlsDisabled}
             label="Enabled"
             sub="Turn the Mattermost adapter on or off independently of the global messaging switch."
             source={sourceBadge(mattermost.enabled)}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -251,6 +251,18 @@ function SettingsSectionBody(props: {
             },
           });
         }}
+        onMessagingEnabledChange={async (enabled) => {
+          if (props.snapshot.runtime.messaging.overrideActive) {
+            await props.desktopApi?.setMessagingEnabled?.({ enabled });
+            await props.settings.refresh();
+            return;
+          }
+          await props.settings.writeConfig({
+            messaging: {
+              enabled,
+            },
+          });
+        }}
         onSaveDiscord={async (discord) => {
           const delta = buildDiscordPatchDelta(
             props.snapshot.messaging.discord,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -44,6 +44,7 @@ function createSnapshot(
       },
     },
     messaging: {
+      enabled: { value: true, source: "default" },
       inputDebounceMs: { value: 500, source: "default" },
       toolUpdateMode: { value: "show_some", source: "default" },
       telegram: {
@@ -864,6 +865,7 @@ describe("SettingsScreen", () => {
             runtime: {
               messaging: {
                 disabled: true,
+                overrideActive: true,
                 disabledReason: "--disable-messaging was provided at startup",
               },
             },
@@ -879,8 +881,59 @@ describe("SettingsScreen", () => {
       "Messaging disabled for this app instance",
     );
     expect(screen.getByRole("status")).toHaveTextContent(
-      "--disable-messaging was provided at startup",
+      "The override applies to this session only",
     );
+  });
+
+  it("persists the master messaging switch when no runtime override is active", async () => {
+    const settings = createSettingsState();
+    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    fireEvent.click(screen.getByRole("switch", { name: "Messaging" }));
+
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: { enabled: false },
+      });
+    });
+  });
+
+  it("uses a session-only master messaging switch when the runtime override is active", async () => {
+    const setMessagingEnabled = vi.fn(async () => ({
+      enabled: true,
+      overridden: true,
+      overrideReason: "--disable-messaging was provided at startup",
+    }));
+    const settings = createSettingsState(
+      createSnapshot({
+        runtime: {
+          messaging: {
+            disabled: true,
+            overrideActive: true,
+            disabledReason: "--disable-messaging was provided at startup",
+          },
+        },
+      }),
+    );
+    render(
+      <SettingsScreen
+        desktopApi={{ setMessagingEnabled }}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    fireEvent.click(screen.getByRole("switch", { name: "Messaging" }));
+
+    await waitFor(() => {
+      expect(setMessagingEnabled).toHaveBeenCalledWith({ enabled: true });
+      expect(settings.refresh).toHaveBeenCalled();
+    });
+    expect(settings.writeConfig).not.toHaveBeenCalledWith({
+      messaging: { enabled: true },
+    });
   });
 
   it("keeps a secret draft when replacement fails", async () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -42,6 +42,8 @@ import type {
   ListMessagingActivityResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
+  SetMessagingEnabledRequest,
+  SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
   RegisterDirectoryFromDiskRequest,
   RegisterDirectoryFromDiskResponse,
@@ -253,6 +255,9 @@ export type DesktopApi = {
   reportRendererError?: (report: RendererErrorReport) => Promise<void>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   getMessagingPlatformStatuses?: () => Promise<MessagingPlatformStatus[]>;
+  setMessagingEnabled?: (
+    request: SetMessagingEnabledRequest,
+  ) => Promise<SetMessagingEnabledResponse>;
   onMessagingPlatformStatusEvent?: (
     callback: (event: MessagingPlatformStatusEvent) => void,
   ) => () => void;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -43,6 +43,7 @@ export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
   "messaging:platform-status-event";
 export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
+export const MESSAGING_SET_ENABLED_CHANNEL = "messaging:set-enabled";
 export const MESSAGING_LIST_ACTIVITY_CHANNEL = "messaging:list-activity";
 /**
  * Fire-and-forget IPC: opens the dedicated Messaging Activity window

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -29,6 +29,10 @@ describe("desktop settings contracts", () => {
         },
       },
       messaging: {
+        enabled: {
+          value: true,
+          source: "default",
+        },
         inputDebounceMs: {
           value: 500,
           source: "default",

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -159,15 +159,10 @@ export type SetMessagingEnabledRequest = {
 };
 
 export type SetMessagingEnabledResponse = {
-  /**
-   * Effective state after the toggle. May not equal the requested
-   * `enabled` if the startup override
-   * (`--disable-messaging` / `PWRAGENT_DISABLE_MESSAGING`) is in
-   * force.
-   */
+  /** Effective runtime state after the toggle. */
   enabled: boolean;
-  /** True when an override prevented the runtime from honoring the request. */
+  /** True when the process was launched with a no-messaging override. */
   overridden: boolean;
-  /** Human-readable explanation of the override, when applicable. */
+  /** Human-readable explanation of the launch override, when applicable. */
   overrideReason?: string;
 };

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -188,6 +188,7 @@ export type DesktopSettingsSnapshot = {
     messaging: {
       disabled: boolean;
       disabledReason?: string;
+      overrideActive?: boolean;
     };
   };
   secretStorage: DesktopSettingsSecretStorageState;
@@ -210,6 +211,7 @@ export type DesktopSettingsSnapshot = {
     };
   };
   messaging: {
+    enabled: DesktopSettingsValue<boolean>;
     inputDebounceMs: DesktopSettingsValue<number>;
     toolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
     attachments: DesktopMessagingAttachmentSettingsSnapshot;
@@ -266,6 +268,7 @@ export type DesktopSettingsConfigPatch = {
     };
   };
   messaging?: {
+    enabled?: boolean;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
     attachments?: {


### PR DESCRIPTION
## Summary

I added runtime messaging lifecycle toggles so Settings -> Messaging can turn all messaging on/off, and each platform enable switch now hot-applies without restarting the desktop app.

## What Changed

- Added persisted `messaging.enabled` with default `true`.
- Added `DesktopMessagingRuntime.applyConfig(...)` to diff the current and new messaging config, stop removed/disabled adapters, start newly enabled adapters, restart changed adapters, and leave unchanged adapters alone.
- Wired settings config and messaging secret writes to hot-apply the runtime config.
- Added a session-only runtime enable IPC path for `--disable-messaging` / `PWRAGENT_DISABLE_MESSAGING`, so the launch override can be bypassed for the current session without changing the saved default.
- Added the master Messaging switch at the top of Settings -> Messaging and reframed the launch-override warning copy.
- Kept platform status events on the existing health path, including `suspended` when adapters are stopped.

## Validation

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm lint:boundaries`
- `git diff --check`

Fixes #259
