### PR TITLE
fix(messaging): prevent providers blocking desktop startup

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -24,6 +24,7 @@ const registerSettingsIpcHandlersMock = vi.fn();
 const disposeSettingsIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
+const mainLogErrorMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -125,6 +126,7 @@ vi.mock("../log", () => ({
   initializeMainLogger: initializeMainLoggerMock,
   getMainLogger: vi.fn(() => ({
     info: mainLogInfoMock,
+    error: mainLogErrorMock,
   })),
 }));
 
@@ -173,6 +175,7 @@ describe("bootstrapApp", () => {
     disposeSettingsIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
     mainLogInfoMock.mockReset();
+    mainLogErrorMock.mockReset();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     disposeDesktopMessagingRuntimeMock.mockReset();
@@ -229,6 +232,38 @@ describe("bootstrapApp", () => {
     expect(registerSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates the first window without waiting for messaging startup", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    messagingRuntimeStartMock.mockReturnValue(new Promise(() => {}));
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(messagingRuntimeStartMock).toHaveBeenCalledTimes(1);
+    expect(registerMessagingStatusIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(createMainWindowMock).toHaveBeenCalledWith({
+      startupCpuProfiler: startupProfilerInstance,
+    });
+  });
+
+  it("logs unexpected background messaging startup failures", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    messagingRuntimeStartMock.mockRejectedValue(new Error("config load failed"));
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(createMainWindowMock).toHaveBeenCalledWith({
+      startupCpuProfiler: startupProfilerInstance,
+    });
+    expect(mainLogErrorMock).toHaveBeenCalledWith(
+      "messaging runtime failed during background startup",
+      expect.objectContaining({
+        error: "config load failed",
+      }),
+    );
   });
 
   it("reuses the same startup CPU profiler on app activate", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -584,6 +584,106 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("starts adapters in parallel and reports pending adapters as loading", async () => {
+    await prepareRuntimeStore();
+    const telegramStart = createDeferred<void>();
+    const slowTelegramAdapter = createAdapter("telegram");
+    slowTelegramAdapter.start.mockImplementation(async (listener) => {
+      slowTelegramAdapter.listener = listener;
+      await telegramStart.promise;
+    });
+    const workingDiscordAdapter = createAdapter("discord");
+    const bridge = createBackendBridge();
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [slowTelegramAdapter, workingDiscordAdapter],
+      backendBridge: bridge,
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+    const events: unknown[] = [];
+    runtime.onPlatformStatus((event) => events.push(event));
+
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+
+    expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "health-changed",
+        platform: "telegram",
+        health: "unknown",
+      }),
+    );
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "telegram",
+          health: "unknown",
+        }),
+        expect.objectContaining({
+          platform: "discord",
+          health: "enabled",
+        }),
+      ]),
+    );
+    await workingDiscordAdapter.listener?.(
+      buildCallbackEvent(
+        "bind:codex:thread-1",
+        {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        "discord",
+      ),
+    );
+    workingDiscordAdapter.delivered.length = 0;
+    await bridge.emitBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Discord is already online" }],
+          },
+        },
+      },
+    });
+
+    expect(
+      workingDiscordAdapter.delivered.find((intent) => intent.kind === "message"),
+    ).toMatchObject({ kind: "message" });
+
+    telegramStart.resolve();
+    await startPromise;
+
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "telegram",
+          health: "enabled",
+        }),
+      ]),
+    );
+  });
+
   it("isolates backend event delivery failures between adapters", async () => {
     await prepareRuntimeStore();
     const failingAdapter = createAdapter("telegram", {
@@ -1319,6 +1419,26 @@ async function prepareRuntimeStore(): Promise<void> {
     "../messaging/desktop-messaging-store"
   );
   resetDesktopMessagingStoreForTests();
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
 }
 
 function createAdapter(

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -684,6 +684,123 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("serializes stop requests behind pending startup", async () => {
+    await prepareRuntimeStore();
+    const telegramStart = createDeferred<void>();
+    const slowTelegramAdapter = createAdapter("telegram");
+    slowTelegramAdapter.start.mockImplementation(async (listener) => {
+      slowTelegramAdapter.listener = listener;
+      await telegramStart.promise;
+    });
+    const workingDiscordAdapter = createAdapter("discord");
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [slowTelegramAdapter, workingDiscordAdapter],
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+    const stopPromise = runtime.stop();
+    await flushMicrotasks();
+
+    expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
+    expect(slowTelegramAdapter.stop).not.toHaveBeenCalled();
+
+    telegramStart.resolve();
+    await Promise.all([startPromise, stopPromise]);
+
+    expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.isEnabled()).toBe(false);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "telegram",
+          health: "suspended",
+        }),
+        expect.objectContaining({
+          platform: "discord",
+          health: "suspended",
+        }),
+      ]),
+    );
+  });
+
+  it("serializes config changes behind pending startup", async () => {
+    await prepareRuntimeStore();
+    const firstTelegramStart = createDeferred<void>();
+    const firstTelegramAdapter = createAdapter("telegram");
+    firstTelegramAdapter.start.mockImplementation(async (listener) => {
+      firstTelegramAdapter.listener = listener;
+      await firstTelegramStart.promise;
+    });
+    const secondTelegramAdapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => {
+      if (!config.telegram) return [];
+      return [
+        config.telegram.botToken === "telegram-token-2"
+          ? secondTelegramAdapter
+          : firstTelegramAdapter,
+      ];
+    });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token-1",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+    const applyPromise = runtime.applyConfig({
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token-2",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+    await flushMicrotasks();
+
+    expect(firstTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(secondTelegramAdapter.start).not.toHaveBeenCalled();
+
+    firstTelegramStart.resolve();
+    await Promise.all([startPromise, applyPromise]);
+
+    expect(firstTelegramAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(secondTelegramAdapter.start).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        health: "enabled",
+      }),
+    ]);
+  });
+
   it("isolates backend event delivery failures between adapters", async () => {
     await prepareRuntimeStore();
     const failingAdapter = createAdapter("telegram", {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -123,7 +123,11 @@ export function bootstrapApp(): void {
         reason: messagingOverride.reason,
       });
     } else {
-      await messagingRuntime.start();
+      void messagingRuntime.start().catch((error) => {
+        mainLog.error("messaging runtime failed during background startup", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
     // Register status IPC after the runtime is constructed so the
     // initial subscriber attaches before the renderer asks for the

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -164,6 +164,7 @@ export class DesktopMessagingRuntime {
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
+  private lifecycleQueue: Promise<void> = Promise.resolve();
   /**
    * Listeners notified whenever any controller mutates a binding
    * (create / refresh metadata / sync title / detach / revoke). The
@@ -183,11 +184,19 @@ export class DesktopMessagingRuntime {
   ) {}
 
   async start(): Promise<void> {
-    const config = await this.loadConfig({ logStartupEligibility: true });
-    await this.applyConfig(config);
+    await this.enqueueLifecycle(async () => {
+      const config = await this.loadConfig({ logStartupEligibility: true });
+      await this.applyConfigNow(config);
+    });
   }
 
   async stop(): Promise<void> {
+    await this.enqueueLifecycle(async () => {
+      await this.stopNow();
+    });
+  }
+
+  private async stopNow(): Promise<void> {
     if (!this.started) {
       return;
     }
@@ -216,8 +225,17 @@ export class DesktopMessagingRuntime {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
+    await this.enqueueLifecycle(async () => {
+      await this.applyConfigNow(config, options);
+    });
+  }
+
+  private async applyConfigNow(
+    config: DesktopMessagingConfig,
+    options: { allowStart?: boolean } = {},
+  ): Promise<void> {
     if (config.enabled === false) {
-      await this.stop();
+      await this.stopNow();
       return;
     }
 
@@ -303,7 +321,9 @@ export class DesktopMessagingRuntime {
   async applyLatestConfig(
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
-    await this.applyConfig(await this.loadConfig(), options);
+    await this.enqueueLifecycle(async () => {
+      await this.applyConfigNow(await this.loadConfig(), options);
+    });
   }
 
   isEnabled(): boolean {
@@ -504,6 +524,17 @@ export class DesktopMessagingRuntime {
         );
       }
     }
+  }
+
+  private async enqueueLifecycle(
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    const run = this.lifecycleQueue.catch(() => undefined).then(operation);
+    this.lifecycleQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    await run;
   }
 
   private async startRunningAdapter(params: {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -251,25 +251,28 @@ export class DesktopMessagingRuntime {
         stoppedChannels.push(channel);
       }
     }
+    this.syncRunningAdapterLists();
 
-    const startedChannels: MessagingChannelKind[] = [];
-    const failedChannels: MessagingChannelKind[] = [];
-    for (const [channel, adapter] of nextAdapters.entries()) {
-      if (this.runningAdapters.has(channel)) {
-        continue;
-      }
+    const startResults = await Promise.all(
+      [...nextAdapters.entries()].map(async ([channel, adapter]) => {
+        if (this.runningAdapters.has(channel)) {
+          return { channel, started: false, unchanged: true };
+        }
 
-      const started = await this.startRunningAdapter({
-        adapter,
-        config,
-        store,
-      });
-      if (started) {
-        startedChannels.push(channel);
-      } else {
-        failedChannels.push(channel);
-      }
-    }
+        const started = await this.startRunningAdapter({
+          adapter,
+          config,
+          store,
+        });
+        return { channel, started, unchanged: false };
+      }),
+    );
+    const startedChannels = startResults
+      .filter((result) => result.started)
+      .map((result) => result.channel);
+    const failedChannels = startResults
+      .filter((result) => !result.unchanged && !result.started)
+      .map((result) => result.channel);
 
     this.syncRunningAdapterLists();
 
@@ -542,6 +545,7 @@ export class DesktopMessagingRuntime {
           reason: event.reason,
         });
       });
+      this.setPlatformHealth(adapter.channel, "unknown");
       await adapter.start?.(async (event) => {
         // Activity ping fires on every inbound, before authorization checks.
         this.emitPlatformActivity(adapter.channel);
@@ -616,6 +620,7 @@ export class DesktopMessagingRuntime {
       unsubscribeInboundRejected,
       unsubscribeRuntimeError,
     });
+    this.syncRunningAdapterLists();
     this.setPlatformHealth(adapter.channel, "enabled");
     messagingLog.info(`${adapter.channel}: adapter started successfully`, {
       channel: adapter.channel,

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -25,7 +25,7 @@ const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
   enabled: "Enabled",
   suspended: "Suspended",
   errored: "Errored",
-  unknown: "Unknown",
+  unknown: "Loading",
 };
 
 /**
@@ -90,6 +90,7 @@ function PlatformChip(props: {
   const className = `messaging-status-chip messaging-status-chip--${status.health}${
     active ? " is-active" : ""
   }`;
+  const blink = active || status.health === "unknown";
   const content = (
     <>
       {Icon ? (
@@ -101,7 +102,7 @@ function PlatformChip(props: {
       )}
       <span
         className={`status-dot status-dot--${dotTone(status.health)}${
-          active ? " status-dot--blink" : ""
+          blink ? " status-dot--blink" : ""
         }`}
         aria-hidden="true"
       />
@@ -148,7 +149,7 @@ function dotTone(
     case "errored":
       return "error";
     case "unknown":
-      return "warning";
+      return "suspended";
   }
 }
 


### PR DESCRIPTION
## Summary

I fixed messaging startup so the desktop window is created without waiting for platform adapters to finish connecting.

This PR also starts configured messaging adapters in parallel. A slow or unavailable provider now reports as loading while other providers can finish startup, go green, and handle backend traffic.

Fixes #265.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
