### PR TITLE
fix(messaging): sweep unbound callback state

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  MessagingBindingRecord,
+  MessagingCallbackHandleRecord,
+  MessagingPendingIntentRecord,
+} from "@pwragent/messaging-interface";
+import { SqliteMessagingStore } from "../state/messaging-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+const tempDirs: string[] = [];
+const stateDbs: StateDb[] = [];
+
+async function createStore(): Promise<SqliteMessagingStore> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-sqlite-msg-"));
+  tempDirs.push(tempDir);
+  const stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDbs.push(stateDb);
+  return new SqliteMessagingStore(stateDb);
+}
+
+function buildBinding(
+  overrides: Partial<MessagingBindingRecord> = {},
+): MessagingBindingRecord {
+  return {
+    id: "binding-1",
+    channel: {
+      channel: "telegram",
+      conversation: {
+        id: "chat-1",
+        kind: "dm",
+      },
+    },
+    backend: "codex",
+    threadId: "thread-1",
+    authorizedActorIds: ["user-1"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildPendingIntent(
+  overrides: Partial<MessagingPendingIntentRecord> = {},
+): MessagingPendingIntentRecord {
+  return {
+    id: "intent-1",
+    bindingId: "binding-1",
+    allowedActorIds: ["user-1"],
+    createdAt: 1000,
+    expiresAt: 2000,
+    intent: {
+      id: "surface-1",
+      kind: "single_select",
+      createdAt: 1000,
+      prompt: "Choose",
+      choices: [{ id: "choice-a", label: "Choice A" }],
+    },
+    ...overrides,
+  };
+}
+
+function buildCallbackHandle(
+  overrides: Partial<MessagingCallbackHandleRecord> = {},
+): MessagingCallbackHandleRecord {
+  return {
+    id: "callback-1",
+    actionId: "status:refresh",
+    allowedActorIds: ["user-1"],
+    bindingId: "binding-1",
+    channel: buildBinding().channel,
+    createdAt: 1000,
+    updatedAt: 1000,
+    expiresAt: 2000,
+    handle: "tg:short",
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  for (const stateDb of stateDbs.splice(0)) {
+    stateDb.close();
+  }
+  await Promise.all(
+    tempDirs.splice(0).map((tempDir) =>
+      rm(tempDir, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe("SqliteMessagingStore", () => {
+  it("sweeps binding and channel state when a binding is revoked", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding());
+    await store.upsertPendingIntent(buildPendingIntent());
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "channel-intent",
+        bindingId: undefined,
+        channel: buildBinding().channel,
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "other-channel-intent",
+        bindingId: undefined,
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "other-chat",
+            kind: "dm",
+          },
+        },
+      }),
+    );
+    await store.upsertCallbackHandle(buildCallbackHandle());
+    await store.upsertCallbackHandle(
+      buildCallbackHandle({
+        id: "other-callback",
+        bindingId: "binding-2",
+        handle: "tg:other",
+      }),
+    );
+
+    await store.revokeBinding({ bindingId: "binding-1", revokedAt: 3000 });
+
+    await expect(store.getPendingIntent("intent-1", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(store.getPendingIntent("channel-intent", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(
+      store.getPendingIntent("other-channel-intent", { now: 1500 }),
+    ).resolves.toMatchObject({
+      id: "other-channel-intent",
+    });
+    await expect(store.getCallbackHandle("callback-1", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(store.getCallbackHandle("other-callback", { now: 1500 })).resolves
+      .toMatchObject({
+        id: "other-callback",
+      });
+  });
+
+  it("can delete callback handles for a binding without revoking it", async () => {
+    const store = await createStore();
+    await store.upsertCallbackHandle(buildCallbackHandle());
+    await store.upsertCallbackHandle(
+      buildCallbackHandle({
+        id: "other-callback",
+        bindingId: "binding-2",
+        handle: "tg:other",
+      }),
+    );
+
+    await expect(
+      store.deleteCallbackHandlesForBinding({ bindingId: "binding-1" }),
+    ).resolves.toEqual(["callback-1"]);
+    await expect(store.getCallbackHandle("callback-1", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(store.getCallbackHandle("other-callback", { now: 1500 })).resolves
+      .toMatchObject({
+        id: "other-callback",
+      });
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -297,24 +297,84 @@ describe("MessagingStore", () => {
     });
   });
 
-  it("removes pending intents for a binding when the binding is revoked", async () => {
+  it("sweeps binding and channel state when a binding is revoked", async () => {
     const { store } = await createStore();
     await store.upsertBinding(buildBinding());
     await store.upsertPendingIntent(buildPendingIntent());
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "channel-intent",
+        bindingId: undefined,
+        channel: buildBinding().channel,
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "other-channel-intent",
+        bindingId: undefined,
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "other-chat",
+            kind: "dm",
+          },
+        },
+      }),
+    );
     await store.upsertBrowseSession(buildBrowseSession());
     await store.upsertCallbackHandle(buildCallbackHandle());
+    await store.upsertCallbackHandle(
+      buildCallbackHandle({
+        id: "other-callback",
+        bindingId: "binding-2",
+        handle: "tg:other",
+      }),
+    );
 
     await store.revokeBinding({ bindingId: "binding-1", revokedAt: 3000 });
 
     await expect(store.getPendingIntent("intent-1", { now: 1500 })).resolves
       .toBeUndefined();
+    await expect(store.getPendingIntent("channel-intent", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(
+      store.getPendingIntent("other-channel-intent", { now: 1500 }),
+    ).resolves.toMatchObject({
+      id: "other-channel-intent",
+    });
     await expect(store.getBrowseSession("browse-1", { now: 1500 })).resolves
       .toBeUndefined();
     await expect(store.getCallbackHandle("callback-1", { now: 1500 })).resolves
       .toBeUndefined();
+    await expect(store.getCallbackHandle("other-callback", { now: 1500 })).resolves
+      .toMatchObject({
+        id: "other-callback",
+      });
     await expect(store.getBinding("binding-1")).resolves.toMatchObject({
       revokedAt: 3000,
     });
+  });
+
+  it("can delete callback handles for a binding without revoking it", async () => {
+    const { store } = await createStore();
+    await store.upsertCallbackHandle(buildCallbackHandle());
+    await store.upsertCallbackHandle(
+      buildCallbackHandle({
+        id: "other-callback",
+        bindingId: "binding-2",
+        handle: "tg:other",
+      }),
+    );
+
+    await expect(
+      store.deleteCallbackHandlesForBinding({ bindingId: "binding-1" }),
+    ).resolves.toEqual(["callback-1"]);
+    await expect(store.getCallbackHandle("callback-1", { now: 1500 })).resolves
+      .toBeUndefined();
+    await expect(store.getCallbackHandle("other-callback", { now: 1500 })).resolves
+      .toMatchObject({
+        id: "other-callback",
+      });
   });
 
   it("ignores and cleans up expired pending intents and browse state without deleting active records", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -182,18 +182,7 @@ export class MessagingStore {
   }): Promise<string[]> {
     const channelKey = buildMessagingConversationKey(params.channel);
     return await this.withData((data) => {
-      const removed: string[] = [];
-      for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
-        if (intent.bindingId) continue;
-        if (
-          intent.channel &&
-          buildMessagingConversationKey(intent.channel) === channelKey
-        ) {
-          delete data.pendingIntents[intentId];
-          removed.push(intentId);
-        }
-      }
-      return removed;
+      return deletePendingIntentsForChannelInData(data, channelKey);
     });
   }
 
@@ -337,6 +326,14 @@ export class MessagingStore {
     await this.withData((data) => {
       delete data.callbackHandles[id];
     });
+  }
+
+  async deleteCallbackHandlesForBinding(params: {
+    bindingId: string;
+  }): Promise<string[]> {
+    return await this.withData((data) =>
+      deleteCallbackHandlesForBindingInData(data, params.bindingId),
+    );
   }
 
   async cleanupExpiredCallbackHandles(options?: { now?: number }): Promise<string[]> {
@@ -508,6 +505,10 @@ function revokeBindingInData(
   };
   data.bindings[bindingId] = revoked;
 
+  deletePendingIntentsForChannelInData(
+    data,
+    buildMessagingConversationKey(current.channel),
+  );
   for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
     if (intent.bindingId === bindingId) {
       delete data.pendingIntents[intentId];
@@ -518,13 +519,41 @@ function revokeBindingInData(
       delete data.browseSessions[sessionId];
     }
   }
+  deleteCallbackHandlesForBindingInData(data, bindingId);
+
+  return revoked;
+}
+
+function deletePendingIntentsForChannelInData(
+  data: MessagingStoreData,
+  channelKey: string,
+): string[] {
+  const removed: string[] = [];
+  for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
+    if (intent.bindingId) continue;
+    if (
+      intent.channel &&
+      buildMessagingConversationKey(intent.channel) === channelKey
+    ) {
+      delete data.pendingIntents[intentId];
+      removed.push(intentId);
+    }
+  }
+  return removed;
+}
+
+function deleteCallbackHandlesForBindingInData(
+  data: MessagingStoreData,
+  bindingId: string,
+): string[] {
+  const removed: string[] = [];
   for (const [handleId, handle] of Object.entries(data.callbackHandles)) {
     if (handle.bindingId === bindingId) {
       delete data.callbackHandles[handleId];
+      removed.push(handleId);
     }
   }
-
-  return revoked;
+  return removed;
 }
 
 function sanitizeSurfaceRef<T extends { state?: MessagingAdapterState }>(

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -117,18 +117,8 @@ export class SqliteMessagingStore {
     this.stateDb.raw
       .prepare("DELETE FROM browse_sessions WHERE binding_id = ?")
       .run(params.bindingId);
-
-    const handles = this.stateDb.raw
-      .prepare("SELECT handle_id, payload FROM callback_handles")
-      .all() as { handle_id: string; payload: string }[];
-    for (const h of handles) {
-      const handle: MessagingCallbackHandleRecord = JSON.parse(h.payload);
-      if (handle.bindingId === params.bindingId) {
-        this.stateDb.raw
-          .prepare("DELETE FROM callback_handles WHERE handle_id = ?")
-          .run(h.handle_id);
-      }
-    }
+    await this.deletePendingIntentsForChannel({ channel: current.channel });
+    await this.deleteCallbackHandlesForBinding({ bindingId: params.bindingId });
 
     return structuredClone(revoked);
   }
@@ -258,10 +248,15 @@ export class SqliteMessagingStore {
       }
     }
     if (removed.length === 0) return [];
-    const placeholders = removed.map(() => "?").join(",");
-    this.stateDb.raw
-      .prepare(`DELETE FROM pending_intents WHERE intent_id IN (${placeholders})`)
-      .run(...removed);
+    const deleteIntent = this.stateDb.raw.prepare(
+      "DELETE FROM pending_intents WHERE intent_id = ?",
+    );
+    const deleteIntents = this.stateDb.raw.transaction((ids: string[]) => {
+      for (const id of ids) {
+        deleteIntent.run(id);
+      }
+    });
+    deleteIntents(removed);
     return removed;
   }
 
@@ -427,6 +422,37 @@ export class SqliteMessagingStore {
     this.stateDb.raw
       .prepare("DELETE FROM callback_handles WHERE handle_id = ?")
       .run(id);
+  }
+
+  async deleteCallbackHandlesForBinding(params: {
+    bindingId: string;
+  }): Promise<string[]> {
+    const rows = this.stateDb.raw
+      .prepare("SELECT handle_id, payload FROM callback_handles")
+      .all() as { handle_id: string; payload: string }[];
+    const removed: string[] = [];
+    for (const row of rows) {
+      try {
+        const handle = JSON.parse(row.payload) as MessagingCallbackHandleRecord;
+        if (handle.bindingId === params.bindingId) {
+          removed.push(row.handle_id);
+        }
+      } catch {
+        // Malformed payload — skip; the row will be cleaned up by GC
+        // on its expiry.
+      }
+    }
+    if (removed.length === 0) return [];
+    const deleteHandle = this.stateDb.raw.prepare(
+      "DELETE FROM callback_handles WHERE handle_id = ?",
+    );
+    const deleteHandles = this.stateDb.raw.transaction((ids: string[]) => {
+      for (const id of ids) {
+        deleteHandle.run(id);
+      }
+    });
+    deleteHandles(removed);
+    return removed;
   }
 
   async cleanupExpiredCallbackHandles(options?: {
@@ -651,6 +677,7 @@ export type MessagingStoreLike = Pick<
   | "getCallbackHandle"
   | "resolveCallbackHandle"
   | "deleteCallbackHandle"
+  | "deleteCallbackHandlesForBinding"
   | "cleanupExpiredCallbackHandles"
   | "recordDelivery"
   | "getDelivery"


### PR DESCRIPTION
## Summary

I fixed messaging unbind cleanup so revoked bindings no longer leave channel-scoped pending intents or binding-scoped callback handles behind.

This closes #204.

## What changed

- I made binding revocation sweep channel-scoped pending intents for the revoked channel, covering stale picker/action prompts that were not tied to a specific binding.
- I added a narrow `deleteCallbackHandlesForBinding` store method and used it from SQLite-backed revocation instead of keeping callback cleanup buried inline.
- I kept the SQL cleanup compatible with the strict SQL-template lint rule by deleting matched ids through prepared statements.
- I added coverage for both the file-backed messaging store and the production SQLite store.

## Verification

I verified this locally with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
- `pnpm lint:sql`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
