### PR TITLE
feat(profiles): map Codex auth profiles

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -708,10 +708,10 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     await expect(startedThreadChips.getByText("worktree", { exact: true })).toBeVisible();
     await expect(startedThreadChips.getByText("local", { exact: true })).toHaveCount(0);
 
-    await app.window.getByRole("button", { name: "Open context rail" }).click();
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",
     });
+    await contextRail.hover();
     await expect(
       contextRail.getByLabel("Path for worktree FixtureRepo", { exact: true }),
     ).toBeVisible();

--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -9,14 +9,17 @@ const REPLAY_FIXTURE_PATH_ENV = "PWRAGENT_REPLAY_FIXTURE_PATH";
 const constructorState = vi.hoisted(() => ({
   codexCount: 0,
   codexArgs: [] as Array<string[] | undefined>,
+  codexEnvs: [] as Array<NodeJS.ProcessEnv | undefined>,
+  codexMetadataHomes: [] as Array<string | undefined>,
   grokCount: 0,
 }));
 
 vi.mock("../codex-app-server/client", () => ({
   CodexAppServerClient: class {
-    constructor(options?: { args?: string[] }) {
+    constructor(options?: { args?: string[]; env?: NodeJS.ProcessEnv }) {
       constructorState.codexCount += 1;
       constructorState.codexArgs.push(options?.args);
+      constructorState.codexEnvs.push(options?.env);
     }
 
     async close(): Promise<void> {
@@ -68,9 +71,27 @@ vi.mock("../codex-app-server/client", () => ({
   }
 }));
 
+vi.mock("../app-server/codex-session-metadata-service", () => ({
+  CodexSessionMetadataService: class {
+    constructor(options?: { codexHome?: string }) {
+      constructorState.codexMetadataHomes.push(options?.codexHome);
+    }
+
+    async updateThreadCwd() {
+      return { updated: false, reason: "missing-session" };
+    }
+  },
+}));
+
+const settingsState = vi.hoisted(() => ({
+  codexEnv: undefined as NodeJS.ProcessEnv | undefined,
+}));
+
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: () => ({
     resolveCodexCommandPreference: () => undefined,
+    resolveCodexSpawnEnv: () => settingsState.codexEnv,
+    resolveWorktreeStorage: () => "in-repo",
   }),
 }));
 
@@ -156,7 +177,10 @@ function createOverlayStoreMock() {
 beforeEach(() => {
   constructorState.codexCount = 0;
   constructorState.codexArgs = [];
+  constructorState.codexEnvs = [];
+  constructorState.codexMetadataHomes = [];
   constructorState.grokCount = 0;
+  settingsState.codexEnv = undefined;
 });
 
 afterEach(() => {
@@ -261,6 +285,23 @@ describe("DesktopBackendRegistry replay isolation", () => {
         'sandbox_mode="workspace-write"',
       ],
     ]);
+
+    await registry.close();
+  });
+
+  it("passes the selected Codex home to the live client and metadata helper", async () => {
+    const codexHome = path.join(os.tmpdir(), "pwragent-codex-profile-home");
+    settingsState.codexEnv = {
+      CODEX_HOME: codexHome,
+    } as NodeJS.ProcessEnv;
+
+    const registry = new DesktopBackendRegistry({
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    expect(constructorState.codexCount).toBe(1);
+    expect(constructorState.codexEnvs[0]?.CODEX_HOME).toBe(codexHome);
+    expect(constructorState.codexMetadataHomes).toEqual([codexHome]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3255,6 +3255,53 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("writes the session index under CODEX_HOME from the client environment", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-session-index-"));
+    const codexHome = path.join(tempDir, "codex-profile-home");
+    const sessionIndexPath = path.join(codexHome, "session_index.jsonl");
+    MockTransport.threadStartResult = {
+      thread: {
+        id: "thread-profile-home",
+        path: path.join(codexHome, "sessions/thread-profile-home.jsonl"),
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+        preview: "Use selected Codex home for helper state",
+        name: "Untitled thread",
+        updatedAt: 1_777_401_255,
+      },
+      model: "gpt-5.5",
+    };
+
+    try {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+        env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+      });
+
+      await client.startThread({
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      });
+      await client.close();
+
+      const indexLines = (await fs.readFile(sessionIndexPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(indexLines).toEqual([
+        expect.objectContaining({
+          id: "thread-profile-home",
+          source: "pwragent",
+          thread_name: "Use selected Codex home for helper state",
+        }),
+      ]);
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it("records a derived session-index name when Codex returns the placeholder name", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-session-index-"));
     const sessionIndexPath = path.join(tempDir, "session_index.jsonl");

--- a/apps/desktop/src/main/__tests__/codex-profiles.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-profiles.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  discoverCodexAuthProfiles,
+  resolveCodexHomeForProfile,
+} from "../settings/codex-profiles";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-codex-profiles-"));
+  tempRoots.push(root);
+  return root;
+}
+
+describe("Codex auth profile discovery", () => {
+  it("lists the system default and named CODEX_HOME profile directories", () => {
+    const root = createTempRoot();
+    const codexHome = path.join(root, "codex");
+    const profileHome = path.join(codexHome, "profiles", "work");
+    fs.mkdirSync(profileHome, { recursive: true });
+    fs.writeFileSync(path.join(profileHome, "auth.json"), "{}", "utf8");
+    fs.writeFileSync(path.join(codexHome, "config.toml"), "", "utf8");
+
+    const discovery = discoverCodexAuthProfiles({
+      configuredProfile: "work",
+      env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+    });
+
+    expect(discovery.profileRoot).toBe(path.join(codexHome, "profiles"));
+    expect(discovery.effectiveCodexHome).toBe(profileHome);
+    expect(discovery.profiles).toMatchObject([
+      {
+        name: "",
+        displayName: "System default",
+        codexHome,
+        selected: false,
+        hasConfigFile: true,
+      },
+      {
+        name: "work",
+        displayName: "work",
+        codexHome: profileHome,
+        selected: true,
+        hasAuthFile: true,
+      },
+    ]);
+  });
+
+  it("adds the configured profile even when the directory does not exist yet", () => {
+    const root = createTempRoot();
+    const codexHome = path.join(root, "codex");
+
+    const discovery = discoverCodexAuthProfiles({
+      configuredProfile: "personal",
+      env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+    });
+
+    expect(discovery.profiles.at(-1)).toMatchObject({
+      name: "personal",
+      source: "config",
+      exists: false,
+      selected: true,
+    });
+  });
+
+  it("rejects invalid profile names before resolving a CODEX_HOME override", () => {
+    const root = createTempRoot();
+    expect(
+      resolveCodexHomeForProfile("../work", {
+        env: { CODEX_HOME: path.join(root, "codex") } as NodeJS.ProcessEnv,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -46,6 +46,7 @@ describe("DesktopSettingsService", () => {
         "",
         "[models.codex]",
         'path = "codex-beta"',
+        'profile = "work"',
         "",
         "[applications.editor]",
         'preferred_id = "vscode"',
@@ -108,6 +109,13 @@ describe("DesktopSettingsService", () => {
       value: "codex-beta",
       source: "config",
     });
+    expect(snapshot.models.codex.profile).toEqual({
+      value: "work",
+      source: "config",
+    });
+    expect(snapshot.models.codex.profiles.effectiveCodexHome).toMatch(
+      /\.codex\/profiles\/work$/,
+    );
     expect(snapshot.applications.preferredEditorId).toEqual({
       value: "vscode",
       source: "config",
@@ -389,6 +397,47 @@ describe("DesktopSettingsService", () => {
 
     const snapshot = await service.readSettings();
     expect(snapshot.worktrees.storage.value).toBe("in-repo");
+  });
+
+  it("round-trips the Codex auth profile through write + read", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    await service.writeConfigPatch({ models: { codex: { profile: "work" } } });
+
+    const tomlOnDisk = fs.readFileSync(configPath, "utf8");
+    expect(tomlOnDisk).toContain("[models.codex]");
+    expect(tomlOnDisk).toContain('profile = "work"');
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.models.codex.profile).toEqual({
+      value: "work",
+      source: "config",
+    });
+  });
+
+  it("sets CODEX_HOME for the selected Codex auth profile", () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[models.codex]", 'profile = "work"'].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: { CODEX_HOME: path.join(root, "codex") } as NodeJS.ProcessEnv,
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect(service.resolveCodexSpawnEnv().CODEX_HOME).toBe(
+      path.join(root, "codex", "profiles", "work"),
+    );
   });
 
   it("applies env overrides above TOML and keeps the Grok API key in keychain", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -172,6 +172,32 @@ describe("GitDirectoryService", () => {
     expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
   });
 
+  it("creates Codex user-home worktrees under the selected Codex profile home", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-codex-home-"));
+    cleanupPaths.push(homeDir);
+    const codexHome = path.join(homeDir, "codex", "profiles", "work");
+    const service = new GitDirectoryService({
+      codexHome,
+      resolveWorktreeStorage: () => "user-home",
+      homeDir,
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      backend: "codex",
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    const expectedRoot = path.join(codexHome, "worktrees");
+    expect(workspace.cwd!.startsWith(`${expectedRoot}${path.sep}`)).toBe(true);
+    expect(path.basename(workspace.cwd!)).toBe(path.basename(repoDir));
+  });
+
   it("records Codex owner metadata in the worktree git directory", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -17,6 +17,8 @@ const registerImageNormalizationIpcHandlersMock = vi.fn();
 const disposeImageNormalizationIpcHandlersMock = vi.fn();
 const registerPreloadLogIpcHandlersMock = vi.fn();
 const disposePreloadLogIpcHandlersMock = vi.fn();
+const registerProfilesIpcHandlersMock = vi.fn();
+const disposeProfilesIpcHandlersMock = vi.fn();
 const registerRendererErrorIpcHandlersMock = vi.fn();
 const registerRuntimeIdentityIpcHandlersMock = vi.fn();
 const disposeRuntimeIdentityIpcHandlersMock = vi.fn();
@@ -108,6 +110,11 @@ vi.mock("../ipc/preload-log", () => ({
   disposePreloadLogIpcHandlers: disposePreloadLogIpcHandlersMock,
 }));
 
+vi.mock("../ipc/profiles", () => ({
+  registerProfilesIpcHandlers: registerProfilesIpcHandlersMock,
+  disposeProfilesIpcHandlers: disposeProfilesIpcHandlersMock,
+}));
+
 vi.mock("../ipc/renderer-error", () => ({
   registerRendererErrorIpcHandlers: registerRendererErrorIpcHandlersMock,
 }));
@@ -168,6 +175,8 @@ describe("bootstrapApp", () => {
     disposeImageNormalizationIpcHandlersMock.mockReset();
     registerPreloadLogIpcHandlersMock.mockReset();
     disposePreloadLogIpcHandlersMock.mockReset();
+    registerProfilesIpcHandlersMock.mockReset();
+    disposeProfilesIpcHandlersMock.mockReset();
     registerRendererErrorIpcHandlersMock.mockReset();
     registerRuntimeIdentityIpcHandlersMock.mockReset();
     disposeRuntimeIdentityIpcHandlersMock.mockReset();

--- a/apps/desktop/src/main/__tests__/state-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/state-migration.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PWRAGENT_HOME_ENV,
+  PWRAGENT_PROFILE_ENV,
+} from "../profile";
+import { migrateIfNeeded } from "../state/migration";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-migration-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function writeLegacyConfig(root: string): string {
+  const configPath = path.join(root, "xdg-config", "pwragnt", "config.toml");
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(
+    configPath,
+    [
+      "[messaging]",
+      "enabled = true",
+      "",
+      "[messaging.discord]",
+      "enabled = true",
+      'application_id = "1480556454498009352"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return configPath;
+}
+
+function readProfileName(dbPath: string): string {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare("SELECT value FROM meta WHERE key = 'profile_name'")
+      .get() as { value: string };
+    return row.value;
+  } finally {
+    db.close();
+  }
+}
+
+describe("state migration", () => {
+  it("does not copy legacy default settings into a new named profile", () => {
+    const root = createTempRoot();
+    const pwragentHome = path.join(root, "pwragent");
+    writeLegacyConfig(root);
+
+    const outcome = migrateIfNeeded({
+      env: {
+        [PWRAGENT_HOME_ENV]: pwragentHome,
+        [PWRAGENT_PROFILE_ENV]: "dev",
+      } as NodeJS.ProcessEnv,
+      xdgConfigHome: path.join(root, "xdg-config"),
+      xdgStateHome: path.join(root, "xdg-state"),
+    });
+
+    const devConfigPath = path.join(
+      pwragentHome,
+      "profiles",
+      "dev",
+      "config.toml",
+    );
+
+    expect(outcome.status).toBe("fresh-install");
+    if (outcome.status !== "fresh-install") throw new Error("expected fresh install");
+    expect(fs.existsSync(devConfigPath)).toBe(false);
+    expect(readProfileName(outcome.dbPath)).toBe("dev");
+  });
+
+  it("still migrates legacy settings into the default profile", () => {
+    const root = createTempRoot();
+    const pwragentHome = path.join(root, "pwragent");
+    const legacyConfigPath = writeLegacyConfig(root);
+
+    const outcome = migrateIfNeeded({
+      env: {
+        [PWRAGENT_HOME_ENV]: pwragentHome,
+      } as NodeJS.ProcessEnv,
+      xdgConfigHome: path.join(root, "xdg-config"),
+      xdgStateHome: path.join(root, "xdg-state"),
+    });
+
+    const defaultConfigPath = path.join(
+      pwragentHome,
+      "profiles",
+      "default",
+      "config.toml",
+    );
+
+    expect(outcome.status).toBe("migrated");
+    if (outcome.status !== "migrated") throw new Error("expected migration");
+    expect(fs.readFileSync(defaultConfigPath, "utf8")).toBe(
+      fs.readFileSync(legacyConfigPath, "utf8"),
+    );
+    expect(readProfileName(outcome.dbPath)).toBe("default");
+  });
+});

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -1357,6 +1357,26 @@ describe("TelegramAdapter", () => {
     });
   });
 
+  it("clears Telegram webhook on startup even when webhook info is empty", async () => {
+    const api = createApi();
+    api.getWebhookInfo.mockResolvedValueOnce({ url: "" });
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      pollOnStart: false,
+    });
+
+    await adapter.start(async () => {});
+
+    expect(api.deleteWebhook).toHaveBeenCalledWith({
+      drop_pending_updates: false,
+    });
+  });
+
   it("registers PwrAgent bot commands on startup", async () => {
     const api = createApi();
     const adapter = new TelegramAdapter({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1103,13 +1103,14 @@ export class DesktopBackendRegistry {
     ]);
     const createsLiveCodexClient =
       !options?.codexClient && !replayClients?.codexClient;
-    const settingsService = getDesktopSettingsService();
-    const codexCommand = createsLiveCodexClient
-      ? settingsService.resolveCodexCommandPreference()
+    const settingsService = createsLiveCodexClient
+      ? getDesktopSettingsService()
       : undefined;
-    const codexEnv = createsLiveCodexClient
-      ? settingsService.resolveCodexSpawnEnv()
-      : undefined;
+    const codexCommand = settingsService?.resolveCodexCommandPreference();
+    const codexEnv =
+      typeof settingsService?.resolveCodexSpawnEnv === "function"
+        ? settingsService.resolveCodexSpawnEnv()
+        : undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const grokApiKey = createsLiveGrokClient
       ? resolveGrokApiKeyForLiveClient()

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1103,8 +1103,12 @@ export class DesktopBackendRegistry {
     ]);
     const createsLiveCodexClient =
       !options?.codexClient && !replayClients?.codexClient;
+    const settingsService = getDesktopSettingsService();
     const codexCommand = createsLiveCodexClient
-      ? getDesktopSettingsService().resolveCodexCommandPreference()
+      ? settingsService.resolveCodexCommandPreference()
+      : undefined;
+    const codexEnv = createsLiveCodexClient
+      ? settingsService.resolveCodexSpawnEnv()
       : undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const grokApiKey = createsLiveGrokClient
@@ -1120,6 +1124,7 @@ export class DesktopBackendRegistry {
         args: buildCodexClientArgs(),
         command: codexCommand,
         connectionObserver: codexObserver,
+        env: codexEnv,
         clientVersion,
       });
     this.grokClient =

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1111,6 +1111,7 @@ export class DesktopBackendRegistry {
       typeof settingsService?.resolveCodexSpawnEnv === "function"
         ? settingsService.resolveCodexSpawnEnv()
         : undefined;
+    const codexHome = codexEnv?.CODEX_HOME?.trim() || undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const grokApiKey = createsLiveGrokClient
       ? resolveGrokApiKeyForLiveClient()
@@ -1139,11 +1140,14 @@ export class DesktopBackendRegistry {
     this.gitDirectoryService =
       options?.gitDirectoryService ??
       new GitDirectoryService({
+        codexHome,
         resolveWorktreeStorage: () =>
           getDesktopSettingsService().resolveWorktreeStorage(),
       });
     this.codexSessionMetadataService =
-      options?.codexSessionMetadataService ?? new CodexSessionMetadataService();
+      options?.codexSessionMetadataService ?? new CodexSessionMetadataService({
+        codexHome,
+      });
     this.worktreeArchiveService =
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
     this.gitWorkspaceHandoffService =

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -66,11 +66,15 @@ function worktreesRootFor(
   storage: DesktopWorktreeStorageLocation,
   options?: {
     backend?: AppServerBackendKind;
+    codexHome?: string;
     homeDir?: string;
   },
 ): string {
   if (storage === "user-home" && options?.backend === "codex") {
-    return codexHomeWorktreesRoot(options.homeDir);
+    return codexHomeWorktreesRoot({
+      codexHome: options.codexHome,
+      homeDir: options.homeDir,
+    });
   }
 
   return storage === "user-home"
@@ -78,10 +82,17 @@ function worktreesRootFor(
     : path.join(repoRoot, ".worktrees");
 }
 
-function codexHomeWorktreesRoot(homeDir?: string): string {
+function codexHomeWorktreesRoot(options: {
+  codexHome?: string;
+  homeDir?: string;
+}): string {
   const codexHome =
-    homeDir === undefined ? process.env.CODEX_HOME?.trim() : undefined;
-  return path.join(codexHome || path.join(homeDir ?? os.homedir(), ".codex"), "worktrees");
+    options.codexHome?.trim() ||
+    (options.homeDir === undefined ? process.env.CODEX_HOME?.trim() : undefined);
+  return path.join(
+    codexHome || path.join(options.homeDir ?? os.homedir(), ".codex"),
+    "worktrees",
+  );
 }
 
 async function pathExists(target: string): Promise<boolean> {
@@ -107,6 +118,7 @@ async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
 
 export async function computeWorktreePath(params: {
   backend?: AppServerBackendKind;
+  codexHome?: string;
   repoRoot: string;
   storage: DesktopWorktreeStorageLocation;
   homeDir?: string;
@@ -114,6 +126,7 @@ export async function computeWorktreePath(params: {
 }): Promise<string> {
   const root = worktreesRootFor(params.repoRoot, params.storage, {
     backend: params.backend,
+    codexHome: params.codexHome,
     homeDir: params.homeDir,
   });
   const projectName = path.basename(path.resolve(params.repoRoot)) || "project";
@@ -227,6 +240,7 @@ type CachedDirectoryStatus = {
 
 type GitDirectoryServiceOptions = {
   cacheTtlMs?: number;
+  codexHome?: string;
   resolveWorktreeStorage?: () =>
     | DesktopWorktreeStorageLocation
     | Promise<DesktopWorktreeStorageLocation>;
@@ -236,6 +250,7 @@ type GitDirectoryServiceOptions = {
 export class GitDirectoryService {
   private readonly statusCache = new Map<string, CachedDirectoryStatus>();
   private readonly cacheTtlMs: number;
+  private readonly codexHome?: string;
   private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
   private readonly homeDir: string;
 
@@ -243,6 +258,7 @@ export class GitDirectoryService {
     const normalized: GitDirectoryServiceOptions =
       typeof options === "number" ? { cacheTtlMs: options } : options;
     this.cacheTtlMs = normalized.cacheTtlMs ?? 3_000;
+    this.codexHome = normalized.codexHome;
     this.homeDir = normalized.homeDir ?? os.homedir();
     const resolveStorage = normalized.resolveWorktreeStorage;
     this.resolveStorage = async () =>
@@ -431,6 +447,7 @@ export class GitDirectoryService {
     const storage = await this.resolveStorage();
     const worktreePath = await computeWorktreePath({
       backend: launchpad.backend,
+      codexHome: launchpad.backend === "codex" ? this.codexHome : undefined,
       repoRoot,
       storage,
       homeDir: this.homeDir,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3548,9 +3548,10 @@ export class CodexAppServerClient {
   }
 
   private getSessionIndexPath(): string {
+    const codexHome = this.options.env?.CODEX_HOME?.trim() || process.env.CODEX_HOME?.trim();
     return (
       this.options.sessionIndexPath?.trim() ||
-      path.join(os.homedir(), ".codex", "session_index.jsonl")
+      path.join(codexHome || path.join(os.homedir(), ".codex"), "session_index.jsonl")
     );
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -26,6 +26,10 @@ import {
   disposePreloadLogIpcHandlers,
   registerPreloadLogIpcHandlers,
 } from "./ipc/preload-log";
+import {
+  disposeProfilesIpcHandlers,
+  registerProfilesIpcHandlers,
+} from "./ipc/profiles";
 import { registerRendererErrorIpcHandlers } from "./ipc/renderer-error";
 import {
   disposeRuntimeIdentityIpcHandlers,
@@ -105,6 +109,7 @@ export function bootstrapApp(): void {
     registerAppUpdateIpcHandlers();
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
+    registerProfilesIpcHandlers();
     registerRendererErrorIpcHandlers();
     registerSettingsIpcHandlers();
     if (isDevelopment) {
@@ -164,6 +169,7 @@ export function bootstrapApp(): void {
     disposeAppUpdateIpcHandlers();
     disposeImageNormalizationIpcHandlers();
     disposePreloadLogIpcHandlers();
+    disposeProfilesIpcHandlers();
     disposeSettingsIpcHandlers();
     if (isDevelopment) {
       disposeRuntimeIdentityIpcHandlers();

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -1,0 +1,106 @@
+import { ipcMain } from "electron";
+import { spawn } from "node:child_process";
+import type {
+  ListDesktopPwrAgentProfilesResponse,
+  OpenDesktopPwrAgentProfileRequest,
+  OpenDesktopPwrAgentProfileResponse,
+} from "@pwragent/shared";
+import {
+  PROFILES_LIST_CHANNEL,
+  PROFILES_OPEN_CHANNEL,
+} from "../../shared/ipc";
+import {
+  PWRAGENT_PROFILE_ENV,
+  ensureProfileExists,
+  isValidProfileName,
+  readProfilesRegistry,
+  resolveActiveProfileName,
+} from "../profile";
+
+export function listDesktopPwrAgentProfiles(): ListDesktopPwrAgentProfilesResponse {
+  const activeProfile = resolveActiveProfileName();
+  const registry = readProfilesRegistry();
+  const byName = new Map(
+    registry.profiles.map((profile) => [profile.name, profile]),
+  );
+  if (!byName.has(activeProfile)) {
+    byName.set(activeProfile, { name: activeProfile });
+  }
+  if (!byName.has("default")) {
+    byName.set("default", { name: "default" });
+  }
+
+  return {
+    activeProfile,
+    profiles: [...byName.values()]
+      .sort((left, right) => {
+        if (left.name === activeProfile) return -1;
+        if (right.name === activeProfile) return 1;
+        return left.name.localeCompare(right.name);
+      })
+      .map((profile) => ({
+        name: profile.name,
+        displayName: profile.display_name,
+        lastUsed: profile.last_used,
+        active: profile.name === activeProfile,
+      })),
+  };
+}
+
+export function openDesktopPwrAgentProfile(
+  request: OpenDesktopPwrAgentProfileRequest,
+): OpenDesktopPwrAgentProfileResponse {
+  const profile = request.profile.trim();
+  if (!isValidProfileName(profile)) {
+    throw new Error(`Invalid profile name "${profile}".`);
+  }
+
+  const activeProfile = resolveActiveProfileName();
+  if (profile === activeProfile) {
+    return { opened: false, profile, reason: "active" };
+  }
+
+  ensureProfileExists({
+    env: {
+      ...process.env,
+      [PWRAGENT_PROFILE_ENV]: profile,
+    },
+  });
+
+  const args = process.defaultApp ? process.argv.slice(1) : [];
+  const child = spawn(process.execPath, args, {
+    detached: true,
+    env: {
+      ...process.env,
+      [PWRAGENT_PROFILE_ENV]: profile,
+    },
+    stdio: "ignore",
+  });
+  child.unref();
+
+  return { opened: true, profile };
+}
+
+export function registerProfilesIpcHandlers(): void {
+  ipcMain.removeHandler(PROFILES_LIST_CHANNEL);
+  ipcMain.handle(
+    PROFILES_LIST_CHANNEL,
+    async (): Promise<ListDesktopPwrAgentProfilesResponse> =>
+      listDesktopPwrAgentProfiles(),
+  );
+
+  ipcMain.removeHandler(PROFILES_OPEN_CHANNEL);
+  ipcMain.handle(
+    PROFILES_OPEN_CHANNEL,
+    async (
+      _event,
+      request: OpenDesktopPwrAgentProfileRequest,
+    ): Promise<OpenDesktopPwrAgentProfileResponse> =>
+      openDesktopPwrAgentProfile(request),
+  );
+}
+
+export function disposeProfilesIpcHandlers(): void {
+  ipcMain.removeHandler(PROFILES_LIST_CHANNEL);
+  ipcMain.removeHandler(PROFILES_OPEN_CHANNEL);
+}

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -49,7 +49,11 @@ async function refreshModelBackendsIfNeeded(params: {
   patch?: WriteDesktopSettingsConfigRequest["patch"];
   secret?: ReplaceDesktopSettingsSecretRequest["secret"];
 }): Promise<void> {
-  if (params.patch?.models?.codex?.path !== undefined || params.secret === "grokApiKey") {
+  if (
+    params.patch?.models?.codex?.path !== undefined
+    || params.patch?.models?.codex?.profile !== undefined
+    || params.secret === "grokApiKey"
+  ) {
     await disposeDesktopBackendRegistry();
   }
 }

--- a/apps/desktop/src/main/settings/codex-profiles.ts
+++ b/apps/desktop/src/main/settings/codex-profiles.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  DesktopCodexAuthProfileCandidate,
+  DesktopCodexAuthProfileDiscoverySnapshot,
+} from "@pwragent/shared";
+import { isValidProfileName } from "../profile";
+
+export const CODEX_HOME_ENV = "CODEX_HOME";
+
+export function resolveDefaultCodexHome(options?: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): string {
+  const env = options?.env ?? process.env;
+  const envCodexHome = env[CODEX_HOME_ENV]?.trim();
+  if (envCodexHome) return path.resolve(envCodexHome);
+  return path.join(options?.homeDir ?? os.homedir(), ".codex");
+}
+
+export function resolveCodexProfileRoot(options?: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): string {
+  return path.join(resolveDefaultCodexHome(options), "profiles");
+}
+
+export function resolveCodexHomeForProfile(
+  profileName: string | undefined,
+  options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
+): string | undefined {
+  const name = profileName?.trim();
+  if (!name) return undefined;
+  if (!isValidProfileName(name)) return undefined;
+  return path.join(resolveCodexProfileRoot(options), name);
+}
+
+export function discoverCodexAuthProfiles(options?: {
+  configuredProfile?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): DesktopCodexAuthProfileDiscoverySnapshot {
+  const defaultCodexHome = resolveDefaultCodexHome(options);
+  const profileRoot = resolveCodexProfileRoot(options);
+  const configuredProfile = options?.configuredProfile?.trim() ?? "";
+  const selectedProfile = isValidProfileName(configuredProfile)
+    ? configuredProfile
+    : "";
+  const profiles: DesktopCodexAuthProfileCandidate[] = [
+    {
+      name: "",
+      displayName: "System default",
+      codexHome: defaultCodexHome,
+      source: "default",
+      exists: fs.existsSync(defaultCodexHome),
+      selected: selectedProfile === "",
+      hasAuthFile: fileExists(path.join(defaultCodexHome, "auth.json")),
+      hasConfigFile: fileExists(path.join(defaultCodexHome, "config.toml")),
+    },
+  ];
+
+  let error: string | undefined;
+
+  try {
+    for (const entry of fs.readdirSync(profileRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !isValidProfileName(entry.name)) continue;
+      profiles.push(buildDirectoryProfile(entry.name, profileRoot, selectedProfile));
+    }
+  } catch (readError) {
+    const code =
+      typeof readError === "object" && readError !== null && "code" in readError
+        ? (readError as { code?: string }).code
+        : undefined;
+    if (code !== "ENOENT") {
+      error = readError instanceof Error ? readError.message : String(readError);
+    }
+  }
+
+  if (selectedProfile && !profiles.some((profile) => profile.name === selectedProfile)) {
+    profiles.push(buildDirectoryProfile(selectedProfile, profileRoot, selectedProfile));
+  }
+
+  if (configuredProfile && !selectedProfile) {
+    error = `Invalid Codex profile "${configuredProfile}". Profile names must match PwrAgent profile naming rules.`;
+  }
+
+  const selected =
+    profiles.find((profile) => profile.selected) ?? profiles[0]!;
+
+  return {
+    profileRoot,
+    effectiveCodexHome: selected.codexHome,
+    profiles,
+    ...(error ? { error } : {}),
+  };
+}
+
+function buildDirectoryProfile(
+  name: string,
+  profileRoot: string,
+  selectedProfile: string,
+): DesktopCodexAuthProfileCandidate {
+  const codexHome = path.join(profileRoot, name);
+  return {
+    name,
+    displayName: name,
+    codexHome,
+    source: fs.existsSync(codexHome) ? "directory" : "config",
+    exists: fs.existsSync(codexHome),
+    selected: selectedProfile === name,
+    hasAuthFile: fileExists(path.join(codexHome, "auth.json")),
+    hasConfigFile: fileExists(path.join(codexHome, "config.toml")),
+  };
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -91,6 +91,7 @@ export type DesktopSettingsConfig = {
   models?: {
     codex?: {
       path?: string;
+      profile?: string;
     };
   };
   applications?: {
@@ -427,6 +428,9 @@ export function desktopSettingsPatchToEdits(
   if (patch.models?.codex?.path !== undefined) {
     set(["models", "codex", "path"], patch.models.codex.path);
   }
+  if (patch.models?.codex?.profile !== undefined) {
+    set(["models", "codex", "profile"], patch.models.codex.profile);
+  }
 
   if (patch.applications?.editor?.preferredId !== undefined) {
     set(["applications", "editor", "preferred_id"], patch.applications.editor.preferredId);
@@ -547,6 +551,7 @@ function normalizeDesktopConfig(
     models: {
       codex: {
         path: readString(codex?.path),
+        profile: readString(codex?.profile),
       },
     },
     applications: {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -71,6 +71,10 @@ import {
   readEnvWorktreeStorage,
 } from "./desktop-settings-env";
 import { discoverCodexCommands } from "./codex-discovery";
+import {
+  discoverCodexAuthProfiles,
+  resolveCodexHomeForProfile,
+} from "./codex-profiles";
 import { discoverDesktopApplications } from "./application-discovery";
 import { discoverGhCommands } from "./gh-discovery";
 import { getMainLogger } from "../log";
@@ -158,6 +162,10 @@ export class DesktopSettingsService {
     );
     const codexDiscovery = await discoverCodexCommands({
       configuredCommand: config.models?.codex?.path,
+      env: this.env,
+    });
+    const codexProfiles = discoverCodexAuthProfiles({
+      configuredProfile: config.models?.codex?.profile,
       env: this.env,
     });
     const ghDiscovery = await discoverGhCommands({
@@ -355,7 +363,9 @@ export class DesktopSettingsService {
       models: {
         codex: {
           path: this.resolveString(config.models?.codex?.path, CODEX_COMMAND_ENV),
+          profile: this.resolveConfigString(config.models?.codex?.profile),
           discovery: codexDiscovery,
+          profiles: codexProfiles,
         },
         grok: {
           apiKey: grokApiKey,
@@ -463,6 +473,18 @@ export class DesktopSettingsService {
       || this.readConfig().config.models?.codex?.path
       || undefined
     );
+  }
+
+  resolveCodexSpawnEnv(): NodeJS.ProcessEnv {
+    const configuredProfile = this.readConfig().config.models?.codex?.profile;
+    const codexHome = resolveCodexHomeForProfile(configuredProfile, {
+      env: this.env,
+    });
+    if (!codexHome) return this.env;
+    return {
+      ...this.env,
+      CODEX_HOME: codexHome,
+    };
   }
 
   resolveGhCommandPreference(): string | undefined {

--- a/apps/desktop/src/main/state/migration.ts
+++ b/apps/desktop/src/main/state/migration.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import type BetterSqlite3 from "better-sqlite3";
 import Database from "better-sqlite3";
 import { migrateMessagingStoreData } from "../messaging/core/messaging-migrations.js";
-import { resolveActiveProfilePath, resolvePwragentRoot } from "../profile";
+import {
+  resolveActiveProfileName,
+  resolveActiveProfilePath,
+  resolvePwragentRoot,
+} from "../profile";
 import { getNativeBinding } from "./native-binding.js";
 import { StateDb } from "./state-db.js";
 
@@ -68,6 +72,7 @@ export function migrateIfNeeded(options?: {
   xdgConfigHome?: string;
   xdgStateHome?: string;
 }): MigrationOutcome {
+  const profileName = resolveActiveProfileName(options);
   const dbPath = resolveActiveProfilePath("state/state.db", options);
   const nativeBinding = getNativeBinding();
 
@@ -85,6 +90,12 @@ export function migrateIfNeeded(options?: {
     }
   }
 
+  if (profileName !== "default") {
+    const stateDb = StateDb.open(dbPath, { profileName });
+    stateDb.close();
+    return { status: "fresh-install", dbPath };
+  }
+
   const legacy = findLegacyPaths(options);
   const hasAnySources =
     legacy.messagingState ||
@@ -95,7 +106,7 @@ export function migrateIfNeeded(options?: {
 
   if (!hasAnySources) {
     const stateDb = StateDb.open(dbPath, {
-      profileName: options?.cliProfile ?? "default",
+      profileName,
     });
     stateDb.close();
     return { status: "fresh-install", dbPath };
@@ -122,9 +133,7 @@ export function migrateIfNeeded(options?: {
     tmpDb.pragma("synchronous = NORMAL");
     tmpDb.pragma("auto_vacuum = INCREMENTAL");
 
-    const stateDb = StateDb.open(tmpDbPath, {
-      profileName: options?.cliProfile ?? "default",
-    });
+    const stateDb = StateDb.open(tmpDbPath, { profileName });
 
     const counts: Record<string, number> = {};
     const timestamp = new Date().toISOString();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,7 @@ import type {
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   QueueThreadExecutionModeRequest,
@@ -94,6 +95,8 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenDesktopPwrAgentProfileRequest,
+  OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
@@ -171,6 +174,8 @@ import {
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
   PRELOAD_LOG_CHANNEL,
+  PROFILES_LIST_CHANNEL,
+  PROFILES_OPEN_CHANNEL,
   RENDERER_ERROR_REPORT_CHANNEL,
   RUNTIME_IDENTITY_CHANNEL,
   SETTINGS_CLEAR_SECRET_CHANNEL,
@@ -216,6 +221,12 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(APP_METADATA_READ_CHANNEL),
   checkForAppUpdates: async (): Promise<AppUpdateCheckResult> =>
     await ipcRenderer.invoke(APP_UPDATE_CHECK_CHANNEL),
+  listPwrAgentProfiles: async (): Promise<ListDesktopPwrAgentProfilesResponse> =>
+    await ipcRenderer.invoke(PROFILES_LIST_CHANNEL),
+  openPwrAgentProfile: async (
+    request: OpenDesktopPwrAgentProfileRequest,
+  ): Promise<OpenDesktopPwrAgentProfileResponse> =>
+    await ipcRenderer.invoke(PROFILES_OPEN_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
+import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
@@ -68,6 +69,7 @@ function DesktopAppShell(props: {
     void desktopApi?.openMessagingActivityWindow?.();
   }, [desktopApi]);
   const settings = props.settings;
+  const profiles = usePwrAgentProfiles(desktopApi);
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
@@ -125,6 +127,8 @@ function DesktopAppShell(props: {
         archiveThreadError={navigation.archiveThreadError}
         renameThreadError={navigation.renameThreadError}
         runtimeIdentity={runtimeIdentity}
+        activeProfile={profiles.activeProfile}
+        profiles={profiles.profiles}
         launchpadError={navigation.launchpadError}
         loading={navigation.loading}
         approvalRequestThreadKeys={session.approvalRequestThreadKeys}
@@ -142,6 +146,7 @@ function DesktopAppShell(props: {
           setSettingsInitialSection(undefined);
           setMainView("settings");
         }}
+        onOpenProfile={profiles.openProfile}
         onSelectThread={(thread) => {
           setMainView("thread");
           navigation.selectThread(thread);

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -154,9 +154,15 @@ describe("App", () => {
       models: {
         codex: {
           path: { value: "", source: "default" },
+          profile: { value: "", source: "default" },
           discovery: {
             selectedCommand: undefined,
             candidates: [],
+          },
+          profiles: {
+            profileRoot: "/home/example/.codex/profiles",
+            effectiveCodexHome: "/home/example/.codex",
+            profiles: [],
           },
         },
         grok: {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent } from "react";
 import type {
   AppServerBackendKind,
   BackendSummary,
+  DesktopPwrAgentProfileSummary,
   MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
@@ -42,6 +43,8 @@ type SidebarProps = {
   archiveThreadError?: string;
   renameThreadError?: string;
   runtimeIdentity?: RuntimeIdentity;
+  activeProfile?: string;
+  profiles?: DesktopPwrAgentProfileSummary[];
   settingsActive?: boolean;
   approvalRequestThreadKeys?: Record<string, boolean>;
   selectedItemKey?: string;
@@ -54,6 +57,7 @@ type SidebarProps = {
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
   onOpenSettings?: () => void;
+  onOpenProfile?: (profile: string) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRenameThread?: (thread: NavigationThreadSummary, name: string) => Promise<void>;
@@ -116,6 +120,7 @@ export function Sidebar(props: SidebarProps) {
   const onArchiveThread = props.onArchiveThread ?? (async () => undefined);
   const onRenameThread = props.onRenameThread ?? (async () => undefined);
   const [copiedRuntimeValue, setCopiedRuntimeValue] = useState<"branch" | "cwd">();
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
   const runtimeGitRefLabel = props.runtimeIdentity
     ? formatRuntimeGitRef(props.runtimeIdentity)
     : undefined;
@@ -170,6 +175,26 @@ export function Sidebar(props: SidebarProps) {
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [contextMenu]);
+
+  useEffect(() => {
+    if (!profileMenuOpen) {
+      return;
+    }
+
+    const closeMenu = (): void => setProfileMenuOpen(false);
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        closeMenu();
+      }
+    };
+
+    window.addEventListener("click", closeMenu);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("click", closeMenu);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [profileMenuOpen]);
 
   useLayoutEffect(() => {
     if (!contextMenu) {
@@ -342,6 +367,49 @@ export function Sidebar(props: SidebarProps) {
               valueKind="branch"
               onCopied={setCopiedRuntimeValue}
             />
+          ) : null}
+        </div>
+      ) : null}
+
+      {props.activeProfile ? (
+        <div className="runtime-identity" aria-label="PwrAgent profile">
+          <button
+            className="runtime-identity__button"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setProfileMenuOpen((open) => !open);
+            }}
+          >
+            {`profile:${props.activeProfile}`}
+          </button>
+          {profileMenuOpen && props.profiles?.length ? (
+            <div
+              className="sidebar__menu sidebar__menu--profile"
+              role="menu"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {props.profiles.map((profile) => (
+                <button
+                  key={profile.name}
+                  className="sidebar__menu-item"
+                  disabled={profile.active || !props.onOpenProfile}
+                  role="menuitem"
+                  type="button"
+                  onClick={() => {
+                    setProfileMenuOpen(false);
+                    void props.onOpenProfile?.(profile.name);
+                  }}
+                >
+                  <span className="sidebar__menu-item-title">
+                    {profile.displayName || profile.name}
+                  </span>
+                  <span className="sidebar__menu-item-detail">
+                    {profile.active ? "Current profile" : "Open in new app instance"}
+                  </span>
+                </button>
+              ))}
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -528,7 +528,7 @@ export function MessagingSettings(props: {
             help={
               <>
                 Click <strong>Generate</strong> to fill the field with a fresh
-                256-bit secret (then click Replace to save), <em>or</em> run
+                256-bit secret (then click Save to commit), <em>or</em> run
                 this in a terminal if you'd rather generate it yourself:
                 <br />
                 <code>openssl rand -hex 32</code>
@@ -997,6 +997,7 @@ function PairingTokenField(props: {
 }) {
   const [scope, setScope] = useState<MessagingPairingScope>("user_dm");
   const [message, setMessage] = useState<string | undefined>(undefined);
+  const [messageEntryId, setMessageEntryId] = useState<string | undefined>(undefined);
   const [entries, setEntries] = useState<MessagingPairingEntry[]>([]);
   const [busyId, setBusyId] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
@@ -1012,9 +1013,20 @@ function PairingTokenField(props: {
   useEffect(() => {
     void refresh();
     return props.desktopApi?.onMessagingPairingChanged?.((event) => {
-      if (event.entry.platform === props.platform) void refresh();
+      if (event.entry.platform !== props.platform) return;
+      if (event.entry.id === messageEntryId && event.entry.status !== "pending") {
+        setMessage(undefined);
+        setMessageEntryId(undefined);
+      }
+      void refresh();
     });
-  }, [props.desktopApi, props.platform]);
+  }, [messageEntryId, props.desktopApi, props.platform]);
+
+  const selectScope = (nextScope: MessagingPairingScope) => {
+    setScope(nextScope);
+    setMessage(undefined);
+    setMessageEntryId(undefined);
+  };
 
   const generate = async () => {
     if (!props.desktopApi?.generateMessagingPairingToken) return;
@@ -1026,6 +1038,7 @@ function PairingTokenField(props: {
         scope,
       });
       setMessage(result.message);
+      setMessageEntryId(result.entry.id);
       await refresh();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -1045,11 +1058,19 @@ function PairingTokenField(props: {
         const result = await props.desktopApi?.approveMessagingPairing?.({
           entryId: entry.id,
         });
+        if (result?.entry.id === messageEntryId) {
+          setMessage(undefined);
+          setMessageEntryId(undefined);
+        }
         if (result?.added) {
           await props.onSettingsChanged?.();
         }
       } else {
-        await props.desktopApi?.rejectMessagingPairing?.({ entryId: entry.id });
+        const result = await props.desktopApi?.rejectMessagingPairing?.({ entryId: entry.id });
+        if (result?.entry.id === messageEntryId) {
+          setMessage(undefined);
+          setMessageEntryId(undefined);
+        }
       }
       await refresh();
     } catch (caught) {
@@ -1098,7 +1119,7 @@ function PairingTokenField(props: {
                   disabled={props.disabled}
                   role="radio"
                   type="button"
-                  onClick={() => setScope(option.value)}
+                  onClick={() => selectScope(option.value)}
                 >
                   {option.label}
                 </button>
@@ -1694,8 +1715,7 @@ function SecretField(props: {
   state: DesktopSettingsSnapshot["models"]["grok"]["apiKey"];
   /**
    * Optional generator. When provided, a "Generate" button appears
-   * that fills the input with the produced value (the user still has
-   * to click Replace to commit). Used by the Mattermost HMAC field
+   * that fills the input with the produced value. Used by the Mattermost HMAC field
    * so users don't have to leave the app to run openssl.
    */
   onGenerate?: () => string;
@@ -1706,6 +1726,7 @@ function SecretField(props: {
   ) => Promise<boolean>;
 }) {
   const [value, setValue] = useState("");
+  const dirty = value.length > 0;
   const status = props.state.configured ? "Set" : "Not set";
   const source = formatSourceLabel(props.state.source, props.state.overriddenByEnv);
 
@@ -1752,8 +1773,18 @@ function SecretField(props: {
               });
             }}
           >
-            Replace
+            Save
           </button>
+          {dirty ? (
+            <button
+              className="button button--ghost"
+              disabled={props.disabled}
+              type="button"
+              onClick={() => setValue("")}
+            >
+              Discard
+            </button>
+          ) : null}
           <button
             className="button button--ghost"
             disabled={props.disabled || props.state.source === "env"}

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type {
+  DesktopCodexAuthProfileCandidate,
   DesktopCodexDiscoveryCandidate,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
@@ -30,6 +31,7 @@ export function ModelsSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onSaveCodexPath: (path: string) => Promise<void>;
+  onSaveCodexProfile: (profile: string) => Promise<void>;
 }) {
   const [codexPath, setCodexPath] = useState(props.snapshot.models.codex.path.value);
   const [codexMode, setCodexMode] = useState<CodexPathMode>(
@@ -49,6 +51,8 @@ export function ModelsSettings(props: {
   // a duplicate of this same chip; that's gone now.
   const codexSource =
     codex.path.source === "default" ? "auto" : sourceBadge(codex.path);
+  const codexProfileSource =
+    codex.profile.source === "default" ? "default" : sourceBadge(codex.profile);
   const grokConfigured = grok.configured;
   const grokSource = formatSourceLabel(grok.source, grok.overriddenByEnv);
 
@@ -160,6 +164,29 @@ export function ModelsSettings(props: {
             }
           />
           <SettingsField
+            label="Auth profile"
+            sub="Select the Codex home used for auth, config, sessions, skills, and state."
+            source={codexProfileSource}
+            error={codex.profiles.error}
+            control={
+              <div
+                className="settings-paths"
+                aria-label="Codex auth profiles"
+              >
+                {codex.profiles.profiles.map((profile) => (
+                  <CodexProfileRow
+                    key={profile.name || "default"}
+                    profile={profile}
+                    disabled={props.saving}
+                    onUse={(profileName) => {
+                      void props.onSaveCodexProfile(profileName);
+                    }}
+                  />
+                ))}
+              </div>
+            }
+          />
+          <SettingsField
             label="Connection test"
             sub="Spawns the selected Codex binary with --version and validates the version banner."
             control={
@@ -245,6 +272,40 @@ export function ModelsSettings(props: {
         </div>
       </SettingsSection>
     </SettingsSectionStack>
+  );
+}
+
+function CodexProfileRow(props: {
+  profile: DesktopCodexAuthProfileCandidate;
+  disabled?: boolean;
+  onUse: (profile: string) => void;
+}) {
+  const profile = props.profile;
+  const chips: SettingsPathRowChip[] = [
+    { label: profile.source === "default" ? "default" : "profile", tone: "muted" },
+    {
+      label: profile.hasAuthFile ? "auth" : "no auth",
+      tone: profile.hasAuthFile || !profile.name ? "muted" : "err",
+    },
+  ];
+
+  if (profile.hasConfigFile) {
+    chips.push({ label: "config", tone: "muted" });
+  }
+  if (!profile.exists) {
+    chips.push({ label: "missing", tone: "err" });
+  }
+
+  return (
+    <SettingsPathRow
+      title={profile.displayName}
+      path={profile.codexHome}
+      chips={chips}
+      selected={profile.selected}
+      selectedLabel="Using"
+      disabled={props.disabled || !profile.exists}
+      onUse={() => props.onUse(profile.name)}
+    />
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -356,6 +356,13 @@ function SettingsSectionBody(props: {
           },
         });
       }}
+      onSaveCodexProfile={async (profile) => {
+        await props.settings.writeConfig({
+          models: {
+            codex: { profile },
+          },
+        });
+      }}
     />
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -10,7 +10,10 @@ import {
 } from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import type {
+  DesktopSettingsSnapshot,
+  MessagingPairingEntry,
+} from "@pwragent/shared";
 import { SettingsScreen } from "../SettingsScreen";
 import type { DesktopSettingsState } from "../useDesktopSettings";
 
@@ -652,6 +655,75 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("clears a generated pairing message after the token is observed", async () => {
+    const snapshot = createSnapshot();
+    const settings = createSettingsState({
+      ...snapshot,
+      messaging: {
+        ...snapshot.messaging,
+        telegram: {
+          ...snapshot.messaging.telegram,
+          enabled: { value: true, source: "config" as const },
+        },
+      },
+    });
+    const pairingMessage = "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY";
+    const entry: MessagingPairingEntry = {
+      id: "pairing-1",
+      platform: "telegram",
+      instanceId: "default",
+      scope: "user_dm",
+      status: "pending",
+      generatedAt: 1,
+      expiresAt: 2,
+    };
+    let pairingChanged:
+      | ((event: { at: number; entry: MessagingPairingEntry }) => void)
+      | undefined;
+    const desktopApi = {
+      generateMessagingPairingToken: vi.fn(async () => ({
+        entry,
+        expiresAt: 2,
+        message: pairingMessage,
+        token: "123456789ABCDEFGHJKLMNPQRSTUVWXY",
+      })),
+      listMessagingPairingRequests: vi.fn(async () => ({ entries: [] })),
+      onMessagingPairingChanged: vi.fn((callback) => {
+        pairingChanged = callback;
+        return () => undefined;
+      }),
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Generate" })[0]!);
+    expect(await screen.findByText(pairingMessage)).toBeInTheDocument();
+
+    act(() => {
+      pairingChanged?.({
+        at: 3,
+        entry: {
+          ...entry,
+          status: "observed",
+          observedAt: 3,
+          observedActor: { id: "8460800771", displayName: "Harold Hunt" },
+          observedChat: { id: "8460800771", kind: "dm", title: "Harold Hunt" },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(pairingMessage)).not.toBeInTheDocument();
+    });
+  });
+
   it("shows observed pairing IDs and refreshes authorized IDs after approval", async () => {
     const snapshot = createSnapshot();
     const initialSnapshot: DesktopSettingsSnapshot = {
@@ -899,7 +971,7 @@ describe("SettingsScreen", () => {
     });
     fireEvent.click(
       within(signingSecretControls as HTMLElement).getByRole("button", {
-        name: "Replace",
+        name: "Save",
       }),
     );
 
@@ -1345,7 +1417,7 @@ describe("SettingsScreen", () => {
     fireEvent.change(tokenInput, {
       target: { value: "123456789:secret-token" },
     });
-    fireEvent.click(screen.getAllByRole("button", { name: "Replace" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
 
     await waitFor(() => {
       expect(settings.replaceSecret).toHaveBeenCalledWith(
@@ -1354,6 +1426,22 @@ describe("SettingsScreen", () => {
       );
     });
     expect(tokenInput).toHaveValue("123456789:secret-token");
+  });
+
+  it("lets users discard an unsaved secret draft", () => {
+    const settings = createSettingsState();
+    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    const tokenInput = screen.getAllByLabelText("Bot Token")[0];
+    fireEvent.change(tokenInput, {
+      target: { value: "123456789:secret-token" },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Discard" })[0]);
+
+    expect(tokenInput).toHaveValue("");
+    expect(settings.replaceSecret).not.toHaveBeenCalled();
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -105,6 +105,7 @@ function createSnapshot(
     models: {
       codex: {
         path: { value: "", source: "default" },
+        profile: { value: "", source: "default" },
         discovery: {
           selectedCommand: "/usr/local/bin/codex",
           selectedSource: "path",
@@ -122,6 +123,32 @@ function createSnapshot(
               selected: false,
               source: "application",
               version: "0.120.0",
+            },
+          ],
+        },
+        profiles: {
+          profileRoot: "/home/example/.codex/profiles",
+          effectiveCodexHome: "/home/example/.codex",
+          profiles: [
+            {
+              name: "",
+              displayName: "System default",
+              codexHome: "/home/example/.codex",
+              source: "default",
+              exists: true,
+              selected: true,
+              hasAuthFile: true,
+              hasConfigFile: true,
+            },
+            {
+              name: "work",
+              displayName: "work",
+              codexHome: "/home/example/.codex/profiles/work",
+              source: "directory",
+              exists: true,
+              selected: false,
+              hasAuthFile: true,
+              hasConfigFile: false,
             },
           ],
         },
@@ -303,13 +330,25 @@ describe("SettingsScreen", () => {
     // `/usr/local/bin/codex`, so the single "Use" here points at
     // `/Applications/Codex.app/Contents/Resources/codex`.
     const useButtons = screen.getAllByRole("button", { name: "Use" });
-    expect(useButtons).toHaveLength(1);
+    expect(useButtons).toHaveLength(2);
     fireEvent.click(useButtons[0]!);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         models: {
           codex: {
             path: "/Applications/Codex.app/Contents/Resources/codex",
+          },
+        },
+      });
+    });
+    expect(screen.getByText("System default")).toBeInTheDocument();
+    expect(screen.getByText("/home/example/.codex/profiles/work")).toBeInTheDocument();
+    fireEvent.click(useButtons[1]!);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          codex: {
+            profile: "work",
           },
         },
       });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -31,6 +31,7 @@ import type {
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  ListDesktopPwrAgentProfilesResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   MarkThreadSeenRequest,
@@ -99,6 +100,8 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenDesktopPwrAgentProfileRequest,
+  OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   PickGhCommandResponse,
@@ -124,6 +127,10 @@ export type DesktopApi = {
   getRuntimeIdentity?: () => Promise<RuntimeIdentity>;
   readAppMetadata?: () => Promise<AppMetadata>;
   checkForAppUpdates?: () => Promise<AppUpdateCheckResult>;
+  listPwrAgentProfiles?: () => Promise<ListDesktopPwrAgentProfilesResponse>;
+  openPwrAgentProfile?: (
+    request: OpenDesktopPwrAgentProfileRequest,
+  ) => Promise<OpenDesktopPwrAgentProfileResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/usePwrAgentProfiles.ts
+++ b/apps/desktop/src/renderer/src/lib/usePwrAgentProfiles.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  DesktopPwrAgentProfileSummary,
+  ListDesktopPwrAgentProfilesResponse,
+} from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+
+export type PwrAgentProfilesState = {
+  activeProfile?: string;
+  error?: string;
+  loading: boolean;
+  profiles: DesktopPwrAgentProfileSummary[];
+  openProfile: (profile: string) => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+export function usePwrAgentProfiles(
+  desktopApi?: DesktopApi,
+): PwrAgentProfilesState {
+  const [response, setResponse] = useState<ListDesktopPwrAgentProfilesResponse>();
+  const [loading, setLoading] = useState(Boolean(desktopApi?.listPwrAgentProfiles));
+  const [error, setError] = useState<string>();
+
+  const refresh = useCallback(async () => {
+    if (!desktopApi?.listPwrAgentProfiles) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(undefined);
+    try {
+      setResponse(await desktopApi.listPwrAgentProfiles());
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : String(nextError));
+    } finally {
+      setLoading(false);
+    }
+  }, [desktopApi]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const openProfile = useCallback(
+    async (profile: string) => {
+      if (!desktopApi?.openPwrAgentProfile) return;
+      await desktopApi.openPwrAgentProfile({ profile });
+      await refresh();
+    },
+    [desktopApi, refresh],
+  );
+
+  return {
+    activeProfile: response?.activeProfile,
+    error,
+    loading,
+    profiles: response?.profiles ?? [],
+    openProfile,
+    refresh,
+  };
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -775,12 +775,18 @@ textarea,
 
 .runtime-identity {
   display: flex;
+  position: relative;
   min-width: 0;
   align-items: center;
   gap: 6px;
   padding: 6px 0;
   border-bottom: 1px solid var(--border-subtle);
   -webkit-app-region: no-drag;
+}
+
+.sidebar__menu--profile {
+  right: auto;
+  left: 0;
 }
 
 .runtime-identity__button {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2988,10 +2988,15 @@ textarea,
 }
 
 .settings-secret {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.settings-secret .settings-input {
+  flex: 1 1 220px;
+  min-width: 0;
 }
 
 .settings-inline-actions {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -136,3 +136,5 @@ export const SETTINGS_PICK_GH_COMMAND_CHANNEL =
 export const APPLICATION_OPEN_CHANNEL = "application:open";
 export const APP_METADATA_READ_CHANNEL = "app:read-metadata";
 export const APP_UPDATE_CHECK_CHANNEL = "app:check-for-updates";
+export const PROFILES_LIST_CHANNEL = "profiles:list";
+export const PROFILES_OPEN_CHANNEL = "profiles:open";

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -516,9 +516,8 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       });
     }
 
-    let webhookInfo: { url: string };
     try {
-      webhookInfo = await this.bot.api.getWebhookInfo();
+      await this.bot.api.getWebhookInfo();
     } catch (error) {
       this.options.logger?.warn?.("telegram getWebhookInfo failed", {
         error: errorMessage(error),
@@ -527,11 +526,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       });
       throw error;
     }
-    if (webhookInfo.url) {
-      await this.bot.api.deleteWebhook({
-        drop_pending_updates: false,
-      });
-    }
+    await this.bot.api.deleteWebhook({
+      drop_pending_updates: false,
+    });
     await this.bot.api.setMyCommands({
       commands: [
         {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -127,8 +127,14 @@ describe("desktop settings contracts", () => {
       models: {
         codex: {
           path: { value: "", source: "default" },
+          profile: { value: "", source: "default" },
           discovery: {
             candidates: [],
+          },
+          profiles: {
+            profileRoot: "/home/example/.codex/profiles",
+            effectiveCodexHome: "/home/example/.codex",
+            profiles: [],
           },
         },
         grok: {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -399,6 +399,28 @@ export type DesktopSettingsWriteResponse = {
   snapshot: DesktopSettingsSnapshot;
 };
 
+export type DesktopPwrAgentProfileSummary = {
+  name: string;
+  displayName?: string;
+  lastUsed?: string;
+  active: boolean;
+};
+
+export type ListDesktopPwrAgentProfilesResponse = {
+  activeProfile: string;
+  profiles: DesktopPwrAgentProfileSummary[];
+};
+
+export type OpenDesktopPwrAgentProfileRequest = {
+  profile: string;
+};
+
+export type OpenDesktopPwrAgentProfileResponse = {
+  opened: boolean;
+  profile: string;
+  reason?: "active";
+};
+
 export type OpenDesktopApplicationRequest = {
   applicationId: string;
   kind: DesktopApplicationKind;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -130,6 +130,26 @@ export type DesktopCodexDiscoverySnapshot = {
   error?: string;
 };
 
+export type DesktopCodexAuthProfileSource = "default" | "directory" | "config";
+
+export type DesktopCodexAuthProfileCandidate = {
+  name: string;
+  displayName: string;
+  codexHome: string;
+  source: DesktopCodexAuthProfileSource;
+  exists: boolean;
+  selected: boolean;
+  hasAuthFile: boolean;
+  hasConfigFile: boolean;
+};
+
+export type DesktopCodexAuthProfileDiscoverySnapshot = {
+  profileRoot: string;
+  effectiveCodexHome: string;
+  profiles: DesktopCodexAuthProfileCandidate[];
+  error?: string;
+};
+
 export type DesktopGhCandidateSource =
   | "env"
   | "config"
@@ -260,7 +280,9 @@ export type DesktopSettingsSnapshot = {
   models: {
     codex: {
       path: DesktopSettingsValue<string>;
+      profile: DesktopSettingsValue<string>;
       discovery: DesktopCodexDiscoverySnapshot;
+      profiles: DesktopCodexAuthProfileDiscoverySnapshot;
     };
     grok: {
       apiKey: DesktopSettingsSecretState;
@@ -326,6 +348,7 @@ export type DesktopSettingsConfigPatch = {
   models?: {
     codex?: {
       path?: string;
+      profile?: string;
     };
   };
   applications?: {


### PR DESCRIPTION
## Summary

I added v1 support for mapping each PwrAgent profile to a separate Codex auth profile.

- Add `models.codex.profile` to the desktop settings contract and per-profile `config.toml`
- Discover Codex auth profiles under `CODEX_HOME/profiles/<name>` while preserving the unset/default Codex home behavior
- Surface a Codex auth profile picker in Settings -> Models -> Codex
- Spawn Codex App Server with the selected profile's `CODEX_HOME`
- Show the active PwrAgent profile in the sidebar and allow opening another registered PwrAgent profile in a separate app instance

## Investigation / Architecture

Codex CLI does not expose a first-class auth-profile flag today. The practical isolation boundary is `CODEX_HOME`; the installed Codex CLI honors it for config/auth/state lookup. I verified that by running Codex against a temporary `CODEX_HOME` and confirming it wrote config into that temporary home.

For v1, this keeps the issue's separate-process-per-profile model: a PwrAgent profile maps to a Codex home, and opening another PwrAgent profile launches a separate app process with `PWRAGENT_PROFILE=<name>`.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-profiles.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/main/__tests__/index.test.ts packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm exec tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/shared/tsconfig.json --noEmit`
- `pnpm lint:boundaries`
- `git diff --check`
- Confirmed `CODEX_HOME` override behavior with the installed Codex CLI using a temporary home directory


Refs #256
