### PR TITLE
fix(agent-core): group profile scratch projects

### DIFF
--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -273,6 +273,33 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("groups profile-scoped scratch projects under Workspaces", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragent/profiles/default/projects/2026-05-08-9bc2d3",
+              label: "2026-05-08-9bc2d3",
+              path: "/Users/huntharo/.pwragent/profiles/default/projects/2026-05-08-9bc2d3",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "workspace:/Users/huntharo/.pwragent/profiles/default/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/huntharo/.pwragent/profiles/default/projects",
+        threadKeys: ["codex:thread-1"],
+      }),
+    ]);
+  });
+
   it("keeps same-named Codex worktrees as separate directory rows", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -58,30 +58,30 @@ function isToolManagedWorktreePath(value: string): boolean {
   );
 }
 
+function matchScratchProjectsRoot(value: string): string | undefined {
+  const scratchWorkspaceRootMatch = value.match(
+    /^(.*[\\/]\.pwrag(?:ent|nt)(?:[\\/]profiles[\\/][^\\/]+)?[\\/]projects)$/,
+  );
+  if (scratchWorkspaceRootMatch) {
+    return scratchWorkspaceRootMatch[1];
+  }
+
+  const scratchWorkspaceMatch = value.match(
+    /^(.*[\\/]\.pwrag(?:ent|nt)(?:[\\/]profiles[\\/][^\\/]+)?[\\/]projects)[\\/][^\\/]+$/,
+  );
+  return scratchWorkspaceMatch?.[1];
+}
+
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
   // Match both current ".pwragent" and legacy ".pwragnt" home directory names
   // so pre-rebrand thread data classifies correctly.
-  const scratchWorkspaceRootMatch = directory.path.match(
-    /^(.*[\\/]\.pwrag(?:ent|nt)[\\/]projects)$/,
-  );
-  if (scratchWorkspaceRootMatch) {
+  const scratchProjectsRoot = matchScratchProjectsRoot(directory.path);
+  if (scratchProjectsRoot) {
     return {
-      key: `workspace:${scratchWorkspaceRootMatch[1]}`,
+      key: `workspace:${scratchProjectsRoot}`,
       kind: "workspace",
       label: "Workspaces",
-      path: scratchWorkspaceRootMatch[1],
-    };
-  }
-
-  const scratchWorkspaceMatch = directory.path.match(
-    /^(.*[\\/]\.pwrag(?:ent|nt)[\\/]projects)[\\/][^\\/]+$/,
-  );
-  if (scratchWorkspaceMatch) {
-    return {
-      key: `workspace:${scratchWorkspaceMatch[1]}`,
-      kind: "workspace",
-      label: "Workspaces",
-      path: scratchWorkspaceMatch[1],
+      path: scratchProjectsRoot,
     };
   }
 


### PR DESCRIPTION
## Summary

I fixed directory classification so profile-scoped PwrAgent scratch projects are grouped under the synthetic `Workspaces` directory instead of showing up as ordinary Directories.

The classifier already handled the legacy `~/.pwragent/projects` shape, but missed the current profile-aware path:

```text
~/.pwragent/profiles/<profile>/projects/<id>
```

## Root Cause

Repo-less Codex threads still need an explicit cwd because the Codex app server falls back to its process cwd when `thread/start` omits `cwd`. PwrAgent creates scratch project directories to avoid that unsafe fallback, but the Directories lens only recognized the older scratch path shape.

## Changes

- Recognize both legacy and profile-scoped PwrAgent scratch project roots.
- Coalesce matching scratch directories into the `Workspaces` synthetic group.
- Add regression coverage for profile-scoped scratch project paths.

## Follow-Up

The broader scratch workspace storage and cleanup behavior is tracked in #277.

## Verification

I verified this with:

```text
pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts
git diff --check
```
