### PR TITLE
fix(desktop): refresh thread git and PR metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -133,10 +133,12 @@ function createOverlayStoreMock(params?: {
       backend,
       threadId,
       branch,
+      expectedBranch,
     }: {
       backend: "codex" | "grok";
       threadId: string;
       branch?: string;
+      expectedBranch?: string;
     }) => {
       const key = `${backend}:${threadId}`;
       const current = overlays.get(key) ?? {
@@ -145,8 +147,24 @@ function createOverlayStoreMock(params?: {
         executionMode: "default",
         extraLinkedDirectories: [],
       };
+      const previousObservedBranch = current.observedGitBranch?.trim();
+      const nextObservedBranch = branch?.trim();
+      const fallbackExpectedBranch =
+        !current.gitBranch?.trim() &&
+        previousObservedBranch &&
+        nextObservedBranch &&
+        previousObservedBranch !== nextObservedBranch
+          ? previousObservedBranch
+          : undefined;
+      const requestedExpectedBranch =
+        expectedBranch?.trim() && expectedBranch.trim() !== nextObservedBranch
+          ? expectedBranch.trim()
+          : undefined;
       const next = {
         ...current,
+        gitBranch: current.gitBranch?.trim()
+          ? current.gitBranch
+          : requestedExpectedBranch ?? fallbackExpectedBranch,
         observedGitBranch: branch,
       } as ThreadOverlayState;
       overlays.set(key, next);
@@ -2960,6 +2978,60 @@ describe("DesktopBackendRegistry", () => {
       expectedBranch: "feat/thread-workspace-handoff-plan",
       observedBranch: "feat/thread-workspace-handoff-plan",
       drifted: false,
+    });
+
+    await registry.close();
+  });
+
+  it("preserves the renderer expected branch when a fresh thread list reports a new branch", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Moved thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      gitBranch: "fix/steering-composer-navigation",
+      observedGitBranch: "fix/steering-composer-navigation",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "full-access",
+          observedGitBranch: "fix/queued-composer-navigation",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [thread],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const response = await registry.checkThreadBranchDrift({
+      backend: "codex",
+      expectedBranch: "fix/queued-composer-navigation",
+      threadId: "thread-1",
+    });
+
+    expect(response).toMatchObject({
+      expectedBranch: "fix/queued-composer-navigation",
+      observedBranch: "fix/steering-composer-navigation",
+      drifted: true,
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "fix/queued-composer-navigation",
+      observedGitBranch: "fix/steering-composer-navigation",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3018,10 +3018,10 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("does not flag drift when observed branch is HEAD (restored archived snapshot)", async () => {
+  it("flags drift when a thread is still detached at HEAD after a turn", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-archived",
-      title: "Restored from archive",
+      title: "Detached after work",
       titleSource: "explicit",
       linkedDirectories: [
         {
@@ -3033,7 +3033,6 @@ describe("DesktopBackendRegistry", () => {
       ],
       source: "codex",
       gitBranch: "feature/work-from-archive",
-      // Worktree was restored to a snapshot ref → detached HEAD.
       observedGitBranch: "HEAD",
       updatedAt: 2,
     };
@@ -3065,8 +3064,9 @@ describe("DesktopBackendRegistry", () => {
     });
 
     expect(response).toMatchObject({
+      expectedBranch: "feature/work-from-archive",
       observedBranch: "HEAD",
-      drifted: false,
+      drifted: true,
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1497,7 +1497,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("shows HEAD for detached worktrees even when session metadata still names a source branch", async () => {
+  it("keeps the protocol branch when a workspace is detached at HEAD", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -1525,7 +1525,7 @@ describe("CodexAppServerClient", () => {
 
     expect(thread).toMatchObject({
       id: "019d88a2-0e0b-77f0-bfce-130ae8e37d8f",
-      gitBranch: "HEAD",
+      gitBranch: "codex/plan-slidev-theme-extraction",
       observedGitBranch: "HEAD",
     });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1431,7 +1431,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("surfaces the locally observed branch when protocol metadata omits the branch name", async () => {
+  it("keeps protocol branch metadata separate from the locally observed branch", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -1457,7 +1457,7 @@ describe("CodexAppServerClient", () => {
 
     expect(thread).toMatchObject({
       id: "thread-2",
-      gitBranch: "main",
+      gitBranch: undefined,
       observedGitBranch: "main",
     });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-branches-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore branch metadata", () => {
+  it("promotes legacy observed branch metadata before recording checkout drift", async () => {
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/expected",
+    });
+
+    const initialOverlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(initialOverlay?.gitBranch).toBeUndefined();
+    expect(initialOverlay?.observedGitBranch).toBe("feature/expected");
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/current",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "feature/expected",
+      observedGitBranch: "feature/current",
+    });
+  });
+
+  it("uses the caller supplied expected branch when recording checkout drift", async () => {
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/current",
+      expectedBranch: "feature/expected",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "feature/expected",
+      observedGitBranch: "feature/current",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -1,0 +1,69 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectPullRequestsForThread } from "../pr-status/pr-detection";
+import type { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
+
+const execFileAsync = promisify(execFile);
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("detectPullRequestsForThread", () => {
+  it("uses local branches pointing at HEAD when the thread is detached", async () => {
+    const repo = await createDetachedRepoWithBranchAtHead("fix/messaging-nonblocking-startup");
+    const fetchedBranches: string[] = [];
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
+        fetchedBranches.push(branch);
+        if (branch !== "fix/messaging-nonblocking-startup") {
+          return [];
+        }
+        return [
+          {
+            number: 271,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: `https://github.com/pwrdrvr/PwrAgent/pull/${branch}`,
+          },
+        ];
+      }),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "HEAD",
+      directoryPaths: [repo],
+    });
+
+    expect(fetchedBranches).toEqual(
+      expect.arrayContaining(["fix/messaging-nonblocking-startup"]),
+    );
+    expect(prs).toHaveLength(1);
+  });
+});
+
+async function createDetachedRepoWithBranchAtHead(branch: string): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
+  tempDirs.push(repo);
+  await git(repo, "init");
+  await git(repo, "config", "user.email", "test@example.com");
+  await git(repo, "config", "user.name", "PwrAgent Test");
+  await git(repo, "commit", "--allow-empty", "-m", "initial");
+  const sha = (await git(repo, "rev-parse", "HEAD")).trim();
+  await git(repo, "branch", branch, sha);
+  await git(repo, "checkout", "--detach", sha);
+  return repo;
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout;
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2377,10 +2377,13 @@ export class DesktopBackendRegistry {
       callerReason: "branch-drift",
       threadId: params.threadId,
     });
-    const expectedBranch = resolveExpectedThreadBranch({
-      overlay,
-      thread,
-    });
+    const requestedExpectedBranch = params.expectedBranch?.trim();
+    const expectedBranch =
+      requestedExpectedBranch ||
+      resolveExpectedThreadBranch({
+        overlay,
+        thread,
+      });
     const sourcePath = resolveThreadGitSourcePath(
       thread,
       overlay?.extraLinkedDirectories ?? [],
@@ -2390,13 +2393,14 @@ export class DesktopBackendRegistry {
       : thread?.observedGitBranch;
     const normalizedObservedBranch = observedBranch?.trim() || undefined;
 
+    const drifted = isBranchDrifted(expectedBranch, normalizedObservedBranch);
+
     await this.overlayStore.setThreadObservedBranch({
       backend: params.backend,
       threadId: params.threadId,
       branch: normalizedObservedBranch,
+      expectedBranch: drifted ? expectedBranch : undefined,
     });
-
-    const drifted = isBranchDrifted(expectedBranch, normalizedObservedBranch);
 
     backendRegistryLog.debug("checked thread branch drift", {
       backend: params.backend,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2844,13 +2844,6 @@ type EnrichedCodexThread = AppServerThreadSummary & {
   gitOriginUrl?: string;
 };
 
-function resolveDisplayGitBranch(params: {
-  gitBranch?: string;
-  observedGitBranch?: string;
-}): string | undefined {
-  return params.gitBranch ?? params.observedGitBranch;
-}
-
 function hydrateMissingLinkedDirectoriesFromSiblingRepos(
   threads: EnrichedCodexThread[]
 ): EnrichedCodexThread[] {
@@ -3704,10 +3697,7 @@ export class CodexAppServerClient {
         return {
           ...thread,
           projectKey,
-          gitBranch: resolveDisplayGitBranch({
-            gitBranch: thread.gitBranch,
-            observedGitBranch: enrichment.observedGitBranch,
-          }),
+          gitBranch: thread.gitBranch,
           linkedDirectories: enrichment.linkedDirectories,
           observedGitBranch: enrichment.observedGitBranch,
           source: "codex" as const

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2848,10 +2848,6 @@ function resolveDisplayGitBranch(params: {
   gitBranch?: string;
   observedGitBranch?: string;
 }): string | undefined {
-  if (params.observedGitBranch === "HEAD") {
-    return "HEAD";
-  }
-
   return params.gitBranch ?? params.observedGitBranch;
 }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -460,9 +460,11 @@ class DesktopAppServerService {
       threadId: request.threadId,
     });
     const existingPrs = existing?.prs ?? [];
+    const branch = request.branch.trim();
     // Terminal-state short-circuit: once a PR is merged or closed, we
-    // never re-query gh for that thread. The chip is frozen at its
-    // terminal color and we just hand back what's persisted.
+    // do not need to re-query gh for the same branch/directory lookup.
+    // A different lookup can mean the thread moved to a new branch after
+    // merging an older PR, so stale terminal chips must not block it.
     //
     // No log here on purpose — this path runs on every navigation
     // refresh tick (once a minute per renderer) for every thread with
@@ -474,7 +476,7 @@ class DesktopAppServerService {
     const hasTerminalPr = existingPrs.some(
       (pr) => pr.state === "merged" || pr.state === "closed",
     );
-    if (hasTerminalPr) {
+    if (hasTerminalPr && branch !== "HEAD" && existing?.prsRefreshKey === requestKey) {
       return {
         backend,
         threadId: request.threadId,
@@ -484,7 +486,6 @@ class DesktopAppServerService {
       };
     }
 
-    const branch = request.branch.trim();
     if (!branch || request.directoryPaths.length === 0) {
       return {
         backend,

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -1,8 +1,13 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type {
   LinkedDirectorySummary,
   PrSummary,
 } from "@pwragent/shared";
 import type { GithubPrFetcher } from "./github-pr-fetcher";
+
+const execFileAsync = promisify(execFile);
+const GIT_BRANCH_LOOKUP_TIMEOUT_MS = 2_000;
 
 /**
  * Detect PRs for a single thread by walking the resolved directory paths
@@ -31,11 +36,17 @@ export async function detectPullRequestsForThread(params: {
   }
 
   const results = await Promise.all(
-    dirs.map((cwd) =>
-      params.fetcher
-        .fetchAllPullRequestsForBranch({ cwd, branch })
-        .catch(() => []),
-    ),
+    dirs.map(async (cwd) => {
+      const branches = await resolvePrLookupBranches({ branch, cwd });
+      const prsByBranch = await Promise.all(
+        branches.map((lookupBranch) =>
+          params.fetcher
+            .fetchAllPullRequestsForBranch({ cwd, branch: lookupBranch })
+            .catch(() => []),
+        ),
+      );
+      return prsByBranch.flat();
+    }),
   );
 
   const seenByUrl = new Map<string, PrSummary>();
@@ -47,6 +58,46 @@ export async function detectPullRequestsForThread(params: {
     }
   }
   return [...seenByUrl.values()];
+}
+
+async function resolvePrLookupBranches(params: {
+  branch: string;
+  cwd: string;
+}): Promise<string[]> {
+  if (params.branch !== "HEAD") {
+    return [params.branch];
+  }
+
+  const branchesAtHead = await readLocalBranchesPointingAtHead(params.cwd);
+  return branchesAtHead.length > 0 ? branchesAtHead : ["HEAD"];
+}
+
+async function readLocalBranchesPointingAtHead(cwd: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      [
+        "for-each-ref",
+        "--points-at",
+        "HEAD",
+        "--format=%(refname:short)",
+        "refs/heads",
+      ],
+      {
+        cwd,
+        maxBuffer: 64 * 1024,
+        timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
+      },
+    );
+    return uniqueNonEmpty(
+      stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line && line !== "HEAD"),
+    );
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -480,6 +480,7 @@ export class SqliteOverlayStore {
   async setThreadObservedBranch(params: {
     backend: ThreadOverlayState["backend"];
     branch?: string;
+    expectedBranch?: string;
     threadId: string;
   }): Promise<ThreadOverlayState> {
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
@@ -491,19 +492,23 @@ export class SqliteOverlayStore {
     };
     const previousObservedBranch = current.observedGitBranch?.trim();
     const nextObservedBranch = params.branch?.trim();
-    const legacyHandoffExpectedBranch =
+    const fallbackExpectedBranch =
       !current.gitBranch?.trim() &&
       previousObservedBranch &&
       nextObservedBranch &&
-      previousObservedBranch !== nextObservedBranch &&
-      hasHandoffWorkspace(current.extraLinkedDirectories)
+      previousObservedBranch !== nextObservedBranch
         ? previousObservedBranch
+        : undefined;
+    const requestedExpectedBranch =
+      params.expectedBranch?.trim() &&
+      params.expectedBranch.trim() !== nextObservedBranch
+        ? params.expectedBranch.trim()
         : undefined;
     const nextState: ThreadOverlayState = {
       ...current,
       gitBranch: current.gitBranch?.trim()
         ? current.gitBranch
-        : legacyHandoffExpectedBranch,
+        : requestedExpectedBranch ?? fallbackExpectedBranch,
       observedGitBranch: params.branch,
     };
     this.putThread(threadKey, nextState);
@@ -696,12 +701,6 @@ function isHandoffDirectory(directory: LinkedDirectorySummary): boolean {
     directory.id.startsWith("pwragent-handoff:") ||
     directory.id.startsWith("pwragnt-handoff:")  // legacy prefix from pre-rebrand data
   );
-}
-
-function hasHandoffWorkspace(
-  directories: ThreadOverlayState["extraLinkedDirectories"] = [],
-): boolean {
-  return directories.some(isHandoffDirectory);
 }
 
 export type OverlayStoreLike = Pick<

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -18,6 +18,7 @@ export function ThreadMetaChips({
   thread,
 }: ThreadMetaChipsProps) {
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
+  const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const linkedDirectoryChips = includeLinkedDirectories
     ? thread.linkedDirectories.length > 0
       ? linkedDirectoryMode === "kind"
@@ -137,12 +138,15 @@ export function ThreadMetaChips({
 
       {linkedDirectoryChips}
 
-      {thread.gitBranch ? (
-        <span className="thread-row__chip thread-row__chip--mono">
+      {branchChip ? (
+        <span
+          className="thread-row__chip thread-row__chip--mono"
+          title={thread.gitBranch ? undefined : `Current branch: ${branchChip}`}
+        >
           <span aria-hidden="true" className="thread-row__chip-icon">
             <BranchIcon size={12} />
           </span>
-          {thread.gitBranch}
+          {branchChip}
         </span>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -155,6 +155,19 @@ describe("ThreadRow chip flow", () => {
     expect(onSelectThread).toHaveBeenCalledOnce();
   });
 
+  it("renders an observed branch chip without treating it as expected branch drift", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitBranch: undefined,
+        observedGitBranch: "fix/current",
+      },
+    });
+
+    expect(screen.getByText("fix/current")).toBeInTheDocument();
+    expect(screen.queryByText("now fix/current")).not.toBeInTheDocument();
+  });
+
   it("orders chips: meta → PR → bindings → reactions → add-reaction", () => {
     const threadWithEverything: NavigationThreadSummary = {
       ...baseThread,

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -172,4 +172,31 @@ describe("usePullRequestRefresh", () => {
       directoryPaths: ["/repo"],
     });
   });
+
+  it("uses the observed branch for PR refresh when it differs from the expected branch", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({ prs: [] }));
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+        selectedThread: buildThread({
+          gitBranch: "feat/old",
+          observedGitBranch: "fix/new-pr",
+          prs: [],
+        }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        branch: "fix/new-pr",
+        directoryPaths: ["/repo"],
+      });
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -32,7 +32,7 @@ export function usePullRequestRefresh(params: {
   const refresh = useCallback(
     (thread: NavigationThreadSummary): void => {
       if (!desktopApi?.refreshThreadPullRequests) return;
-      const branch = thread.gitBranch?.trim();
+      const branch = resolvePullRequestLookupBranch(thread);
       if (!branch) return;
       const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
       if (directoryPaths.length === 0) return;
@@ -116,7 +116,7 @@ export function usePullRequestRefresh(params: {
 }
 
 function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undefined {
-  const branch = thread.gitBranch?.trim();
+  const branch = resolvePullRequestLookupBranch(thread);
   if (!branch) return undefined;
 
   const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
@@ -127,6 +127,12 @@ function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undef
     branch,
     directoryPaths,
   });
+}
+
+function resolvePullRequestLookupBranch(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  return thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || undefined;
 }
 
 function prSummariesEqual(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -826,6 +826,7 @@ export function ThreadView(props: ThreadViewProps) {
     try {
       const result = await props.desktopApi.checkThreadBranchDrift({
         backend: thread.source,
+        expectedBranch: thread.gitBranch,
         threadId: thread.id,
       });
       // Stale-closure guard: user navigated away mid-IPC.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2852,6 +2852,11 @@ describe("ThreadView", () => {
       await waitFor(() => {
         expect(checkThreadBranchDrift).toHaveBeenCalledTimes(1);
       });
+      expect(checkThreadBranchDrift).toHaveBeenLastCalledWith({
+        backend: "codex",
+        expectedBranch: "feature/old",
+        threadId: "thread-branch",
+      });
       expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30_000);
 
       await act(async () => {
@@ -2860,6 +2865,11 @@ describe("ThreadView", () => {
 
       await waitFor(() => {
         expect(checkThreadBranchDrift).toHaveBeenCalledTimes(2);
+      });
+      expect(checkThreadBranchDrift).toHaveBeenLastCalledWith({
+        backend: "codex",
+        expectedBranch: "feature/old",
+        threadId: "thread-branch",
       });
     } finally {
       setIntervalSpy.mockRestore();

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -187,20 +187,9 @@ describe("OverlayStore", () => {
     });
   });
 
-  it("promotes legacy observed handoff branch metadata before recording checkout drift", async () => {
+  it("promotes legacy observed branch metadata before recording checkout drift", async () => {
     const store = await createStore();
 
-    await store.addLinkedDirectory({
-      backend: "codex",
-      threadId: "thread-1",
-      directory: {
-        id: "pwragent-handoff:codex:thread-1",
-        kind: "worktree",
-        label: "repo",
-        path: "/repo",
-        worktreePath: "/repo/.worktrees/repo-feature",
-      },
-    });
     await store.setThreadObservedBranch({
       backend: "codex",
       threadId: "thread-1",
@@ -218,6 +207,24 @@ describe("OverlayStore", () => {
       backend: "codex",
       threadId: "thread-1",
       branch: "feature/current",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "feature/expected",
+      observedGitBranch: "feature/current",
+    });
+  });
+
+  it("uses the caller supplied expected branch when recording checkout drift", async () => {
+    const store = await createStore();
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/current",
+      expectedBranch: "feature/expected",
     });
 
     await expect(

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -155,6 +155,36 @@ describe("refresh reconciliation", () => {
     expect(snapshot.threads[0]?.observedGitBranch).toBe("fix/testing-detached-head");
   });
 
+  it("prefers persisted observed branch metadata over stale thread cache after drift handling", async () => {
+    const store = await createStore();
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "HEAD",
+    });
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "fix/testing-detached-head",
+      expectedBranch: "HEAD",
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [
+        buildThread({
+          gitBranch: undefined,
+          observedGitBranch: "HEAD",
+        }),
+      ],
+    });
+
+    expect(snapshot.threads[0]?.gitBranch).toBe("HEAD");
+    expect(snapshot.threads[0]?.observedGitBranch).toBe("fix/testing-detached-head");
+  });
+
   it("uses overlay expected branch metadata when a workspace handoff updates the checkout", async () => {
     const store = await createStore();
 
@@ -183,7 +213,9 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.threads[0]?.gitBranch).toBe("feat/thread-workspace-handoff-plan");
-    expect(snapshot.threads[0]?.observedGitBranch).toBe("main");
+    expect(snapshot.threads[0]?.observedGitBranch).toBe(
+      "feat/thread-workspace-handoff-plan",
+    );
   });
 
   it("uses observed handoff branch metadata when legacy overlay state has no expected branch", async () => {

--- a/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
+++ b/packages/agent-core/src/__tests__/refresh-reconciliation.test.ts
@@ -131,7 +131,31 @@ describe("refresh reconciliation", () => {
     expect(snapshot.threads[0]?.observedGitBranch).toBe("fix/testing-detached-head");
   });
 
-  it("uses overlay branch metadata when a workspace handoff updates the checkout", async () => {
+  it("treats prior observed branch metadata as expected when the live checkout changes", async () => {
+    const store = await createStore();
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "HEAD",
+    });
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 2000,
+      threads: [
+        buildThread({
+          gitBranch: undefined,
+          observedGitBranch: "fix/testing-detached-head",
+        }),
+      ],
+    });
+
+    expect(snapshot.threads[0]?.gitBranch).toBe("HEAD");
+    expect(snapshot.threads[0]?.observedGitBranch).toBe("fix/testing-detached-head");
+  });
+
+  it("uses overlay expected branch metadata when a workspace handoff updates the checkout", async () => {
     const store = await createStore();
 
     await store.replaceWorkspaceLinkedDirectory({
@@ -159,9 +183,7 @@ describe("refresh reconciliation", () => {
     });
 
     expect(snapshot.threads[0]?.gitBranch).toBe("feat/thread-workspace-handoff-plan");
-    expect(snapshot.threads[0]?.observedGitBranch).toBe(
-      "feat/thread-workspace-handoff-plan",
-    );
+    expect(snapshot.threads[0]?.observedGitBranch).toBe("main");
   });
 
   it("uses observed handoff branch metadata when legacy overlay state has no expected branch", async () => {

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -67,6 +67,35 @@ function hasHandoffWorkspace(directories: LinkedDirectorySummary[]): boolean {
   return directories.map(normalizeLinkedDirectoryKind).some(isHandoffDirectory);
 }
 
+function resolveNavigationGitBranch(params: {
+  overlay?: ThreadOverlayState;
+  thread: AppServerThreadSummary;
+}): string | undefined {
+  const overlayBranch = params.overlay?.gitBranch?.trim();
+  if (overlayBranch) {
+    return overlayBranch;
+  }
+
+  const overlayObservedBranch = params.overlay?.observedGitBranch?.trim();
+  const threadObservedBranch = params.thread.observedGitBranch?.trim();
+  if (
+    overlayObservedBranch &&
+    threadObservedBranch &&
+    overlayObservedBranch !== threadObservedBranch
+  ) {
+    return overlayObservedBranch;
+  }
+
+  if (
+    overlayObservedBranch &&
+    hasHandoffWorkspace(params.overlay?.extraLinkedDirectories ?? [])
+  ) {
+    return overlayObservedBranch;
+  }
+
+  return params.thread.gitBranch;
+}
+
 export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
@@ -90,17 +119,13 @@ export function materializeNavigationThreads(params: {
       ...thread.linkedDirectories,
       ...(overlay?.extraLinkedDirectories ?? []),
     ]);
-    const overlayGitBranch =
-      overlay?.gitBranch ??
-      (overlay?.observedGitBranch && hasHandoffWorkspace(overlay.extraLinkedDirectories)
-        ? overlay.observedGitBranch
-        : undefined);
+    const gitBranch = resolveNavigationGitBranch({ overlay, thread });
     const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
 
     return {
       ...thread,
-      gitBranch: overlayGitBranch ?? thread.gitBranch,
-      observedGitBranch: overlay?.observedGitBranch ?? thread.observedGitBranch,
+      gitBranch,
+      observedGitBranch: thread.observedGitBranch ?? overlay?.observedGitBranch,
       retainedBranchDriftPairs: overlay?.retainedBranchDriftPairs,
       executionMode: overlay?.executionMode ?? thread.executionMode ?? "default",
       queuedExecutionMode: overlay?.queuedExecutionMode,

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -96,6 +96,20 @@ function resolveNavigationGitBranch(params: {
   return params.thread.gitBranch;
 }
 
+function resolveNavigationObservedBranch(params: {
+  overlay?: ThreadOverlayState;
+  thread: AppServerThreadSummary;
+}): string | undefined {
+  const overlayBranch = params.overlay?.gitBranch?.trim();
+  const overlayObservedBranch = params.overlay?.observedGitBranch?.trim();
+
+  if (overlayBranch && overlayObservedBranch) {
+    return overlayObservedBranch;
+  }
+
+  return params.thread.observedGitBranch ?? params.overlay?.observedGitBranch;
+}
+
 export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
@@ -120,12 +134,13 @@ export function materializeNavigationThreads(params: {
       ...(overlay?.extraLinkedDirectories ?? []),
     ]);
     const gitBranch = resolveNavigationGitBranch({ overlay, thread });
+    const observedGitBranch = resolveNavigationObservedBranch({ overlay, thread });
     const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
 
     return {
       ...thread,
       gitBranch,
-      observedGitBranch: thread.observedGitBranch ?? overlay?.observedGitBranch,
+      observedGitBranch,
       retainedBranchDriftPairs: overlay?.retainedBranchDriftPairs,
       executionMode: overlay?.executionMode ?? thread.executionMode ?? "default",
       queuedExecutionMode: overlay?.queuedExecutionMode,

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -503,6 +503,7 @@ export class OverlayStore {
   async setThreadObservedBranch(params: {
     backend: ThreadOverlayState["backend"];
     branch?: string;
+    expectedBranch?: string;
     threadId: string;
   }): Promise<ThreadOverlayState> {
     return await this.withData(async (data) => {
@@ -515,19 +516,23 @@ export class OverlayStore {
       };
       const previousObservedBranch = current.observedGitBranch?.trim();
       const nextObservedBranch = params.branch?.trim();
-      const legacyHandoffExpectedBranch =
+      const fallbackExpectedBranch =
         !current.gitBranch?.trim() &&
         previousObservedBranch &&
         nextObservedBranch &&
-        previousObservedBranch !== nextObservedBranch &&
-        hasHandoffWorkspace(current.extraLinkedDirectories)
+        previousObservedBranch !== nextObservedBranch
           ? previousObservedBranch
+          : undefined;
+      const requestedExpectedBranch =
+        params.expectedBranch?.trim() &&
+        params.expectedBranch.trim() !== nextObservedBranch
+          ? params.expectedBranch.trim()
           : undefined;
       const nextState: ThreadOverlayState = {
         ...current,
         gitBranch: current.gitBranch?.trim()
           ? current.gitBranch
-          : legacyHandoffExpectedBranch,
+          : requestedExpectedBranch ?? fallbackExpectedBranch,
         observedGitBranch: params.branch,
       };
       data.threads[threadKey] = nextState;
@@ -677,14 +682,4 @@ export class OverlayStore {
     await writeFile(tempPath, JSON.stringify(data, null, 2), "utf8");
     await rename(tempPath, this.filePath);
   }
-}
-
-function hasHandoffWorkspace(
-  directories: ThreadOverlayState["extraLinkedDirectories"] = [],
-): boolean {
-  return directories.some(
-    (directory) =>
-      directory.id.startsWith("pwragent-handoff:") ||
-      directory.id.startsWith("pwragnt-handoff:"),  // legacy prefix
-  );
 }

--- a/packages/shared/src/contracts/__tests__/branch-drift.test.ts
+++ b/packages/shared/src/contracts/__tests__/branch-drift.test.ts
@@ -23,8 +23,8 @@ describe("isBranchDrifted", () => {
     expect(isBranchDrifted("HEAD", "fix/release-skill-squash-merge")).toBe(true);
   });
 
-  it("returns false when observed is HEAD and expected is a named branch", () => {
-    expect(isBranchDrifted("main", "HEAD")).toBe(false);
+  it("returns true when observed is HEAD and expected is a named branch", () => {
+    expect(isBranchDrifted("main", "HEAD")).toBe(true);
   });
 
   it("returns false when both are HEAD", () => {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -162,6 +162,7 @@ export type SetThreadModelSettingsResponse = SetThreadModelSettingsRequest;
 
 export type CheckThreadBranchDriftRequest = {
   backend: AppServerBackendKind;
+  expectedBranch?: string;
   threadId: ThreadIdentifier;
 };
 

--- a/packages/shared/src/contracts/branch-drift.ts
+++ b/packages/shared/src/contracts/branch-drift.ts
@@ -3,6 +3,5 @@ export function isBranchDrifted(
   observed: string | undefined,
 ): boolean {
   if (!expected || !observed) return false;
-  if (observed === "HEAD") return false;
   return expected !== observed;
 }


### PR DESCRIPTION
## Summary

I fixed thread git and PR metadata refresh after a thread moves through branch changes, detached `HEAD`, and a new PR.

The desktop app now preserves the expected protocol branch when the observed workspace is detached, treats a still-detached workspace as branch drift when it differs from the expected branch, and refreshes PR metadata against the observed/current branch. For detached `HEAD`, PR detection now checks local branches pointing at `HEAD`, which catches the reported PR #271 case.

Fixes #276.

## Verification

I verified this with:

- `pnpm test packages/shared/src/contracts/__tests__/branch-drift.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/pr-detection.test.ts apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint`
