### PR TITLE
fix(desktop): preserve steering composer turns across navigation

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -57,6 +57,7 @@ import {
   useComposerDraftStore,
   type ComposerDraftSnapshot,
   type ComposerDraftStore,
+  type ComposerPendingSteerSnapshot,
   type ComposerQueuedTurnSnapshot,
 } from "./useComposerDraftStore";
 
@@ -876,6 +877,9 @@ export function Composer(props: ComposerProps) {
   const savedInitialQueuedTurn = props.thread
     ? draftStore.getQueuedTurn(composerScopeKey)
     : undefined;
+  const savedInitialPendingSteer = props.thread
+    ? draftStore.getPendingSteer(composerScopeKey)
+    : undefined;
   const hydratedInitialLaunchpad =
     savedInitialDraft || !props.launchpad
       ? undefined
@@ -930,7 +934,13 @@ export function Composer(props: ComposerProps) {
   const [queuedTurn, setQueuedTurnState] = useState<QueuedTurnDraft | undefined>(
     savedInitialQueuedTurn
   );
-  const [pendingSteer, setPendingSteer] = useState<PendingSteerDraft>();
+  const [pendingSteer, setPendingSteerState] = useState<
+    PendingSteerDraft | undefined
+  >(
+    savedInitialPendingSteer
+      ? { ...savedInitialPendingSteer, status: "pending" }
+      : undefined
+  );
   const [activeTurnId, setActiveTurnId] = useState<string | undefined>(
     props.activeTurnId
   );
@@ -1055,6 +1065,21 @@ export function Composer(props: ComposerProps) {
   };
   const isQueuedTurnStoreScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
+  const savePendingSteerSnapshot = (
+    scopeKey: string,
+    state?: ComposerPendingSteerSnapshot,
+  ): void => {
+    if (!isQueuedTurnStoreScope(scopeKey)) {
+      return;
+    }
+
+    if (!state || (!state.text.trim() && state.imageAttachments.length === 0)) {
+      draftStore.deletePendingSteer(scopeKey);
+      return;
+    }
+
+    draftStore.setPendingSteer(scopeKey, state);
+  };
   const saveQueuedTurnSnapshot = (
     scopeKey: string,
     state?: ComposerQueuedTurnSnapshot,
@@ -1073,6 +1098,27 @@ export function Composer(props: ComposerProps) {
   const setQueuedTurn = (nextQueuedTurn?: QueuedTurnDraft): void => {
     saveQueuedTurnSnapshot(composerScopeKey, nextQueuedTurn);
     setQueuedTurnState(nextQueuedTurn);
+  };
+  const setPendingSteer = (nextPendingSteer?: PendingSteerDraft): void => {
+    if (nextPendingSteer?.status === "pending") {
+      savePendingSteerSnapshot(composerScopeKey, nextPendingSteer);
+    } else {
+      savePendingSteerSnapshot(composerScopeKey);
+    }
+    setPendingSteerState(nextPendingSteer);
+  };
+  const updatePendingSteer = (
+    updater: (current?: PendingSteerDraft) => PendingSteerDraft | undefined,
+  ): void => {
+    setPendingSteerState((current) => {
+      const nextPendingSteer = updater(current);
+      if (nextPendingSteer?.status === "pending") {
+        savePendingSteerSnapshot(composerScopeKey, nextPendingSteer);
+      } else {
+        savePendingSteerSnapshot(composerScopeKey);
+      }
+      return nextPendingSteer;
+    });
   };
   const markComposerDraftSubmitted = (scopeKey: string): void => {
     if (!isDraftStoreScope(scopeKey)) {
@@ -1254,13 +1300,18 @@ export function Composer(props: ComposerProps) {
 
     if (props.thread) {
       const saved = draftStore.get(composerScopeKey);
+      const savedPendingSteer = draftStore.getPendingSteer(composerScopeKey);
       const savedQueuedTurn = draftStore.getQueuedTurn(composerScopeKey);
       setDraft(saved?.draft ?? "");
       setEditorDocument(saved?.editorDocument);
       setImageAttachments(saved?.imageAttachments ?? []);
       setSkillTokens(saved?.skillTokens ?? []);
+      setPendingSteerState(
+        savedPendingSteer ? { ...savedPendingSteer, status: "pending" } : undefined
+      );
       setQueuedTurnState(savedQueuedTurn);
     } else {
+      setPendingSteerState(undefined);
       setQueuedTurnState(undefined);
     }
     setSending(false);
@@ -1770,6 +1821,28 @@ export function Composer(props: ComposerProps) {
     });
   }, [activeTurnId, queuedTurn, sending, props.disabled, props.launchpad]);
 
+  useEffect(() => {
+    if (
+      !pendingSteer ||
+      pendingSteer.status !== "pending" ||
+      activeTurnId ||
+      props.launchpad
+    ) {
+      return;
+    }
+
+    if (queuedTurn) {
+      setComposerDraftFromCanonical(pendingSteer.text);
+      setImageAttachments(pendingSteer.imageAttachments);
+    } else {
+      setQueuedTurn({
+        text: pendingSteer.text,
+        imageAttachments: pendingSteer.imageAttachments,
+      });
+    }
+    setPendingSteer(undefined);
+  }, [activeTurnId, pendingSteer, props.launchpad, queuedTurn]);
+
   const queueCurrentDraft = (): void => {
     if (!hasComposerContent && imageAttachments.length === 0) {
       return;
@@ -1808,7 +1881,7 @@ export function Composer(props: ComposerProps) {
 
     setSendError(undefined);
     setSteering(true);
-    setPendingSteer((current) =>
+    updatePendingSteer((current) =>
       current?.text === pending.text &&
       current.imageAttachments === pending.imageAttachments
         ? { ...current, status: "steering" }
@@ -1842,7 +1915,7 @@ export function Composer(props: ComposerProps) {
         props.onPendingStatusChange?.(staleSteer.active ? "Thinking" : undefined);
         return;
       }
-      setPendingSteer((current) =>
+      updatePendingSteer((current) =>
         current?.text === pending.text &&
         current.imageAttachments === pending.imageAttachments
           ? { ...current, status: "pending" }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1320,7 +1320,6 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-    setPendingSteer(undefined);
   }, [composerScopeKey, draft, editorDocument, imageAttachments, skillTokens]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -948,6 +948,95 @@ describe("Composer", () => {
     });
   });
 
+  it("restores a pending steer after switching thread props away and back", async () => {
+    const draftStore = createComposerDraftStore();
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const baseProps = {
+      activeTurnId: "turn-1",
+      backends: [
+        {
+          ...backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                supportsReasoning: true,
+                supportsSteering: true,
+              },
+            ],
+          }),
+          capabilities: {
+            ...backendSummary("codex").capabilities,
+            steerTurn: true,
+          },
+        },
+      ],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        steerTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const threadA = {
+      id: "thread-1",
+      title: "Steerable thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB = {
+      ...threadA,
+      id: "thread-2",
+      title: "Another thread",
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        thread={threadA}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Keep steering through prop navigation" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter", metaKey: true });
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "Keep steering through prop navigation"
+    );
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />
+    );
+    expect(screen.queryByLabelText("Pending steer message")).not.toBeInTheDocument();
+
+    rerender(
+      <Composer
+        {...baseProps}
+        thread={threadA}
+      />
+    );
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "Keep steering through prop navigation"
+    );
+    expect(steerTurn).not.toHaveBeenCalled();
+  });
+
   it("sends a restored pending steer as the next turn when the active turn cleared while away", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -14,6 +14,7 @@ import { Composer } from "../Composer";
 import type {
   ComposerDraftSnapshot,
   ComposerDraftStore,
+  ComposerPendingSteerSnapshot,
   ComposerQueuedTurnSnapshot,
 } from "../useComposerDraftStore";
 
@@ -53,16 +54,24 @@ function chooseDropdownOption(label: string, optionName: string): void {
 
 function createComposerDraftStore(): ComposerDraftStore {
   const drafts = new Map<string, ComposerDraftSnapshot>();
+  const pendingSteers = new Map<string, ComposerPendingSteerSnapshot>();
   const queuedTurns = new Map<string, ComposerQueuedTurnSnapshot>();
   return {
     delete: (scopeKey) => {
       drafts.delete(scopeKey);
     },
     get: (scopeKey) => drafts.get(scopeKey),
+    deletePendingSteer: (scopeKey) => {
+      pendingSteers.delete(scopeKey);
+    },
     deleteQueuedTurn: (scopeKey) => {
       queuedTurns.delete(scopeKey);
     },
+    getPendingSteer: (scopeKey) => pendingSteers.get(scopeKey),
     getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey),
+    setPendingSteer: (scopeKey, snapshot) => {
+      pendingSteers.set(scopeKey, snapshot);
+    },
     setQueuedTurn: (scopeKey, snapshot) => {
       queuedTurns.set(scopeKey, snapshot);
     },
@@ -809,6 +818,223 @@ describe("Composer", () => {
     });
 
     expect(screen.queryByText("Steering now")).not.toBeInTheDocument();
+  });
+
+  it("restores a pending steer after navigating away and back", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const draftStore = createComposerDraftStore();
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const baseProps = {
+      activeTurnId: "turn-1",
+      backends: [
+        {
+          ...backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                supportsReasoning: true,
+                supportsSteering: true,
+              },
+            ],
+          }),
+          capabilities: {
+            ...backendSummary("codex").capabilities,
+            steerTurn: true,
+          },
+        },
+      ],
+      desktopApi: {
+        onAgentEvent: (callback: unknown) => {
+          agentEventHandler = callback as typeof agentEventHandler;
+          return () => undefined;
+        },
+        steerTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const threadA = {
+      id: "thread-1",
+      title: "Steerable thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB = {
+      ...threadA,
+      id: "thread-2",
+      title: "Another thread",
+    };
+
+    const { unmount } = render(
+      <Composer
+        {...baseProps}
+        thread={threadA}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Keep steering direction" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "Keep steering direction"
+    );
+    expect(steerTurn).not.toHaveBeenCalled();
+
+    unmount();
+    const { unmount: unmountThreadB } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />
+    );
+    expect(screen.queryByLabelText("Pending steer message")).not.toBeInTheDocument();
+
+    unmountThreadB();
+    render(
+      <Composer
+        {...baseProps}
+        thread={threadA}
+      />
+    );
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "Keep steering direction"
+    );
+    expect(steerTurn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "ready for steering",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "Keep steering direction" }],
+      });
+    });
+  });
+
+  it("sends a restored pending steer as the next turn when the active turn cleared while away", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const baseProps = {
+      backends: [
+        {
+          ...backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                supportsReasoning: true,
+                supportsSteering: true,
+              },
+            ],
+          }),
+          capabilities: {
+            ...backendSummary("codex").capabilities,
+            steerTurn: true,
+          },
+        },
+      ],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+        steerTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Steerable thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { unmount } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Continue after active turn" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter", metaKey: true });
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "Continue after active turn"
+    );
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(steerTurn).not.toHaveBeenCalled();
+
+    unmount();
+    render(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Continue after active turn" }],
+        })
+      );
+    });
+    expect(screen.queryByLabelText("Pending steer message")).not.toBeInTheDocument();
   });
 
   it("lets pending steers be edited before they are injected", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -15,17 +15,26 @@ export type ComposerQueuedTurnSnapshot = {
   imageAttachments: NavigationLaunchpadImageAttachment[];
 };
 
+export type ComposerPendingSteerSnapshot = {
+  text: string;
+  imageAttachments: NavigationLaunchpadImageAttachment[];
+};
+
 export type ComposerDraftStore = {
   delete(scopeKey: string): void;
   get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  deletePendingSteer(scopeKey: string): void;
   deleteQueuedTurn(scopeKey: string): void;
+  getPendingSteer(scopeKey: string): ComposerPendingSteerSnapshot | undefined;
   getQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
+  setPendingSteer(scopeKey: string, snapshot: ComposerPendingSteerSnapshot): void;
   setQueuedTurn(scopeKey: string, snapshot: ComposerQueuedTurnSnapshot): void;
   set(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
 };
 
 export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
+  const pendingSteerStoreRef = useRef(new Map<string, ComposerPendingSteerSnapshot>());
   const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot>());
 
   return useMemo(
@@ -34,10 +43,17 @@ export function useComposerDraftStore(): ComposerDraftStore {
         storeRef.current.delete(scopeKey);
       },
       get: (scopeKey) => storeRef.current.get(scopeKey),
+      deletePendingSteer: (scopeKey) => {
+        pendingSteerStoreRef.current.delete(scopeKey);
+      },
       deleteQueuedTurn: (scopeKey) => {
         queuedTurnStoreRef.current.delete(scopeKey);
       },
+      getPendingSteer: (scopeKey) => pendingSteerStoreRef.current.get(scopeKey),
       getQueuedTurn: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey),
+      setPendingSteer: (scopeKey, snapshot) => {
+        pendingSteerStoreRef.current.set(scopeKey, snapshot);
+      },
       setQueuedTurn: (scopeKey, snapshot) => {
         queuedTurnStoreRef.current.set(scopeKey, snapshot);
       },


### PR DESCRIPTION
## Summary

This fixes the steering side of the composer navigation bug that #242 addressed for queued messages.

Pending steer drafts now live in the renderer-level composer draft store by thread scope, so navigating away from an active thread and back restores the `Pending steer` pill instead of silently dropping the user’s steering instruction.

The restore path keeps steering semantics intact:

- pending steers are restored only as pending, not as in-flight `Steering now` work
- restored pending steers do not call `steerTurn` until the next injection opportunity
- if the active turn ended while the user was away, the pending steer becomes the next queued turn and sends through the normal queued-message path

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

The new tests cover restoring a pending steer after thread navigation and preserving the instruction when the active turn clears while the composer is unmounted.
