### PR TITLE
chore(npm): add placeholder pwragent package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pwragent",
+  "name": "pwragent-workspace",
   "version": "1.0.0-alpha.0",
   "private": true,
   "description": "Thread-centric coding agent desktop app",

--- a/packages/pwragent/LICENSE
+++ b/packages/pwragent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PwrDrvr LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pwragent/README.md
+++ b/packages/pwragent/README.md
@@ -1,0 +1,4 @@
+# PwrAgent
+
+Coming soon.
+

--- a/packages/pwragent/bin/pwragent.js
+++ b/packages/pwragent/bin/pwragent.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("PwrAgent is coming soon.");

--- a/packages/pwragent/package.json
+++ b/packages/pwragent/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "pwragent",
+  "version": "0.0.0",
+  "private": false,
+  "type": "module",
+  "description": "Coming soon: PwrAgent command-line tools.",
+  "author": "PwrDrvr LLC <harold@pwrdrvr.com>",
+  "license": "MIT",
+  "copyright": "Copyright (c) 2026 PwrDrvr LLC",
+  "homepage": "https://github.com/pwrdrvr/PwrAgent#readme",
+  "bugs": {
+    "url": "https://github.com/pwrdrvr/PwrAgent/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pwrdrvr/PwrAgent.git",
+    "directory": "packages/pwragent"
+  },
+  "keywords": [
+    "pwragent",
+    "agent",
+    "coding-agent",
+    "cli"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "files": [
+    "bin",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "pwragent": "bin/pwragent.js"
+  },
+  "scripts": {
+    "pack:check": "npm pack --dry-run"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,8 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
+  packages/pwragent: {}
+
   packages/shared: {}
 
 packages:


### PR DESCRIPTION
## Summary

I added a minimal public npm package for the unscoped `pwragent` name so PwrDrvr can reserve the brand namespace on npm.

The package lives at `packages/pwragent` and includes only:

- `LICENSE`
- `README.md`
- `bin/pwragent.js`
- `package.json`

I also renamed the private workspace root package from `pwragent` to `pwragent-workspace` so the repository can contain the publishable `pwragent` workspace package without a name collision.

## Validation

I verified the local package with:

- `node packages/pwragent/bin/pwragent.js`
- `pnpm --filter pwragent pack:check`
- `npm publish --dry-run`
- `pnpm lint:boundaries`

After publishing `pwragent@0.0.0` to npm, I also verified the registry package with:

- `npm view pwragent name version author license bin dist --json`
- `npm pack pwragent@0.0.0 --pack-destination .local/npm-registry-check`
- `tar -tvzf .local/npm-registry-check/pwragent-0.0.0.tgz`
- `npm exec --yes pwragent@0.0.0 --`

The published registry tarball contains exactly the four intended package files, and the CLI prints `PwrAgent is coming soon.`
