### PR TITLE
fix(desktop): count file-change lines by variant

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1669,6 +1669,146 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("counts added, removed, and updated FileChange variants from thread/read", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-file-change-counts", {
+      thread: {
+        id: "thread-file-change-counts",
+        turns: [
+          {
+            id: "turn-file-change-counts",
+            status: "completed",
+            startedAt: 1_763_500_100,
+            items: [
+              {
+                type: "fileChange",
+                id: "item-file-change",
+                status: "completed",
+                changes: [
+                  {
+                    path: "/repo/new-file.ts",
+                    kind: {
+                      type: "add",
+                      content: "first\nsecond\nthird\n"
+                    }
+                  },
+                  {
+                    path: "/repo/removed-file.ts",
+                    kind: {
+                      type: "delete",
+                      content: "old first\nold second"
+                    }
+                  },
+                  {
+                    path: "/repo/updated-file.ts",
+                    kind: {
+                      type: "update",
+                      unified_diff: [
+                        "--- a/updated-file.ts",
+                        "+++ b/updated-file.ts",
+                        "@@ -1,4 +1,6 @@",
+                        " unchanged",
+                        "-removed one",
+                        "-removed two",
+                        "+added one",
+                        "+added two",
+                        "+added three",
+                        "+added four"
+                      ].join("\n"),
+                      move_path: null
+                    }
+                  },
+                  {
+                    path: "/repo/empty-file.ts",
+                    kind: {
+                      type: "add",
+                      content: ""
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-file-change-counts"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "activity",
+        id: "activity-item-file-change",
+        summary: "Edited 4 files, +7, -4",
+        createdAt: 1_763_500_100_000,
+        status: "completed",
+        turn: {
+          id: "turn-file-change-counts",
+          startedAt: 1_763_500_100_000,
+          status: "completed"
+        },
+        details: [
+          expect.objectContaining({
+            label: "Add new-file.ts",
+            fileDiff: {
+              kind: "add",
+              diff: "first\nsecond\nthird\n",
+              additions: 3,
+              removals: 0
+            }
+          }),
+          expect.objectContaining({
+            label: "Delete removed-file.ts",
+            fileDiff: {
+              kind: "delete",
+              diff: "old first\nold second",
+              additions: 0,
+              removals: 2
+            }
+          }),
+          expect.objectContaining({
+            label: "Update updated-file.ts",
+            fileDiff: {
+              kind: "update",
+              diff: [
+                "--- a/updated-file.ts",
+                "+++ b/updated-file.ts",
+                "@@ -1,4 +1,6 @@",
+                " unchanged",
+                "-removed one",
+                "-removed two",
+                "+added one",
+                "+added two",
+                "+added three",
+                "+added four"
+              ].join("\n"),
+              additions: 4,
+              removals: 2
+            }
+          }),
+          expect.objectContaining({
+            label: "Add empty-file.ts",
+            fileDiff: {
+              kind: "add",
+              diff: "",
+              additions: 0,
+              removals: 0
+            }
+          })
+        ]
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("extracts thread status from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-idle-status", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1719,6 +1719,31 @@ describe("CodexAppServerClient", () => {
                     }
                   },
                   {
+                    path: "/repo/patch-added-file.ts",
+                    kind: {
+                      type: "add"
+                    },
+                    diff: [
+                      "--- /dev/null",
+                      "+++ b/patch-added-file.ts",
+                      "@@ -0,0 +1,2 @@",
+                      "+patch added one",
+                      "+patch added two"
+                    ].join("\n")
+                  },
+                  {
+                    path: "/repo/patch-deleted-file.ts",
+                    kind: {
+                      type: "delete"
+                    },
+                    diff: [
+                      "--- a/patch-deleted-file.ts",
+                      "+++ /dev/null",
+                      "@@ -1,1 +0,0 @@",
+                      "-patch deleted one"
+                    ].join("\n")
+                  },
+                  {
                     path: "/repo/empty-file.ts",
                     kind: {
                       type: "add",
@@ -1746,7 +1771,7 @@ describe("CodexAppServerClient", () => {
       {
         type: "activity",
         id: "activity-item-file-change",
-        summary: "Edited 4 files, +7, -4",
+        summary: "Edited 6 files, +9, -5",
         createdAt: 1_763_500_100_000,
         status: "completed",
         turn: {
@@ -1759,7 +1784,14 @@ describe("CodexAppServerClient", () => {
             label: "Add new-file.ts",
             fileDiff: {
               kind: "add",
-              diff: "first\nsecond\nthird\n",
+              diff: [
+                "--- /dev/null",
+                "+++ b/repo/new-file.ts",
+                "@@ -0,0 +1,3 @@",
+                "+first",
+                "+second",
+                "+third"
+              ].join("\n"),
               additions: 3,
               removals: 0
             }
@@ -1768,7 +1800,13 @@ describe("CodexAppServerClient", () => {
             label: "Delete removed-file.ts",
             fileDiff: {
               kind: "delete",
-              diff: "old first\nold second",
+              diff: [
+                "--- a/repo/removed-file.ts",
+                "+++ /dev/null",
+                "@@ -1,2 +0,0 @@",
+                "-old first",
+                "-old second"
+              ].join("\n"),
               additions: 0,
               removals: 2
             }
@@ -1794,10 +1832,43 @@ describe("CodexAppServerClient", () => {
             }
           }),
           expect.objectContaining({
+            label: "Add patch-added-file.ts",
+            fileDiff: {
+              kind: "add",
+              diff: [
+                "--- /dev/null",
+                "+++ b/patch-added-file.ts",
+                "@@ -0,0 +1,2 @@",
+                "+patch added one",
+                "+patch added two"
+              ].join("\n"),
+              additions: 2,
+              removals: 0
+            }
+          }),
+          expect.objectContaining({
+            label: "Delete patch-deleted-file.ts",
+            fileDiff: {
+              kind: "delete",
+              diff: [
+                "--- a/patch-deleted-file.ts",
+                "+++ /dev/null",
+                "@@ -1,1 +0,0 @@",
+                "-patch deleted one"
+              ].join("\n"),
+              additions: 0,
+              removals: 1
+            }
+          }),
+          expect.objectContaining({
             label: "Add empty-file.ts",
             fileDiff: {
               kind: "add",
-              diff: "",
+              diff: [
+                "--- /dev/null",
+                "+++ b/repo/empty-file.ts",
+                "@@ -0,0 +1,0 @@"
+              ].join("\n"),
               additions: 0,
               removals: 0
             }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1691,23 +1691,32 @@ function extractDiffText(change: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+type FileChangeText = {
+  source: "content" | "diff";
+  text: string;
+};
+
 function extractFileChangeText(params: {
   change: Record<string, unknown>;
   changeKind: Record<string, unknown> | null;
   changeType: "add" | "delete" | "update";
-}): string | undefined {
+}): FileChangeText | undefined {
   if (params.changeType === "add" || params.changeType === "delete") {
-    return (
+    const content =
       pickStringAllowEmpty(params.changeKind, ["content"]) ??
-      pickStringAllowEmpty(params.change, ["content"]) ??
-      extractDiffText(params.change)
-    );
+      pickStringAllowEmpty(params.change, ["content"]);
+    if (content !== undefined) {
+      return { source: "content", text: content };
+    }
+
+    const diff = extractDiffText(params.change);
+    return diff !== undefined ? { source: "diff", text: diff } : undefined;
   }
 
-  return (
+  const diff =
     pickStringAllowEmpty(params.changeKind, ["unified_diff", "unifiedDiff"]) ??
-    extractDiffText(params.change)
-  );
+    extractDiffText(params.change);
+  return diff !== undefined ? { source: "diff", text: diff } : undefined;
 }
 
 function summarizeDiff(diff: string): { additions: number; removals: number } {
@@ -1739,27 +1748,74 @@ function summarizeDiff(diff: string): { additions: number; removals: number } {
 }
 
 function countContentLines(content: string): number {
-  if (content.length === 0) {
-    return 0;
-  }
-
-  const lineCount = content.split("\n").length;
-  return content.endsWith("\n") ? lineCount - 1 : lineCount;
+  return splitFileContentLines(content).length;
 }
 
-function summarizeFileChangeText(
+function splitFileContentLines(content: string): string[] {
+  if (content.length === 0) {
+    return [];
+  }
+
+  const lines = content.split("\n");
+  if (content.endsWith("\n")) {
+    lines.pop();
+  }
+  return lines;
+}
+
+function summarizeFileChangeText(params: {
   changeType: "add" | "delete" | "update",
-  text: string
-): { additions: number; removals: number } {
-  if (changeType === "add") {
-    return { additions: countContentLines(text), removals: 0 };
+  text: FileChangeText;
+}): { additions: number; removals: number } {
+  if (params.text.source === "diff") {
+    return summarizeDiff(params.text.text);
   }
 
-  if (changeType === "delete") {
-    return { additions: 0, removals: countContentLines(text) };
+  if (params.changeType === "add") {
+    return { additions: countContentLines(params.text.text), removals: 0 };
   }
 
-  return summarizeDiff(text);
+  if (params.changeType === "delete") {
+    return { additions: 0, removals: countContentLines(params.text.text) };
+  }
+
+  return summarizeDiff(params.text.text);
+}
+
+function buildContentDiff(params: {
+  changeType: "add" | "delete" | "update";
+  content: string;
+  path?: string;
+}): string {
+  if (params.changeType === "update") {
+    return params.content;
+  }
+
+  const lines = splitFileContentLines(params.content);
+  const path = params.path?.replace(/^\/+/, "") ?? "file";
+  const hunkLineCount = lines.length;
+  const header =
+    params.changeType === "add"
+      ? [`--- /dev/null`, `+++ b/${path}`, `@@ -0,0 +1,${hunkLineCount} @@`]
+      : [`--- a/${path}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
+  const prefix = params.changeType === "add" ? "+" : "-";
+  return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
+}
+
+function buildFileChangeDiff(params: {
+  changeType: "add" | "delete" | "update";
+  text: FileChangeText;
+  path?: string;
+}): string {
+  if (params.text.source === "diff") {
+    return params.text.text;
+  }
+
+  return buildContentDiff({
+    changeType: params.changeType,
+    content: params.text.text,
+    path: params.path
+  });
 }
 
 function formatCommandLabel(command: string | undefined): string {
@@ -2113,9 +2169,19 @@ function summarizeActivityItems(
         const changeType = normalizeFileChangeKind(
           pickString(changeKind ?? {}, ["type"]) ?? pickString(change, ["kind"])
         );
-        const diff = extractFileChangeText({ change, changeKind, changeType });
+        const changeText = extractFileChangeText({ change, changeKind, changeType });
         const diffSummary =
-          diff !== undefined ? summarizeFileChangeText(changeType, diff) : undefined;
+          changeText !== undefined
+            ? summarizeFileChangeText({ changeType, text: changeText })
+            : undefined;
+        const diff =
+          changeText !== undefined
+            ? buildFileChangeDiff({
+                changeType,
+                text: changeText,
+                path: changePath
+              })
+            : undefined;
         changedFiles += 1;
         changedFileAdditions += diffSummary?.additions ?? 0;
         changedFileRemovals += diffSummary?.removals ?? 0;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -384,6 +384,23 @@ function pickRawString(
   return undefined;
 }
 
+function pickStringAllowEmpty(
+  record: Record<string, unknown> | null | undefined,
+  keys: string[]
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function pickNumber(
   record: Record<string, unknown>,
   keys: string[]
@@ -1674,6 +1691,25 @@ function extractDiffText(change: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+function extractFileChangeText(params: {
+  change: Record<string, unknown>;
+  changeKind: Record<string, unknown> | null;
+  changeType: "add" | "delete" | "update";
+}): string | undefined {
+  if (params.changeType === "add" || params.changeType === "delete") {
+    return (
+      pickStringAllowEmpty(params.changeKind, ["content"]) ??
+      pickStringAllowEmpty(params.change, ["content"]) ??
+      extractDiffText(params.change)
+    );
+  }
+
+  return (
+    pickStringAllowEmpty(params.changeKind, ["unified_diff", "unifiedDiff"]) ??
+    extractDiffText(params.change)
+  );
+}
+
 function summarizeDiff(diff: string): { additions: number; removals: number } {
   let additions = 0;
   let removals = 0;
@@ -1700,6 +1736,30 @@ function summarizeDiff(diff: string): { additions: number; removals: number } {
   }
 
   return { additions, removals };
+}
+
+function countContentLines(content: string): number {
+  if (content.length === 0) {
+    return 0;
+  }
+
+  const lineCount = content.split("\n").length;
+  return content.endsWith("\n") ? lineCount - 1 : lineCount;
+}
+
+function summarizeFileChangeText(
+  changeType: "add" | "delete" | "update",
+  text: string
+): { additions: number; removals: number } {
+  if (changeType === "add") {
+    return { additions: countContentLines(text), removals: 0 };
+  }
+
+  if (changeType === "delete") {
+    return { additions: 0, removals: countContentLines(text) };
+  }
+
+  return summarizeDiff(text);
 }
 
 function formatCommandLabel(command: string | undefined): string {
@@ -2053,8 +2113,9 @@ function summarizeActivityItems(
         const changeType = normalizeFileChangeKind(
           pickString(changeKind ?? {}, ["type"]) ?? pickString(change, ["kind"])
         );
-        const diff = extractDiffText(change);
-        const diffSummary = diff ? summarizeDiff(diff) : undefined;
+        const diff = extractFileChangeText({ change, changeKind, changeType });
+        const diffSummary =
+          diff !== undefined ? summarizeFileChangeText(changeType, diff) : undefined;
         changedFiles += 1;
         changedFileAdditions += diffSummary?.additions ?? 0;
         changedFileRemovals += diffSummary?.removals ?? 0;
@@ -2066,7 +2127,7 @@ function summarizeActivityItems(
           }`,
           path: changePath,
           status: itemStatus,
-          ...(diff && diffSummary
+          ...(diff !== undefined && diffSummary
             ? {
                 fileDiff: {
                   kind: changeType,


### PR DESCRIPTION
## Summary

I fixed the desktop Codex replay normalizer so file-change activity counts respect the protocol variant instead of treating every change payload as a unified diff.

This closes #274.

## Root Cause

`thread/read` can return file changes in two supported shapes:

- Raw `content` for `add` and `delete` variants.
- Unified patches through `diff` / `patch` / `unified_diff` fields.

The previous counting path only handled unified patches correctly. The first fix counted add/delete raw content, but review caught that patch-backed add/delete entries could then be miscounted as raw content. I split those formats explicitly.

## Changes

- Count raw add/delete `content` by file-content lines, with correct trailing-newline behavior.
- Preserve patch-backed add/delete entries as unified diffs and count them with the existing diff parser.
- Convert raw add/delete content into synthetic unified diffs before storing `fileDiff.diff`, so transcript diff rendering still works.
- Add regression coverage for raw-content adds/deletes, patch-backed adds/deletes, updates, aggregate rollups, and empty files.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts -t "counts added"`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
