### PR TITLE
fix(desktop): clarify branch drift dialog

### DIFF
--- a/apps/desktop/e2e/thread-branch-drift.spec.ts
+++ b/apps/desktop/e2e/thread-branch-drift.spec.ts
@@ -162,6 +162,27 @@ async function createBranchDriftFixture(): Promise<{
   };
 }
 
+function readThreadPayload(homeDir: string): Record<string, unknown> {
+  const dbPath = path.join(
+    homeDir,
+    ".pwragent",
+    "profiles",
+    "default",
+    "state",
+    "state.db",
+  );
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare("SELECT payload FROM threads WHERE thread_id = ?")
+      .get("codex:thread-branch-drift") as { payload: string } | undefined;
+    expect(row).toBeDefined();
+    return JSON.parse(row!.payload) as Record<string, unknown>;
+  } finally {
+    db.close();
+  }
+}
+
 test("keeps the branch drift warning open after refreshing observed checkout state", async () => {
   const fixture = await createBranchDriftFixture();
   const app = await launchElectronApp({
@@ -178,33 +199,92 @@ test("keeps the branch drift warning open after refreshing observed checkout sta
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText("codex/expected-branch");
     await expect(dialog).toContainText("codex/current-branch");
+    await expect(dialog).toContainText("I'll switch back");
+    await expect(dialog).toContainText("Keep current branch");
+    await expect(
+      app.window.getByRole("button", {
+        name: "Keep warning. I'll switch back to codex/expected-branch",
+      }),
+    ).toBeVisible();
+    await expect(
+      app.window.getByRole("button", {
+        name: "Use current branch. Continue on codex/current-branch",
+      }),
+    ).toBeVisible();
 
     await app.window.waitForTimeout(7_000);
 
     await expect(dialog).toBeVisible();
 
-    const dbPath = path.join(
-      fixture.homeDir,
-      ".pwragent",
-      "profiles",
-      "default",
-      "state",
-      "state.db",
-    );
-    const db = new Database(dbPath, { readonly: true });
-    try {
-      const row = db
-        .prepare("SELECT payload FROM threads WHERE thread_id = ?")
-        .get("codex:thread-branch-drift") as { payload: string } | undefined;
-      expect(row).toBeDefined();
-      const thread = JSON.parse(row!.payload);
-      expect(thread).toMatchObject({
-        gitBranch: "codex/expected-branch",
-        observedGitBranch: "codex/current-branch",
-      });
-    } finally {
-      db.close();
-    }
+    expect(readThreadPayload(fixture.homeDir)).toMatchObject({
+      gitBranch: "codex/expected-branch",
+      observedGitBranch: "codex/current-branch",
+    });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("keeps the branch drift indicator when the user keeps the warning", async () => {
+  const fixture = await createBranchDriftFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      HOME: fixture.homeDir,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", {
+        name: "Keep warning. I'll switch back to codex/expected-branch",
+      })
+      .click();
+
+    await expect(
+      app.window.getByRole("dialog", { name: "Thread branch changed" }),
+    ).toBeHidden();
+    await expect(app.window.getByText(/Branch warning:/)).toBeVisible();
+    expect(readThreadPayload(fixture.homeDir)).toMatchObject({
+      gitBranch: "codex/expected-branch",
+      observedGitBranch: "codex/current-branch",
+      retainedBranchDriftPairs: [
+        {
+          expectedBranch: "codex/expected-branch",
+          observedBranch: "codex/current-branch",
+        },
+      ],
+    });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("updates the expected branch when the user accepts the current branch", async () => {
+  const fixture = await createBranchDriftFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      HOME: fixture.homeDir,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", {
+        name: "Use current branch. Continue on codex/current-branch",
+      })
+      .click();
+
+    await expect(
+      app.window.getByRole("dialog", { name: "Thread branch changed" }),
+    ).toBeHidden();
+    expect(readThreadPayload(fixture.homeDir)).toMatchObject({
+      gitBranch: "codex/current-branch",
+      observedGitBranch: "codex/current-branch",
+    });
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -1,6 +1,7 @@
-import type {
-  MessagingChannelKind,
-  NavigationThreadSummary,
+import {
+  isBranchDrifted,
+  type MessagingChannelKind,
+  type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
@@ -25,6 +26,10 @@ function missingDirectoryPath(thread: NavigationThreadSummary): string | undefin
 
 export function ThreadHeader(props: ThreadHeaderProps) {
   const missingPath = missingDirectoryPath(props.thread);
+  const branchDrifted = isBranchDrifted(
+    props.thread.gitBranch,
+    props.thread.observedGitBranch,
+  );
 
   return (
     <header className="thread-header">
@@ -44,6 +49,12 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           <p className="thread-header__warning" role="alert">
             This thread is linked to a directory that no longer exists:{" "}
             <code>{missingPath}</code>
+          </p>
+        ) : null}
+        {branchDrifted ? (
+          <p className="thread-header__warning" role="status">
+            Branch warning: this thread expects <code>{props.thread.gitBranch}</code>, but the
+            worktree is on <code>{props.thread.observedGitBranch}</code>.
           </p>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -753,6 +753,19 @@ export function ThreadView(props: ThreadViewProps) {
     ? `${selectedThread.source}:${selectedThread.id}`
     : undefined;
 
+  useEffect(() => {
+    if (!branchDriftDialog) return;
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !branchDriftBusy) {
+        setBranchDriftDialog(undefined);
+      }
+    };
+
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [branchDriftBusy, branchDriftDialog]);
+
   const branchDriftRetained = (
     thread: NavigationThreadSummary,
     expectedBranch: string,
@@ -1651,38 +1664,83 @@ export function ThreadView(props: ThreadViewProps) {
             className="workspace-handoff-dialog"
             role="dialog"
           >
-            <h2 id="branch-drift-title">Thread branch changed</h2>
+            <div className="workspace-handoff-dialog__header">
+              <h2 id="branch-drift-title">Thread branch changed</h2>
+              <button
+                aria-label="Close branch warning"
+                className="workspace-handoff-dialog__close"
+                disabled={branchDriftBusy}
+                type="button"
+                onClick={() => {
+                  setBranchDriftDialog(undefined);
+                }}
+              >
+                x
+              </button>
+            </div>
             <p>
-              This thread was working on branch{" "}
-              <strong>{branchDriftDialog.expectedBranch}</strong> and now has moved to branch{" "}
-              <strong>{branchDriftDialog.observedBranch}</strong>.
+              The worktree is already on a different branch. PwrAgent will not change git state
+              for you.
             </p>
-            <p>
-              Some context understood by the agent may have changed. Asking the agent to
-              continue with a change that is no longer available on the current branch will not
-              work.
-            </p>
-            <dl className="workspace-handoff-dialog__summary">
+            <dl className="workspace-handoff-dialog__branch-path">
               <div>
-                <dt>Expected branch</dt>
+                <dt>Thread expects</dt>
                 <dd>{branchDriftDialog.expectedBranch}</dd>
               </div>
+              <span aria-hidden="true" className="workspace-handoff-dialog__branch-arrow">
+                -&gt;
+              </span>
               <div>
-                <dt>Current branch</dt>
+                <dt>Worktree is on</dt>
                 <dd>{branchDriftDialog.observedBranch}</dd>
               </div>
             </dl>
+            <p>
+              If earlier turns made commits on{" "}
+              <code>{branchDriftDialog.expectedBranch}</code>, those commits may not be visible
+              on <code>{branchDriftDialog.observedBranch}</code>. Continuing now operates on the
+              current branch.
+            </p>
+            <div className="workspace-handoff-dialog__comparison" aria-label="Branch choices">
+              <section>
+                <h3>I'll switch back</h3>
+                <p>
+                  Keep the warning because the thread should still expect{" "}
+                  <code>{branchDriftDialog.expectedBranch}</code>.
+                </p>
+                <p>
+                  Next: switch the worktree back to{" "}
+                  <code>{branchDriftDialog.expectedBranch}</code> yourself.
+                </p>
+              </section>
+              <section>
+                <h3>Keep current branch</h3>
+                <p>
+                  Treat <code>{branchDriftDialog.observedBranch}</code> as the branch this thread
+                  should use from now on.
+                </p>
+                <p>
+                  Next: start the next turn on{" "}
+                  <code>{branchDriftDialog.observedBranch}</code> with no warning.
+                </p>
+              </section>
+            </div>
             {branchDriftError ? (
               <p className="workspace-handoff-dialog__error">{branchDriftError}</p>
             ) : null}
             <div className="workspace-handoff-dialog__actions">
               <button
-                className="button-secondary"
+                aria-label={
+                  branchDriftDialog.reason === "turn"
+                    ? `Cancel turn. I'll switch back to ${branchDriftDialog.expectedBranch}`
+                    : `Keep warning. I'll switch back to ${branchDriftDialog.expectedBranch}`
+                }
+                className="button-secondary workspace-handoff-dialog__action"
                 disabled={branchDriftBusy}
                 title={
                   branchDriftDialog.reason === "turn"
-                    ? "Cancel this send and leave the expected branch unchanged."
-                    : "Keep the detected branch warning visible so you can switch back to the expected branch."
+                    ? `Cancel this send and keep the warning for ${branchDriftDialog.expectedBranch}.`
+                    : `Keep the warning so you can switch back to ${branchDriftDialog.expectedBranch}.`
                 }
                 type="button"
                 onClick={async () => {
@@ -1714,12 +1772,14 @@ export function ThreadView(props: ThreadViewProps) {
                   }
                 }}
               >
-                {branchDriftDialog.reason === "turn"
-                  ? "Cancel"
-                  : "Retain Expected Branch"}
+                <span>
+                  {branchDriftDialog.reason === "turn" ? "Cancel Turn" : "Keep Warning"}
+                </span>
+                <small>I'll switch back to {branchDriftDialog.expectedBranch}</small>
               </button>
               <button
-                className="button-primary"
+                aria-label={`Use current branch. Continue on ${branchDriftDialog.observedBranch}`}
+                className="button-primary workspace-handoff-dialog__action"
                 disabled={branchDriftBusy}
                 type="button"
                 onClick={async () => {
@@ -1744,7 +1804,8 @@ export function ThreadView(props: ThreadViewProps) {
                   }
                 }}
               >
-                Update Expected Branch
+                <span>Use Current Branch</span>
+                <small>Continue on {branchDriftDialog.observedBranch}</small>
               </button>
             </div>
           </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2782,11 +2782,23 @@ describe("ThreadView", () => {
     );
 
     const dialog = await screen.findByRole("dialog", { name: "Thread branch changed" });
+    expect(dialog).toHaveTextContent(/Thread expects\s*feature\/old/);
+    expect(dialog).toHaveTextContent(/Worktree is on\s*main/);
+    expect(dialog).toHaveTextContent("I'll switch back");
+    expect(dialog).toHaveTextContent("Keep current branch");
     expect(dialog).toHaveTextContent(
-      "This thread was working on branch feature/old and now has moved to branch main",
+      "If earlier turns made commits on feature/old, those commits may not be visible on main",
     );
+    expect(
+      within(dialog).getByRole("button", {
+        name: "Keep warning. I'll switch back to feature/old",
+      }),
+    ).toBeInTheDocument();
+    const useCurrentBranchButton = within(dialog).getByRole("button", {
+      name: "Use current branch. Continue on main",
+    });
 
-    fireEvent.click(within(dialog).getByRole("button", { name: "Update Expected Branch" }));
+    fireEvent.click(useCurrentBranchButton);
 
     await waitFor(() => {
       expect(updateThreadExpectedBranch).toHaveBeenCalledWith({
@@ -2796,6 +2808,70 @@ describe("ThreadView", () => {
       });
     });
     expect(refreshNavigation).toHaveBeenCalled();
+  });
+
+  it("can dismiss the branch drift dialog while keeping a visible drift indicator", async () => {
+    const updateThreadExpectedBranch = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      branch: "main",
+      updatedAt: Date.now(),
+    }));
+    const retainThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      expectedBranch: "feature/old",
+      observedBranch: "main",
+      retainedAt: Date.now(),
+    }));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{
+          retainThreadBranchDrift,
+          updateThreadExpectedBranch,
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-branch",
+          title: "Branch drift",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "feature/old",
+          observedGitBranch: "main",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "Thread branch changed" });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close branch warning" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Thread branch changed" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(updateThreadExpectedBranch).not.toHaveBeenCalled();
+    expect(retainThreadBranchDrift).not.toHaveBeenCalled();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Branch warning: this thread expects feature/old, but the worktree is on main.",
+    );
   });
 
   it("checks branch drift on selection and focus without background polling", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6242,12 +6242,19 @@ textarea,
 }
 
 .workspace-handoff-dialog {
-  width: min(460px, 100%);
+  width: min(680px, 100%);
   padding: 16px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+}
+
+.workspace-handoff-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .workspace-handoff-dialog h2 {
@@ -6257,6 +6264,28 @@ textarea,
   line-height: 1.25;
 }
 
+.workspace-handoff-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-muted);
+  background: var(--bg-input);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.workspace-handoff-dialog__close:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
 .workspace-handoff-dialog p {
   margin: 10px 0 0;
   color: var(--text-secondary);
@@ -6264,8 +6293,16 @@ textarea,
   line-height: 1.45;
 }
 
-.workspace-handoff-dialog__summary {
+.workspace-handoff-dialog code {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.workspace-handoff-dialog__branch-path {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
   gap: 8px;
   margin: 14px 0 0;
   padding: 10px 12px;
@@ -6274,11 +6311,11 @@ textarea,
   background: var(--bg-input);
 }
 
-.workspace-handoff-dialog__summary div {
+.workspace-handoff-dialog__branch-path div {
   min-width: 0;
 }
 
-.workspace-handoff-dialog__summary dt {
+.workspace-handoff-dialog__branch-path dt {
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 700;
@@ -6286,11 +6323,45 @@ textarea,
   text-transform: uppercase;
 }
 
-.workspace-handoff-dialog__summary dd {
+.workspace-handoff-dialog__branch-path dd {
   margin: 4px 0 0;
   overflow-wrap: anywhere;
   color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.workspace-handoff-dialog__branch-arrow {
+  color: var(--accent);
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.workspace-handoff-dialog__comparison {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.workspace-handoff-dialog__comparison section {
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+}
+
+.workspace-handoff-dialog__comparison h3 {
+  margin: 0;
+  color: var(--text-primary);
   font-size: 13px;
+  line-height: 1.3;
+}
+
+.workspace-handoff-dialog__comparison p {
+  margin-top: 8px;
 }
 
 .workspace-handoff-dialog__field {
@@ -6351,6 +6422,21 @@ textarea,
   justify-content: flex-end;
   gap: 10px;
   margin-top: 16px;
+}
+
+.workspace-handoff-dialog__action {
+  display: inline-grid;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+}
+
+.workspace-handoff-dialog__action small {
+  max-width: 220px;
+  overflow-wrap: anywhere;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
 }
 
 .composer__checkbox {
@@ -6929,6 +7015,23 @@ textarea,
 
   .composer__review-options {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workspace-handoff-dialog__branch-path,
+  .workspace-handoff-dialog__comparison {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workspace-handoff-dialog__branch-arrow {
+    display: none;
+  }
+
+  .workspace-handoff-dialog__actions {
+    flex-direction: column;
+  }
+
+  .workspace-handoff-dialog__action {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary

- Reworked the "Thread branch changed" dialog around user intent instead of expected-branch metadata operations.
- Added prominent expected/current branch presentation, a two-column choice comparison, and concrete consequence copy.
- Added a neutral close/Esc path that leaves branch drift visible through a persistent selected-thread warning.
- Expanded renderer and Electron E2E coverage for dismissing, keeping the warning, and accepting the current branch.

## Why

Users were choosing "Retain Expected Branch" because it sounded like the safe option, even when they intentionally switched branches and wanted the thread to follow the new branch. The old dialog described the internal metadata operation instead of what the user was promising to do next.

## Verification

I verified:

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e -- thread-branch-drift.spec.ts`
- `git diff --check`
