### PR TITLE
feat(messaging): show channel binding notifications

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -209,6 +209,29 @@ describe("MessagingController", () => {
       .resolves.toMatchObject({
         revokedAt: 1000,
       });
+    expect(harness.recordMessagingBindingTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "old-thread",
+        transition: expect.objectContaining({
+          action: "unbound",
+          bindingId: "binding:telegram:dm::chat-1:codex:old-thread",
+          platform: "telegram",
+          occurredAt: 1000,
+        }),
+      }),
+    );
+    expect(harness.recordMessagingBindingTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "new-thread-1",
+        transition: expect.objectContaining({
+          action: "bound",
+          platform: "telegram",
+          occurredAt: 1000,
+        }),
+      }),
+    );
   });
 
   it("binds a callback-selected thread to the channel", async () => {
@@ -231,6 +254,19 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       authorizedActorIds: ["user-1"],
     });
+    expect(harness.recordMessagingBindingTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        transition: expect.objectContaining({
+          action: "bound",
+          bindingId: "binding:telegram:dm::chat-1:codex:thread-1",
+          conversationKind: "dm",
+          platform: "telegram",
+          occurredAt: 1000,
+        }),
+      }),
+    );
     expect(harness.delivered.find((intent) => intent.kind === "confirmation")).toMatchObject({
       kind: "confirmation",
       title: "Thread bound",
@@ -368,6 +404,16 @@ describe("MessagingController", () => {
     harness.onBindingChanged.mockClear();
     await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
     expect(harness.onBindingChanged).toHaveBeenCalled();
+    expect(harness.recordMessagingBindingTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        transition: expect.objectContaining({
+          action: "unbound",
+          platform: "telegram",
+        }),
+      }),
+    );
   });
 
   it("routes text to the bound thread after a /resume → select-thread bind", async () => {
@@ -4005,6 +4051,7 @@ async function createHarness(options?: {
   listBackends: ReturnType<typeof vi.fn>;
   onBindingChanged: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
+  recordMessagingBindingTransition: ReturnType<typeof vi.fn>;
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
   setThreadModelSettings: ReturnType<typeof vi.fn>;
   startThread: ReturnType<typeof vi.fn>;
@@ -4144,6 +4191,7 @@ async function createHarness(options?: {
     backends: [buildBackendSummary()],
   }));
   const readThreadStatus = vi.fn(async () => undefined);
+  const recordMessagingBindingTransition = vi.fn(async () => undefined);
   const submitServerRequest = vi.fn(async (request: SubmitServerRequestRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -4158,6 +4206,7 @@ async function createHarness(options?: {
     interruptTurn,
     listBackends,
     readThreadStatus,
+    recordMessagingBindingTransition,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
@@ -4197,6 +4246,7 @@ async function createHarness(options?: {
     listBackends,
     onBindingChanged,
     readThreadStatus,
+    recordMessagingBindingTransition,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -26,6 +26,7 @@ import type {
   SteerTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  ThreadMessagingBindingTransition,
 } from "@pwragent/shared";
 import type {
   MessagingDeliveryResult,
@@ -93,6 +94,11 @@ export type MessagingBackendBridge = {
   setThreadModelSettings?(
     request: SetThreadModelSettingsRequest,
   ): Promise<SetThreadModelSettingsResponse>;
+  recordMessagingBindingTransition?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    transition: ThreadMessagingBindingTransition;
+  }): Promise<void>;
   submitServerRequest?(
     request: SubmitServerRequestRequest,
   ): Promise<SubmitServerRequestResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -13,6 +13,7 @@ import type {
   NavigationDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
+  ThreadMessagingBindingTransition,
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "@pwragent/shared";
@@ -3429,6 +3430,7 @@ export class MessagingController {
       bindingId: binding.id,
       revokedAt: this.now(),
     });
+    await this.recordBindingTransition("unbound", binding);
     this.notifyBindingChanged("detach");
     await this.deliver(
       buildConfirmationIntent({
@@ -3759,11 +3761,50 @@ export class MessagingController {
     }
   }
 
+  private async recordBindingTransition(
+    action: ThreadMessagingBindingTransition["action"],
+    binding: MessagingBindingRecord,
+    occurredAt: number = this.now(),
+  ): Promise<void> {
+    if (!this.options.backend.recordMessagingBindingTransition) {
+      return;
+    }
+    const conversation = binding.channel.conversation;
+    const transition: ThreadMessagingBindingTransition = {
+      id: randomUUID(),
+      action,
+      bindingId: binding.id,
+      platform: binding.channel.channel,
+      conversationKind: conversation.kind,
+      conversationTitle: conversation.title,
+      parentTitle: conversation.parentTitle,
+      ancestorTitle: conversation.ancestorTitle,
+      occurredAt,
+    };
+    try {
+      await this.options.backend.recordMessagingBindingTransition({
+        backend: binding.backend,
+        threadId: binding.threadId,
+        transition,
+      });
+    } catch (error) {
+      this.logger.debug?.("messaging binding-transition audit failed", {
+        action,
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: binding.threadId,
+      });
+    }
+  }
+
   private async bindChannelToThread(
     event: MessagingInboundCallbackEvent,
     target: { backend: AppServerBackendKind; threadId: ThreadIdentifier },
   ): Promise<MessagingBindingRecord> {
     const now = this.now();
+    const previousBinding = await this.options.store.findActiveBindingForChannel(
+      event.channel,
+    );
     const binding: MessagingBindingRecord = {
       id: `binding:${buildMessagingConversationKey(event.channel)}:${target.backend}:${target.threadId}`,
       channel: event.channel,
@@ -3775,7 +3816,31 @@ export class MessagingController {
       updatedAt: now,
       displayName: event.actor.displayName ?? event.actor.username,
     };
+    if (
+      previousBinding &&
+      (previousBinding.backend !== binding.backend ||
+        previousBinding.threadId !== binding.threadId)
+    ) {
+      await this.options.store.revokeBinding({
+        bindingId: previousBinding.id,
+        revokedAt: now,
+      });
+    }
     const upserted = await this.options.store.upsertBinding(binding);
+    if (
+      previousBinding &&
+      (previousBinding.backend !== upserted.backend ||
+        previousBinding.threadId !== upserted.threadId)
+    ) {
+      await this.recordBindingTransition("unbound", previousBinding, now);
+    }
+    if (
+      !previousBinding ||
+      previousBinding.backend !== upserted.backend ||
+      previousBinding.threadId !== upserted.threadId
+    ) {
+      await this.recordBindingTransition("bound", upserted, now);
+    }
     // Retire any channel-scoped pending intents that pre-date this
     // bind. Without this, the resume browser's pending intent (and any
     // other pre-binding picker intent) survives the bind, and the next
@@ -3938,6 +4003,7 @@ export class MessagingController {
         bindingId: binding.id,
         revokedAt: this.now(),
       });
+      await this.recordBindingTransition("unbound", binding);
       this.notifyBindingChanged("permanent-delivery-failure");
       this.logger.debug?.("messaging binding revoked after permanent delivery failure", {
         bindingId: binding.id,

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -26,6 +26,7 @@ import type {
   StartThreadResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  ThreadMessagingBindingTransition,
 } from "@pwragent/shared";
 import type { MessagingBackendBridge } from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
@@ -128,6 +129,14 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     request: SetThreadModelSettingsRequest,
   ): Promise<SetThreadModelSettingsResponse> {
     return await this.registry.setThreadModelSettings(request);
+  }
+
+  async recordMessagingBindingTransition(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    transition: ThreadMessagingBindingTransition;
+  }): Promise<void> {
+    await getDesktopOverlayStore().appendMessagingBindingTransition(request);
   }
 
   async submitServerRequest(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { MessagingController } from "./core/messaging-controller";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import type {
@@ -411,6 +412,7 @@ export class DesktopMessagingRuntime {
     const notifiedPlatform = await this.dispatchRevokeToControllers(binding);
     if (!notifiedPlatform) {
       await store.revokeBinding({ bindingId: binding.id });
+      await this.recordBindingUnbound(binding);
       this.broadcastBindingsChanged();
     }
 
@@ -458,6 +460,7 @@ export class DesktopMessagingRuntime {
 
     for (const binding of fallbackBindings) {
       await store.revokeBinding({ bindingId: binding.id });
+      await this.recordBindingUnbound(binding);
     }
     if (fallbackBindings.length > 0) {
       this.broadcastBindingsChanged();
@@ -739,6 +742,36 @@ export class DesktopMessagingRuntime {
       }
     }
     return false;
+  }
+
+  private async recordBindingUnbound(binding: MessagingBindingRecord): Promise<void> {
+    if (!this.options.backendBridge.recordMessagingBindingTransition) {
+      return;
+    }
+    const conversation = binding.channel.conversation;
+    try {
+      await this.options.backendBridge.recordMessagingBindingTransition({
+        backend: binding.backend,
+        threadId: binding.threadId,
+        transition: {
+          id: randomUUID(),
+          action: "unbound",
+          bindingId: binding.id,
+          platform: binding.channel.channel,
+          conversationKind: conversation.kind,
+          conversationTitle: conversation.title,
+          parentTitle: conversation.parentTitle,
+          ancestorTitle: conversation.ancestorTitle,
+          occurredAt: Date.now(),
+        },
+      });
+    } catch (error) {
+      messagingLog.warn("messaging binding-transition audit failed", {
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: binding.threadId,
+      });
+    }
   }
 
   private broadcastBindingsChanged(): void {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -10,11 +10,13 @@ import type {
   NavigationSnapshot,
   PrSummary,
   ThreadExecutionMode,
+  ThreadMessagingBindingTransition,
   ThreadOverlayState,
   ThreadPermissionTransition,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import {
+  MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   buildThreadIdentityKey,
 } from "@pwragent/shared";
@@ -77,6 +79,9 @@ export class SqliteOverlayStore {
           extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
           worktreeSnapshots: current?.worktreeSnapshots ?? [],
           pinnedRank: current?.pinnedRank,
+          permissionTransitionLog: current?.permissionTransitionLog,
+          messagingBindingTransitionLog:
+            current?.messagingBindingTransitionLog,
         });
       }
     }
@@ -425,6 +430,36 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async appendMessagingBindingTransition(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    transition: ThreadMessagingBindingTransition;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextLog = [
+      ...(current.messagingBindingTransitionLog ?? []),
+      params.transition,
+    ];
+    const trimmed =
+      nextLog.length > MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES
+        ? nextLog.slice(
+            nextLog.length - MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
+          )
+        : nextLog;
+    const nextState: ThreadOverlayState = {
+      ...current,
+      messagingBindingTransitionLog: trimmed,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadModelSettings(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -723,6 +758,7 @@ export type OverlayStoreLike = Pick<
   | "setThreadObservedBranch"
   | "retainThreadBranchDrift"
   | "appendPermissionTransition"
+  | "appendMessagingBindingTransition"
   | "getLaunchpadDefaults"
   | "setLaunchpadDefaults"
   | "getDirectoryLaunchpad"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1539,6 +1539,9 @@ export function ThreadView(props: ThreadViewProps) {
             <TranscriptList
               entries={props.transcriptEntries}
               permissionTransitions={selectedThread!.permissionTransitionLog}
+              messagingBindingTransitions={
+                selectedThread!.messagingBindingTransitionLog
+              }
               activeTurnId={props.activeTurnId}
               activeTurnStartedAt={props.activeTurnStartedAt}
               applications={props.applications}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -16,8 +16,10 @@ import type {
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
   DesktopApplicationsSnapshot,
-  ThreadPermissionTransition
+  ThreadMessagingBindingTransition,
+  ThreadPermissionTransition,
 } from "@pwragent/shared";
+import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThinkingScanner } from "./ThinkingScanner";
@@ -59,6 +61,7 @@ type TranscriptListProps = {
   pendingStatusText?: string;
   pagination?: AppServerThreadReplayPagination;
   permissionTransitions?: ThreadPermissionTransition[];
+  messagingBindingTransitions?: ThreadMessagingBindingTransition[];
   restoredViewport?: TranscriptViewport;
   reglueRequestKey?: number;
   threadId?: string;
@@ -325,13 +328,17 @@ export function TranscriptList(props: TranscriptListProps) {
     ])) {
       insertPendingEntry(entries, pendingEntry);
     }
-    return injectPermissionTransitions(entries, props.permissionTransitions);
+    return injectMessagingBindingTransitions(
+      injectPermissionTransitions(entries, props.permissionTransitions),
+      props.messagingBindingTransitions,
+    );
   }, [
     props.entries,
     props.pendingActivityEntry,
     props.pendingProtocolActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
+    props.messagingBindingTransitions,
     props.permissionTransitions,
   ]);
   const transcriptRenderItems = useMemo(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -358,6 +358,13 @@ export function TranscriptList(props: TranscriptListProps) {
       transcriptEntries,
     ]
   );
+  const visibleItemCount =
+    transcriptEntries.length +
+    (props.pendingStatusText ? 1 : 0) +
+    (props.pendingRequest ? 1 : 0) +
+    (props.pendingMcpInteraction ? 1 : 0) +
+    (props.pendingUserInput ? 1 : 0);
+  const hasTranscriptContent = transcriptEntries.length > 0;
   useEffect(() => {
     setExpandedCommentaryGroupIds(new Set());
   }, [props.threadId]);
@@ -393,18 +400,8 @@ export function TranscriptList(props: TranscriptListProps) {
       return undefined;
     }
 
-    const firstMessageId = props.entries[0]?.id;
-    const lastMessageId = props.entries[props.entries.length - 1]?.id;
-    const itemCount =
-      props.entries.length +
-      (props.pendingActivityEntry ? 1 : 0) +
-      (props.pendingProtocolActivityEntry ? 1 : 0) +
-      (props.pendingAssistantMessage ? 1 : 0) +
-      (props.pendingPlanEntry ? 1 : 0) +
-      (props.pendingStatusText ? 1 : 0) +
-      (props.pendingRequest ? 1 : 0) +
-      (props.pendingMcpInteraction ? 1 : 0) +
-      (props.pendingUserInput ? 1 : 0);
+    const firstMessageId = transcriptEntries[0]?.id;
+    const lastMessageId = transcriptEntries[transcriptEntries.length - 1]?.id;
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
       0
@@ -414,7 +411,7 @@ export function TranscriptList(props: TranscriptListProps) {
       clientHeight: container.clientHeight,
       distanceFromBottom,
       firstMessageId,
-      itemCount,
+      itemCount: visibleItemCount,
       lastMessageId,
       pendingStatusText: props.pendingStatusText,
       scrollHeight: container.scrollHeight,
@@ -422,16 +419,13 @@ export function TranscriptList(props: TranscriptListProps) {
       threadId: props.threadId
     };
   }, [
-    props.entries,
-    props.pendingActivityEntry,
-    props.pendingProtocolActivityEntry,
-    props.pendingAssistantMessage,
-    props.pendingPlanEntry,
     props.pendingRequest,
     props.pendingMcpInteraction,
     props.pendingUserInput,
     props.pendingStatusText,
-    props.threadId
+    props.threadId,
+    transcriptEntries,
+    visibleItemCount
   ]);
 
   const syncScrollState = useCallback((options?: SyncScrollStateOptions) => {
@@ -500,10 +494,10 @@ export function TranscriptList(props: TranscriptListProps) {
   }, []);
 
   useEffect(() => {
-    if (props.loading && props.entries.length === 0) {
+    if (props.loading && !hasTranscriptContent) {
       shouldScrollToBottomRef.current = true;
     }
-  }, [props.entries.length, props.loading]);
+  }, [hasTranscriptContent, props.loading]);
 
   useEffect(() => {
     if (typeof props.reglueRequestKey !== "number" || props.reglueRequestKey <= 0) {
@@ -531,7 +525,7 @@ export function TranscriptList(props: TranscriptListProps) {
 
   useLayoutEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container || props.entries.length === 0) {
+    if (!container || !hasTranscriptContent) {
       snapshotRef.current = undefined;
       isGluedToBottomRef.current = true;
       setHasContentBelow(false);
@@ -542,8 +536,8 @@ export function TranscriptList(props: TranscriptListProps) {
     const restoredViewport =
       props.restoredViewport ??
       (props.threadId ? savedViewportsRef.current.get(props.threadId) : undefined);
-    const firstMessageId = props.entries[0]?.id;
-    const lastMessageId = props.entries[props.entries.length - 1]?.id;
+    const firstMessageId = transcriptEntries[0]?.id;
+    const lastMessageId = transcriptEntries[transcriptEntries.length - 1]?.id;
     const hasPrependedMessages = Boolean(
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
@@ -556,16 +550,7 @@ export function TranscriptList(props: TranscriptListProps) {
         previousSnapshot.firstMessageId === firstMessageId &&
         (previousSnapshot.lastMessageId !== lastMessageId ||
           previousSnapshot.pendingStatusText !== props.pendingStatusText ||
-      previousSnapshot.itemCount <
-            props.entries.length +
-              (props.pendingActivityEntry ? 1 : 0) +
-              (props.pendingProtocolActivityEntry ? 1 : 0) +
-              (props.pendingAssistantMessage ? 1 : 0) +
-              (props.pendingPlanEntry ? 1 : 0) +
-              (props.pendingStatusText ? 1 : 0) +
-              (props.pendingRequest ? 1 : 0) +
-              (props.pendingMcpInteraction ? 1 : 0) +
-              (props.pendingUserInput ? 1 : 0))
+          previousSnapshot.itemCount < visibleItemCount)
     );
     const hasGrownWhileFollowingBottom = Boolean(
       previousSnapshot &&
@@ -619,11 +604,7 @@ export function TranscriptList(props: TranscriptListProps) {
 
     syncScrollState();
   }, [
-    props.entries,
-    props.pendingActivityEntry,
-    props.pendingProtocolActivityEntry,
-    props.pendingAssistantMessage,
-    props.pendingPlanEntry,
+    hasTranscriptContent,
     props.pendingRequest,
     props.pendingMcpInteraction,
     props.pendingUserInput,
@@ -632,6 +613,8 @@ export function TranscriptList(props: TranscriptListProps) {
     props.threadId,
     scrollToBottom,
     syncScrollState,
+    transcriptEntries,
+    visibleItemCount,
   ]);
 
   useEffect(() => {
@@ -655,15 +638,15 @@ export function TranscriptList(props: TranscriptListProps) {
     };
   }, [scrollToBottom, syncScrollState]);
 
-  if (props.loading && props.entries.length === 0 && !hasPendingContent) {
+  if (props.loading && !hasTranscriptContent && !hasPendingContent) {
     return <p className="transcript-empty">Loading transcript…</p>;
   }
 
-  if (props.error && props.entries.length === 0 && !hasPendingContent) {
+  if (props.error && !hasTranscriptContent && !hasPendingContent) {
     return <p className="transcript-error">{props.error}</p>;
   }
 
-  if (props.entries.length === 0 && !hasPendingContent) {
+  if (!hasTranscriptContent && !hasPendingContent) {
     return <p className="transcript-empty">No thread history yet.</p>;
   }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/messaging-binding-transition-entries.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/messaging-binding-transition-entries.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadEntry,
+  ThreadMessagingBindingTransition,
+} from "@pwragent/shared";
+import {
+  MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX,
+  buildMessagingBindingTransitionActivityEntries,
+  injectMessagingBindingTransitions,
+  isMessagingBindingTransitionEntry,
+} from "../messaging-binding-transition-entries";
+
+const bound: ThreadMessagingBindingTransition = {
+  id: "bind-1",
+  action: "bound",
+  bindingId: "binding-1",
+  platform: "telegram",
+  conversationKind: "topic",
+  conversationTitle: "PwrDrvr/Topic",
+  parentTitle: "PwrDrvr",
+  occurredAt: 1_000,
+};
+
+const unbound: ThreadMessagingBindingTransition = {
+  id: "unbind-1",
+  action: "unbound",
+  bindingId: "binding-1",
+  platform: "discord",
+  conversationKind: "channel",
+  conversationTitle: "release",
+  parentTitle: "PwrAgent",
+  occurredAt: 2_000,
+};
+
+describe("messaging-binding-transition-entries", () => {
+  it("builds synthetic activity entries with prefixed ids", () => {
+    const entries = buildMessagingBindingTransitionActivityEntries([
+      bound,
+      unbound,
+    ]);
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry.type).toBe("activity");
+      expect(entry.id.startsWith(MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX))
+        .toBe(true);
+      expect(isMessagingBindingTransitionEntry(entry)).toBe(true);
+    }
+  });
+
+  it("summarizes bound and unbound channel transitions", () => {
+    const [boundEntry, unboundEntry] =
+      buildMessagingBindingTransitionActivityEntries([bound, unbound]);
+
+    expect(boundEntry.summary).toBe(
+      "Channel bound: Telegram - PwrDrvr / PwrDrvr/Topic",
+    );
+    expect(unboundEntry.summary).toBe(
+      "Channel unbound: Discord - PwrAgent / release",
+    );
+  });
+
+  it("returns the original entries array when transitions is empty", () => {
+    const original: AppServerThreadEntry[] = [];
+    expect(injectMessagingBindingTransitions(original, undefined)).toBe(original);
+    expect(injectMessagingBindingTransitions(original, [])).toBe(original);
+  });
+
+  it("merges and orders synthetic entries by occurredAt", () => {
+    const existing: AppServerThreadEntry[] = [
+      {
+        type: "message",
+        id: "msg-1",
+        role: "user",
+        phase: "final",
+        createdAt: 500,
+        text: "hi",
+      },
+      {
+        type: "message",
+        id: "msg-2",
+        role: "assistant",
+        phase: "final",
+        createdAt: 2_500,
+        text: "hello",
+      },
+    ];
+
+    const merged = injectMessagingBindingTransitions(existing, [unbound, bound]);
+    expect(merged.map((entry) => entry.id)).toEqual([
+      "msg-1",
+      `${MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX}${bound.id}`,
+      `${MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX}${unbound.id}`,
+      "msg-2",
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -106,6 +106,34 @@ describe("TranscriptList", () => {
     vi.restoreAllMocks();
   });
 
+  it("renders messaging binding transitions without transcript history", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        messagingBindingTransitions={[
+          {
+            id: "bind-1",
+            action: "bound",
+            bindingId: "binding-1",
+            platform: "telegram",
+            conversationKind: "topic",
+            conversationTitle: "PwrDrvr/Topic",
+            parentTitle: "PwrDrvr",
+            occurredAt: 1_000,
+          },
+        ]}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.queryByText("No thread history yet.")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Channel bound: Telegram - PwrDrvr / PwrDrvr/Topic")
+    ).toBeInTheDocument();
+  });
+
   it("renders transcript history and exposes incremental history loading when available", () => {
     const loadOlder = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/messaging-binding-transition-entries.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/messaging-binding-transition-entries.ts
@@ -1,0 +1,106 @@
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+  MessagingChannelKind,
+  MessagingConversationKind,
+  ThreadMessagingBindingTransition,
+} from "@pwragent/shared";
+
+export const MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX =
+  "messaging-binding-transition-";
+
+const PLATFORM_LABELS: Partial<Record<MessagingChannelKind, string>> = {
+  discord: "Discord",
+  mattermost: "Mattermost",
+  slack: "Slack",
+  telegram: "Telegram",
+};
+
+const CONVERSATION_KIND_LABELS: Record<MessagingConversationKind, string> = {
+  channel: "channel",
+  dm: "DM",
+  thread: "thread",
+  topic: "topic",
+};
+
+function formatPlatformLabel(platform: MessagingChannelKind): string {
+  return PLATFORM_LABELS[platform] ?? platform;
+}
+
+function formatConversationLabel(
+  transition: ThreadMessagingBindingTransition,
+): string {
+  const titles = [
+    transition.ancestorTitle,
+    transition.parentTitle,
+    transition.conversationTitle,
+  ].filter((title): title is string => Boolean(title?.trim()));
+
+  if (titles.length > 0) {
+    return titles.join(" / ");
+  }
+
+  return transition.conversationKind
+    ? CONVERSATION_KIND_LABELS[transition.conversationKind]
+    : "conversation";
+}
+
+function summarizeTransition(
+  transition: ThreadMessagingBindingTransition,
+): string {
+  const platform = formatPlatformLabel(transition.platform);
+  const conversation = formatConversationLabel(transition);
+  return transition.action === "bound"
+    ? `Channel bound: ${platform} - ${conversation}`
+    : `Channel unbound: ${platform} - ${conversation}`;
+}
+
+export function buildMessagingBindingTransitionActivityEntries(
+  transitions: ThreadMessagingBindingTransition[] | undefined,
+): AppServerThreadActivityEntry[] {
+  if (!transitions || transitions.length === 0) {
+    return [];
+  }
+  return transitions.map((transition) => ({
+    type: "activity",
+    id: `${MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX}${transition.id}`,
+    summary: summarizeTransition(transition),
+    createdAt: transition.occurredAt,
+    details: [],
+  }));
+}
+
+export function injectMessagingBindingTransitions(
+  entries: AppServerThreadEntry[],
+  transitions: ThreadMessagingBindingTransition[] | undefined,
+): AppServerThreadEntry[] {
+  const synthetic = buildMessagingBindingTransitionActivityEntries(transitions);
+  if (synthetic.length === 0) {
+    return entries;
+  }
+  const merged: AppServerThreadEntry[] = [...entries, ...synthetic];
+  merged.sort((left, right) => {
+    const leftAt = left.createdAt ?? 0;
+    const rightAt = right.createdAt ?? 0;
+    if (leftAt !== rightAt) {
+      return leftAt - rightAt;
+    }
+    const leftIsTransition = left.id.startsWith(
+      MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX,
+    );
+    const rightIsTransition = right.id.startsWith(
+      MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX,
+    );
+    if (leftIsTransition === rightIsTransition) {
+      return 0;
+    }
+    return leftIsTransition ? 1 : -1;
+  });
+  return merged;
+}
+
+export function isMessagingBindingTransitionEntry(
+  entry: AppServerThreadEntry,
+): boolean {
+  return entry.id.startsWith(MESSAGING_BINDING_TRANSITION_ENTRY_PREFIX);
+}

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -146,6 +146,7 @@ export function materializeNavigationThreads(params: {
       queuedExecutionMode: overlay?.queuedExecutionMode,
       queuedExecutionModeAt: overlay?.queuedExecutionModeAt,
       permissionTransitionLog: overlay?.permissionTransitionLog,
+      messagingBindingTransitionLog: overlay?.messagingBindingTransitionLog,
       model: overlay?.model ?? thread.model,
       reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
@@ -247,6 +248,19 @@ export function buildNavigationSnapshotHash(params: {
           note: entry.note ?? null,
         }),
       ),
+      messagingBindingTransitionLog: (
+        thread.messagingBindingTransitionLog ?? []
+      ).map((entry) => ({
+        id: entry.id,
+        action: entry.action,
+        bindingId: entry.bindingId,
+        platform: entry.platform,
+        conversationKind: entry.conversationKind ?? null,
+        conversationTitle: entry.conversationTitle ?? null,
+        parentTitle: entry.parentTitle ?? null,
+        ancestorTitle: entry.ancestorTitle ?? null,
+        occurredAt: entry.occurredAt,
+      })),
       model: thread.model ?? null,
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -4,6 +4,8 @@ import type {
   DirectoryLaunchpadOverlayState,
   NavigationLaunchpadDefaults,
   ThreadExecutionMode,
+  ThreadMessagingBindingTransition,
+  ThreadMessagingBindingTransitionAction,
   ThreadOverlayState,
   ThreadPermissionTransition,
   ThreadPermissionTransitionStatus,
@@ -155,6 +157,59 @@ function migratePermissionTransitionLog(
         queueId:
           typeof record.queueId === "string" ? record.queueId : undefined,
         note: typeof record.note === "string" ? record.note : undefined,
+      },
+    ];
+  });
+  return entries.length > 0 ? entries : undefined;
+}
+
+function isMessagingBindingTransitionAction(
+  value: unknown,
+): value is ThreadMessagingBindingTransitionAction {
+  return value === "bound" || value === "unbound";
+}
+
+function migrateMessagingBindingTransitionLog(
+  value: unknown,
+): ThreadOverlayState["messagingBindingTransitionLog"] {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = value.flatMap((item): ThreadMessagingBindingTransition[] => {
+    const record = asRecord(item);
+    if (
+      !record ||
+      typeof record.id !== "string" ||
+      typeof record.bindingId !== "string" ||
+      typeof record.platform !== "string" ||
+      typeof record.occurredAt !== "number" ||
+      !isMessagingBindingTransitionAction(record.action)
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: record.id,
+        action: record.action,
+        bindingId: record.bindingId,
+        platform: record.platform as ThreadMessagingBindingTransition["platform"],
+        conversationKind:
+          typeof record.conversationKind === "string"
+            ? (record.conversationKind as ThreadMessagingBindingTransition["conversationKind"])
+            : undefined,
+        conversationTitle:
+          typeof record.conversationTitle === "string"
+            ? record.conversationTitle
+            : undefined,
+        parentTitle:
+          typeof record.parentTitle === "string"
+            ? record.parentTitle
+            : undefined,
+        ancestorTitle:
+          typeof record.ancestorTitle === "string"
+            ? record.ancestorTitle
+            : undefined,
+        occurredAt: record.occurredAt,
       },
     ];
   });
@@ -385,6 +440,9 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
               : [],
             permissionTransitionLog: migratePermissionTransitionLog(
               threadRecord.permissionTransitionLog,
+            ),
+            messagingBindingTransitionLog: migrateMessagingBindingTransitionLog(
+              threadRecord.messagingBindingTransitionLog,
             ),
             reactions: migrateThreadReactions(threadRecord.reactions),
           } satisfies ThreadOverlayState,

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -12,11 +12,13 @@ import type {
   NavigationSnapshot,
   PrSummary,
   ThreadExecutionMode,
+  ThreadMessagingBindingTransition,
   ThreadOverlayState,
   ThreadPermissionTransition,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import {
+  MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   buildThreadIdentityKey,
 } from "@pwragent/shared";
@@ -68,6 +70,9 @@ export class OverlayStore {
             extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
             worktreeSnapshots: current?.worktreeSnapshots ?? [],
             pinnedRank: current?.pinnedRank,
+            permissionTransitionLog: current?.permissionTransitionLog,
+            messagingBindingTransitionLog:
+              current?.messagingBindingTransitionLog,
           };
         }
       }
@@ -338,6 +343,38 @@ export class OverlayStore {
       const nextState: ThreadOverlayState = {
         ...current,
         permissionTransitionLog: trimmed,
+      };
+      data.threads[threadKey] = nextState;
+      return nextState;
+    });
+  }
+
+  async appendMessagingBindingTransition(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    transition: ThreadMessagingBindingTransition;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const nextLog = [
+        ...(current.messagingBindingTransitionLog ?? []),
+        params.transition,
+      ];
+      const trimmed =
+        nextLog.length > MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES
+          ? nextLog.slice(
+              nextLog.length - MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
+            )
+          : nextLog;
+      const nextState: ThreadOverlayState = {
+        ...current,
+        messagingBindingTransitionLog: trimmed,
       };
       data.threads[threadKey] = nextState;
       return nextState;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -43,6 +43,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * `MAX_PERMISSION_TRANSITION_LOG_ENTRIES` with oldest-first eviction.
    */
   permissionTransitionLog?: ThreadPermissionTransition[];
+  /**
+   * Per-thread messaging binding transition log. Persisted via the
+   * overlay store so bind/unbind actions appear inline in the chat
+   * transcript after the navigation snapshot refreshes.
+   */
+  messagingBindingTransitionLog?: ThreadMessagingBindingTransition[];
   optimisticUserMessage?: {
     text: string;
     imageParts?: AppServerThreadImagePart[];
@@ -384,6 +390,12 @@ export type ThreadOverlayState = {
    * represent the lifecycle of one queued change.
    */
   permissionTransitionLog?: ThreadPermissionTransition[];
+  /**
+   * Per-thread messaging binding transition audit log. Persisted to
+   * the overlay store and rendered as synthetic transcript activity
+   * entries for channel bind/unbind actions.
+   */
+  messagingBindingTransitionLog?: ThreadMessagingBindingTransition[];
 };
 
 /**
@@ -424,6 +436,34 @@ export type ThreadPermissionTransition = {
    * flush failures.
    */
   note?: string;
+};
+
+/**
+ * Maximum number of messaging binding transition entries retained per
+ * thread. Kept separate from permission transitions so either audit
+ * stream can roll independently without evicting the other.
+ */
+export const MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES = 100;
+
+export type ThreadMessagingBindingTransitionAction = "bound" | "unbound";
+
+/**
+ * One entry in the per-thread messaging binding audit log. The title
+ * fields mirror `MessagingThreadBindingSummary` so renderer code can
+ * format the same conversation breadcrumb without inspecting adapter
+ * routing state.
+ */
+export type ThreadMessagingBindingTransition = {
+  id: string;
+  action: ThreadMessagingBindingTransitionAction;
+  bindingId: string;
+  platform: MessagingChannelKind;
+  conversationKind?: MessagingConversationKind;
+  conversationTitle?: string;
+  parentTitle?: string;
+  ancestorTitle?: string;
+  /** Epoch ms. */
+  occurredAt: number;
 };
 
 export type ThreadBranchDriftPair = {


### PR DESCRIPTION
## Summary

- Persist messaging channel bind/unbind transitions on each thread so they survive refreshes and restarts.
- Render those transitions inline in the desktop transcript as synthetic activity rows, matching the existing permission-change audit row pattern.
- Cover bind, rebind, detach, runtime fallback unbind, and transition-only transcript rendering with tests.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/messaging-binding-transition-entries.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/permission-transition-entries.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/messaging-binding-transition-entries.test.ts`.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.
