### PR TITLE
fix(messaging): label Telegram topic pairing IDs

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1128,6 +1128,80 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("logs Telegram topic pairing activity with supergroup parent metadata", async () => {
+    const { runtime, adapter } = await createRuntimeHarness();
+    await runtime.start();
+    const { token } = runtime.generatePairingToken({
+      platform: "telegram",
+      scope: "bucket",
+    });
+
+    await adapter.listener?.({
+      id: "telegram:update:1:message:2",
+      kind: "command",
+      actor: {
+        platformUserId: "8460800771",
+        displayName: "Harold Hunt",
+        username: "huntharo",
+      },
+      args: [token],
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "5642",
+          kind: "topic",
+          parentId: "-1003841603622",
+          title: "Release",
+          parentTitle: "PwrDrvr",
+        },
+      },
+      command: "pair",
+      rawText: `/pair ${token}`,
+      receivedAt: 1000,
+      routingState: {
+        opaque: {
+          chatId: -1003841603622,
+          messageThreadId: 5642,
+        },
+      },
+    });
+
+    const observed = runtime.listPairingRequests({ platform: "telegram" }).entries[0];
+    expect(observed).toMatchObject({
+      status: "observed",
+      observedChat: {
+        id: "5642",
+        kind: "topic",
+        parentId: "-1003841603622",
+        bucketId: "-1003841603622",
+      },
+    });
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const row = getAppStateDb().raw
+      .prepare(
+        `SELECT conversation_id, actor_id, payload
+         FROM messaging_activity_log
+         WHERE kind = ? AND summary = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .get("pairing", "Observed pairing token") as
+        | { actor_id: string; conversation_id: string; payload: string }
+        | undefined;
+
+    expect(row).toMatchObject({
+      actor_id: "8460800771",
+      conversation_id: "5642",
+    });
+    expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
+      conversationKind: "topic",
+      conversationParentId: "-1003841603622",
+      conversationBucketId: "-1003841603622",
+      actorUsername: "huntharo",
+    });
+  });
+
   it("emits health=suspended for each running adapter when stopped", async () => {
     const { runtime } = await createRuntimeHarness();
     await runtime.start();

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -201,6 +201,11 @@ function recordPairingActivity(entry: MessagingPairingEntry, summary: string): v
         status: entry.status,
         instanceId: entry.instanceId,
         expiresAt: entry.expiresAt,
+        conversationKind: entry.observedChat?.kind,
+        conversationParentId: entry.observedChat?.parentId,
+        conversationParentTitle: entry.observedChat?.parentTitle,
+        conversationBucketId: entry.observedChat?.bucketId,
+        actorUsername: entry.observedActor?.username,
       },
     });
   } catch (error) {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1062,6 +1062,11 @@ export class DesktopMessagingRuntime {
           instanceId: entry.instanceId,
           expiresAt: entry.expiresAt,
           failureReason: entry.failureReason,
+          conversationKind: entry.observedChat?.kind,
+          conversationParentId: entry.observedChat?.parentId,
+          conversationParentTitle: entry.observedChat?.parentTitle,
+          conversationBucketId: entry.observedChat?.bucketId,
+          actorUsername: entry.observedActor?.username,
         },
       });
     } catch (error) {

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -230,12 +230,23 @@ function copyFieldsForEntry(
     typeof entry.payload?.conversationParentId === "string"
       ? entry.payload.conversationParentId
       : undefined;
+  const bucketId =
+    typeof entry.payload?.conversationBucketId === "string"
+      ? entry.payload.conversationBucketId
+      : undefined;
 
   if (parentId) {
     fields.push({
       key: "parent",
       label: parentIdLabel(entry.platform, conversationKind),
       value: parentId,
+    });
+  }
+  if (bucketId && bucketId !== parentId && bucketId !== entry.conversationId) {
+    fields.push({
+      key: "bucket",
+      label: bucketIdLabel(entry.platform),
+      value: bucketId,
     });
   }
   if (entry.conversationId) {
@@ -252,6 +263,7 @@ function copyFieldsForEntry(
 function userIdLabel(platform: MessagingActivityEntry["platform"]): string {
   if (platform === "telegram") return "Peer ID";
   if (platform === "discord") return "User ID";
+  if (platform === "slack") return "User ID";
   if (platform === "mattermost") return "User ID";
   return "Actor ID";
 }
@@ -266,6 +278,14 @@ function parentIdLabel(
   return "Parent ID";
 }
 
+function bucketIdLabel(platform: MessagingActivityEntry["platform"]): string {
+  if (platform === "telegram") return "Supergroup ID";
+  if (platform === "discord") return "Guild ID";
+  if (platform === "slack") return "Workspace ID";
+  if (platform === "mattermost") return "Team ID";
+  return "Bucket ID";
+}
+
 function conversationIdLabel(
   platform: MessagingActivityEntry["platform"],
   conversationKind?: string,
@@ -274,6 +294,7 @@ function conversationIdLabel(
     return conversationKind === "topic" ? "Topic ID" : "Supergroup ID";
   }
   if (platform === "discord" && conversationKind !== "dm") return "Channel ID";
+  if (platform === "slack" && conversationKind !== "dm") return "Channel ID";
   if (platform === "mattermost" && conversationKind !== "dm") return "Channel ID";
   return "Conversation ID";
 }

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -44,4 +44,74 @@ describe("MessagingActivityScreen", () => {
     expect(screen.getByText("1480554271907905000").closest("button"))
       .toHaveTextContent("Channel ID");
   });
+
+  it("labels Telegram topic pairing IDs with their parent supergroup", async () => {
+    const desktopApi = {
+      listMessagingActivity: vi.fn(async () => ({
+        entries: [
+          {
+            id: 1,
+            platform: "telegram",
+            kind: "pairing",
+            conversationId: "5642",
+            actorId: "8460800771",
+            actorDisplayName: "Harold",
+            summary: "Observed pairing token",
+            createdAt: Date.now(),
+            payload: {
+              conversationKind: "topic",
+              conversationParentId: "-1003841603622",
+            },
+          },
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<MessagingActivityScreen desktopApi={desktopApi} />);
+
+    await waitFor(() => {
+      expect(desktopApi.listMessagingActivity).toHaveBeenCalledWith({ limit: 200 });
+    });
+    expect((await screen.findByText("8460800771")).closest("button"))
+      .toHaveTextContent("Peer ID");
+    expect(screen.getByText("-1003841603622").closest("button"))
+      .toHaveTextContent("Supergroup ID");
+    expect(screen.getByText("5642").closest("button"))
+      .toHaveTextContent("Topic ID");
+  });
+
+  it("shows Slack workspace IDs from bucket metadata", async () => {
+    const desktopApi = {
+      listMessagingActivity: vi.fn(async () => ({
+        entries: [
+          {
+            id: 1,
+            platform: "slack",
+            kind: "pairing",
+            conversationId: "C079K80HTGS",
+            actorId: "U079K80HTGS",
+            actorDisplayName: "Harold",
+            summary: "Observed pairing token",
+            createdAt: Date.now(),
+            payload: {
+              conversationKind: "channel",
+              conversationBucketId: "T079K80HTGS",
+            },
+          },
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<MessagingActivityScreen desktopApi={desktopApi} />);
+
+    await waitFor(() => {
+      expect(desktopApi.listMessagingActivity).toHaveBeenCalledWith({ limit: 200 });
+    });
+    expect((await screen.findByText("U079K80HTGS")).closest("button"))
+      .toHaveTextContent("User ID");
+    expect(screen.getByText("T079K80HTGS").closest("button"))
+      .toHaveTextContent("Workspace ID");
+    expect(screen.getByText("C079K80HTGS").closest("button"))
+      .toHaveTextContent("Channel ID");
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1227,15 +1227,21 @@ function pairingEntryDetails(entry: MessagingPairingEntry): string[] {
   if (entry.observedActor?.phoneNumber) {
     details.push(`Phone ${entry.observedActor.phoneNumber}`);
   }
-  if (entry.observedChat?.id) {
-    const chatLabel = entry.observedChat.kind === "dm" ? "DM peer" : "Chat";
-    details.push(`${chatLabel} ID ${entry.observedChat.id}`);
+  const chat = entry.observedChat;
+  if (chat?.id) {
+    if (entry.platform === "telegram" && chat.kind === "topic") {
+      details.push(`Topic ID ${chat.id}`);
+    } else {
+      const chatLabel = chat.kind === "dm" ? "DM peer" : "Chat";
+      details.push(`${chatLabel} ID ${chat.id}`);
+    }
   }
   if (entry.observedChat?.title) {
     details.push(entry.observedChat.title);
   }
-  if (entry.observedChat?.bucketId && entry.observedChat.bucketId !== entry.observedChat.id) {
-    details.push(`Bucket ID ${entry.observedChat.bucketId}`);
+  if (chat?.bucketId && chat.bucketId !== chat.id) {
+    const bucketLabel = entry.platform === "telegram" ? "Supergroup ID" : "Bucket ID";
+    details.push(`${bucketLabel} ${chat.bucketId}`);
   }
   return details;
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -720,6 +720,65 @@ describe("SettingsScreen", () => {
     expect(screen.getByDisplayValue("Harold Hunt")).toBeInTheDocument();
   });
 
+  it("labels Telegram topic pairing request IDs distinctly", async () => {
+    const snapshot = createSnapshot();
+    const settings = createSettingsState({
+      ...snapshot,
+      messaging: {
+        ...snapshot.messaging,
+        telegram: {
+          ...snapshot.messaging.telegram,
+          enabled: { value: true, source: "config" },
+        },
+      },
+    });
+    const observedEntry = {
+      id: "pairing-topic-1",
+      platform: "telegram" as const,
+      instanceId: "default",
+      scope: "bucket" as const,
+      status: "observed" as const,
+      generatedAt: 1,
+      expiresAt: 2,
+      observedAt: 1,
+      observedActor: {
+        id: "8460800771",
+        displayName: "Harold Hunt",
+      },
+      observedChat: {
+        id: "5642",
+        kind: "topic" as const,
+        title: "Release",
+        parentId: "-1003841603622",
+        parentTitle: "PwrDrvr",
+        bucketId: "-1003841603622",
+      },
+    };
+    const desktopApi = {
+      listMessagingPairingRequests: vi.fn(async (request) => ({
+        entries: request?.platform === "telegram" ? [observedEntry] : [],
+      })),
+      onMessagingPairingChanged: vi.fn(() => () => undefined),
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        initialSection="messaging"
+        onClose={() => undefined}
+      />,
+    );
+
+    const request = await screen.findByText("Release wants group access");
+    const requestCard = request.closest(".settings-pairing__request");
+    expect(requestCard).not.toBeNull();
+    expect(requestCard).toHaveTextContent("Topic ID 5642");
+    expect(requestCard).toHaveTextContent("Supergroup ID -1003841603622");
+    expect(requestCard).not.toHaveTextContent("Chat ID 5642");
+    expect(requestCard).not.toHaveTextContent("Bucket ID -1003841603622");
+  });
+
   it("looks up Slack authorized user display names", async () => {
     const snapshot = createSnapshot();
     const settings = createSettingsState({


### PR DESCRIPTION
## Summary

I fixed Telegram topic pairing activity so the UI no longer labels a topic id as a supergroup id.

## What Changed

- Added conversation kind, parent id, parent title, bucket id, and actor username metadata to pairing activity rows.
- Updated Messaging Activity coverage so Telegram topic pairing rows show both the parent Supergroup ID and the Topic ID.
- Updated Settings pairing request details to label Telegram topic requests as Topic ID plus Supergroup ID instead of generic Chat/Bucket labels.

## Why

Pairing activity rows were only storing `observedChat.id`. For Telegram forum topics that value is the topic id, while the supergroup id lives on the parent/bucket metadata. Without the missing metadata, the activity renderer could only apply the generic Telegram non-DM label and displayed the topic id as the Supergroup ID.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
