### PR TITLE
feat(skills): add PwrAgent dev restart helper

### DIFF
--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -39,8 +39,8 @@ Use this skill when the running Electron app must be stopped and restarted from 
 
 ## Script Notes
 
-- The script stops processes matching the target checkout path, PwrAgent's dev user-data path, and their parent process chain, then starts `pnpm dev` from the checkout.
-- It uses `launchctl submit` on macOS so the delayed restart is not owned by the current shell. If `launchctl` is unavailable, it falls back to `nohup`.
+- The script stops processes matching the target checkout path and their bounded parent dev-server chain, then starts `pnpm dev` from the checkout.
+- It uses `launchctl submit` on macOS so the delayed restart is not owned by the current shell. If `launchctl` is unavailable or submission fails, it falls back to `nohup`.
 - Default root is `/Users/huntharo/github/PwrAgnt`.
 - Default log is `<root>/.local/pwragent-dev-restart.log`.
 - Use `--dry-run` before scheduling unless the user explicitly asks to restart immediately.

--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -40,7 +40,7 @@ Use this skill when the running Electron app must be stopped and restarted from 
 ## Script Notes
 
 - The script stops processes matching the target checkout path and their bounded parent dev-server chain, then starts `pnpm dev` from the checkout.
-- It uses `launchctl submit` on macOS so the delayed restart is not owned by the current shell. If `launchctl` is unavailable or submission fails, it falls back to `nohup`.
+- It uses `launchctl submit` on macOS for the delayed timer, then starts `pnpm dev` detached and removes the one-shot launchd job. If `launchctl` is unavailable or submission fails, it falls back to `nohup`.
 - Default root is `/Users/huntharo/github/PwrAgnt`.
 - Default log is `<root>/.local/pwragent-dev-restart.log`.
 - Use `--dry-run` before scheduling unless the user explicitly asks to restart immediately.

--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pwragent-dev-restart
+description: Safely restart the local PwrAgent Electron development app after pulling, rebasing, or merging changes. Use when Codex is running inside or alongside the PwrAgent dev app and a normal restart could kill the current session before `pnpm dev` is relaunched.
+---
+
+# PwrAgent Dev Restart
+
+Use this skill when the running Electron app must be stopped and restarted from a freshly updated checkout, especially after merging a PR into `~/github/PwrAgnt`.
+
+## Workflow
+
+1. Confirm the target checkout is updated and clean enough to run:
+
+   ```bash
+   git -C /Users/huntharo/github/PwrAgnt status --short --branch
+   git -C /Users/huntharo/github/PwrAgnt log -1 --oneline --decorate
+   ```
+
+2. Dry-run the restart to see which processes would be stopped:
+
+   ```bash
+   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh \
+     schedule --root /Users/huntharo/github/PwrAgnt --delay 30 --dry-run
+   ```
+
+3. Schedule the restart and answer the user before the delay expires:
+
+   ```bash
+   .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh \
+     schedule --root /Users/huntharo/github/PwrAgnt --delay 30
+   ```
+
+4. After the delay, verify the app came back:
+
+   ```bash
+   tail -120 /Users/huntharo/github/PwrAgnt/.local/pwragent-dev-restart.log
+   pgrep -fl '/Users/huntharo/github/PwrAgnt|PwrAgent|pnpm.*dev|electron-vite'
+   ```
+
+## Script Notes
+
+- The script stops processes matching the target checkout path, PwrAgent's dev user-data path, and their parent process chain, then starts `pnpm dev` from the checkout.
+- It uses `launchctl submit` on macOS so the delayed restart is not owned by the current shell. If `launchctl` is unavailable, it falls back to `nohup`.
+- Default root is `/Users/huntharo/github/PwrAgnt`.
+- Default log is `<root>/.local/pwragent-dev-restart.log`.
+- Use `--dry-run` before scheduling unless the user explicitly asks to restart immediately.

--- a/.agents/skills/pwragent-dev-restart/agents/openai.yaml
+++ b/.agents/skills/pwragent-dev-restart/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PwrAgent Dev Restart"
+  short_description: "Safely restart local PwrAgent dev"
+  default_prompt: "Use $pwragent-dev-restart to restart the local PwrAgent dev app after pulling changes."

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -8,8 +8,8 @@ Usage:
   restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run]
 
 Schedules or performs a local PwrAgent dev restart. The restart stops processes
-that match the target checkout path or PwrAgent dev user-data path, then starts
-`pnpm dev` from the target checkout.
+that match the target checkout path plus the bounded parent dev-server chain,
+then starts `pnpm dev` from the target checkout.
 USAGE
 }
 
@@ -81,14 +81,15 @@ fi
 mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
 
 script_path="${0:A}"
-user_data_path="/Users/huntharo/Library/Application Support/PwrAgent"
 
 matching_pids() {
-  local pattern="$1"
+  local command pattern="$1"
   pgrep -f "$pattern" 2>/dev/null | while read -r pid; do
     [[ -z "$pid" ]] && continue
     [[ "$pid" == "$$" ]] && continue
     [[ "$pid" == "$PPID" ]] && continue
+    command="$(process_command "$pid")"
+    [[ "$command" == *"restart-pwragent-dev.zsh"* ]] && continue
     print -r -- "$pid"
   done
 }
@@ -97,18 +98,36 @@ parent_pid() {
   ps -p "$1" -o ppid= 2>/dev/null | tr -d ' '
 }
 
+process_command() {
+  ps -p "$1" -o command= 2>/dev/null
+}
+
+is_dev_chain_parent() {
+  local command="$1"
+  [[ "$command" == *"pnpm dev"* ]] && return 0
+  [[ "$command" == *"pnpm --filter @pwragent/desktop dev"* ]] && return 0
+  [[ "$command" == *"electron-vite"* && "$command" == *"dev"* ]] && return 0
+  [[ "$command" == *"scripts/rebuild-native-for-electron.mjs"* && "$command" == *"electron-vite dev"* ]] && return 0
+  return 1
+}
+
 candidate_pids() {
-  local pattern pid parent
-  for pattern in "$root" "$user_data_path"; do
-    for pid in $(matching_pids "$pattern"); do
-      while [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
-        [[ "$pid" != "$$" && "$pid" != "$PPID" ]] && print -r -- "$pid"
-        parent="$(parent_pid "$pid")"
-        [[ -z "$parent" || "$parent" == "$pid" ]] && break
-        pid="$parent"
-      done
+  local command parent pid
+  for pid in $(matching_pids "$root"); do
+    [[ "$pid" != "$$" && "$pid" != "$PPID" ]] && print -r -- "$pid"
+
+    parent="$(parent_pid "$pid")"
+    while [[ -n "$parent" && "$parent" != "0" && "$parent" != "1" ]]; do
+      [[ "$parent" == "$$" || "$parent" == "$PPID" ]] && break
+      command="$(process_command "$parent")"
+      if [[ "$command" == *"$root"* ]] || is_dev_chain_parent "$command"; then
+        print -r -- "$parent"
+        parent="$(parent_pid "$parent")"
+      else
+        break
+      fi
     done
-  done | sort -nu
+  done | sort -rnu
 }
 
 describe_candidates() {
@@ -116,6 +135,11 @@ describe_candidates() {
   for pid in $(candidate_pids); do
     ps -p "$pid" -o pid=,ppid=,command= 2>/dev/null || true
   done
+}
+
+log_candidates() {
+  log_line "candidate processes:"
+  describe_candidates | while read -r line; do log_line "$line"; done
 }
 
 stop_matches() {
@@ -138,23 +162,26 @@ schedule_restart() {
   log_line "scheduled command: $command"
 
   if [[ "$dry_run" == "true" ]]; then
+    log_candidates
     return 0
   fi
 
   if command -v launchctl >/dev/null 2>&1; then
     local label="com.pwragent.dev.restart.$(date +%s)"
-    launchctl submit -l "$label" -- /bin/zsh -lc "$command"
-    log_line "submitted launchctl label=$label"
-  else
-    nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &
-    log_line "submitted nohup pid=$!"
+    if launchctl submit -l "$label" -- /bin/zsh -lc "$command"; then
+      log_line "submitted launchctl label=$label"
+      return 0
+    fi
+    log_line "launchctl submit failed label=$label; falling back to nohup"
   fi
+
+  nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &
+  log_line "submitted nohup pid=$!"
 }
 
 restart_now() {
   log_line "restart starting root=$root dryRun=$dry_run"
-  log_line "candidate processes:"
-  describe_candidates | while read -r line; do log_line "$line"; done
+  log_candidates
 
   stop_matches TERM
 

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -5,7 +5,7 @@ usage() {
   cat <<'USAGE'
 Usage:
   restart-pwragent-dev.zsh schedule [--root PATH] [--delay SECONDS] [--log PATH] [--dry-run]
-  restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run]
+  restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run] [--detach-start]
 
 Schedules or performs a local PwrAgent dev restart. The restart stops processes
 that match the target checkout path plus the bounded parent dev-server chain,
@@ -41,6 +41,7 @@ root="/Users/huntharo/github/PwrAgnt"
 delay="30"
 log_path=""
 dry_run="false"
+detach_start="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +62,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run)
       dry_run="true"
+      shift
+      ;;
+    --detach-start)
+      detach_start="true"
       shift
       ;;
     *)
@@ -155,7 +160,7 @@ stop_matches() {
 
 schedule_restart() {
   local command
-  command="sleep $(shell_quote "$delay"); $(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path")"
+  command="sleep $(shell_quote "$delay"); $(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path") --detach-start"
   [[ "$dry_run" == "true" ]] && command="$command --dry-run"
 
   log_line "schedule root=$root delay=${delay}s log=$log_path dryRun=$dry_run"
@@ -168,6 +173,7 @@ schedule_restart() {
 
   if command -v launchctl >/dev/null 2>&1; then
     local label="com.pwragent.dev.restart.$(date +%s)"
+    command="$command; launchctl remove $(shell_quote "$label") >/dev/null 2>&1 || true"
     if launchctl submit -l "$label" -- /bin/zsh -lc "$command"; then
       log_line "submitted launchctl label=$label"
       return 0
@@ -194,6 +200,12 @@ restart_now() {
   stop_matches KILL
 
   log_line "starting pnpm dev in $root"
+  if [[ "$detach_start" == "true" ]]; then
+    nohup /bin/zsh -lc "cd $(shell_quote "$root") && pnpm dev" >> "$log_path" 2>&1 &
+    log_line "started detached pnpm dev pid=$!"
+    return 0
+  fi
+
   exec /bin/zsh -lc "cd $(shell_quote "$root") && pnpm dev"
 }
 

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -1,0 +1,184 @@
+#!/bin/zsh
+set -u
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  restart-pwragent-dev.zsh schedule [--root PATH] [--delay SECONDS] [--log PATH] [--dry-run]
+  restart-pwragent-dev.zsh restart-now [--root PATH] [--log PATH] [--dry-run]
+
+Schedules or performs a local PwrAgent dev restart. The restart stops processes
+that match the target checkout path or PwrAgent dev user-data path, then starts
+`pnpm dev` from the target checkout.
+USAGE
+}
+
+timestamp() {
+  date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+shell_quote() {
+  printf "%q" "$1"
+}
+
+log_line() {
+  print -r -- "[$(timestamp)] $*"
+}
+
+die() {
+  print -u2 -r -- "restart-pwragent-dev: $*"
+  exit 1
+}
+
+mode="${1:-}"
+if [[ -z "$mode" || "$mode" == "--help" || "$mode" == "-h" ]]; then
+  usage
+  exit 0
+fi
+shift
+
+root="/Users/huntharo/github/PwrAgnt"
+delay="30"
+log_path=""
+dry_run="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      [[ $# -ge 2 ]] || die "--root requires a path"
+      root="$2"
+      shift 2
+      ;;
+    --delay)
+      [[ $# -ge 2 ]] || die "--delay requires seconds"
+      delay="$2"
+      shift 2
+      ;;
+    --log)
+      [[ $# -ge 2 ]] || die "--log requires a path"
+      log_path="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$mode" == "schedule" || "$mode" == "restart-now" ]] || die "unknown mode: $mode"
+[[ "$delay" == <-> ]] || die "--delay must be an integer number of seconds"
+
+root="${root:A}"
+[[ -d "$root" ]] || die "root does not exist: $root"
+
+if [[ -z "$log_path" ]]; then
+  log_path="$root/.local/pwragent-dev-restart.log"
+fi
+mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
+
+script_path="${0:A}"
+user_data_path="/Users/huntharo/Library/Application Support/PwrAgent"
+
+matching_pids() {
+  local pattern="$1"
+  pgrep -f "$pattern" 2>/dev/null | while read -r pid; do
+    [[ -z "$pid" ]] && continue
+    [[ "$pid" == "$$" ]] && continue
+    [[ "$pid" == "$PPID" ]] && continue
+    print -r -- "$pid"
+  done
+}
+
+parent_pid() {
+  ps -p "$1" -o ppid= 2>/dev/null | tr -d ' '
+}
+
+candidate_pids() {
+  local pattern pid parent
+  for pattern in "$root" "$user_data_path"; do
+    for pid in $(matching_pids "$pattern"); do
+      while [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
+        [[ "$pid" != "$$" && "$pid" != "$PPID" ]] && print -r -- "$pid"
+        parent="$(parent_pid "$pid")"
+        [[ -z "$parent" || "$parent" == "$pid" ]] && break
+        pid="$parent"
+      done
+    done
+  done | sort -nu
+}
+
+describe_candidates() {
+  local pid
+  for pid in $(candidate_pids); do
+    ps -p "$pid" -o pid=,ppid=,command= 2>/dev/null || true
+  done
+}
+
+stop_matches() {
+  local signal="$1"
+  local pid
+  for pid in $(candidate_pids); do
+    log_line "$signal pid=$pid"
+    if [[ "$dry_run" != "true" ]]; then
+      kill "-$signal" "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+schedule_restart() {
+  local command
+  command="sleep $(shell_quote "$delay"); $(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path")"
+  [[ "$dry_run" == "true" ]] && command="$command --dry-run"
+
+  log_line "schedule root=$root delay=${delay}s log=$log_path dryRun=$dry_run"
+  log_line "scheduled command: $command"
+
+  if [[ "$dry_run" == "true" ]]; then
+    return 0
+  fi
+
+  if command -v launchctl >/dev/null 2>&1; then
+    local label="com.pwragent.dev.restart.$(date +%s)"
+    launchctl submit -l "$label" -- /bin/zsh -lc "$command"
+    log_line "submitted launchctl label=$label"
+  else
+    nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &
+    log_line "submitted nohup pid=$!"
+  fi
+}
+
+restart_now() {
+  log_line "restart starting root=$root dryRun=$dry_run"
+  log_line "candidate processes:"
+  describe_candidates | while read -r line; do log_line "$line"; done
+
+  stop_matches TERM
+
+  if [[ "$dry_run" == "true" ]]; then
+    log_line "dry run complete; pnpm dev not started"
+    return 0
+  fi
+
+  sleep 5
+  stop_matches KILL
+
+  log_line "starting pnpm dev in $root"
+  exec /bin/zsh -lc "cd $(shell_quote "$root") && pnpm dev"
+}
+
+run_main() {
+  case "$mode" in
+    schedule) schedule_restart ;;
+    restart-now) restart_now ;;
+  esac
+}
+
+if [[ "$dry_run" == "true" ]]; then
+  run_main
+else
+  run_main >> "$log_path" 2>&1
+fi


### PR DESCRIPTION
## Summary

- Add a repo-local `$pwragent-dev-restart` skill for safely restarting the local PwrAgent Electron dev app after merges or pulls.
- Bundle a `restart-pwragent-dev.zsh` helper that can dry-run, schedule a delayed restart through `launchctl`, and fall back to `nohup` when needed.
- Make the helper stop the matched PwrAgent checkout, Electron helpers, esbuild workers, and parent dev process chain before relaunching `pnpm dev` from the target checkout.

## Validation

- `zsh -n .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh`
- `uv run --with pyyaml python /Users/huntharo/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/pwragent-dev-restart`
- Dry-run schedule and dry-run restart-now against `/Users/huntharo/github/PwrAgnt`; confirmed it identifies the full PwrAgent dev process chain without stopping it.
