### PR TITLE
fix(messaging): improve mobile worktree handoff choices

### DIFF
--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -97,6 +97,31 @@ describe("GitWorkspaceHandoffService", () => {
     );
   });
 
+  it("moves a local branch to a new worktree and leaves local detached", async () => {
+    const repoPath = await createRepo();
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      leaveLocalBranch: "HEAD",
+      now: 1250,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.branch).toBe("feature/handoff");
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("");
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe(
+      "feature/handoff",
+    );
+  });
+
   it("moves dirty local changes to a detached worktree and leaves local on the current branch", async () => {
     const repoPath = await createRepo();
     await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");
@@ -141,6 +166,42 @@ describe("GitWorkspaceHandoffService", () => {
       false,
     );
     expect(await git(repoPath, ["status", "--porcelain", "--untracked-files=normal"])).toBe("");
+  });
+
+  it("creates a clean detached worktree from the selected base branch", async () => {
+    const repoPath = await createRepo();
+    await git(repoPath, ["switch", "main"]);
+    await writeFile(path.join(repoPath, "main-only.txt"), "main\n", "utf8");
+    await git(repoPath, ["add", "main-only.txt"]);
+    await git(repoPath, ["commit", "-m", "main only"]);
+    await git(repoPath, ["switch", "feature/handoff"]);
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      baseBranch: "main",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      now: 1750,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.strategy).toBe("detached-changes");
+    expect(result.baseBranch).toBe("main");
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("feature/handoff");
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe("");
+    expect(await git(result.targetPath, ["rev-parse", "HEAD"])).toBe(
+      await git(repoPath, ["rev-parse", "main"]),
+    );
+    await expect(readFile(path.join(result.targetPath, "main-only.txt"), "utf8")).resolves.toBe(
+      "main\n",
+    );
   });
 
   it("moves a dirty worktree branch back to local and archives the old worktree", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1991,6 +1991,7 @@ describe("MessagingController", () => {
               retryAfterMs: 5_000,
               observedAt: now,
               message: "Too Many Requests",
+              retryable: true,
             },
           };
         }
@@ -2008,6 +2009,7 @@ describe("MessagingController", () => {
       },
     });
     await bindThread(harness);
+    const deliveriesBefore = Object.keys((await harness.store.readSnapshot()).deliveries).length;
     attempts.length = 0;
     rejectNextStream = true;
 
@@ -2030,6 +2032,81 @@ describe("MessagingController", () => {
         text: "Hello",
       }),
     ]);
+    expect(Object.keys((await harness.store.readSnapshot()).deliveries)).toHaveLength(
+      deliveriesBefore,
+    );
+  });
+
+  it("does not replay non-retryable provider rate-limit failures", async () => {
+    let now = 1000;
+    let rejectNextStream = false;
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:dm:chat-1",
+      kind: "dm",
+      budget: { limit: 10, intervalMs: 60_000, reserved: 1 },
+    };
+    const attempts: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      now: () => now,
+      deliveryBudget: new MessagingDeliveryBudget({ now: () => now }),
+      deliver: async (intent) => {
+        attempts.push(intent);
+        if (rejectNextStream && intent.kind === "stream_update") {
+          return {
+            channel: "telegram" as const,
+            deliveredAt: now,
+            errorMessage: "Too Many Requests after partial send",
+            outcome: "failed" as const,
+            rateLimit: {
+              scope,
+              retryAfterMs: 5_000,
+              observedAt: now,
+              message: "Too Many Requests after partial send",
+              retryable: false,
+            },
+          };
+        }
+        return {
+          channel: "telegram" as const,
+          deliveredAt: now,
+          outcome: intent.kind === "status" && intent.delivery?.pin
+            ? "pinned" as const
+            : "presented" as const,
+          surface: {
+            channel: "telegram" as const,
+            id: `surface:${intent.id}`,
+          },
+        };
+      },
+    });
+    await bindThread(harness);
+    const deliveriesBefore = Object.keys((await harness.store.readSnapshot()).deliveries).length;
+    attempts.length = 0;
+    rejectNextStream = true;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+          delta: "Hello",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(attempts).toHaveLength(1);
+    const deliveries = Object.values((await harness.store.readSnapshot()).deliveries);
+    expect(deliveries).toHaveLength(deliveriesBefore + 1);
+    expect(deliveries.at(-1)).toMatchObject({
+      outcome: "failed",
+      rateLimit: {
+        retryable: false,
+      },
+    });
   });
 
   it("serializes concurrent assistant stream deliveries onto one surface", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -19,6 +19,7 @@ import type {
 } from "@pwragent/shared";
 import type {
   MessagingSurfaceAction,
+  MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundCallbackEvent,
   MessagingInboundEvent,
@@ -31,6 +32,7 @@ import {
   type MessagingControllerOptions,
 } from "../messaging/core/messaging-controller";
 import type { MessagingAdapter, MessagingBackendBridge } from "../messaging/core/messaging-adapter";
+import { MessagingDeliveryBudget } from "../messaging/core/messaging-delivery-budget";
 import { MessagingStore } from "../messaging/core/messaging-store";
 
 const tempDirs: string[] = [];
@@ -1961,6 +1963,73 @@ describe("MessagingController", () => {
       },
     });
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([]);
+  });
+
+  it("rechecks budget admission after a provider rate-limit rejection", async () => {
+    let now = 1000;
+    let rejectNextStream = false;
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:dm:chat-1",
+      kind: "dm",
+      budget: { limit: 10, intervalMs: 60_000, reserved: 1 },
+    };
+    const attempts: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      now: () => now,
+      deliveryBudget: new MessagingDeliveryBudget({ now: () => now }),
+      deliver: async (intent) => {
+        attempts.push(intent);
+        if (rejectNextStream && intent.kind === "stream_update") {
+          return {
+            channel: "telegram" as const,
+            deliveredAt: now,
+            errorMessage: "Too Many Requests",
+            outcome: "failed" as const,
+            rateLimit: {
+              scope,
+              retryAfterMs: 5_000,
+              observedAt: now,
+              message: "Too Many Requests",
+            },
+          };
+        }
+        return {
+          channel: "telegram" as const,
+          deliveredAt: now,
+          outcome: intent.kind === "status" && intent.delivery?.pin
+            ? "pinned" as const
+            : "presented" as const,
+          surface: {
+            channel: "telegram" as const,
+            id: `surface:${intent.id}`,
+          },
+        };
+      },
+    });
+    await bindThread(harness);
+    attempts.length = 0;
+    rejectNextStream = true;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+          delta: "Hello",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(attempts).toEqual([
+      expect.objectContaining({
+        kind: "stream_update",
+        text: "Hello",
+      }),
+    ]);
   });
 
   it("serializes concurrent assistant stream deliveries onto one surface", async () => {
@@ -4068,12 +4137,14 @@ describe("MessagingController", () => {
 });
 
 async function createHarness(options?: {
+  deliveryBudget?: MessagingDeliveryBudget;
   deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
   handoff?: false;
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
   now?: () => number;
+  resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
   /**
    * Set to `false` to construct the controller WITHOUT an
    * `onBindingChanged` callback. Used by tests that verify the
@@ -4111,6 +4182,9 @@ async function createHarness(options?: {
     capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
     ...(options?.downloadAttachment
       ? { downloadAttachment: options.downloadAttachment }
+      : {}),
+    ...(options?.resolveDeliveryScope
+      ? { resolveDeliveryScope: options.resolveDeliveryScope }
       : {}),
     deliver: vi.fn(
       options?.deliver ??
@@ -4265,6 +4339,7 @@ async function createHarness(options?: {
     adapter,
     authorizedActorIds: ["user-1"],
     backend,
+    deliveryBudget: options?.deliveryBudget,
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -19,6 +19,7 @@ import type {
 } from "@pwragent/shared";
 import type {
   MessagingSurfaceAction,
+  MessagingChannelKind,
   MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundCallbackEvent,
@@ -29,6 +30,7 @@ import type {
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import {
   MessagingController,
+  messagingDeliveryPriority,
   type MessagingControllerOptions,
 } from "../messaging/core/messaging-controller";
 import type { MessagingAdapter, MessagingBackendBridge } from "../messaging/core/messaging-adapter";
@@ -2107,6 +2109,123 @@ describe("MessagingController", () => {
         retryable: false,
       },
     });
+  });
+
+  it("reports budget deferrals before holding final stream updates", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:group:chat-1",
+      kind: "group",
+      budget: { limit: 1, intervalMs: 60_000, reserved: 0 },
+    };
+    const budgetEvents: Parameters<
+      NonNullable<MessagingControllerOptions["onDeliveryBudgetEvent"]>
+    >[0][] = [];
+    const onDeliveryBudgetEvent = vi.fn(
+      (event: Parameters<
+        NonNullable<MessagingControllerOptions["onDeliveryBudgetEvent"]>
+      >[0]) => {
+        budgetEvents.push(event);
+      },
+    );
+    const harness = await createHarness({
+      channel: "telegram",
+      now: () => now,
+      deliveryBudget: new MessagingDeliveryBudget({ now: () => now }),
+      resolveDeliveryScope: (intent) =>
+        intent.kind === "stream_update" ? scope : undefined,
+      onDeliveryBudgetEvent,
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+          delta: "Hello",
+        },
+      },
+    } satisfies AgentEvent);
+
+    const finalDelivery = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Hello final." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await vi.waitFor(() => {
+      expect(onDeliveryBudgetEvent).toHaveBeenCalledTimes(1);
+    });
+    expect(budgetEvents).toEqual([
+      expect.objectContaining({
+        intentKind: "stream_update",
+        outcome: "deferred",
+        priority: "final_turn",
+        retryAt: 61_000,
+        scope,
+      }),
+    ]);
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "stream_update" && intent.stream.isFinal,
+      ),
+    ).toEqual([]);
+
+    now = 61_001;
+    await vi.advanceTimersByTimeAsync(60_001);
+    await finalDelivery;
+
+    expect(
+      harness.delivered.find(
+        (intent) => intent.kind === "stream_update" && intent.stream.isFinal,
+      ),
+    ).toMatchObject({
+      kind: "stream_update",
+      text: "Hello final.",
+    });
+  });
+
+  it("treats actionless approval cleanup edits as routine budget traffic", () => {
+    const approvalWithButtons = {
+      id: "approval-1",
+      kind: "approval",
+      createdAt: 1_000,
+      title: "Approve",
+      body: "Run command?",
+      decisions: [
+        {
+          id: "accept",
+          label: "Approve",
+          decision: "accept",
+        },
+      ],
+    } satisfies MessagingSurfaceIntent;
+    const approvalCleanup = {
+      ...approvalWithButtons,
+      id: "approval-2",
+      decisions: [],
+    } satisfies MessagingSurfaceIntent;
+
+    expect(messagingDeliveryPriority(approvalWithButtons)).toBe(
+      "critical_interactive",
+    );
+    expect(messagingDeliveryPriority(approvalCleanup)).toBe("routine_status");
   });
 
   it("serializes concurrent assistant stream deliveries onto one surface", async () => {
@@ -4221,6 +4340,8 @@ async function createHarness(options?: {
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
   now?: () => number;
+  channel?: MessagingChannelKind;
+  onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
   /**
    * Set to `false` to construct the controller WITHOUT an
@@ -4416,10 +4537,12 @@ async function createHarness(options?: {
     adapter,
     authorizedActorIds: ["user-1"],
     backend,
+    channel: options?.channel,
     deliveryBudget: options?.deliveryBudget,
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),
+    onDeliveryBudgetEvent: options?.onDeliveryBudgetEvent,
     // Pass the spy by default so tests can assert on fan-out. The
     // `bindingChangedListener: false` opt-out exists for tests that
     // verify the nullish-callback guard — production wiring always

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2177,6 +2177,7 @@ describe("MessagingController", () => {
         intentKind: "stream_update",
         outcome: "deferred",
         priority: "final_turn",
+        reason: "budget-exhausted",
         retryAt: 61_000,
         scope,
       }),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -653,14 +653,10 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "activity",
       activity: "typing",
       state: "active",
-    });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Turn: working"),
     });
 
     await harness.controller.handleBackendEvent({
@@ -679,14 +675,10 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "activity",
       activity: "typing",
       state: "idle",
-    });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Turn: completed"),
     });
   });
 
@@ -725,7 +717,7 @@ describe("MessagingController", () => {
         },
       },
     } satisfies AgentEvent);
-    expect(harness.delivered).toHaveLength(2);
+    expect(harness.delivered).toHaveLength(1);
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -743,7 +735,7 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered).toHaveLength(2);
+    expect(harness.delivered).toHaveLength(1);
   });
 
   it("stops typing when the backend reports idle without a turn completion event", async () => {
@@ -765,14 +757,10 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "activity",
       activity: "typing",
       state: "idle",
-    });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Turn: completed"),
     });
   });
 
@@ -1790,8 +1778,9 @@ describe("MessagingController", () => {
         ],
       });
     expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Turn: completed"),
+      kind: "activity",
+      activity: "typing",
+      state: "idle",
     });
   });
 
@@ -2608,7 +2597,7 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "activity",
       activity: "typing",
       state: "idle",
@@ -2738,7 +2727,7 @@ describe("MessagingController", () => {
     ]);
   });
 
-  it("batches noisy default tool updates and flushes them before turn status", async () => {
+  it("batches noisy default tool updates and flushes them before turn completion activity", async () => {
     const harness = await createHarness();
     await bindThread(harness);
     await harness.controller.handleInboundEvent(buildTextEvent("start work"));
@@ -2777,12 +2766,15 @@ describe("MessagingController", () => {
           (part) => part.type === "text" && part.text.includes("Tool updates: ran 1 tool"),
         ),
     );
-    const statusIndex = harness.delivered.findIndex(
-      (intent) => intent.kind === "status" && intent.status === "idle",
+    const activityIndex = harness.delivered.findIndex(
+      (intent) =>
+        intent.kind === "activity" &&
+        intent.activity === "typing" &&
+        intent.state === "idle",
     );
 
     expect(batchIndex).toBeGreaterThanOrEqual(0);
-    expect(statusIndex).toBeGreaterThan(batchIndex);
+    expect(activityIndex).toBeGreaterThan(batchIndex);
   });
 
   it("flushes queued tool updates before assistant final text", async () => {
@@ -2899,15 +2891,11 @@ describe("MessagingController", () => {
       },
     } as unknown as AgentEvent);
 
-    expect(harness.delivered).toHaveLength(2);
-    expect(harness.delivered.at(-2)).toMatchObject({
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "activity",
       activity: "typing",
       state: "idle",
-    });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Turn: completed"),
     });
   });
 
@@ -3140,9 +3128,14 @@ describe("MessagingController", () => {
         decision: "accept_for_session",
       },
     });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: "Approval response sent.",
+    expect(
+      harness.delivered.find(
+        (intent) => intent.kind === "approval" && intent.decisions.length === 0,
+      ),
+    ).toMatchObject({
+      kind: "approval",
+      body: expect.stringContaining("Response Received: Approved for Session"),
+      decisions: [],
     });
   });
 
@@ -3169,20 +3162,13 @@ describe("MessagingController", () => {
     expect(harness.delivered).toEqual([
       expect.objectContaining({
         kind: "approval",
+        body: expect.stringContaining("Response Received: Approved"),
         decisions: [],
       }),
       expect.objectContaining({
         kind: "activity",
         activity: "typing",
         state: "active",
-      }),
-      expect.objectContaining({
-        kind: "status",
-        status: "working",
-      }),
-      expect.objectContaining({
-        kind: "status",
-        text: "Approval response sent.",
       }),
     ]);
   });
@@ -3229,6 +3215,7 @@ describe("MessagingController", () => {
       ),
     ).toMatchObject({
       kind: "approval",
+      body: expect.stringContaining("Response Received: Approved"),
       decisions: [],
       delivery: {
         mode: "update",
@@ -3238,10 +3225,6 @@ describe("MessagingController", () => {
       targetSurface: {
         id: `surface:${approvalIntent?.id}`,
       },
-    });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: "Approval response sent.",
     });
   });
 
@@ -3286,6 +3269,7 @@ describe("MessagingController", () => {
       ),
     ).toMatchObject({
       kind: "approval",
+      body: expect.stringContaining("Response Received: Resolved"),
       decisions: [],
       delivery: {
         mode: "update",
@@ -3330,6 +3314,7 @@ describe("MessagingController", () => {
     expect(harness.delivered).toEqual([
       expect.objectContaining({
         kind: "approval",
+        body: expect.stringContaining("Response Received: Resolved"),
         decisions: [],
         targetSurface: expect.objectContaining({
           id: `surface:${approvalIntent?.id}`,
@@ -3339,10 +3324,6 @@ describe("MessagingController", () => {
         kind: "activity",
         activity: "typing",
         state: "active",
-      }),
-      expect.objectContaining({
-        kind: "status",
-        status: "working",
       }),
     ]);
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -286,6 +286,51 @@ describe("MessagingController", () => {
           label: "Tools: Show Some",
           fallbackText: "tools",
         }),
+        expect.objectContaining({
+          id: "status:streaming",
+          label: "Stream: Inherit",
+          fallbackText: "stream",
+        }),
+      ]),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      text: expect.stringContaining("Streaming: Inherit"),
+    });
+  });
+
+  it("cycles per-binding streaming mode from the status card", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:streaming" }),
+    );
+
+    const bindingAfterDisable = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(bindingAfterDisable?.preferences?.streamingResponses).toBe("disabled");
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Streaming: Off"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ label: "Stream: Off" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:streaming" }),
+    );
+
+    const bindingAfterEnable = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(bindingAfterEnable?.preferences?.streamingResponses).toBe("enabled");
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Streaming: Advanced"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ label: "Stream: Advanced" }),
       ]),
     });
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -144,6 +144,17 @@ describe("MessagingController", () => {
       }),
     );
 
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Workspace: Local"),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:start",
+      }),
+    );
+
     expect(harness.startThread).toHaveBeenCalledWith({
       backend: "codex",
       cwd: "/repo/pwragent",
@@ -152,6 +163,8 @@ describe("MessagingController", () => {
       model: undefined,
       reasoningEffort: undefined,
       serviceTier: undefined,
+      workMode: "local",
+      branchName: undefined,
     });
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
@@ -193,6 +206,11 @@ describe("MessagingController", () => {
           label: "PwrAgent",
           path: "/repo/pwragent",
         },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:start",
       }),
     );
     await harness.controller.handleInboundEvent(buildTextEvent("continue on the new thread"));
@@ -3952,13 +3970,13 @@ describe("MessagingController", () => {
       prompt: expect.stringContaining("Workspace Handoff"),
       choices: expect.arrayContaining([
         expect.objectContaining({
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
+          id: "handoff:move-branch",
+          label: "Move Branch",
         }),
       ]),
     });
 
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -3972,22 +3990,22 @@ describe("MessagingController", () => {
       choices: expect.arrayContaining([
         expect.objectContaining({
           id: "handoff:select-leave-branch",
-          label: "1. main",
+          label: "1. Detached HEAD",
         }),
       ]),
     });
 
-    const leaveMain = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
+    const leaveDetached = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
-        actionId: leaveMain.id,
-        value: leaveMain.value,
+        actionId: leaveDetached.id,
+        value: leaveDetached.value,
       }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      body: expect.stringContaining("Leave Local on: main"),
+      body: expect.stringContaining("Leave Local on: Detached HEAD"),
     });
 
     const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
@@ -4005,10 +4023,11 @@ describe("MessagingController", () => {
     expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
       backend: "codex",
       direction: "local-to-worktree",
-      leaveLocalBranch: "main",
+      leaveLocalBranch: "HEAD",
       repositoryPath: "/repo/pwragent",
       sourceBranch: "feature/handoff",
       sourcePath: "/repo/pwragent",
+      strategy: "move-branch",
       threadId: "thread-1",
     });
     expect(harness.delivered.at(-2)).toMatchObject({
@@ -4038,7 +4057,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4076,7 +4095,7 @@ describe("MessagingController", () => {
     expect(secondPage.prompt).toContain("Page 2/3.");
     expect(secondPage.choices[0]).toMatchObject({
       id: "handoff:select-leave-branch",
-      label: "9. branch-9",
+      label: "9. branch-8",
     });
     expect(secondPage.choices).toContainEqual(
       expect.objectContaining({
@@ -4122,14 +4141,14 @@ describe("MessagingController", () => {
       }),
     );
 
-    expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
+    expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith(expect.objectContaining({
       backend: "codex",
       direction: "worktree-to-local",
       repositoryPath: "/repo/pwragent",
       sourceBranch: "feature/handoff",
       sourcePath: "/repo/pwragent/.worktrees/pwragent-feature-handoff",
       threadId: "thread-1",
-    });
+    }));
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
       text: expect.stringContaining("Directory: /repo/pwragent"),
@@ -4150,7 +4169,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4190,7 +4209,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,

--- a/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
@@ -17,9 +17,11 @@ describe("MessagingDeliveryBudget", () => {
     expect(budget.admit({ scope, priority: "stream_partial" })).toMatchObject({
       outcome: "dropped",
       reason: "budget-exhausted",
+      slowMode: true,
     });
     expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
       outcome: "admitted",
+      slowMode: true,
     });
 
     now += 60_001;
@@ -46,6 +48,7 @@ describe("MessagingDeliveryBudget", () => {
     });
     expect(budget.admit({ scope, priority: "final_turn" })).toEqual({
       outcome: "deferred",
+      reason: "cool-off",
       retryAt: 28_000,
       slowMode: true,
     });
@@ -59,6 +62,39 @@ describe("MessagingDeliveryBudget", () => {
     expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
       outcome: "admitted",
       slowMode: true,
+    });
+  });
+
+  it("enters slow mode when the local budget is exhausted", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 1, reserved: 0 });
+
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+    expect(budget.admit({ scope, priority: "routine_status" })).toEqual({
+      outcome: "dropped",
+      reason: "budget-exhausted",
+      slowMode: true,
+    });
+    expect(budget.admit({ scope, priority: "stream_partial" })).toEqual({
+      outcome: "dropped",
+      reason: "slow-mode",
+      slowMode: true,
+    });
+    expect(budget.admit({ scope, priority: "final_turn" })).toEqual({
+      outcome: "deferred",
+      reason: "budget-exhausted",
+      retryAt: 61_000,
+      slowMode: true,
+    });
+
+    now = 61_001;
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { MessagingDeliveryScope } from "@pwragent/messaging-interface";
+import { MessagingDeliveryBudget } from "../messaging/core/messaging-delivery-budget";
+
+describe("MessagingDeliveryBudget", () => {
+  it("admits traffic under budget and reserves capacity for final turns", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 3, reserved: 1 });
+
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+    });
+    expect(budget.admit({ scope, priority: "tool_progress" })).toMatchObject({
+      outcome: "admitted",
+    });
+    expect(budget.admit({ scope, priority: "stream_partial" })).toMatchObject({
+      outcome: "dropped",
+      reason: "budget-exhausted",
+    });
+    expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
+      outcome: "admitted",
+    });
+
+    now += 60_001;
+    expect(budget.admit({ scope, priority: "stream_partial" })).toMatchObject({
+      outcome: "admitted",
+    });
+  });
+
+  it("enters cool-off after a provider rate limit and then slow mode", () => {
+    let now = 10_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 20, reserved: 5 });
+
+    budget.recordRateLimit({
+      scope,
+      retryAfterMs: 16_000,
+      observedAt: now,
+    });
+
+    expect(budget.admit({ scope, priority: "stream_partial" })).toEqual({
+      outcome: "dropped",
+      reason: "cool-off",
+      slowMode: true,
+    });
+    expect(budget.admit({ scope, priority: "final_turn" })).toEqual({
+      outcome: "deferred",
+      retryAt: 28_000,
+      slowMode: true,
+    });
+
+    now = 28_001;
+    expect(budget.admit({ scope, priority: "tool_progress" })).toEqual({
+      outcome: "dropped",
+      reason: "slow-mode",
+      slowMode: true,
+    });
+    expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: true,
+    });
+  });
+
+  it("keeps independent scopes from throttling each other", () => {
+    const budget = new MessagingDeliveryBudget({ now: () => 1_000 });
+    const first = testScope({ id: "telegram:group:1", limit: 1, reserved: 0 });
+    const second = testScope({ id: "telegram:group:2", limit: 1, reserved: 0 });
+
+    expect(budget.admit({ scope: first, priority: "routine_status" }))
+      .toMatchObject({ outcome: "admitted" });
+    expect(budget.admit({ scope: first, priority: "routine_status" }))
+      .toMatchObject({ outcome: "dropped" });
+    expect(budget.admit({ scope: second, priority: "routine_status" }))
+      .toMatchObject({ outcome: "admitted" });
+  });
+});
+
+function testScope(options: {
+  id?: string;
+  limit: number;
+  reserved: number;
+}): MessagingDeliveryScope {
+  return {
+    platform: "telegram",
+    id: options.id ?? "telegram:supergroup:-1003841603622",
+    kind: "group",
+    budget: {
+      limit: options.limit,
+      intervalMs: 60_000,
+      reserved: options.reserved,
+    },
+  };
+}

--- a/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
@@ -227,6 +227,124 @@ describe("messaging resume browser", () => {
     expect(intent.prompt).not.toContain("1. PwrAgent");
     expect(intent.fallbackText).toContain("1. PwrAgent");
   });
+
+  it("renders new-thread workspace options after a project is selected", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot(),
+      session: buildBrowseSession({
+        launchAction: "start_new_thread",
+        mode: "new_thread_options",
+        selectedProject: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    });
+
+    expect(intent).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Workspace: Local"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({ id: "browse:new:start", label: "Start in Local" }),
+        expect.objectContaining({ id: "browse:new:toggle-workmode", label: "New Worktree" }),
+      ]),
+    });
+  });
+
+  it("shows the default base branch when new-thread worktree mode is selected", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot({
+        directories: [
+          {
+            key: "directory:pwragent",
+            kind: "directory",
+            label: "PwrAgent",
+            path: "/repo/pwragent",
+            threadKeys: ["codex:thread-1"],
+            needsAttentionCount: 0,
+            latestUpdatedAt: 1000,
+            gitStatus: {
+              currentBranch: "feature/current",
+              defaultBranch: "main",
+              branches: ["feature/current", "main", "release"],
+            },
+          },
+        ],
+      }),
+      session: buildBrowseSession({
+        launchAction: "start_new_thread",
+        mode: "new_thread_options",
+        newThreadWorkMode: "worktree",
+        selectedProject: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    });
+
+    expect(intent).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Base branch: main"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:base-branch",
+          label: "Base Branch (main)",
+        }),
+      ]),
+    });
+  });
+
+  it("renders a base-branch picker for new worktree threads", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot({
+        directories: [
+          {
+            key: "directory:pwragent",
+            kind: "directory",
+            label: "PwrAgent",
+            path: "/repo/pwragent",
+            threadKeys: ["codex:thread-1"],
+            needsAttentionCount: 0,
+            latestUpdatedAt: 1000,
+            gitStatus: {
+              currentBranch: "feature/current",
+              defaultBranch: "main",
+              branches: ["feature/current", "main", "release"],
+            },
+          },
+        ],
+      }),
+      session: buildBrowseSession({
+        launchAction: "start_new_thread",
+        mode: "new_base_branch",
+        newThreadWorkMode: "worktree",
+        selectedProject: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    });
+
+    expect(intent).toMatchObject({
+      kind: "single_select",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:select-base-branch",
+          label: "1. main (current)",
+          value: { branch: "main" },
+        }),
+      ]),
+    });
+  });
 });
 
 function buildBrowseSession(

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -10,8 +10,11 @@ import type {
 import type {
   MessagingChannelKind,
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingRateLimitInfo,
+  MessagingReconnectInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -997,6 +1000,124 @@ describe("DesktopMessagingRuntime", () => {
         reason: expect.stringContaining("409"),
       }),
     ]);
+  });
+
+  it("emits health=degraded during rate-limit cool-off and reconnect attempts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    await prepareRuntimeStore();
+    let fireRateLimit: ((info: MessagingRateLimitInfo) => void) | undefined;
+    let fireReconnect: ((info: MessagingReconnectInfo) => void) | undefined;
+    const scope: MessagingDeliveryScope = {
+      id: "telegram:group:-100123",
+      kind: "group",
+      label: "Telegram group -100123",
+      platform: "telegram",
+    };
+    const adapter = createAdapter("telegram", {
+      onRateLimit: (listener: (info: MessagingRateLimitInfo) => void) => {
+        fireRateLimit = listener;
+        return () => {
+          fireRateLimit = undefined;
+        };
+      },
+      onReconnect: (listener: (info: MessagingReconnectInfo) => void) => {
+        fireReconnect = listener;
+        return () => {
+          fireReconnect = undefined;
+        };
+      },
+    });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: createBackendBridge(),
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    try {
+      await runtime.start();
+      const events: unknown[] = [];
+      runtime.onPlatformStatus((event) => events.push(event));
+
+      fireRateLimit?.({
+        message: "Too many requests",
+        observedAt: 1000,
+        retryAfterMs: 5000,
+        scope,
+      });
+
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "degraded",
+          platform: "telegram",
+          degradationReasons: [
+            expect.objectContaining({
+              kind: "rate-limited",
+              scope: expect.objectContaining({ id: scope.id }),
+            }),
+          ],
+        }),
+      ]);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          health: "degraded",
+          platform: "telegram",
+          degradationReasons: [
+            expect.objectContaining({ kind: "rate-limited" }),
+          ],
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(7000);
+
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "enabled",
+          platform: "telegram",
+          degradationReasons: [],
+        }),
+      ]);
+
+      fireReconnect?.({
+        attemptCount: 1,
+        lastFailureReason: "socket closed",
+        observedAt: Date.now(),
+        state: "started",
+      });
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "degraded",
+          platform: "telegram",
+          degradationReasons: [
+            expect.objectContaining({
+              attemptCount: 1,
+              kind: "reconnecting",
+            }),
+          ],
+        }),
+      ]);
+
+      fireReconnect?.({ observedAt: Date.now(), state: "recovered" });
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "enabled",
+          platform: "telegram",
+          degradationReasons: [],
+        }),
+      ]);
+    } finally {
+      await runtime.stop();
+      vi.useRealTimers();
+    }
   });
 
   it("detaches adapter runtime-error listeners on stop so a graceful shutdown does not flip to errored", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -275,7 +275,9 @@ describe("DesktopMessagingRuntime", () => {
         role: "assistant",
       });
     expect(adapter.delivered.at(-1)).toMatchObject({
-      kind: "status",
+      kind: "activity",
+      activity: "typing",
+      state: "idle",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -67,7 +67,15 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Reasoning: high");
     expect(intent.text).toContain("Fast mode: on");
     expect(intent.text).toContain("Permissions: Full Access");
+    expect(intent.text).toContain("Streaming: Inherit");
     expect(intent.text).toContain("Context usage: unavailable");
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "status:streaming",
+        label: "Stream: Inherit",
+        fallbackText: "stream",
+      }),
+    );
   });
 
   it("targets an existing status surface for updates", () => {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@pwragent/messaging-interface";
 import {
   buildBindingStatusIntent,
+  buildHandoffBaseBranchPickerIntent,
   buildHandoffBranchPickerIntent,
   buildHandoffConfirmationIntent,
   buildHandoffOverviewIntent,
@@ -382,8 +383,12 @@ describe("buildBindingStatusIntent", () => {
       prompt: expect.stringContaining("Workspace Handoff"),
       choices: expect.arrayContaining([
         expect.objectContaining({
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
+          id: "handoff:move-branch",
+          label: "Move Branch",
+        }),
+        expect.objectContaining({
+          id: "handoff:create-detached",
+          label: "Create Detached HEAD",
         }),
       ]),
     });
@@ -396,9 +401,9 @@ describe("buildBindingStatusIntent", () => {
     });
     expect(branchPicker.choices[0]).toMatchObject({
       id: "handoff:select-leave-branch",
-      label: "1. main",
+      label: "1. Detached HEAD",
       value: expect.objectContaining({
-        leaveLocalBranch: "main",
+        leaveLocalBranch: "HEAD",
       }),
     });
 
@@ -407,17 +412,46 @@ describe("buildBindingStatusIntent", () => {
       binding,
       context,
       createdAt: 1000,
-      leaveLocalBranch: "main",
+      leaveLocalBranch: "HEAD",
     });
     expect(confirmation).toMatchObject({
       kind: "confirmation",
       title: "Confirm Handoff",
-      body: expect.stringContaining("Leave Local on: main"),
+      body: expect.stringContaining("Leave Local on: Detached HEAD"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "handoff:confirm",
           value: expect.objectContaining({
-            leaveLocalBranch: "main",
+            leaveLocalBranch: "HEAD",
+          }),
+        }),
+      ]),
+    });
+  });
+
+  it("builds a clean detached handoff base branch picker", () => {
+    const binding = buildBinding();
+    const context = {
+      ...buildHandoffContext(),
+      hasUncommittedChanges: false,
+    };
+    const picker = buildHandoffBaseBranchPickerIntent({
+      id: "handoff-base-branch-1",
+      binding,
+      context,
+      createdAt: 1000,
+    });
+
+    expect(picker).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("base branch"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "handoff:select-base-branch",
+          label: "1. main (default)",
+          value: expect.objectContaining({
+            baseBranch: "main",
+            strategy: "detached-changes",
           }),
         }),
       ]),
@@ -483,18 +517,22 @@ describe("buildBindingStatusIntent", () => {
     expect(
       handoffRequestFromValue({
         backend: "codex",
+        baseBranch: "main",
         direction: "local-to-worktree",
         repositoryPath: "/repo/pwragent",
         sourceBranch: "feature/handoff",
         sourcePath: "/repo/pwragent",
+        strategy: "detached-changes",
         threadId: "thread-1",
       }),
     ).toEqual({
       backend: "codex",
+      baseBranch: "main",
       direction: "local-to-worktree",
       repositoryPath: "/repo/pwragent",
       sourceBranch: "feature/handoff",
       sourcePath: "/repo/pwragent",
+      strategy: "detached-changes",
       threadId: "thread-1",
     });
     expect(handoffRequestFromValue({ direction: "local-to-worktree" })).toBeUndefined();
@@ -522,8 +560,12 @@ function buildBinding(): MessagingBindingRecord {
 function buildHandoffContext(): MessagingWorkspaceHandoffContext {
   return {
     backend: "codex",
+    baseBranches: ["main", "develop", "release"],
     branch: "feature/handoff",
-    leaveLocalBranches: ["main", "develop"],
+    currentSha: "abc123",
+    defaultBranch: "main",
+    hasUncommittedChanges: true,
+    leaveLocalBranches: ["HEAD", "main", "develop"],
     projectLabel: "PwrAgent",
     repositoryPath: "/repo/pwragent",
     threadId: "thread-1",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1542,15 +1542,46 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    workMode?: NavigationLaunchpadDraft["workMode"];
+    branchName?: string;
     linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
-    const { backend, executionMode = "default", linkedDirectories, ...request } = params;
+    const {
+      backend,
+      executionMode = "default",
+      linkedDirectories,
+      workMode,
+      branchName,
+      ...request
+    } = params;
     const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
     const modelSettings = await this.resolveModelSettings(backend, request);
+    const requestedCwd = request.cwd?.trim();
+    const preparedWorkspace =
+      workMode === "worktree" && requestedCwd
+          ? await this.gitDirectoryService.prepareLaunchpadWorkspace({
+            backend,
+            branchName,
+            directoryKind: "directory",
+            directoryLabel: path.basename(requestedCwd) || requestedCwd,
+            directoryPath: requestedCwd,
+            workMode: "worktree",
+          })
+        : undefined;
     const cwd =
-      backend === "codex" && !request.cwd?.trim()
+      preparedWorkspace?.cwd ??
+      (backend === "codex" && !requestedCwd
         ? await this.createScratchProjectDirectory()
-        : request.cwd;
+        : request.cwd);
+    const effectiveLinkedDirectories =
+      linkedDirectories ??
+      (preparedWorkspace?.workMode === "worktree"
+        ? buildWorktreeLinkedDirectory({
+            label: path.basename(preparedWorkspace.repositoryPath ?? requestedCwd ?? ""),
+            repositoryPath: preparedWorkspace.repositoryPath ?? requestedCwd,
+            worktreePath: preparedWorkspace.cwd,
+          })
+        : undefined);
 
     const result = await this.getClient(backend, executionMode).startThread({
       ...request,
@@ -1573,12 +1604,22 @@ export class DesktopBackendRegistry {
         executionMode,
         ...modelSettings,
         linkedDirectories: (
-          linkedDirectories?.length ? linkedDirectories : buildLocalLinkedDirectory(cwd)
+          effectiveLinkedDirectories?.length
+            ? effectiveLinkedDirectories
+            : buildLocalLinkedDirectory(cwd)
         ).map(normalizeLinkedDirectoryKind),
         gitBranch: cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined,
       },
     );
     this.invalidateThreadListCache(backend);
+
+    if (preparedWorkspace?.workMode === "worktree") {
+      await this.recordCodexWorktreeOwnerThread({
+        backend,
+        threadId: result.threadId,
+        worktreePath: preparedWorkspace.cwd,
+      });
+    }
 
     if (backend === "codex") {
       await this.overlayStore.setThreadExecutionMode({

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -320,8 +320,12 @@ export class GitDirectoryService {
   private async loadDirectoryStatus(
     cwd: string,
   ): Promise<NavigationDirectoryGitStatus | undefined> {
-    const [currentBranch, branchesOutput, remoteHead, worktreeList] = await Promise.all([
+    const [currentBranch, currentSha, dirtyStatus, branchesOutput, remoteHead, worktreeList] = await Promise.all([
       runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
+      runGit(cwd, ["rev-parse", "--verify", "HEAD^{commit}"]).catch(() => ""),
+      runGit(cwd, ["status", "--porcelain", "--untracked-files=normal"]).catch(
+        () => "",
+      ),
       runGit(cwd, [
         "for-each-ref",
         "refs/heads",
@@ -355,9 +359,11 @@ export class GitDirectoryService {
     if (!upstreamBranch) {
       return {
         currentBranch,
+        currentSha: currentSha || undefined,
         defaultBranch,
         branches,
         handoffBranches,
+        hasUncommittedChanges: dirtyStatus.trim().length > 0,
         syncState: "untracked",
       };
     }
@@ -384,12 +390,14 @@ export class GitDirectoryService {
 
     return {
       currentBranch,
+      currentSha: currentSha || undefined,
       upstreamBranch,
       ahead,
       behind,
       defaultBranch,
       branches,
       handoffBranches,
+      hasUncommittedChanges: dirtyStatus.trim().length > 0,
       syncState,
     };
   }

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -38,6 +38,7 @@ type HandoffParams = {
   sourcePath?: string;
   sourceBranch?: string;
   leaveLocalBranch?: string;
+  baseBranch?: string;
   now?: number;
 };
 
@@ -325,7 +326,11 @@ export class GitWorkspaceHandoffService {
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
-    await runGit(context.sourcePath, ["switch", leaveLocalBranch]);
+    if (leaveLocalBranch === "HEAD") {
+      await runGit(context.sourcePath, ["switch", "--detach"]);
+    } else {
+      await runGit(context.sourcePath, ["switch", leaveLocalBranch]);
+    }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
     await runGit(context.repositoryPath, ["worktree", "add", targetPath, context.branch]);
@@ -358,6 +363,7 @@ export class GitWorkspaceHandoffService {
     context: HandoffContext,
   ): Promise<HandoffThreadWorkspaceResponse> {
     const baseSha = context.headSha;
+    const requestedBaseBranch = sanitizeBranchName(params.baseBranch ?? "");
     const storage = await this.resolveStorage();
     const targetPath = await computeWorktreePath({
       backend: context.backend,
@@ -375,12 +381,22 @@ export class GitWorkspaceHandoffService {
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
-    if (!sourceStash) {
+    const baseRef = sourceStash || !requestedBaseBranch ? baseSha : requestedBaseBranch;
+    if (sourceStash && requestedBaseBranch) {
+      warnings.push(
+        `Dirty changes were present; the detached worktree starts at ${baseSha} instead of ${requestedBaseBranch}.`,
+      );
+    } else if (!sourceStash && requestedBaseBranch) {
+      warnings.push(`The new worktree starts detached from ${requestedBaseBranch}.`);
+    } else if (!sourceStash) {
       warnings.push("No dirty non-ignored changes were available to move.");
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseSha]);
+    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseRef]);
+    const detachedBaseSha = trim(
+      (await runGit(targetPath, ["rev-parse", "--verify", "HEAD^{commit}"])).stdout,
+    );
     const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
 
     const linkedDirectory = this.buildLinkedDirectory({
@@ -395,7 +411,8 @@ export class GitWorkspaceHandoffService {
       direction: "local-to-worktree",
       strategy: "detached-changes",
       workMode: "worktree",
-      baseSha,
+      baseSha: detachedBaseSha,
+      baseBranch: requestedBaseBranch && !sourceStash ? requestedBaseBranch : undefined,
       repositoryPath: context.repositoryPath,
       targetPath,
       linkedDirectory,

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -35,6 +35,7 @@ import type {
   MessagingAttachmentDownloadRequest,
   MessagingAttachmentDownloadResult,
   MessagingCapabilityProfile,
+  MessagingClientRateLimitStrategy,
   MessagingInboundEvent,
   MessagingActorIdentity,
   MessagingAdapterState,
@@ -62,6 +63,7 @@ export type MessagingConversationTitleUpdateResult = {
 
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
+  clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -30,6 +30,8 @@ import type {
 } from "@pwragent/shared";
 import type {
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
+  MessagingRateLimitInfo,
   MessagingAttachmentDownloadRequest,
   MessagingAttachmentDownloadResult,
   MessagingCapabilityProfile,
@@ -38,6 +40,7 @@ import type {
   MessagingAdapterState,
   MessagingChannelRef,
   MessagingChannelKind,
+  MessagingReconnectInfo,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 
@@ -60,6 +63,9 @@ export type MessagingConversationTitleUpdateResult = {
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
+  onReconnect?(listener: (info: MessagingReconnectInfo) => void): () => void;
   downloadAttachment?(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4044,7 +4044,18 @@ export class MessagingController {
       if (this.deliveryBudget && result.rateLimit) {
         scope = result.rateLimit.scope;
         this.deliveryBudget.recordRateLimit(result.rateLimit);
-        this.logger.debug?.("messaging delivery rate-limited; rechecking budget", {
+        if (result.rateLimit.retryable === true) {
+          this.logger.debug?.("messaging delivery rate-limited; rechecking budget", {
+            bindingId: binding?.id ?? intent.bindingId,
+            intentId: routedIntent.id,
+            intentKind: routedIntent.kind,
+            priority,
+            retryAfterMs: result.rateLimit.retryAfterMs,
+            scopeId: result.rateLimit.scope.id,
+          });
+          continue;
+        }
+        this.logger.debug?.("messaging delivery rate-limited; not retrying non-replayable attempt", {
           bindingId: binding?.id ?? intent.bindingId,
           intentId: routedIntent.id,
           intentKind: routedIntent.kind,
@@ -4052,7 +4063,6 @@ export class MessagingController {
           retryAfterMs: result.rateLimit.retryAfterMs,
           scopeId: result.rateLimit.scope.id,
         });
-        continue;
       }
       await this.options.store.recordDelivery({
         ...result,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4084,6 +4084,7 @@ export class MessagingController {
             intentKind: routedIntent.kind,
             outcome: "deferred",
             priority,
+            reason: admission.reason,
             retryAt: admission.retryAt,
             scope,
             slowMode: admission.slowMode,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -22,6 +22,7 @@ import type {
   MessagingCallbackHandleRecord,
   MessagingBrowseSessionRecord,
   MessagingActiveTurnSummary,
+  MessagingApprovalDecision,
   MessagingChannelKind,
   MessagingConfirmationIntent,
   MessagingDeliveryScope,
@@ -519,7 +520,9 @@ export class MessagingController {
           reason: event.notification.method,
           force: true,
         });
-        await this.renderBindingStatus(binding);
+        if (shouldRenderStatusForTurnStateChange(event, lifecycle)) {
+          await this.renderBindingStatus(binding);
+        }
         await this.startNextQueuedTurn(binding);
       } else if (activeTurn?.status === "waiting" && isTurnWorkActivityEvent(event, activeTurn)) {
         const previousTurn = activeTurn;
@@ -539,7 +542,6 @@ export class MessagingController {
           reason: event.notification.method,
           force: true,
         });
-        await this.renderBindingStatus(binding);
       } else {
         const latestActiveTurn = this.getActiveTurn(binding);
         if (latestActiveTurn?.status !== "working") {
@@ -1387,25 +1389,19 @@ export class MessagingController {
         (candidate) => candidate.id === (event.actionId ?? event.interaction.id),
       );
       if (action && pendingIntent.intent.kind === "approval") {
-        await this.submitApprovalAction(pendingIntent.intent, action.id);
-        await this.retireApprovalIntent(pendingIntent, event);
+        const decision = await this.submitApprovalAction(
+          pendingIntent.intent,
+          action.id,
+        );
+        await this.retireApprovalIntent(
+          pendingIntent,
+          event,
+          approvalResponseLabel(decision),
+        );
         await this.options.store.deletePendingIntent(pendingIntent.id);
-        const resumedBinding = await this.resumeBindingForPendingIntent(
+        await this.resumeBindingForPendingIntent(
           pendingIntent,
           "pending_request.submitted",
-        );
-        if (resumedBinding) {
-          await this.renderBindingStatus(resumedBinding, event);
-        }
-        await this.deliver(
-          buildStatusIntent({
-            id: this.newIntentId("approval-submitted"),
-            createdAt: this.now(),
-            status: "completed",
-            text: "Approval response sent.",
-          }),
-          undefined,
-          event,
         );
         return;
       }
@@ -1442,11 +1438,11 @@ export class MessagingController {
   private async submitApprovalAction(
     intent: Extract<MessagingSurfaceIntent, { kind: "approval" }>,
     actionId: string,
-  ): Promise<void> {
+  ): Promise<MessagingApprovalDecision | undefined> {
     const requestContext = intent.requestContext;
     const decision = intent.decisions.find((action) => action.id === actionId)?.decision;
     if (!requestContext || !decision || !this.options.backend.submitServerRequest) {
-      return;
+      return decision;
     }
 
     await this.options.backend.submitServerRequest({
@@ -1458,6 +1454,7 @@ export class MessagingController {
         decision,
       },
     });
+    return decision;
   }
 
   /**
@@ -1730,21 +1727,19 @@ export class MessagingController {
     for (const pendingIntent of pendingIntents.filter((intent) =>
       this.isChannelInScope(intent.channel),
     )) {
-      await this.retireApprovalIntent(pendingIntent);
+      await this.retireApprovalIntent(pendingIntent, undefined, "Resolved");
       await this.options.store.deletePendingIntent(pendingIntent.id);
-      const resumedBinding = await this.resumeBindingForPendingIntent(
+      await this.resumeBindingForPendingIntent(
         pendingIntent,
         event.notification.method,
       );
-      if (resumedBinding) {
-        await this.renderBindingStatus(resumedBinding);
-      }
     }
   }
 
   private async retireApprovalIntent(
     pendingIntent: MessagingPendingIntentRecord,
     event?: MessagingInboundCallbackEvent,
+    responseLabel = "Resolved",
   ): Promise<void> {
     if (pendingIntent.intent.kind !== "approval") {
       return;
@@ -1759,12 +1754,14 @@ export class MessagingController {
       await this.deliver(
         {
           ...pendingIntent.intent,
+          body: approvalBodyWithResponse(pendingIntent.intent.body, responseLabel),
           decisions: [],
           delivery: {
             mode: "update",
             replaceMarkup: true,
             fallback: "fail",
           },
+          fallbackText: `Approval response received: ${responseLabel}.`,
           targetSurface,
         },
         undefined,
@@ -4726,6 +4723,16 @@ function isThreadNameUpdatedEvent(event: AgentEvent): boolean {
   return event.notification.method === "thread/name/updated";
 }
 
+function shouldRenderStatusForTurnStateChange(
+  event: AgentEvent,
+  lifecycle: MessagingActiveTurnSummary | undefined,
+): boolean {
+  if (event.notification.method === "thread/status/changed") {
+    return false;
+  }
+  return Boolean(lifecycle && ["failed", "interrupted"].includes(lifecycle.status));
+}
+
 function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boolean {
   if (intent.kind === "activity" || intent.kind === "dismiss") {
     return false;
@@ -4774,6 +4781,38 @@ export function messagingDeliveryPriority(
     case "error":
       return "user_command";
   }
+}
+
+function approvalResponseLabel(
+  decision: MessagingApprovalDecision | undefined,
+): string {
+  switch (decision) {
+    case "accept":
+      return "Approved";
+    case "accept_for_session":
+      return "Approved for Session";
+    case "decline":
+      return "Declined";
+    case "cancel":
+      return "Canceled";
+    case undefined:
+      return "Resolved";
+  }
+}
+
+function approvalBodyWithResponse(body: string, responseLabel: string): string {
+  const blocks = body
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+  const preservedBlocks = blocks.filter((block, index) => {
+    if (index === 0) {
+      return false;
+    }
+    return !/^Reply with\b/i.test(block);
+  });
+
+  return [...preservedBlocks, `Response Received: ${responseLabel}`].join("\n\n");
 }
 
 function sleepUntil(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -24,6 +24,7 @@ import type {
   MessagingActiveTurnSummary,
   MessagingChannelKind,
   MessagingConfirmationIntent,
+  MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundCallbackEvent,
   MessagingInboundCommandEvent,
@@ -213,6 +214,22 @@ type MessagingToolUpdateDefaultModeResolver =
   | MessagingToolUpdateMode
   | (() => MessagingToolUpdateMode | Promise<MessagingToolUpdateMode>);
 
+export type MessagingControllerDeliveryBudgetEvent = {
+  at: number;
+  backend?: AppServerBackendKind;
+  bindingId?: string;
+  channel: MessagingChannelKind;
+  intentId: string;
+  intentKind: MessagingSurfaceIntent["kind"];
+  outcome: "deferred" | "dropped";
+  priority: MessagingDeliveryPriority;
+  reason?: "cool-off" | "slow-mode" | "budget-exhausted" | "missing-scope";
+  retryAt?: number;
+  scope?: MessagingDeliveryScope;
+  slowMode: boolean;
+  threadId?: ThreadIdentifier;
+};
+
 type QueuedTurnAction = {
   entryId: string;
   kind: "cancel" | "steer";
@@ -253,6 +270,7 @@ export type MessagingControllerOptions = {
   store: MessagingStoreLike;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
   deliveryBudget?: MessagingDeliveryBudget;
+  onDeliveryBudgetEvent?: (event: MessagingControllerDeliveryBudgetEvent) => void;
   /**
    * Notification hook invoked after any binding mutation the
    * controller performs (create, conversation-metadata refresh,
@@ -3794,9 +3812,6 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     occurredAt: number = this.now(),
   ): Promise<void> {
-    if (!this.options.backend.recordMessagingBindingTransition) {
-      return;
-    }
     const conversation = binding.channel.conversation;
     const transition: ThreadMessagingBindingTransition = {
       id: randomUUID(),
@@ -3809,20 +3824,23 @@ export class MessagingController {
       ancestorTitle: conversation.ancestorTitle,
       occurredAt,
     };
-    try {
-      await this.options.backend.recordMessagingBindingTransition({
-        backend: binding.backend,
-        threadId: binding.threadId,
-        transition,
-      });
-    } catch (error) {
-      this.logger.debug?.("messaging binding-transition audit failed", {
-        action,
-        bindingId: binding.id,
-        error: error instanceof Error ? error.message : String(error),
-        threadId: binding.threadId,
-      });
+    if (this.options.backend.recordMessagingBindingTransition) {
+      try {
+        await this.options.backend.recordMessagingBindingTransition({
+          backend: binding.backend,
+          threadId: binding.threadId,
+          transition,
+        });
+      } catch (error) {
+        this.logger.debug?.("messaging binding-transition audit failed", {
+          action,
+          bindingId: binding.id,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: binding.threadId,
+        });
+      }
     }
+    this.recordBindingActivity(action, binding, occurredAt);
   }
 
   private async bindChannelToThread(
@@ -3975,16 +3993,7 @@ export class MessagingController {
     const conversation = binding?.channel.conversation;
     const summary = describeOutboundIntent(intent);
     try {
-      // Lazy import keeps the controller free of a top-level dep on
-      // the desktop activity-log singleton (the controller is shared
-      // with other harnesses; this method is the only main-process
-      // entry that needs it).
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const log = (require(
-        "../desktop-messaging-activity-log",
-      ) as typeof import("../desktop-messaging-activity-log"))
-        .getDesktopMessagingActivityLog();
-      log.record({
+      this.desktopActivityLog().record({
         platform: channel,
         kind: "outbound",
         backend: binding?.backend,
@@ -4005,6 +4014,48 @@ export class MessagingController {
     }
   }
 
+  private recordBindingActivity(
+    action: ThreadMessagingBindingTransition["action"],
+    binding: MessagingBindingRecord,
+    occurredAt: number,
+  ): void {
+    try {
+      const conversation = binding.channel.conversation;
+      const log = this.desktopActivityLog();
+      log.record({
+        platform: binding.channel.channel,
+        kind: "binding",
+        backend: binding.backend,
+        threadId: binding.threadId,
+        bindingId: binding.id,
+        conversationId: conversation.id,
+        conversationTitle: conversation.title,
+        summary: `Channel ${action}: ${describeConversation(conversation)} / ${binding.threadId}`,
+        createdAt: occurredAt,
+        payload: {
+          action,
+          conversationKind: conversation.kind,
+          conversationParentId: conversation.parentId,
+          parentTitle: conversation.parentTitle,
+          ancestorTitle: conversation.ancestorTitle,
+        },
+      });
+    } catch {
+      // Activity log is best-effort observability.
+    }
+  }
+
+  private desktopActivityLog(): import("../messaging-activity-log").MessagingActivityLog {
+    // Lazy import keeps the controller free of a top-level dep on the
+    // desktop activity-log singleton (the controller is shared with
+    // other harnesses).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return (require(
+      "../desktop-messaging-activity-log",
+    ) as typeof import("../desktop-messaging-activity-log"))
+      .getDesktopMessagingActivityLog();
+  }
+
   private async deliver(
     intent: MessagingSurfaceIntent,
     binding?: MessagingBindingRecord,
@@ -4016,14 +4067,57 @@ export class MessagingController {
     const routedIntent = this.withRoutingAudit(intent, binding, event);
     let scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
     const priority = messagingDeliveryPriority(routedIntent);
+    const channel = binding?.channel.channel ??
+      routedIntent.audit?.channel.channel ??
+      this.options.channel;
     while (true) {
       if (this.deliveryBudget) {
+        const budgetChannel = channel ?? scope?.platform ?? "telegram";
         let admission = this.deliveryBudget.admit({ priority, scope });
         while (admission.outcome === "deferred") {
+          const budgetEvent: MessagingControllerDeliveryBudgetEvent = {
+            at: this.now(),
+            backend: binding?.backend,
+            bindingId: binding?.id ?? intent.bindingId,
+            channel: budgetChannel,
+            intentId: routedIntent.id,
+            intentKind: routedIntent.kind,
+            outcome: "deferred",
+            priority,
+            retryAt: admission.retryAt,
+            scope,
+            slowMode: admission.slowMode,
+            threadId: binding?.threadId,
+          };
+          this.logger.info?.("messaging delivery budget deferred intent", {
+            bindingId: binding?.id ?? intent.bindingId,
+            delayMs: Math.max(0, admission.retryAt - this.now()),
+            intentId: routedIntent.id,
+            intentKind: routedIntent.kind,
+            priority,
+            retryAt: admission.retryAt,
+            scopeId: scope?.id,
+            slowMode: admission.slowMode,
+          });
+          this.notifyDeliveryBudgetEvent(budgetEvent);
           await sleepUntil(admission.retryAt, this.now);
           admission = this.deliveryBudget.admit({ priority, scope });
         }
         if (admission.outcome !== "admitted") {
+          const budgetEvent: MessagingControllerDeliveryBudgetEvent = {
+            at: this.now(),
+            backend: binding?.backend,
+            bindingId: binding?.id ?? intent.bindingId,
+            channel: budgetChannel,
+            intentId: routedIntent.id,
+            intentKind: routedIntent.kind,
+            outcome: "dropped",
+            priority,
+            reason: admission.reason,
+            scope,
+            slowMode: admission.slowMode,
+            threadId: binding?.threadId,
+          };
           this.logger.debug?.("messaging delivery budget skipped intent", {
             bindingId: binding?.id ?? intent.bindingId,
             intentId: routedIntent.id,
@@ -4032,9 +4126,11 @@ export class MessagingController {
             priority,
             reason: admission.outcome === "dropped" ? admission.reason : undefined,
             scopeId: scope?.id,
+            slowMode: admission.slowMode,
           });
+          this.notifyDeliveryBudgetEvent(budgetEvent);
           return {
-            channel: binding?.channel.channel ?? routedIntent.audit?.channel.channel ?? this.options.channel ?? "custom",
+            channel: channel ?? "telegram",
             deliveredAt: this.now(),
             outcome: "discarded",
           };
@@ -4092,6 +4188,21 @@ export class MessagingController {
         });
       }
       return result;
+    }
+  }
+
+  private notifyDeliveryBudgetEvent(
+    event: MessagingControllerDeliveryBudgetEvent,
+  ): void {
+    if (!this.options.onDeliveryBudgetEvent) return;
+    try {
+      this.options.onDeliveryBudgetEvent(event);
+    } catch (error) {
+      this.logger.debug?.("messaging delivery-budget listener threw", {
+        error: error instanceof Error ? error.message : String(error),
+        intentId: event.intentId,
+        outcome: event.outcome,
+      });
     }
   }
 
@@ -4628,11 +4739,15 @@ function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boo
   return true;
 }
 
-function messagingDeliveryPriority(
+export function messagingDeliveryPriority(
   intent: MessagingSurfaceIntent,
 ): MessagingDeliveryPriority {
   switch (intent.kind) {
     case "approval":
+      if (intent.decisions.length === 0) {
+        return "routine_status";
+      }
+      return "critical_interactive";
     case "questionnaire":
       return "critical_interactive";
     case "stream_update":
@@ -5149,4 +5264,15 @@ function describeOutboundIntent(intent: MessagingSurfaceIntent): string {
   if (intent.kind === "approval") return "Sent approval request";
   if (intent.kind === "error") return "Sent error notice";
   return `Sent ${intent.kind}`;
+}
+
+function describeConversation(
+  conversation: MessagingBindingRecord["channel"]["conversation"],
+): string {
+  const pieces = [
+    conversation.ancestorTitle,
+    conversation.parentTitle,
+    conversation.title,
+  ].filter((piece): piece is string => Boolean(piece));
+  return pieces.length > 0 ? pieces.join(" / ") : conversation.id;
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -79,7 +79,9 @@ import {
   buildStatusReasoningPickerIntent,
   formatExecutionModeLabel,
   handoffRequestFromValue,
+  nextMessagingStreamingResponseMode,
   nextMessagingToolUpdateMode,
+  resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
   type MessagingWorkspaceHandoffContext,
 } from "./messaging-status-card.js";
@@ -89,6 +91,10 @@ import {
   MessagingToolUpdatePolicy,
   type MessagingToolUpdatePolicyDelivery,
 } from "./messaging-tool-update-policy.js";
+import {
+  MessagingDeliveryBudget,
+  type MessagingDeliveryPriority,
+} from "./messaging-delivery-budget.js";
 import {
   DEFAULT_MESSAGING_ATTACHMENT_POLICY,
   processMessagingAttachments,
@@ -246,6 +252,7 @@ export type MessagingControllerOptions = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
+  deliveryBudget?: MessagingDeliveryBudget;
   /**
    * Notification hook invoked after any binding mutation the
    * controller performs (create, conversation-metadata refresh,
@@ -272,6 +279,7 @@ export class MessagingController {
   private readonly logger: MessagingControllerLogger;
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
   private readonly turnAdmission: MessagingTurnAdmission;
+  private readonly deliveryBudget?: MessagingDeliveryBudget;
   /**
    * Per-thread map of the most-recent "permissions queued" audit message
    * we posted to each bound conversation. Cleared when the queue resolves
@@ -290,6 +298,7 @@ export class MessagingController {
     this.pendingIntentTtlMs =
       options.pendingIntentTtlMs ?? DEFAULT_PENDING_INTENT_TTL_MS;
     this.interactionMapper = options.interactionMapper ?? new DeterministicInteractionMapper();
+    this.deliveryBudget = options.deliveryBudget;
     this.logger = options.logger ?? messagingControllerLog;
     this.turnAdmission = new MessagingTurnAdmission({
       debounceMs: options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS,
@@ -797,6 +806,10 @@ export class MessagingController {
 
     if (isToolsFallbackText(event.text)) {
       await this.cycleToolUpdateMode(binding, event);
+      return;
+    }
+    if (isStreamFallbackText(event.text)) {
+      await this.cycleStreamingResponseMode(binding, event);
       return;
     }
 
@@ -2556,6 +2569,10 @@ export class MessagingController {
       await this.cycleToolUpdateMode(binding, event);
       return;
     }
+    if (actionId === "status:streaming") {
+      await this.cycleStreamingResponseMode(binding, event);
+      return;
+    }
     if (actionId === "status:stop") {
       await this.stopActiveTurn(binding, event);
       return;
@@ -3334,6 +3351,17 @@ export class MessagingController {
     await this.renderBindingStatus(updatedBinding, event);
   }
 
+  private async cycleStreamingResponseMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const currentMode = resolveMessagingStreamingResponseMode(binding);
+    const updatedBinding = await this.updateBindingPreferences(binding, {
+      streamingResponses: nextMessagingStreamingResponseMode(currentMode),
+    });
+    await this.renderBindingStatus(updatedBinding, event);
+  }
+
   private async updateBindingPreferences(
     binding: MessagingBindingRecord,
     patch: Partial<NonNullable<MessagingBindingRecord["preferences"]>>,
@@ -3986,6 +4014,31 @@ export class MessagingController {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
     }
     const routedIntent = this.withRoutingAudit(intent, binding, event);
+    const scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
+    const priority = messagingDeliveryPriority(routedIntent);
+    if (this.deliveryBudget) {
+      let admission = this.deliveryBudget.admit({ priority, scope });
+      while (admission.outcome === "deferred") {
+        await sleepUntil(admission.retryAt, this.now);
+        admission = this.deliveryBudget.admit({ priority, scope });
+      }
+      if (admission.outcome !== "admitted") {
+        this.logger.debug?.("messaging delivery budget skipped intent", {
+          bindingId: binding?.id ?? intent.bindingId,
+          intentId: routedIntent.id,
+          intentKind: routedIntent.kind,
+          outcome: admission.outcome,
+          priority,
+          reason: admission.outcome === "dropped" ? admission.reason : undefined,
+          scopeId: scope?.id,
+        });
+        return {
+          channel: binding?.channel.channel ?? routedIntent.audit?.channel.channel ?? this.options.channel ?? "custom",
+          deliveredAt: this.now(),
+          outcome: "discarded",
+        };
+      }
+    }
     const result = await this.options.adapter.deliver(routedIntent);
     await this.options.store.recordDelivery({
       ...result,
@@ -4550,6 +4603,51 @@ function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boo
   return true;
 }
 
+function messagingDeliveryPriority(
+  intent: MessagingSurfaceIntent,
+): MessagingDeliveryPriority {
+  switch (intent.kind) {
+    case "approval":
+    case "questionnaire":
+      return "critical_interactive";
+    case "stream_update":
+      return intent.stream.isFinal ? "final_turn" : "stream_partial";
+    case "message":
+      if (intent.role === "assistant") {
+        return "final_turn";
+      }
+      if (intent.role === "system" && intent.id.startsWith("tool-update")) {
+        return "tool_progress";
+      }
+      return "user_command";
+    case "status":
+    case "activity":
+    case "progress":
+    case "dismiss":
+      return "routine_status";
+    case "thread_picker":
+    case "project_picker":
+    case "single_select":
+    case "multi_select":
+    case "confirmation":
+    case "error":
+      return "user_command";
+  }
+}
+
+function sleepUntil(
+  retryAt: number,
+  now: () => number,
+): Promise<void> {
+  const delayMs = Math.max(0, retryAt - now());
+  if (delayMs === 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
 function assistantTextForBackendEvent(event: AgentEvent): string | undefined {
   if (event.notification.method === "item/completed") {
     const params = event.notification.params as {
@@ -4959,6 +5057,10 @@ function parseTextCommandArgs(text: string): string[] {
 
 function isToolsFallbackText(text: string): boolean {
   return text.trim().toLowerCase() === "tools";
+}
+
+function isStreamFallbackText(text: string): boolean {
+  return text.trim().toLowerCase() === "stream";
 }
 
 function readBindingTarget(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4014,60 +4014,75 @@ export class MessagingController {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
     }
     const routedIntent = this.withRoutingAudit(intent, binding, event);
-    const scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
+    let scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
     const priority = messagingDeliveryPriority(routedIntent);
-    if (this.deliveryBudget) {
-      let admission = this.deliveryBudget.admit({ priority, scope });
-      while (admission.outcome === "deferred") {
-        await sleepUntil(admission.retryAt, this.now);
-        admission = this.deliveryBudget.admit({ priority, scope });
+    while (true) {
+      if (this.deliveryBudget) {
+        let admission = this.deliveryBudget.admit({ priority, scope });
+        while (admission.outcome === "deferred") {
+          await sleepUntil(admission.retryAt, this.now);
+          admission = this.deliveryBudget.admit({ priority, scope });
+        }
+        if (admission.outcome !== "admitted") {
+          this.logger.debug?.("messaging delivery budget skipped intent", {
+            bindingId: binding?.id ?? intent.bindingId,
+            intentId: routedIntent.id,
+            intentKind: routedIntent.kind,
+            outcome: admission.outcome,
+            priority,
+            reason: admission.outcome === "dropped" ? admission.reason : undefined,
+            scopeId: scope?.id,
+          });
+          return {
+            channel: binding?.channel.channel ?? routedIntent.audit?.channel.channel ?? this.options.channel ?? "custom",
+            deliveredAt: this.now(),
+            outcome: "discarded",
+          };
+        }
       }
-      if (admission.outcome !== "admitted") {
-        this.logger.debug?.("messaging delivery budget skipped intent", {
+      const result = await this.options.adapter.deliver(routedIntent);
+      if (this.deliveryBudget && result.rateLimit) {
+        scope = result.rateLimit.scope;
+        this.deliveryBudget.recordRateLimit(result.rateLimit);
+        this.logger.debug?.("messaging delivery rate-limited; rechecking budget", {
           bindingId: binding?.id ?? intent.bindingId,
           intentId: routedIntent.id,
           intentKind: routedIntent.kind,
-          outcome: admission.outcome,
           priority,
-          reason: admission.outcome === "dropped" ? admission.reason : undefined,
-          scopeId: scope?.id,
+          retryAfterMs: result.rateLimit.retryAfterMs,
+          scopeId: result.rateLimit.scope.id,
         });
-        return {
-          channel: binding?.channel.channel ?? routedIntent.audit?.channel.channel ?? this.options.channel ?? "custom",
-          deliveredAt: this.now(),
-          outcome: "discarded",
-        };
+        continue;
       }
-    }
-    const result = await this.options.adapter.deliver(routedIntent);
-    await this.options.store.recordDelivery({
-      ...result,
-      id: `delivery:${routedIntent.id}:${randomUUID()}`,
-      bindingId: binding?.id ?? intent.bindingId,
-      intentId: routedIntent.id,
-    });
-    this.recordOutboundActivity(routedIntent, binding, result);
-    if (
-      binding &&
-      result.channel === binding.channel.channel &&
-      isPermanentMessagingTargetFailure(result)
-    ) {
-      await this.options.store.revokeBinding({
-        bindingId: binding.id,
-        revokedAt: this.now(),
+      await this.options.store.recordDelivery({
+        ...result,
+        id: `delivery:${routedIntent.id}:${randomUUID()}`,
+        bindingId: binding?.id ?? intent.bindingId,
+        intentId: routedIntent.id,
       });
-      await this.recordBindingTransition("unbound", binding);
-      this.notifyBindingChanged("permanent-delivery-failure");
-      this.logger.debug?.("messaging binding revoked after permanent delivery failure", {
-        bindingId: binding.id,
-        channel: binding.channel.channel,
-        conversationId: binding.channel.conversation.id,
-        errorMessage: result.errorMessage,
-        outcome: result.outcome,
-        threadId: binding.threadId,
-      });
+      this.recordOutboundActivity(routedIntent, binding, result);
+      if (
+        binding &&
+        result.channel === binding.channel.channel &&
+        isPermanentMessagingTargetFailure(result)
+      ) {
+        await this.options.store.revokeBinding({
+          bindingId: binding.id,
+          revokedAt: this.now(),
+        });
+        await this.recordBindingTransition("unbound", binding);
+        this.notifyBindingChanged("permanent-delivery-failure");
+        this.logger.debug?.("messaging binding revoked after permanent delivery failure", {
+          bindingId: binding.id,
+          channel: binding.channel.channel,
+          conversationId: binding.channel.conversation.id,
+          errorMessage: result.errorMessage,
+          outcome: result.outcome,
+          threadId: binding.threadId,
+        });
+      }
+      return result;
     }
-    return result;
   }
 
   private async deliverToolActivityForBackendEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -69,11 +69,13 @@ import {
   directoryForProjectSelection,
   parseResumeCommandArgs,
   resumeBrowserPageSize,
+  selectBaseBranchFromValue,
   selectProjectFromValue,
   selectThreadFromValue,
 } from "./messaging-resume-browser.js";
 import {
   buildBindingStatusIntent,
+  buildHandoffBaseBranchPickerIntent,
   buildHandoffBranchPickerIntent,
   buildHandoffConfirmationIntent,
   buildHandoffOverviewIntent,
@@ -2242,6 +2244,70 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:options") {
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          mode: "new_thread_options",
+          pageIndex: 0,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:new:toggle-workmode") {
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          mode: "new_thread_options",
+          newThreadWorkMode:
+            (nextSession.newThreadWorkMode ?? "local") === "worktree"
+              ? "local"
+              : "worktree",
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:new:base-branch") {
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          mode: "new_base_branch",
+          pageIndex: 0,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:new:select-base-branch") {
+      const selection = selectBaseBranchFromValue(event.value);
+      if (!selection) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          mode: "new_thread_options",
+          newThreadBranchName: selection.branch,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:new:start") {
+      if (!session.selectedProject) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.startNewThreadFromProject(event, session, navigation, session.selectedProject);
+      return;
+    }
     if (actionId === "browse:cancel") {
       await this.options.store.deleteBrowseSession(session.id);
       await this.deliver(
@@ -2271,7 +2337,16 @@ export class MessagingController {
         return;
       }
       if (session.launchAction === "start_new_thread") {
-        await this.startNewThreadFromProject(event, session, navigation, project);
+        await this.renderResumeBrowser(
+          {
+            ...nextSession,
+            mode: "new_thread_options",
+            pageIndex: 0,
+            selectedProject: project,
+          },
+          navigation,
+          event,
+        );
         return;
       }
       await this.renderResumeBrowser(
@@ -2411,9 +2486,18 @@ export class MessagingController {
 
     const directory = directoryForProjectSelection(navigation, project);
     const preferences = session.preferences;
+    const workMode = session.newThreadWorkMode ?? "local";
+    const branchName =
+      workMode === "worktree"
+        ? session.newThreadBranchName ??
+          directory?.gitStatus?.defaultBranch ??
+          directory?.gitStatus?.currentBranch
+        : undefined;
     const started = await this.options.backend.startThread({
       backend: navigation.launchpadDefaults.backend,
       cwd: directory?.path ?? project.path,
+      workMode,
+      branchName,
       executionMode: preferences?.executionMode ?? navigation.launchpadDefaults.executionMode,
       fastMode: preferences?.fastMode ?? navigation.launchpadDefaults.fastMode,
       model: preferences?.model ?? navigation.launchpadDefaults.model,
@@ -2428,16 +2512,24 @@ export class MessagingController {
     const updatedBinding = preferences
       ? await this.updateBindingPreferences(binding, preferences)
       : binding;
-    const optimisticNavigation = navigationWithStartedThread({
-      backend: started.backend,
-      directory,
-      executionMode: started.executionMode,
-      navigation,
-      now: this.now(),
-      preferences,
-      project,
-      threadId: started.threadId,
+    const refreshedNavigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+      filter: session.query,
     });
+    const statusNavigation = refreshedNavigation.threads.some(
+      (thread) => thread.source === started.backend && thread.id === started.threadId,
+    )
+      ? refreshedNavigation
+      : navigationWithStartedThread({
+          backend: started.backend,
+          directory,
+          executionMode: started.executionMode,
+          navigation,
+          now: this.now(),
+          preferences,
+          project,
+          threadId: started.threadId,
+        });
     await this.options.store.deleteBrowseSession(session.id);
     await this.deliver(
       buildConfirmationIntent({
@@ -2451,14 +2543,19 @@ export class MessagingController {
             }
           : undefined,
         title: "Thread started",
-        body: `Started and bound a new thread for ${project.label}.`,
+        body: [
+          `Started and bound a new thread for ${project.label}.`,
+          workMode === "worktree"
+            ? `Workspace: New Worktree${branchName ? ` from ${branchName}` : ""}.`
+            : "Workspace: Local.",
+        ].join("\n"),
         fallbackText: "Send a message to continue the new thread.",
         targetSurface: session.surface,
       }),
       undefined,
       event,
     );
-    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
+    await this.renderBindingStatus(updatedBinding, event, statusNavigation);
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -2529,8 +2626,12 @@ export class MessagingController {
       await this.renderBindingStatus(binding, event);
       return;
     }
-    if (actionId === "handoff:local-to-worktree") {
+    if (actionId === "handoff:move-branch" || actionId === "handoff:local-to-worktree") {
       await this.presentHandoffBranchPicker(binding, event);
+      return;
+    }
+    if (actionId === "handoff:create-detached") {
+      await this.presentHandoffDetachedFlow(binding, event);
       return;
     }
     if (
@@ -2545,6 +2646,10 @@ export class MessagingController {
       return;
     }
     if (actionId === "handoff:worktree-to-local") {
+      await this.presentHandoffConfirmation(binding, event);
+      return;
+    }
+    if (actionId === "handoff:select-base-branch") {
       await this.presentHandoffConfirmation(binding, event);
       return;
     }
@@ -2688,6 +2793,58 @@ export class MessagingController {
     );
   }
 
+  private async presentHandoffDetachedFlow(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    if (this.handoffBlockedByActiveTurn(binding)) {
+      await this.deliverHandoffUnavailable(binding, event, ACTIVE_TURN_HANDOFF_ERROR);
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const context = handoffContextForBinding(binding, navigation);
+    const request = handoffRequestFromValue(event.value);
+    if (!context || context.workspaceKind !== "local" || !request) {
+      await this.deliverInvalidHandoffSelection(binding, event);
+      return;
+    }
+
+    if (context.hasUncommittedChanges !== false) {
+      await this.deliverAndStoreStatusSubmode(
+        {
+          ...buildHandoffConfirmationIntent({
+            id: this.newIntentId("handoff-confirm-detached"),
+            capabilityProfile: this.capabilityProfile,
+            binding,
+            context,
+            createdAt: this.now(),
+            strategy: "detached-changes",
+          }),
+          audit: this.buildHandoffAudit("handoff.confirmation.detached_current", binding, event),
+        },
+        binding,
+        event,
+      );
+      return;
+    }
+
+    await this.deliverAndStoreStatusSubmode(
+      {
+        ...buildHandoffBaseBranchPickerIntent({
+          id: this.newIntentId("handoff-base-branch"),
+          capabilityProfile: this.capabilityProfile,
+          binding,
+          context,
+          createdAt: this.now(),
+        }),
+        audit: this.buildHandoffAudit("handoff.base_branch_picker", binding, event),
+      },
+      binding,
+      event,
+    );
+  }
+
   private async presentHandoffConfirmation(
     binding: MessagingBindingRecord,
     event: MessagingInboundCallbackEvent,
@@ -2719,6 +2876,8 @@ export class MessagingController {
           binding,
           context,
           createdAt: this.now(),
+          strategy: request.strategy,
+          baseBranch: request.baseBranch,
           leaveLocalBranch: request.leaveLocalBranch,
         }),
         audit: this.buildHandoffAudit(
@@ -4564,14 +4723,19 @@ function handoffContextForBinding(
     (candidate, index, branches) =>
       candidate !== branch && branches.indexOf(candidate) === index,
   );
-  if (leaveLocalBranches.length === 0) {
+  const leaveChoices = ["HEAD", ...leaveLocalBranches];
+  if (leaveChoices.length === 0) {
     return undefined;
   }
 
   return {
     backend: binding.backend,
+    baseBranches: directorySummary?.gitStatus?.branches,
     branch,
-    leaveLocalBranches,
+    currentSha: directorySummary?.gitStatus?.currentSha,
+    defaultBranch: directorySummary?.gitStatus?.defaultBranch,
+    hasUncommittedChanges: directorySummary?.gitStatus?.hasUncommittedChanges,
+    leaveLocalBranches: leaveChoices,
     projectLabel: localDirectory.label,
     repositoryPath: localDirectory.path,
     threadId: binding.threadId,
@@ -4628,6 +4792,18 @@ function validateHandoffRequest(
     };
   }
   if (request.direction === "local-to-worktree") {
+    if (request.strategy === "detached-changes") {
+      if (
+        request.baseBranch &&
+        !(context.baseBranches ?? []).includes(request.baseBranch)
+      ) {
+        return {
+          valid: false,
+          reason: "That base branch is no longer available. Use /status to refresh.",
+        };
+      }
+      return { valid: true };
+    }
     if (!request.leaveLocalBranch) {
       return {
         valid: false,
@@ -4658,6 +4834,8 @@ function handoffSuccessText(result: HandoffThreadWorkspaceResponse): string {
     `Workspace: ${result.workMode === "worktree" ? "Worktree" : "Local"}`,
     `Target: ${result.targetPath}`,
     result.branch ? `Branch: ${result.branch}` : undefined,
+    result.baseBranch ? `Base branch: ${result.baseBranch}` : undefined,
+    !result.branch && result.baseSha ? `Detached at: ${result.baseSha}` : undefined,
     ...result.warnings.map((warning) => `Warning: ${warning}`),
   ]
     .filter((line): line is string => Boolean(line))

--- a/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
@@ -1,0 +1,189 @@
+import type {
+  MessagingDeliveryScope,
+  MessagingRateLimitInfo,
+} from "@pwragent/messaging-interface";
+
+export type MessagingDeliveryPriority =
+  | "critical_interactive"
+  | "final_turn"
+  | "user_command"
+  | "routine_status"
+  | "tool_progress"
+  | "stream_partial";
+
+export type MessagingDeliveryAdmission =
+  | {
+      outcome: "admitted";
+      slowMode: boolean;
+    }
+  | {
+      outcome: "deferred";
+      retryAt: number;
+      slowMode: boolean;
+    }
+  | {
+      outcome: "dropped";
+      reason:
+        | "cool-off"
+        | "slow-mode"
+        | "budget-exhausted"
+        | "missing-scope";
+      slowMode: boolean;
+    };
+
+type ScopeState = {
+  coolOffUntil?: number;
+  slowModeUntil?: number;
+  timestamps: number[];
+};
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_LIMIT = 60;
+const DEFAULT_RESERVED = 1;
+const RATE_LIMIT_SAFETY_BUFFER_MS = 2_000;
+const SLOW_MODE_RECOVERY_MS = 5 * 60_000;
+
+const SLOW_MODE_DROP_PRIORITIES = new Set<MessagingDeliveryPriority>([
+  "routine_status",
+  "tool_progress",
+  "stream_partial",
+]);
+
+const DEFERABLE_PRIORITIES = new Set<MessagingDeliveryPriority>([
+  "critical_interactive",
+  "final_turn",
+  "user_command",
+]);
+
+export class MessagingDeliveryBudget {
+  private readonly now: () => number;
+  private readonly scopes = new Map<string, ScopeState>();
+
+  constructor(options?: { now?: () => number }) {
+    this.now = options?.now ?? Date.now;
+  }
+
+  admit(request: {
+    priority: MessagingDeliveryPriority;
+    scope?: MessagingDeliveryScope;
+  }): MessagingDeliveryAdmission {
+    if (!request.scope) {
+      return { outcome: "admitted", slowMode: false };
+    }
+
+    const now = this.now();
+    const state = this.stateFor(request.scope);
+    this.pruneState(state, request.scope, now);
+    const slowMode = this.isScopeInSlowMode(request.scope);
+
+    if (state.coolOffUntil !== undefined && state.coolOffUntil > now) {
+      if (DEFERABLE_PRIORITIES.has(request.priority)) {
+        return { outcome: "deferred", retryAt: state.coolOffUntil, slowMode };
+      }
+      return { outcome: "dropped", reason: "cool-off", slowMode };
+    }
+
+    if (slowMode && SLOW_MODE_DROP_PRIORITIES.has(request.priority)) {
+      return { outcome: "dropped", reason: "slow-mode", slowMode };
+    }
+
+    if (!this.hasCapacity(request.scope, state, request.priority)) {
+      if (DEFERABLE_PRIORITIES.has(request.priority)) {
+        return {
+          outcome: "deferred",
+          retryAt: nextWindowAt(request.scope, state, now),
+          slowMode,
+        };
+      }
+      return { outcome: "dropped", reason: "budget-exhausted", slowMode };
+    }
+
+    state.timestamps.push(now);
+    return { outcome: "admitted", slowMode };
+  }
+
+  recordRateLimit(info: MessagingRateLimitInfo): void {
+    const now = info.observedAt ?? this.now();
+    const retryAfterMs = Math.max(0, Math.floor(info.retryAfterMs ?? 0));
+    const state = this.stateFor(info.scope);
+    const coolOffUntil = now + retryAfterMs + RATE_LIMIT_SAFETY_BUFFER_MS;
+    state.coolOffUntil = Math.max(state.coolOffUntil ?? 0, coolOffUntil);
+    state.slowModeUntil = Math.max(
+      state.slowModeUntil ?? 0,
+      state.coolOffUntil + SLOW_MODE_RECOVERY_MS,
+    );
+  }
+
+  isScopeInSlowMode(scope: MessagingDeliveryScope | undefined): boolean {
+    if (!scope) {
+      return false;
+    }
+    const state = this.scopes.get(scope.id);
+    if (!state) {
+      return false;
+    }
+    this.pruneState(state, scope, this.now());
+    return state.slowModeUntil !== undefined && state.slowModeUntil > this.now();
+  }
+
+  private stateFor(scope: MessagingDeliveryScope): ScopeState {
+    let state = this.scopes.get(scope.id);
+    if (!state) {
+      state = { timestamps: [] };
+      this.scopes.set(scope.id, state);
+    }
+    return state;
+  }
+
+  private pruneState(
+    state: ScopeState,
+    scope: MessagingDeliveryScope,
+    now: number,
+  ): void {
+    const intervalMs = budgetIntervalMs(scope);
+    const cutoff = now - intervalMs;
+    state.timestamps = state.timestamps.filter((timestamp) => timestamp > cutoff);
+    if (state.coolOffUntil !== undefined && state.coolOffUntil <= now) {
+      state.coolOffUntil = undefined;
+    }
+    if (state.slowModeUntil !== undefined && state.slowModeUntil <= now) {
+      state.slowModeUntil = undefined;
+    }
+  }
+
+  private hasCapacity(
+    scope: MessagingDeliveryScope,
+    state: ScopeState,
+    priority: MessagingDeliveryPriority,
+  ): boolean {
+    const limit = budgetLimit(scope);
+    if (state.timestamps.length >= limit) {
+      return false;
+    }
+    if (DEFERABLE_PRIORITIES.has(priority)) {
+      return true;
+    }
+    return state.timestamps.length < Math.max(0, limit - budgetReserved(scope));
+  }
+}
+
+function nextWindowAt(
+  scope: MessagingDeliveryScope,
+  state: ScopeState,
+  now: number,
+): number {
+  const oldest = state.timestamps[0];
+  return oldest === undefined ? now : oldest + budgetIntervalMs(scope);
+}
+
+function budgetLimit(scope: MessagingDeliveryScope): number {
+  return Math.max(1, Math.floor(scope.budget?.limit ?? DEFAULT_LIMIT));
+}
+
+function budgetIntervalMs(scope: MessagingDeliveryScope): number {
+  return Math.max(1, Math.floor(scope.budget?.intervalMs ?? DEFAULT_INTERVAL_MS));
+}
+
+function budgetReserved(scope: MessagingDeliveryScope): number {
+  return Math.max(0, Math.floor(scope.budget?.reserved ?? DEFAULT_RESERVED));
+}

--- a/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
@@ -18,6 +18,7 @@ export type MessagingDeliveryAdmission =
     }
   | {
       outcome: "deferred";
+      reason: "cool-off" | "budget-exhausted";
       retryAt: number;
       slowMode: boolean;
     }
@@ -42,6 +43,7 @@ const DEFAULT_LIMIT = 60;
 const DEFAULT_RESERVED = 1;
 const RATE_LIMIT_SAFETY_BUFFER_MS = 2_000;
 const SLOW_MODE_RECOVERY_MS = 5 * 60_000;
+const SLOW_MODE_MINIMUM_MS = 5_000;
 
 const SLOW_MODE_DROP_PRIORITIES = new Set<MessagingDeliveryPriority>([
   "routine_status",
@@ -74,11 +76,16 @@ export class MessagingDeliveryBudget {
     const now = this.now();
     const state = this.stateFor(request.scope);
     this.pruneState(state, request.scope, now);
-    const slowMode = this.isScopeInSlowMode(request.scope);
+    let slowMode = this.isScopeInSlowMode(request.scope);
 
     if (state.coolOffUntil !== undefined && state.coolOffUntil > now) {
       if (DEFERABLE_PRIORITIES.has(request.priority)) {
-        return { outcome: "deferred", retryAt: state.coolOffUntil, slowMode };
+        return {
+          outcome: "deferred",
+          reason: "cool-off",
+          retryAt: state.coolOffUntil,
+          slowMode,
+        };
       }
       return { outcome: "dropped", reason: "cool-off", slowMode };
     }
@@ -88,10 +95,17 @@ export class MessagingDeliveryBudget {
     }
 
     if (!this.hasCapacity(request.scope, state, request.priority)) {
+      const slowModeUntil = Math.max(
+        nextWindowAt(request.scope, state, now),
+        now + SLOW_MODE_MINIMUM_MS,
+      );
+      state.slowModeUntil = Math.max(state.slowModeUntil ?? 0, slowModeUntil);
+      slowMode = true;
       if (DEFERABLE_PRIORITIES.has(request.priority)) {
         return {
           outcome: "deferred",
-          retryAt: nextWindowAt(request.scope, state, now),
+          reason: "budget-exhausted",
+          retryAt: slowModeUntil,
           slowMode,
         };
       }

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -13,6 +13,7 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingJsonValue,
   MessagingProjectPickerIntent,
+  MessagingSingleSelectIntent,
   MessagingSurfaceAction,
   MessagingThreadPickerIntent,
 } from "@pwragent/messaging-interface";
@@ -51,6 +52,9 @@ export type ResumeBrowserThreadSelection = {
 };
 
 export type ResumeBrowserProjectSelection = MessagingBrowseSelectedProject;
+export type ResumeBrowserBaseBranchSelection = {
+  branch: string;
+};
 
 export function parseResumeCommandArgs(args: string[]): ParsedResumeCommand {
   const tokens = normalizeOptionDashes(args.join(" "))
@@ -128,7 +132,13 @@ export function buildResumeIntent(params: {
   id: string;
   navigation: NavigationSnapshot;
   session: MessagingBrowseSessionRecord;
-}): MessagingThreadPickerIntent | MessagingProjectPickerIntent {
+}): MessagingThreadPickerIntent | MessagingProjectPickerIntent | MessagingSingleSelectIntent {
+  if (params.session.mode === "new_thread_options") {
+    return buildNewThreadOptionsIntent(params);
+  }
+  if (params.session.mode === "new_base_branch") {
+    return buildNewThreadBaseBranchPickerIntent(params);
+  }
   if (params.session.mode === "projects" || params.session.mode === "new_project") {
     return buildProjectPickerIntent(params);
   }
@@ -149,6 +159,16 @@ export function selectProjectFromValue(
     label: value.label,
     path: typeof value.path === "string" ? value.path : undefined,
   };
+}
+
+export function selectBaseBranchFromValue(
+  value: unknown,
+): ResumeBrowserBaseBranchSelection | undefined {
+  if (!isRecord(value) || typeof value.branch !== "string") {
+    return undefined;
+  }
+  const branch = value.branch.trim();
+  return branch ? { branch } : undefined;
 }
 
 export function selectThreadFromValue(
@@ -287,6 +307,144 @@ function buildProjectPickerIntent(params: {
     },
     prompt: projectPickerPromptText(params.session, page.totalPages, page.totalItems),
     targetSurface: params.session.surface,
+  };
+}
+
+function buildNewThreadOptionsIntent(params: {
+  createdAt: number;
+  id: string;
+  navigation: NavigationSnapshot;
+  session: MessagingBrowseSessionRecord;
+}): MessagingSingleSelectIntent {
+  const project = params.session.selectedProject;
+  const directory = project
+    ? directoryForProjectSelection(params.navigation, project)
+    : undefined;
+  const workMode = params.session.newThreadWorkMode ?? "local";
+  const baseBranch = params.session.newThreadBranchName ??
+    defaultBaseBranchForDirectory(directory);
+  const worktreeSelected = workMode === "worktree";
+  const projectLabel = project?.label ?? "selected project";
+  const choices: MessagingSurfaceAction[] = [
+    {
+      id: "browse:new:start",
+      label: worktreeSelected ? "Start New Worktree" : "Start in Local",
+      style: "primary",
+      fallbackText: "start",
+      priority: 1,
+    },
+    {
+      id: "browse:new:toggle-workmode",
+      label: worktreeSelected ? "Use Local" : "New Worktree",
+      style: "secondary",
+      fallbackText: worktreeSelected ? "local" : "worktree",
+      priority: 2,
+    },
+    ...(worktreeSelected
+      ? [
+          {
+            id: "browse:new:base-branch",
+            label: `Base Branch (${baseBranch ?? "default"})`,
+            style: "secondary" as const,
+            fallbackText: "base branch",
+            priority: 3,
+          },
+        ]
+      : []),
+    {
+      id: "browse:mode:new",
+      label: "Projects",
+      style: "navigation",
+      fallbackText: "projects",
+      priority: 4,
+    },
+    {
+      id: "browse:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+      priority: 5,
+    },
+  ];
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.session.bindingId,
+    browseSessionId: params.session.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.session.surface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.session.surface,
+    fallbackText: [
+      newThreadOptionsPromptText(projectLabel, workMode, baseBranch),
+      `Reply Start, ${worktreeSelected ? "Local" : "Worktree"}, Projects, or Cancel.`,
+    ].join("\n"),
+    prompt: newThreadOptionsPromptText(projectLabel, workMode, baseBranch),
+    choices,
+  };
+}
+
+function buildNewThreadBaseBranchPickerIntent(params: {
+  createdAt: number;
+  id: string;
+  navigation: NavigationSnapshot;
+  session: MessagingBrowseSessionRecord;
+}): MessagingSingleSelectIntent {
+  const project = params.session.selectedProject;
+  const directory = project
+    ? directoryForProjectSelection(params.navigation, project)
+    : undefined;
+  const branches = branchChoicesForDirectory(directory);
+  const currentBranch = params.session.newThreadBranchName ??
+    defaultBaseBranchForDirectory(directory);
+  const choices: MessagingSurfaceAction[] = [
+    ...branches.map((branch, index) => ({
+      id: "browse:new:select-base-branch",
+      label: `${index + 1}. ${branch}${branch === currentBranch ? " (current)" : ""}`,
+      style: "secondary" as const,
+      fallbackText: String(index + 1),
+      priority: 10 + index,
+      value: {
+        branch,
+      },
+    })),
+    {
+      id: "browse:new:options",
+      label: "Back",
+      style: "navigation",
+      fallbackText: "back",
+      priority: 1,
+    },
+    {
+      id: "browse:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+      priority: 2,
+    },
+  ];
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.session.bindingId,
+    browseSessionId: params.session.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.session.surface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.session.surface,
+    fallbackText: [
+      `Choose the base branch for the new worktree${project?.label ? ` in ${project.label}` : ""}.`,
+      ...branches.map((branch, index) => `${index + 1}. ${branch}`),
+      "Reply with a number, Back, or Cancel.",
+    ].join("\n"),
+    prompt: `Choose the base branch for the new worktree${project?.label ? ` in ${project.label}` : ""}.`,
+    choices,
   };
 }
 
@@ -515,6 +673,44 @@ function projectPickerFallbackText(
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function newThreadOptionsPromptText(
+  projectLabel: string,
+  workMode: "local" | "worktree",
+  baseBranch: string | undefined,
+): string {
+  return [
+    `New thread: ${projectLabel}`,
+    `Workspace: ${workMode === "worktree" ? "New Worktree" : "Local"}`,
+    workMode === "worktree"
+      ? `Base branch: ${baseBranch ?? "repository default"}`
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+function defaultBaseBranchForDirectory(
+  directory: NavigationDirectorySummary | undefined,
+): string | undefined {
+  return (
+    directory?.gitStatus?.defaultBranch ??
+    directory?.gitStatus?.currentBranch ??
+    directory?.gitStatus?.branches?.[0]
+  );
+}
+
+function branchChoicesForDirectory(
+  directory: NavigationDirectorySummary | undefined,
+): string[] {
+  const branches = directory?.gitStatus?.branches ?? [];
+  const defaultBranch = defaultBaseBranchForDirectory(directory);
+  const ordered = [
+    defaultBranch,
+    ...branches.filter((branch) => branch !== defaultBranch),
+  ].filter((branch): branch is string => Boolean(branch));
+  return [...new Set(ordered)];
 }
 
 function formatThreadLabel(thread: NavigationThreadSummary): string {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -9,6 +9,7 @@ import type {
   MessagingBindingRecord,
   MessagingConfirmationIntent,
   MessagingJsonValue,
+  MessagingStreamingResponseMode,
   MessagingSingleSelectIntent,
   MessagingSurfaceAction,
   MessagingStatusIntent,
@@ -86,6 +87,7 @@ export function buildBindingStatusIntent(params: {
     params.binding,
     params.toolUpdateMode,
   );
+  const streamingMode = resolveMessagingStreamingResponseMode(params.binding);
 
   return {
     id: params.id,
@@ -112,6 +114,7 @@ export function buildBindingStatusIntent(params: {
       "Plan mode: unavailable",
       `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
+      `Streaming: ${formatMessagingStreamingResponseModeLabel(streamingMode)}`,
       "Context usage: unavailable",
       "Account: unavailable",
       "Rate limits: unavailable",
@@ -127,6 +130,7 @@ export function buildBindingStatusIntent(params: {
       permissionsMode,
       queuedExecutionMode,
       reasoning,
+      streamingMode,
       toolUpdateMode,
     }),
   };
@@ -139,6 +143,7 @@ function buildStatusActions(params: {
   permissionsMode: string;
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning: string;
+  streamingMode: MessagingStreamingResponseMode;
   toolUpdateMode: MessagingToolUpdateMode;
 }): MessagingSurfaceAction[] {
   const profile = params.capabilityProfile;
@@ -198,18 +203,25 @@ function buildStatusActions(params: {
       priority: 9,
     },
     {
+      id: "status:streaming",
+      label: `Stream: ${formatMessagingStreamingResponseModeLabel(params.streamingMode)}`,
+      style: "secondary",
+      fallbackText: "stream",
+      priority: 10,
+    },
+    {
       id: "status:compact",
       label: "Compact",
       style: "secondary",
       fallbackText: "compact",
-      priority: 10,
+      priority: 11,
     },
     {
       id: "status:sync-name",
       label: "Sync name",
       style: "secondary",
       fallbackText: "sync name",
-      priority: 11,
+      priority: 12,
     },
     {
       id: "status:stop",
@@ -290,6 +302,38 @@ export function nextMessagingToolUpdateMode(
 ): MessagingToolUpdateMode {
   const index = TOOL_UPDATE_MODE_ORDER.indexOf(mode);
   return TOOL_UPDATE_MODE_ORDER[(index + 1) % TOOL_UPDATE_MODE_ORDER.length]!;
+}
+
+export function resolveMessagingStreamingResponseMode(
+  binding: MessagingBindingRecord,
+): MessagingStreamingResponseMode {
+  return binding.preferences?.streamingResponses ?? "inherit";
+}
+
+export function nextMessagingStreamingResponseMode(
+  mode: MessagingStreamingResponseMode,
+): MessagingStreamingResponseMode {
+  switch (mode) {
+    case "inherit":
+      return "disabled";
+    case "disabled":
+      return "enabled";
+    case "enabled":
+      return "inherit";
+  }
+}
+
+export function formatMessagingStreamingResponseModeLabel(
+  mode: MessagingStreamingResponseMode,
+): string {
+  switch (mode) {
+    case "inherit":
+      return "Inherit";
+    case "disabled":
+      return "Off";
+    case "enabled":
+      return "Advanced";
+  }
 }
 
 export function formatMessagingToolUpdateModeLabel(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -32,7 +32,11 @@ const STATUS_CARD_MIN_ACTIONS = 3;
 
 export type MessagingWorkspaceHandoffContext = {
   backend: AppServerBackendKind;
+  baseBranches?: string[];
   branch?: string;
+  currentSha?: string;
+  defaultBranch?: string;
+  hasUncommittedChanges?: boolean;
   leaveLocalBranches: string[];
   projectLabel?: string;
   repositoryPath: string;
@@ -360,22 +364,39 @@ export function buildHandoffOverviewIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingSingleSelectIntent {
-  const action =
+  const primaryActions: MessagingSurfaceAction[] =
     params.context.workspaceKind === "local"
-      ? {
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
-          fallbackText: "1",
-          style: "primary" as const,
-          value: handoffValue(params.context),
-        }
-      : {
-          id: "handoff:worktree-to-local",
-          label: "Handoff to Local",
-          fallbackText: "1",
-          style: "primary" as const,
-          value: handoffValue(params.context),
-        };
+      ? [
+          {
+            id: "handoff:move-branch",
+            label: "Move Branch",
+            fallbackText: "1",
+            style: "primary" as const,
+            value: {
+              ...handoffValue(params.context),
+              strategy: "move-branch",
+            },
+          },
+          {
+            id: "handoff:create-detached",
+            label: "Create Detached HEAD",
+            fallbackText: "2",
+            style: "secondary" as const,
+            value: {
+              ...handoffValue(params.context),
+              strategy: "detached-changes",
+            },
+          },
+        ]
+      : [
+          {
+            id: "handoff:worktree-to-local",
+            label: "Handoff to Local",
+            fallbackText: "1",
+            style: "primary" as const,
+            value: handoffValue(params.context),
+          },
+        ];
 
   return {
     id: params.id,
@@ -389,13 +410,13 @@ export function buildHandoffOverviewIntent(params: {
     targetSurface: params.binding.statusSurface,
     fallbackText: [
       handoffOverviewText(params.context),
-      `1. ${action.label}`,
-      "Reply with 1, Back, Refresh, or Cancel.",
+      ...primaryActions.map((action, index) => `${index + 1}. ${action.label}`),
+      "Reply with a number, Back, Refresh, or Cancel.",
     ].join("\n"),
     prompt: handoffOverviewText(params.context),
     choices: applyActionCapabilityLimits(
       [
-        action,
+        ...primaryActions,
         {
           // Back from the handoff overview returns to the status card.
           // Distinct id from the sibling "Refresh" button so callback
@@ -476,7 +497,7 @@ export function buildHandoffBranchPickerIntent(params: {
     const branchNumber = pageStart + index + 1;
     return {
       id: "handoff:select-leave-branch",
-      label: `${branchNumber}. ${branch}`,
+      label: `${branchNumber}. ${formatLeaveBranchChoice(branch)}`,
       fallbackText: String(branchNumber),
       style: "secondary" as const,
       // Branch entries are the lowest priority — under tight action
@@ -486,6 +507,7 @@ export function buildHandoffBranchPickerIntent(params: {
       priority: 100 + index,
       value: {
         ...handoffValue(params.context),
+        strategy: "move-branch",
         leaveLocalBranch: branch,
       },
     };
@@ -583,6 +605,67 @@ export function buildHandoffBranchPickerIntent(params: {
   };
 }
 
+export function buildHandoffBaseBranchPickerIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  context: MessagingWorkspaceHandoffContext;
+  createdAt: number;
+  id: string;
+}): MessagingSingleSelectIntent {
+  const branches = handoffBaseBranches(params.context);
+  const choices = applyActionCapabilityLimits(
+    [
+      ...branches.map((branch, index) => ({
+        id: "handoff:select-base-branch",
+        label: `${index + 1}. ${branch}${branch === params.context.defaultBranch ? " (default)" : ""}`,
+        fallbackText: String(index + 1),
+        style: "secondary" as const,
+        priority: 10 + index,
+        value: {
+          ...handoffValue(params.context),
+          strategy: "detached-changes",
+          baseBranch: branch,
+        },
+      })),
+      {
+        id: "status:handoff",
+        label: "Back",
+        fallbackText: "back",
+        style: "secondary" as const,
+        priority: 1,
+        value: handoffValue(params.context),
+      },
+      {
+        id: "handoff:cancel",
+        label: "Cancel",
+        fallbackText: "cancel",
+        style: "secondary" as const,
+        priority: 2,
+      },
+    ],
+    params.capabilityProfile,
+  );
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: [
+      "Choose the base branch for the new detached worktree.",
+      ...branches.map((branch, index) => `${index + 1}. ${branch}`),
+      "Reply with a number, Back, or Cancel.",
+    ].join("\n"),
+    prompt: "Choose the base branch for the new detached worktree.",
+    choices,
+  };
+}
+
 function clampPageIndex(pageIndex: number, totalPages: number): number {
   if (!Number.isFinite(pageIndex)) {
     return 0;
@@ -596,21 +679,34 @@ export function buildHandoffConfirmationIntent(params: {
   context: MessagingWorkspaceHandoffContext;
   createdAt: number;
   id: string;
+  strategy?: HandoffThreadWorkspaceRequest["strategy"];
+  baseBranch?: string;
   leaveLocalBranch?: string;
 }): MessagingConfirmationIntent {
   const direction =
     params.context.workspaceKind === "local" ? "local-to-worktree" : "worktree-to-local";
+  const strategy = params.strategy ??
+    (params.baseBranch ? "detached-changes" : undefined) ??
+    "move-branch";
   const body = [
-    direction === "local-to-worktree"
-      ? "Confirm handoff to a new worktree."
+    direction === "local-to-worktree" && strategy === "detached-changes"
+      ? "Confirm new detached worktree."
+      : direction === "local-to-worktree"
+        ? "Confirm handoff to a new worktree."
       : "Confirm handoff to Local.",
     `Thread: ${params.context.threadTitle ?? params.context.threadId} (${params.context.backend})`,
     `Project: ${params.context.projectLabel ?? unavailable()}`,
     `Repository: ${params.context.repositoryPath}`,
     `Working directory: ${params.context.workingDirectoryPath}`,
     `Branch: ${params.context.branch ?? unavailable()}`,
-    params.leaveLocalBranch
-      ? `Leave Local on: ${params.leaveLocalBranch}`
+    strategy === "detached-changes" && params.baseBranch
+      ? `Base branch: ${params.baseBranch}`
+      : undefined,
+    strategy === "detached-changes" && !params.baseBranch
+      ? `Base: ${params.context.currentSha ?? "current HEAD"} on ${params.context.branch ?? "current branch"}`
+      : undefined,
+    strategy === "move-branch" && params.leaveLocalBranch
+      ? `Leave Local on: ${formatLeaveBranchChoice(params.leaveLocalBranch)}`
       : undefined,
   ]
     .filter((line): line is string => Boolean(line))
@@ -639,14 +735,16 @@ export function buildHandoffConfirmationIntent(params: {
           priority: 1,
           value: {
             ...handoffValue(params.context),
+            strategy,
+            ...(params.baseBranch ? { baseBranch: params.baseBranch } : {}),
             ...(params.leaveLocalBranch
               ? { leaveLocalBranch: params.leaveLocalBranch }
               : {}),
           },
         },
         {
-          id: params.context.workspaceKind === "local"
-            ? "handoff:local-to-worktree"
+          id: params.context.workspaceKind === "local" && strategy === "move-branch"
+            ? "handoff:move-branch"
             : "status:handoff",
           label: "Back",
           fallbackText: "back",
@@ -695,6 +793,12 @@ export function handoffRequestFromValue(
     repositoryPath: value.repositoryPath,
     sourcePath: value.sourcePath,
     sourceBranch: typeof value.sourceBranch === "string" ? value.sourceBranch : undefined,
+    strategy:
+      value.strategy === "move-branch" || value.strategy === "detached-changes"
+        ? value.strategy
+        : undefined,
+    baseBranch:
+      typeof value.baseBranch === "string" ? value.baseBranch : undefined,
     leaveLocalBranch:
       typeof value.leaveLocalBranch === "string" ? value.leaveLocalBranch : undefined,
   };
@@ -835,6 +939,19 @@ function handoffValue(
     sourcePath: context.workingDirectoryPath,
     ...(context.branch ? { sourceBranch: context.branch } : {}),
   };
+}
+
+function handoffBaseBranches(context: MessagingWorkspaceHandoffContext): string[] {
+  const branches = context.baseBranches ?? [];
+  const ordered = [
+    context.defaultBranch,
+    ...branches.filter((branch) => branch !== context.defaultBranch),
+  ].filter((branch): branch is string => Boolean(branch));
+  return [...new Set(ordered)];
+}
+
+function formatLeaveBranchChoice(branch: string): string {
+  return branch === "HEAD" ? "Detached HEAD" : branch;
 }
 
 function handoffOverviewText(context: MessagingWorkspaceHandoffContext): string {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1041,7 +1041,9 @@ export class DesktopMessagingRuntime {
     this.addPlatformDegradationReason(platform, {
       kind: "rate-limited",
       key,
-      message: clipStatusText(info.message),
+      message: clipStatusText(
+        info.message ?? `Cool Off active for ${formatDurationForStatus(retryAfterMs)}.`,
+      ),
       scope: sanitizeDeliveryScope(info.scope),
       retryAfterMs,
       startedAt,
@@ -1049,10 +1051,10 @@ export class DesktopMessagingRuntime {
     });
     this.recordDiagnosticActivity({
       platform,
-      summary: `Provider rate limit: ${info.scope.id}`,
+      summary: `Cool Off started: ${info.scope.id}`,
       createdAt: startedAt,
       payload: {
-        type: "provider-rate-limit",
+        type: "provider-cool-off",
         scope: sanitizeDeliveryScope(info.scope),
         retryAfterMs,
         expiresAt,
@@ -1065,12 +1067,12 @@ export class DesktopMessagingRuntime {
     event: MessagingControllerDeliveryBudgetEvent,
   ): void {
     const scopeId = event.scope?.id ?? "unknown";
-    const reason = event.outcome === "deferred"
-      ? "deferred"
-      : event.reason ?? "dropped";
+    const reason = event.reason ?? (event.outcome === "deferred" ? "deferred" : "dropped");
     const retryDelayMs = event.retryAt !== undefined
       ? Math.max(0, event.retryAt - event.at)
       : undefined;
+    const isCoolOff = reason === "cool-off";
+    const modeLabel = isCoolOff ? "Cool Off" : "Slow Mode";
 
     const diagnosticKey = [
       event.channel,
@@ -1100,7 +1102,7 @@ export class DesktopMessagingRuntime {
       retryAt: event.retryAt,
       retryDelayMs,
       scopeId,
-      slowMode: event.slowMode,
+      slowModeActive: event.slowMode,
       threadId: event.threadId,
     });
 
@@ -1112,8 +1114,8 @@ export class DesktopMessagingRuntime {
       kind: "warning",
       key,
       message: event.outcome === "deferred"
-        ? `Delivery budget saturated; holding ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}.`
-        : `Delivery budget dropped ${event.priority} (${reason}).`,
+        ? `${modeLabel} active; holding ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}.`
+        : `${modeLabel} active; dropped ${event.priority} (${reason}).`,
       scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
       startedAt: event.at,
       expiresAt,
@@ -1124,11 +1126,11 @@ export class DesktopMessagingRuntime {
       threadId: event.threadId,
       bindingId: event.bindingId,
       summary: event.outcome === "deferred"
-        ? `Delivery budget deferred ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}`
-        : `Delivery budget dropped ${event.priority}: ${reason}`,
+        ? `${modeLabel} held ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}`
+        : `${modeLabel} dropped ${event.priority}: ${reason}`,
       createdAt: event.at,
       payload: {
-        type: "delivery-budget",
+        type: isCoolOff ? "cool-off" : "slow-mode",
         intentId: event.intentId,
         intentKind: event.intentKind,
         outcome: event.outcome,
@@ -1137,7 +1139,7 @@ export class DesktopMessagingRuntime {
         retryAt: event.retryAt,
         retryDelayMs,
         scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
-        slowMode: event.slowMode,
+        slowModeActive: event.slowMode,
       },
     });
   }

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1,5 +1,8 @@
 import { randomBytes, randomUUID } from "node:crypto";
-import { MessagingController } from "./core/messaging-controller";
+import {
+  MessagingController,
+  type MessagingControllerDeliveryBudgetEvent,
+} from "./core/messaging-controller";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import type {
   MessagingAdapter,
@@ -114,6 +117,8 @@ const MAX_OUTSTANDING_PAIRING_TOKENS = 5;
 const PAIRING_TOKEN_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const RATE_LIMIT_HEALTH_BUFFER_MS = 2_000;
+const DELIVERY_BUDGET_WARNING_TTL_MS = 30_000;
+const DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS = 30_000;
 
 export type MessagingPairingChangedEvent = {
   at: number;
@@ -210,6 +215,7 @@ export class DesktopMessagingRuntime {
     string,
     ReturnType<typeof setTimeout>
   >();
+  private readonly deliveryBudgetDiagnosticLastLoggedAt = new Map<string, number>();
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
@@ -721,6 +727,7 @@ export class DesktopMessagingRuntime {
       toolUpdateDefaultMode: async () =>
         (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
       onBindingChanged: () => this.broadcastBindingsChanged(),
+      onDeliveryBudgetEvent: (event) => this.handleDeliveryBudgetEvent(event),
     });
 
     let unsubscribeInboundRejected: (() => void) | undefined;
@@ -928,33 +935,34 @@ export class DesktopMessagingRuntime {
   }
 
   private async recordBindingUnbound(binding: MessagingBindingRecord): Promise<void> {
-    if (!this.options.backendBridge.recordMessagingBindingTransition) {
-      return;
-    }
     const conversation = binding.channel.conversation;
-    try {
-      await this.options.backendBridge.recordMessagingBindingTransition({
-        backend: binding.backend,
-        threadId: binding.threadId,
-        transition: {
-          id: randomUUID(),
-          action: "unbound",
+    const occurredAt = Date.now();
+    if (this.options.backendBridge.recordMessagingBindingTransition) {
+      try {
+        await this.options.backendBridge.recordMessagingBindingTransition({
+          backend: binding.backend,
+          threadId: binding.threadId,
+          transition: {
+            id: randomUUID(),
+            action: "unbound",
+            bindingId: binding.id,
+            platform: binding.channel.channel,
+            conversationKind: conversation.kind,
+            conversationTitle: conversation.title,
+            parentTitle: conversation.parentTitle,
+            ancestorTitle: conversation.ancestorTitle,
+            occurredAt,
+          },
+        });
+      } catch (error) {
+        messagingLog.warn("messaging binding-transition audit failed", {
           bindingId: binding.id,
-          platform: binding.channel.channel,
-          conversationKind: conversation.kind,
-          conversationTitle: conversation.title,
-          parentTitle: conversation.parentTitle,
-          ancestorTitle: conversation.ancestorTitle,
-          occurredAt: Date.now(),
-        },
-      });
-    } catch (error) {
-      messagingLog.warn("messaging binding-transition audit failed", {
-        bindingId: binding.id,
-        error: error instanceof Error ? error.message : String(error),
-        threadId: binding.threadId,
-      });
+          error: error instanceof Error ? error.message : String(error),
+          threadId: binding.threadId,
+        });
+      }
     }
+    this.recordBindingActivity("unbound", binding, occurredAt);
   }
 
   private broadcastBindingsChanged(): void {
@@ -1038,6 +1046,99 @@ export class DesktopMessagingRuntime {
       retryAfterMs,
       startedAt,
       expiresAt,
+    });
+    this.recordDiagnosticActivity({
+      platform,
+      summary: `Provider rate limit: ${info.scope.id}`,
+      createdAt: startedAt,
+      payload: {
+        type: "provider-rate-limit",
+        scope: sanitizeDeliveryScope(info.scope),
+        retryAfterMs,
+        expiresAt,
+        message: clipStatusText(info.message),
+      },
+    });
+  }
+
+  private handleDeliveryBudgetEvent(
+    event: MessagingControllerDeliveryBudgetEvent,
+  ): void {
+    const scopeId = event.scope?.id ?? "unknown";
+    const reason = event.outcome === "deferred"
+      ? "deferred"
+      : event.reason ?? "dropped";
+    const retryDelayMs = event.retryAt !== undefined
+      ? Math.max(0, event.retryAt - event.at)
+      : undefined;
+
+    const diagnosticKey = [
+      event.channel,
+      scopeId,
+      event.outcome,
+      event.reason ?? "deferred",
+      event.priority,
+      event.intentKind,
+    ].join("\0");
+    const lastLoggedAt = this.deliveryBudgetDiagnosticLastLoggedAt.get(diagnosticKey);
+    if (
+      lastLoggedAt !== undefined &&
+      event.at - lastLoggedAt < DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS
+    ) {
+      return;
+    }
+    this.deliveryBudgetDiagnosticLastLoggedAt.set(diagnosticKey, event.at);
+
+    messagingLog.info("messaging delivery budget constrained", {
+      bindingId: event.bindingId,
+      channel: event.channel,
+      intentId: event.intentId,
+      intentKind: event.intentKind,
+      outcome: event.outcome,
+      priority: event.priority,
+      reason,
+      retryAt: event.retryAt,
+      retryDelayMs,
+      scopeId,
+      slowMode: event.slowMode,
+      threadId: event.threadId,
+    });
+
+    const expiresAt = event.outcome === "deferred"
+      ? event.retryAt
+      : event.at + DELIVERY_BUDGET_WARNING_TTL_MS;
+    const key = degradationKey(event.channel, "warning", `delivery-budget:${scopeId}`);
+    this.addPlatformDegradationReason(event.channel, {
+      kind: "warning",
+      key,
+      message: event.outcome === "deferred"
+        ? `Delivery budget saturated; holding ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}.`
+        : `Delivery budget dropped ${event.priority} (${reason}).`,
+      scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
+      startedAt: event.at,
+      expiresAt,
+    });
+    this.recordDiagnosticActivity({
+      platform: event.channel,
+      backend: event.backend,
+      threadId: event.threadId,
+      bindingId: event.bindingId,
+      summary: event.outcome === "deferred"
+        ? `Delivery budget deferred ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}`
+        : `Delivery budget dropped ${event.priority}: ${reason}`,
+      createdAt: event.at,
+      payload: {
+        type: "delivery-budget",
+        intentId: event.intentId,
+        intentKind: event.intentKind,
+        outcome: event.outcome,
+        priority: event.priority,
+        reason,
+        retryAt: event.retryAt,
+        retryDelayMs,
+        scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
+        slowMode: event.slowMode,
+      },
     });
   }
 
@@ -1337,6 +1438,69 @@ export class DesktopMessagingRuntime {
     }
   }
 
+  private recordBindingActivity(
+    action: "bound" | "unbound",
+    binding: MessagingBindingRecord,
+    occurredAt: number,
+  ): void {
+    try {
+      const conversation = binding.channel.conversation;
+      getDesktopMessagingActivityLog().record({
+        platform: binding.channel.channel,
+        kind: "binding",
+        backend: binding.backend,
+        threadId: binding.threadId,
+        bindingId: binding.id,
+        conversationId: conversation.id,
+        conversationTitle: conversation.title,
+        summary: `Channel ${action}: ${describeConversation(conversation)} / ${binding.threadId}`,
+        createdAt: occurredAt,
+        payload: {
+          action,
+          conversationKind: conversation.kind,
+          conversationParentId: conversation.parentId,
+          parentTitle: conversation.parentTitle,
+          ancestorTitle: conversation.ancestorTitle,
+        },
+      });
+    } catch (error) {
+      messagingLog.warn("messaging binding activity write failed", {
+        action,
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private recordDiagnosticActivity(params: {
+    platform: MessagingChannelKind;
+    backend?: AgentEvent["backend"];
+    threadId?: string;
+    bindingId?: string;
+    summary: string;
+    createdAt: number;
+    payload: Record<string, unknown>;
+  }): void {
+    try {
+      getDesktopMessagingActivityLog().record({
+        platform: params.platform,
+        kind: "diagnostic",
+        backend: params.backend,
+        threadId: params.threadId,
+        bindingId: params.bindingId,
+        summary: params.summary,
+        createdAt: params.createdAt,
+        payload: params.payload,
+      });
+    } catch (error) {
+      messagingLog.warn("messaging diagnostic activity write failed", {
+        bindingId: params.bindingId,
+        error: error instanceof Error ? error.message : String(error),
+        platform: params.platform,
+      });
+    }
+  }
+
   private recordActivityFromInbound(
     platform: MessagingChannelKind,
     event: MessagingInboundEvent,
@@ -1633,6 +1797,26 @@ function clipStatusText(value: string | undefined): string | undefined {
   }
   const normalized = value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
   return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function describeConversation(
+  conversation: MessagingBindingRecord["channel"]["conversation"],
+): string {
+  const pieces = [
+    conversation.ancestorTitle,
+    conversation.parentTitle,
+    conversation.title,
+  ].filter((piece): piece is string => Boolean(piece));
+  return pieces.length > 0 ? pieces.join(" / ") : conversation.id;
+}
+
+function formatDurationForStatus(durationMs: number): string {
+  const seconds = Math.max(0, Math.ceil(durationMs / 1000));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes}m`;
 }
 
 function isMessagingPendingRequest(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -26,6 +26,7 @@ import type {
   MessagingBindingRecord,
   MessagingCapabilityProfile,
   MessagingChannelKind,
+  MessagingClientRateLimitStrategy,
   MessagingCredentialValidationResult,
   MessagingDeliveryResult,
   MessagingDeliveryScope,
@@ -60,6 +61,7 @@ export type DesktopMessagingAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: MessagingChannelKind;
+  clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
@@ -701,6 +703,12 @@ export class DesktopMessagingRuntime {
     const authorizedActorIds = [...adapter.authorizedActorIds];
     const authorizedActorIdSet = new Set(authorizedActorIds);
     const deliveryBudget = new MessagingDeliveryBudget();
+    if (adapter.clientRateLimitStrategy === "sdk-managed") {
+      messagingLog.warn(`${adapter.channel}: SDK-managed rate-limit retries are enabled`, {
+        channel: adapter.channel,
+        clientRateLimitStrategy: adapter.clientRateLimitStrategy,
+      });
+    }
     const controller = new MessagingController({
       adapter,
       attachmentPolicy: config.attachmentPolicy,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -14,6 +14,7 @@ import type {
   GenerateMessagingPairingTokenResponse,
   ListMessagingPairingRequestsRequest,
   ListMessagingPairingRequestsResponse,
+  MessagingDegradationReason,
   MessagingPairingEntry,
   MessagingPairingObservedActor,
   MessagingPairingObservedChat,
@@ -27,8 +28,11 @@ import type {
   MessagingChannelKind,
   MessagingCredentialValidationResult,
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingRateLimitInfo,
+  MessagingReconnectInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -50,12 +54,14 @@ import { DesktopMessagingBackendBridge } from "./desktop-backend-bridge";
 import { getDesktopMessagingActivityLog } from "./desktop-messaging-activity-log";
 import { getDesktopMessagingPairingStore } from "./desktop-messaging-pairing-store";
 import { loadConfiguredMessagingAdapters } from "./provider-loader";
+import { MessagingDeliveryBudget } from "./core/messaging-delivery-budget";
 
 export type DesktopMessagingAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: MessagingChannelKind;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
   /**
    * Optional subscription for fatal runtime errors that took the
@@ -66,6 +72,8 @@ export type DesktopMessagingAdapter = {
    * cannot detect post-start failures may simply omit the method.
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
+  onReconnect?(listener: (info: MessagingReconnectInfo) => void): () => void;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
@@ -90,6 +98,8 @@ type RunningMessagingAdapter = {
   controller: MessagingController;
   fingerprint: string;
   unsubscribeInboundRejected?: () => void;
+  unsubscribeRateLimit?: () => void;
+  unsubscribeReconnect?: () => void;
   unsubscribeRuntimeError?: () => void;
 };
 
@@ -101,6 +111,7 @@ const MAX_PAIRING_TTL_MS = 30 * 60 * 1000;
 const MAX_OUTSTANDING_PAIRING_TOKENS = 5;
 const PAIRING_TOKEN_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const RATE_LIMIT_HEALTH_BUFFER_MS = 2_000;
 
 export type MessagingPairingChangedEvent = {
   at: number;
@@ -188,6 +199,14 @@ export class DesktopMessagingRuntime {
   private readonly platformStatuses = new Map<
     MessagingChannelKind,
     MessagingPlatformStatus
+  >();
+  private readonly platformDegradationReasons = new Map<
+    MessagingChannelKind,
+    Map<string, MessagingDegradationReason>
+  >();
+  private readonly platformDegradationTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
   >();
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
@@ -383,6 +402,9 @@ export class DesktopMessagingRuntime {
    * subscribes to the event stream right after to stay current.
    */
   getPlatformStatuses(): MessagingPlatformStatus[] {
+    for (const platform of this.platformStatuses.keys()) {
+      this.clearExpiredDegradationReasons(platform);
+    }
     return [...this.platformStatuses.values()];
   }
 
@@ -678,12 +700,14 @@ export class DesktopMessagingRuntime {
     const { adapter, config, store } = params;
     const authorizedActorIds = [...adapter.authorizedActorIds];
     const authorizedActorIdSet = new Set(authorizedActorIds);
+    const deliveryBudget = new MessagingDeliveryBudget();
     const controller = new MessagingController({
       adapter,
       attachmentPolicy: config.attachmentPolicy,
       authorizedActorIds,
       backend: this.options.backendBridge,
       channel: adapter.channel,
+      deliveryBudget,
       inputDebounceMs: config.inputDebounceMs,
       store,
       toolUpdateDefaultMode: async () =>
@@ -779,12 +803,21 @@ export class DesktopMessagingRuntime {
       });
       this.setPlatformHealth(adapter.channel, "errored", { reason });
     });
+    const unsubscribeRateLimit = adapter.onRateLimit?.((info) => {
+      deliveryBudget.recordRateLimit(info);
+      this.handleAdapterRateLimit(adapter.channel, info);
+    });
+    const unsubscribeReconnect = adapter.onReconnect?.((info) => {
+      this.handleAdapterReconnect(adapter.channel, info);
+    });
 
     this.runningAdapters.set(adapter.channel, {
       adapter,
       controller,
       fingerprint: messagingAdapterConfigFingerprint(config, adapter.channel),
       unsubscribeInboundRejected,
+      unsubscribeRateLimit,
+      unsubscribeReconnect,
       unsubscribeRuntimeError,
     });
     this.syncRunningAdapterLists();
@@ -796,6 +829,20 @@ export class DesktopMessagingRuntime {
   }
 
   private async stopRunningAdapter(running: RunningMessagingAdapter): Promise<void> {
+    try {
+      running.unsubscribeRateLimit?.();
+    } catch (error) {
+      messagingLog.warn("messaging adapter rate-limit unsubscribe threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    try {
+      running.unsubscribeReconnect?.();
+    } catch (error) {
+      messagingLog.warn("messaging adapter reconnect unsubscribe threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     try {
       running.unsubscribeRuntimeError?.();
     } catch (error) {
@@ -934,12 +981,23 @@ export class DesktopMessagingRuntime {
   ): void {
     const at = Date.now();
     const previous = this.platformStatuses.get(platform);
+    if (health === "enabled" || health === "suspended" || health === "errored") {
+      if (health !== "enabled") {
+        this.clearPlatformDegradationReasons(platform, { broadcast: false });
+      } else {
+        this.clearExpiredDegradationReasons(platform);
+      }
+    }
+    const degradationReasons = this.currentDegradationReasons(platform);
+    const effectiveHealth =
+      health === "enabled" && degradationReasons.length > 0 ? "degraded" : health;
     const next: MessagingPlatformStatus = {
       ...previous,
       platform,
-      health,
+      health: effectiveHealth,
       changedAt: at,
       reason: options.reason,
+      degradationReasons,
       // Preserve the existing activity timestamp through health
       // transitions; activity is independent of health and shouldn't
       // be reset just because the user toggled messaging off.
@@ -949,10 +1007,184 @@ export class DesktopMessagingRuntime {
     this.broadcastPlatformStatus({
       kind: "health-changed",
       platform,
-      health,
+      health: effectiveHealth,
       reason: options.reason,
+      degradationReasons,
       at,
     });
+  }
+
+  private handleAdapterRateLimit(
+    platform: MessagingChannelKind,
+    info: MessagingRateLimitInfo,
+  ): void {
+    const startedAt = info.observedAt ?? Date.now();
+    const retryAfterMs = Math.max(0, Math.floor(info.retryAfterMs ?? 0));
+    const expiresAt = startedAt + retryAfterMs + RATE_LIMIT_HEALTH_BUFFER_MS;
+    const key = degradationKey(platform, "rate-limited", info.scope.id);
+    this.addPlatformDegradationReason(platform, {
+      kind: "rate-limited",
+      key,
+      message: clipStatusText(info.message),
+      scope: sanitizeDeliveryScope(info.scope),
+      retryAfterMs,
+      startedAt,
+      expiresAt,
+    });
+  }
+
+  private handleAdapterReconnect(
+    platform: MessagingChannelKind,
+    info: MessagingReconnectInfo,
+  ): void {
+    const key = degradationKey(platform, "reconnecting", "adapter");
+    if (info.state === "recovered") {
+      this.clearPlatformDegradationReason(platform, key);
+      return;
+    }
+    this.addPlatformDegradationReason(platform, {
+      kind: "reconnecting",
+      key,
+      attemptCount: info.attemptCount,
+      lastFailureReason: clipStatusText(info.lastFailureReason),
+      startedAt: info.observedAt ?? Date.now(),
+    });
+  }
+
+  private addPlatformDegradationReason(
+    platform: MessagingChannelKind,
+    reason: MessagingDegradationReason,
+  ): void {
+    this.clearExpiredDegradationReasons(platform);
+    const reasons = this.platformDegradationReasonsFor(platform);
+    reasons.set(reason.key, reason);
+    this.scheduleDegradationExpiry(platform, reason);
+    this.refreshDegradedPlatformHealth(platform);
+  }
+
+  private clearPlatformDegradationReason(
+    platform: MessagingChannelKind,
+    key: string,
+  ): void {
+    const reasons = this.platformDegradationReasons.get(platform);
+    if (!reasons?.delete(key)) {
+      return;
+    }
+    this.clearDegradationTimer(platform, key);
+    this.refreshDegradedPlatformHealth(platform);
+  }
+
+  private clearPlatformDegradationReasons(
+    platform: MessagingChannelKind,
+    options: { broadcast: boolean },
+  ): void {
+    const reasons = this.platformDegradationReasons.get(platform);
+    if (!reasons || reasons.size === 0) {
+      return;
+    }
+    for (const key of reasons.keys()) {
+      this.clearDegradationTimer(platform, key);
+    }
+    reasons.clear();
+    if (options.broadcast) {
+      this.refreshDegradedPlatformHealth(platform);
+    }
+  }
+
+  private clearExpiredDegradationReasons(platform: MessagingChannelKind): void {
+    const reasons = this.platformDegradationReasons.get(platform);
+    if (!reasons || reasons.size === 0) {
+      return;
+    }
+    const now = Date.now();
+    let mutated = false;
+    for (const [key, reason] of [...reasons.entries()]) {
+      const expiresAt = degradationExpiresAt(reason);
+      if (expiresAt !== undefined && expiresAt <= now) {
+        reasons.delete(key);
+        this.clearDegradationTimer(platform, key);
+        mutated = true;
+      }
+    }
+    if (mutated) {
+      this.refreshDegradedPlatformHealth(platform);
+    }
+  }
+
+  private refreshDegradedPlatformHealth(platform: MessagingChannelKind): void {
+    const previous = this.platformStatuses.get(platform);
+    if (!previous || previous.health === "errored" || previous.health === "suspended") {
+      return;
+    }
+    const degradationReasons = this.currentDegradationReasons(platform);
+    const nextHealth: MessagingPlatformHealth =
+      degradationReasons.length > 0 ? "degraded" : "enabled";
+    const at = Date.now();
+    this.platformStatuses.set(platform, {
+      ...previous,
+      health: nextHealth,
+      changedAt: at,
+      reason: nextHealth === "degraded" ? previous.reason : undefined,
+      degradationReasons,
+    });
+    this.broadcastPlatformStatus({
+      kind: "health-changed",
+      platform,
+      health: nextHealth,
+      reason: nextHealth === "degraded" ? previous.reason : undefined,
+      degradationReasons,
+      at,
+    });
+  }
+
+  private currentDegradationReasons(
+    platform: MessagingChannelKind,
+  ): MessagingDegradationReason[] {
+    return [...(this.platformDegradationReasons.get(platform)?.values() ?? [])];
+  }
+
+  private platformDegradationReasonsFor(
+    platform: MessagingChannelKind,
+  ): Map<string, MessagingDegradationReason> {
+    let reasons = this.platformDegradationReasons.get(platform);
+    if (!reasons) {
+      reasons = new Map();
+      this.platformDegradationReasons.set(platform, reasons);
+    }
+    return reasons;
+  }
+
+  private scheduleDegradationExpiry(
+    platform: MessagingChannelKind,
+    reason: MessagingDegradationReason,
+  ): void {
+    const expiresAt = degradationExpiresAt(reason);
+    if (expiresAt === undefined) {
+      return;
+    }
+    const timerKey = degradationTimerKey(platform, reason.key);
+    this.clearDegradationTimer(platform, reason.key);
+    const delayMs = Math.max(0, expiresAt - Date.now());
+    this.platformDegradationTimers.set(
+      timerKey,
+      setTimeout(() => {
+        this.platformDegradationTimers.delete(timerKey);
+        this.clearPlatformDegradationReason(platform, reason.key);
+      }, delayMs),
+    );
+  }
+
+  private clearDegradationTimer(
+    platform: MessagingChannelKind,
+    key: string,
+  ): void {
+    const timerKey = degradationTimerKey(platform, key);
+    const timer = this.platformDegradationTimers.get(timerKey);
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    this.platformDegradationTimers.delete(timerKey);
   }
 
   private emitPlatformActivity(platform: MessagingChannelKind): void {
@@ -1354,6 +1586,45 @@ function bucketIdFromEvent(event: MessagingInboundEvent): string | undefined {
     }
   }
   return event.channel.conversation.parentId ?? event.channel.conversation.id;
+}
+
+function degradationKey(
+  platform: MessagingChannelKind,
+  kind: MessagingDegradationReason["kind"],
+  id: string,
+): string {
+  return `${platform}:${kind}:${id}`;
+}
+
+function degradationTimerKey(
+  platform: MessagingChannelKind,
+  key: string,
+): string {
+  return `${platform}\0${key}`;
+}
+
+function degradationExpiresAt(
+  reason: MessagingDegradationReason,
+): number | undefined {
+  return "expiresAt" in reason ? reason.expiresAt : undefined;
+}
+
+function sanitizeDeliveryScope(
+  scope: MessagingDeliveryScope,
+): MessagingDeliveryScope {
+  return {
+    ...scope,
+    label: clipStatusText(scope.label),
+    bucketId: clipStatusText(scope.bucketId),
+  };
+}
+
+function clipStatusText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
 }
 
 function isMessagingPendingRequest(

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -14,6 +14,8 @@ const KIND_LABEL: Record<MessagingActivityKind, string> = {
   "inbound-ignored": "Ignored",
   pairing: "Pairing",
   outbound: "Sent",
+  binding: "Binding",
+  diagnostic: "Diagnostic",
 };
 const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "muted"> = {
   "inbound-routed": "ok",
@@ -21,6 +23,8 @@ const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "mut
   "inbound-ignored": "warning",
   pairing: "warning",
   outbound: "muted",
+  binding: "ok",
+  diagnostic: "warning",
 };
 
 /**
@@ -98,9 +102,9 @@ export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
       {/* Primary list — fills available height with internal scroll. */}
       <ActivitySection
         className="messaging-activity__main"
-        title="Currently bound"
+        title="Bound activity"
         emptyLabel="No bound conversations have sent messages recently."
-        kinds={["inbound-routed", "outbound"]}
+        kinds={["binding", "inbound-routed", "outbound"]}
         groups={groups}
       />
 
@@ -108,9 +112,9 @@ export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
           Stays pinned to the bottom of the pane. */}
       <ActivitySection
         className="messaging-activity__aside"
-        title="Received but ignored"
-        emptyLabel="No rejected or ignored inbound messages — your authorization list is doing its job."
-        kinds={["inbound-rejected", "inbound-ignored", "pairing"]}
+        title="Attention"
+        emptyLabel="No rejected messages, pairing attempts, or delivery diagnostics."
+        kinds={["diagnostic", "inbound-rejected", "inbound-ignored", "pairing"]}
         groups={groups}
       />
     </section>
@@ -287,6 +291,8 @@ function groupByKind(
     "inbound-ignored": [],
     pairing: [],
     outbound: [],
+    binding: [],
+    diagnostic: [],
   };
   for (const entry of entries) {
     groups[entry.kind]?.push(entry);

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -1,0 +1,54 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MessagingPlatformStatus } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { MessagingStatusBar } from "./MessagingStatusBar";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MessagingStatusBar", () => {
+  it("renders degraded status with rate-limit detail in the tooltip", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        degradationReasons: [
+          {
+            expiresAt: 8000,
+            key: "telegram:rate-limited:group",
+            kind: "rate-limited",
+            retryAfterMs: 5000,
+            scope: {
+              id: "telegram:group:-100123",
+              kind: "group",
+              label: "Telegram group -100123",
+              platform: "telegram",
+            },
+            startedAt: 1000,
+          },
+        ],
+        health: "degraded",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    const chip = await screen.findByRole("group", {
+      name: "Messaging platform status",
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/Telegram: Degraded/),
+      ).toBeInTheDocument();
+    });
+    expect(chip).toHaveTextContent("Rate limited");
+    expect(chip).toHaveTextContent("Telegram group -100123");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement } from "react";
+import { useId, type ReactElement } from "react";
 import type {
   MessagingChannelKind,
+  MessagingDegradationReason,
   MessagingPlatformHealth,
   MessagingPlatformStatus,
 } from "@pwragent/shared";
@@ -25,6 +26,7 @@ const ICONS: Partial<
 
 const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
   enabled: "Enabled",
+  degraded: "Degraded",
   suspended: "Suspended",
   errored: "Errored",
   unknown: "Loading",
@@ -82,10 +84,15 @@ function PlatformChip(props: {
   onClick?: () => void;
 }) {
   const { status, active, onClick } = props;
+  const tooltipId = useId();
   const Icon = ICONS[status.platform];
-  const baseLabel = `${formatPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}${
-    status.reason ? ` (${status.reason})` : ""
-  }`;
+  const labelLines = [
+    `${formatPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
+    status.reason,
+    ...formatDegradationReasons(status.degradationReasons ?? []),
+  ]
+    .filter((line): line is string => Boolean(line));
+  const baseLabel = labelLines.join("\n");
   const label = onClick
     ? `${baseLabel} — click to view messaging activity`
     : baseLabel;
@@ -108,11 +115,16 @@ function PlatformChip(props: {
         }`}
         aria-hidden="true"
       />
+      <span className="messaging-status-chip__tooltip" id={tooltipId} role="tooltip">
+        {labelLines.map((line) => (
+          <span key={line}>{line}</span>
+        ))}
+      </span>
     </>
   );
   if (!onClick) {
     return (
-      <span className={className} title={label} aria-label={label}>
+      <span className={className} aria-describedby={tooltipId} aria-label={label}>
         {content}
       </span>
     );
@@ -121,7 +133,7 @@ function PlatformChip(props: {
     <button
       type="button"
       className={`${className} messaging-status-chip--clickable`}
-      title={label}
+      aria-describedby={tooltipId}
       aria-label={label}
       onClick={onClick}
     >
@@ -136,7 +148,7 @@ function hasRecentActivity(
 ): boolean {
   // Suspended/errored platforms shouldn't blink even if a stale activity
   // timestamp is hanging around — the dot is a status indicator first.
-  if (status.health !== "enabled") return false;
+  if (status.health !== "enabled" && status.health !== "degraded") return false;
   return Boolean(observedAt);
 }
 
@@ -146,6 +158,8 @@ function dotTone(
   switch (health) {
     case "enabled":
       return "ok";
+    case "degraded":
+      return "warning";
     case "suspended":
       return "suspended";
     case "errored":
@@ -153,6 +167,34 @@ function dotTone(
     case "unknown":
       return "suspended";
   }
+}
+
+function formatDegradationReasons(
+  reasons: readonly MessagingDegradationReason[],
+): string[] {
+  return reasons.map((reason) => {
+    const scopeLabel = reason.scope?.label ? ` (${reason.scope.label})` : "";
+    switch (reason.kind) {
+      case "rate-limited":
+        return `Rate limited${scopeLabel}${formatRetry(reason.retryAfterMs)}`;
+      case "reconnecting":
+        return `Reconnecting${formatAttempt(reason.attemptCount)}${reason.lastFailureReason ? `: ${reason.lastFailureReason}` : ""}`;
+      case "missing-permission":
+        return `Missing permission${reason.permission ? `: ${reason.permission}` : ""}`;
+      case "warning":
+        return reason.message ?? `Warning${scopeLabel}`;
+    }
+  });
+}
+
+function formatRetry(retryAfterMs: number | undefined): string {
+  if (retryAfterMs === undefined) return "";
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  return `; retrying in ${seconds}s`;
+}
+
+function formatAttempt(attemptCount: number | undefined): string {
+  return attemptCount === undefined ? "" : ` (attempt ${attemptCount})`;
 }
 
 function formatPlatformName(platform: MessagingChannelKind): string {

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -102,6 +102,7 @@ function upsertHealth(
     health: event.health,
     changedAt: event.at,
     reason: event.reason,
+    degradationReasons: event.degradationReasons,
     lastActivityAt: existing?.lastActivityAt,
   };
   if (!existing) {

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -213,8 +213,8 @@ export function MessagingSettings(props: {
           <ToggleField
             checked={telegram.streamingResponses.value}
             disabled={props.saving}
-            label="Streaming Responses"
-            sub="Send partial assistant tokens as Telegram message edits."
+            label="Streaming Responses (Advanced)"
+            sub="Sends partial assistant text as Telegram message edits."
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(telegram.streamingResponses)}
             onChange={(streamingResponses) => {
@@ -328,8 +328,8 @@ export function MessagingSettings(props: {
           <ToggleField
             checked={discord.streamingResponses.value}
             disabled={props.saving}
-            label="Streaming Responses"
-            sub="Send partial assistant tokens as Discord message edits."
+            label="Streaming Responses (Advanced)"
+            sub="Sends partial assistant text as Discord message edits."
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(discord.streamingResponses)}
             onChange={(streamingResponses) => {
@@ -480,8 +480,8 @@ export function MessagingSettings(props: {
           <ToggleField
             checked={mattermost.streamingResponses.value}
             disabled={props.saving}
-            label="Streaming Responses"
-            sub="Send partial assistant tokens as Mattermost message edits."
+            label="Streaming Responses (Advanced)"
+            sub="Sends partial assistant text as Mattermost message edits."
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(mattermost.streamingResponses)}
             onChange={(streamingResponses) => {
@@ -696,8 +696,8 @@ export function MessagingSettings(props: {
           <ToggleField
             checked={slack.streamingResponses.value}
             disabled={props.saving}
-            label="Streaming Responses"
-            sub="Send partial assistant tokens as Slack message edits."
+            label="Streaming Responses (Advanced)"
+            sub="Sends partial assistant text as Slack message edits."
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(slack.streamingResponses)}
             onChange={(streamingResponses) => {
@@ -813,7 +813,7 @@ const SLACK_INBOUND_MODE_OPTIONS: Array<{
 ];
 
 const STREAMING_RESPONSES_WARNING =
-  "Leave this off unless you know you need live edits. Voice readers may speak each partial edit as a separate incomplete reply, and frequent edits can quickly hit platform rate limits.";
+  "Advanced. Leave this off unless you specifically need live message edits. It does not make turns finish sooner; it repeatedly edits the same platform message, which can break voice readers and reach platform rate limits much sooner.";
 
 function chipLabelForBotToken(
   botToken: DesktopSettingsSnapshot["messaging"]["telegram"]["botToken"],

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -262,9 +262,11 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("radio", { name: "Group/supergroup chat" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/Voice readers may speak each partial edit/)).toHaveLength(4);
-    expect(screen.getAllByText(/quickly hit platform rate limits/)).toHaveLength(4);
-    fireEvent.click(screen.getAllByRole("switch", { name: "Streaming Responses" })[0]!);
+    expect(screen.getAllByText(/does not make turns finish sooner/)).toHaveLength(4);
+    expect(screen.getAllByText(/reach platform rate limits much sooner/)).toHaveLength(4);
+    fireEvent.click(
+      screen.getAllByRole("switch", { name: "Streaming Responses (Advanced)" })[0]!,
+    );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -287,6 +287,38 @@ textarea,
   border: 1.5px solid var(--bg-panel);
 }
 
+.messaging-status-chip__tooltip {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  display: none;
+  width: max-content;
+  max-width: min(280px, calc(100vw - 32px));
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+  pointer-events: none;
+  text-align: left;
+  white-space: normal;
+}
+
+.messaging-status-chip__tooltip > span {
+  display: block;
+}
+
+.messaging-status-chip:hover .messaging-status-chip__tooltip,
+.messaging-status-chip:focus-visible .messaging-status-chip__tooltip,
+.messaging-status-chip:focus-within .messaging-status-chip__tooltip {
+  display: block;
+}
+
 /* Binding chip menu — small popover anchored to the chip wrap. The
    chip itself uses the shared .thread-row__chip primitive; only the
    menu has its own styling. */

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -140,12 +140,42 @@ current update unsafe to edit. Discarding a stream update is not a delivery
 failure and must not be treated as evidence that the conversation target is
 invalid.
 
+Streaming is an advanced capability, not the normal progress-notification path.
+It repeatedly edits the same provider message with partial assistant text. That
+can consume the same write budget needed for final answers, approvals, and
+status replies, and voice readers that announce messages when first received may
+not observe later edits. Providers should honor binding policy as:
+
+- `disabled`: discard stream updates.
+- `enabled`: allow stream updates even when the provider-global setting is off.
+- `inherit`: follow the provider-global setting.
+
 When streaming is enabled, adapters should use accumulated text for idempotent
 edits and keep any stream-key-to-platform-surface mapping in runtime memory
 only. Stream surfaces are transient; completed assistant message delivery
 remains the authoritative final response. Partial stream text may contain
 unfinished markdown, code fences, or links, so adapters should use conservative
 formatting until the final update or final assistant message arrives.
+
+## Rate-Limit and Reconnect Health
+
+Adapters may expose `resolveDeliveryScope(intent)`, `onRateLimit(listener)`,
+and `onReconnect(listener)` to the desktop runtime. Scope metadata must be
+provider-neutral: platform, stable scope id, kind, optional label, optional
+provider bucket id, and conservative write budget hints. Do not leak provider
+SDK error objects through these hooks.
+
+The controller budgets all outbound intent kinds against the resolved scope:
+final assistant messages, user prompts, command replies, status updates, tool
+updates, and stream updates. Provider 429 feedback puts that scope into a
+cool-off window, then slow mode. In slow mode, obsolete low-priority traffic
+such as non-final stream updates, routine status edits, and intermediate tool
+progress can be dropped; final turn results and interactive prompts are
+reserved and deferred when possible.
+
+The runtime reports a platform as `degraded` while a rate-limit or reconnect
+reason is active. `degraded` means connected but constrained. Fatal startup or
+runtime failures still report `errored`.
 
 Workspace handoff is expressed with the same generic status, single-select,
 confirmation, and error intents as other messaging workflows. Adapters should

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -165,6 +165,14 @@ provider-neutral: platform, stable scope id, kind, optional label, optional
 provider bucket id, and conservative write budget hints. Do not leak provider
 SDK error objects through these hooks.
 
+Outbound rate-limit retries are owned by the desktop delivery budget, not by
+provider SDKs. Adapters that use SDKs with built-in 429 queues must configure
+those SDKs to reject/surface rate-limit responses before constructing the
+adapter. Set `clientRateLimitStrategy` to `externalized` when the SDK has been
+configured this way, `direct` when calls go straight to the platform without a
+hidden retry queue, or `sdk-managed` only as a temporary diagnostic state. Do
+not ship a new provider with `sdk-managed`; fix or wrap the client first.
+
 The controller budgets all outbound intent kinds against the resolved scope:
 final assistant messages, user prompts, command replies, status updates, tool
 updates, and stream updates. Provider 429 feedback puts that scope into a
@@ -172,6 +180,13 @@ cool-off window, then slow mode. In slow mode, obsolete low-priority traffic
 such as non-final stream updates, routine status edits, and intermediate tool
 progress can be dropped; final turn results and interactive prompts are
 reserved and deferred when possible.
+
+If a send attempt is rejected with a rate-limit error, `deliver()` should return
+a failed `MessagingDeliveryResult` with structured `rateLimit` metadata. The
+controller records that feedback and re-runs admission for the same intent. A
+low-priority intent that would not be admitted under the new cool-off/slow-mode
+state is discarded instead of being queued for retry; reserved priority intents
+wait for the external budget window to reopen.
 
 The runtime reports a platform as `degraded` while a rate-limit or reconnect
 reason is active. `degraded` means connected but constrained. Fatal startup or

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -175,11 +175,13 @@ not ship a new provider with `sdk-managed`; fix or wrap the client first.
 
 The controller budgets all outbound intent kinds against the resolved scope:
 final assistant messages, user prompts, command replies, status updates, tool
-updates, and stream updates. Provider 429 feedback puts that scope into a
-cool-off window, then slow mode. In slow mode, obsolete low-priority traffic
-such as non-final stream updates, routine status edits, and intermediate tool
-progress can be dropped; final turn results and interactive prompts are
-reserved and deferred when possible.
+updates, and stream updates. Slow Mode is local: it starts when the shared
+budget for a scope is exhausted or close enough that reserved capacity must be
+protected. Provider 429 feedback starts a Cool Off window instead: the
+controller sends nothing to that scope until the provider retry window clears.
+In Slow Mode, obsolete low-priority traffic such as non-final stream updates,
+routine status edits, and intermediate tool progress can be dropped; final turn
+results and interactive prompts are reserved and deferred when possible.
 
 If a send attempt is rejected with a rate-limit error, `deliver()` should return
 a failed `MessagingDeliveryResult` with structured `rateLimit` metadata. Set

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -182,11 +182,12 @@ progress can be dropped; final turn results and interactive prompts are
 reserved and deferred when possible.
 
 If a send attempt is rejected with a rate-limit error, `deliver()` should return
-a failed `MessagingDeliveryResult` with structured `rateLimit` metadata. The
-controller records that feedback and re-runs admission for the same intent. A
-low-priority intent that would not be admitted under the new cool-off/slow-mode
-state is discarded instead of being queued for retry; reserved priority intents
-wait for the external budget window to reopen.
+a failed `MessagingDeliveryResult` with structured `rateLimit` metadata. Set
+`rateLimit.retryable: true` only when replaying the same intent cannot duplicate
+visible platform side effects from the failed attempt. The controller always
+records the cooldown. It only re-runs admission for retryable attempts; partial
+successes are recorded as failed delivery attempts so they do not duplicate
+already visible messages or attachments.
 
 The runtime reports a platform as `degraded` while a rate-limit or reconnect
 reason is active. `degraded` means connected but constrained. Fatal startup or

--- a/docs/messaging-adding-a-provider.md
+++ b/docs/messaging-adding-a-provider.md
@@ -207,11 +207,14 @@ Before adding a provider, check the client SDK's outbound rate-limit behavior:
 
 When a send is rejected with rate-limit information, emit it through
 `onRateLimit` and include it on the failed `MessagingDeliveryResult.rateLimit`.
-The desktop controller records that cooldown, re-runs admission for the same
-intent, and only retries messages that would still be admitted under the new
-slow-mode state. Non-final stream updates, intermediate tool updates, and
-routine status edits should be dropped by the controller once slow mode applies;
-do not queue them inside the adapter.
+Set `rateLimit.retryable: true` only if the failed attempt had no visible side
+effects. For example, a rejected first HTTP call is retryable; a failure after
+one Discord chunk was already sent, after a Slack message was posted but before
+file upload completed, or after one Telegram file/message was sent is not
+retryable. The desktop controller records every cooldown, but only re-runs
+admission for retryable attempts. Non-final stream updates, intermediate tool
+updates, and routine status edits should be dropped by the controller once slow
+mode applies; do not queue them inside the adapter.
 
 Current examples:
 
@@ -530,7 +533,7 @@ Mirror the patterns in `packages/messaging/providers/discord/src/__tests__/` and
 | Authorization | Unauthorized actor IDs are rejected before the controller sees the event. |
 | HMAC | (HTTP-callback platforms only) HMAC generation and verification, positive and negative. |
 | Threading | Parent post id round-trip for threaded conversations. |
-| Rate-limit ownership | SDK 429 handling is externalized or direct; rejected sends return `rateLimit` metadata and do not enter an SDK-owned queue. |
+| Rate-limit ownership | SDK 429 handling is externalized or direct; rejected sends return `rateLimit` metadata, mark partial-success failures `retryable: false`, and do not enter an SDK-owned queue. |
 | Reconnect | (For platforms with persistent connections) WS or gateway disconnect / reconnect doesn't drop in-flight callback handles. |
 
 Optional but valuable:

--- a/docs/messaging-adding-a-provider.md
+++ b/docs/messaging-adding-a-provider.md
@@ -163,8 +163,11 @@ export type DesktopMessagingAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: MessagingChannelKind;
+  clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
   setConversationTitle?(req): Promise<MessagingConversationTitleUpdateResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
@@ -178,10 +181,48 @@ Implement, in order:
 3. **`start(listener)`** — connect to the platform (WebSocket subscribe, gateway connect, long-poll loop, etc.). Begin authenticating. Save the listener so inbound events can reach the controller. If your platform uses out-of-band HTTP callbacks, also start the HTTP server here.
 4. **`stop()`** — disconnect and shut down anything started.
 5. **`deliver(intent)`** — the giant switch over `intent.kind`. Return `MessagingDeliveryResult`. See [Step 5](#step-5--render-outbound-intents) for the full table.
-6. **`downloadAttachment(req)`** — fetch a user-uploaded file's bytes by the opaque handle persisted in the inbound `media` event.
-7. **`setConversationTitle(req)`** — update the channel topic / DM title, if your platform exposes it.
+6. **`clientRateLimitStrategy` / `resolveDeliveryScope` / `onRateLimit`** — make outbound rate-limit ownership explicit. See [Rate-limit queue ownership](#rate-limit-queue-ownership).
+7. **`downloadAttachment(req)`** — fetch a user-uploaded file's bytes by the opaque handle persisted in the inbound `media` event.
+8. **`setConversationTitle(req)`** — update the channel topic / DM title, if your platform exposes it.
 
 > **Important:** the adapter must NOT call `turn/start` or any backend operation directly. It only translates events. The `MessagingController` owns workflow logic. Adapters that try to "be helpful" by debouncing input or starting turns themselves break the controller's turn-admission policy.
+
+### Rate-limit queue ownership
+
+PwrAgent must own outbound retry queues outside the platform SDK. This lets the
+controller stop sending before a provider-imposed cooldown closes the next send
+window, preserve reserved capacity for final turn and interactive messages, and
+discard obsolete low-priority updates while in slow mode.
+
+Before adding a provider, check the client SDK's outbound rate-limit behavior:
+
+- If the SDK can be configured to reject on 429 instead of sleeping/queueing,
+  enable that mode and set `clientRateLimitStrategy: "externalized"`.
+- If your adapter uses direct HTTP/fetch calls that return or throw immediately
+  on 429, set `clientRateLimitStrategy: "direct"`.
+- If the SDK silently queues or retries outbound sends and this cannot be
+  disabled through a supported option, do not ship the provider in that state.
+  Raise it as a client-SDK issue or wrap/replace the client so PwrAgent can own
+  the queue.
+
+When a send is rejected with rate-limit information, emit it through
+`onRateLimit` and include it on the failed `MessagingDeliveryResult.rateLimit`.
+The desktop controller records that cooldown, re-runs admission for the same
+intent, and only retries messages that would still be admitted under the new
+slow-mode state. Non-final stream updates, intermediate tool updates, and
+routine status edits should be dropped by the controller once slow mode applies;
+do not queue them inside the adapter.
+
+Current examples:
+
+- Discord uses `discord.js` REST with `rejectOnRateLimit`, so its strategy is
+  `externalized`.
+- Slack uses `@slack/web-api` with `rejectRateLimitedCalls`, so its strategy is
+  `externalized`.
+- Telegram's grammY adapter path does not install the auto-retry plugin for
+  outbound sends, so its strategy is `direct`.
+- Mattermost's `Client4` REST calls surface request failures directly, so its
+  strategy is `direct`.
 
 ## Step 4 — Translate inbound events
 
@@ -489,6 +530,7 @@ Mirror the patterns in `packages/messaging/providers/discord/src/__tests__/` and
 | Authorization | Unauthorized actor IDs are rejected before the controller sees the event. |
 | HMAC | (HTTP-callback platforms only) HMAC generation and verification, positive and negative. |
 | Threading | Parent post id round-trip for threaded conversations. |
+| Rate-limit ownership | SDK 429 handling is externalized or direct; rejected sends return `rateLimit` metadata and do not enter an SDK-owned queue. |
 | Reconnect | (For platforms with persistent connections) WS or gateway disconnect / reconnect doesn't drop in-flight callback handles. |
 
 Optional but valuable:

--- a/docs/messaging-adding-a-provider.md
+++ b/docs/messaging-adding-a-provider.md
@@ -190,9 +190,10 @@ Implement, in order:
 ### Rate-limit queue ownership
 
 PwrAgent must own outbound retry queues outside the platform SDK. This lets the
-controller stop sending before a provider-imposed cooldown closes the next send
-window, preserve reserved capacity for final turn and interactive messages, and
-discard obsolete low-priority updates while in slow mode.
+controller stop sending before a provider-imposed Cool Off closes the next send
+window, enter local Slow Mode when its own scope budget is exhausted, preserve
+reserved capacity for final turn and interactive messages, and discard obsolete
+low-priority updates while Slow Mode is active.
 
 Before adding a provider, check the client SDK's outbound rate-limit behavior:
 
@@ -215,6 +216,11 @@ retryable. The desktop controller records every cooldown, but only re-runs
 admission for retryable attempts. Non-final stream updates, intermediate tool
 updates, and routine status edits should be dropped by the controller once slow
 mode applies; do not queue them inside the adapter.
+
+Treat message edits as outbound writes unless the provider has explicit,
+documented semantics saying otherwise. Some platforms put edits in a different
+bucket from new messages, but they are still API calls and may still produce
+provider rate-limit feedback.
 
 Current examples:
 

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -160,6 +160,22 @@ Discord and Mattermost rate-limit API requests/routes, and Telegram documents
 edit calls as Bot API requests while its public send-message limits do not
 guarantee edits are exempt.
 
+Telegram-specific guidance:
+
+- Treat Telegram sends and edits as consuming the same practical supergroup
+  write budget. In a May 9, 2026 live probe, one bot message plus 19 one-second
+  edits in a PwrDrvr supergroup succeeded, and the next edit received a 429
+  with `retry_after=36`.
+- The same probe pattern run concurrently in two different supergroups
+  completed independently: each supergroup accepted one message plus 19 edits
+  without hitting a shared bot-wide 20/minute ceiling.
+- Active PwrAgent threads should usually be bound to separate Telegram
+  supergroups. Binding multiple active threads to topics in the same supergroup
+  is likely to exhaust that supergroup's budget, trigger PwrAgent Slow Mode,
+  and drop routine updates.
+- Topics should be treated as sharing the parent supergroup budget unless a
+  future live probe proves Telegram isolates their edit/send budgets.
+
 ## Attachments
 
 Bound, authorized conversations can send supported attachments into the active

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -142,12 +142,23 @@ default, then `Show Some` for old state. Pending batches flush before assistant
 messages, approval or questionnaire prompts, status replies, and terminal turn
 status so tool progress does not arrive after the response it explains.
 
-When provider rate-limit feedback is observed, PwrAgent enters a cool-off for
-that provider scope and then a conservative slow mode. Slow mode preserves
-final assistant messages and interactive prompts, but may drop non-final
-streaming edits, routine status-card edits, and intermediate tool updates
-instead of queueing stale noise. The messaging status dot turns orange while a
-cool-off or reconnect reason is active.
+PwrAgent uses two related but distinct protection states:
+
+- **Slow Mode** is our local budget-protection state. It begins when a
+  provider-defined scope is close to or at its configured write budget. Slow
+  Mode preserves final assistant messages and interactive prompts, but may drop
+  non-final streaming edits, routine status-card edits, and intermediate tool
+  updates instead of queueing stale noise.
+- **Cool Off** is provider-imposed. It begins when a provider returns
+  rate-limit feedback with a retry window. PwrAgent stops sending to that scope
+  until the retry window clears, then resumes conservatively.
+
+The messaging status dot turns orange while Slow Mode, Cool Off, or reconnect
+degradation is active. Message edits should not be treated as free capacity:
+Slack documents `chat.update` as a separately rate-limited Web API method,
+Discord and Mattermost rate-limit API requests/routes, and Telegram documents
+edit calls as Bot API requests while its public send-message limits do not
+guarantee edits are exempt.
 
 ## Attachments
 

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -160,15 +160,20 @@ Discord and Mattermost rate-limit API requests/routes, and Telegram documents
 edit calls as Bot API requests while its public send-message limits do not
 guarantee edits are exempt.
 
-Telegram-specific guidance:
+Observed edit-rate behavior from May 9, 2026 probes:
+
+| Platform / surface | Probe | Result | Operational guidance |
+| --- | --- | --- | --- |
+| Telegram supergroup | One new bot message, then one edit per second in the same PwrDrvr supergroup. | 19 edits succeeded; edit 20 returned 429 with `retry_after=36`. | Treat sends and edits as consuming the same practical supergroup write budget. Telegram is the tightest provider for active agent turns. |
+| Telegram two-supergroup fan-out | Same pattern run concurrently in the PwrDrvr and GifGrid supergroups. | Each supergroup accepted one message plus 19 edits without a shared bot-wide 20/minute ceiling. | Active PwrAgent threads should usually be bound to separate Telegram supergroups. |
+| Slack DM | One new bot message in the existing `hhunt` DM, then 60 edits at one edit per second. | Passed without a 429. | Slack edits are more permissive than Telegram in this DM, but new messages should still be budgeted conservatively because `chat.postMessage` has its own special limits. |
+| Discord DM and guild channel | One new bot message in the `huntharo2` DM and one in `huntharo-claw / #general`, then 60 edits at one edit per second on both messages. | Passed without a 429. Discord returned an edit bucket of 5 requests / 1 second. | Discord edits are much less restrictive than Telegram, but still count as REST requests and can hit route/global buckets. |
+| Mattermost | Not probed as a provider-global claim. | Rate limits are server-configured. | Use the target Mattermost server's `RateLimitSettings` rather than assuming a public SaaS limit. |
+
+Telegram-specific binding guidance:
 
 - Treat Telegram sends and edits as consuming the same practical supergroup
-  write budget. In a May 9, 2026 live probe, one bot message plus 19 one-second
-  edits in a PwrDrvr supergroup succeeded, and the next edit received a 429
-  with `retry_after=36`.
-- The same probe pattern run concurrently in two different supergroups
-  completed independently: each supergroup accepted one message plus 19 edits
-  without hitting a shared bot-wide 20/minute ceiling.
+  write budget.
 - Active PwrAgent threads should usually be bound to separate Telegram
   supergroups. Binding multiple active threads to topics in the same supergroup
   is likely to exhaust that supergroup's budget, trigger PwrAgent Slow Mode,

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -166,6 +166,7 @@ Observed edit-rate behavior from May 9, 2026 probes:
 | --- | --- | --- | --- |
 | Telegram supergroup | One new bot message, then one edit per second in the same PwrDrvr supergroup. | 19 edits succeeded; edit 20 returned 429 with `retry_after=36`. | Treat sends and edits as consuming the same practical supergroup write budget. Telegram is the tightest provider for active agent turns. |
 | Telegram two-supergroup fan-out | Same pattern run concurrently in the PwrDrvr and GifGrid supergroups. | Each supergroup accepted one message plus 19 edits without a shared bot-wide 20/minute ceiling. | Active PwrAgent threads should usually be bound to separate Telegram supergroups. |
+| Telegram two-topic fan-out | Same pattern run concurrently in PwrDrvr topics `5642` and `3509`. | Two sends plus 9 edits on each topic succeeded; edit 10 returned 429 with `retry_after=35`. | Topics share the parent supergroup budget. Do not bind multiple active high-volume threads to different topics in one supergroup expecting isolation. |
 | Slack DM | One new bot message in the existing `hhunt` DM, then 60 edits at one edit per second. | Passed without a 429. | Slack edits are more permissive than Telegram in this DM, but new messages should still be budgeted conservatively because `chat.postMessage` has its own special limits. |
 | Discord DM and guild channel | One new bot message in the `huntharo2` DM and one in `huntharo-claw / #general`, then 60 edits at one edit per second on both messages. | Passed without a 429. Discord returned an edit bucket of 5 requests / 1 second. | Discord edits are much less restrictive than Telegram, but still count as REST requests and can hit route/global buckets. |
 | Mattermost | Not probed as a provider-global claim. | Rate limits are server-configured. | Use the target Mattermost server's `RateLimitSettings` rather than assuming a public SaaS limit. |
@@ -178,8 +179,7 @@ Telegram-specific binding guidance:
   supergroups. Binding multiple active threads to topics in the same supergroup
   is likely to exhaust that supergroup's budget, trigger PwrAgent Slow Mode,
   and drop routine updates.
-- Topics should be treated as sharing the parent supergroup budget unless a
-  future live probe proves Telegram isolates their edit/send budgets.
+- Topics share the parent supergroup budget.
 
 ## Attachments
 

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -84,18 +84,32 @@ resume for the same turn until terminal completion.
 
 ## Streaming Responses
 
-Telegram and Discord can optionally show live assistant response text while
-backend `item/agentMessage/delta` events are arriving. The controller emits a
-generic stream update intent with accumulated assistant text; each provider then
-renders it only when that provider's streaming setting is enabled. When
-streaming is disabled or an update exceeds a safe platform edit limit, the
-provider discards the stream update and waits for the normal final assistant
-message.
+Streaming Responses are advanced. They optionally show live assistant response
+text while backend `item/agentMessage/delta` events are arriving. The controller
+emits a generic stream update intent with accumulated assistant text; each
+provider renders it only when the effective streaming policy allows it. When
+streaming is disabled, slow mode is active, or an update exceeds a safe platform
+edit limit, the provider discards the stream update and waits for the normal
+final assistant message.
 
 Streaming is separate from typing indicators and tool update notifications.
 Typing still reflects turn lifecycle, and the completed assistant message
-remains authoritative. Stream surfaces are transient runtime state and are not
-persisted as restart-safe managed messages.
+remains authoritative. Streaming does not make a turn finish sooner; it edits
+the same provider message repeatedly. Those edits can consume provider write
+budget quickly and can break voice-reader workflows that announce messages when
+received but do not observe later edits. Stream surfaces are transient runtime
+state and are not persisted as restart-safe managed messages.
+
+Effective streaming mode is resolved per binding first, then provider setting:
+
+| Mode | Behavior |
+| --- | --- |
+| `Inherit` | Follow the provider-level Streaming Responses toggle. |
+| `Off` | Suppress stream updates for this binding. |
+| `Advanced` | Enable stream updates for this binding even when the provider toggle is off. |
+
+Use the status card's `Stream: <mode>` action, or reply `stream` when actions
+are not available, to cycle a binding through these modes.
 
 ## Tool Update Verbosity
 
@@ -127,6 +141,13 @@ Effective mode is resolved as binding override, then Settings > Messaging
 default, then `Show Some` for old state. Pending batches flush before assistant
 messages, approval or questionnaire prompts, status replies, and terminal turn
 status so tool progress does not arrive after the response it explains.
+
+When provider rate-limit feedback is observed, PwrAgent enters a cool-off for
+that provider scope and then a conservative slow mode. Slow mode preserves
+final assistant messages and interactive prompts, but may drop non-final
+streaming edits, routine status-card edits, and intermediate tool updates
+instead of queueing stale noise. The messaging status dot turns orange while a
+cool-off or reconnect reason is active.
 
 ## Attachments
 
@@ -225,10 +246,12 @@ first-run discovery. Bot tokens are redacted from runtime logs. Telegram also
 accepts `TELEGRAM_BOT_TOKEN` and Discord also accepts `DISCORD_BOT_TOKEN` as
 local migration fallbacks.
 
-The TOML equivalents are `streaming_responses = true` under
-`[messaging.telegram]` or `[messaging.discord]`. Both providers default to
-`false`; the Settings > Messaging toggles and environment overrides expose the
-same booleans.
+The TOML equivalents are `streaming_responses = true` under a provider section,
+for example `[messaging.telegram]`, `[messaging.discord]`,
+`[messaging.mattermost]`, or `[messaging.slack]`. Providers default to `false`;
+the Settings > Messaging toggles and environment overrides expose the same
+booleans. Binding-level `Stream: Advanced` can opt a single binding into
+streaming without changing the provider default.
 
 Discord slash commands are reconciled on adapter startup when an Application ID
 is configured. The reconciler reads existing commands and only creates, patches,

--- a/docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md
+++ b/docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add messaging rate-limit slow mode and degraded health
 type: feat
-status: active
+status: implemented
 date: 2026-05-09
 origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
 deepened: 2026-05-09
@@ -31,7 +31,7 @@ PwrAgent's messaging integration is designed for remote agent operation, includi
 - R3. On provider rate-limit feedback, halt sends to that scope until the retry window clears, then enter slow mode with stricter coalescing and drop policy (#220).
 - R4. Reserve limited budget for turn-completed assistant messages and user-response-critical prompts; non-terminal tool/status/stream updates may be dropped while slow mode is active (#220).
 - R5. Stop avoidable per-turn status-message churn in slow mode, and reduce status-card "turn started/turn completed" edits where they are not product-critical (#220).
-- R6. Add `degraded` platform health with structured degradation reasons, auto-recovery, and rich renderer tooltip/popover behavior (#230).
+- R6. Add `degraded` platform health with structured degradation reasons, auto-recovery, and rich renderer tooltip behavior (#230).
 - R7. Add provider hooks for rate-limit and reconnect signals without leaking provider SDK errors into shared contracts (#230).
 - R8. Mark Streaming Responses as Advanced / Cautioned in Settings and docs, including voice-reader and rate-limit tradeoffs (#218).
 - R9. Expose per-binding streaming controls through existing binding preference/status-card command surfaces, defaulting to inherited/global behavior (#218).
@@ -150,13 +150,13 @@ flowchart TB
   U3 --> U4["Unit 4: Controller priority and coalescing integration"]
   U1 --> U5["Unit 5: Runtime degraded health state"]
   U2 --> U5
-  U5 --> U6["Unit 6: Renderer degraded popover"]
+  U5 --> U6["Unit 6: Renderer degraded tooltip"]
   U4 --> U7["Unit 7: Streaming cautions and per-binding controls"]
   U7 --> U8["Unit 8: Docs and operational verification"]
   U6 --> U8
 ```
 
-- [ ] **Unit 1: Extend messaging contracts for degradation and delivery scopes**
+- [x] **Unit 1: Extend messaging contracts for degradation and delivery scopes**
 
 **Goal:** Add channel-neutral types for degraded health reasons, rate-limit scope metadata, and outbound priority hints without importing provider SDKs into shared packages.
 
@@ -192,7 +192,7 @@ flowchart TB
 **Verification:**
 - Contract tests prove the new status and scope shapes are exported, serializable through IPC-facing shared contracts, and provider-neutral.
 
-- [ ] **Unit 2: Add provider rate-limit/reconnect hooks and scope metadata**
+- [x] **Unit 2: Add provider rate-limit/reconnect hooks and scope metadata**
 
 **Goal:** Let adapters report 429/cool-off and reconnect-in-progress signals while declaring the rate-limit scope that should govern each outbound delivery.
 
@@ -237,7 +237,7 @@ flowchart TB
 **Verification:**
 - Provider and runtime tests show hooks fire for rate-limit/reconnect conditions and remain optional for providers that cannot yet expose detailed metadata.
 
-- [ ] **Unit 3: Add shared delivery budget and slow-mode policy**
+- [x] **Unit 3: Add shared delivery budget and slow-mode policy**
 
 **Goal:** Implement a reusable desktop-main budget service that admits, queues, or drops outbound intents across all message kinds for the same provider-defined scope.
 
@@ -277,7 +277,7 @@ flowchart TB
 **Verification:**
 - Unit tests prove budget state transitions, reservation behavior, slow-mode drop policy, and auto-recovery are deterministic without provider SDKs.
 
-- [ ] **Unit 4: Integrate budget admission into controller delivery paths**
+- [x] **Unit 4: Integrate budget admission into controller delivery paths**
 
 **Goal:** Route every outbound messaging intent through the shared budget, classify priority correctly, and reduce status/tool/stream churn while preserving final responses.
 
@@ -321,7 +321,7 @@ flowchart TB
 **Verification:**
 - Controller tests demonstrate cross-kind budget sharing, priority behavior, no lost final responses, and no accidental permanent-target revocation for budget drops.
 
-- [ ] **Unit 5: Add runtime degraded health state and auto-recovery**
+- [x] **Unit 5: Add runtime degraded health state and auto-recovery**
 
 **Goal:** Track structured transient degradation reasons in the desktop runtime and publish orange `degraded` platform status events to the renderer.
 
@@ -360,9 +360,9 @@ flowchart TB
 **Verification:**
 - Runtime and IPC tests show status snapshots and events carry effective health plus reason detail through auto-recovery.
 
-- [ ] **Unit 6: Build degraded status chip popover**
+- [x] **Unit 6: Build degraded status chip tooltip**
 
-**Goal:** Replace the status chip's plain title tooltip with a keyboard-accessible popover that explains degraded reasons and links to Messaging Activity.
+**Goal:** Replace the status chip's plain title tooltip with a keyboard-accessible tooltip that explains degraded reasons while keeping click-through to Messaging Activity.
 
 **Requirements:** R6
 
@@ -373,14 +373,13 @@ flowchart TB
 - Modify: `apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts`
 - Modify: `apps/desktop/src/renderer/src/styles/app.css`
 - Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
-- Test: `apps/desktop/src/renderer/src/features/messaging-status/__tests__/MessagingStatusBar.test.tsx` if the suite already has a colocated pattern; otherwise add coverage to the existing settings/sidebar tests.
+- Test: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx`
 
 **Approach:**
 - Map `degraded` to `status-dot--warning` and a `messaging-status-chip--degraded` text/border treatment using existing `--status-warning`.
-- Add a small popover that opens on hover/focus and pins on click or keyboard activation. Escape closes it.
-- Render a platform summary plus each active degradation reason with sanitized, clipped text and time remaining when an expiry exists.
-- Use a one-second timer only while the popover is open to refresh "remaining" text.
-- Keep click behavior compatible with existing activity navigation; either make the popover include "View activity" or retain chip click as the navigation when no pinned popover is open.
+- Add a small tooltip that opens on hover/focus and includes structured degradation reason lines.
+- Render a platform summary plus each active degradation reason with sanitized, clipped text and retry duration when available.
+- Keep click behavior compatible with existing activity navigation.
 - Preserve vendor logo rendering as `<img>` where current icons require it and avoid recoloring brand assets.
 
 **Patterns to follow:**
@@ -390,17 +389,16 @@ flowchart TB
 
 **Test scenarios:**
 - Happy path: degraded Telegram renders orange dot and warning-toned chip.
-- Happy path: hovering or focusing a degraded chip opens a popover with the rate-limit reason and remaining time.
-- Happy path: clicking pins the popover; Escape dismisses it.
+- Happy path: hovering or focusing a degraded chip exposes a tooltip with the rate-limit reason and retry duration.
 - Edge case: multiple reasons render as separate clipped rows.
 - Edge case: expired reasons are not shown after the hook receives a cleared status.
-- Accessibility: chip has an informative accessible label and uses `aria-describedby` while the popover is open.
+- Accessibility: chip has an informative accessible label and uses `aria-describedby` for the tooltip.
 - Regression: enabled/suspended/errored/unknown chips retain existing visual behavior.
 
 **Verification:**
-- Renderer tests prove the popover interaction and degraded visual state without relying on native `title` tooltips.
+- Renderer tests prove the tooltip content and degraded visual state without relying on native `title` tooltips.
 
-- [ ] **Unit 7: Mark streaming as advanced/cautioned and expose per-binding control**
+- [x] **Unit 7: Mark streaming as advanced/cautioned and expose per-binding control**
 
 **Goal:** Make streaming opt-in feel like an advanced power-user setting and let individual bindings override inherited streaming behavior.
 
@@ -443,7 +441,7 @@ flowchart TB
 **Verification:**
 - Settings and controller tests prove the warning is visible, per-binding control works, and streaming cannot outrank final response delivery under slow mode.
 
-- [ ] **Unit 8: Update docs, smoke checks, and operational guidance**
+- [x] **Unit 8: Update docs, smoke checks, and operational guidance**
 
 **Goal:** Document the new streaming cautions, delivery budget behavior, degraded health semantics, and manual validation flow for provider rate limits.
 
@@ -488,7 +486,7 @@ flowchart TB
   Controller["MessagingController.deliver()"] --> Budget
   Budget --> Provider
   Runtime --> IPC["messaging status IPC"]
-  IPC --> Renderer["MessagingStatusBar popover"]
+  IPC --> Renderer["MessagingStatusBar tooltip"]
   Controller --> Store["MessagingStore delivery/activity records"]
   Controller --> Docs["Operator docs and smoke checks"]
 ```
@@ -508,7 +506,7 @@ flowchart TB
 | Slow mode drops an update the user expected | Restrict dropping to non-final stream, routine status, and intermediate tool progress; preserve final and action-required messages. |
 | Final assistant message is delayed behind lower-priority backlog | Budget service reserves capacity and controller sends final/prompt before optional tool/status flushes. |
 | Degraded status becomes noisy or flaps | Reasons have expiry/recovery semantics; runtime coalesces health transitions and `errored` remains sticky. |
-| UI popover grows too complex | Keep one compact popover, no new positioning library, and reuse existing tokens. |
+| UI tooltip grows too complex | Keep one compact tooltip, no new positioning library, and reuse existing tokens. |
 | Per-binding streaming controls inflate status-card actions | Follow existing action priority/capability limits and text fallback patterns. |
 | Hard-coded platform limits drift | Use documented limits as conservative defaults, parse provider retry metadata when present, and document that exact tuning is operational. |
 

--- a/docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md
+++ b/docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md
@@ -1,0 +1,554 @@
+---
+title: feat: Add messaging rate-limit slow mode and degraded health
+type: feat
+status: active
+date: 2026-05-09
+origin: docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md
+deepened: 2026-05-09
+---
+
+# feat: Add messaging rate-limit slow mode and degraded health
+
+## Overview
+
+Add one shared messaging delivery budget per provider-defined rate-limit scope, enter a conservative slow mode after provider 429s, prioritize turn-completed and user-response-critical messages, and surface transient degradation in the desktop status bar. At the same time, make Streaming Responses visibly advanced and cautioned because streaming edits are not agent progress updates; they repeatedly edit the same response text and consume the same platform write budgets that final messages, questions, status cards, and tool updates need.
+
+This plan combines GitHub issues #220, #230, and #218 because the work shares the same delivery paths. Splitting it would create conflicting edits around `MessagingController.deliver()`, provider delivery results, runtime health state, and Settings copy.
+
+## Problem Frame
+
+PwrAgent's messaging integration is designed for remote agent operation, including mobile and voice-reader workflows (see origin: `docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md`). The current streaming and tool-update behavior can defeat that goal:
+
+- Streaming response edits consume platform write budget rapidly and break tools that read messages on receipt but do not observe later edits.
+- Tool update messages, status card edits, streaming edits, and final assistant messages are all admitted through separate local policies even when a provider rate limit applies across all writes to the same chat or channel.
+- Telegram 429s currently slow only a stream-specific path; fresh messages, status posts, and tool updates can keep arriving and retrigger the same limit.
+- The renderer has no `degraded` health state for "connected but cooling off" or "reconnecting", so the user sees either green silence or red overstatement.
+
+## Requirements Trace
+
+- R1. Preserve the channel-agnostic surface boundary: workflow code must not import provider SDKs or parse provider payloads (origin R1-R6, R25-R27).
+- R2. Add shared delivery-budget admission across status, message, stream update, tool update, confirmation, questionnaire, approval, and error intents for the same provider-defined rate-limit scope (#220).
+- R3. On provider rate-limit feedback, halt sends to that scope until the retry window clears, then enter slow mode with stricter coalescing and drop policy (#220).
+- R4. Reserve limited budget for turn-completed assistant messages and user-response-critical prompts; non-terminal tool/status/stream updates may be dropped while slow mode is active (#220).
+- R5. Stop avoidable per-turn status-message churn in slow mode, and reduce status-card "turn started/turn completed" edits where they are not product-critical (#220).
+- R6. Add `degraded` platform health with structured degradation reasons, auto-recovery, and rich renderer tooltip/popover behavior (#230).
+- R7. Add provider hooks for rate-limit and reconnect signals without leaking provider SDK errors into shared contracts (#230).
+- R8. Mark Streaming Responses as Advanced / Cautioned in Settings and docs, including voice-reader and rate-limit tradeoffs (#218).
+- R9. Expose per-binding streaming controls through existing binding preference/status-card command surfaces, defaulting to inherited/global behavior (#218).
+- R10. Keep final assistant message delivery authoritative; streaming must never suppress or delay the completed turn answer (#218, #220).
+
+## Scope Boundaries
+
+- In scope: generic messaging interface extensions, desktop runtime status contract, delivery admission/budgeting, slow-mode policy, provider rate-limit/reconnect hooks, Telegram/Discord/Mattermost/Slack adapter participation where current adapters make it straightforward, renderer degraded status UI, Settings caution copy, per-binding streaming preference control, docs, and tests.
+- In scope: replacing Telegram's stream-only limiter with, or subordinating it to, the shared budget so all Telegram writes for the same scope compete fairly.
+- Out of scope: paid Telegram broadcasts, operator-managed manual degradation overrides, historical degradation trend charts, cross-platform aggregate health rollups, and exact production tuning of every platform threshold.
+- Out of scope: changing the app-server protocol or desktop transcript renderer.
+- Out of scope: persisting slow-mode queues across app restart. Restart may drop non-critical queued updates; completed transcript state remains authoritative.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` owns backend event handling, active-turn lifecycle, tool update delivery, status rendering, assistant stream delivery, and the central `deliver()` wrapper.
+- `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts` already implements `Show Some` / `Show Less` batching, but it is per-binding and unaware of platform budget pressure.
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts` has stream-only rate tracking keyed by chat id; it detects Telegram retry-after only in `deliverStreamUpdate()`.
+- `packages/messaging/providers/discord/src/discord-adapter.ts`, `packages/messaging/providers/slack/src/slack-adapter.ts`, and `packages/messaging/providers/mattermost/src/mattermost-adapter.ts` return failed delivery results but do not currently expose structured rate-limit events to the runtime.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` owns per-platform health snapshots, runtime error hooks, activity events, and renderer-facing status events.
+- `packages/shared/src/contracts/messaging.ts` currently defines `MessagingPlatformHealth` without `degraded`.
+- `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx` maps health states to status dots and currently uses a plain `title` tooltip.
+- `docs/UI-THEME.md` already defines `--status-warning` and `.status-dot--warning`, which is the right token path for degraded/orange health.
+- `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx` already exposes Streaming Responses toggles and has warning/help text plumbing.
+- `packages/messaging/interface/src/index.ts` already has `MessagingStreamingResponseMode = "inherit" | "enabled" | "disabled"` and binding preferences already participate in stream policy.
+- `apps/desktop/AGENTS.md` and `packages/messaging/AGENTS.md` require channel-neutral workflow semantics, provider SDK isolation, and the existing thread-state update bus for persistent thread state.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` says UX must be honest when upstream semantics impose waiting: queue or delay visibly instead of pretending changes are immediate.
+- `docs/plans/2026-05-02-002-feat-messaging-streaming-responses-plan.md` established that stream updates are optional, degradable, transient, and subordinate to final assistant delivery.
+- `docs/plans/2026-05-02-001-feat-messaging-tool-update-verbosity-plan.md` established `Show Some` as the default tool-update posture; slow mode should become stricter than `Show Less`, not invent another user-visible verbosity mode.
+- `docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md` established queued messaging inputs and turn-completion handoff as a priority workflow; delivery budget should reserve space for those completion and prompt surfaces.
+
+### External References
+
+- Telegram Bot FAQ documents bot send limits: avoid more than one message per second in one chat, no more than 20 messages per minute in groups, and about 30 messages per second for bulk notifications unless paid broadcasts are enabled.
+- Discord's rate-limit docs say limits are per route and global, should not be hard-coded, and clients should use rate-limit headers and 429 `retry_after` data.
+- Slack's Web API docs say writes are generally one message per second per channel, with 429 `Retry-After` on HTTP APIs.
+- Mattermost server rate limiting is deployment-configurable, defaults to off, and may throttle APIs by requests per second when enabled.
+
+## Key Technical Decisions
+
+- **Centralize admission in desktop messaging orchestration.** Providers know how to define rate-limit scopes and detect provider feedback, but `MessagingController.deliver()` is the only shared place where all outbound intent kinds meet before persistence, activity logging, and permanent-target handling.
+- **Provider scopes, not workflow branches.** Adapters should expose channel-neutral scope metadata such as platform, scope id, scope kind, and conservative default capacity. The controller/runtime can budget against that without learning Telegram topics, Discord buckets, Slack thread timestamps, or Mattermost server configuration.
+- **Use priority classes instead of independent queues per message kind.** Final assistant messages, questionnaires, approvals, and queued-input notices outrank streaming edits, tool progress, and routine status refreshes. This lets slow mode preserve useful turn-completed and action-required messages while dropping noisy intermediate updates.
+- **Slow mode drops non-essential messages instead of building unbounded backlog.** Streaming partials, routine turn status edits, and low-priority tool updates are stale by the time the provider cool-off ends. The correct output is the latest/final aggregate, not delayed noise.
+- **Degraded health is platform-level, reasons are structured.** Platform chips should turn orange when any active reason exists and health is not already `errored`. `errored` still wins because it means the adapter is offline or fatally failed.
+- **Streaming remains available but visually discouraged.** A power user can enable it globally or per binding, but Settings and docs should make the tradeoff explicit: streaming response text is edit churn, not the same as agent turn progress or tool update coalescing.
+- **Status churn is not guaranteed delivery.** In slow mode, the plan should avoid editing status cards just to say "turn started" and then "turn completed"; typing indicators and final messages carry the important user signal. Explicit prompts, queued-input notices, binding changes, and `/status` requests still deserve delivery attempts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the rate budget live in providers?** No. Providers cannot see the full cross-kind traffic mix and should not own tool/status/final-message priority decisions.
+- **Should streaming be disabled completely?** No. Keep it as an advanced capability with warnings and per-binding control, because some desktop-visible chat workflows may still value it.
+- **Should slow mode queue every skipped update?** No. Queue only latest/final aggregates and action-required surfaces. Drop obsolete intermediate tool/status/stream updates.
+- **Should degraded be a replacement for errored?** No. `degraded` is transient and auto-clearing; `errored` remains sticky for sustained adapter failure.
+
+### Deferred to Implementation
+
+- Exact default token-bucket numbers for Discord, Slack, and Mattermost after inspecting SDK response metadata and existing tests.
+- Whether Telegram topic-scoped deliveries should reserve at supergroup scope only or at both supergroup and topic scopes. Start with supergroup-level budget because the documented group limit is the safest constraint.
+- Exact UI placement for the advanced streaming caution within the current Settings layout after seeing how much copy fits without clutter.
+- Whether the first implementation stores per-binding streaming controls only in status-card actions or also adds a dedicated settings affordance later.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant Backend as Agent/backend events
+  participant Controller as MessagingController
+  participant Budget as DeliveryBudget
+  participant Adapter as Provider adapter
+  participant Runtime as DesktopMessagingRuntime
+  participant Renderer as Status UI
+
+  Backend->>Controller: tool/status/stream/final/prompt event
+  Controller->>Budget: classify intent priority + provider scope
+  alt budget available
+    Budget-->>Controller: admit now
+    Controller->>Adapter: deliver intent
+    Adapter-->>Controller: delivery result
+  else slow mode or exhausted budget
+    Budget-->>Controller: defer latest critical / drop non-critical
+  end
+  Adapter-->>Runtime: rate-limit or reconnect signal
+  Runtime->>Budget: enter cool-off / adjust degraded scope
+  Runtime-->>Renderer: platform degraded + reason metadata
+  Budget-->>Controller: flush critical deferred item after cool-off
+```
+
+Priority classes:
+
+| Class | Examples | Slow-mode behavior |
+| --- | --- | --- |
+| Critical interactive | approval, questionnaire, pending request, queued-input controls | reserve budget; queue latest until cool-off ends |
+| Final turn result | completed assistant message, terminal failure/cancel notice | reserve budget; queue latest per turn |
+| User-command response | `/status`, `/resume`, `/detach`, explicit errors | admit when possible; queue briefly if actionable |
+| Routine status | turn started/working/completed status-card refresh | skip unless user requested or binding state changed |
+| Tool progress | generated tool updates | batch at turn boundary; drop non-terminal batches in slow mode |
+| Streaming partial | non-final `stream_update` | drop while slow mode active; final aggregate may use final-turn class |
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["Unit 1: Extend contracts for degradation and rate scopes"] --> U2["Unit 2: Provider hooks and scope metadata"]
+  U1 --> U3["Unit 3: Delivery budget and slow-mode policy"]
+  U2 --> U3
+  U3 --> U4["Unit 4: Controller priority and coalescing integration"]
+  U1 --> U5["Unit 5: Runtime degraded health state"]
+  U2 --> U5
+  U5 --> U6["Unit 6: Renderer degraded popover"]
+  U4 --> U7["Unit 7: Streaming cautions and per-binding controls"]
+  U7 --> U8["Unit 8: Docs and operational verification"]
+  U6 --> U8
+```
+
+- [ ] **Unit 1: Extend messaging contracts for degradation and delivery scopes**
+
+**Goal:** Add channel-neutral types for degraded health reasons, rate-limit scope metadata, and outbound priority hints without importing provider SDKs into shared packages.
+
+**Requirements:** R1, R2, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Modify: `packages/messaging/interface/src/index.ts`
+- Test: `packages/shared/src/contracts/__tests__/settings.test.ts`
+- Test: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Approach:**
+- Add `degraded` to `MessagingPlatformHealth`.
+- Add structured `MessagingDegradationReason` entries for rate-limited, reconnecting, missing-permission, and warning-style conditions.
+- Extend `MessagingPlatformStatus` and `MessagingPlatformStatusEvent` so renderer consumers receive reason lists, expiry metadata, and optional sanitized scope labels.
+- Add generic delivery scope metadata that providers can attach or expose through an adapter helper: platform, scope id, scope kind, conservative capacity, and optional provider bucket id.
+- Add or document priority classifications for outbound intents at the interface level only if the controller needs to pass them through tests; keep most priority logic in desktop core.
+
+**Patterns to follow:**
+- Current shared/interface type mirroring in `packages/shared/src/contracts/messaging.ts` and `packages/messaging/interface/src/index.ts`.
+- Existing `MessagingStreamingResponseMode` policy vocabulary.
+- Boundary rules in `packages/messaging/AGENTS.md`.
+
+**Test scenarios:**
+- Happy path: `MessagingPlatformHealth` accepts `degraded` and platform status snapshots can carry multiple degradation reasons.
+- Happy path: a rate-limited reason includes retry/cool-off expiry metadata and a provider-neutral scope label.
+- Edge case: an expired reason can be represented without requiring platform-specific fields.
+- Error path: a reason detail with long provider-sourced text is clipped or marked for renderer sanitization before display.
+- Regression: `packages/messaging/interface` still imports only allowed lower-layer packages and no provider package.
+
+**Verification:**
+- Contract tests prove the new status and scope shapes are exported, serializable through IPC-facing shared contracts, and provider-neutral.
+
+- [ ] **Unit 2: Add provider rate-limit/reconnect hooks and scope metadata**
+
+**Goal:** Let adapters report 429/cool-off and reconnect-in-progress signals while declaring the rate-limit scope that should govern each outbound delivery.
+
+**Requirements:** R1, R2, R3, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Modify: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- Modify: `packages/messaging/providers/mattermost/src/mattermost-adapter.ts`
+- Modify: `packages/messaging/providers/slack/src/slack-adapter.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Test: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Test: `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts`
+- Test: `packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts`
+- Test: `packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts`
+
+**Approach:**
+- Extend the desktop adapter interface with optional `resolveDeliveryScope(intent)` and rate/reconnect subscriptions.
+- Telegram scope should start at chat/supergroup granularity for group/topic traffic and DM granularity for private chat traffic. It should report `retry_after` from any send/edit/pin path, not only streaming.
+- Discord should surface rate-limit metadata from REST failures where the SDK/API wrapper exposes 429, retry-after, route bucket, scope, or global flags. If the current wrapper hides headers, the first slice should still support generic failed-result parsing and leave fuller bucket extraction deferred.
+- Slack should map channel/thread deliveries to a channel-level write scope and report `Retry-After` when API errors expose it.
+- Mattermost should report reconnecting for websocket reconnect attempts below the fatal threshold and rate-limited when HTTP responses or API wrappers surface throttling.
+- Keep provider-specific identifiers opaque in persisted state and logs; scope labels may be sanitized summaries for diagnostics/UI.
+
+**Patterns to follow:**
+- Existing `onRuntimeError` hook in `apps/desktop/src/main/messaging/messaging-runtime.ts`.
+- Telegram stream retry-after detection in `packages/messaging/providers/telegram/src/telegram-adapter.ts`.
+- Mattermost websocket reconnect/fail threshold behavior in `packages/messaging/providers/mattermost/src/mattermost-adapter.ts`.
+
+**Test scenarios:**
+- Happy path: Telegram send/edit 429 emits one rate-limit event with retry-after and the supergroup-level scope.
+- Happy path: a Telegram topic target maps to a supergroup scope so sibling topics share conservative group budget.
+- Happy path: Mattermost reconnect attempt 1 or 2 emits reconnecting degradation and the threshold transition emits errored instead.
+- Edge case: a provider without structured headers still returns a normal delivery failure and does not crash budget resolution.
+- Error path: provider-sourced scope labels are clipped and do not echo untrusted raw text into renderer status.
+- Regression: normal successful deliveries do not emit degradation signals.
+
+**Verification:**
+- Provider and runtime tests show hooks fire for rate-limit/reconnect conditions and remain optional for providers that cannot yet expose detailed metadata.
+
+- [ ] **Unit 3: Add shared delivery budget and slow-mode policy**
+
+**Goal:** Implement a reusable desktop-main budget service that admits, queues, or drops outbound intents across all message kinds for the same provider-defined scope.
+
+**Requirements:** R2, R3, R4, R5, R10
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Create: `apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Approach:**
+- Model each provider scope as a token/window budget with reserved capacity for critical interactive and final-turn messages.
+- Track hard cool-off windows from provider rate-limit events: no sends until `retryAfter + safety buffer`, then slow mode for a bounded recovery period.
+- Have the runtime construct one budget coordinator per running adapter/platform and inject it into that adapter's controller so multiple bindings on the same platform share one scope map.
+- During slow mode, admit final assistant messages and user-response-critical prompts first, coalesce one latest item per turn/scope where possible, and drop stale routine items.
+- Treat non-final stream updates as immediately discardable in slow mode.
+- Treat tool-update deliveries as coalescible by turn; allow one terminal batch only if budget remains after final/prompt reservations.
+- Keep the service deterministic and easy to test with injected clock/timers.
+- Return explicit admission outcomes: admitted, deferred, coalesced, dropped, and reason.
+
+**Patterns to follow:**
+- Timer/clock injection style in `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts`.
+- Queue lifecycle style from `apps/desktop/src/main/messaging/core/messaging-turn-admission.ts`.
+
+**Test scenarios:**
+- Happy path: under budget, status/message/stream/tool intents are admitted in arrival order.
+- Happy path: when the scope has limited remaining budget, a final assistant message is admitted while routine status and stream partials are dropped.
+- Happy path: a 429 event halts all sends for the scope until retry-after plus buffer, then enters slow mode.
+- Edge case: ten active turns in one Telegram supergroup reserve capacity for terminal messages and force tool/stream traffic into drop/coalesce outcomes.
+- Edge case: two independent scopes do not throttle each other.
+- Error path: a deferred critical item is replaced by the latest item for the same turn where replacement is safe, avoiding unbounded memory growth.
+- Regression: disposing the budget service clears timers and deferred queues.
+
+**Verification:**
+- Unit tests prove budget state transitions, reservation behavior, slow-mode drop policy, and auto-recovery are deterministic without provider SDKs.
+
+- [ ] **Unit 4: Integrate budget admission into controller delivery paths**
+
+**Goal:** Route every outbound messaging intent through the shared budget, classify priority correctly, and reduce status/tool/stream churn while preserving final responses.
+
+**Requirements:** R2, R3, R4, R5, R10
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-renderer.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-tool-update-policy.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+
+**Approach:**
+- Inject the delivery budget into `MessagingController` and make the private `deliver()` wrapper the single admission gate before `adapter.deliver()`.
+- Classify intent priority from intent kind plus context: final assistant messages, pending requests, queued-turn notices, approvals, questionnaires, explicit command replies, routine status refreshes, tool updates, and stream updates.
+- Ensure `flushToolUpdatesForBinding()` can ask the budget whether slow mode is active and either emit one terminal batch or drop pending non-terminal updates.
+- For `renderBindingStatus()`, suppress routine active/completed status-card updates in slow mode unless triggered by explicit `/status`, binding preference mutation, permission queue action, handoff, or other user-actionable state.
+- Preserve the existing "flush tool updates before final assistant/prompt" invariant only when budget admission says the tool flush should still be sent; otherwise log/drop the flush and send the final/prompt.
+- Treat a final stream update as subordinate to final assistant delivery. If the stream final cannot be admitted, send the completed assistant message path instead.
+- Record dropped/deferred outcomes in activity/logging without treating them as permanent target failures or revoking bindings.
+
+**Patterns to follow:**
+- Current `MessagingController.deliver()` wrapper for delivery records, activity logging, and permanent target failure handling.
+- `shouldFlushToolUpdatesBeforeIntent()` ordering.
+- Existing final-message dedupe via `assistantMessageDeliveryKey()`.
+
+**Test scenarios:**
+- Happy path: ordinary traffic below budget behaves as before and records deliveries.
+- Happy path: slow mode drops non-final stream updates and still delivers the final assistant response exactly once.
+- Happy path: slow mode with pending tool updates sends the final assistant response before any optional terminal tool batch.
+- Happy path: explicit `/status` still gets a response when budget is available, while automatic turn-start/turn-complete status refreshes are skipped in slow mode.
+- Edge case: a questionnaire or approval prompt during cool-off is deferred and sent when the scope reopens rather than being dropped.
+- Edge case: adapter delivery failure after budget admission reports rate-limited and causes subsequent same-scope intents to slow down.
+- Error path: dropped/coalesced intents do not call `recordDelivery()` as successful provider deliveries and do not revoke bindings.
+- Regression: queued-turn notices, permission queue audit messages, and final assistant dedupe still work when budget is inactive.
+
+**Verification:**
+- Controller tests demonstrate cross-kind budget sharing, priority behavior, no lost final responses, and no accidental permanent-target revocation for budget drops.
+
+- [ ] **Unit 5: Add runtime degraded health state and auto-recovery**
+
+**Goal:** Track structured transient degradation reasons in the desktop runtime and publish orange `degraded` platform status events to the renderer.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Modify: `apps/desktop/src/main/ipc/messaging-status.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts`
+
+**Approach:**
+- Add runtime APIs for adding, replacing, and clearing degradation reasons by platform and reason key.
+- Subscribe to provider rate-limit/reconnect hooks after adapter start, similar to `onRuntimeError`.
+- Convert active reasons into effective platform health: `errored` wins, `suspended` remains suspended, otherwise non-empty reasons produce `degraded`, and empty reasons return to `enabled`.
+- Clear rate-limit reasons automatically at their expiry and reconnecting reasons when providers report recovery.
+- Drop stale reasons before `getPlatformStatuses()` returns snapshots so renderer initial paint is accurate.
+- Record compact activity entries for rate-limit and recovery transitions when they help operators diagnose message delays.
+
+**Patterns to follow:**
+- Existing `platformStatuses` and `broadcastPlatformStatus()` lifecycle in `messaging-runtime.ts`.
+- Existing runtime-error subscription handling.
+- Messaging Activity logging for inbound/outbound observability.
+
+**Test scenarios:**
+- Happy path: enabled -> degraded(rate-limited) -> enabled after expiry emits health transitions.
+- Happy path: enabled -> degraded(reconnecting) -> enabled on recovered event.
+- Happy path: two concurrent reasons keep the platform degraded until both clear.
+- Edge case: `errored` supersedes active degradation reasons and red health remains sticky.
+- Edge case: `suspended` platform does not appear green/orange while messaging is intentionally off.
+- Error path: provider hook listener throwing is logged and does not stop runtime lifecycle.
+- Regression: existing enabled/suspended/errored status snapshots remain compatible except for the added reason fields.
+
+**Verification:**
+- Runtime and IPC tests show status snapshots and events carry effective health plus reason detail through auto-recovery.
+
+- [ ] **Unit 6: Build degraded status chip popover**
+
+**Goal:** Replace the status chip's plain title tooltip with a keyboard-accessible popover that explains degraded reasons and links to Messaging Activity.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/messaging-status/__tests__/MessagingStatusBar.test.tsx` if the suite already has a colocated pattern; otherwise add coverage to the existing settings/sidebar tests.
+
+**Approach:**
+- Map `degraded` to `status-dot--warning` and a `messaging-status-chip--degraded` text/border treatment using existing `--status-warning`.
+- Add a small popover that opens on hover/focus and pins on click or keyboard activation. Escape closes it.
+- Render a platform summary plus each active degradation reason with sanitized, clipped text and time remaining when an expiry exists.
+- Use a one-second timer only while the popover is open to refresh "remaining" text.
+- Keep click behavior compatible with existing activity navigation; either make the popover include "View activity" or retain chip click as the navigation when no pinned popover is open.
+- Preserve vendor logo rendering as `<img>` where current icons require it and avoid recoloring brand assets.
+
+**Patterns to follow:**
+- Tooltip guidance in `docs/UI-THEME.md`.
+- Existing status dot utility classes in `apps/desktop/src/renderer/src/styles/app.css`.
+- Existing `MessagingStatusBar` mounting in the Settings titlebar tests.
+
+**Test scenarios:**
+- Happy path: degraded Telegram renders orange dot and warning-toned chip.
+- Happy path: hovering or focusing a degraded chip opens a popover with the rate-limit reason and remaining time.
+- Happy path: clicking pins the popover; Escape dismisses it.
+- Edge case: multiple reasons render as separate clipped rows.
+- Edge case: expired reasons are not shown after the hook receives a cleared status.
+- Accessibility: chip has an informative accessible label and uses `aria-describedby` while the popover is open.
+- Regression: enabled/suspended/errored/unknown chips retain existing visual behavior.
+
+**Verification:**
+- Renderer tests prove the popover interaction and degraded visual state without relying on native `title` tooltips.
+
+- [ ] **Unit 7: Mark streaming as advanced/cautioned and expose per-binding control**
+
+**Goal:** Make streaming opt-in feel like an advanced power-user setting and let individual bindings override inherited streaming behavior.
+
+**Requirements:** R8, R9, R10
+
+**Dependencies:** Units 3 and 4
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `packages/messaging/interface/src/index.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts` only if binding summaries need to expose the effective streaming mode to renderer/navigation surfaces.
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Change Settings label/copy from a neutral toggle to an Advanced / Cautioned control. The copy should state that streaming edits the same message repeatedly, can trigger provider rate limits sooner, and is poor for voice readers that announce messages when first received.
+- Keep global provider defaults off.
+- Add a binding status-card action that cycles `Streaming: Auto`, `Streaming: Off`, and `Streaming: On`, using existing `binding.preferences.streamingResponses` where possible.
+- Ensure `/status` or status-card text fallback can change the binding preference without a desktop-only path.
+- Use existing binding-local mutation patterns: update store/preferences and re-render binding status inline because this does not flow through the thread-state bus.
+- In slow mode, effective streaming should behave as disabled even when global or binding preference says enabled, with degraded/slow-mode docs explaining why.
+- Do not add edit-rate floor or first-edit delay settings in this pass; the shared budget and slow mode supersede them for the observed storm.
+
+**Patterns to follow:**
+- Tool update mode action cycle in `apps/desktop/src/main/messaging/core/messaging-status-card.ts`.
+- `cycleToolUpdateMode` handling in `MessagingController`.
+- Existing streaming policy resolution in `deliverAssistantStreamBuffer()`.
+
+**Test scenarios:**
+- Happy path: Settings renders Streaming Responses as advanced/cautioned with warning text about voice readers and rate limits.
+- Happy path: status-card action cycles inherited -> disabled -> enabled -> inherited and persists the binding preference.
+- Happy path: a binding with `Streaming: Off` discards stream updates even if provider global streaming is enabled.
+- Edge case: slow mode forces non-final streaming off while preserving final assistant delivery.
+- Error path: invalid callback/text fallback for streaming mode returns a recoverable error without changing the binding.
+- Regression: existing Tool Updates cycle and status-card actions remain within provider action limits.
+
+**Verification:**
+- Settings and controller tests prove the warning is visible, per-binding control works, and streaming cannot outrank final response delivery under slow mode.
+
+- [ ] **Unit 8: Update docs, smoke checks, and operational guidance**
+
+**Goal:** Document the new streaming cautions, delivery budget behavior, degraded health semantics, and manual validation flow for provider rate limits.
+
+**Requirements:** R3, R4, R5, R6, R8, R9, R10
+
+**Dependencies:** Units 1-7
+
+**Files:**
+- Modify: `docs/messaging-adapter-contract.md`
+- Modify: `docs/messaging-platform-integration.md`
+- Modify: `docs/UI-THEME.md` only if degraded status wording needs to clarify the warning token usage.
+- Test: `apps/desktop/src/main/__tests__/messaging-docs-links.test.ts`
+
+**Approach:**
+- Update adapter contract docs with delivery scope metadata, rate-limit hooks, benign drop/defer outcomes, and the rule that final assistant delivery remains authoritative.
+- Update platform integration docs to explain slow mode, reserved budget, dropped intermediate updates, and user-visible degraded health.
+- Rewrite Streaming Responses docs to say streaming is advanced/cautioned, separate from tool updates and typing, and usually not what users want for mobile/voice-reader workflows.
+- Document per-binding streaming controls and how they interact with global provider defaults.
+- Update Telegram/Discord/Mattermost/Slack smoke checks with a controlled noisy-turn scenario and expected no-message-loss behavior.
+- Add manual checks that a rate-limit/reconnect degradation turns the status chip orange and then auto-recovers.
+
+**Patterns to follow:**
+- Current Streaming Responses and Tool Update Verbosity sections in `docs/messaging-platform-integration.md`.
+- Current adapter Rendering Policy and Streaming Responses sections in `docs/messaging-adapter-contract.md`.
+
+**Test scenarios:**
+- Documentation link test: new docs links resolve and existing links stay valid.
+- Manual Telegram: noisy long response plus tool activity in a supergroup/topic sends final completion and avoids repeated 429 storms; intermediate tool/stream updates may be dropped in slow mode.
+- Manual Discord: simulated or observed 429 produces degraded status and retry-based recovery without losing final assistant response.
+- Manual Mattermost: reconnect attempts below fatal threshold show degraded/reconnecting; fatal threshold still shows errored.
+- Manual Settings: Streaming Responses warning is visible and per-binding override appears on the status surface.
+
+**Verification:**
+- Docs explain the operator-visible behavior well enough that delayed or dropped intermediate updates are understood as intentional slow-mode behavior, not silent message loss.
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+  Provider["Provider adapters"] --> Runtime["DesktopMessagingRuntime degradation state"]
+  Provider --> Budget["MessagingDeliveryBudget"]
+  Controller["MessagingController.deliver()"] --> Budget
+  Budget --> Provider
+  Runtime --> IPC["messaging status IPC"]
+  IPC --> Renderer["MessagingStatusBar popover"]
+  Controller --> Store["MessagingStore delivery/activity records"]
+  Controller --> Docs["Operator docs and smoke checks"]
+```
+
+- **Interaction graph:** Backend events, inbound commands, status-card callbacks, pending requests, and provider reconnect/rate-limit events now converge through budgeted outbound delivery.
+- **Error propagation:** Provider 429s should produce rate-limit degradation and budget cool-off, not permanent binding revocation. True 403/404-style target failures still revoke through existing permanent-failure logic.
+- **State lifecycle risks:** Budget queues and stream buffers remain runtime state; final assistant content and thread transcript remain the restart-safe source of truth.
+- **API surface parity:** Telegram, Discord, Mattermost, and Slack should all use the same hook/scope vocabulary even if provider-specific metadata is richer for some adapters.
+- **Integration coverage:** Unit tests must cover the budget service in isolation plus controller integration across stream/tool/status/final/prompt kinds.
+- **Unchanged invariants:** Provider packages remain isolated; shared workflow code remains channel-neutral; authorization, callback handle security, attachment ingestion, and final assistant dedupe do not change.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Provider rate-limit metadata is incomplete or SDK-hidden | Design hooks as optional and fall back to conservative static scopes plus failed-result parsing; defer richer bucket extraction per provider. |
+| Slow mode drops an update the user expected | Restrict dropping to non-final stream, routine status, and intermediate tool progress; preserve final and action-required messages. |
+| Final assistant message is delayed behind lower-priority backlog | Budget service reserves capacity and controller sends final/prompt before optional tool/status flushes. |
+| Degraded status becomes noisy or flaps | Reasons have expiry/recovery semantics; runtime coalesces health transitions and `errored` remains sticky. |
+| UI popover grows too complex | Keep one compact popover, no new positioning library, and reuse existing tokens. |
+| Per-binding streaming controls inflate status-card actions | Follow existing action priority/capability limits and text fallback patterns. |
+| Hard-coded platform limits drift | Use documented limits as conservative defaults, parse provider retry metadata when present, and document that exact tuning is operational. |
+
+## Alternative Approaches Considered
+
+- **Leave rate limiting inside each provider adapter.** Rejected because providers cannot see status, tool, prompt, final-response, and stream traffic as one priority queue. This would preserve the current failure mode where each kind behaves correctly in isolation but overloads the shared provider limit.
+- **Disable Streaming Responses globally and remove the setting.** Rejected because streaming is still a valid advanced preference for some low-volume bindings. The safer product posture is strong warning, per-binding control, and automatic slow-mode override.
+- **Queue every outbound intent until the provider recovers.** Rejected because intermediate stream/status/tool updates become stale quickly and can create a second storm after cool-off. The plan keeps only critical/final/latest aggregates.
+- **Represent degraded health only in logs or Messaging Activity.** Rejected because users need immediate status-bar feedback when messages are delayed but the adapter is not dead.
+
+## Success Metrics
+
+- A noisy Telegram supergroup/topic turn with streaming enabled and tool activity delivers the final assistant response and any action-required prompt without repeated 429 storms.
+- A provider 429 produces a visible degraded/orange platform status with a bounded recovery time and no red/offline false alarm.
+- Slow mode demonstrably drops or coalesces non-terminal stream/tool/status traffic while preserving final turn output.
+- Settings and docs make Streaming Responses read as an advanced, cautioned option rather than a normal recommended mode.
+
+## Documentation / Operational Notes
+
+- Streaming Responses should remain default off at provider level.
+- In slow mode, "message loss" means non-authoritative progress surfaces were intentionally dropped; final assistant responses and pending user prompts are the protected outputs.
+- Telegram group/topic budgets should be treated conservatively because the documented group limit is low and issue #220 observed topic traffic hitting 429s.
+- Rate-limit and degraded events should be visible in Messaging Activity for post-incident diagnosis without exposing raw provider secrets or oversized scope labels.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-30-messaging-platform-integration-requirements.md](../brainstorms/2026-04-30-messaging-platform-integration-requirements.md)
+- Related issue: [#220 messaging rate-limit storm](https://github.com/pwrdrvr/PwrAgent/issues/220)
+- Related issue: [#230 degraded messaging health](https://github.com/pwrdrvr/PwrAgent/issues/230)
+- Related issue: [#218 streaming response tradeoffs](https://github.com/pwrdrvr/PwrAgent/issues/218)
+- Related plan: [docs/plans/2026-05-02-002-feat-messaging-streaming-responses-plan.md](2026-05-02-002-feat-messaging-streaming-responses-plan.md)
+- Related learning: [docs/solutions/2026-05-07-codex-permission-mode-state-machine.md](../solutions/2026-05-07-codex-permission-mode-state-machine.md)
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts`
+- Related code: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Related code: `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- Related code: `packages/messaging/providers/discord/src/discord-adapter.ts`
+- Related code: `packages/messaging/providers/mattermost/src/mattermost-adapter.ts`
+- Related code: `packages/messaging/providers/slack/src/slack-adapter.ts`
+- External docs: [Telegram Bot FAQ - limits](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this)
+- External docs: [Discord rate limits](https://docs.discord.com/developers/topics/rate-limits)
+- External docs: [Slack Web API rate limits](https://docs.slack.dev/apis/web-api/rate-limits/)
+- External docs: [Mattermost rate limiting configuration](https://docs.mattermost.com/administration-guide/configure/rate-limiting-configuration-settings.html)

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -5,6 +5,9 @@ import {
   MESSAGING_SURFACE_INTENT_KINDS,
   MESSAGING_TOOL_UPDATE_MODES,
   layoutMessagingActionRows,
+  type MessagingDeliveryScope,
+  type MessagingPlatformStatus,
+  type MessagingRateLimitInfo,
   type MessagingApprovalIntent,
   type MessagingBindingRecord,
   type MessagingBrowseSessionRecord,
@@ -218,6 +221,47 @@ describe("messaging surface contract", () => {
 
     expect(intent.text).toBe("hello world");
     expect(JSON.stringify(intent)).not.toMatch(/agentMessage\/delta|telegram|discord/);
+  });
+
+  it("describes degraded platform health and provider-neutral rate scopes", () => {
+    const scope = {
+      platform: "telegram",
+      id: "telegram:supergroup:-1003841603622",
+      kind: "group",
+      label: "Telegram supergroup",
+      budget: {
+        limit: 20,
+        intervalMs: 60_000,
+        reserved: 5,
+      },
+    } satisfies MessagingDeliveryScope;
+    const rateLimit = {
+      scope,
+      retryAfterMs: 16_000,
+      observedAt: 1_000,
+    } satisfies MessagingRateLimitInfo;
+    const status = {
+      platform: "telegram",
+      health: "degraded",
+      changedAt: 1_000,
+      degradationReasons: [
+        {
+          kind: "rate-limited",
+          key: "rate-limited:telegram:supergroup:-1003841603622",
+          scope: rateLimit.scope,
+          retryAfterMs: rateLimit.retryAfterMs,
+          startedAt: 1_000,
+          expiresAt: 17_000,
+        },
+      ],
+    } satisfies MessagingPlatformStatus;
+
+    expect(status.health).toBe("degraded");
+    expect(status.degradationReasons?.[0]).toMatchObject({
+      kind: "rate-limited",
+      expiresAt: 17_000,
+    });
+    expect(JSON.stringify(status)).not.toMatch(/callback_data|custom_id/);
   });
 
   it("keeps approval audit data separate from adapter action payloads", () => {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -10,6 +10,7 @@ import type {
   NavigationDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
+  LaunchpadWorkMode,
 } from "@pwragent/shared";
 // Re-export shared messaging primitives so consumers can pick either
 // import path without seeing two parallel declarations.
@@ -611,6 +612,7 @@ export type MessagingProjectPickerIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingSingleSelectIntent = MessagingBaseSurfaceIntent & {
   kind: "single_select";
+  browseSessionId?: string;
   prompt: string;
   choices: MessagingChoice[];
 };
@@ -867,7 +869,8 @@ export type MessagingBrowseMode =
   | "projects"
   | "project_threads"
   | "new_project"
-  | "new_thread_options";
+  | "new_thread_options"
+  | "new_base_branch";
 
 export type MessagingBrowseLaunchAction = "resume_thread" | "start_new_thread";
 
@@ -890,6 +893,8 @@ export type MessagingBrowseSessionRecord = {
   pageSize: number;
   preferences?: MessagingBindingPreferences;
   query?: string;
+  newThreadWorkMode?: LaunchpadWorkMode;
+  newThreadBranchName?: string;
   selectedProject?: MessagingBrowseSelectedProject;
   surface?: MessagingSurfaceRef;
   updatedAt: number;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -3,6 +3,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadSummary,
+  MessagingDeliveryScope,
   MessagingToolUpdateMode,
   ThreadIdentifier,
   ThreadExecutionMode,
@@ -24,7 +25,18 @@ export {
   validateTelegramSupergroupId,
   type IdentifierValidationReason,
   type IdentifierValidationResult,
+  type MessagingDegradationReason,
+  type MessagingDeliveryScope,
+  type MessagingDeliveryScopeBudget,
+  type MessagingDeliveryScopeKind,
+  type MessagingMissingPermissionDegradationReason,
+  type MessagingPlatformHealth,
+  type MessagingPlatformStatus,
+  type MessagingPlatformStatusEvent,
+  type MessagingRateLimitedDegradationReason,
+  type MessagingReconnectingDegradationReason,
   type MessagingToolUpdateMode,
+  type MessagingWarningDegradationReason,
 } from "@pwragent/shared";
 
 export const MESSAGING_SURFACE_INTENT_KINDS = [
@@ -131,6 +143,25 @@ function isAsciiWhitespace(charCode: number): boolean {
     || charCode === 0x0c
     || charCode === 0x0d;
 }
+
+export type MessagingRateLimitInfo = {
+  retryAfterMs?: number;
+  scope: MessagingDeliveryScope;
+  message?: string;
+  observedAt?: number;
+};
+
+export type MessagingReconnectInfo =
+  | {
+      state: "started";
+      attemptCount?: number;
+      lastFailureReason?: string;
+      observedAt?: number;
+    }
+  | {
+      state: "recovered";
+      observedAt?: number;
+    };
 
 export type MessagingChannelKind =
   | "telegram"

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -149,6 +149,11 @@ export type MessagingRateLimitInfo = {
   scope: MessagingDeliveryScope;
   message?: string;
   observedAt?: number;
+  /**
+   * True only when replaying the same outbound intent cannot duplicate visible
+   * platform side effects from the failed attempt.
+   */
+  retryable?: boolean;
 };
 
 /**
@@ -675,8 +680,8 @@ export type MessagingDeliveryResult = {
   /**
    * Structured provider rate-limit feedback for this delivery attempt.
    * When present, the desktop controller should feed it back through
-   * its external admission budget instead of letting provider SDKs own
-   * hidden retry queues.
+   * its external admission budget. The controller only replays the
+   * intent when `rateLimit.retryable` is true.
    */
   rateLimit?: MessagingRateLimitInfo;
   deliveredAt: number;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -151,6 +151,16 @@ export type MessagingRateLimitInfo = {
   observedAt?: number;
 };
 
+/**
+ * Describes where outbound 429 retry ownership lives for a provider client.
+ * `sdk-managed` is diagnostic only; shipped adapters should externalize SDK
+ * queues or use direct calls so the desktop budget can preserve priority slots.
+ */
+export type MessagingClientRateLimitStrategy =
+  | "externalized"
+  | "direct"
+  | "sdk-managed";
+
 export type MessagingReconnectInfo =
   | {
       state: "started";
@@ -662,6 +672,13 @@ export type MessagingDeliveryResult = {
   channel: MessagingChannelKind;
   surface?: MessagingSurfaceRef;
   errorMessage?: string;
+  /**
+   * Structured provider rate-limit feedback for this delivery attempt.
+   * When present, the desktop controller should feed it back through
+   * its external admission budget instead of letting provider SDKs own
+   * hidden retry queues.
+   */
+  rateLimit?: MessagingRateLimitInfo;
   deliveredAt: number;
 };
 

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -62,6 +62,57 @@ describe("discord adapter", () => {
     );
   });
 
+  it("returns structured rate-limit feedback when Discord REST rejects a send", async () => {
+    const rateLimitError = Object.assign(new Error("Too Many Requests"), {
+      retryAfter: 2,
+    });
+    const adapter = new DiscordAdapter({
+      api: createApi({
+        createMessage: vi.fn().mockRejectedValue(rateLimitError),
+      }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+    const observed: unknown[] = [];
+    adapter.onRateLimit((info) => {
+      observed.push(info);
+    });
+
+    await expect(
+      adapter.deliver({
+        audit: discordAudit(),
+        createdAt: 1234,
+        id: "message-1",
+        kind: "message",
+        role: "assistant",
+        parts: [{ type: "text", text: "Final answer" }],
+      }),
+    ).resolves.toMatchObject({
+      channel: "discord",
+      deliveredAt: 1234,
+      errorMessage: "Too Many Requests",
+      outcome: "failed",
+      rateLimit: {
+        retryAfterMs: 2000,
+        scope: {
+          id: "discord:channel:channel-1",
+        },
+      },
+    });
+    expect(observed).toEqual([
+      expect.objectContaining({
+        retryAfterMs: 2000,
+        scope: expect.objectContaining({
+          id: "discord:channel:channel-1",
+        }),
+      }),
+    ]);
+  });
+
   it("returns a failed delivery when updating a stale message fails", async () => {
     const adapter = new DiscordAdapter({
       api: createApi({

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -64,7 +64,7 @@ describe("discord adapter", () => {
 
   it("returns structured rate-limit feedback when Discord REST rejects a send", async () => {
     const rateLimitError = Object.assign(new Error("Too Many Requests"), {
-      retryAfter: 2,
+      retryAfter: 500,
     });
     const adapter = new DiscordAdapter({
       api: createApi({
@@ -97,7 +97,8 @@ describe("discord adapter", () => {
       errorMessage: "Too Many Requests",
       outcome: "failed",
       rateLimit: {
-        retryAfterMs: 2000,
+        retryAfterMs: 500,
+        retryable: true,
         scope: {
           id: "discord:channel:channel-1",
         },
@@ -105,12 +106,84 @@ describe("discord adapter", () => {
     });
     expect(observed).toEqual([
       expect.objectContaining({
-        retryAfterMs: 2000,
+        retryAfterMs: 500,
+        retryable: true,
         scope: expect.objectContaining({
           id: "discord:channel:channel-1",
         }),
       }),
     ]);
+  });
+
+  it("converts Discord API retry_after seconds without scaling REST retryAfter milliseconds", async () => {
+    const restRateLimitError = Object.assign(new Error("REST bucket"), {
+      retryAfter: 750,
+    });
+    const apiRateLimitError = Object.assign(new Error("API body"), {
+      retry_after: 2,
+    });
+    const createMessage = vi.fn()
+      .mockRejectedValueOnce(restRateLimitError)
+      .mockRejectedValueOnce(apiRateLimitError);
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    const intent = {
+      audit: discordAudit(),
+      createdAt: 1234,
+      id: "message-1",
+      kind: "message" as const,
+      role: "assistant" as const,
+      parts: [{ type: "text" as const, text: "Final answer" }],
+    };
+    await expect(adapter.deliver(intent)).resolves.toMatchObject({
+      rateLimit: { retryAfterMs: 750 },
+    });
+    await expect(adapter.deliver({ ...intent, id: "message-2" })).resolves.toMatchObject({
+      rateLimit: { retryAfterMs: 2000 },
+    });
+  });
+
+  it("marks chunked Discord sends non-retryable after a visible partial send", async () => {
+    const rateLimitError = Object.assign(new Error("Too Many Requests"), {
+      retryAfter: 500,
+    });
+    const createMessage = vi.fn()
+      .mockResolvedValueOnce({ channel_id: "channel-1", id: "message-1" })
+      .mockRejectedValueOnce(rateLimitError);
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    await expect(
+      adapter.deliver({
+        audit: discordAudit(),
+        createdAt: 1234,
+        id: "message-1",
+        kind: "message",
+        role: "assistant",
+        parts: [{ type: "text", text: `${"a".repeat(2000)}${"b".repeat(2000)}` }],
+      }),
+    ).resolves.toMatchObject({
+      outcome: "failed",
+      rateLimit: {
+        retryAfterMs: 500,
+        retryable: false,
+      },
+    });
   });
 
   it("returns a failed delivery when updating a stale message fails", async () => {

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -21,9 +21,11 @@ import type {
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
   MessagingFilePart,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingRateLimitInfo,
   MessagingCallbackHandleStore,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
@@ -239,6 +241,8 @@ export type DiscordProviderAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   channel: "discord";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
   downloadAttachment?(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
@@ -307,6 +311,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private readonly guildCache = new Map<string, DiscordGuildInfo>();
   private readonly unauthorizedGuildLogKeys = new Set<string>();
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
+  private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
   private listener?: (event: MessagingInboundEvent) => Promise<void>;
   private readonly options: DiscordAdapterOptions;
   private streamSurfaces = new Map<string, string>();
@@ -327,6 +332,18 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     return () => {
       this.inboundRejectedListeners.delete(listener);
     };
+  }
+
+  onRateLimit(listener: (info: MessagingRateLimitInfo) => void): () => void {
+    this.rateLimitListeners.add(listener);
+    return () => {
+      this.rateLimitListeners.delete(listener);
+    };
+  }
+
+  resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
+    const target = this.resolveTarget(intent);
+    return target ? this.rateLimitScopeForTarget(target) : undefined;
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
@@ -534,6 +551,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       };
     } catch (error) {
       const message = errorMessage(error);
+      this.emitRateLimitFromError(error, target);
       this.options.logger?.warn?.(
         `discord deliver failed kind=${intent.kind} channel=${target.channelId} error=${message}`,
       );
@@ -571,8 +589,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     target: { channelId: string; guildId?: string; messageId?: string },
   ): Promise<MessagingDeliveryResult> {
     if (
-      this.options.config.streamingResponses !== true ||
-      intent.policy === "disabled"
+      intent.policy === "disabled" ||
+      (
+        this.options.config.streamingResponses !== true &&
+        intent.policy !== "enabled"
+      )
     ) {
       return {
         channel: this.channel,
@@ -1249,6 +1270,46 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         },
       },
     };
+  }
+
+  private rateLimitScopeForTarget(target: {
+    channelId: string;
+    guildId?: string;
+  }): MessagingDeliveryScope {
+    return {
+      platform: this.channel,
+      id: `discord:channel:${target.channelId}`,
+      kind: "channel",
+      parentId: target.guildId,
+      label: "Discord channel",
+      budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
+    };
+  }
+
+  private emitRateLimitFromError(
+    error: unknown,
+    target: { channelId: string; guildId?: string },
+  ): void {
+    const retryAfterMs = retryAfterMsFromError(error);
+    if (retryAfterMs === undefined) {
+      return;
+    }
+    this.emitRateLimit({
+      scope: this.rateLimitScopeForTarget(target),
+      retryAfterMs,
+      message: errorMessage(error),
+      observedAt: this.now(),
+    });
+  }
+
+  private emitRateLimit(info: MessagingRateLimitInfo): void {
+    for (const listener of this.rateLimitListeners) {
+      try {
+        listener(info);
+      } catch {
+        // Runtime listeners are observability. Delivery handling continues.
+      }
+    }
   }
 
   private firstImageUrl(intent: MessagingSurfaceIntent): string | undefined {
@@ -2258,6 +2319,28 @@ function discordChannelIsThread(channel: unknown): boolean {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function retryAfterMsFromError(error: unknown): number | undefined {
+  const retryAfter =
+    readNumberProperty(error, "retry_after") ??
+    readNumberProperty(error, "retryAfter") ??
+    readNumberProperty(error, "retryAfterMs");
+  if (retryAfter !== undefined) {
+    return retryAfter > 1_000 ? Math.ceil(retryAfter) : Math.ceil(retryAfter * 1000);
+  }
+  const status = readNumberProperty(error, "status") ?? readNumberProperty(error, "code");
+  return status === 429 ? 1_000 : undefined;
+}
+
+function readNumberProperty(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== "object" || !(key in value)) {
+    return undefined;
+  }
+  const property = (value as Record<string, unknown>)[key];
+  return typeof property === "number" && Number.isFinite(property)
+    ? property
+    : undefined;
 }
 
 function commandArgsFromOptions(

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -442,6 +442,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       return await this.deliverStreamUpdate(intent, target);
     }
 
+    let deliveredSideEffects = false;
     try {
       const callbackHandleWrites: Promise<unknown>[] = [];
       const components = buildDiscordComponents(
@@ -512,6 +513,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             surface: this.surfaceForMessage(message, target),
           };
         } catch (error) {
+          if (retryAfterMsFromError(error) !== undefined) {
+            throw error;
+          }
           if (intent.delivery.fallback !== "present_new") {
             throw error;
           }
@@ -538,6 +542,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           files: index === chunks.length - 1 ? filesForDiscordRequest(files) : undefined,
         };
         messages.push(await this.api.createMessage(target.channelId, request));
+        deliveredSideEffects = true;
       }
 
       const lastMessage = messages.at(-1);
@@ -554,7 +559,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       };
     } catch (error) {
       const message = errorMessage(error);
-      const rateLimit = this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target, {
+        retryable: !deliveredSideEffects,
+      });
       this.options.logger?.warn?.(
         `discord deliver failed kind=${intent.kind} channel=${target.channelId} error=${message}`,
       );
@@ -640,7 +647,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         surface: this.surfaceForMessage(message, target),
       };
     } catch (error) {
-      const rateLimit = this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target, {
+        retryable: true,
+      });
       return {
         channel: this.channel,
         deliveredAt: this.now(),
@@ -1295,6 +1304,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: { channelId: string; guildId?: string },
+    options?: { retryable?: boolean },
   ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = retryAfterMsFromError(error);
     if (retryAfterMs === undefined) {
@@ -1305,6 +1315,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       retryAfterMs,
       message: errorMessage(error),
       observedAt: this.now(),
+      retryable: options?.retryable ?? false,
     };
     this.emitRateLimit(info);
     return info;
@@ -2333,12 +2344,15 @@ function errorMessage(error: unknown): string {
 }
 
 function retryAfterMsFromError(error: unknown): number | undefined {
-  const retryAfter =
-    readNumberProperty(error, "retry_after") ??
+  const retryAfterMs =
     readNumberProperty(error, "retryAfter") ??
     readNumberProperty(error, "retryAfterMs");
-  if (retryAfter !== undefined) {
-    return retryAfter > 1_000 ? Math.ceil(retryAfter) : Math.ceil(retryAfter * 1000);
+  if (retryAfterMs !== undefined) {
+    return Math.ceil(retryAfterMs);
+  }
+  const retryAfterSeconds = readNumberProperty(error, "retry_after");
+  if (retryAfterSeconds !== undefined) {
+    return Math.ceil(retryAfterSeconds * 1000);
   }
   const status = readNumberProperty(error, "status") ?? readNumberProperty(error, "code");
   return status === 429 ? 1_000 : undefined;

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -28,6 +28,7 @@ import type {
   MessagingRateLimitInfo,
   MessagingCallbackHandleStore,
   MessagingRejectedInboundEvent,
+  MessagingClientRateLimitStrategy,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -240,6 +241,7 @@ export type DiscordProviderAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: "discord";
+  clientRateLimitStrategy: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
@@ -256,6 +258,7 @@ export type DiscordProviderAdapter = {
 
 export class DiscordAdapter implements DiscordProviderAdapter {
   readonly channel = "discord" as const;
+  readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "externalized";
   readonly capabilityProfile: MessagingCapabilityProfile = {
     actions: {
       maxActions: 25,
@@ -551,7 +554,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       };
     } catch (error) {
       const message = errorMessage(error);
-      this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target);
       this.options.logger?.warn?.(
         `discord deliver failed kind=${intent.kind} channel=${target.channelId} error=${message}`,
       );
@@ -560,6 +563,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         deliveredAt: this.now(),
         errorMessage: message,
         outcome: "failed",
+        ...(rateLimit ? { rateLimit } : {}),
         surface: intent.targetSurface,
       };
     }
@@ -636,11 +640,13 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         surface: this.surfaceForMessage(message, target),
       };
     } catch (error) {
+      const rateLimit = this.emitRateLimitFromError(error, target);
       return {
         channel: this.channel,
         deliveredAt: this.now(),
         errorMessage: errorMessage(error),
         outcome: "failed",
+        ...(rateLimit ? { rateLimit } : {}),
       };
     }
   }
@@ -1289,17 +1295,19 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: { channelId: string; guildId?: string },
-  ): void {
+  ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = retryAfterMsFromError(error);
     if (retryAfterMs === undefined) {
-      return;
+      return undefined;
     }
-    this.emitRateLimit({
+    const info: MessagingRateLimitInfo = {
       scope: this.rateLimitScopeForTarget(target),
       retryAfterMs,
       message: errorMessage(error),
       observedAt: this.now(),
-    });
+    };
+    this.emitRateLimit(info);
+    return info;
   }
 
   private emitRateLimit(info: MessagingRateLimitInfo): void {
@@ -1881,7 +1889,10 @@ class DiscordRestApi implements DiscordApi {
   private readonly rest: REST;
 
   constructor(botToken: string) {
-    this.rest = new REST({ version: "10" }).setToken(botToken);
+    this.rest = new REST({
+      rejectOnRateLimit: () => true,
+      version: "10",
+    }).setToken(botToken);
   }
 
   async createApplicationCommand(

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -172,6 +172,7 @@ describe("MattermostAdapter — capability profile", () => {
       websocketClient: fakeWebSocketClient(),
     });
     expect(adapter.channel).toBe("mattermost");
+    expect(adapter.clientRateLimitStrategy).toBe("direct");
   });
 
   it("emits rejected activity for unauthorized actionable posts", async () => {

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -21,7 +21,9 @@ import type {
   MessagingCallbackHandleStore,
   MessagingCapabilityProfile,
   MessagingChannelRef,
+  MessagingClientRateLimitStrategy,
   MessagingConversationKind,
+  MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
@@ -129,7 +131,9 @@ export type MattermostProviderAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: "mattermost";
+  clientRateLimitStrategy: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   downloadAttachment(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
@@ -214,6 +218,7 @@ type MattermostSurfaceOpaqueState = {
 
 export class MattermostAdapter implements MattermostProviderAdapter {
   readonly channel = "mattermost" as const;
+  readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "direct";
   readonly capabilityProfile: MessagingCapabilityProfile = {
     actions: {
       // Mattermost docs are silent on the per-attachment / per-post hard
@@ -602,6 +607,34 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         errorMessage: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
+    const targetSurface = (intent as { targetSurface?: MessagingSurfaceRef }).targetSurface;
+    const targetOpaque = targetSurface?.state?.opaque as
+      | MattermostSurfaceOpaqueState
+      | undefined;
+    const audit = (intent as { audit?: { channel?: MessagingChannelRef } }).audit;
+    const channelRef = audit?.channel;
+    const channelId = targetOpaque?.channelId ?? channelRef?.conversation.id;
+    if (!channelId) {
+      return undefined;
+    }
+    const rootId =
+      targetOpaque?.rootId
+      ?? (channelRef?.conversation.kind === "thread"
+        ? channelRef.conversation.parentId
+        : undefined);
+    return {
+      platform: this.channel,
+      id: rootId
+        ? `mattermost:thread:${channelId}:${rootId}`
+        : `mattermost:channel:${channelId}`,
+      kind: rootId ? "thread" : "channel",
+      label: rootId ? "Mattermost thread" : "Mattermost channel",
+      ...(rootId ? { parentId: channelId } : {}),
+      budget: { limit: 1, intervalMs: 1_000, reserved: 0 },
+    };
   }
 
   async downloadAttachment(

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -27,6 +27,7 @@ import type {
   MessagingInboundRejectedListener,
   MessagingJsonValue,
   MessagingRejectedInboundEvent,
+  MessagingReconnectInfo,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
   MessagingSurfaceRef,
@@ -143,6 +144,7 @@ export type MattermostProviderAdapter = {
    * `<img>` icon, which is structurally insulated from `currentColor`).
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
+  onReconnect?(listener: (info: MessagingReconnectInfo) => void): () => void;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle?(request: {
     actor?: MessagingActorIdentity;
@@ -297,6 +299,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
    */
   private wsErroredLatched = false;
   private readonly runtimeErrorListeners = new Set<(reason: string) => void>();
+  private readonly reconnectListeners = new Set<
+    (info: MessagingReconnectInfo) => void
+  >();
+  private websocketReconnectActive = false;
   /**
    * Live token set, owned by the adapter and shared by reference with
    * the callback server. The reconciler mutates this on every
@@ -397,6 +403,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     // too in case a caller constructs the adapter directly.
     const wsUrl = `${this.config.serverUrl.replace(/^http/, "ws").replace(/\/+$/, "")}/api/v4/websocket`;
     this.websocketClient.addMessageListener((message) => {
+      if (this.websocketReconnectActive) {
+        this.websocketReconnectActive = false;
+        this.emitReconnect({ state: "recovered", observedAt: this.now() });
+      }
       this.handleWebsocketMessage(message).catch((error) => {
         this.logger.error("mattermost websocket message handler crashed", {
           error: error instanceof Error ? error.message : String(error),
@@ -428,6 +438,13 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         this.emitRuntimeError(
           `websocket disconnected (${connectFailCount} consecutive failures)`,
         );
+      } else if (!this.stopping && connectFailCount > 0) {
+        this.websocketReconnectActive = true;
+        this.emitReconnect({
+          state: "started",
+          attemptCount: connectFailCount,
+          observedAt: this.now(),
+        });
       }
     });
     this.websocketClient.addErrorListener((event) => {
@@ -490,7 +507,9 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     await this.callbackServer.stop();
     // Reset latch + drop listeners so a subsequent `start()` re-arms.
     this.runtimeErrorListeners.clear();
+    this.reconnectListeners.clear();
     this.wsErroredLatched = false;
+    this.websocketReconnectActive = false;
     this.stopping = false;
     this.logger.info("mattermost adapter stopped", {});
   }
@@ -508,12 +527,31 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     };
   }
 
+  onReconnect(listener: (info: MessagingReconnectInfo) => void): () => void {
+    this.reconnectListeners.add(listener);
+    return () => {
+      this.reconnectListeners.delete(listener);
+    };
+  }
+
   private emitRuntimeError(reason: string): void {
     for (const listener of this.runtimeErrorListeners) {
       try {
         listener(reason);
       } catch (error) {
         this.logger.warn("mattermost runtime-error listener threw", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  private emitReconnect(info: MessagingReconnectInfo): void {
+    for (const listener of this.reconnectListeners) {
+      try {
+        listener(info);
+      } catch (error) {
+        this.logger.warn("mattermost reconnect listener threw", {
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -1858,7 +1896,10 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   private async deliverStreamUpdate(
     intent: MessagingSurfaceIntent & { kind: "stream_update" },
   ): Promise<MessagingDeliveryResult> {
-    if (this.config.streamingResponses === false) {
+    if (
+      intent.policy === "disabled" ||
+      (this.config.streamingResponses !== true && intent.policy !== "enabled")
+    ) {
       return {
         channel: this.channel,
         deliveredAt: this.now(),

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -178,6 +178,7 @@ describe("SlackAdapter", () => {
       outcome: "failed",
       rateLimit: {
         retryAfterMs: 3000,
+        retryable: true,
         scope: {
           id: "slack:channel:C012ABCDEF0",
         },
@@ -186,11 +187,62 @@ describe("SlackAdapter", () => {
     expect(observed).toEqual([
       expect.objectContaining({
         retryAfterMs: 3000,
+        retryable: true,
         scope: expect.objectContaining({
           id: "slack:channel:C012ABCDEF0",
         }),
       }),
     ]);
+  });
+
+  it("marks Slack file-upload rate limits non-retryable after posting the message", async () => {
+    const rateLimitError = Object.assign(new Error("rate_limited"), {
+      retryAfter: 3,
+    });
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: {
+        ...fakeApi({}),
+        uploadFile: async () => {
+          throw rateLimitError;
+        },
+      },
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await expect(adapter.deliver({
+      id: "message-1",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Final answer" },
+        {
+          type: "file",
+          data: new Uint8Array([1, 2, 3]),
+          mimeType: "text/plain",
+          name: "answer.txt",
+        },
+      ],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: { id: "C012ABCDEF0", kind: "channel" },
+        },
+        occurredAt: 1,
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "failed",
+      rateLimit: {
+        retryAfterMs: 3000,
+        retryable: false,
+      },
+    });
   });
 
   it("delivers interactive status cards as Block Kit messages", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -128,9 +128,69 @@ describe("SlackAdapter", () => {
 
     expect(adapter.channel).toBe("slack");
     expect(adapter.authorizedActorIds).toEqual(["U012ABCDEF0"]);
+    expect(adapter.clientRateLimitStrategy).toBe("externalized");
     expect(adapter.capabilityProfile.actions?.maxActions).toBe(25);
     expect(adapter.capabilityProfile.actions?.supportsLayoutHints).toBe(true);
     expect(adapter.capabilityProfile.text.markdownDialect).toBe("slack-mrkdwn");
+  });
+
+  it("returns structured rate-limit feedback when Slack rejects a send", async () => {
+    const store = fakeStore();
+    const rateLimitError = Object.assign(new Error("rate_limited"), {
+      retryAfter: 3,
+    });
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: store,
+      api: {
+        ...fakeApi({}),
+        postMessage: async () => {
+          throw rateLimitError;
+        },
+      },
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const observed: unknown[] = [];
+    adapter.onRateLimit((info) => {
+      observed.push(info);
+    });
+
+    await expect(adapter.deliver({
+      id: "message-1",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [{ type: "text", text: "Final answer" }],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: { id: "C012ABCDEF0", kind: "channel" },
+        },
+        occurredAt: 1,
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      deliveredAt: 1_700_000_000_000,
+      errorMessage: "rate_limited",
+      outcome: "failed",
+      rateLimit: {
+        retryAfterMs: 3000,
+        scope: {
+          id: "slack:channel:C012ABCDEF0",
+        },
+      },
+    });
+    expect(observed).toEqual([
+      expect.objectContaining({
+        retryAfterMs: 3000,
+        scope: expect.objectContaining({
+          id: "slack:channel:C012ABCDEF0",
+        }),
+      }),
+    ]);
   });
 
   it("delivers interactive status cards as Block Kit messages", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -14,10 +14,12 @@ import type {
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
   MessagingFilePart,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
@@ -138,6 +140,8 @@ export type SlackProviderAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   channel: "slack";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
   downloadAttachment(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
@@ -268,6 +272,7 @@ export class SlackAdapter implements SlackProviderAdapter {
   private readonly signingSecret: string;
   private readonly socketClient: SlackSocketClient | undefined;
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
+  private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
   private readonly conversationTitleCache = new Map<string, string | undefined>();
   private readonly recentInboundMessageEvents = new Map<string, number>();
   private readonly threadTitleCache = new Map<string, string | undefined>();
@@ -303,6 +308,18 @@ export class SlackAdapter implements SlackProviderAdapter {
     return () => {
       this.inboundRejectedListeners.delete(listener);
     };
+  }
+
+  onRateLimit(listener: (info: MessagingRateLimitInfo) => void): () => void {
+    this.rateLimitListeners.add(listener);
+    return () => {
+      this.rateLimitListeners.delete(listener);
+    };
+  }
+
+  resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
+    const target = this.resolveTarget(intent);
+    return target ? this.rateLimitScopeForTarget(target) : undefined;
   }
 
   async start(listener: SlackInboundListener): Promise<void> {
@@ -433,6 +450,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         },
       };
     } catch (error) {
+      this.emitRateLimitFromError(error, target);
       return {
         outcome: "failed",
         channel: this.channel,
@@ -761,7 +779,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   private async deliverStreamUpdate(
     intent: Extract<MessagingSurfaceIntent, { kind: "stream_update" }>,
   ): Promise<MessagingDeliveryResult> {
-    if (this.config.streamingResponses === false || intent.policy === "disabled") {
+    if (
+      intent.policy === "disabled" ||
+      (this.config.streamingResponses !== true && intent.policy !== "enabled")
+    ) {
       return {
         outcome: "discarded",
         channel: this.channel,
@@ -845,6 +866,42 @@ export class SlackAdapter implements SlackProviderAdapter {
       ...(threadTs ? { threadTs } : {}),
       ...(surfaceState?.ts ? { ts: surfaceState.ts } : {}),
     };
+  }
+
+  private rateLimitScopeForTarget(target: { channelId: string }): MessagingDeliveryScope {
+    return {
+      platform: this.channel,
+      id: `slack:channel:${target.channelId}`,
+      kind: target.channelId.startsWith("D") ? "dm" : "channel",
+      label: target.channelId.startsWith("D") ? "Slack DM" : "Slack channel",
+      budget: { limit: 1, intervalMs: 1_000, reserved: 0 },
+    };
+  }
+
+  private emitRateLimitFromError(
+    error: unknown,
+    target: { channelId: string },
+  ): void {
+    const retryAfterMs = retryAfterMsFromError(error);
+    if (retryAfterMs === undefined) {
+      return;
+    }
+    this.emitRateLimit({
+      scope: this.rateLimitScopeForTarget(target),
+      retryAfterMs,
+      message: error instanceof Error ? error.message : String(error),
+      observedAt: this.now(),
+    });
+  }
+
+  private emitRateLimit(info: MessagingRateLimitInfo): void {
+    for (const listener of this.rateLimitListeners) {
+      try {
+        listener(info);
+      } catch {
+        // Runtime listeners are observability. Delivery handling continues.
+      }
+    }
   }
 
   private buildCallbackValueBuilder(params: {
@@ -1569,6 +1626,28 @@ function requiredConversationHistoryScope(channelId: string): string {
   if (channelId.startsWith("D")) return "im:history";
   if (channelId.startsWith("G")) return "groups:history or mpim:history";
   return "channels:history/groups:history/im:history/mpim:history";
+}
+
+function retryAfterMsFromError(error: unknown): number | undefined {
+  const retryAfter =
+    readNumberProperty(error, "retryAfter") ??
+    readNumberProperty(error, "retry_after") ??
+    readNumberProperty(error, "retryAfterMs");
+  if (retryAfter !== undefined) {
+    return retryAfter > 1_000 ? Math.ceil(retryAfter) : Math.ceil(retryAfter * 1000);
+  }
+  const status = readNumberProperty(error, "status") ?? readNumberProperty(error, "code");
+  return status === 429 ? 1_000 : undefined;
+}
+
+function readNumberProperty(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== "object" || !(key in value)) {
+    return undefined;
+  }
+  const property = (value as Record<string, unknown>)[key];
+  return typeof property === "number" && Number.isFinite(property)
+    ? property
+    : undefined;
 }
 
 function safeEqual(left: string, right: string): boolean {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -10,6 +10,7 @@ import type {
   MessagingCallbackHandleStore,
   MessagingCapabilityProfile,
   MessagingChannelRef,
+  MessagingClientRateLimitStrategy,
   MessagingConversationKind,
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
@@ -139,6 +140,7 @@ export type SlackProviderAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: "slack";
+  clientRateLimitStrategy: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
@@ -215,6 +217,7 @@ type SlackSlashCommandPayload = {
 
 export class SlackAdapter implements SlackProviderAdapter {
   readonly channel = "slack" as const;
+  readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "externalized";
   readonly capabilityProfile: MessagingCapabilityProfile = {
     actions: {
       // Slack Block Kit actions blocks allow at most 25 elements.
@@ -450,12 +453,13 @@ export class SlackAdapter implements SlackProviderAdapter {
         },
       };
     } catch (error) {
-      this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target);
       return {
         outcome: "failed",
         channel: this.channel,
         deliveredAt: this.now(),
         errorMessage: error instanceof Error ? error.message : String(error),
+        ...(rateLimit ? { rateLimit } : {}),
       };
     }
   }
@@ -759,19 +763,22 @@ export class SlackAdapter implements SlackProviderAdapter {
         errorMessage: "Slack dismiss target is missing",
       };
     }
+    const channelId = target.channelId;
     try {
-      await this.api.deleteMessage({ channel: target.channelId, ts: target.ts });
+      await this.api.deleteMessage({ channel: channelId, ts: target.ts });
       return {
         outcome: "dismissed",
         channel: this.channel,
         deliveredAt: this.now(),
       };
     } catch (error) {
+      const rateLimit = this.emitRateLimitFromError(error, { channelId });
       return {
         outcome: "failed",
         channel: this.channel,
         deliveredAt: this.now(),
         errorMessage: error instanceof Error ? error.message : String(error),
+        ...(rateLimit ? { rateLimit } : {}),
       };
     }
   }
@@ -824,11 +831,13 @@ export class SlackAdapter implements SlackProviderAdapter {
         },
       };
     } catch (error) {
+      const rateLimit = this.emitRateLimitFromError(error, target);
       return {
         outcome: "failed",
         channel: this.channel,
         deliveredAt: this.now(),
         errorMessage: error instanceof Error ? error.message : String(error),
+        ...(rateLimit ? { rateLimit } : {}),
       };
     }
   }
@@ -881,17 +890,19 @@ export class SlackAdapter implements SlackProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: { channelId: string },
-  ): void {
+  ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = retryAfterMsFromError(error);
     if (retryAfterMs === undefined) {
-      return;
+      return undefined;
     }
-    this.emitRateLimit({
+    const info: MessagingRateLimitInfo = {
       scope: this.rateLimitScopeForTarget(target),
       retryAfterMs,
       message: error instanceof Error ? error.message : String(error),
       observedAt: this.now(),
-    });
+    };
+    this.emitRateLimit(info);
+    return info;
   }
 
   private emitRateLimit(info: MessagingRateLimitInfo): void {
@@ -1409,7 +1420,7 @@ export function createSlackAdapter(
 }
 
 export function createSlackApi(botToken: string): SlackApi {
-  const client = new WebClient(botToken);
+  const client = new WebClient(botToken, { rejectRateLimitedCalls: true });
   return {
     async authTest() {
       return (await client.auth.test()) as SlackAuthTestResult;

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -413,6 +413,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       unfurl_media: false,
     };
 
+    let deliveredSideEffects = false;
     try {
       const updated =
         intent.delivery?.mode === "update" && target.ts
@@ -421,6 +422,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       const result = updated ?? (await this.api.postMessage(body));
       const channelId = result.channel ?? target.channelId;
       const ts = result.ts ?? target.ts;
+      deliveredSideEffects = true;
       if (!ts) {
         return {
           outcome: "failed",
@@ -453,7 +455,9 @@ export class SlackAdapter implements SlackProviderAdapter {
         },
       };
     } catch (error) {
-      const rateLimit = this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target, {
+        retryable: !deliveredSideEffects,
+      });
       return {
         outcome: "failed",
         channel: this.channel,
@@ -772,7 +776,9 @@ export class SlackAdapter implements SlackProviderAdapter {
         deliveredAt: this.now(),
       };
     } catch (error) {
-      const rateLimit = this.emitRateLimitFromError(error, { channelId });
+      const rateLimit = this.emitRateLimitFromError(error, { channelId }, {
+        retryable: true,
+      });
       return {
         outcome: "failed",
         channel: this.channel,
@@ -831,7 +837,9 @@ export class SlackAdapter implements SlackProviderAdapter {
         },
       };
     } catch (error) {
-      const rateLimit = this.emitRateLimitFromError(error, target);
+      const rateLimit = this.emitRateLimitFromError(error, target, {
+        retryable: true,
+      });
       return {
         outcome: "failed",
         channel: this.channel,
@@ -890,6 +898,7 @@ export class SlackAdapter implements SlackProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: { channelId: string },
+    options?: { retryable?: boolean },
   ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = retryAfterMsFromError(error);
     if (retryAfterMs === undefined) {
@@ -900,6 +909,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       retryAfterMs,
       message: error instanceof Error ? error.message : String(error),
       observedAt: this.now(),
+      retryable: options?.retryable ?? false,
     };
     this.emitRateLimit(info);
     return info;

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -12,6 +12,7 @@ import type {
   MessagingDeliveryResult,
   MessagingDeliveryScope,
   MessagingFilePart,
+  MessagingClientRateLimitStrategy,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
   MessagingRateLimitInfo,
@@ -340,6 +341,7 @@ export type TelegramProviderAdapter = {
   authorizedActorIds: readonly string[];
   capabilityProfile: MessagingCapabilityProfile;
   channel: "telegram";
+  clientRateLimitStrategy: MessagingClientRateLimitStrategy;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
@@ -365,6 +367,7 @@ export type TelegramProviderAdapter = {
 
 export class TelegramAdapter implements TelegramProviderAdapter {
   readonly channel = "telegram" as const;
+  readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "direct";
   readonly capabilityProfile: MessagingCapabilityProfile = {
     actions: {
       maxActions: 100,
@@ -640,9 +643,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       return await this.deliverSurface(intent);
     } catch (error) {
       const target = this.resolveTarget(intent);
-      if (target) {
-        this.emitRateLimitFromError(error, target);
-      }
+      const rateLimit = target
+        ? this.emitRateLimitFromError(error, target)
+        : undefined;
       this.options.logger?.warn?.(
         `telegram deliver failed kind=${intent.kind} target=${target ? this.compactTypingTarget(target) : "missing"} error=${errorMessage(error)}`,
       );
@@ -651,6 +654,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         deliveredAt: this.now(),
         errorMessage: errorMessage(error),
         outcome: "failed",
+        ...(rateLimit ? { rateLimit } : {}),
         surface: intent.targetSurface,
       };
     }
@@ -965,14 +969,16 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         };
       }
       const retryAfterMs = telegramRetryAfterMs(error);
+      let rateLimit: MessagingRateLimitInfo | undefined;
       if (retryAfterMs !== undefined) {
         this.blockStreamRateLimitTarget(target, retryAfterMs);
-        this.emitRateLimit({
+        rateLimit = {
           scope: this.rateLimitScopeForTarget(target),
           retryAfterMs,
           message: errorMessage(error),
           observedAt: this.now(),
-        });
+        };
+        this.emitRateLimit(rateLimit);
         this.options.logger?.warn?.(
           `telegram stream update rate limited retryAfterMs=${retryAfterMs} target=${this.compactTypingTarget(target)} stream=${intent.stream.key}`,
         );
@@ -982,6 +988,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         deliveredAt: this.now(),
         errorMessage: errorMessage(error),
         outcome: "failed",
+        ...(rateLimit ? { rateLimit } : {}),
       };
     }
   }
@@ -1987,17 +1994,19 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: TelegramDeliveryTarget,
-  ): void {
+  ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = telegramRetryAfterMs(error);
     if (retryAfterMs === undefined) {
-      return;
+      return undefined;
     }
-    this.emitRateLimit({
+    const info: MessagingRateLimitInfo = {
       scope: this.rateLimitScopeForTarget(target),
       retryAfterMs,
       message: errorMessage(error),
       observedAt: this.now(),
-    });
+    };
+    this.emitRateLimit(info);
+    return info;
   }
 
   private emitRateLimit(info: MessagingRateLimitInfo): void {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -644,7 +644,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     } catch (error) {
       const target = this.resolveTarget(intent);
       const rateLimit = target
-        ? this.emitRateLimitFromError(error, target)
+        ? this.emitRateLimitFromError(error, target, { retryable: false })
         : undefined;
       this.options.logger?.warn?.(
         `telegram deliver failed kind=${intent.kind} target=${target ? this.compactTypingTarget(target) : "missing"} error=${errorMessage(error)}`,
@@ -977,6 +977,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           retryAfterMs,
           message: errorMessage(error),
           observedAt: this.now(),
+          retryable: true,
         };
         this.emitRateLimit(rateLimit);
         this.options.logger?.warn?.(
@@ -1994,6 +1995,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   private emitRateLimitFromError(
     error: unknown,
     target: TelegramDeliveryTarget,
+    options?: { retryable?: boolean },
   ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = telegramRetryAfterMs(error);
     if (retryAfterMs === undefined) {
@@ -2004,6 +2006,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       retryAfterMs,
       message: errorMessage(error),
       observedAt: this.now(),
+      retryable: options?.retryable ?? false,
     };
     this.emitRateLimit(info);
     return info;

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -10,9 +10,11 @@ import type {
   MessagingConversationTitleUpdateRequest,
   MessagingConversationTitleUpdateResult,
   MessagingDeliveryResult,
+  MessagingDeliveryScope,
   MessagingFilePart,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
@@ -339,6 +341,8 @@ export type TelegramProviderAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   channel: "telegram";
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
+  resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
+  onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
   downloadAttachment?(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
@@ -449,6 +453,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
    */
   private stopping = false;
   private readonly runtimeErrorListeners = new Set<(reason: string) => void>();
+  private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
   private typingSignalSequence = 0;
   private typingSignals = new Map<string, TelegramTypingSignal>();
 
@@ -465,6 +470,18 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return () => {
       this.inboundRejectedListeners.delete(listener);
     };
+  }
+
+  onRateLimit(listener: (info: MessagingRateLimitInfo) => void): () => void {
+    this.rateLimitListeners.add(listener);
+    return () => {
+      this.rateLimitListeners.delete(listener);
+    };
+  }
+
+  resolveDeliveryScope(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined {
+    const target = this.resolveTarget(intent);
+    return target ? this.rateLimitScopeForTarget(target) : undefined;
   }
 
   async start(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void> {
@@ -623,6 +640,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       return await this.deliverSurface(intent);
     } catch (error) {
       const target = this.resolveTarget(intent);
+      if (target) {
+        this.emitRateLimitFromError(error, target);
+      }
       this.options.logger?.warn?.(
         `telegram deliver failed kind=${intent.kind} target=${target ? this.compactTypingTarget(target) : "missing"} error=${errorMessage(error)}`,
       );
@@ -828,8 +848,11 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     target: TelegramDeliveryTarget,
   ): Promise<MessagingDeliveryResult> {
     if (
-      this.options.config.streamingResponses !== true ||
-      intent.policy === "disabled"
+      intent.policy === "disabled" ||
+      (
+        this.options.config.streamingResponses !== true &&
+        intent.policy !== "enabled"
+      )
     ) {
       return {
         channel: this.channel,
@@ -944,6 +967,12 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       const retryAfterMs = telegramRetryAfterMs(error);
       if (retryAfterMs !== undefined) {
         this.blockStreamRateLimitTarget(target, retryAfterMs);
+        this.emitRateLimit({
+          scope: this.rateLimitScopeForTarget(target),
+          retryAfterMs,
+          message: errorMessage(error),
+          observedAt: this.now(),
+        });
         this.options.logger?.warn?.(
           `telegram stream update rate limited retryAfterMs=${retryAfterMs} target=${this.compactTypingTarget(target)} stream=${intent.stream.key}`,
         );
@@ -1935,6 +1964,52 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return Number.isFinite(chatId) && chatId < 0 ? "group" : "dm";
   }
 
+  private rateLimitScopeForTarget(
+    target: TelegramDeliveryTarget,
+  ): MessagingDeliveryScope {
+    const policy = this.streamRateLimitPolicy(target);
+    const chatId = String(target.chatId);
+    return {
+      platform: this.channel,
+      id: policy === "group" ? `telegram:group:${chatId}` : `telegram:dm:${chatId}`,
+      kind: policy === "group" ? "group" : "dm",
+      label:
+        policy === "group"
+          ? `Telegram group ${compactIdentifier(chatId)}`
+          : "Telegram DM",
+      budget:
+        policy === "group"
+          ? { limit: 20, intervalMs: 60_000, reserved: 5 }
+          : { limit: 1, intervalMs: 1_000, reserved: 0 },
+    };
+  }
+
+  private emitRateLimitFromError(
+    error: unknown,
+    target: TelegramDeliveryTarget,
+  ): void {
+    const retryAfterMs = telegramRetryAfterMs(error);
+    if (retryAfterMs === undefined) {
+      return;
+    }
+    this.emitRateLimit({
+      scope: this.rateLimitScopeForTarget(target),
+      retryAfterMs,
+      message: errorMessage(error),
+      observedAt: this.now(),
+    });
+  }
+
+  private emitRateLimit(info: MessagingRateLimitInfo): void {
+    for (const listener of this.rateLimitListeners) {
+      try {
+        listener(info);
+      } catch {
+        // Runtime listeners are observability. Delivery handling continues.
+      }
+    }
+  }
+
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);
@@ -2465,6 +2540,13 @@ function telegramRetryAfterSeconds(value: unknown): number | undefined {
       "retry_after",
     )
   );
+}
+
+function compactIdentifier(value: string): string {
+  if (value.length <= 12) {
+    return value;
+  }
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
 }
 
 function telegramBotTokenDiagnostics(token: string): Record<string, unknown> {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -25,6 +25,8 @@ export type StartThreadRequest = {
   serviceTier?: string;
   reasoningEffort?: string;
   fastMode?: boolean;
+  workMode?: LaunchpadWorkMode;
+  branchName?: string;
 };
 
 export type StartThreadResponse = {

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -176,7 +176,9 @@ export type MessagingActivityKind =
   | "inbound-rejected"
   | "inbound-ignored"
   | "pairing"
-  | "outbound";
+  | "outbound"
+  | "binding"
+  | "diagnostic";
 
 export type MessagingActivityEntry = {
   id: number;

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -53,9 +53,74 @@ export type MessagingChannelKind =
 
 export type MessagingConversationKind = "dm" | "channel" | "thread" | "topic";
 
+export type MessagingDeliveryScopeKind =
+  | "global"
+  | "dm"
+  | "group"
+  | "channel"
+  | "thread"
+  | "topic"
+  | "route"
+  | "workspace"
+  | "server"
+  | "custom";
+
+export type MessagingDeliveryScopeBudget = {
+  limit: number;
+  intervalMs: number;
+  reserved?: number;
+};
+
+export type MessagingDeliveryScope = {
+  platform: MessagingChannelKind;
+  id: string;
+  kind: MessagingDeliveryScopeKind;
+  label?: string;
+  parentId?: string;
+  bucketId?: string;
+  budget?: MessagingDeliveryScopeBudget;
+};
+
+type MessagingDegradationBase = {
+  key: string;
+  message?: string;
+  scope?: MessagingDeliveryScope;
+  startedAt: number;
+};
+
+export type MessagingRateLimitedDegradationReason = MessagingDegradationBase & {
+  kind: "rate-limited";
+  retryAfterMs?: number;
+  expiresAt: number;
+};
+
+export type MessagingReconnectingDegradationReason = MessagingDegradationBase & {
+  kind: "reconnecting";
+  attemptCount?: number;
+  lastFailureReason?: string;
+};
+
+export type MessagingMissingPermissionDegradationReason = MessagingDegradationBase & {
+  kind: "missing-permission";
+  bindingId?: string;
+  permission?: string;
+};
+
+export type MessagingWarningDegradationReason = MessagingDegradationBase & {
+  kind: "warning";
+  expiresAt?: number;
+};
+
+export type MessagingDegradationReason =
+  | MessagingRateLimitedDegradationReason
+  | MessagingReconnectingDegradationReason
+  | MessagingMissingPermissionDegradationReason
+  | MessagingWarningDegradationReason;
+
 /**
  * Health/lifecycle state for a single configured messaging platform.
  *   - `enabled`   adapter started successfully and is currently listening
+ *   - `degraded` adapter is connected but temporarily constrained
  *   - `suspended` configured but stopped (user toggled messaging off)
  *   - `errored`   the adapter failed to start, or hit a fatal runtime error
  *   - `unknown`   we know the platform is configured but haven't observed
@@ -63,6 +128,7 @@ export type MessagingConversationKind = "dm" | "channel" | "thread" | "topic";
  */
 export type MessagingPlatformHealth =
   | "enabled"
+  | "degraded"
   | "suspended"
   | "errored"
   | "unknown";
@@ -79,6 +145,8 @@ export type MessagingPlatformStatus = {
   changedAt: number;
   /** When errored, a human-readable reason for the UI tooltip. */
   reason?: string;
+  /** Transient provider/runtime reasons that make an enabled platform degraded. */
+  degradationReasons?: MessagingDegradationReason[];
   /**
    * Wall-clock ms of the last sent or received message that the
    * runtime told us about. Used to keep the activity dot blinking for
@@ -93,6 +161,7 @@ export type MessagingPlatformStatusEvent =
       platform: MessagingChannelKind;
       health: MessagingPlatformHealth;
       reason?: string;
+      degradationReasons?: MessagingDegradationReason[];
       at: number;
     }
   | {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -177,12 +177,14 @@ export type NavigationLaunchpadImageAttachment = {
 
 export type NavigationDirectoryGitStatus = {
   currentBranch?: string;
+  currentSha?: string;
   defaultBranch?: string;
   upstreamBranch?: string;
   ahead?: number;
   behind?: number;
   branches?: string[];
   handoffBranches?: string[];
+  hasUncommittedChanges?: boolean;
   syncState?:
     | "in-sync"
     | "ahead"

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -366,6 +366,7 @@ export type HandoffThreadWorkspaceRequest = {
   threadId: ThreadIdentifier;
   direction: ThreadWorkspaceHandoffDirection;
   strategy?: ThreadWorkspaceHandoffStrategy;
+  baseBranch?: string;
   repositoryPath?: string;
   sourcePath?: string;
   sourceBranch?: string;
@@ -379,6 +380,7 @@ export type HandoffThreadWorkspaceResponse = {
   strategy?: ThreadWorkspaceHandoffStrategy;
   workMode: "local" | "worktree";
   branch?: string;
+  baseBranch?: string;
   baseSha?: string;
   repositoryPath: string;
   targetPath: string;


### PR DESCRIPTION
## Summary

This improves the messaging-platform workflow for creating and moving worktrees from mobile.

I changed handoff so it first asks whether to move the current branch or create a new detached worktree. The move flow now offers Detached HEAD as the first "leave Local on" choice, and the detached flow picks the right next step based on Git state: clean workspaces get a base-branch picker, while dirty workspaces confirm that the detached worktree will be based on the current commit SHA/current branch and bring the changes along.

I also changed `/resume --new` so new-thread creation asks whether the thread should start in Local or a New Worktree. When New Worktree is selected, the messaging UI shows the default base branch and lets the user open a base-branch picker before starting the thread.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
