### PR TITLE
fix(desktop): gate messaging thread creation on first prompt

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -148,10 +148,14 @@ describe("MessagingController", () => {
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
     ).resolves.toBeUndefined();
-    expect(harness.delivered.at(-1)).toMatchObject({
+    const readyIntent = harness.delivered.at(-1);
+    expect(readyIntent).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
       body: expect.stringContaining("PwrAgent"),
+    });
+    expect(readyIntent).toMatchObject({
+      browseSessionId: expect.stringMatching(/^browse:/),
     });
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
@@ -224,6 +228,50 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Resume cancelled",
+    });
+  });
+
+  it("resolves pending new-thread Back through persisted callback handles", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    const readyIntent = harness.delivered.at(-1);
+    if (readyIntent?.kind !== "confirmation" || !readyIntent.browseSessionId) {
+      throw new Error("Expected ready-to-start confirmation with a browse session id");
+    }
+    await harness.store.upsertCallbackHandle({
+      id: "callback:ready-back",
+      actionId: "browse:mode:new",
+      allowedActorIds: ["user-1"],
+      browseSessionId: readyIntent.browseSessionId,
+      channel: buildCommandEvent("/resume").channel,
+      createdAt: 1000,
+      updatedAt: 1000,
+      expiresAt: 2000,
+      handle: "tg:ready-back",
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:new",
+        interactionId: "tg:ready-back",
+      }),
+    );
+
+    expect(harness.startThread).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("Choose a project for the new PwrAgent thread"),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -129,7 +129,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("starts a new thread from /resume --new project selection", async () => {
+  it("starts a new thread from /resume --new only after the first prompt arrives", async () => {
     const harness = await createHarness();
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
@@ -144,6 +144,18 @@ describe("MessagingController", () => {
       }),
     );
 
+    expect(harness.startThread).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toBeUndefined();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("PwrAgent"),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
     expect(harness.startThread).toHaveBeenCalledWith({
       backend: "codex",
       cwd: "/repo/pwragent",
@@ -153,6 +165,18 @@ describe("MessagingController", () => {
       reasoningEffort: undefined,
       serviceTier: undefined,
     });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "new-thread-1",
+        input: [
+          {
+            type: "text",
+            text: "Fix bug",
+          },
+        ],
+      }),
+    );
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
     ).resolves.toMatchObject({
@@ -170,6 +194,77 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       text: expect.stringContaining("Directory: /repo/pwragent"),
     });
+  });
+
+  it("cancels a pending new-thread prompt without creating a thread", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:cancel",
+      }),
+    );
+
+    expect(harness.startThread).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toBeUndefined();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Resume cancelled",
+    });
+  });
+
+  it("debounces split first prompts before creating a messaging-started thread", async () => {
+    const harness = await createHarness({ inputDebounceMs: 10 });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    await harness.controller.handleInboundEvent(buildTextEvent("First prompt chunk"));
+    await harness.controller.handleInboundEvent(buildTextEvent("second prompt chunk"));
+    expect(harness.startThread).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(harness.startThread).toHaveBeenCalledTimes(1);
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "new-thread-1",
+        input: [
+          {
+            type: "text",
+            text: "First prompt chunk",
+          },
+          {
+            type: "text",
+            text: "second prompt chunk",
+          },
+        ],
+      }),
+    );
   });
 
   it("routes messages to the new thread after rebinding an already-bound conversation", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -229,6 +229,17 @@ describe("MessagingController", () => {
       kind: "confirmation",
       title: "Resume cancelled",
     });
+
+    harness.delivered.length = 0;
+    await harness.controller.handleInboundEvent(buildTextEvent("@huntharo_bot"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Choose a thread",
+    });
+    expect(harness.delivered.at(-1)).not.toMatchObject({
+      title: "Choose an option",
+    });
   });
 
   it("resolves pending new-thread Back through persisted callback handles", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -257,6 +257,17 @@ type PendingQueueAuditMessage = {
 
 const PERMISSIONS_QUEUE_CANCEL_ACTION_PREFIX = "permissions:queue:cancel:";
 
+type PendingNewThreadPromptWindow = {
+  events: MessagingTurnInputEvent[];
+  session: MessagingBrowseSessionRecord;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+type PendingNewThreadPromptBundle = {
+  events: MessagingTurnInputEvent[];
+  session: MessagingBrowseSessionRecord;
+};
+
 export type MessagingControllerOptions = {
   adapter: MessagingAdapter;
   authorizedActorIds: string[];
@@ -298,6 +309,7 @@ export class MessagingController {
   private readonly logger: MessagingControllerLogger;
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
   private readonly turnAdmission: MessagingTurnAdmission;
+  private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
   private readonly deliveryBudget?: MessagingDeliveryBudget;
   /**
    * Per-thread map of the most-recent "permissions queued" audit message
@@ -759,6 +771,7 @@ export class MessagingController {
       return;
     }
 
+    const pendingNewThread = await this.findPendingNewThreadSession(event);
     const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
       actorId: event.actor.platformUserId,
       channel: event.channel,
@@ -782,6 +795,10 @@ export class MessagingController {
         });
         return;
       }
+      if (pendingNewThread) {
+        await this.appendPendingNewThreadPrompt(pendingNewThread, event);
+        return;
+      }
       if (mapped.kind === "ambiguous") {
         await this.deliver(
           buildConfirmationIntent({
@@ -797,6 +814,11 @@ export class MessagingController {
         );
         return;
       }
+    }
+
+    if (pendingNewThread) {
+      await this.appendPendingNewThreadPrompt(pendingNewThread, event);
+      return;
     }
 
     const binding = await this.options.store.findActiveBindingForChannel(event.channel);
@@ -846,6 +868,12 @@ export class MessagingController {
         args: parseTextCommandArgs(event.text ?? ""),
         rawText: event.text ?? "",
       });
+      return;
+    }
+
+    const pendingNewThread = await this.findPendingNewThreadSession(event);
+    if (pendingNewThread) {
+      await this.appendPendingNewThreadPrompt(pendingNewThread, event);
       return;
     }
 
@@ -904,9 +932,91 @@ export class MessagingController {
     });
   }
 
+  private async findPendingNewThreadSession(
+    event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
+  ): Promise<MessagingBrowseSessionRecord | undefined> {
+    const session = await this.options.store.findActiveBrowseSessionForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (
+      session?.launchAction === "start_new_thread" &&
+      session.mode === "new_thread_options" &&
+      session.selectedProject
+    ) {
+      return session;
+    }
+    return undefined;
+  }
+
+  private async appendPendingNewThreadPrompt(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingTurnInputEvent,
+  ): Promise<void> {
+    const key = this.pendingNewThreadPromptKey(session);
+    const existing = this.pendingNewThreadPrompts.get(key);
+    if (existing) {
+      existing.events.push(event);
+      existing.session = session;
+      if ((this.options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS) <= 0) {
+        await this.flushPendingNewThreadPrompt(key);
+        return;
+      }
+      if (existing.timer) {
+        clearTimeout(existing.timer);
+      }
+      existing.timer = this.schedulePendingNewThreadPrompt(key);
+      return;
+    }
+
+    this.pendingNewThreadPrompts.set(key, {
+      events: [event],
+      session,
+      timer:
+        (this.options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS) > 0
+          ? this.schedulePendingNewThreadPrompt(key)
+          : undefined,
+    });
+    if ((this.options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS) <= 0) {
+      await this.flushPendingNewThreadPrompt(key);
+    }
+  }
+
+  private schedulePendingNewThreadPrompt(
+    key: string,
+  ): ReturnType<typeof setTimeout> {
+    return setTimeout(() => {
+      void this.flushPendingNewThreadPrompt(key);
+    }, this.options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS);
+  }
+
+  private async flushPendingNewThreadPrompt(key: string): Promise<void> {
+    const pending = this.pendingNewThreadPrompts.get(key);
+    if (!pending) {
+      return;
+    }
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+    this.pendingNewThreadPrompts.delete(key);
+    await this.createNewThreadFromPromptBundle({
+      events: pending.events,
+      session: pending.session,
+    });
+  }
+
+  private pendingNewThreadPromptKey(session: MessagingBrowseSessionRecord): string {
+    return [
+      buildMessagingConversationKey(session.channel),
+      session.allowedActorIds.join(","),
+      session.id,
+    ].join(":");
+  }
+
   private async prepareTurnInput(
     events: MessagingTurnInputEvent[],
-    binding: MessagingBindingRecord,
+    binding: MessagingBindingRecord | undefined,
     event?: MessagingInboundEvent,
   ): Promise<
     | {
@@ -991,6 +1101,7 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
+    navigation?: NavigationSnapshot;
     preview: string;
     queueOnConcurrentStart?: boolean;
     threadKey: string;
@@ -999,7 +1110,7 @@ export class MessagingController {
     let turnStarted = false;
 
     try {
-      const navigation = await this.options.backend.getNavigationSnapshot({
+      const navigation = params.navigation ?? await this.options.backend.getNavigationSnapshot({
         backend: "all",
       });
       const turnSettings = turnSettingsForBinding(params.binding, navigation);
@@ -2050,6 +2161,12 @@ export class MessagingController {
 
   dispose(): void {
     this.turnAdmission.dispose();
+    for (const pending of this.pendingNewThreadPrompts.values()) {
+      if (pending.timer) {
+        clearTimeout(pending.timer);
+      }
+    }
+    this.pendingNewThreadPrompts.clear();
     this.toolUpdatePolicy.dispose();
   }
 
@@ -2409,8 +2526,110 @@ export class MessagingController {
       return;
     }
 
+    await this.presentNewThreadPromptGate(
+      {
+        ...session,
+        mode: "new_thread_options",
+        pageIndex: 0,
+        selectedProject: project,
+        updatedAt: this.now(),
+        expiresAt: this.now() + this.pendingIntentTtlMs,
+      },
+      event,
+    );
+  }
+
+  private async presentNewThreadPromptGate(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.options.store.upsertBrowseSession(session);
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-ready"),
+      capabilityProfile: this.capabilityProfile,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? {
+            mode: "update",
+            replaceMarkup: true,
+          }
+        : undefined,
+      title: "Ready to start",
+      body: `Send the first instruction for ${session.selectedProject?.label ?? "this project"}. The thread will be created when that message arrives.`,
+      fallbackText: "Send your first instruction, reply back to change the project, or reply cancel.",
+      targetSurface: session.surface,
+      actions: [
+        {
+          id: "browse:mode:new",
+          label: "Back",
+          style: "navigation",
+          fallbackText: "back",
+        },
+        {
+          id: "browse:cancel",
+          label: "Cancel",
+          style: "secondary",
+          fallbackText: "cancel",
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (!result.surface) {
+      return;
+    }
+
+    const updatedSession = {
+      ...session,
+      surface: result.surface,
+      updatedAt: this.now(),
+    };
+    await this.options.store.upsertBrowseSession(updatedSession);
+    await this.options.store.upsertPendingIntent({
+      id: intent.id,
+      channel: event.channel,
+      intent,
+      allowedActorIds: [event.actor.platformUserId],
+      createdAt: this.now(),
+      expiresAt: this.now() + this.pendingIntentTtlMs,
+      surface: result.surface,
+    });
+  }
+
+  private async createNewThreadFromPromptBundle(
+    bundle: PendingNewThreadPromptBundle,
+  ): Promise<void> {
+    const event = bundle.events[0];
+    if (!event || !bundle.session.selectedProject) {
+      return;
+    }
+
+    const prepared = await this.prepareTurnInput(bundle.events, undefined, event);
+    if (!prepared) {
+      return;
+    }
+
+    if (!this.options.backend.startThread) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-unavailable"),
+          createdAt: this.now(),
+          title: "New thread unavailable",
+          body: "This backend does not support starting a thread from messaging yet.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const project = bundle.session.selectedProject;
     const directory = directoryForProjectSelection(navigation, project);
-    const preferences = session.preferences;
+    const preferences = bundle.session.preferences;
     const started = await this.options.backend.startThread({
       backend: navigation.launchpadDefaults.backend,
       cwd: directory?.path ?? project.path,
@@ -2438,13 +2657,13 @@ export class MessagingController {
       project,
       threadId: started.threadId,
     });
-    await this.options.store.deleteBrowseSession(session.id);
+    await this.options.store.deleteBrowseSession(bundle.session.id);
     await this.deliver(
       buildConfirmationIntent({
         id: this.newIntentId("new-thread-bound"),
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
-        delivery: session.surface
+        delivery: bundle.session.surface
           ? {
               mode: "update",
               replaceMarkup: true,
@@ -2452,13 +2671,20 @@ export class MessagingController {
           : undefined,
         title: "Thread started",
         body: `Started and bound a new thread for ${project.label}.`,
-        fallbackText: "Send a message to continue the new thread.",
-        targetSurface: session.surface,
+        fallbackText: "Started the thread with your first instruction.",
+        targetSurface: bundle.session.surface,
       }),
       undefined,
       event,
     );
-    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
+    await this.startPreparedInput({
+      binding: updatedBinding,
+      input: prepared.input,
+      preview: prepared.preview,
+      threadKey: buildThreadIdentityKey(started.backend, started.threadId),
+      event,
+      navigation: optimisticNavigation,
+    });
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -3841,7 +4067,7 @@ export class MessagingController {
   }
 
   private async bindChannelToThread(
-    event: MessagingInboundCallbackEvent,
+    event: MessagingInboundEvent,
     target: { backend: AppServerBackendKind; threadId: ThreadIdentifier },
   ): Promise<MessagingBindingRecord> {
     const now = this.now();

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1006,6 +1006,18 @@ export class MessagingController {
     });
   }
 
+  private clearPendingNewThreadPrompt(sessionId: string): void {
+    for (const [key, pending] of this.pendingNewThreadPrompts.entries()) {
+      if (pending.session.id !== sessionId) {
+        continue;
+      }
+      if (pending.timer) {
+        clearTimeout(pending.timer);
+      }
+      this.pendingNewThreadPrompts.delete(key);
+    }
+  }
+
   private pendingNewThreadPromptKey(session: MessagingBrowseSessionRecord): string {
     return [
       buildMessagingConversationKey(session.channel),
@@ -2360,7 +2372,7 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:cancel") {
-      await this.options.store.deleteBrowseSession(session.id);
+      await this.retireBrowseSession(session);
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("browse-cancelled"),
@@ -2458,6 +2470,31 @@ export class MessagingController {
       channel: event.channel,
       now: this.now(),
     });
+  }
+
+  private async retireBrowseSession(
+    session: MessagingBrowseSessionRecord,
+  ): Promise<void> {
+    this.clearPendingNewThreadPrompt(session.id);
+    await this.options.store.deleteBrowseSession(session.id);
+    try {
+      const removed = await this.options.store.deletePendingIntentsForChannel({
+        channel: session.channel,
+      });
+      if (removed.length > 0) {
+        this.logger.debug?.("messaging retired channel pending intents on browse close", {
+          channel: session.channel.channel,
+          removedCount: removed.length,
+          sessionId: session.id,
+        });
+      }
+    } catch (error) {
+      this.logger.debug?.("messaging pending-intent cleanup failed on browse close", {
+        channel: session.channel.channel,
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: session.id,
+      });
+    }
   }
 
   private async resolveCallbackHandleForEvent(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2547,6 +2547,7 @@ export class MessagingController {
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
       capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
       createdAt: this.now(),
       delivery: session.surface
         ? {

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -138,6 +138,7 @@ export function buildToolUpdateBatchMessageIntent(params: {
 export function buildConfirmationIntent(params: {
   actions?: MessagingSurfaceAction[];
   body: string;
+  browseSessionId?: MessagingConfirmationIntent["browseSessionId"];
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
   delivery?: MessagingConfirmationIntent["delivery"];
@@ -151,6 +152,7 @@ export function buildConfirmationIntent(params: {
     kind: "confirmation",
     actions: applyActionCapabilityLimits(params.actions ?? [], params.capabilityProfile),
     body: params.body,
+    browseSessionId: params.browseSessionId,
     createdAt: params.createdAt,
     delivery: params.delivery,
     fallbackText: params.fallbackText,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -638,6 +638,7 @@ export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingConfirmationIntent = MessagingBaseSurfaceIntent & {
   kind: "confirmation";
+  browseSessionId?: string;
   title: string;
   body: string;
   actions: MessagingSurfaceAction[];

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -2297,7 +2297,9 @@ function sanitizeDiscordThreadName(title: string): string {
 }
 
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
-  return intent.kind === "thread_picker" || intent.kind === "project_picker"
+  return intent.kind === "thread_picker" ||
+    intent.kind === "project_picker" ||
+    intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;
 }

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -2416,7 +2416,9 @@ function parseTelegramIdentifier(value: string): number | string {
 }
 
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
-  return intent.kind === "thread_picker" || intent.kind === "project_picker"
+  return intent.kind === "thread_picker" ||
+    intent.kind === "project_picker" ||
+    intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;
 }


### PR DESCRIPTION
## Summary

I changed messaging-initiated new-thread creation so selecting a project no longer creates or binds a thread immediately. The controller now holds the selected project in the existing browse-session state, prompts for the first instruction, then creates the thread and starts its first turn from the user's actual messaging input.

I also kept the messaging debounce behavior for the first prompt, so split follow-up messages can be coalesced before the thread is created.

Follow-up fix: I also wired the Ready-to-start Back/Cancel buttons into the persisted callback-handle path. The confirmation intent now carries the browse session id, and Telegram/Discord persist that id on the opaque callback handle so those buttons resolve through sqlite instead of expiring immediately.

Second follow-up: Cancel now retires the browse session, clears any pending first-prompt debounce window, and removes channel-scoped pending intents for that browser flow. This prevents the next `@bot` text from being interpreted against the cancelled Ready-to-start prompt.

Fixes #305.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
- `pnpm exec tsc --noEmit -p apps/desktop/tsconfig.json`
- `pnpm lint:boundaries`
- `git diff --check`
