### PR TITLE
fix(desktop): fail loud on archive worktree cleanup

### DIFF
--- a/apps/desktop/e2e/thread-archive-worktree-cleanup.spec.ts
+++ b/apps/desktop/e2e/thread-archive-worktree-cleanup.spec.ts
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  }).trim();
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function createArchiveWorktreeFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoPath: string;
+  worktreePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-archive-e2e-"));
+  const repoPath = path.join(rootDir, "PwrAgnt");
+  const worktreeRoot = path.join(rootDir, ".codex", "worktrees", "mozycyl1");
+  const worktreePath = path.join(worktreeRoot, "PwrAgnt");
+
+  await mkdir(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  git(repoPath, ["config", "user.email", "pwragent-tests@example.invalid"]);
+  git(repoPath, ["config", "user.name", "PwrAgent Tests"]);
+  await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+  git(repoPath, ["add", "README.md"]);
+  git(repoPath, ["commit", "-m", "Seed archive fixture"]);
+  await mkdir(worktreeRoot, { recursive: true });
+  git(repoPath, ["worktree", "add", "-b", "feat/archive-cleanup", worktreePath, "main"]);
+
+  const resolvedWorktreePath = await realpath(worktreePath);
+  const fixturePath = path.join(rootDir, "thread-archive-worktree-cleanup.fixture.json");
+  const thread = {
+    id: "thread-archive-worktree",
+    title: "Archive worktree cleanup",
+    titleSource: "explicit",
+    summary: "Archive removes the backing worktree",
+    source: "codex",
+    executionMode: "default",
+    gitBranch: "feat/archive-cleanup",
+    linkedDirectories: [
+      {
+        id: `directory:${repoPath}`,
+        label: "PwrAgnt",
+        path: repoPath,
+        kind: "worktree",
+        worktreePath: resolvedWorktreePath,
+      },
+    ],
+    inbox: {
+      inInbox: false,
+    },
+    updatedAt: 1760000000000,
+  };
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-archive-worktree-cleanup",
+          threadId: "thread-archive-worktree",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "thread/archive", "skills/list"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [thread],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Archive this thread and clean up the worktree.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Archive this thread and clean up the worktree.",
+                },
+              ],
+              lastUserMessage: "Archive this thread and clean up the worktree.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-list-archive-cleanup",
+            kind: "response",
+            method: "thread/list",
+            result: [thread],
+          },
+          {
+            id: "thread-archive-1",
+            kind: "response",
+            method: "thread/archive",
+            result: {
+              threadId: "thread-archive-worktree",
+            },
+          },
+          {
+            id: "thread-list-post-archive",
+            kind: "response",
+            method: "thread/list",
+            result: [],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    fixturePath,
+    repoPath,
+    worktreePath: resolvedWorktreePath,
+  };
+}
+
+test("archiving a replay-backed thread removes its real Git worktree", async () => {
+  const fixture = await createArchiveWorktreeFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: /Archive worktree cleanup/i }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Archive worktree cleanup",
+      }),
+    ).toBeVisible();
+
+    await app.window.waitForTimeout(900);
+    await app.window.getByRole("button", { name: "Open thread actions" }).click();
+    await app.window.getByRole("menuitem", { name: "Archive Thread" }).click();
+
+    await expect
+      .poll(async () => await pathExists(fixture.worktreePath))
+      .toBe(false);
+    await expect
+      .poll(() => git(fixture.repoPath, ["worktree", "list", "--porcelain"]))
+      .not.toContain(fixture.worktreePath);
+    await expect(app.window.getByRole("button", { name: /Archive worktree cleanup/i })).toHaveCount(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,3 +1,8 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
@@ -18,8 +23,32 @@ import type {
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
+const execFileAsync = promisify(execFileCallback);
+
 async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  return stdout.trim();
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 async function waitForCondition(predicate: () => boolean): Promise<void> {
@@ -423,6 +452,7 @@ class MockBackendClient {
       modelListErrors?: Error[];
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
+      listThreadsError?: Error;
       startTurnError?: Error;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
@@ -448,6 +478,9 @@ class MockBackendClient {
     this.listThreadsCallCount += 1;
     this.lastListThreadsDiagnostics = diagnostics;
     this.lastListThreadsParams = params;
+    if (this.options.listThreadsError) {
+      throw this.options.listThreadsError;
+    }
     return this.options.threads ?? [];
   }
 
@@ -2545,6 +2578,107 @@ describe("DesktopBackendRegistry", () => {
     });
 
     await registry.close();
+  });
+
+  it("refuses to archive when worktree cleanup metadata cannot be loaded", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      listThreadsError: new Error("thread list unavailable"),
+    });
+    const archiveWorktree = vi.fn();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    await expect(
+      registry.archiveThread({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).rejects.toThrow("Unable to load thread metadata for archive cleanup.");
+
+    expect(codexClient.lastArchiveThreadParams).toBeUndefined();
+    expect(archiveWorktree).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("removes a real Git worktree and unregisters it from the source repo when archiving a thread", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-archive-"));
+    const repoPath = path.join(root, "PwrAgnt");
+    const worktreeRoot = path.join(root, ".codex", "worktrees", "mozycyl1");
+    const worktreePath = path.join(worktreeRoot, "PwrAgnt");
+
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+      await git(repoPath, ["config", "user.email", "test@example.com"]);
+      await git(repoPath, ["config", "user.name", "Test User"]);
+      await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+      await git(repoPath, ["add", "README.md"]);
+      await git(repoPath, ["commit", "-m", "initial"]);
+      await mkdir(worktreeRoot, { recursive: true });
+      await git(repoPath, ["worktree", "add", "-b", "feat/archive-cleanup", worktreePath, "main"]);
+      const resolvedWorktreePath = await realpath(worktreePath);
+
+      const thread: AppServerThreadSummary = {
+        id: "thread-1",
+        title: "Archive real worktree",
+        titleSource: "explicit",
+        linkedDirectories: [
+          {
+            id: `directory:${repoPath}`,
+            label: "PwrAgnt",
+            path: repoPath,
+            kind: "worktree",
+            worktreePath,
+          },
+        ],
+        source: "codex",
+        gitBranch: "feat/archive-cleanup",
+        updatedAt: 2,
+      };
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: [thread],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      const response = await registry.archiveThread({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+
+      expect(response.cleanup).toEqual([
+        {
+          worktreePath: resolvedWorktreePath,
+          branch: "feat/archive-cleanup",
+          removedWorktree: true,
+          deletedBranch: false,
+        },
+      ]);
+      expect(await pathExists(resolvedWorktreePath)).toBe(false);
+      expect(await git(repoPath, ["worktree", "list", "--porcelain"])).not.toContain(
+        resolvedWorktreePath,
+      );
+
+      await registry.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("hands off a local thread to a worktree and records the new workspace overlay", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1314,10 +1314,21 @@ export class DesktopBackendRegistry {
     request: ArchiveThreadRequest,
   ): Promise<ArchiveThreadResponse> {
     const backend = request.backend ?? "codex";
-    const thread = await this.findThreadForArchiveCleanup({
-      backend,
-      threadId: request.threadId,
-    });
+    let thread: AppServerThreadSummary;
+    try {
+      thread = await this.findThreadForArchiveCleanup({
+        backend,
+        threadId: request.threadId,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("archive cleanup metadata lookup failed", {
+        backend,
+        threadId: request.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new Error("Unable to load thread metadata for archive cleanup.");
+    }
+
     const result =
       backend === "codex"
         ? await this.withCodexThreadClient(request.threadId, async (client) =>
@@ -1325,12 +1336,10 @@ export class DesktopBackendRegistry {
           )
         : await this.archiveWithClient(this.grokClient, request.threadId);
     this.invalidateThreadListCache(backend);
-    const cleanup = thread
-      ? await this.archiveThreadWorktrees({
-          backend,
-          thread,
-        })
-      : [];
+    const cleanup = await this.archiveThreadWorktrees({
+      backend,
+      thread,
+    });
 
     return {
       backend,
@@ -3217,23 +3226,28 @@ export class DesktopBackendRegistry {
   private async findThreadForArchiveCleanup(params: {
     backend: AppServerBackendKind;
     threadId: string;
-  }): Promise<AppServerThreadSummary | undefined> {
+  }): Promise<AppServerThreadSummary> {
     const activeThreads = await this.listThreads({
       backend: params.backend,
       archived: false,
       callerReason: "archive-cleanup",
-    }).catch(() => []);
-    const archivedThreads = activeThreads.some((thread) => thread.id === params.threadId)
-      ? []
-      : await this.listThreads({
-          backend: params.backend,
-          archived: true,
-          callerReason: "archive-cleanup",
-        }).catch(() => []);
+    });
+    const activeThread = activeThreads.find((thread) => thread.id === params.threadId);
+    if (activeThread) {
+      return activeThread;
+    }
 
-    return [...activeThreads, ...archivedThreads].find(
-      (thread) => thread.id === params.threadId,
-    );
+    const archivedThreads = await this.listThreads({
+      backend: params.backend,
+      archived: true,
+      callerReason: "archive-cleanup",
+    });
+    const archivedThread = archivedThreads.find((thread) => thread.id === params.threadId);
+    if (archivedThread) {
+      return archivedThread;
+    }
+
+    throw new Error("Thread metadata was not found.");
   }
 
   private async findThreadForWorkspaceHandoff(params: {
@@ -3424,6 +3438,13 @@ export class DesktopBackendRegistry {
             deletedBranch: false,
           };
         } catch (error) {
+          backendRegistryLog.warn("archive thread worktree cleanup failed", {
+            backend: params.backend,
+            threadId: params.thread.id,
+            repositoryPath: candidate.repositoryPath,
+            worktreePath: candidate.worktreePath,
+            error: error instanceof Error ? error.message : String(error),
+          });
           return {
             worktreePath: candidate.worktreePath,
             branch: params.thread.observedGitBranch ?? params.thread.gitBranch,

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -126,6 +126,15 @@ export class ReplayClient {
     return asThreadReplay(this.controller.consumeResponse("thread/read").result);
   }
 
+  async archiveThread(params: {
+    threadId: string;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+    return this.controller.consumeResponse("thread/archive").result as {
+      threadId: string;
+    };
+  }
+
   async startThread(_params?: {
     cwd?: string;
     model?: string;

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -139,6 +139,9 @@ type ReplayRuntimeClient = {
     before?: string;
     limit?: number;
   }): Promise<AppServerReadThreadResponse["replay"]>;
+  archiveThread?(params: {
+    threadId: string;
+  }): Promise<{ threadId: string }>;
   startThread(params: {
     cwd?: string;
     model?: string;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -452,6 +452,83 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
   });
 
+  it("surfaces archive worktree cleanup failures returned by the desktop bridge", async () => {
+    let archived = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: archived
+        ? []
+        : [
+            {
+              id: "thread-archived",
+              title: "Archive me",
+              titleSource: "explicit" as const,
+              summary: "This thread has a worktree",
+              source: "codex" as const,
+              linkedDirectories: [
+                {
+                  id: "directory:/repo/app",
+                  label: "app",
+                  path: "/repo/app",
+                  kind: "worktree" as const,
+                  worktreePath: "/repo/.worktrees/archive-me",
+                },
+              ],
+              inbox: {
+                inInbox: false,
+              },
+              updatedAt: 1_000,
+            },
+          ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => {
+      archived = true;
+      return {
+        backend: "codex" as const,
+        threadId: "thread-archived",
+        archivedAt: 3_000,
+        cleanup: [
+          {
+            worktreePath: "/repo/.worktrees/archive-me",
+            removedWorktree: false,
+            deletedBranch: false,
+            error: "Worktree is not registered with Git",
+          },
+        ],
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-archived",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!);
+    });
+
+    expect(result.current.archiveThreadError).toBe(
+      "Thread archived, but worktree cleanup failed for /repo/.worktrees/archive-me: Worktree is not registered with Git",
+    );
+  });
+
   it("restores focus to the selected thread when archive fails", async () => {
     const navigationSnapshot = {
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5,6 +5,7 @@ import type {
   AppServerReviewTarget,
   AppServerThreadImagePart,
   AppServerTurnInputItem,
+  ArchiveThreadCleanupResult,
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
   NavigationDirectorySummary,
@@ -46,6 +47,21 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
   }
 
   return selectionKey.slice("launchpad:".length);
+}
+
+function formatArchiveCleanupFailure(
+  cleanup: ArchiveThreadCleanupResult[]
+): string | undefined {
+  const failures = cleanup.filter(
+    (item) => !item.removedWorktree || item.error || item.skippedReason
+  );
+  const firstFailure = failures[0];
+  if (!firstFailure) {
+    return undefined;
+  }
+
+  const reason = firstFailure.error ?? firstFailure.skippedReason ?? "cleanup was skipped";
+  return `Thread archived, but worktree cleanup failed for ${firstFailure.worktreePath}: ${reason}`;
 }
 
 function linkedDirectoriesEqual(
@@ -2229,10 +2245,14 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       );
 
       try {
-        await archiveThreadRequest({
+        const response = await archiveThreadRequest({
           backend: thread.source,
           threadId: thread.id,
         });
+        const cleanupFailure = formatArchiveCleanupFailure(response.cleanup);
+        if (cleanupFailure) {
+          setArchiveThreadError(cleanupFailure);
+        }
         await refresh();
       } catch (error) {
         suppressedArchivedThreadKeysRef.current.delete(threadKey);


### PR DESCRIPTION
## Summary

I fixed archived desktop threads silently leaving their Git worktrees behind.

The archive path now loads cleanup metadata before archiving and refuses to archive if that metadata cannot be loaded. If a post-archive worktree cleanup attempt fails, the main process logs a warning and the renderer surfaces the failure instead of hiding it behind a successful archive.

Fixes #303.

## What changed

- Made archive cleanup metadata lookup a hard precondition for thread archive.
- Added warning logs for cleanup metadata lookup failures and worktree cleanup failures.
- Surfaced cleanup failures returned by the desktop bridge in the navigation error masthead.
- Added replay-client support for `thread/archive`.
- Added real-Git registry coverage and a desktop E2E that verifies the worktree directory and `git worktree list` entry are removed.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/worktree-archive-service.test.ts apps/desktop/src/main/__tests__/replay-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/thread-archive-worktree-cleanup.spec.ts`
- `pnpm lint:boundaries`
- `git diff --check`
