### PR TITLE
fix(desktop): keep archive available when cleanup metadata is missing

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2580,7 +2580,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("refuses to archive when worktree cleanup metadata cannot be loaded", async () => {
+  it("archives and reports skipped cleanup when worktree cleanup metadata cannot be loaded", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list", "thread/archive"] },
       listThreadsError: new Error("thread list unavailable"),
@@ -2597,15 +2597,26 @@ describe("DesktopBackendRegistry", () => {
       } as unknown as WorktreeArchiveService,
     });
 
-    await expect(
-      registry.archiveThread({
-        backend: "codex",
-        threadId: "thread-1",
-      }),
-    ).rejects.toThrow("Unable to load thread metadata for archive cleanup.");
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
 
-    expect(codexClient.lastArchiveThreadParams).toBeUndefined();
+    expect(codexClient.lastArchiveThreadParams).toEqual({ threadId: "thread-1" });
     expect(archiveWorktree).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      archivedAt: expect.any(Number),
+      cleanup: [
+        {
+          removedWorktree: false,
+          deletedBranch: false,
+          skippedReason:
+            "Unable to load thread metadata for archive cleanup: thread list unavailable",
+        },
+      ],
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1314,19 +1314,20 @@ export class DesktopBackendRegistry {
     request: ArchiveThreadRequest,
   ): Promise<ArchiveThreadResponse> {
     const backend = request.backend ?? "codex";
-    let thread: AppServerThreadSummary;
+    let thread: AppServerThreadSummary | undefined;
+    let cleanupMetadataError: string | undefined;
     try {
       thread = await this.findThreadForArchiveCleanup({
         backend,
         threadId: request.threadId,
       });
     } catch (error) {
+      cleanupMetadataError = error instanceof Error ? error.message : String(error);
       backendRegistryLog.warn("archive cleanup metadata lookup failed", {
         backend,
         threadId: request.threadId,
-        error: error instanceof Error ? error.message : String(error),
+        error: cleanupMetadataError,
       });
-      throw new Error("Unable to load thread metadata for archive cleanup.");
     }
 
     const result =
@@ -1336,10 +1337,12 @@ export class DesktopBackendRegistry {
           )
         : await this.archiveWithClient(this.grokClient, request.threadId);
     this.invalidateThreadListCache(backend);
-    const cleanup = await this.archiveThreadWorktrees({
-      backend,
-      thread,
-    });
+    const cleanup = thread
+      ? await this.archiveThreadWorktrees({
+          backend,
+          thread,
+        })
+      : this.buildArchiveCleanupMetadataSkippedResult(cleanupMetadataError);
 
     return {
       backend,
@@ -1347,6 +1350,20 @@ export class DesktopBackendRegistry {
       archivedAt: Date.now(),
       cleanup,
     };
+  }
+
+  private buildArchiveCleanupMetadataSkippedResult(
+    error?: string,
+  ): ArchiveThreadCleanupResult[] {
+    return [
+      {
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason: error
+          ? `Unable to load thread metadata for archive cleanup: ${error}`
+          : "Unable to load thread metadata for archive cleanup.",
+      },
+    ];
   }
 
   async restoreThread(
@@ -2967,7 +2984,13 @@ export class DesktopBackendRegistry {
   }): Promise<AppServerThreadSummary[]> {
     const defaultThreads = await this.codexClient
       .listThreads(params, diagnostics)
-      .catch(() => []);
+      .catch((error) => {
+        if (diagnostics?.callerReason === "archive-cleanup") {
+          throw error;
+        }
+
+        return [];
+      });
     const allThreads = defaultThreads.map((thread) => ({
       ...thread,
       executionMode: "default" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -529,6 +529,75 @@ describe("useThreadNavigation", () => {
     );
   });
 
+  it("surfaces archive cleanup metadata lookup skips without requiring a worktree path", async () => {
+    let archived = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: archived
+        ? []
+        : [
+            {
+              id: "thread-archived",
+              title: "Archive me",
+              titleSource: "explicit" as const,
+              summary: "Archive remains available without cleanup metadata",
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: {
+                inInbox: false,
+              },
+              updatedAt: 1_000,
+            },
+          ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => {
+      archived = true;
+      return {
+        backend: "codex" as const,
+        threadId: "thread-archived",
+        archivedAt: 3_000,
+        cleanup: [
+          {
+            removedWorktree: false,
+            deletedBranch: false,
+            skippedReason:
+              "Unable to load thread metadata for archive cleanup: thread list unavailable",
+          },
+        ],
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-archived",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!);
+    });
+
+    expect(result.current.archiveThreadError).toBe(
+      "Thread archived, but worktree cleanup was skipped: Unable to load thread metadata for archive cleanup: thread list unavailable",
+    );
+  });
+
   it("restores focus to the selected thread when archive fails", async () => {
     const navigationSnapshot = {
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -61,7 +61,9 @@ function formatArchiveCleanupFailure(
   }
 
   const reason = firstFailure.error ?? firstFailure.skippedReason ?? "cleanup was skipped";
-  return `Thread archived, but worktree cleanup failed for ${firstFailure.worktreePath}: ${reason}`;
+  return firstFailure.worktreePath
+    ? `Thread archived, but worktree cleanup failed for ${firstFailure.worktreePath}: ${reason}`
+    : `Thread archived, but worktree cleanup was skipped: ${reason}`;
 }
 
 function linkedDirectoriesEqual(

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -300,7 +300,7 @@ export type AppServerListThreadsResponse = {
 };
 
 export type ArchiveThreadCleanupResult = {
-  worktreePath: string;
+  worktreePath?: string;
   branch?: string;
   removedWorktree: boolean;
   deletedBranch: boolean;


### PR DESCRIPTION
## Summary

I fixed the follow-up regression from #307 where archive could be blocked if cleanup metadata lookup failed.

Thread archive now remains fail-soft with respect to cleanup metadata: if the pre-archive metadata lookup fails, the backend archive still runs, and the response includes a skipped cleanup result so the renderer can surface the issue.

## What changed

- Changed `archiveThread` to continue to `thread/archive` when cleanup metadata cannot be loaded.
- Preserved warning logs for cleanup metadata lookup failures.
- Returned a pathless skipped cleanup entry for metadata lookup failures.
- Allowed `ArchiveThreadCleanupResult.worktreePath` to be optional for cleanup skips where no path is known.
- Updated renderer cleanup messaging for pathless skipped cleanup results.
- Updated regression tests so archive still happens when metadata lookup fails.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
