### PR TITLE
fix(messaging): handle deferred new-thread failures

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -327,6 +327,55 @@ describe("MessagingController", () => {
     );
   });
 
+  it("surfaces debounced new-thread creation failures", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const harness = await createHarness({
+      inputDebounceMs: 10,
+      logger,
+      startThread: async () => {
+        throw new Error("backend unavailable");
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    expect(harness.startThread).not.toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(harness.startThread).toHaveBeenCalledTimes(1);
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Thread could not start",
+      body: "backend unavailable",
+      recoverable: true,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "messaging new-thread prompt failed",
+      expect.objectContaining({
+        error: "backend unavailable",
+      }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toBeUndefined();
+  });
+
   it("routes messages to the new thread after rebinding an already-bound conversation", async () => {
     const harness = await createHarness();
     await harness.store.upsertBinding({
@@ -4621,6 +4670,7 @@ async function createHarness(options?: {
    */
   bindingChangedListener?: false;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
+  startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
 }): Promise<{
   controller: MessagingController;
@@ -4674,11 +4724,14 @@ async function createHarness(options?: {
       : {}),
   };
   const getNavigationSnapshot = vi.fn(async () => buildNavigationSnapshot());
-  const startThread = vi.fn(async (request: StartThreadRequest) => ({
-    backend: request.backend,
-    threadId: "new-thread-1",
-    executionMode: request.executionMode ?? "default",
-  }));
+  const startThread = vi.fn(
+    options?.startThread ??
+      (async (request: StartThreadRequest) => ({
+        backend: request.backend,
+        threadId: "new-thread-1",
+        executionMode: request.executionMode ?? "default",
+      })),
+  );
   const startTurn = vi.fn(async (request: StartTurnRequest) => ({
     backend: request.backend,
     threadId: request.threadId,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1000,10 +1000,50 @@ export class MessagingController {
       clearTimeout(pending.timer);
     }
     this.pendingNewThreadPrompts.delete(key);
-    await this.createNewThreadFromPromptBundle({
-      events: pending.events,
-      session: pending.session,
-    });
+    try {
+      await this.createNewThreadFromPromptBundle({
+        events: pending.events,
+        session: pending.session,
+      });
+    } catch (error) {
+      this.logger.warn?.("messaging new-thread prompt failed", {
+        channel: pending.session.channel.channel,
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: pending.session.id,
+      });
+      await this.deliverNewThreadPromptFailure(pending, error);
+    }
+  }
+
+  private async deliverNewThreadPromptFailure(
+    pending: PendingNewThreadPromptWindow,
+    error: unknown,
+  ): Promise<void> {
+    const event = pending.events[0];
+    if (!event) {
+      return;
+    }
+    try {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-start-failed"),
+          createdAt: this.now(),
+          title: "Thread could not start",
+          body: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+    } catch (deliveryError) {
+      this.logger.debug?.("messaging new-thread failure notice failed", {
+        channel: pending.session.channel.channel,
+        deliveryError: deliveryError instanceof Error
+          ? deliveryError.message
+          : String(deliveryError),
+        sessionId: pending.session.id,
+      });
+    }
   }
 
   private clearPendingNewThreadPrompt(sessionId: string): void {


### PR DESCRIPTION
## Summary

I fixed the debounced messaging new-thread startup path so backend/store failures no longer become unhandled promise rejections from the timer callback.

- Catch and log failures while flushing a pending first prompt for a messaging-created thread
- Surface a recoverable "Thread could not start" error back to the originating channel
- Add a regression test that forces `startThread` to fail after the debounce delay

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm exec tsc --noEmit -p apps/desktop/tsconfig.json`
- `pnpm lint:boundaries`
- `git diff --check`
