### PR TITLE
fix(messaging): preserve cool-off for typing activity

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -31,7 +31,7 @@ import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/tes
 import {
   MessagingController,
   messagingDeliveryPriority,
-  shouldApplyDeliveryBudget,
+  shouldConsumeDeliveryBudget,
   type MessagingControllerOptions,
 } from "../messaging/core/messaging-controller";
 import type { MessagingAdapter, MessagingBackendBridge } from "../messaging/core/messaging-adapter";
@@ -850,6 +850,85 @@ describe("MessagingController", () => {
       kind: "activity",
       activity: "typing",
       state: "idle",
+    });
+  });
+
+  it("drops typing activity during provider cool-off without spending write budget", async () => {
+    let now = 1_000;
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:group:chat-1",
+      kind: "group",
+      budget: { limit: 20, intervalMs: 60_000, reserved: 5 },
+    };
+    const deliveryBudget = new MessagingDeliveryBudget({ now: () => now });
+    const budgetEvents: Parameters<
+      NonNullable<MessagingControllerOptions["onDeliveryBudgetEvent"]>
+    >[0][] = [];
+    const harness = await createHarness({
+      channel: "telegram",
+      now: () => now,
+      deliveryBudget,
+      resolveDeliveryScope: (intent) =>
+        intent.kind === "activity" || intent.kind === "status" ? scope : undefined,
+      onDeliveryBudgetEvent: (event) => {
+        budgetEvents.push(event);
+      },
+    });
+    await bindThread(harness);
+    deliveryBudget.recordRateLimit({
+      scope,
+      retryAfterMs: 5_000,
+      observedAt: now,
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+    expect(budgetEvents.at(-1)).toMatchObject({
+      intentKind: "activity",
+      outcome: "dropped",
+      reason: "cool-off",
+      scope,
+    });
+
+    now = 8_001;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+    expect(budgetEvents.at(-1)).toMatchObject({
+      intentKind: "activity",
+      outcome: "dropped",
+      reason: "slow-mode",
+      scope,
     });
   });
 
@@ -2500,8 +2579,8 @@ describe("MessagingController", () => {
       text: "Working",
     } satisfies MessagingSurfaceIntent;
 
-    expect(shouldApplyDeliveryBudget(activity)).toBe(false);
-    expect(shouldApplyDeliveryBudget(status)).toBe(true);
+    expect(shouldConsumeDeliveryBudget(activity)).toBe(false);
+    expect(shouldConsumeDeliveryBudget(status)).toBe(true);
   });
 
   it("serializes concurrent assistant stream deliveries onto one surface", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
@@ -65,6 +65,63 @@ describe("MessagingDeliveryBudget", () => {
     });
   });
 
+  it("checks cool-off and slow mode for non-consuming activity", () => {
+    let now = 10_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 20, reserved: 5 });
+
+    budget.recordRateLimit({
+      scope,
+      retryAfterMs: 16_000,
+      observedAt: now,
+    });
+
+    expect(
+      budget.admit({
+        consumeCapacity: false,
+        scope,
+        priority: "routine_status",
+      }),
+    ).toEqual({
+      outcome: "dropped",
+      reason: "cool-off",
+      slowMode: true,
+    });
+
+    now = 28_001;
+    expect(
+      budget.admit({
+        consumeCapacity: false,
+        scope,
+        priority: "routine_status",
+      }),
+    ).toEqual({
+      outcome: "dropped",
+      reason: "slow-mode",
+      slowMode: true,
+    });
+  });
+
+  it("does not consume capacity for non-consuming activity", () => {
+    const budget = new MessagingDeliveryBudget({ now: () => 1_000 });
+    const scope = testScope({ limit: 1, reserved: 0 });
+
+    expect(
+      budget.admit({
+        consumeCapacity: false,
+        scope,
+        priority: "routine_status",
+      }),
+    ).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+  });
+
   it("enters slow mode when the local budget is exhausted", () => {
     let now = 1_000;
     const budget = new MessagingDeliveryBudget({ now: () => now });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4330,9 +4330,8 @@ export class MessagingController {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
     }
     const routedIntent = this.withRoutingAudit(intent, binding, event);
-    let scope = shouldApplyDeliveryBudget(routedIntent)
-      ? this.options.adapter.resolveDeliveryScope?.(routedIntent)
-      : undefined;
+    const consumeDeliveryBudget = shouldConsumeDeliveryBudget(routedIntent);
+    let scope = this.options.adapter.resolveDeliveryScope?.(routedIntent);
     const priority = messagingDeliveryPriority(routedIntent);
     const channel = binding?.channel.channel ??
       routedIntent.audit?.channel.channel ??
@@ -4340,7 +4339,11 @@ export class MessagingController {
     while (true) {
       if (this.deliveryBudget) {
         const budgetChannel = channel ?? scope?.platform ?? "telegram";
-        let admission = this.deliveryBudget.admit({ priority, scope });
+        let admission = this.deliveryBudget.admit({
+          consumeCapacity: consumeDeliveryBudget,
+          priority,
+          scope,
+        });
         while (admission.outcome === "deferred") {
           const budgetEvent: MessagingControllerDeliveryBudgetEvent = {
             at: this.now(),
@@ -4369,7 +4372,11 @@ export class MessagingController {
           });
           this.notifyDeliveryBudgetEvent(budgetEvent);
           await sleepUntil(admission.retryAt, this.now);
-          admission = this.deliveryBudget.admit({ priority, scope });
+          admission = this.deliveryBudget.admit({
+            consumeCapacity: consumeDeliveryBudget,
+            priority,
+            scope,
+          });
         }
         if (admission.outcome !== "admitted") {
           const budgetEvent: MessagingControllerDeliveryBudgetEvent = {
@@ -5017,7 +5024,7 @@ function shouldFlushToolUpdatesBeforeIntent(intent: MessagingSurfaceIntent): boo
   return true;
 }
 
-export function shouldApplyDeliveryBudget(intent: MessagingSurfaceIntent): boolean {
+export function shouldConsumeDeliveryBudget(intent: MessagingSurfaceIntent): boolean {
   return intent.kind !== "activity";
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
@@ -66,6 +66,7 @@ export class MessagingDeliveryBudget {
   }
 
   admit(request: {
+    consumeCapacity?: boolean;
     priority: MessagingDeliveryPriority;
     scope?: MessagingDeliveryScope;
   }): MessagingDeliveryAdmission {
@@ -92,6 +93,10 @@ export class MessagingDeliveryBudget {
 
     if (slowMode && SLOW_MODE_DROP_PRIORITIES.has(request.priority)) {
       return { outcome: "dropped", reason: "slow-mode", slowMode };
+    }
+
+    if (request.consumeCapacity === false) {
+      return { outcome: "admitted", slowMode };
     }
 
     if (!this.hasCapacity(request.scope, state, request.priority)) {


### PR DESCRIPTION
## Summary

This fixes the post-merge review finding where typing activity could bypass a provider cool-off window after the messaging budget change that stopped charging typing against the write budget.

The controller now still resolves the provider delivery scope for typing/activity intents, but admits those intents as non-consuming budget traffic. That preserves provider cool-off and existing Slow Mode drops while keeping typing indicators from spending Telegram send/edit budget.

## Changes

- Add `consumeCapacity` to `MessagingDeliveryBudget.admit()`.
- Resolve delivery scope for typing activity again in the controller.
- Rename the helper to `shouldConsumeDeliveryBudget()` so the semantics match the new behavior.
- Add controller and delivery-budget tests for non-consuming activity during cool-off, Slow Mode, and normal capacity checks.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
