### PR TITLE
feat(messaging): redesign handoff branch workflow

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -159,9 +159,13 @@ describe("MessagingController", () => {
         expect.objectContaining({ id: "browse:new:workspace:worktree" }),
         expect.objectContaining({ id: "browse:new:permissions" }),
         expect.objectContaining({ id: "browse:new:fast" }),
+        expect.objectContaining({ id: "browse:new:streaming" }),
         expect.objectContaining({ id: "browse:new:model" }),
         expect.objectContaining({ id: "browse:new:reasoning" }),
       ]),
+    });
+    expect(readyIntent).toMatchObject({
+      body: expect.stringContaining("Streaming: off"),
     });
     expect(readyIntent).toMatchObject({
       browseSessionId: expect.stringMatching(/^browse:/),
@@ -202,11 +206,67 @@ describe("MessagingController", () => {
     expect(binding).not.toHaveProperty("threadDisplay");
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
+      delivery: expect.objectContaining({
+        mode: "update",
+      }),
       text: expect.stringContaining("Project: PwrAgent"),
     });
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Thread started",
+      }),
+    );
     expect(harness.delivered.at(-1)).toMatchObject({
       text: expect.stringContaining("Directory: /repo/pwragent"),
     });
+  });
+
+  it("updates the ready prompt into the first status card without exhausting the DM budget", async () => {
+    let now = 0;
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:dm:chat-1",
+      kind: "dm",
+      budget: { limit: 1, intervalMs: 1000, reserved: 0 },
+    };
+    const budgetEvents: Array<
+      Parameters<NonNullable<MessagingControllerOptions["onDeliveryBudgetEvent"]>>[0]
+    > = [];
+    const harness = await createHarness({
+      deliveryBudget: new MessagingDeliveryBudget({ now: () => now }),
+      now: () => now,
+      onDeliveryBudgetEvent: (event) => budgetEvents.push(event),
+      resolveDeliveryScope: () => scope,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    now = 2000;
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    now = 4000;
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Thread started",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      delivery: expect.objectContaining({ mode: "update" }),
+    });
+    expect(budgetEvents).toEqual([]);
   });
 
   it("starts a new messaging thread in a new worktree from the selected base branch", async () => {
@@ -662,13 +722,13 @@ describe("MessagingController", () => {
         }),
         expect.objectContaining({
           id: "status:streaming",
-          label: "Stream: Default",
+          label: "Stream: Off",
           fallbackText: "stream",
         }),
       ]),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
-      text: expect.stringContaining("Streaming: Default"),
+      text: expect.stringContaining("Streaming: Off"),
     });
   });
 
@@ -712,17 +772,59 @@ describe("MessagingController", () => {
       buildCallbackEvent({ actionId: "status:streaming" }),
     );
 
-    const bindingAfterDefault = await harness.store.findActiveBindingForChannel(
+    const bindingAfterReenable = await harness.store.findActiveBindingForChannel(
       buildCommandEvent("/resume").channel,
     );
-    expect(bindingAfterDefault?.preferences?.streamingResponses).toBe("inherit");
+    expect(bindingAfterReenable?.preferences?.streamingResponses).toBe("enabled");
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Streaming: Default"),
+      text: expect.stringContaining("Streaming: On"),
       actions: expect.arrayContaining([
-        expect.objectContaining({ label: "Stream: Default" }),
+        expect.objectContaining({ label: "Stream: On" }),
       ]),
     });
+  });
+
+  it("shows and toggles the effective streaming default from the new-thread screen", async () => {
+    const harness = await createHarness({ streamingResponsesDefault: true });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Streaming: on"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:streaming",
+          label: "Stream: on",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:streaming" }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Start with streams off"));
+
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(binding?.preferences?.streamingResponses).toBe("disabled");
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "new-thread-1",
+      }),
+    );
   });
 
   it("updates the resume picker and removes actions when selecting a thread", async () => {
@@ -4985,6 +5087,7 @@ async function createHarness(options?: {
   channel?: MessagingChannelKind;
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+  streamingResponsesDefault?: boolean;
   /**
    * Set to `false` to construct the controller WITHOUT an
    * `onBindingChanged` callback. Used by tests that verify the
@@ -5199,6 +5302,7 @@ async function createHarness(options?: {
       ? {}
       : { onBindingChanged }),
     store,
+    streamingResponsesDefault: options?.streamingResponsesDefault,
     toolUpdateDefaultMode: options?.toolUpdateDefaultMode,
   });
   controllerRef = controller;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -154,6 +154,14 @@ describe("MessagingController", () => {
       kind: "confirmation",
       title: "Ready to start",
       body: expect.stringContaining("PwrAgent"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "browse:new:workspace:local", label: "Local ✓" }),
+        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
+        expect.objectContaining({ id: "browse:new:permissions" }),
+        expect.objectContaining({ id: "browse:new:fast" }),
+        expect.objectContaining({ id: "browse:new:model" }),
+        expect.objectContaining({ id: "browse:new:reasoning" }),
+      ]),
     });
     expect(readyIntent).toMatchObject({
       browseSessionId: expect.stringMatching(/^browse:/),
@@ -198,6 +206,88 @@ describe("MessagingController", () => {
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       text: expect.stringContaining("Directory: /repo/pwragent"),
+    });
+  });
+
+  it("starts a new messaging thread in a new worktree from the selected base branch", async () => {
+    const harness = await createHarness({
+      navigation: {
+        ...buildNavigationSnapshot(),
+        directories: [
+          {
+            ...buildNavigationSnapshot().directories[0]!,
+            gitStatus: {
+              currentBranch: "feature/current",
+              defaultBranch: "main",
+              branches: ["main", "release/v2", "feature/current"],
+            },
+          },
+        ],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:workspace:worktree",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Workspace: New Worktree"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:base-branch",
+          label: "Base: main",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:base-branch",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      title: "Pick base branch",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-base-branch",
+          label: "release/v2",
+          value: { branchName: "release/v2" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-base-branch",
+        value: { branchName: "release/v2" },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug in a worktree"));
+
+    expect(harness.startThread).toHaveBeenCalledWith({
+      backend: "codex",
+      cwd: "/repo/pwragent",
+      executionMode: "default",
+      fastMode: undefined,
+      model: undefined,
+      reasoningEffort: undefined,
+      serviceTier: undefined,
+      workMode: "worktree",
+      branchName: "release/v2",
     });
   });
 
@@ -4400,13 +4490,13 @@ describe("MessagingController", () => {
       prompt: expect.stringContaining("Workspace Handoff"),
       choices: expect.arrayContaining([
         expect.objectContaining({
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
+          id: "handoff:move-branch",
+          label: "Move Existing Branch",
         }),
       ]),
     });
 
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4486,7 +4576,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4532,6 +4622,51 @@ describe("MessagingController", () => {
         value: expect.objectContaining({ pageIndex: 0 }),
       }),
     );
+  });
+
+  it("runs a detached-head worktree handoff without asking for a leave-local branch", async () => {
+    const harness = await createHarness();
+    harness.getNavigationSnapshot.mockResolvedValue(buildLocalHandoffNavigationSnapshot());
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+    const createDetached = findChoice(harness.delivered.at(-1), "handoff:create-detached");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: createDetached.id,
+        value: createDetached.value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Confirm new detached-head worktree."),
+    });
+
+    const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
+    harness.getNavigationSnapshot.mockResolvedValue(buildWorktreeHandoffNavigationSnapshot());
+    harness.getNavigationSnapshot.mockResolvedValueOnce(
+      buildLocalHandoffNavigationSnapshot(),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: confirm.id,
+        value: confirm.value,
+      }),
+    );
+
+    expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      direction: "local-to-worktree",
+      strategy: "detached-changes",
+      repositoryPath: "/repo/pwragent",
+      sourceBranch: "feature/handoff",
+      sourcePath: "/repo/pwragent",
+      threadId: "thread-1",
+    });
   });
 
   it("runs a worktree-to-local handoff from the status menu", async () => {
@@ -4598,7 +4733,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4638,7 +4773,7 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:handoff" }),
     );
-    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:local-to-worktree");
+    const toWorktree = findChoice(harness.delivered.at(-1), "handoff:move-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: toWorktree.id,
@@ -4769,6 +4904,7 @@ async function createHarness(options?: {
   handoff?: false;
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
+  navigation?: NavigationSnapshot;
   now?: () => number;
   channel?: MessagingChannelKind;
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
@@ -4836,7 +4972,9 @@ async function createHarness(options?: {
       ? { setConversationTitle: options.setConversationTitle }
       : {}),
   };
-  const getNavigationSnapshot = vi.fn(async () => buildNavigationSnapshot());
+  const getNavigationSnapshot = vi.fn(
+    async () => options?.navigation ?? buildNavigationSnapshot(),
+  );
   const startThread = vi.fn(
     options?.startThread ??
       (async (request: StartThreadRequest) => ({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -264,7 +264,7 @@ describe("MessagingController", () => {
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:set-base-branch",
-          label: "release/v2",
+          label: "2. release/v2",
           value: { branchName: "release/v2" },
         }),
       ]),
@@ -289,6 +289,82 @@ describe("MessagingController", () => {
       workMode: "worktree",
       branchName: "release/v2",
     });
+  });
+
+  it("paginates the new-thread base branch picker", async () => {
+    const branches = Array.from({ length: 18 }, (_, index) => `branch-${index + 1}`);
+    const harness = await createHarness({
+      navigation: {
+        ...buildNavigationSnapshot(),
+        directories: [
+          {
+            ...buildNavigationSnapshot().directories[0]!,
+            gitStatus: {
+              currentBranch: "feature/current",
+              defaultBranch: "main",
+              branches,
+            },
+          },
+        ],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:workspace:worktree" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:base-branch" }),
+    );
+
+    const firstPage = harness.delivered.at(-1);
+    if (!firstPage || firstPage.kind !== "confirmation") {
+      throw new Error("Expected new-thread base branch picker");
+    }
+    expect(firstPage.body).toContain("Page 1/3.");
+    expect(
+      firstPage.actions.filter((action) => action.id === "browse:new:set-base-branch"),
+    ).toHaveLength(8);
+    expect(firstPage.actions).toContainEqual(
+      expect.objectContaining({
+        id: "browse:new:branches:next",
+        value: expect.objectContaining({ pageIndex: 1 }),
+      }),
+    );
+
+    const nextPage = findAction(firstPage, "browse:new:branches:next");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: nextPage.id,
+        value: nextPage.value,
+      }),
+    );
+
+    const secondPage = harness.delivered.at(-1);
+    if (!secondPage || secondPage.kind !== "confirmation") {
+      throw new Error("Expected second new-thread base branch picker page");
+    }
+    expect(secondPage.body).toContain("Page 2/3.");
+    expect(secondPage.actions[0]).toMatchObject({
+      id: "browse:new:set-base-branch",
+      label: "9. branch-8",
+    });
+    expect(secondPage.actions).toContainEqual(
+      expect.objectContaining({
+        id: "browse:new:branches:previous",
+        value: expect.objectContaining({ pageIndex: 0 }),
+      }),
+    );
   });
 
   it("cancels a pending new-thread prompt without creating a thread", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4847,6 +4847,40 @@ describe("MessagingController", () => {
     });
   });
 
+  it("offers detached-head handoff for a local checkout with no alternate branches", async () => {
+    const harness = await createHarness();
+    const navigation = buildLocalHandoffNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        currentBranch: "feature/handoff",
+        branches: ["feature/handoff"],
+        handoffBranches: [],
+      },
+    };
+    harness.getNavigationSnapshot.mockResolvedValue(navigation);
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:handoff" }),
+    );
+
+    const overview = harness.delivered.at(-1);
+    if (!overview || !("choices" in overview)) {
+      throw new Error("Expected handoff overview");
+    }
+    expect(overview.choices).not.toContainEqual(
+      expect.objectContaining({ id: "handoff:move-branch" }),
+    );
+    expect(overview.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:create-detached",
+        fallbackText: "1",
+      }),
+    );
+  });
+
   it("runs a worktree-to-local handoff from the status menu", async () => {
     const harness = await createHarness();
     harness.getNavigationSnapshot.mockResolvedValue(buildWorktreeHandoffNavigationSnapshot());

--- a/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
@@ -155,6 +155,48 @@ describe("MessagingDeliveryBudget", () => {
     });
   });
 
+  it("allows bursts within a sliding minute budget", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 60, reserved: 0 });
+
+    for (let index = 0; index < 20; index += 1) {
+      now = 1_000 + (index * 500);
+      expect(budget.admit({ scope, priority: "routine_status" })).toEqual({
+        outcome: "admitted",
+        slowMode: false,
+      });
+    }
+
+    expect(budget.isScopeInSlowMode(scope)).toBe(false);
+  });
+
+  it("enters slow mode when a sliding minute budget is exhausted", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    const scope = testScope({ limit: 60, reserved: 0 });
+
+    for (let index = 0; index < 60; index += 1) {
+      now = 1_000 + (index * 500);
+      expect(budget.admit({ scope, priority: "routine_status" })).toEqual({
+        outcome: "admitted",
+        slowMode: false,
+      });
+    }
+
+    now = 31_000;
+    expect(budget.admit({ scope, priority: "routine_status" })).toEqual({
+      outcome: "dropped",
+      reason: "budget-exhausted",
+      slowMode: true,
+    });
+    expect(budget.admit({ scope, priority: "stream_partial" })).toEqual({
+      outcome: "dropped",
+      reason: "slow-mode",
+      slowMode: true,
+    });
+  });
+
   it("keeps independent scopes from throttling each other", () => {
     const budget = new MessagingDeliveryBudget({ now: () => 1_000 });
     const first = testScope({ id: "telegram:group:1", limit: 1, reserved: 0 });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -382,8 +382,12 @@ describe("buildBindingStatusIntent", () => {
       prompt: expect.stringContaining("Workspace Handoff"),
       choices: expect.arrayContaining([
         expect.objectContaining({
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
+          id: "handoff:move-branch",
+          label: "Move Existing Branch",
+        }),
+        expect.objectContaining({
+          id: "handoff:create-detached",
+          label: "Create Detached Head",
         }),
       ]),
     });
@@ -487,6 +491,7 @@ describe("buildBindingStatusIntent", () => {
         repositoryPath: "/repo/pwragent",
         sourceBranch: "feature/handoff",
         sourcePath: "/repo/pwragent",
+        strategy: "detached-changes",
         threadId: "thread-1",
       }),
     ).toEqual({
@@ -495,6 +500,7 @@ describe("buildBindingStatusIntent", () => {
       repositoryPath: "/repo/pwragent",
       sourceBranch: "feature/handoff",
       sourcePath: "/repo/pwragent",
+      strategy: "detached-changes",
       threadId: "thread-1",
     });
     expect(handoffRequestFromValue({ direction: "local-to-worktree" })).toBeUndefined();

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -462,6 +462,33 @@ describe("buildBindingStatusIntent", () => {
     });
   });
 
+  it("offers detached handoff without move-branch choices", () => {
+    const binding = buildBinding();
+    const context = {
+      ...buildHandoffContext(),
+      leaveLocalBranches: [],
+    };
+    const overview = buildHandoffOverviewIntent({
+      id: "handoff-overview-1",
+      binding,
+      context,
+      createdAt: 1000,
+    });
+
+    expect(overview.choices).not.toContainEqual(
+      expect.objectContaining({ id: "handoff:move-branch" }),
+    );
+    expect(overview.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:create-detached",
+        fallbackText: "1",
+        label: "Create Detached Head",
+        style: "primary",
+      }),
+    );
+    expect(overview.fallbackText).toContain("Reply with 1, Back, Refresh, or Cancel.");
+  });
+
   it("paginates handoff branch picker choices", () => {
     const binding = buildBinding();
     const context = {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -67,13 +67,47 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Reasoning: high");
     expect(intent.text).toContain("Fast mode: on");
     expect(intent.text).toContain("Permissions: Full Access");
-    expect(intent.text).toContain("Streaming: Default");
+    expect(intent.text).toContain("Streaming: Off");
     expect(intent.text).toContain("Context usage: unavailable");
     expect(intent.actions).toContainEqual(
       expect.objectContaining({
         id: "status:streaming",
-        label: "Stream: Default",
+        label: "Stream: Off",
         fallbackText: "stream",
+      }),
+    );
+  });
+
+  it("renders inherited streaming as on when the channel default is on", () => {
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1000,
+      threadId: "thread-1",
+      updatedAt: 1000,
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-1",
+      createdAt: 1000,
+      binding,
+      streamingResponsesDefault: true,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Streaming: On");
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "status:streaming",
+        label: "Stream: On",
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -39,6 +39,50 @@ afterEach(async () => {
 });
 
 describe("TelegramAdapter", () => {
+  it("uses a sliding minute delivery budget for direct messages", () => {
+    const adapter = new TelegramAdapter({
+      api: createApi() as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      now: () => 1000,
+      pollOnStart: false,
+    });
+
+    const scope = adapter.resolveDeliveryScope({
+      audit: {
+        actor: {
+          platformUserId: "42",
+        },
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+        occurredAt: 1000,
+      },
+      actions: [],
+      body: "Hello",
+      createdAt: 1000,
+      id: "intent-dm-budget",
+      kind: "confirmation",
+      title: "Hello",
+    });
+
+    expect(scope).toMatchObject({
+      id: "telegram:dm:777",
+      kind: "dm",
+      budget: {
+        limit: 60,
+        intervalMs: 60_000,
+      },
+    });
+  });
+
   it("registers a Telegram bot error handler for polling middleware failures", async () => {
     const api = createApi();
     const logger = {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1578,15 +1578,42 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    workMode?: NavigationLaunchpadDraft["workMode"];
+    branchName?: string;
     linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
-    const { backend, executionMode = "default", linkedDirectories, ...request } = params;
+    const {
+      backend,
+      executionMode = "default",
+      linkedDirectories,
+      workMode,
+      branchName,
+      ...request
+    } = params;
     const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
     const modelSettings = await this.resolveModelSettings(backend, request);
-    const cwd =
+    let cwd =
       backend === "codex" && !request.cwd?.trim()
         ? await this.createScratchProjectDirectory()
         : request.cwd;
+    let resolvedLinkedDirectories = linkedDirectories;
+    if (workMode === "worktree" && request.cwd?.trim()) {
+      const preparedWorkspace =
+        await this.gitDirectoryService.prepareLaunchpadWorkspace({
+          backend,
+          branchName,
+          directoryKind: "directory",
+          directoryLabel: path.basename(request.cwd) || request.cwd,
+          directoryPath: request.cwd,
+          workMode: "worktree",
+        });
+      cwd = preparedWorkspace.cwd;
+      resolvedLinkedDirectories = buildWorktreeLinkedDirectory({
+        label: path.basename(request.cwd) || request.cwd,
+        repositoryPath: preparedWorkspace.repositoryPath ?? request.cwd,
+        worktreePath: preparedWorkspace.cwd,
+      });
+    }
 
     const result = await this.getClient(backend, executionMode).startThread({
       ...request,
@@ -1609,11 +1636,18 @@ export class DesktopBackendRegistry {
         executionMode,
         ...modelSettings,
         linkedDirectories: (
-          linkedDirectories?.length ? linkedDirectories : buildLocalLinkedDirectory(cwd)
+          resolvedLinkedDirectories?.length ? resolvedLinkedDirectories : buildLocalLinkedDirectory(cwd)
         ).map(normalizeLinkedDirectoryKind),
         gitBranch: cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined,
       },
     );
+    if (workMode === "worktree") {
+      await this.recordCodexWorktreeOwnerThread({
+        backend,
+        threadId: result.threadId,
+        worktreePath: cwd,
+      });
+    }
     this.invalidateThreadListCache(backend);
 
     if (backend === "codex") {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -9,6 +9,7 @@ import type {
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
+  LaunchpadWorkMode,
   MessagingToolUpdateMode,
   NavigationDirectorySummary,
   NavigationSnapshot,
@@ -2463,6 +2464,147 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:workspace:local") {
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          workMode: "local",
+          branchName: undefined,
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:workspace:worktree") {
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          workMode: "worktree",
+          branchName: resolveNewThreadBaseBranch(nextSession, navigation),
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:base-branch") {
+      await this.presentNewThreadBranchPicker(nextSession, navigation, event);
+      return;
+    }
+    if (actionId === "browse:new:set-base-branch") {
+      const branchName = readStringValue(event.value, "branchName");
+      if (!branchName) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          workMode: "worktree",
+          branchName,
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:permissions") {
+      const currentMode =
+        nextSession.preferences?.executionMode ??
+        navigation.launchpadDefaults.executionMode;
+      const executionMode = currentMode === "full-access" ? "default" : "full-access";
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            executionMode,
+            permissionsMode: executionMode,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:fast") {
+      const fastMode = !(
+        nextSession.preferences?.fastMode ??
+        navigation.launchpadDefaults.fastMode ??
+        false
+      );
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            fastMode,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:model") {
+      await this.presentNewThreadModelPicker(
+        nextSession,
+        event,
+        navigation.launchpadDefaults.backend,
+      );
+      return;
+    }
+    if (actionId === "browse:new:set-model") {
+      const model = readStringValue(event.value, "model");
+      if (!model) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            model,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
+    if (actionId === "browse:new:reasoning") {
+      await this.presentNewThreadReasoningPicker(
+        nextSession,
+        event,
+        navigation.launchpadDefaults.backend,
+      );
+      return;
+    }
+    if (actionId === "browse:new:set-reasoning") {
+      const reasoningEffort = readStringValue(event.value, "reasoningEffort");
+      if (!reasoningEffort) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            reasoningEffort,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
     if (actionId === "browse:select-thread") {
       const target = selectThreadFromValue(event.value);
       if (!target) {
@@ -2616,18 +2758,29 @@ export class MessagingController {
         ...session,
         mode: "new_thread_options",
         pageIndex: 0,
+        workMode: session.workMode ?? navigation.launchpadDefaults.workMode ?? "local",
+        branchName: session.branchName,
         selectedProject: project,
         updatedAt: this.now(),
         expiresAt: this.now() + this.pendingIntentTtlMs,
       },
       event,
+      navigation,
     );
   }
 
   private async presentNewThreadPromptGate(
     session: MessagingBrowseSessionRecord,
     event: MessagingInboundEvent,
+    navigation?: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
   ): Promise<void> {
+    const snapshot = navigation ?? await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(snapshot, session.selectedProject)
+      : undefined;
+    const options = newThreadOptionsForSession(session, snapshot, directory);
     await this.options.store.upsertBrowseSession(session);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -2637,14 +2790,60 @@ export class MessagingController {
       delivery: session.surface
         ? {
             mode: "update",
-            replaceMarkup: true,
-          }
+          replaceMarkup: true,
+        }
         : undefined,
       title: "Ready to start",
-      body: `Send the first instruction for ${session.selectedProject?.label ?? "this project"}. The thread will be created when that message arrives.`,
-      fallbackText: "Send your first instruction, reply back to change the project, or reply cancel.",
+      body: newThreadPromptGateBody(session, options),
+      fallbackText: "Send your first instruction, or use the option buttons before sending it.",
       targetSurface: session.surface,
       actions: [
+        {
+          id: "browse:new:workspace:local",
+          label: options.workMode === "local" ? "Local ✓" : "Local",
+          style: options.workMode === "local" ? "primary" : "secondary",
+          fallbackText: "local",
+        },
+        {
+          id: "browse:new:workspace:worktree",
+          label: options.workMode === "worktree" ? "New Worktree ✓" : "New Worktree",
+          style: options.workMode === "worktree" ? "primary" : "secondary",
+          fallbackText: "worktree",
+        },
+        ...(options.workMode === "worktree"
+          ? [
+              {
+                id: "browse:new:base-branch",
+                label: `Base: ${options.branchName}`,
+                style: "secondary" as const,
+                fallbackText: "base",
+              },
+            ]
+          : []),
+        {
+          id: "browse:new:permissions",
+          label: `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
+          style: "secondary",
+          fallbackText: "permissions",
+        },
+        {
+          id: "browse:new:fast",
+          label: options.fastMode ? "Fast: on" : "Fast: off",
+          style: "secondary",
+          fallbackText: "fast",
+        },
+        {
+          id: "browse:new:model",
+          label: "Model",
+          style: "secondary",
+          fallbackText: "model",
+        },
+        {
+          id: "browse:new:reasoning",
+          label: `Reasoning: ${options.reasoningEffort}`,
+          style: "secondary",
+          fallbackText: "reasoning",
+        },
         {
           id: "browse:mode:new",
           label: "Back",
@@ -2682,6 +2881,184 @@ export class MessagingController {
     });
   }
 
+  private async presentNewThreadBranchPicker(
+    session: MessagingBrowseSessionRecord,
+    navigation: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const branches = newThreadBranchChoices(session, navigation, directory);
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-branch"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? {
+            mode: "update",
+            replaceMarkup: true,
+          }
+        : undefined,
+      title: "Pick base branch",
+      body: `New worktree base for ${session.selectedProject?.label ?? "this project"}.`,
+      fallbackText: "Choose a branch, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...branches.map((branch, index) => ({
+          id: "browse:new:set-base-branch",
+          label: branch,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { branchName: branch },
+        })),
+        {
+          id: "browse:new:workspace:worktree",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+        {
+          id: "browse:cancel",
+          label: "Cancel",
+          style: "secondary" as const,
+          fallbackText: "cancel",
+          priority: 2,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async presentNewThreadModelPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    backend: AppServerBackendKind,
+  ): Promise<void> {
+    const summary = await this.getBackendSummary(backend);
+    const models = summary?.launchpadOptions?.models ?? [];
+    if (models.length === 0) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-models-unavailable"),
+          createdAt: this.now(),
+          title: "Models unavailable",
+          body: "This backend did not report model choices.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-model"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select model",
+      body: "Choose the model for the new thread.",
+      fallbackText: "Choose a model, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...models.map((model, index) => ({
+          id: "browse:new:set-model",
+          label: model.label ?? model.id,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { model: model.id },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async presentNewThreadReasoningPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    backend: AppServerBackendKind,
+  ): Promise<void> {
+    const summary = await this.getBackendSummary(backend);
+    const efforts = summary?.launchpadOptions?.reasoningEfforts ?? [
+      "low",
+      "medium",
+      "high",
+    ];
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-reasoning"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select reasoning",
+      body: "Choose the reasoning effort for the new thread.",
+      fallbackText: "Choose a reasoning option, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...efforts.map((effort, index) => ({
+          id: "browse:new:set-reasoning",
+          label: effort,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { reasoningEffort: effort },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
   private async createNewThreadFromPromptBundle(
     bundle: PendingNewThreadPromptBundle,
   ): Promise<void> {
@@ -2716,15 +3093,22 @@ export class MessagingController {
     const project = bundle.session.selectedProject;
     const directory = directoryForProjectSelection(navigation, project);
     const preferences = bundle.session.preferences;
+    const options = newThreadOptionsForSession(bundle.session, navigation, directory);
     const started = await this.options.backend.startThread({
       backend: navigation.launchpadDefaults.backend,
       cwd: directory?.path ?? project.path,
-      executionMode: preferences?.executionMode ?? navigation.launchpadDefaults.executionMode,
+      executionMode: options.executionMode,
       fastMode: preferences?.fastMode ?? navigation.launchpadDefaults.fastMode,
       model: preferences?.model ?? navigation.launchpadDefaults.model,
       reasoningEffort:
         preferences?.reasoningEffort ?? navigation.launchpadDefaults.reasoningEffort,
       serviceTier: preferences?.serviceTier ?? navigation.launchpadDefaults.serviceTier,
+      ...(options.workMode === "worktree"
+        ? {
+            workMode: "worktree" as const,
+            branchName: options.branchName,
+          }
+        : {}),
     });
     const binding = await this.bindChannelToThread(event, {
       backend: started.backend,
@@ -2742,6 +3126,7 @@ export class MessagingController {
       preferences,
       project,
       threadId: started.threadId,
+      workMode: options.workMode,
     });
     await this.options.store.deleteBrowseSession(bundle.session.id);
     await this.deliver(
@@ -2841,8 +3226,12 @@ export class MessagingController {
       await this.renderBindingStatus(binding, event);
       return;
     }
-    if (actionId === "handoff:local-to-worktree") {
+    if (actionId === "handoff:move-branch" || actionId === "handoff:local-to-worktree") {
       await this.presentHandoffBranchPicker(binding, event);
+      return;
+    }
+    if (actionId === "handoff:create-detached") {
+      await this.presentHandoffConfirmation(binding, event);
       return;
     }
     if (
@@ -3032,6 +3421,7 @@ export class MessagingController {
           context,
           createdAt: this.now(),
           leaveLocalBranch: request.leaveLocalBranch,
+          strategy: request.strategy,
         }),
         audit: this.buildHandoffAudit(
           `handoff.confirmation.${request.direction}`,
@@ -4950,6 +5340,9 @@ function validateHandoffRequest(
     };
   }
   if (request.direction === "local-to-worktree") {
+    if (request.strategy === "detached-changes") {
+      return { valid: true };
+    }
     if (!request.leaveLocalBranch) {
       return {
         valid: false,
@@ -4984,6 +5377,100 @@ function handoffSuccessText(result: HandoffThreadWorkspaceResponse): string {
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
+}
+
+type NewThreadOptionsSummary = {
+  branchName: string;
+  executionMode: ThreadExecutionMode;
+  fastMode: boolean;
+  model: string;
+  reasoningEffort: string;
+  workMode: LaunchpadWorkMode;
+};
+
+function newThreadOptionsForSession(
+  session: MessagingBrowseSessionRecord,
+  navigation: NavigationSnapshot,
+  directory: NavigationDirectorySummary | undefined,
+): NewThreadOptionsSummary {
+  const workMode = session.workMode ?? navigation.launchpadDefaults.workMode ?? "local";
+  return {
+    branchName: resolveNewThreadBaseBranch(session, navigation, directory),
+    executionMode:
+      session.preferences?.executionMode ?? navigation.launchpadDefaults.executionMode,
+    fastMode:
+      session.preferences?.fastMode ?? navigation.launchpadDefaults.fastMode ?? false,
+    model:
+      session.preferences?.model ?? navigation.launchpadDefaults.model ?? "default",
+    reasoningEffort:
+      session.preferences?.reasoningEffort ??
+      navigation.launchpadDefaults.reasoningEffort ??
+      "medium",
+    workMode,
+  };
+}
+
+function newThreadPromptGateBody(
+  session: MessagingBrowseSessionRecord,
+  options: NewThreadOptionsSummary,
+): string {
+  return [
+    `Send the first instruction for ${session.selectedProject?.label ?? "this project"}.`,
+    "The thread will be created when that message arrives.",
+    `Workspace: ${options.workMode === "worktree" ? "New Worktree" : "Local"}`,
+    options.workMode === "worktree" ? `Base branch: ${options.branchName}` : undefined,
+    `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
+    `Model: ${options.model}`,
+    `Reasoning: ${options.reasoningEffort}`,
+    `Fast mode: ${options.fastMode ? "on" : "off"}`,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+function formatPermissionsShortLabel(mode: ThreadExecutionMode): string {
+  return mode === "full-access" ? "Full" : "Default";
+}
+
+function resolveNewThreadBaseBranch(
+  session: MessagingBrowseSessionRecord,
+  navigation: NavigationSnapshot,
+  directory?: NavigationDirectorySummary,
+): string {
+  const selectedDirectory =
+    directory ??
+    (session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined);
+  return (
+    sanitizeBranchLabel(session.branchName) ??
+    sanitizeBranchLabel(selectedDirectory?.gitStatus?.defaultBranch) ??
+    sanitizeBranchLabel(selectedDirectory?.gitStatus?.branches?.[0]) ??
+    sanitizeBranchLabel(selectedDirectory?.gitStatus?.currentBranch) ??
+    "main"
+  );
+}
+
+function newThreadBranchChoices(
+  session: MessagingBrowseSessionRecord,
+  navigation: NavigationSnapshot,
+  directory: NavigationDirectorySummary | undefined,
+): string[] {
+  const defaultBranch = resolveNewThreadBaseBranch(session, navigation, directory);
+  const branches = [
+    defaultBranch,
+    ...(directory?.gitStatus?.branches ?? []),
+    directory?.gitStatus?.currentBranch,
+  ].flatMap((branch) => {
+    const sanitized = sanitizeBranchLabel(branch);
+    return sanitized ? [sanitized] : [];
+  });
+  return branches.filter((branch, index) => branches.indexOf(branch) === index);
+}
+
+function sanitizeBranchLabel(branch: string | undefined): string | undefined {
+  const normalized = branch?.replace(/^refs\/heads\//, "").trim();
+  return normalized || undefined;
 }
 
 function normalizeConversationTitle(title: string | undefined): string | undefined {
@@ -5497,6 +5984,7 @@ function navigationWithStartedThread(params: {
   preferences?: MessagingBrowseSessionRecord["preferences"];
   project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
   threadId: ThreadIdentifier;
+  workMode?: LaunchpadWorkMode;
 }): NavigationSnapshot {
   const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
   if (
@@ -5511,9 +5999,10 @@ function navigationWithStartedThread(params: {
   const linkedDirectory: LinkedDirectorySummary | undefined = directoryPath
     ? {
         id: params.directory?.key ?? directoryPath,
-        kind: "local",
+        kind: params.workMode === "worktree" ? "worktree" : "local",
         label: params.directory?.label ?? params.project.label,
         path: directoryPath,
+        ...(params.workMode === "worktree" ? { worktreePath: directoryPath } : {}),
       }
     : undefined;
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -75,6 +75,7 @@ import {
 } from "./messaging-resume-browser.js";
 import {
   buildBindingStatusIntent,
+  buildBranchPickerPage,
   buildHandoffBranchPickerIntent,
   buildHandoffConfirmationIntent,
   buildHandoffOverviewIntent,
@@ -2492,6 +2493,18 @@ export class MessagingController {
       await this.presentNewThreadBranchPicker(nextSession, navigation, event);
       return;
     }
+    if (
+      actionId === "browse:new:branches:next" ||
+      actionId === "browse:new:branches:previous"
+    ) {
+      await this.presentNewThreadBranchPicker(
+        nextSession,
+        navigation,
+        event,
+        branchPageIndexFromValue(event.value),
+      );
+      return;
+    }
     if (actionId === "browse:new:set-base-branch") {
       const branchName = readStringValue(event.value, "branchName");
       if (!branchName) {
@@ -2885,11 +2898,23 @@ export class MessagingController {
     session: MessagingBrowseSessionRecord,
     navigation: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
     event: MessagingInboundEvent,
+    pageIndex = 0,
   ): Promise<void> {
     const directory = session.selectedProject
       ? directoryForProjectSelection(navigation, session.selectedProject)
       : undefined;
     const branches = newThreadBranchChoices(session, navigation, directory);
+    const page = buildBranchPickerPage({
+      branches,
+      branchActionId: "browse:new:set-base-branch",
+      branchValue: (branchName) => ({ branchName }),
+      capabilityProfile: this.capabilityProfile,
+      navActionCountBase: 2,
+      navActionCountMultipage: 4,
+      nextActionId: "browse:new:branches:next",
+      pageIndex,
+      previousActionId: "browse:new:branches:previous",
+    });
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-branch"),
       capabilityProfile: this.capabilityProfile,
@@ -2902,18 +2927,22 @@ export class MessagingController {
           }
         : undefined,
       title: "Pick base branch",
-      body: `New worktree base for ${session.selectedProject?.label ?? "this project"}.`,
-      fallbackText: "Choose a branch, or reply back.",
+      body: [
+        `New worktree base for ${session.selectedProject?.label ?? "this project"}.`,
+        page.totalPages > 1
+          ? `Page ${page.pageIndex + 1}/${page.totalPages}.`
+          : undefined,
+      ]
+        .filter((line): line is string => Boolean(line))
+        .join("\n"),
+      fallbackText: [
+        "Choose a branch, or reply back.",
+        ...page.branchChoices.map((choice) => choice.label),
+      ].join("\n"),
       targetSurface: session.surface,
       actions: [
-        ...branches.map((branch, index) => ({
-          id: "browse:new:set-base-branch",
-          label: branch,
-          style: "secondary" as const,
-          fallbackText: String(index + 1),
-          priority: 10 + index,
-          value: { branchName: branch },
-        })),
+        ...page.branchChoices,
+        ...page.pageActions,
         {
           id: "browse:new:workspace:worktree",
           label: "Back",
@@ -3241,7 +3270,7 @@ export class MessagingController {
       await this.presentHandoffBranchPicker(
         binding,
         event,
-        handoffBranchPageIndexFromValue(event.value),
+        branchPageIndexFromValue(event.value),
       );
       return;
     }
@@ -5293,7 +5322,7 @@ function handoffContextForBinding(
   };
 }
 
-function handoffBranchPageIndexFromValue(value: MessagingJsonValue | undefined): number {
+function branchPageIndexFromValue(value: MessagingJsonValue | undefined): number {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return 0;
   }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -285,6 +285,7 @@ export type MessagingControllerOptions = {
   pendingIntentTtlMs?: number;
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
+  streamingResponsesDefault?: boolean;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
   deliveryBudget?: MessagingDeliveryBudget;
   onDeliveryBudgetEvent?: (event: MessagingControllerDeliveryBudgetEvent) => void;
@@ -312,6 +313,7 @@ export class MessagingController {
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
+  private readonly streamingResponsesDefault: boolean;
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
@@ -336,6 +338,7 @@ export class MessagingController {
     this.interactionMapper = options.interactionMapper ?? new DeterministicInteractionMapper();
     this.deliveryBudget = options.deliveryBudget;
     this.logger = options.logger ?? messagingControllerLog;
+    this.streamingResponsesDefault = options.streamingResponsesDefault ?? false;
     this.turnAdmission = new MessagingTurnAdmission({
       debounceMs: options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS,
       now: this.now,
@@ -2562,6 +2565,25 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:streaming") {
+      const streamingResponses = nextMessagingStreamingResponseMode(
+        nextSession.preferences?.streamingResponses ?? "inherit",
+        this.streamingResponsesDefault,
+      );
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            streamingResponses,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
     if (actionId === "browse:new:model") {
       await this.presentNewThreadModelPicker(
         nextSession,
@@ -2793,7 +2815,12 @@ export class MessagingController {
     const directory = session.selectedProject
       ? directoryForProjectSelection(snapshot, session.selectedProject)
       : undefined;
-    const options = newThreadOptionsForSession(session, snapshot, directory);
+    const options = newThreadOptionsForSession(
+      session,
+      snapshot,
+      directory,
+      this.streamingResponsesDefault,
+    );
     await this.options.store.upsertBrowseSession(session);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -2844,6 +2871,12 @@ export class MessagingController {
           label: options.fastMode ? "Fast: on" : "Fast: off",
           style: "secondary",
           fallbackText: "fast",
+        },
+        {
+          id: "browse:new:streaming",
+          label: options.streamingResponses ? "Stream: on" : "Stream: off",
+          style: "secondary",
+          fallbackText: "stream",
         },
         {
           id: "browse:new:model",
@@ -3122,7 +3155,12 @@ export class MessagingController {
     const project = bundle.session.selectedProject;
     const directory = directoryForProjectSelection(navigation, project);
     const preferences = bundle.session.preferences;
-    const options = newThreadOptionsForSession(bundle.session, navigation, directory);
+    const options = newThreadOptionsForSession(
+      bundle.session,
+      navigation,
+      directory,
+      this.streamingResponsesDefault,
+    );
     const started = await this.options.backend.startThread({
       backend: navigation.launchpadDefaults.backend,
       cwd: directory?.path ?? project.path,
@@ -3143,9 +3181,16 @@ export class MessagingController {
       backend: started.backend,
       threadId: started.threadId,
     });
-    const updatedBinding = preferences
+    let updatedBinding = preferences
       ? await this.updateBindingPreferences(binding, preferences)
       : binding;
+    if (bundle.session.surface) {
+      updatedBinding = await this.options.store.upsertBinding({
+        ...updatedBinding,
+        statusSurface: bundle.session.surface,
+        updatedAt: this.now(),
+      });
+    }
     const optimisticNavigation = navigationWithStartedThread({
       backend: started.backend,
       directory,
@@ -3158,25 +3203,6 @@ export class MessagingController {
       workMode: options.workMode,
     });
     await this.options.store.deleteBrowseSession(bundle.session.id);
-    await this.deliver(
-      buildConfirmationIntent({
-        id: this.newIntentId("new-thread-bound"),
-        capabilityProfile: this.capabilityProfile,
-        createdAt: this.now(),
-        delivery: bundle.session.surface
-          ? {
-              mode: "update",
-              replaceMarkup: true,
-            }
-          : undefined,
-        title: "Thread started",
-        body: `Started and bound a new thread for ${project.label}.`,
-        fallbackText: "Started the thread with your first instruction.",
-        targetSurface: bundle.session.surface,
-      }),
-      undefined,
-      event,
-    );
     await this.startPreparedInput({
       binding: updatedBinding,
       input: prepared.input,
@@ -4103,7 +4129,10 @@ export class MessagingController {
   ): Promise<void> {
     const currentMode = resolveMessagingStreamingResponseMode(binding);
     const updatedBinding = await this.updateBindingPreferences(binding, {
-      streamingResponses: nextMessagingStreamingResponseMode(currentMode),
+      streamingResponses: nextMessagingStreamingResponseMode(
+        currentMode,
+        this.streamingResponsesDefault,
+      ),
     });
     await this.renderBindingStatus(updatedBinding, event);
   }
@@ -4365,6 +4394,7 @@ export class MessagingController {
       handoff: this.options.backend.handoffThreadWorkspace
         ? handoffContextForBinding(binding, snapshot)
         : undefined,
+      streamingResponsesDefault: this.streamingResponsesDefault,
       threadState: resolveMessagingThreadState({
         activeTurn,
         binding,
@@ -5414,6 +5444,7 @@ type NewThreadOptionsSummary = {
   fastMode: boolean;
   model: string;
   reasoningEffort: string;
+  streamingResponses: boolean;
   workMode: LaunchpadWorkMode;
 };
 
@@ -5421,8 +5452,10 @@ function newThreadOptionsForSession(
   session: MessagingBrowseSessionRecord,
   navigation: NavigationSnapshot,
   directory: NavigationDirectorySummary | undefined,
+  streamingResponsesDefault: boolean,
 ): NewThreadOptionsSummary {
   const workMode = session.workMode ?? navigation.launchpadDefaults.workMode ?? "local";
+  const streamingMode = session.preferences?.streamingResponses ?? "inherit";
   return {
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
     executionMode:
@@ -5435,6 +5468,10 @@ function newThreadOptionsForSession(
       session.preferences?.reasoningEffort ??
       navigation.launchpadDefaults.reasoningEffort ??
       "medium",
+    streamingResponses:
+      streamingMode === "inherit"
+        ? streamingResponsesDefault
+        : streamingMode === "enabled",
     workMode,
   };
 }
@@ -5452,6 +5489,7 @@ function newThreadPromptGateBody(
     `Model: ${options.model}`,
     `Reasoning: ${options.reasoningEffort}`,
     `Fast mode: ${options.fastMode ? "on" : "off"}`,
+    `Streaming: ${options.streamingResponses ? "on" : "off"}`,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -5335,9 +5335,6 @@ function handoffContextForBinding(
     (candidate, index, branches) =>
       candidate !== branch && branches.indexOf(candidate) === index,
   );
-  if (leaveLocalBranches.length === 0) {
-    return undefined;
-  }
 
   return {
     backend: binding.backend,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -51,6 +51,7 @@ export function buildBindingStatusIntent(params: {
   createdAt: number;
   handoff?: MessagingWorkspaceHandoffContext;
   id: string;
+  streamingResponsesDefault?: boolean;
   threadState: MessagingResolvedThreadState;
   toolUpdateMode?: MessagingToolUpdateMode;
 }): MessagingStatusIntent {
@@ -89,6 +90,10 @@ export function buildBindingStatusIntent(params: {
     params.toolUpdateMode,
   );
   const streamingMode = resolveMessagingStreamingResponseMode(params.binding);
+  const streamingLabel = formatMessagingStreamingResponseModeLabel(
+    streamingMode,
+    params.streamingResponsesDefault,
+  );
 
   return {
     id: params.id,
@@ -115,7 +120,7 @@ export function buildBindingStatusIntent(params: {
       "Plan mode: unavailable",
       `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
-      `Streaming: ${formatMessagingStreamingResponseModeLabel(streamingMode)}`,
+      `Streaming: ${streamingLabel}`,
       "Context usage: unavailable",
       "Account: unavailable",
       "Rate limits: unavailable",
@@ -132,6 +137,7 @@ export function buildBindingStatusIntent(params: {
       queuedExecutionMode,
       reasoning,
       streamingMode,
+      streamingResponsesDefault: params.streamingResponsesDefault,
       toolUpdateMode,
     }),
   };
@@ -145,6 +151,7 @@ function buildStatusActions(params: {
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning: string;
   streamingMode: MessagingStreamingResponseMode;
+  streamingResponsesDefault?: boolean;
   toolUpdateMode: MessagingToolUpdateMode;
 }): MessagingSurfaceAction[] {
   const profile = params.capabilityProfile;
@@ -205,7 +212,10 @@ function buildStatusActions(params: {
     },
     {
       id: "status:streaming",
-      label: `Stream: ${formatMessagingStreamingResponseModeLabel(params.streamingMode)}`,
+      label: `Stream: ${formatMessagingStreamingResponseModeLabel(
+        params.streamingMode,
+        params.streamingResponsesDefault,
+      )}`,
       style: "secondary",
       fallbackText: "stream",
       priority: 10,
@@ -313,23 +323,25 @@ export function resolveMessagingStreamingResponseMode(
 
 export function nextMessagingStreamingResponseMode(
   mode: MessagingStreamingResponseMode,
+  streamingResponsesDefault = false,
 ): MessagingStreamingResponseMode {
   switch (mode) {
     case "inherit":
-      return "enabled";
+      return streamingResponsesDefault ? "disabled" : "enabled";
     case "enabled":
       return "disabled";
     case "disabled":
-      return "inherit";
+      return "enabled";
   }
 }
 
 export function formatMessagingStreamingResponseModeLabel(
   mode: MessagingStreamingResponseMode,
+  streamingResponsesDefault = false,
 ): string {
   switch (mode) {
     case "inherit":
-      return "Default";
+      return streamingResponsesDefault ? "On" : "Off";
     case "disabled":
       return "Off";
     case "enabled":

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -373,39 +373,39 @@ export function buildHandoffOverviewIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingSingleSelectIntent {
-  const actions =
-    params.context.workspaceKind === "local"
-      ? [
-          {
-            id: "handoff:move-branch",
-            label: "Move Existing Branch",
-            fallbackText: "1",
-            style: "primary" as const,
-            value: {
-              ...handoffValue(params.context),
-              strategy: "move-branch",
-            },
-          },
-          {
-            id: "handoff:create-detached",
-            label: "Create Detached Head",
-            fallbackText: "2",
-            style: "secondary" as const,
-            value: {
-              ...handoffValue(params.context),
-              strategy: "detached-changes",
-            },
-          },
-        ]
-      : [
-          {
-            id: "handoff:worktree-to-local",
-            label: "Handoff to Local",
-            fallbackText: "1",
-            style: "primary" as const,
-            value: handoffValue(params.context),
-          },
-        ];
+  const actions: MessagingSurfaceAction[] = [];
+  if (params.context.workspaceKind === "local") {
+    if (params.context.leaveLocalBranches.length > 0) {
+      actions.push({
+        id: "handoff:move-branch",
+        label: "Move Existing Branch",
+        fallbackText: String(actions.length + 1),
+        style: "primary",
+        value: {
+          ...handoffValue(params.context),
+          strategy: "move-branch",
+        },
+      });
+    }
+    actions.push({
+      id: "handoff:create-detached",
+      label: "Create Detached Head",
+      fallbackText: String(actions.length + 1),
+      style: actions.length === 0 ? "primary" : "secondary",
+      value: {
+        ...handoffValue(params.context),
+        strategy: "detached-changes",
+      },
+    });
+  } else {
+    actions.push({
+      id: "handoff:worktree-to-local",
+      label: "Handoff to Local",
+      fallbackText: "1",
+      style: "primary",
+      value: handoffValue(params.context),
+    });
+  }
 
   return {
     id: params.id,
@@ -420,7 +420,7 @@ export function buildHandoffOverviewIntent(params: {
     fallbackText: [
       handoffOverviewText(params.context),
       ...actions.map((action, index) => `${index + 1}. ${action.label}`),
-      `Reply with ${actions.length === 1 ? "1" : "1 or 2"}, Back, Refresh, or Cancel.`,
+      `Reply with ${actions.map((_, index) => index + 1).join(" or ")}, Back, Refresh, or Cancel.`,
     ].join("\n"),
     prompt: handoffOverviewText(params.context),
     choices: applyActionCapabilityLimits(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -42,7 +42,8 @@ export type MessagingWorkspaceHandoffContext = {
   workspaceKind: "local" | "worktree";
 };
 
-export const HANDOFF_BRANCH_PAGE_SIZE = 8;
+export const BRANCH_PICKER_PAGE_SIZE = 8;
+export const HANDOFF_BRANCH_PAGE_SIZE = BRANCH_PICKER_PAGE_SIZE;
 
 export function buildBindingStatusIntent(params: {
   binding: MessagingBindingRecord;
@@ -445,6 +446,99 @@ export function buildHandoffOverviewIntent(params: {
   };
 }
 
+export function buildBranchPickerPage(params: {
+  branches: string[];
+  branchActionId: string;
+  branchValue: (branch: string) => MessagingJsonValue;
+  capabilityProfile?: MessagingCapabilityProfile;
+  maxPageSize?: number;
+  navActionCountBase?: number;
+  navActionCountMultipage?: number;
+  nextActionId: string;
+  pageIndex?: number;
+  pageSize?: number;
+  pageValue?: (pageIndex: number) => MessagingJsonValue;
+  previousActionId: string;
+}): {
+  branchChoices: MessagingSurfaceAction[];
+  pageActions: MessagingSurfaceAction[];
+  pageIndex: number;
+  pageSize: number;
+  totalPages: number;
+} {
+  const navActionCountBase = params.navActionCountBase ?? 3;
+  const navActionCountMultipage = params.navActionCountMultipage ?? 5;
+  const maxPageSize = params.maxPageSize ?? BRANCH_PICKER_PAGE_SIZE;
+  const totalBranches = params.branches.length;
+  const profilePageSize = (navActionCount: number): number =>
+    params.capabilityProfile
+      ? capabilityProfilePageSize(
+          params.capabilityProfile,
+          navActionCount,
+          maxPageSize,
+        )
+      : maxPageSize;
+  const singlePagePageSize = profilePageSize(navActionCountBase);
+  const pageSize = Math.max(
+    1,
+    params.pageSize
+      ?? (totalBranches <= singlePagePageSize
+        ? singlePagePageSize
+        : profilePageSize(navActionCountMultipage)),
+  );
+  const totalPages = Math.max(1, Math.ceil(totalBranches / pageSize));
+  const pageIndex = clampPageIndex(params.pageIndex ?? 0, totalPages);
+  const pageStart = pageIndex * pageSize;
+  const pageBranches = params.branches.slice(pageStart, pageStart + pageSize);
+  const pageValue = params.pageValue ?? ((index) => ({ pageIndex: index }));
+
+  const branchChoices = pageBranches.map((branch, index) => {
+    const branchNumber = pageStart + index + 1;
+    return {
+      id: params.branchActionId,
+      label: `${branchNumber}. ${branch}`,
+      fallbackText: String(branchNumber),
+      style: "secondary" as const,
+      priority: 100 + index,
+      value: params.branchValue(branch),
+    };
+  });
+  const pageActions: MessagingSurfaceAction[] = [
+    ...(pageIndex > 0
+      ? [
+          {
+            id: params.previousActionId,
+            label: "Previous",
+            fallbackText: "previous",
+            style: "secondary" as const,
+            priority: 4,
+            value: pageValue(pageIndex - 1),
+          },
+        ]
+      : []),
+    ...(pageIndex < totalPages - 1
+      ? [
+          {
+            id: params.nextActionId,
+            label: "Next",
+            fallbackText: "next",
+            style: "secondary" as const,
+            priority: 5,
+            value: pageValue(pageIndex + 1),
+          },
+        ]
+      : []),
+  ];
+
+  return {
+    branchChoices,
+    pageActions,
+    pageIndex,
+    pageSize,
+    totalPages,
+  };
+}
+
 export function buildHandoffBranchPickerIntent(params: {
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
@@ -454,96 +548,28 @@ export function buildHandoffBranchPickerIntent(params: {
   pageIndex?: number;
   pageSize?: number;
 }): MessagingSingleSelectIntent {
-  // Three nav buttons always render (Back/Refresh/Cancel). Previous/Next
-  // appear conditionally based on pagination — but pageSize must be a
-  // single value across all pages, so we plan for the worst case (a
-  // middle page with both Previous AND Next visible) when the picker
-  // actually paginates. For a single-page result we only need to reserve
-  // 3 nav slots, freeing 2 more for branches.
-  const NAV_ACTIONS_BASE = 3; // back, refresh, cancel
-  const NAV_ACTIONS_MULTIPAGE = 5; // + previous + next
-  const totalBranches = params.context.leaveLocalBranches.length;
-  const profilePageSize = (navActionCount: number): number =>
-    params.capabilityProfile
-      ? capabilityProfilePageSize(
-          params.capabilityProfile,
-          navActionCount,
-          HANDOFF_BRANCH_PAGE_SIZE,
-        )
-      : HANDOFF_BRANCH_PAGE_SIZE;
-  // First-pass page size assumes single-page (no Previous/Next). If the
-  // branches don't all fit on one page, recompute with the multi-page
-  // budget so middle pages still leave room for both nav buttons.
-  const singlePagePageSize = profilePageSize(NAV_ACTIONS_BASE);
-  const pageSize = Math.max(
-    1,
-    params.pageSize
-      ?? (totalBranches <= singlePagePageSize
-        ? singlePagePageSize
-        : profilePageSize(NAV_ACTIONS_MULTIPAGE)),
-  );
-  const totalPages = Math.max(1, Math.ceil(totalBranches / pageSize));
-  const pageIndex = clampPageIndex(params.pageIndex ?? 0, totalPages);
-  const pageStart = pageIndex * pageSize;
-  const pageBranches = params.context.leaveLocalBranches.slice(
-    pageStart,
-    pageStart + pageSize,
-  );
-  const branchChoices = pageBranches.map((branch, index) => {
-    const branchNumber = pageStart + index + 1;
-    return {
-      id: "handoff:select-leave-branch",
-      label: `${branchNumber}. ${branch}`,
-      fallbackText: String(branchNumber),
-      style: "secondary" as const,
-      // Branch entries are the lowest priority — under tight action
-      // budgets, drop branches before nav buttons. The page-size math
-      // should already prevent this from triggering, but the priority
-      // pass is the safety net.
-      priority: 100 + index,
-      value: {
-        ...handoffValue(params.context),
-        leaveLocalBranch: branch,
-      },
-    };
+  const page = buildBranchPickerPage({
+    branches: params.context.leaveLocalBranches,
+    branchActionId: "handoff:select-leave-branch",
+    branchValue: (branch) => ({
+      ...handoffValue(params.context),
+      leaveLocalBranch: branch,
+    }),
+    capabilityProfile: params.capabilityProfile,
+    nextActionId: "handoff:branches:next",
+    pageIndex: params.pageIndex,
+    pageSize: params.pageSize,
+    pageValue: (pageIndex) => ({
+      ...handoffValue(params.context),
+      pageIndex,
+    }),
+    previousActionId: "handoff:branches:previous",
   });
-  const pageActions: MessagingSurfaceAction[] = [
-    ...(pageIndex > 0
-      ? [
-          {
-            id: "handoff:branches:previous",
-            label: "Previous",
-            fallbackText: "previous",
-            style: "secondary" as const,
-            priority: 4,
-            value: {
-              ...handoffValue(params.context),
-              pageIndex: pageIndex - 1,
-            },
-          },
-        ]
-      : []),
-    ...(pageIndex < totalPages - 1
-      ? [
-          {
-            id: "handoff:branches:next",
-            label: "Next",
-            fallbackText: "next",
-            style: "secondary" as const,
-            priority: 5,
-            value: {
-              ...handoffValue(params.context),
-              pageIndex: pageIndex + 1,
-            },
-          },
-        ]
-      : []),
-  ];
 
   const choices = applyActionCapabilityLimits(
     [
-      ...branchChoices,
-      ...pageActions,
+      ...page.branchChoices,
+      ...page.pageActions,
       {
         id: "status:handoff",
         label: "Back",
@@ -582,15 +608,19 @@ export function buildHandoffBranchPickerIntent(params: {
     targetSurface: params.binding.statusSurface,
     fallbackText: [
       "Choose the branch that should remain checked out in Local.",
-      totalPages > 1 ? `Page ${pageIndex + 1}/${totalPages}.` : undefined,
-      ...branchChoices.map((choice) => choice.label),
+      page.totalPages > 1
+        ? `Page ${page.pageIndex + 1}/${page.totalPages}.`
+        : undefined,
+      ...page.branchChoices.map((choice) => choice.label),
       "Reply with a number, Back, Refresh, or Cancel.",
     ]
       .filter((line): line is string => Boolean(line))
       .join("\n"),
     prompt: [
       "Choose the branch that should remain checked out in Local.",
-      totalPages > 1 ? `Page ${pageIndex + 1}/${totalPages}.` : undefined,
+      page.totalPages > 1
+        ? `Page ${page.pageIndex + 1}/${page.totalPages}.`
+        : undefined,
       `Moving branch: ${params.context.branch ?? unavailable()}`,
       `Local: ${params.context.repositoryPath}`,
     ]

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -360,22 +360,39 @@ export function buildHandoffOverviewIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingSingleSelectIntent {
-  const action =
+  const actions =
     params.context.workspaceKind === "local"
-      ? {
-          id: "handoff:local-to-worktree",
-          label: "Handoff to New Worktree",
-          fallbackText: "1",
-          style: "primary" as const,
-          value: handoffValue(params.context),
-        }
-      : {
-          id: "handoff:worktree-to-local",
-          label: "Handoff to Local",
-          fallbackText: "1",
-          style: "primary" as const,
-          value: handoffValue(params.context),
-        };
+      ? [
+          {
+            id: "handoff:move-branch",
+            label: "Move Existing Branch",
+            fallbackText: "1",
+            style: "primary" as const,
+            value: {
+              ...handoffValue(params.context),
+              strategy: "move-branch",
+            },
+          },
+          {
+            id: "handoff:create-detached",
+            label: "Create Detached Head",
+            fallbackText: "2",
+            style: "secondary" as const,
+            value: {
+              ...handoffValue(params.context),
+              strategy: "detached-changes",
+            },
+          },
+        ]
+      : [
+          {
+            id: "handoff:worktree-to-local",
+            label: "Handoff to Local",
+            fallbackText: "1",
+            style: "primary" as const,
+            value: handoffValue(params.context),
+          },
+        ];
 
   return {
     id: params.id,
@@ -389,13 +406,13 @@ export function buildHandoffOverviewIntent(params: {
     targetSurface: params.binding.statusSurface,
     fallbackText: [
       handoffOverviewText(params.context),
-      `1. ${action.label}`,
-      "Reply with 1, Back, Refresh, or Cancel.",
+      ...actions.map((action, index) => `${index + 1}. ${action.label}`),
+      `Reply with ${actions.length === 1 ? "1" : "1 or 2"}, Back, Refresh, or Cancel.`,
     ].join("\n"),
     prompt: handoffOverviewText(params.context),
     choices: applyActionCapabilityLimits(
       [
-        action,
+        ...actions,
         {
           // Back from the handoff overview returns to the status card.
           // Distinct id from the sibling "Refresh" button so callback
@@ -597,13 +614,16 @@ export function buildHandoffConfirmationIntent(params: {
   createdAt: number;
   id: string;
   leaveLocalBranch?: string;
+  strategy?: HandoffThreadWorkspaceRequest["strategy"];
 }): MessagingConfirmationIntent {
   const direction =
     params.context.workspaceKind === "local" ? "local-to-worktree" : "worktree-to-local";
   const body = [
-    direction === "local-to-worktree"
-      ? "Confirm handoff to a new worktree."
-      : "Confirm handoff to Local.",
+    params.strategy === "detached-changes"
+      ? "Confirm new detached-head worktree."
+      : direction === "local-to-worktree"
+        ? "Confirm moving this branch to a new worktree."
+        : "Confirm handoff to Local.",
     `Thread: ${params.context.threadTitle ?? params.context.threadId} (${params.context.backend})`,
     `Project: ${params.context.projectLabel ?? unavailable()}`,
     `Repository: ${params.context.repositoryPath}`,
@@ -612,6 +632,7 @@ export function buildHandoffConfirmationIntent(params: {
     params.leaveLocalBranch
       ? `Leave Local on: ${params.leaveLocalBranch}`
       : undefined,
+    params.strategy ? `Strategy: ${params.strategy}` : undefined,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
@@ -639,6 +660,7 @@ export function buildHandoffConfirmationIntent(params: {
           priority: 1,
           value: {
             ...handoffValue(params.context),
+            ...(params.strategy ? { strategy: params.strategy } : {}),
             ...(params.leaveLocalBranch
               ? { leaveLocalBranch: params.leaveLocalBranch }
               : {}),
@@ -646,7 +668,9 @@ export function buildHandoffConfirmationIntent(params: {
         },
         {
           id: params.context.workspaceKind === "local"
-            ? "handoff:local-to-worktree"
+            ? params.strategy === "move-branch"
+              ? "handoff:move-branch"
+              : "status:handoff"
             : "status:handoff",
           label: "Back",
           fallbackText: "back",
@@ -692,6 +716,10 @@ export function handoffRequestFromValue(
     backend: value.backend,
     threadId: value.threadId,
     direction: value.direction,
+    strategy:
+      value.strategy === "move-branch" || value.strategy === "detached-changes"
+        ? value.strategy
+        : undefined,
     repositoryPath: value.repositoryPath,
     sourcePath: value.sourcePath,
     sourceBranch: typeof value.sourceBranch === "string" ? value.sourceBranch : undefined,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -724,6 +724,10 @@ export class DesktopMessagingRuntime {
       deliveryBudget,
       inputDebounceMs: config.inputDebounceMs,
       store,
+      streamingResponsesDefault: streamingResponsesDefaultForChannel(
+        config,
+        adapter.channel,
+      ),
       toolUpdateDefaultMode: async () =>
         (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
       onBindingChanged: () => this.broadcastBindingsChanged(),
@@ -1773,6 +1777,24 @@ function degradationKey(
   id: string,
 ): string {
   return `${platform}:${kind}:${id}`;
+}
+
+function streamingResponsesDefaultForChannel(
+  config: DesktopMessagingConfig,
+  channel: MessagingChannelKind,
+): boolean {
+  switch (channel) {
+    case "discord":
+      return config.discord?.streamingResponses ?? false;
+    case "mattermost":
+      return config.mattermost?.streamingResponses ?? false;
+    case "slack":
+      return config.slack?.streamingResponses ?? false;
+    case "telegram":
+      return config.telegram?.streamingResponses ?? false;
+    default:
+      return false;
+  }
 }
 
 function degradationTimerKey(

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  LaunchpadWorkMode,
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadSummary,
@@ -893,6 +894,8 @@ export type MessagingBrowseSessionRecord = {
   pageSize: number;
   preferences?: MessagingBindingPreferences;
   query?: string;
+  workMode?: LaunchpadWorkMode;
+  branchName?: string;
   selectedProject?: MessagingBrowseSelectedProject;
   surface?: MessagingSurfaceRef;
   updatedAt: number;

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1986,7 +1986,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       budget:
         policy === "group"
           ? { limit: 20, intervalMs: 60_000, reserved: 5 }
-          : { limit: 1, intervalMs: 1_000, reserved: 0 },
+          : { limit: 60, intervalMs: 60_000, reserved: 0 },
     };
   }
 

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -25,6 +25,8 @@ export type StartThreadRequest = {
   serviceTier?: string;
   reasoningEffort?: string;
   fastMode?: boolean;
+  workMode?: LaunchpadWorkMode;
+  branchName?: string;
 };
 
 export type StartThreadResponse = {


### PR DESCRIPTION
## Summary

I added the first mobile-first messaging workflow slice for #304:

- Added a New-thread options screen that lets the operator choose Local vs New Worktree, base branch, permissions mode, fast mode, model, and reasoning before sending the first prompt.
- Plumbed New Worktree/base-branch choices through the channel-neutral messaging browse session and shared `StartThreadRequest` contract.
- Updated desktop thread startup to prepare a worktree from the selected base branch and record Codex worktree ownership metadata.
- Split the handoff status flow into Move Existing Branch vs Create Detached Head, with the detached path skipping the leave-local branch picker.

## Validation

I verified this locally with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/messaging-interface typecheck`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `git diff --check`

## Notes

This intentionally starts fresh from `main` and does not merge the failed `fix/messaging-handoff-branch-workflow` branch. It does not yet land the full seven-flow E2E suite from #304; this PR establishes the channel-neutral state and controller behavior for the mobile-first path.

Fixes #304
