### PR TITLE
fix(restart): avoid launchctl supervising dev server

### DIFF
--- a/.agents/skills/pwragent-dev-restart/SKILL.md
+++ b/.agents/skills/pwragent-dev-restart/SKILL.md
@@ -40,7 +40,7 @@ Use this skill when the running Electron app must be stopped and restarted from 
 ## Script Notes
 
 - The script stops processes matching the target checkout path and their bounded parent dev-server chain, then starts `pnpm dev` from the checkout.
-- It uses `launchctl submit` on macOS for the delayed timer, then starts `pnpm dev` detached and removes the one-shot launchd job. If `launchctl` is unavailable or submission fails, it falls back to `nohup`.
+- It uses a `nohup` sleep wrapper for the delayed timer. Do not use `launchctl submit` here: launchd can keep descendant `pnpm dev` processes in the submitted job context and relaunch them after they exit.
 - Default root is `/Users/huntharo/github/PwrAgnt`.
 - Default log is `<root>/.local/pwragent-dev-restart.log`.
 - Use `--dry-run` before scheduling unless the user explicitly asks to restart immediately.

--- a/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
+++ b/.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh
@@ -159,26 +159,18 @@ stop_matches() {
 }
 
 schedule_restart() {
-  local command
-  command="sleep $(shell_quote "$delay"); $(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path") --detach-start"
-  [[ "$dry_run" == "true" ]] && command="$command --dry-run"
+  local command restart_command
+  restart_command="$(shell_quote "$script_path") restart-now --root $(shell_quote "$root") --log $(shell_quote "$log_path") --detach-start"
+  [[ "$dry_run" == "true" ]] && restart_command="$restart_command --dry-run"
+  command="sleep $(shell_quote "$delay"); nohup /bin/zsh -lc $(shell_quote "$restart_command") >> $(shell_quote "$log_path") 2>&1 &"
 
   log_line "schedule root=$root delay=${delay}s log=$log_path dryRun=$dry_run"
   log_line "scheduled command: $command"
 
   if [[ "$dry_run" == "true" ]]; then
+    log_line "restart command: $restart_command"
     log_candidates
     return 0
-  fi
-
-  if command -v launchctl >/dev/null 2>&1; then
-    local label="com.pwragent.dev.restart.$(date +%s)"
-    command="$command; launchctl remove $(shell_quote "$label") >/dev/null 2>&1 || true"
-    if launchctl submit -l "$label" -- /bin/zsh -lc "$command"; then
-      log_line "submitted launchctl label=$label"
-      return 0
-    fi
-    log_line "launchctl submit failed label=$label; falling back to nohup"
   fi
 
   nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &


### PR DESCRIPTION
## Summary

This fixes the restart skill after we observed the submitted launchctl job continuing to own and relaunch the PwrAgent dev UI.

The delayed restart now uses a plain `nohup` sleep wrapper instead of `launchctl submit`, so launchd does not keep the long-running `pnpm dev` process in a submitted job context.

## Changes

- Remove `launchctl submit` from the restart scheduler.
- Keep the delayed restart as `nohup /bin/zsh -lc "sleep ...; nohup restart-now ... &"`.
- Update the skill notes to explicitly avoid launchctl for this workflow.

## Verification

- Confirmed no `com.pwragent.dev.restart.*` launchctl job remains registered.
- `zsh -n .agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh`
- `.agents/skills/pwragent-dev-restart/scripts/restart-pwragent-dev.zsh schedule --root /Users/huntharo/github/PwrAgnt --delay 30 --dry-run`
