### PR TITLE
fix(messaging): renew Telegram typing during long turns

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3019,6 +3019,40 @@ describe("MessagingController", () => {
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toHaveLength(1);
   });
 
+  it("passes discrete work activity through so providers can renew typing leases", async () => {
+    let now = 1000;
+    const harness = await createHarness({
+      now: () => now,
+    });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start long work"));
+    harness.delivered.length = 0;
+
+    now += 9_000;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "reasoning-1",
+            type: "reasoning",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "active",
+      }),
+    ]);
+  });
+
   it("suppresses high-frequency typing refreshes without logging each skipped delta", async () => {
     let now = 1000;
     const logger = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -113,6 +113,9 @@ import {
 const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
 const TYPING_ACTIVITY_REFRESH_MS = 10_000;
+// Discrete item lifecycle events are cheap provider lease renewals, not
+// visible message sends. Let them through a little sooner than noisy deltas.
+const TYPING_ACTIVITY_CONTINUATION_REFRESH_MS = 9_000;
 const DEFAULT_INPUT_DEBOUNCE_MS = 500;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
@@ -565,6 +568,7 @@ export class MessagingController {
         }
         await this.signalTurnActivity(binding, latestActiveTurn, {
           reason: event.notification.method,
+          refreshMs: typingActivityRefreshMsForBackendEvent(event),
         });
       }
     }
@@ -4025,16 +4029,17 @@ export class MessagingController {
   private async signalTurnActivity(
     binding: MessagingBindingRecord,
     activeTurn: MessagingActiveTurnSummary,
-    options?: { force?: boolean; reason?: string },
+    options?: { force?: boolean; reason?: string; refreshMs?: number },
   ): Promise<void> {
     const state = activeTurn.status === "working" ? "active" : "idle";
     const now = this.now();
     const lastSignaledAt = this.typingActivityLastSignaledAt.get(binding.id);
+    const refreshMs = options?.refreshMs ?? TYPING_ACTIVITY_REFRESH_MS;
     if (
       state === "active" &&
       !options?.force &&
       lastSignaledAt !== undefined &&
-      now - lastSignaledAt < TYPING_ACTIVITY_REFRESH_MS
+      now - lastSignaledAt < refreshMs
     ) {
       return;
     }
@@ -5395,6 +5400,21 @@ function isTurnWorkActivityEvent(
     event.notification.method.startsWith("item/") ||
     event.notification.method.startsWith("turn/") ||
     event.notification.method.startsWith("thread/")
+  );
+}
+
+function typingActivityRefreshMsForBackendEvent(event: AgentEvent): number {
+  const method = event.notification.method;
+  return method.startsWith("item/") && !isHighFrequencyItemActivityEvent(method)
+    ? TYPING_ACTIVITY_CONTINUATION_REFRESH_MS
+    : TYPING_ACTIVITY_REFRESH_MS;
+}
+
+function isHighFrequencyItemActivityEvent(method: string): boolean {
+  return (
+    method.endsWith("/delta") ||
+    method.endsWith("Delta") ||
+    method.endsWith("/progress")
   );
 }
 


### PR DESCRIPTION
## Summary

This fixes Telegram typing indicators dropping out during long-running turns after the first few replies.

The controller now treats discrete backend item lifecycle events as typing-continuation signals, allowing providers to renew their own typing leases a little sooner than the generic high-frequency delta throttle. Noisy delta-style events remain throttled, and the delivery budget still decides whether typing activity should be discarded during provider cool-off or slow mode.

## Testing

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
