### PR TITLE
fix(desktop): keep sidebar tooltips above clipped surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,20 @@ graph TD
 
 | Layer | Storage | Purpose |
 |-------|---------|---------|
-| Desktop state | `~/.pwragent/profiles/<name>/state/state.db` | Messaging bindings, thread overlay, secrets, launchpad settings |
+| Desktop state | `~/.pwragent/profiles/<name>/state/state.db` | Messaging bindings, thread overlay, `safeStorage`-encrypted secret blobs, launchpad settings |
 | Desktop config | `~/.pwragent/profiles/<name>/config.toml` | Desktop settings (messaging, models, worktrees) |
 | Agent-Core threads | `<state_root>/threads/<id>/rollout.jsonl` | Append-only message + replay-item log per thread |
 | Agent-Core metadata | `<state_root>/threads/<id>/thread.toml` | Thread config (model, cwd, approval policy) |
 | Protocol captures | `~/.pwragent/profiles/<name>/state/protocol-captures/` | Dev-only JSON-RPC session recordings |
+
+Desktop secrets such as bot tokens and API keys are not written to TOML and are
+not stored as plaintext in sqlite. PwrAgent encrypts them with Electron
+[`safeStorage`](https://www.electronjs.org/docs/latest/api/safe-storage) and
+stores only the resulting ciphertext blob in the active profile's `state.db`.
+On macOS, Electron backs `safeStorage` with Keychain Access for the app's
+encryption keys, so decrypting the sqlite blob requires the same OS/user/app
+Keychain context. The app refuses to write secrets when Electron reports an
+unsafe or unavailable `safeStorage` backend.
 
 See [docs/state-layout.md](docs/state-layout.md) for full directory layout, environment variables, and migration details.
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -175,6 +175,13 @@ Enforcement runs via `pnpm lint:boundaries` and fails CI on any violation.
 - Centralize visual tokens in `styles/app.css` before expanding renderer surfaces.
 - Reuse shell primitives instead of adding one-off page styling.
 - When in doubt, make the interface calmer, denser, and more editorial.
+- For tooltips inside clipped or layered surfaces (sidebar, scroll regions,
+  overflow-hidden chips, draggable rails, or anything that must escape the
+  left bar), use `src/renderer/src/lib/useViewportTooltip.tsx` with the
+  shared `.viewport-tooltip` class. CSS pseudo-element tooltips
+  (`tooltip-target` + `data-tooltip`) are only for elements whose ancestors
+  all render with `overflow: visible`; otherwise they get clipped or lose
+  z-order fights against the main surface.
 - Use the project-local [desktop E2E fixture seeding skill](../../.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when capturing or refreshing replay-backed desktop E2E fixtures.
 
 ## Third-Party Brand Assets

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   formatRuntimePath,
   runtimeGitRefCopyValue,
 } from "../../lib/runtime-identity";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
 
@@ -701,26 +702,33 @@ function RuntimeIdentityButton(props: {
   valueKind: "branch" | "cwd";
   onCopied: (valueKind: "branch" | "cwd") => void;
 }) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const tooltipText = props.copied
+    ? "Copied"
+    : `${props.value}\nClick to copy to clipboard`;
+
   return (
-    <button
-      aria-label={`Copy ${
-        props.copyLabel ?? (props.valueKind === "cwd" ? "working directory" : "branch name")
-      }`}
-      className="runtime-identity__button path-copy-target tooltip-target"
-      data-tooltip={
-        props.copied
-          ? "Copied"
-          : `${props.value}\nClick to copy to clipboard`
-      }
-      type="button"
-      onClick={() => {
-        void copyText(props.value).then(() => props.onCopied(props.valueKind));
-      }}
-    >
-      <span aria-hidden="true" className="runtime-identity__icon">
-        {props.valueKind === "cwd" ? <FolderIcon size={13} /> : <BranchIcon size={13} />}
-      </span>
-      <span className="runtime-identity__text">{props.label}</span>
-    </button>
+    <>
+      <button
+        aria-label={`Copy ${
+          props.copyLabel ?? (props.valueKind === "cwd" ? "working directory" : "branch name")
+        }`}
+        className="runtime-identity__button path-copy-target"
+        type="button"
+        onBlur={tooltip.hide}
+        onClick={() => {
+          void copyText(props.value).then(() => props.onCopied(props.valueKind));
+        }}
+        onFocus={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseLeave={tooltip.hide}
+      >
+        <span aria-hidden="true" className="runtime-identity__icon">
+          {props.valueKind === "cwd" ? <FolderIcon size={13} /> : <BranchIcon size={13} />}
+        </span>
+        <span className="runtime-identity__text">{props.label}</span>
+      </button>
+      {tooltip.tooltipNode}
+    </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1140,8 +1140,23 @@ describe("Sidebar", () => {
     expect(screen.getByText(".worktrees/pwragent-fix-t...ng-moioth2352")).toBeInTheDocument();
     expect(screen.getByText("codex/fix-thread-naming-ephemeral")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy working directory" }));
-    fireEvent.click(screen.getByRole("button", { name: "Copy branch name" }));
+    const cwdButton = screen.getByRole("button", { name: "Copy working directory" });
+    fireEvent.mouseEnter(cwdButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "/Users/huntharo/pwrdrvr/PwrAgent/.worktrees/pwragent-fix-thread-naming-moioth2352\nClick to copy to clipboard"
+    );
+    fireEvent.mouseLeave(cwdButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    const branchButton = screen.getByRole("button", { name: "Copy branch name" });
+    fireEvent.mouseEnter(branchButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "codex/fix-thread-naming-ephemeral\nClick to copy to clipboard"
+    );
+    fireEvent.mouseLeave(branchButton);
+
+    fireEvent.click(cwdButton);
+    fireEvent.click(branchButton);
 
     expect(copyText).toHaveBeenNthCalledWith(
       1,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -820,20 +820,6 @@ textarea,
   outline-offset: 2px;
 }
 
-.runtime-identity__button.tooltip-target[data-tooltip]::after {
-  top: calc(100% + 8px);
-  bottom: auto;
-  left: 0;
-  width: min(360px, calc(var(--sidebar-width, 408px) - 48px));
-  max-width: min(360px, calc(var(--sidebar-width, 408px) - 48px));
-  transform: translateY(-4px);
-}
-
-.runtime-identity__button.tooltip-target[data-tooltip]:hover::after,
-.runtime-identity__button.tooltip-target[data-tooltip]:focus-visible::after {
-  transform: translateY(0);
-}
-
 .runtime-identity__icon {
   display: inline-flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary

- Move sidebar runtime folder/branch tooltips to the portal-based viewport tooltip helper
- Keep those tooltips clamped inside the window and above the main surface
- Document when desktop code should use `useViewportTooltip`

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm exec tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- `git diff --check`
