### PR TITLE
ci(agent-core): narrow live smoke shared inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,12 @@ jobs:
           git diff --name-only "$base" "$head" > changed-files.txt
 
           relevant=false
+          matched_path=""
           while IFS= read -r path; do
             case "$path" in
-              packages/agent-core/*|packages/shared/*|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig.base.json|vitest.workspace.ts|.nvmrc|.github/workflows/ci.yml)
+              packages/agent-core/*|packages/shared/src/contracts/normalized-app-server.ts|packages/shared/src/contracts/navigation.ts|packages/shared/src/thread-titles.ts|packages/shared/src/index.ts|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig.base.json|vitest.workspace.ts|.nvmrc|.github/workflows/ci.yml)
                 relevant=true
+                matched_path="$path"
                 break
                 ;;
             esac
@@ -158,6 +160,7 @@ jobs:
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 
           if [[ "$relevant" == "true" ]]; then
+            echo "Live agent-core input changed: $matched_path"
             echo "Live agent-core inputs changed; running live smoke test."
           else
             {
@@ -165,7 +168,7 @@ jobs:
               echo
               echo "Skipped live agent-core smoke test because no agent-core inputs changed."
               echo
-              echo "Relevant inputs: \`packages/agent-core/**\`, \`packages/shared/**\`, root dependency/test config, and this workflow."
+              echo "Relevant inputs: \`packages/agent-core/**\`, shared files imported by agent-core, root dependency/test config, and this workflow."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 


### PR DESCRIPTION
## Summary

I narrowed the `Live Agent Core` changed-file gate so shared-package changes only run the paid Grok smoke test when they touch files that agent-core actually imports.

This fixes the false-positive path from PR #314, where a messaging PR changed `packages/shared/src/contracts/agent.ts` and still triggered the live agent-core test because the gate matched all of `packages/shared/**`.

The live smoke test still runs for:

- `packages/agent-core/**`
- shared files imported by agent-core: `normalized-app-server.ts`, `navigation.ts`, `thread-titles.ts`, and `index.ts`
- root dependency/test config
- `.nvmrc`
- the CI workflow itself

I also added a log line that prints the first matched relevant path when the live test runs, so the reason is visible in future Actions logs.

## Verification

I verified the workflow YAML parses, `git diff --check` is clean, and the Bash matcher now returns:

- `false` for PR #314's changed-file list
- `true` for an agent-core source change
- `true` for a shared navigation-contract change
