### PR TITLE
fix(desktop): add thread detail empty-state gutter

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -156,6 +156,12 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps the startup thread detail empty state off the sidebar edge", () => {
+    const emptyStateRule = extractRuleBody(css, ".thread-empty-state");
+
+    expect(emptyStateRule).toContain("padding: 0 16px;");
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7165,6 +7165,7 @@ textarea,
   justify-content: center;
   min-height: calc(100vh - 48px);
   max-width: 520px;
+  padding: 0 16px;
 }
 
 .renderer-error-boundary {


### PR DESCRIPTION
## Summary

I added a horizontal gutter to the startup Thread Detail empty state so the "Select a thread" message no longer sits flush against the sidebar edge after the transcript double-gutter cleanup.

I also added a stylesheet contract test to keep that empty-state inset from regressing during future transcript layout tuning.

## Verification

I verified the focused theme contract suite passes:

```bash
pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
```

The local replay-backed Electron visual check could not run in this worktree because `node_modules` is missing, so `electron-vite build` could not resolve `@vitejs/plugin-react`.
