### PR TITLE
fix(messaging): preserve Telegram General typing target

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1237,6 +1237,59 @@ describe("MessagingController", () => {
     });
   });
 
+  it("refreshes stale binding routing state before typing activity", async () => {
+    const harness = await createHarness();
+    const generalChannel = {
+      channel: "telegram" as const,
+      conversation: {
+        id: "-1003711601984",
+        kind: "channel" as const,
+        title: "PwrDrvr",
+      },
+    };
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        channel: generalChannel,
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("start work", {
+        channel: generalChannel,
+        routingState: {
+          opaque: {
+            chatId: -1003711601984,
+            messageThreadId: 1,
+          },
+        },
+      }),
+    );
+
+    expect(
+      harness.delivered.find(
+        (intent) => intent.kind === "activity" && intent.state === "active",
+      ),
+    ).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      targetSurface: {
+        channel: "telegram",
+        state: {
+          opaque: {
+            chatId: -1003711601984,
+            messageThreadId: 1,
+          },
+        },
+      },
+    });
+  });
+
   it("drops typing activity during provider cool-off without spending write budget", async () => {
     let now = 1_000;
     const scope: MessagingDeliveryScope = {
@@ -5620,14 +5673,20 @@ function buildCommandEvent(
   };
 }
 
-function buildTextEvent(text: string): MessagingInboundTextEvent {
+function buildTextEvent(
+  text: string,
+  params: {
+    channel?: MessagingInboundTextEvent["channel"];
+    routingState?: MessagingInboundTextEvent["routingState"];
+  } = {},
+): MessagingInboundTextEvent {
   return {
     id: "event-text",
     kind: "text",
     actor: {
       platformUserId: "user-1",
     },
-    channel: {
+    channel: params.channel ?? {
       channel: "telegram",
       conversation: {
         id: "chat-1",
@@ -5635,6 +5694,7 @@ function buildTextEvent(text: string): MessagingInboundTextEvent {
       },
     },
     receivedAt: 1000,
+    routingState: params.routingState,
     text,
   };
 }

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1170,6 +1170,73 @@ describe("MessagingController", () => {
     });
   });
 
+  it("echoes binding routing state into typing activity intents", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "-1003711601984",
+            kind: "channel",
+            title: "PwrDrvr",
+          },
+        },
+        routingState: {
+          opaque: {
+            chatId: -1003711601984,
+            messageThreadId: 1,
+          },
+        },
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "active",
+      audit: {
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "-1003711601984",
+            kind: "channel",
+          },
+        },
+      },
+      targetSurface: {
+        channel: "telegram",
+        state: {
+          opaque: {
+            chatId: -1003711601984,
+            messageThreadId: 1,
+          },
+        },
+      },
+    });
+  });
+
   it("drops typing activity during provider cool-off without spending write budget", async () => {
     let now = 1_000;
     const scope: MessagingDeliveryScope = {
@@ -5593,6 +5660,7 @@ function buildToolCompletedEvent(id: string, command: string): AgentEvent {
 
 function buildCallbackEvent(params: {
   actionId: string;
+  channel?: MessagingInboundCallbackEvent["channel"];
   interactionId?: string;
   routingState?: MessagingInboundCallbackEvent["routingState"];
   value?: MessagingInboundCallbackEvent["value"];
@@ -5603,7 +5671,7 @@ function buildCallbackEvent(params: {
     actor: {
       platformUserId: "user-1",
     },
-    channel: {
+    channel: params.channel ?? {
       channel: "telegram",
       conversation: {
         id: "chat-1",

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2288,6 +2288,7 @@ describe("TelegramAdapter", () => {
       message: {
         chat: {
           id: -1003711601984,
+          is_forum: true,
           title: "PwrDrvr",
           type: "supergroup",
         },
@@ -2296,7 +2297,6 @@ describe("TelegramAdapter", () => {
           id: 42,
           is_bot: false,
         },
-        is_topic_message: true,
         message_id: 106,
         text: "/status",
       },

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -504,6 +504,75 @@ describe("TelegramAdapter", () => {
     expect(api.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("uses General topic routing state for typing without threading message sends", async () => {
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      now: () => 1000,
+    });
+    const audit = {
+      actor: {
+        platformUserId: "42",
+      },
+      channel: {
+        channel: "telegram" as const,
+        conversation: {
+          id: "-1003711601984",
+          kind: "channel" as const,
+          title: "PwrDrvr",
+        },
+      },
+      occurredAt: 1000,
+    };
+    const generalTopicSurface = {
+      channel: "telegram" as const,
+      id: "binding:general",
+      state: {
+        opaque: {
+          chatId: -1003711601984,
+          messageThreadId: 1,
+        },
+      },
+    };
+
+    await adapter.deliver({
+      id: "activity-1",
+      kind: "activity",
+      activity: "typing",
+      createdAt: 1000,
+      state: "active",
+      audit,
+      targetSurface: generalTopicSurface,
+    });
+    await adapter.deliver({
+      id: "message-1",
+      kind: "message",
+      createdAt: 1000,
+      audit,
+      targetSurface: generalTopicSurface,
+      parts: [{ type: "text", text: "Done", markdown: "plain" }],
+      role: "assistant",
+    });
+
+    expect(api.sendChatAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "typing",
+        chat_id: -1003711601984,
+        message_thread_id: 1,
+      }),
+    );
+    expect(api.sendMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        message_thread_id: expect.any(Number),
+      }),
+    );
+  });
+
   it("returns failed delivery results instead of throwing Telegram API errors", async () => {
     const api = createApi();
     const logger = {
@@ -2196,6 +2265,62 @@ describe("TelegramAdapter", () => {
     });
 
     expect(events).toEqual([]);
+  });
+
+  it("preserves Telegram General topic id in opaque routing state", async () => {
+    const events: MessagingInboundEvent[] = [];
+    const api = createApi();
+    const adapter = new TelegramAdapter({
+      api: api as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      pollOnStart: false,
+    });
+
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    await adapter.handleUpdate({
+      update_id: 7,
+      message: {
+        chat: {
+          id: -1003711601984,
+          title: "PwrDrvr",
+          type: "supergroup",
+        },
+        from: {
+          first_name: "Ada",
+          id: 42,
+          is_bot: false,
+        },
+        is_topic_message: true,
+        message_id: 106,
+        text: "/status",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "command",
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "-1003711601984",
+            kind: "channel",
+            title: "PwrDrvr",
+          },
+        },
+        routingState: {
+          opaque: {
+            chatId: -1003711601984,
+            messageThreadId: 1,
+          },
+        },
+      }),
+    ]);
   });
 
   it("ignores Telegram messages authored by the configured bot", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -33,6 +33,7 @@ import type {
   MessagingInboundEvent,
   MessagingInboundMediaEvent,
   MessagingInboundTextEvent,
+  MessagingAdapterState,
   MessagingJsonValue,
   MessagingMessageIntent,
   MessagingPendingIntentRecord,
@@ -680,14 +681,17 @@ export class MessagingController {
       parentTitle: incoming.parentTitle ?? stored.parentTitle,
       ancestorTitle: incoming.ancestorTitle ?? stored.ancestorTitle,
     };
+    const routingState = event.routingState ?? binding.routingState;
     const changed =
       merged.title !== stored.title
       || merged.parentTitle !== stored.parentTitle
-      || merged.ancestorTitle !== stored.ancestorTitle;
+      || merged.ancestorTitle !== stored.ancestorTitle
+      || !messagingAdapterStateEqual(routingState, binding.routingState);
     if (!changed) return;
     await this.options.store.upsertBinding({
       ...binding,
       channel: { ...binding.channel, conversation: merged },
+      routingState,
       updatedAt: this.now(),
     });
     // The chip now has fresher breadcrumbs in the store; nudge the
@@ -6206,6 +6210,13 @@ function describeOutboundIntent(intent: MessagingSurfaceIntent): string {
   if (intent.kind === "approval") return "Sent approval request";
   if (intent.kind === "error") return "Sent error notice";
   return `Sent ${intent.kind}`;
+}
+
+function messagingAdapterStateEqual(
+  left: MessagingAdapterState | undefined,
+  right: MessagingAdapterState | undefined,
+): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
 function describeConversation(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -5080,6 +5080,9 @@ export class MessagingController {
     if (!channel) {
       return intent;
     }
+    const targetRoutingState =
+      event?.routingState ??
+      (intent.kind === "activity" ? binding?.routingState : undefined);
 
     return {
       ...intent,
@@ -5096,12 +5099,12 @@ export class MessagingController {
       }),
       ...(intent.targetSurface
         ? { targetSurface: intent.targetSurface }
-        : event?.routingState
+        : targetRoutingState
           ? {
               targetSurface: {
                 channel: channel.channel,
-                id: event.id,
-                state: event.routingState,
+                id: event?.id ?? binding?.id ?? intent.id,
+                state: targetRoutingState,
               },
             }
           : {}),

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -106,6 +106,7 @@ export type TelegramUser = {
 
 export type TelegramChat = {
   id: number;
+  is_forum?: true;
   title?: string;
   type: "private" | "group" | "supergroup" | "channel";
 };
@@ -2168,7 +2169,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
 
   private messageThreadIdFromMessage(message: TelegramMessage): number | undefined {
     return message.message_thread_id ??
-      (message.is_topic_message === true ? TELEGRAM_GENERAL_TOPIC_THREAD_ID : undefined);
+      (message.is_topic_message === true ||
+      (message.chat.type === "supergroup" && message.chat.is_forum === true)
+        ? TELEGRAM_GENERAL_TOPIC_THREAD_ID
+        : undefined);
   }
 
   /**

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -57,6 +57,7 @@ const TELEGRAM_STREAM_GROUP_FAST_INTERVAL_MS = 1_000;
 const TELEGRAM_STREAM_GROUP_MEDIUM_INTERVAL_MS = 2_000;
 const TELEGRAM_STREAM_GROUP_SLOW_INTERVAL_MS = 3_100;
 const TELEGRAM_STREAM_RETRY_AFTER_BUFFER_MS = 100;
+const TELEGRAM_GENERAL_TOPIC_THREAD_ID = 1;
 
 type TelegramDeliveryTarget = {
   chatId: number | string;
@@ -143,6 +144,7 @@ export type TelegramMessage = {
   from?: TelegramUser;
   general_forum_topic_hidden?: Record<string, never>;
   general_forum_topic_unhidden?: Record<string, never>;
+  is_topic_message?: true;
   message_id: number;
   message_thread_id?: number;
   photo?: Array<{
@@ -1618,6 +1620,15 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   private resolveTarget(intent: MessagingSurfaceIntent): TelegramDeliveryTarget | undefined {
+    if (intent.kind === "activity") {
+      return (
+        this.telegramStateFromSurface(intent.targetSurface?.state) ??
+        (intent.audit?.channel
+          ? this.telegramStateFromChannel(intent.audit.channel.conversation)
+          : undefined)
+      );
+    }
+
     if (intent.delivery?.mode === "update" || intent.kind === "dismiss") {
       return (
         this.telegramStateFromSurface(intent.targetSurface?.state) ??
@@ -2042,7 +2053,11 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         .join(" ") || undefined;
     const chatTitle = message.chat.title ?? senderName;
 
-    if (message.message_thread_id) {
+    const messageThreadId = this.messageThreadIdFromMessage(message);
+    if (
+      messageThreadId !== undefined &&
+      messageThreadId !== TELEGRAM_GENERAL_TOPIC_THREAD_ID
+    ) {
       // Topic-bound messages: title slot belongs to the topic itself.
       // Look up the cached topic name (populated from
       // `forum_topic_created` / `forum_topic_edited` service messages
@@ -2052,12 +2067,12 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       // back to a literal "Topic" placeholder.
       const topicTitle = this.lookupTopicName(
         message.chat.id,
-        message.message_thread_id,
+        messageThreadId,
       );
       return {
         channel: this.channel,
         conversation: {
-          id: String(message.message_thread_id),
+          id: String(messageThreadId),
           kind: "topic",
           parentId: String(message.chat.id),
           title: topicTitle,
@@ -2142,12 +2157,18 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   private routingStateFromMessage(message: TelegramMessage): MessagingAdapterState {
+    const messageThreadId = this.messageThreadIdFromMessage(message);
     return {
       opaque: {
         chatId: message.chat.id,
-        messageThreadId: message.message_thread_id ?? null,
+        messageThreadId: messageThreadId ?? null,
       },
     };
+  }
+
+  private messageThreadIdFromMessage(message: TelegramMessage): number | undefined {
+    return message.message_thread_id ??
+      (message.is_topic_message === true ? TELEGRAM_GENERAL_TOPIC_THREAD_ID : undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary

I fixed Telegram typing indicators for threads bound from the General topic in a forum-enabled supergroup.

Telegram delivers General-topic inbound updates as the parent supergroup conversation while still marking the chat as forum-enabled. I now preserve that General topic id (`messageThreadId: 1`) in Telegram opaque routing state and have typing activity use that state when sending `sendChatAction`. Normal message sends still route to the parent supergroup without forcing `message_thread_id: 1`.

## Changes

- Preserve `is_topic_message` General-topic routing as opaque Telegram adapter state.
- Treat forum-enabled supergroup updates without an explicit thread id as the General topic.
- Refresh stale stored binding routing state from the next inbound message.
- Echo stored binding routing state onto later typing activity intents.
- Prefer opaque activity routing state for Telegram `sendChatAction`.
- Add regression coverage for General-topic routing, typing delivery, and controller activity intent routing.

## Verification

I verified:

- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec tsc --noEmit -p packages/messaging/providers/telegram/tsconfig.json`
- `pnpm lint:boundaries`
