### PR TITLE
fix(desktop): clear messaging state for archived threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -30,6 +30,20 @@ async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args, {
     cwd,
@@ -763,6 +777,15 @@ function createMessagingArchiveCleanupStoreMock(options?: {
           (!binding.backend || binding.backend === params.backend),
       );
     },
+    async findActiveBindingsForBackend(params: {
+      backend: "codex" | "grok";
+    }) {
+      return [...bindings.values()].filter(
+        (binding) =>
+          !binding.revokedAt &&
+          (!binding.backend || binding.backend === params.backend),
+      );
+    },
     async revokeBinding(params: { bindingId: string; revokedAt?: number }) {
       const binding = bindings.get(params.bindingId);
       if (!binding) return undefined;
@@ -786,10 +809,14 @@ function createMessagingArchiveCleanupStoreMock(options?: {
   };
 }
 
-function createMessagingArchiveCleanerMock(result = {
-  notifiedCount: 1,
-  revokedCount: 1,
-}) {
+function createMessagingArchiveCleanerMock(
+  result:
+    | Promise<{ notifiedCount: number; revokedCount: number }>
+    | { notifiedCount: number; revokedCount: number } = {
+    notifiedCount: 1,
+    revokedCount: 1,
+  },
+) {
   const requests: Array<{
     backend: "codex" | "grok";
     threadId: string;
@@ -3082,6 +3109,75 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("coalesces repeated archive messaging cleanup before invoking the cleaner", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive me",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [thread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const cleanerReleased = createDeferred<{
+      notifiedCount: number;
+      revokedCount: number;
+    }>();
+    const messagingArchiveCleaner = createMessagingArchiveCleanerMock(
+      cleanerReleased.promise,
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const archivePromise = registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    while (messagingArchiveCleaner.requests.length === 0) {
+      await flushAsync();
+    }
+    const notificationPromise = codexClient.emit({
+      method: "thread/archived",
+      params: { threadId: "thread-1" },
+    });
+    await flushAsync();
+
+    expect(messagingArchiveCleaner.requests).toEqual([
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        origin: "thread-archive",
+      },
+    ]);
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
+
+    cleanerReleased.resolve({ notifiedCount: 1, revokedCount: 1 });
+    await Promise.all([archivePromise, notificationPromise]);
+    await registry.listThreads({ backend: "codex", archived: true });
+
+    expect(messagingArchiveCleaner.requests).toHaveLength(1);
+    expect(messagingStore.deletedPendingThreads).toHaveLength(1);
+
+    await registry.close();
+  });
+
   it("cleans messaging state when archived threads are discovered by refresh", async () => {
     const archivedThread: AppServerThreadSummary = {
       id: "thread-1",
@@ -3113,6 +3209,47 @@ describe("DesktopBackendRegistry", () => {
       registry.listThreads({ backend: "codex", archived: true }),
     ).resolves.toMatchObject([archivedThread]);
 
+    expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
+
+    await registry.close();
+  });
+
+  it("cleans messaging state for bound threads missing from the active refresh", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archived elsewhere",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [archivedThread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+
+    expect(codexClient.lastListThreadsDiagnostics).toEqual({
+      callerReason: "archive-bound-binding-cleanup",
+      ownerId: expect.any(String),
+    });
     expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
     expect(messagingStore.deletedPendingThreads).toEqual([
       { backend: "codex", threadId: "thread-1" },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -786,6 +786,29 @@ function createMessagingArchiveCleanupStoreMock(options?: {
   };
 }
 
+function createMessagingArchiveCleanerMock(result = {
+  notifiedCount: 1,
+  revokedCount: 1,
+}) {
+  const requests: Array<{
+    backend: "codex" | "grok";
+    threadId: string;
+    origin: "thread-archive";
+  }> = [];
+
+  return {
+    requests,
+    async requestBindingRevokeAllForThread(request: {
+      backend: "codex" | "grok";
+      threadId: string;
+      origin: "thread-archive";
+    }) {
+      requests.push(request);
+      return result;
+    },
+  };
+}
+
 describe("DesktopBackendRegistry", () => {
   it("reports backend availability and capabilities", async () => {
     const codexClient = new MockBackendClient({
@@ -3004,6 +3027,57 @@ describe("DesktopBackendRegistry", () => {
         }),
       ],
     });
+
+    await registry.close();
+  });
+
+  it("routes archive binding revocation through the messaging archive cleaner when available", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive me",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const messagingArchiveCleaner = createMessagingArchiveCleanerMock({
+      notifiedCount: 1,
+      revokedCount: 1,
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
+    expect(messagingArchiveCleaner.requests).toEqual([
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        origin: "thread-archive",
+      },
+    ]);
+    expect(messagingStore.revokedBindingIds).toEqual([]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20,6 +20,7 @@ import type {
   ThreadOverlayState,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
+import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
@@ -336,6 +337,35 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    appendMessagingBindingTransition: async ({
+      backend,
+      threadId,
+      transition,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      transition: import("@pwragent/shared").ThreadMessagingBindingTransition;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const nextLog = [
+        ...(current.messagingBindingTransitionLog ?? []),
+        transition,
+      ];
+      const trimmed =
+        nextLog.length > 100 ? nextLog.slice(nextLog.length - 100) : nextLog;
+      const next = {
+        ...current,
+        messagingBindingTransitionLog: trimmed,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
   } as unknown as InstanceType<typeof import("@pwragent/agent-core").OverlayStore>;
 }
 
@@ -453,6 +483,7 @@ class MockBackendClient {
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
       listThreadsError?: Error;
+      archivedThreads?: AppServerThreadSummary[];
       startTurnError?: Error;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
@@ -481,7 +512,14 @@ class MockBackendClient {
     if (this.options.listThreadsError) {
       throw this.options.listThreadsError;
     }
+    if (params?.archived === true && this.options.archivedThreads) {
+      return this.options.archivedThreads;
+    }
     return this.options.threads ?? [];
+  }
+
+  setThreads(threads: AppServerThreadSummary[]): void {
+    this.options.threads = threads;
   }
 
   async archiveThread(params: { threadId: string }): Promise<{ threadId: string }> {
@@ -676,6 +714,76 @@ class MockBackendClient {
     }
     return await listener(request);
   }
+}
+
+function createMessagingArchiveCleanupStoreMock(options?: {
+  bindings?: Array<{
+    backend?: "codex" | "grok";
+    channel?: "telegram" | "discord";
+    id: string;
+    threadId: string;
+  }>;
+  pendingIntentIds?: string[];
+}) {
+  const revokedBindingIds: string[] = [];
+  const deletedPendingThreads: Array<{ backend: "codex" | "grok"; threadId: string }> = [];
+  const bindings = new Map<string, MessagingBindingRecord>(
+    (options?.bindings ?? []).map((binding) => [
+      binding.id,
+      {
+        id: binding.id,
+        backend: binding.backend ?? "codex",
+        threadId: binding.threadId,
+        channel: {
+          channel: binding.channel ?? "telegram",
+          conversation: {
+            kind: "dm",
+            id: `${binding.id}:conversation`,
+            title: `${binding.id} conversation`,
+          },
+        },
+        authorizedActorIds: [`${binding.id}:actor`],
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]),
+  );
+
+  return {
+    revokedBindingIds,
+    deletedPendingThreads,
+    async findActiveBindingsForThread(params: {
+      backend: "codex" | "grok";
+      threadId: string;
+    }) {
+      return [...bindings.values()].filter(
+        (binding) =>
+          !binding.revokedAt &&
+          binding.threadId === params.threadId &&
+          (!binding.backend || binding.backend === params.backend),
+      );
+    },
+    async revokeBinding(params: { bindingId: string; revokedAt?: number }) {
+      const binding = bindings.get(params.bindingId);
+      if (!binding) return undefined;
+      const revokedAt = params.revokedAt ?? Date.now();
+      const revoked = {
+        ...binding,
+        revokedAt,
+        updatedAt: revokedAt,
+      };
+      bindings.set(params.bindingId, revoked);
+      revokedBindingIds.push(params.bindingId);
+      return revoked;
+    },
+    async deletePendingIntentsForThread(params: {
+      backend: "codex" | "grok";
+      threadId: string;
+    }) {
+      deletedPendingThreads.push(params);
+      return params.threadId === "thread-1" ? options?.pendingIntentIds ?? [] : [];
+    },
+  };
 }
 
 describe("DesktopBackendRegistry", () => {
@@ -2833,6 +2941,161 @@ describe("DesktopBackendRegistry", () => {
         },
       ],
     });
+
+    await registry.close();
+  });
+
+  it("revokes messaging bindings and clears pending intents when archiving a thread", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive me",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [
+        { id: "binding-telegram", threadId: "thread-1", channel: "telegram" },
+        { id: "binding-discord", threadId: "thread-1", channel: "discord" },
+        { id: "binding-other", threadId: "thread-2", channel: "telegram" },
+      ],
+      pendingIntentIds: ["intent-approval", "intent-question"],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingStore,
+      overlayStore,
+    });
+
+    await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(messagingStore.revokedBindingIds).toEqual([
+      "binding-telegram",
+      "binding-discord",
+    ]);
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      messagingBindingTransitionLog: [
+        expect.objectContaining({
+          action: "unbound",
+          bindingId: "binding-telegram",
+          platform: "telegram",
+        }),
+        expect.objectContaining({
+          action: "unbound",
+          bindingId: "binding-discord",
+          platform: "discord",
+        }),
+      ],
+    });
+
+    await registry.close();
+  });
+
+  it("cleans messaging state when archived threads are discovered by refresh", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archived elsewhere",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [archivedThread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex", archived: true }),
+    ).resolves.toMatchObject([archivedThread]);
+
+    expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
+
+    await registry.close();
+  });
+
+  it("cleans messaging state when an active thread refresh transitions to archived", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archived elsewhere",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [thread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toMatchObject([
+      thread,
+    ]);
+    codexClient.setThreads([]);
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "another-thread",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+
+    expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
+    expect(messagingStore.deletedPendingThreads).toEqual([
+      { backend: "codex", threadId: "thread-1" },
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3208,6 +3208,7 @@ describe("DesktopBackendRegistry", () => {
     await expect(
       registry.listThreads({ backend: "codex", archived: true }),
     ).resolves.toMatchObject([archivedThread]);
+    await waitForCondition(() => messagingStore.revokedBindingIds.length === 1);
 
     expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
     expect(messagingStore.deletedPendingThreads).toEqual([
@@ -3245,6 +3246,7 @@ describe("DesktopBackendRegistry", () => {
     });
 
     await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    await waitForCondition(() => messagingStore.revokedBindingIds.length === 1);
 
     expect(codexClient.lastListThreadsDiagnostics).toEqual({
       callerReason: "archive-bound-binding-cleanup",
@@ -3253,6 +3255,70 @@ describe("DesktopBackendRegistry", () => {
     expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
     expect(messagingStore.deletedPendingThreads).toEqual([
       { backend: "codex", threadId: "thread-1" },
+    ]);
+
+    await registry.close();
+  });
+
+  it("does not block thread refresh when archive cleanup asks for navigation", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archived elsewhere",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [archivedThread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+    });
+    let registry!: DesktopBackendRegistry;
+    let nestedNavigationResolved = false;
+    const messagingArchiveCleaner = {
+      requests: [] as Array<{
+        backend: "codex" | "grok";
+        threadId: string;
+        origin: "thread-archive";
+      }>,
+      async requestBindingRevokeAllForThread(request: {
+        backend: "codex" | "grok";
+        threadId: string;
+        origin: "thread-archive";
+      }) {
+        messagingArchiveCleaner.requests.push(request);
+        await registry.listThreads();
+        nestedNavigationResolved = true;
+        return { notifiedCount: 1, revokedCount: 1 };
+      },
+    };
+    registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const timeout = new Promise<"timeout">((resolve) => {
+      setTimeout(() => resolve("timeout"), 100);
+    });
+
+    await expect(Promise.race([registry.listThreads(), timeout])).resolves.toEqual([]);
+    await waitForCondition(() => nestedNavigationResolved);
+
+    expect(messagingArchiveCleaner.requests).toEqual([
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        origin: "thread-archive",
+      },
     ]);
 
     await registry.close();
@@ -3302,6 +3368,7 @@ describe("DesktopBackendRegistry", () => {
       },
     });
     await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    await waitForCondition(() => messagingStore.revokedBindingIds.length === 1);
 
     expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
     expect(messagingStore.deletedPendingThreads).toEqual([

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3178,6 +3178,94 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("clears archive messaging cleanup cache when a thread is restored", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive me again",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/list", "thread/archive", "thread/unarchive"],
+      },
+      threads: [thread],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const messagingArchiveCleaner = createMessagingArchiveCleanerMock({
+      notifiedCount: 1,
+      revokedCount: 1,
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
+    await registry.restoreThread({ backend: "codex", threadId: "thread-1" });
+    await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
+
+    expect(messagingArchiveCleaner.requests).toEqual([
+      { backend: "codex", threadId: "thread-1", origin: "thread-archive" },
+      { backend: "codex", threadId: "thread-1", origin: "thread-archive" },
+    ]);
+
+    await registry.close();
+  });
+
+  it("clears archive messaging cleanup cache when an unarchive notification arrives", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive me again",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+      pendingIntentIds: ["intent-approval"],
+    });
+    const messagingArchiveCleaner = createMessagingArchiveCleanerMock({
+      notifiedCount: 1,
+      revokedCount: 1,
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
+    await codexClient.emit({
+      method: "thread/unarchived",
+      params: { threadId: "thread-1" },
+    });
+    await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
+
+    expect(messagingArchiveCleaner.requests).toHaveLength(2);
+
+    await registry.close();
+  });
+
   it("cleans messaging state when archived threads are discovered by refresh", async () => {
     const archivedThread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -28,6 +28,8 @@ const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const mainLogErrorMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
+const requestBindingRevokeAllForThreadMock = vi.fn();
+const setMessagingArchiveCleanerMock = vi.fn();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
 const disposeMessagingStatusIpcHandlersMock = vi.fn();
@@ -140,10 +142,17 @@ vi.mock("../log", () => ({
 vi.mock("../messaging/messaging-runtime", () => ({
   getDesktopMessagingRuntime: vi.fn(() => ({
     start: messagingRuntimeStartMock,
+    requestBindingRevokeAllForThread: requestBindingRevokeAllForThreadMock,
     onPlatformStatus: vi.fn(() => () => {}),
     getPlatformStatuses: vi.fn(() => []),
   })),
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
+}));
+
+vi.mock("../app-server/backend-registry", () => ({
+  getDesktopBackendRegistry: vi.fn(() => ({
+    setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
+  })),
 }));
 
 vi.mock("../ipc/messaging-status", () => ({
@@ -187,6 +196,8 @@ describe("bootstrapApp", () => {
     mainLogErrorMock.mockReset();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
+    requestBindingRevokeAllForThreadMock.mockReset();
+    setMessagingArchiveCleanerMock.mockReset();
     disposeDesktopMessagingRuntimeMock.mockReset();
     registerMessagingStatusIpcHandlersMock.mockReset();
     disposeMessagingStatusIpcHandlersMock.mockReset();

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -140,7 +140,55 @@ describe("SqliteMessagingStore", () => {
     await expect(store.getCallbackHandle("other-callback", { now: 1500 })).resolves
       .toMatchObject({
         id: "other-callback",
-      });
+    });
+  });
+
+  it("deletes pending intents scoped to a thread", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding({ id: "binding-1", threadId: "thread-1" }));
+    await store.upsertBinding(buildBinding({ id: "binding-2", threadId: "thread-2" }));
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-binding",
+        bindingId: "binding-1",
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-request",
+        bindingId: undefined,
+        intent: {
+          id: "approval-thread-1",
+          kind: "single_select",
+          createdAt: 1000,
+          prompt: "Choose",
+          choices: [{ id: "choice-a", label: "Choice A" }],
+          requestContext: {
+            backend: "codex",
+            method: "approval/request",
+            threadId: "thread-1",
+            requestId: "request-1",
+          },
+        },
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-other-thread",
+        bindingId: "binding-2",
+      }),
+    );
+
+    await expect(
+      store.deletePendingIntentsForThread({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual(["intent-binding", "intent-request"]);
+    await expect(store.getPendingIntent("intent-binding")).resolves.toBeUndefined();
+    await expect(store.getPendingIntent("intent-request")).resolves.toBeUndefined();
+    await expect(store.getPendingIntent("intent-other-thread", { now: 1500 })).resolves
+      .toBeDefined();
   });
 
   it("can delete callback handles for a binding without revoking it", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -191,6 +191,41 @@ describe("SqliteMessagingStore", () => {
       .toBeDefined();
   });
 
+  it("finds active bindings scoped to a backend", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding({ id: "binding-codex" }));
+    await store.upsertBinding(
+      buildBinding({
+        id: "binding-grok",
+        backend: "grok",
+        channel: {
+          channel: "telegram",
+          conversation: { id: "chat-grok", kind: "dm" },
+        },
+        threadId: "thread-grok",
+      }),
+    );
+    await store.upsertBinding(
+      buildBinding({
+        id: "binding-legacy",
+        backend: undefined as unknown as "codex",
+        channel: {
+          channel: "telegram",
+          conversation: { id: "chat-legacy", kind: "dm" },
+        },
+        threadId: "thread-legacy",
+      }),
+    );
+    await store.revokeBinding({ bindingId: "binding-grok", revokedAt: 3000 });
+
+    await expect(
+      store.findActiveBindingsForBackend({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "binding-codex" }),
+      expect.objectContaining({ id: "binding-legacy" }),
+    ]);
+  });
+
   it("can delete callback handles for a binding without revoking it", async () => {
     const store = await createStore();
     await store.upsertCallbackHandle(buildCallbackHandle());

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -355,6 +355,54 @@ describe("MessagingStore", () => {
     });
   });
 
+  it("deletes pending intents scoped to a thread", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({ id: "binding-1", threadId: "thread-1" }));
+    await store.upsertBinding(buildBinding({ id: "binding-2", threadId: "thread-2" }));
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-binding",
+        bindingId: "binding-1",
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-request",
+        bindingId: undefined,
+        intent: {
+          id: "approval-thread-1",
+          kind: "single_select",
+          createdAt: 1000,
+          prompt: "Choose",
+          choices: [{ id: "choice-a", label: "Choice A" }],
+          requestContext: {
+            backend: "codex",
+            method: "approval/request",
+            threadId: "thread-1",
+            requestId: "request-1",
+          },
+        },
+      }),
+    );
+    await store.upsertPendingIntent(
+      buildPendingIntent({
+        id: "intent-other-thread",
+        bindingId: "binding-2",
+      }),
+    );
+
+    await expect(
+      store.deletePendingIntentsForThread({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual(["intent-binding", "intent-request"]);
+    await expect(store.getPendingIntent("intent-binding")).resolves.toBeUndefined();
+    await expect(store.getPendingIntent("intent-request")).resolves.toBeUndefined();
+    await expect(store.getPendingIntent("intent-other-thread", { now: 1500 })).resolves
+      .toBeDefined();
+  });
+
   it("can delete callback handles for a binding without revoking it", async () => {
     const { store } = await createStore();
     await store.upsertCallbackHandle(buildCallbackHandle());

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -403,6 +403,29 @@ describe("MessagingStore", () => {
       .toBeDefined();
   });
 
+  it("finds active bindings scoped to a backend", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({ id: "binding-codex" }));
+    await store.upsertBinding(
+      buildBinding({
+        id: "binding-grok",
+        backend: "grok",
+        channel: {
+          channel: "telegram",
+          conversation: { id: "chat-grok", kind: "dm" },
+        },
+        threadId: "thread-grok",
+      }),
+    );
+    await store.revokeBinding({ bindingId: "binding-grok", revokedAt: 3000 });
+
+    await expect(
+      store.findActiveBindingsForBackend({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "binding-codex" }),
+    ]);
+  });
+
   it("can delete callback handles for a binding without revoking it", async () => {
     const { store } = await createStore();
     await store.upsertCallbackHandle(buildCallbackHandle());

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -826,6 +826,7 @@ let threadListCacheSequence = 0;
 type MessagingArchiveCleanupStore = Pick<
   MessagingStoreLike,
   | "deletePendingIntentsForThread"
+  | "findActiveBindingsForBackend"
   | "findActiveBindingsForThread"
   | "revokeBinding"
 >;
@@ -1065,6 +1066,11 @@ export class DesktopBackendRegistry {
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly messagingStore?: MessagingArchiveCleanupStore | null;
   private messagingArchiveCleaner?: MessagingArchiveCleaner | null;
+  private readonly archivedMessagingCleanupInFlight = new Map<
+    string,
+    Promise<MessagingArchiveCleanupResult>
+  >();
+  private readonly archivedMessagingCleanupCompleted = new Set<string>();
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
@@ -3245,6 +3251,10 @@ export class DesktopBackendRegistry {
     const nextActiveThreadIds = new Set(params.threads.map((thread) => thread.id));
     const previousActiveThreadIds = this.activeThreadIdsByBackend.get(params.backend);
     this.activeThreadIdsByBackend.set(params.backend, nextActiveThreadIds);
+    await this.cleanupArchivedBindingsMissingFromActiveList({
+      backend: params.backend,
+      activeThreadIds: nextActiveThreadIds,
+    });
     if (!previousActiveThreadIds) {
       return;
     }
@@ -3284,6 +3294,63 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async cleanupArchivedBindingsMissingFromActiveList(params: {
+    activeThreadIds: Set<string>;
+    backend: AppServerBackendKind;
+  }): Promise<void> {
+    const store = this.resolveMessagingArchiveCleanupStore();
+    if (!store) return;
+
+    let bindings;
+    try {
+      bindings = await store.findActiveBindingsForBackend({
+        backend: params.backend,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("archived binding lookup failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    const missingBoundThreadIds = [
+      ...new Set(
+        bindings
+          .map((binding) => binding.threadId)
+          .filter((threadId) => !params.activeThreadIds.has(threadId)),
+      ),
+    ];
+    if (missingBoundThreadIds.length === 0) return;
+
+    try {
+      const archivedThreads = await this.getClient(params.backend).listThreads({
+        archived: true,
+      }, {
+        callerReason: "archive-bound-binding-cleanup",
+        ownerId: this.threadListCacheOwnerId,
+      });
+      const archivedThreadIds = new Set(archivedThreads.map((thread) => thread.id));
+      await Promise.all(
+        missingBoundThreadIds
+          .filter((threadId) => archivedThreadIds.has(threadId))
+          .map((threadId) =>
+            this.cleanupMessagingForArchivedThread({
+              backend: params.backend,
+              threadId,
+              origin: "state-refresh",
+            }),
+          ),
+      );
+    } catch (error) {
+      backendRegistryLog.warn("archived bound binding cleanup failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadIds: missingBoundThreadIds,
+      });
+    }
+  }
+
   private resolveMessagingArchiveCleanupStore(): MessagingArchiveCleanupStore | undefined {
     if (this.messagingStore === null) {
       return undefined;
@@ -3303,6 +3370,34 @@ export class DesktopBackendRegistry {
   }
 
   private async cleanupMessagingForArchivedThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    origin: "state-refresh" | "thread-archive";
+  }): Promise<MessagingArchiveCleanupResult> {
+    const key = `${params.backend}:${params.threadId}`;
+    const existing = this.archivedMessagingCleanupInFlight.get(key);
+    if (existing) {
+      return await existing;
+    }
+    if (this.archivedMessagingCleanupCompleted.has(key)) {
+      return { pendingIntentCount: 0, revokedCount: 0 };
+    }
+
+    const cleanup = this.runMessagingCleanupForArchivedThread(params)
+      .then((result) => {
+        if (result.pendingIntentCount > 0 || result.revokedCount > 0) {
+          this.archivedMessagingCleanupCompleted.add(key);
+        }
+        return result;
+      })
+      .finally(() => {
+        this.archivedMessagingCleanupInFlight.delete(key);
+      });
+    this.archivedMessagingCleanupInFlight.set(key, cleanup);
+    return await cleanup;
+  }
+
+  private async runMessagingCleanupForArchivedThread(params: {
     backend: AppServerBackendKind;
     threadId: string;
     origin: "state-refresh" | "thread-archive";

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1333,7 +1333,7 @@ export class DesktopBackendRegistry {
         archived: params.archived,
         filter: params.filter,
       }, diagnostics);
-      await this.handleThreadListArchiveState({
+      this.scheduleThreadListArchiveStateCleanup({
         backend: "codex",
         filter: params.filter,
         archived: params.archived,
@@ -1351,7 +1351,7 @@ export class DesktopBackendRegistry {
         }, diagnostics),
         params,
       );
-      await this.handleThreadListArchiveState({
+      this.scheduleThreadListArchiveStateCleanup({
         backend: "grok",
         filter: params.filter,
         archived: params.archived,
@@ -3223,6 +3223,20 @@ export class DesktopBackendRegistry {
       method === "turn/completed" ||
       method === "turn/failed"
     );
+  }
+
+  private scheduleThreadListArchiveStateCleanup(params: {
+    archived?: boolean;
+    backend: AppServerBackendKind;
+    filter?: string;
+    threads: AppServerThreadSummary[];
+  }): void {
+    void this.handleThreadListArchiveState(params).catch((error) => {
+      backendRegistryLog.warn("thread list archive state cleanup failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   private async handleThreadListArchiveState(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -60,6 +60,7 @@ import {
   type QueueThreadExecutionModeResponse,
   type CancelThreadExecutionModeQueueRequest,
   type CancelThreadExecutionModeQueueResponse,
+  type ThreadMessagingBindingTransition,
   type ThreadPermissionTransition,
   type ThreadPermissionTransitionStatus,
   type SteerTurnRequest,
@@ -88,6 +89,7 @@ import { createReplayClientsFromEnv } from "../testing/replay-runtime";
 import { GitDirectoryService } from "./git-directory-service";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
+import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
 import {
   createCompositeJsonRpcObserver,
   createProtocolLogObserverFromEnv,
@@ -104,6 +106,7 @@ import {
   BackendModelCatalog,
   type BackendModelCatalogCallerReason,
 } from "./backend-model-catalog";
+import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 
 type InitializeResult = {
   serverInfo?: {
@@ -820,6 +823,18 @@ type ThreadListCacheState = {
 
 let threadListCacheSequence = 0;
 
+type MessagingArchiveCleanupStore = Pick<
+  MessagingStoreLike,
+  | "deletePendingIntentsForThread"
+  | "findActiveBindingsForThread"
+  | "revokeBinding"
+>;
+
+type MessagingArchiveCleanupResult = {
+  pendingIntentCount: number;
+  revokedCount: number;
+};
+
 function isEmptyDirectoryLaunchpadDraft(launchpad: NavigationLaunchpadDraft): boolean {
   return (
     launchpad.prompt.trim().length === 0 &&
@@ -1036,11 +1051,13 @@ export class DesktopBackendRegistry {
   private readonly gitDirectoryService: GitDirectoryService;
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
+  private readonly messagingStore?: MessagingArchiveCleanupStore | null;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
+  private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
@@ -1083,6 +1100,7 @@ export class DesktopBackendRegistry {
     gitDirectoryService?: GitDirectoryService;
     gitWorkspaceHandoffService?: GitWorkspaceHandoffService;
     worktreeArchiveService?: WorktreeArchiveService;
+    messagingStore?: MessagingArchiveCleanupStore | null;
     createScratchProjectDirectory?: () => Promise<string>;
     threadTitleGenerationService?: ThreadTitleService | null;
   }) {
@@ -1164,6 +1182,7 @@ export class DesktopBackendRegistry {
       });
     this.worktreeArchiveService =
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
+    this.messagingStore = options?.messagingStore;
     this.gitWorkspaceHandoffService =
       options?.gitWorkspaceHandoffService ??
       new GitWorkspaceHandoffService({
@@ -1283,14 +1302,21 @@ export class DesktopBackendRegistry {
       ownerId: this.threadListCacheOwnerId,
     };
     if (params.backend === "codex") {
-      return await this.listCodexThreads({
+      const threads = await this.listCodexThreads({
         archived: params.archived,
         filter: params.filter,
       }, diagnostics);
+      await this.handleThreadListArchiveState({
+        backend: "codex",
+        filter: params.filter,
+        archived: params.archived,
+        threads,
+      });
+      return threads;
     }
 
     if (params.backend === "grok") {
-      return this.withPendingStartedThreads(
+      const threads = this.withPendingStartedThreads(
         "grok",
         await this.grokClient.listThreads({
           archived: params.archived,
@@ -1298,6 +1324,13 @@ export class DesktopBackendRegistry {
         }, diagnostics),
         params,
       );
+      await this.handleThreadListArchiveState({
+        backend: "grok",
+        filter: params.filter,
+        archived: params.archived,
+        threads,
+      });
+      return threads;
     }
 
     const threadLists = await Promise.all([
@@ -1361,6 +1394,11 @@ export class DesktopBackendRegistry {
           )
         : await this.archiveWithClient(this.grokClient, request.threadId);
     this.invalidateThreadListCache(backend);
+    await this.cleanupMessagingForArchivedThread({
+      backend,
+      threadId: result.threadId,
+      origin: "thread-archive",
+    });
     const cleanup = thread
       ? await this.archiveThreadWorktrees({
           backend,
@@ -3091,6 +3129,13 @@ export class DesktopBackendRegistry {
         if (this.shouldInvalidateThreadListCacheForNotification(notification.method)) {
           this.invalidateThreadListCache(backend);
         }
+        if (notification.method === "thread/archived") {
+          await this.cleanupMessagingForArchivedThread({
+            backend,
+            threadId: notification.params.threadId,
+            origin: "thread-archive",
+          });
+        }
         await this.emit({ backend, notification });
       }),
     );
@@ -3151,6 +3196,175 @@ export class DesktopBackendRegistry {
       method === "turn/completed" ||
       method === "turn/failed"
     );
+  }
+
+  private async handleThreadListArchiveState(params: {
+    archived?: boolean;
+    backend: AppServerBackendKind;
+    filter?: string;
+    threads: AppServerThreadSummary[];
+  }): Promise<void> {
+    if (params.archived === true) {
+      await Promise.all(
+        params.threads.map((thread) =>
+          this.cleanupMessagingForArchivedThread({
+            backend: params.backend,
+            threadId: thread.id,
+            origin: "state-refresh",
+          }),
+        ),
+      );
+      return;
+    }
+
+    if (params.filter?.trim()) {
+      return;
+    }
+
+    const nextActiveThreadIds = new Set(params.threads.map((thread) => thread.id));
+    const previousActiveThreadIds = this.activeThreadIdsByBackend.get(params.backend);
+    this.activeThreadIdsByBackend.set(params.backend, nextActiveThreadIds);
+    if (!previousActiveThreadIds) {
+      return;
+    }
+
+    const missingThreadIds = [...previousActiveThreadIds].filter(
+      (threadId) => !nextActiveThreadIds.has(threadId),
+    );
+    if (missingThreadIds.length === 0) {
+      return;
+    }
+
+    try {
+      const archivedThreads = await this.getClient(params.backend).listThreads({
+        archived: true,
+      }, {
+        callerReason: "archive-transition-cleanup",
+        ownerId: this.threadListCacheOwnerId,
+      });
+      const archivedThreadIds = new Set(archivedThreads.map((thread) => thread.id));
+      await Promise.all(
+        missingThreadIds
+          .filter((threadId) => archivedThreadIds.has(threadId))
+          .map((threadId) =>
+            this.cleanupMessagingForArchivedThread({
+              backend: params.backend,
+              threadId,
+              origin: "state-refresh",
+            }),
+          ),
+      );
+    } catch (error) {
+      backendRegistryLog.warn("archived thread transition cleanup failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadIds: missingThreadIds,
+      });
+    }
+  }
+
+  private resolveMessagingArchiveCleanupStore(): MessagingArchiveCleanupStore | undefined {
+    if (this.messagingStore === null) {
+      return undefined;
+    }
+    if (this.messagingStore) {
+      return this.messagingStore;
+    }
+
+    try {
+      return getDesktopMessagingStore();
+    } catch (error) {
+      backendRegistryLog.debug("messaging store unavailable for archive cleanup", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private async cleanupMessagingForArchivedThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    origin: "state-refresh" | "thread-archive";
+  }): Promise<MessagingArchiveCleanupResult> {
+    try {
+      const store = this.resolveMessagingArchiveCleanupStore();
+      if (!store) {
+        return { pendingIntentCount: 0, revokedCount: 0 };
+      }
+
+      const bindings = await store.findActiveBindingsForThread({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      const pendingIntentIds = await store.deletePendingIntentsForThread({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+
+      for (const binding of bindings) {
+        await store.revokeBinding({ bindingId: binding.id });
+        await this.recordMessagingBindingUnbound({
+          backend: params.backend,
+          binding,
+          threadId: params.threadId,
+        });
+      }
+
+      if (bindings.length > 0 || pendingIntentIds.length > 0) {
+        backendRegistryLog.info("archived thread messaging cleanup completed", {
+          backend: params.backend,
+          origin: params.origin,
+          pendingIntentCount: pendingIntentIds.length,
+          revokedCount: bindings.length,
+          threadId: params.threadId,
+        });
+      }
+
+      return {
+        pendingIntentCount: pendingIntentIds.length,
+        revokedCount: bindings.length,
+      };
+    } catch (error) {
+      backendRegistryLog.warn("archived thread messaging cleanup failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        origin: params.origin,
+        threadId: params.threadId,
+      });
+      return { pendingIntentCount: 0, revokedCount: 0 };
+    }
+  }
+
+  private async recordMessagingBindingUnbound(params: {
+    backend: AppServerBackendKind;
+    binding: Awaited<ReturnType<MessagingArchiveCleanupStore["findActiveBindingsForThread"]>>[number];
+    threadId: string;
+  }): Promise<void> {
+    const conversation = params.binding.channel.conversation;
+    const transition: ThreadMessagingBindingTransition = {
+      id: randomUUID(),
+      action: "unbound",
+      bindingId: params.binding.id,
+      platform: params.binding.channel.channel,
+      conversationKind: conversation.kind,
+      conversationTitle: conversation.title,
+      parentTitle: conversation.parentTitle,
+      ancestorTitle: conversation.ancestorTitle,
+      occurredAt: Date.now(),
+    };
+    try {
+      await this.overlayStore.appendMessagingBindingTransition({
+        backend: params.backend,
+        threadId: params.threadId,
+        transition,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("archived thread messaging audit failed", {
+        bindingId: params.binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+    }
   }
 
   private async listCodexThreads(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1071,6 +1071,7 @@ export class DesktopBackendRegistry {
     Promise<MessagingArchiveCleanupResult>
   >();
   private readonly archivedMessagingCleanupCompleted = new Set<string>();
+  private readonly archivedMessagingCleanupGeneration = new Map<string, number>();
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
@@ -1466,6 +1467,10 @@ export class DesktopBackendRegistry {
           )
         : await this.restoreWithClient(this.grokClient, request.threadId);
     this.invalidateThreadListCache(backend);
+    this.clearArchivedMessagingCleanupCache({
+      backend,
+      threadId: result.threadId,
+    });
 
     return {
       backend,
@@ -3163,6 +3168,12 @@ export class DesktopBackendRegistry {
             origin: "thread-archive",
           });
         }
+        if (notification.method === "thread/unarchived") {
+          this.clearArchivedMessagingCleanupCache({
+            backend,
+            threadId: notification.params.threadId,
+          });
+        }
         await this.emit({ backend, notification });
       }),
     );
@@ -3388,7 +3399,7 @@ export class DesktopBackendRegistry {
     threadId: string;
     origin: "state-refresh" | "thread-archive";
   }): Promise<MessagingArchiveCleanupResult> {
-    const key = `${params.backend}:${params.threadId}`;
+    const key = this.archivedMessagingCleanupKey(params);
     const existing = this.archivedMessagingCleanupInFlight.get(key);
     if (existing) {
       return await existing;
@@ -3397,9 +3408,13 @@ export class DesktopBackendRegistry {
       return { pendingIntentCount: 0, revokedCount: 0 };
     }
 
+    const generation = this.archivedMessagingCleanupGeneration.get(key) ?? 0;
     const cleanup = this.runMessagingCleanupForArchivedThread(params)
       .then((result) => {
-        if (result.pendingIntentCount > 0 || result.revokedCount > 0) {
+        if (
+          (this.archivedMessagingCleanupGeneration.get(key) ?? 0) === generation &&
+          (result.pendingIntentCount > 0 || result.revokedCount > 0)
+        ) {
           this.archivedMessagingCleanupCompleted.add(key);
         }
         return result;
@@ -3409,6 +3424,25 @@ export class DesktopBackendRegistry {
       });
     this.archivedMessagingCleanupInFlight.set(key, cleanup);
     return await cleanup;
+  }
+
+  private clearArchivedMessagingCleanupCache(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): void {
+    const key = this.archivedMessagingCleanupKey(params);
+    this.archivedMessagingCleanupCompleted.delete(key);
+    this.archivedMessagingCleanupGeneration.set(
+      key,
+      (this.archivedMessagingCleanupGeneration.get(key) ?? 0) + 1,
+    );
+  }
+
+  private archivedMessagingCleanupKey(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): string {
+    return `${params.backend}:${params.threadId}`;
   }
 
   private async runMessagingCleanupForArchivedThread(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -830,7 +830,19 @@ type MessagingArchiveCleanupStore = Pick<
   | "revokeBinding"
 >;
 
+type MessagingArchiveCleaner = {
+  requestBindingRevokeAllForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    origin: "thread-archive";
+  }): Promise<{
+    notifiedCount: number;
+    revokedCount: number;
+  }>;
+};
+
 type MessagingArchiveCleanupResult = {
+  notifiedCount?: number;
   pendingIntentCount: number;
   revokedCount: number;
 };
@@ -1052,6 +1064,7 @@ export class DesktopBackendRegistry {
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly messagingStore?: MessagingArchiveCleanupStore | null;
+  private messagingArchiveCleaner?: MessagingArchiveCleaner | null;
   private readonly createScratchProjectDirectory: () => Promise<string>;
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
@@ -1101,6 +1114,7 @@ export class DesktopBackendRegistry {
     gitWorkspaceHandoffService?: GitWorkspaceHandoffService;
     worktreeArchiveService?: WorktreeArchiveService;
     messagingStore?: MessagingArchiveCleanupStore | null;
+    messagingArchiveCleaner?: MessagingArchiveCleaner | null;
     createScratchProjectDirectory?: () => Promise<string>;
     threadTitleGenerationService?: ThreadTitleService | null;
   }) {
@@ -1183,6 +1197,7 @@ export class DesktopBackendRegistry {
     this.worktreeArchiveService =
       options?.worktreeArchiveService ?? new WorktreeArchiveService();
     this.messagingStore = options?.messagingStore;
+    this.messagingArchiveCleaner = options?.messagingArchiveCleaner;
     this.gitWorkspaceHandoffService =
       options?.gitWorkspaceHandoffService ??
       new GitWorkspaceHandoffService({
@@ -1227,6 +1242,12 @@ export class DesktopBackendRegistry {
     return () => {
       this.eventListeners.delete(listener);
     };
+  }
+
+  setMessagingArchiveCleaner(
+    cleaner: MessagingArchiveCleaner | null | undefined,
+  ): void {
+    this.messagingArchiveCleaner = cleaner;
   }
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
@@ -3288,15 +3309,44 @@ export class DesktopBackendRegistry {
   }): Promise<MessagingArchiveCleanupResult> {
     try {
       const store = this.resolveMessagingArchiveCleanupStore();
+      const pendingIntentIds = store
+        ? await store.deletePendingIntentsForThread({
+            backend: params.backend,
+            threadId: params.threadId,
+          })
+        : [];
+
+      if (this.messagingArchiveCleaner) {
+        const revokeResult =
+          await this.messagingArchiveCleaner.requestBindingRevokeAllForThread({
+            backend: params.backend,
+            threadId: params.threadId,
+            origin: "thread-archive",
+          });
+
+        if (revokeResult.revokedCount > 0 || pendingIntentIds.length > 0) {
+          backendRegistryLog.info("archived thread messaging cleanup completed", {
+            backend: params.backend,
+            notifiedCount: revokeResult.notifiedCount,
+            origin: params.origin,
+            pendingIntentCount: pendingIntentIds.length,
+            revokedCount: revokeResult.revokedCount,
+            threadId: params.threadId,
+          });
+        }
+
+        return {
+          notifiedCount: revokeResult.notifiedCount,
+          pendingIntentCount: pendingIntentIds.length,
+          revokedCount: revokeResult.revokedCount,
+        };
+      }
+
       if (!store) {
         return { pendingIntentCount: 0, revokedCount: 0 };
       }
 
       const bindings = await store.findActiveBindingsForThread({
-        backend: params.backend,
-        threadId: params.threadId,
-      });
-      const pendingIntentIds = await store.deletePendingIntentsForThread({
         backend: params.backend,
         threadId: params.threadId,
       });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu, shell } from "electron";
+import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
   disposeAppMetadataIpcHandlers,
@@ -122,6 +123,10 @@ export function bootstrapApp(): void {
         options,
       ),
     );
+    getDesktopBackendRegistry().setMessagingArchiveCleaner({
+      requestBindingRevokeAllForThread: (request) =>
+        messagingRuntime.requestBindingRevokeAllForThread(request),
+    });
     const messagingOverride = resolveRuntimeMessagingOverride();
     if (messagingOverride.disabled) {
       mainLog.info("messaging runtime disabled for this app instance", {

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -186,6 +186,35 @@ export class MessagingStore {
     });
   }
 
+  async deletePendingIntentsForThread(params: {
+    backend: MessagingBindingRecord["backend"];
+    threadId: MessagingBindingRecord["threadId"];
+  }): Promise<string[]> {
+    return await this.withData((data) => {
+      const bindingIds = new Set(
+        Object.values(data.bindings)
+          .filter((binding) => {
+            if (binding.threadId !== params.threadId) return false;
+            return !binding.backend || binding.backend === params.backend;
+          })
+          .map((binding) => binding.id),
+      );
+      const removed: string[] = [];
+      for (const [intentId, intent] of Object.entries(data.pendingIntents)) {
+        const requestContext = intent.intent.requestContext;
+        if (
+          (requestContext?.backend === params.backend &&
+            requestContext.threadId === params.threadId) ||
+          (intent.bindingId && bindingIds.has(intent.bindingId))
+        ) {
+          delete data.pendingIntents[intentId];
+          removed.push(intentId);
+        }
+      }
+      return removed;
+    });
+  }
+
   async cleanupExpiredPendingIntents(options?: { now?: number }): Promise<string[]> {
     const now = options?.now ?? Date.now();
     return await this.withData((data) => {

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -82,6 +82,20 @@ export class MessagingStore {
     );
   }
 
+  async findActiveBindingsForBackend(params: {
+    backend: MessagingBindingRecord["backend"];
+  }): Promise<MessagingBindingRecord[]> {
+    return await this.withReadData((data) =>
+      Object.values(data.bindings)
+        .filter(
+          (binding) =>
+            !binding.revokedAt &&
+            (!binding.backend || binding.backend === params.backend),
+        )
+        .map((binding) => structuredClone(binding)),
+    );
+  }
+
   async revokeBinding(params: {
     bindingId: string;
     revokedAt?: number;

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -96,6 +96,21 @@ export class SqliteMessagingStore {
       });
   }
 
+  async findActiveBindingsForBackend(params: {
+    backend: MessagingBindingRecord["backend"];
+  }): Promise<MessagingBindingRecord[]> {
+    const rows = this.stateDb.raw
+      .prepare("SELECT payload FROM bindings WHERE status = 'active'")
+      .all() as { payload: string }[];
+    return rows
+      .map((row) => JSON.parse(row.payload) as MessagingBindingRecord)
+      .filter((binding) => {
+        if (binding.revokedAt) return false;
+        if (!binding.backend) return true;
+        return binding.backend === params.backend;
+      });
+  }
+
   async revokeBinding(params: {
     bindingId: string;
     revokedAt?: number;
@@ -711,6 +726,7 @@ export type MessagingStoreLike = Pick<
   | "upsertBinding"
   | "getBinding"
   | "findActiveBindingForChannel"
+  | "findActiveBindingsForBackend"
   | "findActiveBindingsForThread"
   | "revokeBinding"
   | "upsertPendingIntent"

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -260,6 +260,58 @@ export class SqliteMessagingStore {
     return removed;
   }
 
+  async deletePendingIntentsForThread(params: {
+    backend: MessagingBindingRecord["backend"];
+    threadId: MessagingBindingRecord["threadId"];
+  }): Promise<string[]> {
+    const bindingRows = this.stateDb.raw
+      .prepare("SELECT payload FROM bindings WHERE thread_id = ?")
+      .all(params.threadId) as { payload: string }[];
+    const bindingIds = new Set<string>();
+    for (const row of bindingRows) {
+      try {
+        const binding = JSON.parse(row.payload) as MessagingBindingRecord;
+        if (!binding.backend || binding.backend === params.backend) {
+          bindingIds.add(binding.id);
+        }
+      } catch {
+        // Malformed binding payloads should not block intent cleanup.
+      }
+    }
+
+    const rows = this.stateDb.raw
+      .prepare("SELECT intent_id, binding_id, payload FROM pending_intents")
+      .all() as { intent_id: string; binding_id: string; payload: string }[];
+    const removed: string[] = [];
+    for (const row of rows) {
+      try {
+        const intent = JSON.parse(row.payload) as MessagingPendingIntentRecord;
+        const requestContext = intent.intent.requestContext;
+        if (
+          (requestContext?.backend === params.backend &&
+            requestContext.threadId === params.threadId) ||
+          (row.binding_id && bindingIds.has(row.binding_id))
+        ) {
+          removed.push(row.intent_id);
+        }
+      } catch {
+        // Malformed payloads are left for expiry cleanup.
+      }
+    }
+    if (removed.length === 0) return [];
+
+    const deleteIntent = this.stateDb.raw.prepare(
+      "DELETE FROM pending_intents WHERE intent_id = ?",
+    );
+    const deleteIntents = this.stateDb.raw.transaction((ids: string[]) => {
+      for (const id of ids) {
+        deleteIntent.run(id);
+      }
+    });
+    deleteIntents(removed);
+    return removed;
+  }
+
   async cleanupExpiredPendingIntents(options?: {
     now?: number;
   }): Promise<string[]> {
@@ -667,6 +719,7 @@ export type MessagingStoreLike = Pick<
   | "findActivePendingIntentsForRequest"
   | "deletePendingIntent"
   | "deletePendingIntentsForChannel"
+  | "deletePendingIntentsForThread"
   | "cleanupExpiredPendingIntents"
   | "upsertBrowseSession"
   | "getBrowseSession"


### PR DESCRIPTION
## Summary

I fixed archived threads leaving messaging state behind. When a thread is archived through PwrAgent or discovered as archived during a thread-list refresh, the desktop app now deletes pending intents tied to either the thread request context or the thread's bindings and revokes any active messaging bindings for that thread.

Archive-triggered binding revocation now routes through the messaging runtime when it is available, so active platforms run the same detach pipeline as `/detach`: retire the status card actions, unpin the status surface, revoke the binding, and deliver the “Thread detached” confirmation. The direct store cleanup remains as a best-effort fallback when the runtime or platform controller is unavailable. I also added the store-level delete primitive for both the file-backed test store and the persisted SQLite messaging store.

I also made the runtime revoke bus idempotent per binding while a detach is in flight. That prevents overlapping archive notifications and state-refresh cleanup from running multiple detach pipelines for the same binding and posting duplicate “Thread detached” confirmations.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts apps/desktop/src/main/__tests__/index.test.ts` (129 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

`pnpm lint:sql` still fails on the existing interpolated SQL check in `apps/desktop/src/main/state/migration.ts:543`, unrelated to this change.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via Codex
