### PR TITLE
feat(desktop): show directory-scoped pinned threads

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -5,7 +5,12 @@ import type {
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  comparePinnedThreads,
+  isPinnedThread,
+  moveThreadKey,
+} from "@pwragent/shared";
 import { FolderIcon, UnlinkedDotIcon, WorkspaceIcon } from "../../icons";
 import { ThreadRow } from "./ThreadRow";
 
@@ -25,6 +30,10 @@ type DirectoriesListProps = {
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onReorderThreadPins?: (
+    backend: AppServerBackendKind,
+    threadIds: string[],
+  ) => Promise<void>;
   onSetReaction?: (
     thread: NavigationThreadSummary,
     emoji: string,
@@ -65,6 +74,129 @@ export function DirectoriesList(props: DirectoriesListProps) {
       ),
     [props.threads]
   );
+  const pinnedThreads = useMemo(
+    () =>
+      props.threads
+        .filter(isPinnedThread)
+        .sort(comparePinnedThreads),
+    [props.threads],
+  );
+  const pinnedThreadKeys = useMemo(
+    () =>
+      pinnedThreads.map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+    [pinnedThreads],
+  );
+
+  const pinnedThreadKeysForBackend = (backend: AppServerBackendKind): string[] =>
+    pinnedThreads
+      .filter((thread) => thread.source === backend)
+      .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
+
+  const reorderPins = (
+    backend: AppServerBackendKind,
+    nextThreadKeys: string[],
+  ): void => {
+    const ids = nextThreadKeys
+      .filter((threadKey) => threadsByKey.get(threadKey)?.source === backend)
+      .map((threadKey) => threadsByKey.get(threadKey)?.id)
+      .filter((threadId): threadId is string => Boolean(threadId));
+    void props.onReorderThreadPins?.(backend, ids);
+  };
+
+  const buildDirectoryPinnedKeys = (
+    directory: NavigationDirectorySummary,
+    backend: AppServerBackendKind,
+  ): string[] =>
+    pinnedThreadKeys.filter(
+      (threadKey) =>
+        directory.threadKeys.includes(threadKey) &&
+        threadsByKey.get(threadKey)?.source === backend,
+    );
+
+  const moveDirectoryPin = (
+    directory: NavigationDirectorySummary,
+    draggedKey: string,
+    targetKey: string,
+    position: "before" | "after",
+  ): void => {
+    if (!directory.threadKeys.includes(draggedKey)) return;
+
+    const draggedThread = threadsByKey.get(draggedKey);
+    const targetThread = threadsByKey.get(targetKey);
+    if (!draggedThread || !targetThread || draggedThread.source !== targetThread.source) {
+      return;
+    }
+
+    const backendPinnedThreadKeys = pinnedThreadKeysForBackend(draggedThread.source);
+    const sourceKeys = backendPinnedThreadKeys.includes(draggedKey)
+      ? backendPinnedThreadKeys
+      : [...backendPinnedThreadKeys, draggedKey];
+    reorderPins(
+      draggedThread.source,
+      moveThreadKey(sourceKeys, draggedKey, targetKey, position),
+    );
+  };
+
+  const dropThreadIntoDirectoryPins = (
+    directory: NavigationDirectorySummary,
+    draggedKey: string,
+    position: "start" | "end",
+  ): void => {
+    if (!directory.threadKeys.includes(draggedKey)) return;
+
+    const draggedThread = threadsByKey.get(draggedKey);
+    if (!draggedThread) return;
+
+    const backendPinnedThreadKeys = pinnedThreadKeysForBackend(draggedThread.source);
+    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(
+      directory,
+      draggedThread.source,
+    );
+    const targetKey =
+      position === "start"
+        ? directoryPinnedThreadKeys[0]
+        : directoryPinnedThreadKeys[directoryPinnedThreadKeys.length - 1];
+
+    if (!targetKey) {
+      if (backendPinnedThreadKeys.includes(draggedKey)) return;
+      reorderPins(draggedThread.source, [...backendPinnedThreadKeys, draggedKey]);
+      return;
+    }
+
+    moveDirectoryPin(
+      directory,
+      draggedKey,
+      targetKey,
+      position === "start" ? "before" : "after",
+    );
+  };
+
+  const movePinnedThreadByKeyboard = (
+    directory: NavigationDirectorySummary,
+    thread: NavigationThreadSummary,
+    direction: "up" | "down",
+  ): void => {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(
+      directory,
+      thread.source,
+    );
+    const currentIndex = directoryPinnedThreadKeys.indexOf(threadKey);
+    if (currentIndex === -1) return;
+
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    const targetKey = directoryPinnedThreadKeys[targetIndex];
+    if (!targetKey) return;
+
+    moveDirectoryPin(
+      directory,
+      threadKey,
+      targetKey,
+      direction === "up" ? "before" : "after",
+    );
+  };
 
   useEffect(() => {
     const selectedItemKey = props.selectedItemKey;
@@ -111,6 +243,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
         const visibleThreads = directory.threadKeys
           .map((threadKey) => threadsByKey.get(threadKey))
           .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
+        const directoryPinnedThreads = visibleThreads
+          .filter(isPinnedThread)
+          .sort(comparePinnedThreads);
+        const directoryUnpinnedThreads = visibleThreads.filter(
+          (thread) => !isPinnedThread(thread),
+        );
 
         return (
           <section key={directory.key} className="directory-row">
@@ -174,18 +312,114 @@ export function DirectoriesList(props: DirectoriesListProps) {
               <div className="directory-row__details">
                 {visibleThreads.length > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
-                    {visibleThreads.map((thread) => {
+                    <div
+                      className="directory-row__pin-zone"
+                      role="separator"
+                      aria-label={`Pinned threads for ${directory.label}`}
+                      onDragOver={(event) => {
+                        event.preventDefault();
+                      }}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        dropThreadIntoDirectoryPins(
+                          directory,
+                          event.dataTransfer.getData("text/plain"),
+                          "start",
+                        );
+                      }}
+                    >
+                      <span>Pinned threads</span>
+                    </div>
+
+                    {directoryPinnedThreads.map((thread) => {
                       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
                       return (
                         <ThreadRow
                           key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                           compact
+                          draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode="kind"
                           selectedThreadKey={props.selectedItemKey}
                           thinkingThreadKeys={props.thinkingThreadKeys}
                           thread={thread}
+                          onDragOverThread={(event) => {
+                            event.preventDefault();
+                          }}
+                          onDragStartThread={(event) => {
+                            event.dataTransfer.effectAllowed = "move";
+                            event.dataTransfer.setData("text/plain", threadKey);
+                          }}
+                          onDropOnThread={(event) => {
+                            event.preventDefault();
+                            const draggedKey = event.dataTransfer.getData("text/plain");
+                            if (!draggedKey) return;
+                            const rect = event.currentTarget.getBoundingClientRect();
+                            const position = event.clientY > rect.top + rect.height / 2
+                              ? "after"
+                              : "before";
+                            moveDirectoryPin(
+                              directory,
+                              draggedKey,
+                              threadKey,
+                              position,
+                            );
+                          }}
+                          onMovePinnedThread={(pinnedThread, direction) => {
+                            movePinnedThreadByKeyboard(
+                              directory,
+                              pinnedThread,
+                              direction,
+                            );
+                          }}
+                          onOpenContextMenu={props.onOpenThreadContextMenu}
+                          onPrefetchPullRequests={props.onPrefetchPullRequests}
+                          onSelectThread={props.onSelectThread}
+                          onSetReaction={props.onSetReaction}
+                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+                        />
+                      );
+                    })}
+
+                    {directoryPinnedThreads.length > 0 ? (
+                      <div
+                        className="recents-pinned-divider directory-row__thread-divider"
+                        role="separator"
+                        aria-label={`Directory threads for ${directory.label}`}
+                        onDragOver={(event) => {
+                          event.preventDefault();
+                        }}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          dropThreadIntoDirectoryPins(
+                            directory,
+                            event.dataTransfer.getData("text/plain"),
+                            "end",
+                          );
+                        }}
+                      >
+                        <span>Directory threads</span>
+                      </div>
+                    ) : null}
+
+                    {directoryUnpinnedThreads.map((thread) => {
+                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+                      return (
+                        <ThreadRow
+                          key={`${directory.key}:${threadKey}`}
+                          approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                          compact
+                          draggable={Boolean(props.onReorderThreadPins)}
+                          includeLinkedDirectories
+                          linkedDirectoryMode="kind"
+                          selectedThreadKey={props.selectedItemKey}
+                          thinkingThreadKeys={props.thinkingThreadKeys}
+                          thread={thread}
+                          onDragStartThread={(event) => {
+                            event.dataTransfer.effectAllowed = "move";
+                            event.dataTransfer.setData("text/plain", threadKey);
+                          }}
                           onOpenContextMenu={props.onOpenThreadContextMenu}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -139,10 +139,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
     );
   };
 
-  const dropThreadIntoDirectoryPins = (
+  const dropThreadAfterDirectoryPins = (
     directory: NavigationDirectorySummary,
     draggedKey: string,
-    position: "start" | "end",
   ): void => {
     if (!directory.threadKeys.includes(draggedKey)) return;
 
@@ -154,10 +153,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       directory,
       draggedThread.source,
     );
-    const targetKey =
-      position === "start"
-        ? directoryPinnedThreadKeys[0]
-        : directoryPinnedThreadKeys[directoryPinnedThreadKeys.length - 1];
+    const targetKey = directoryPinnedThreadKeys[directoryPinnedThreadKeys.length - 1];
 
     if (!targetKey) {
       if (backendPinnedThreadKeys.includes(draggedKey)) return;
@@ -169,7 +165,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       directory,
       draggedKey,
       targetKey,
-      position === "start" ? "before" : "after",
+      "after",
     );
   };
 
@@ -312,25 +308,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
               <div className="directory-row__details">
                 {visibleThreads.length > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
-                    <div
-                      className="directory-row__pin-zone"
-                      role="separator"
-                      aria-label={`Pinned threads for ${directory.label}`}
-                      onDragOver={(event) => {
-                        event.preventDefault();
-                      }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        dropThreadIntoDirectoryPins(
-                          directory,
-                          event.dataTransfer.getData("text/plain"),
-                          "start",
-                        );
-                      }}
-                    >
-                      <span>Pinned threads</span>
-                    </div>
-
                     {directoryPinnedThreads.map((thread) => {
                       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
                       return (
@@ -382,7 +359,8 @@ export function DirectoriesList(props: DirectoriesListProps) {
                       );
                     })}
 
-                    {directoryPinnedThreads.length > 0 ? (
+                    {directoryPinnedThreads.length > 0 &&
+                    directoryUnpinnedThreads.length > 0 ? (
                       <div
                         className="recents-pinned-divider directory-row__thread-divider"
                         role="separator"
@@ -392,10 +370,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         }}
                         onDrop={(event) => {
                           event.preventDefault();
-                          dropThreadIntoDirectoryPins(
+                          dropThreadAfterDirectoryPins(
                             directory,
                             event.dataTransfer.getData("text/plain"),
-                            "end",
                           );
                         }}
                       >

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -457,6 +457,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onReorderThreadPins={props.onReorderThreadPins}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -651,13 +651,13 @@ describe("Sidebar", () => {
     );
 
     const directoryThreads = screen
-      .getByRole("separator", { name: "Pinned threads for PwrAgent" })
+      .getByRole("separator", { name: "Directory threads for PwrAgent" })
       .closest(".directory-row__threads") as HTMLElement;
     expect(
-      within(directoryThreads).getByRole("separator", {
-        name: "Directory threads for PwrAgent",
+      screen.queryByRole("separator", {
+        name: "Pinned threads for PwrAgent",
       }),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
 
     const rows = within(directoryThreads).getAllByRole("button", {
       name: /Cross-project cleanup|Updated thread/i,
@@ -667,7 +667,39 @@ describe("Sidebar", () => {
     expect(rows[1]).toHaveTextContent("Cross-project cleanup");
   });
 
-  it("pins a same-directory thread by dropping it into that directory pin area", () => {
+  it("does not render a directory pin divider when no directory threads are pinned", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByRole("separator", {
+        name: "Pinned threads for PwrAgent",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("separator", {
+        name: "Directory threads for PwrAgent",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("pins a same-directory thread by dropping it on the directory divider", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
     const pinnedThread = {
       ...updatedSinceSeenThread,
@@ -699,22 +731,23 @@ describe("Sidebar", () => {
     );
 
     fireEvent.drop(
-      screen.getByRole("separator", { name: "Pinned threads for PwrAgent" }),
+      screen.getByRole("separator", { name: "Directory threads for PwrAgent" }),
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
 
     expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
-      "thread-1",
       "thread-updated",
+      "thread-1",
     ]);
   });
 
-  it("ignores attempts to drop a thread into another directory pin area", () => {
+  it("ignores attempts to drop a thread on another directory pin divider", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
-    const projectBThread = {
+    const projectBPinnedThread = {
       ...sharedThread,
-      id: "thread-project-b",
-      title: "Project B setup",
+      id: "thread-project-b-pinned",
+      title: "Project B pinned setup",
+      pinnedRank: "2048",
       linkedDirectories: [
         {
           id: "dir-b",
@@ -724,14 +757,20 @@ describe("Sidebar", () => {
         },
       ],
     };
+    const projectBUnpinnedThread = {
+      ...projectBPinnedThread,
+      id: "thread-project-b-unpinned",
+      title: "Project B setup",
+      pinnedRank: undefined,
+    };
     const projectBDirectory: NavigationDirectorySummary = {
       key: "directory:/Users/huntharo/pwrdrvr/ProjectB",
       kind: "directory",
       label: "ProjectB",
       path: "/Users/huntharo/pwrdrvr/ProjectB",
-      threadKeys: ["codex:thread-project-b"],
+      threadKeys: ["codex:thread-project-b-pinned", "codex:thread-project-b-unpinned"],
       needsAttentionCount: 0,
-      latestUpdatedAt: projectBThread.updatedAt,
+      latestUpdatedAt: projectBPinnedThread.updatedAt,
     };
 
     render(
@@ -745,7 +784,7 @@ describe("Sidebar", () => {
         loading={false}
         creatingThread={undefined}
         selectedItemKey="codex:thread-1"
-        threads={[sharedThread, projectBThread]}
+        threads={[sharedThread, projectBPinnedThread, projectBUnpinnedThread]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
@@ -761,7 +800,7 @@ describe("Sidebar", () => {
 
     fireEvent.click(projectBSummary!);
     fireEvent.drop(
-      screen.getByRole("separator", { name: "Pinned threads for ProjectB" }),
+      screen.getByRole("separator", { name: "Directory threads for ProjectB" }),
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -127,6 +127,14 @@ const directories: NavigationDirectorySummary[] = [
   },
 ];
 
+function createDataTransfer(threadKey: string) {
+  return {
+    effectAllowed: "move",
+    getData: vi.fn((type: string) => (type === "text/plain" ? threadKey : "")),
+    setData: vi.fn(),
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   cleanup();
@@ -611,6 +619,153 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Pin Thread" }));
 
     expect(onSetThreadPin).toHaveBeenCalledWith(sharedThread, true);
+  });
+
+  it("renders pinned threads above directory threads inside each expanded directory", () => {
+    const pinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+    const directoryWithPinnedThread = {
+      ...directories[0],
+      threadKeys: ["codex:thread-1", "codex:thread-updated"],
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[directoryWithPinnedThread]}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, pinnedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const directoryThreads = screen
+      .getByRole("separator", { name: "Pinned threads for PwrAgent" })
+      .closest(".directory-row__threads") as HTMLElement;
+    expect(
+      within(directoryThreads).getByRole("separator", {
+        name: "Directory threads for PwrAgent",
+      }),
+    ).toBeInTheDocument();
+
+    const rows = within(directoryThreads).getAllByRole("button", {
+      name: /Cross-project cleanup|Updated thread/i,
+    });
+    expect(rows[0]).toHaveTextContent("Updated thread");
+    expect(rows[0]).toHaveTextContent("Pinned");
+    expect(rows[1]).toHaveTextContent("Cross-project cleanup");
+  });
+
+  it("pins a same-directory thread by dropping it into that directory pin area", () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const pinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+    const directoryWithPinnedThread = {
+      ...directories[0],
+      threadKeys: ["codex:thread-1", "codex:thread-updated"],
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[directoryWithPinnedThread]}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, pinnedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.drop(
+      screen.getByRole("separator", { name: "Pinned threads for PwrAgent" }),
+      { dataTransfer: createDataTransfer("codex:thread-1") },
+    );
+
+    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
+      "thread-1",
+      "thread-updated",
+    ]);
+  });
+
+  it("ignores attempts to drop a thread into another directory pin area", () => {
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const projectBThread = {
+      ...sharedThread,
+      id: "thread-project-b",
+      title: "Project B setup",
+      linkedDirectories: [
+        {
+          id: "dir-b",
+          label: "ProjectB",
+          path: "/Users/huntharo/pwrdrvr/ProjectB",
+          kind: "local" as const,
+        },
+      ],
+    };
+    const projectBDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/pwrdrvr/ProjectB",
+      kind: "directory",
+      label: "ProjectB",
+      path: "/Users/huntharo/pwrdrvr/ProjectB",
+      threadKeys: ["codex:thread-project-b"],
+      needsAttentionCount: 0,
+      latestUpdatedAt: projectBThread.updatedAt,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[directories[0], projectBDirectory]}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, projectBThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const projectBSummary = screen
+      .getAllByRole("button", { name: /ProjectB/i })
+      .find((button) => button.getAttribute("aria-expanded") === "false");
+    expect(projectBSummary).toBeDefined();
+
+    fireEvent.click(projectBSummary!);
+    fireEvent.drop(
+      screen.getByRole("separator", { name: "Pinned threads for ProjectB" }),
+      { dataTransfer: createDataTransfer("codex:thread-1") },
+    );
+
+    expect(onReorderThreadPins).not.toHaveBeenCalled();
   });
 
   it("shows copy actions below the thread context menu divider", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1796,27 +1796,6 @@ textarea,
   padding-left: 8px;
 }
 
-.directory-row__pin-zone {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 26px;
-  margin: 0 6px 2px;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.directory-row__pin-zone::after {
-  content: "";
-  min-width: 16px;
-  height: 1px;
-  flex: 1;
-  background: var(--border-subtle);
-}
-
 .directory-row__thread-divider {
   margin-top: 4px;
   margin-bottom: 2px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1796,6 +1796,32 @@ textarea,
   padding-left: 8px;
 }
 
+.directory-row__pin-zone {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  margin: 0 6px 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.directory-row__pin-zone::after {
+  content: "";
+  min-width: 16px;
+  height: 1px;
+  flex: 1;
+  background: var(--border-subtle);
+}
+
+.directory-row__thread-divider {
+  margin-top: 4px;
+  margin-bottom: 2px;
+}
+
 .directory-row__threads .thread-row--compact {
   flex-direction: column;
   align-items: stretch;


### PR DESCRIPTION
## Summary

This PR makes pinned threads visible and reorderable from the Directories lens while keeping pin state shared with Recents.

- show pinned threads at the top of each expanded directory when those threads belong to that directory
- allow same-directory drag/drop reordering and pin insertion through the directory divider
- reject drops from one directory into another directory's pin area
- keep the directory divider visually consistent with the existing Recents pinned/unpinned divider, with no empty reservation label

## Verification

- I verified the focused sidebar tests pass: `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- I verified the desktop typecheck passes: `pnpm --filter @pwragent/desktop typecheck`
