### PR TITLE
fix(desktop): fall back to local mode outside git repos

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1496,6 +1496,56 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("starts requested worktree threads as local when the cwd is not a git repository", async () => {
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/start"] },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/Users/test/.pwragent/projects",
+          workMode: "local" as const,
+        })),
+        recordCodexWorktreeOwnerThread,
+      } as never,
+    });
+
+    await registry.startThread({
+      backend: "codex",
+      cwd: "/Users/test/.pwragent/projects",
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    expect(codexClient.lastStartThreadParams?.cwd).toBe(
+      "/Users/test/.pwragent/projects",
+    );
+    expect(recordCodexWorktreeOwnerThread).not.toHaveBeenCalled();
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        projectKey: "/Users/test/.pwragent/projects",
+        linkedDirectories: [
+          {
+            id: "/Users/test/.pwragent/projects",
+            kind: "local",
+            label: "projects",
+            path: "/Users/test/.pwragent/projects",
+          },
+        ],
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("materializes workspace launchpads into a scratch directory instead of the workspace root", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -54,6 +54,25 @@ describe("GitDirectoryService", () => {
     });
   });
 
+  it("falls back to local mode when a worktree launchpad targets a non-git directory", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "pwragent-non-git-directory-"));
+    cleanupPaths.push(directory);
+    const service = new GitDirectoryService();
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryKind: "directory",
+        directoryLabel: "Projects",
+        directoryPath: directory,
+        workMode: "worktree",
+        branchName: "main",
+      }),
+    ).resolves.toEqual({
+      cwd: directory,
+      workMode: "local",
+    });
+  });
+
   it("reports default and available handoff branches", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -628,6 +628,64 @@ describe("MessagingController", () => {
     });
   });
 
+  it("pins the Workspaces Scratchpad first when choosing a project for a new thread", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories = [
+      {
+        ...navigation.directories[0]!,
+        latestUpdatedAt: 9_000,
+      },
+      {
+        key: "workspace:/Users/test/.pwragent/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/test/.pwragent/projects",
+        threadKeys: ["codex:scratchpad-thread"],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 1_000,
+      },
+      {
+        key: "directory:giphy-demo",
+        kind: "directory",
+        label: "giphy-demo",
+        path: "/repo/giphy-demo",
+        threadKeys: ["codex:giphy-thread"],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 8_000,
+      },
+    ];
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+
+    const pickerIntent = harness.delivered.at(-1);
+    if (pickerIntent?.kind !== "project_picker") {
+      throw new Error("Expected project picker intent");
+    }
+
+    expect(
+      pickerIntent.page.actions.filter((action) => action.id === "browse:select-project"),
+    ).toEqual([
+      expect.objectContaining({
+        id: "browse:select-project",
+        label: "1. Workspaces Scratchpad (1)",
+        value: {
+          directoryKey: "workspace:/Users/test/.pwragent/projects",
+          label: "Workspaces Scratchpad",
+          path: "/Users/test/.pwragent/projects",
+        },
+      }),
+      expect.objectContaining({
+        id: "browse:select-project",
+        label: "2. PwrAgent (1)",
+      }),
+      expect.objectContaining({
+        id: "browse:select-project",
+        label: "3. giphy-demo (1)",
+      }),
+    ]);
+  });
+
   it("debounces split first prompts before creating a messaging-started thread", async () => {
     const harness = await createHarness({ inputDebounceMs: 10 });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -158,12 +158,16 @@ describe("MessagingController", () => {
       body: expect.stringContaining("PwrAgent"),
       actions: expect.arrayContaining([
         expect.objectContaining({ id: "browse:new:workspace:local", label: "Local ✓" }),
-        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
         expect.objectContaining({ id: "browse:new:permissions" }),
         expect.objectContaining({ id: "browse:new:fast" }),
         expect.objectContaining({ id: "browse:new:streaming" }),
         expect.objectContaining({ id: "browse:new:model" }),
         expect.objectContaining({ id: "browse:new:reasoning" }),
+      ]),
+    });
+    expect(readyIntent).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
       ]),
     });
     expect(readyIntent).toMatchObject({
@@ -358,6 +362,70 @@ describe("MessagingController", () => {
         executionMode: "default",
         workMode: "worktree",
         branchName: "release/v2",
+      }),
+    });
+  });
+
+  it("keeps non-git new-thread prompts local when a worktree action is requested", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Workspace: Local"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:base-branch" }),
+      ]),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:workspace:worktree",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Workspace: Local"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      body: expect.not.stringContaining("Base branch:"),
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:base-branch" }),
+      ]),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug locally"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: expect.stringMatching(/^messaging:browse:/),
+      launchpad: expect.objectContaining({
+        directoryKey: "directory:pwragent",
+        directoryPath: "/repo/pwragent",
+        workMode: "local",
       }),
     });
   });
@@ -5672,6 +5740,11 @@ function buildWorktreeLaunchpadNavigationSnapshot(): NavigationSnapshot {
   const snapshot = buildNavigationSnapshot();
   snapshot.directories[0] = {
     ...snapshot.directories[0]!,
+    gitStatus: {
+      currentBranch: "feature/current",
+      defaultBranch: "main",
+      branches: ["main", "feature/current"],
+    },
     launchpad: {
       directoryKey: "directory:pwragent",
       directoryKind: "directory",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -628,12 +628,21 @@ describe("MessagingController", () => {
     });
   });
 
-  it("pins the Workspaces Scratchpad first when choosing a project for a new thread", async () => {
+  it("pins the Workspaces Scratchpad first without listing duplicate workspace roots", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.directories = [
       {
         ...navigation.directories[0]!,
         latestUpdatedAt: 9_000,
+      },
+      {
+        key: "workspace:/Users/test/.pwragent/profiles/default/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/test/.pwragent/profiles/default/projects",
+        threadKeys: ["codex:profile-scratchpad-1", "codex:profile-scratchpad-2"],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 8_500,
       },
       {
         key: "workspace:/Users/test/.pwragent/projects",
@@ -668,11 +677,11 @@ describe("MessagingController", () => {
     ).toEqual([
       expect.objectContaining({
         id: "browse:select-project",
-        label: "1. Workspaces Scratchpad (1)",
+        label: "1. Workspaces Scratchpad (3)",
         value: {
-          directoryKey: "workspace:/Users/test/.pwragent/projects",
+          directoryKey: "workspace:/Users/test/.pwragent/profiles/default/projects",
           label: "Workspaces Scratchpad",
-          path: "/Users/test/.pwragent/projects",
+          path: "/Users/test/.pwragent/profiles/default/projects",
         },
       }),
       expect.objectContaining({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1608,6 +1608,7 @@ export class DesktopBackendRegistry {
         ? await this.createScratchProjectDirectory()
         : request.cwd;
     let resolvedLinkedDirectories = linkedDirectories;
+    let effectiveWorkMode = workMode;
     if (workMode === "worktree" && request.cwd?.trim()) {
       const preparedWorkspace =
         await this.gitDirectoryService.prepareLaunchpadWorkspace({
@@ -1619,11 +1620,15 @@ export class DesktopBackendRegistry {
           workMode: "worktree",
         });
       cwd = preparedWorkspace.cwd;
-      resolvedLinkedDirectories = buildWorktreeLinkedDirectory({
-        label: path.basename(request.cwd) || request.cwd,
-        repositoryPath: preparedWorkspace.repositoryPath ?? request.cwd,
-        worktreePath: preparedWorkspace.cwd,
-      });
+      effectiveWorkMode = preparedWorkspace.workMode;
+      resolvedLinkedDirectories =
+        preparedWorkspace.workMode === "worktree"
+          ? buildWorktreeLinkedDirectory({
+              label: path.basename(request.cwd) || request.cwd,
+              repositoryPath: preparedWorkspace.repositoryPath ?? request.cwd,
+              worktreePath: preparedWorkspace.cwd,
+            })
+          : buildLocalLinkedDirectory(cwd);
     }
 
     const result = await this.getClient(backend, executionMode).startThread({
@@ -1653,7 +1658,7 @@ export class DesktopBackendRegistry {
         gitBranch,
       },
     );
-    if (workMode === "worktree") {
+    if (effectiveWorkMode === "worktree") {
       await this.recordCodexWorktreeOwnerThread({
         backend,
         threadId: result.threadId,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -25,6 +25,30 @@ async function runGit(cwd: string, args: string[]): Promise<string> {
   return stdout.trim();
 }
 
+function errorText(error: unknown): string {
+  const parts = [error instanceof Error ? error.message : String(error)];
+  const stderr = (error as { stderr?: unknown })?.stderr;
+  if (typeof stderr === "string") {
+    parts.push(stderr);
+  }
+  return parts.join("\n");
+}
+
+function isNotGitRepositoryError(error: unknown): boolean {
+  return errorText(error).includes("not a git repository");
+}
+
+async function readGitRoot(cwd: string): Promise<string | undefined> {
+  try {
+    return await runGit(cwd, ["rev-parse", "--show-toplevel"]);
+  } catch (error) {
+    if (isNotGitRepositoryError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
 export async function recordCodexWorktreeOwnerThread(params: {
   worktreePath: string;
   threadId: string;
@@ -439,7 +463,14 @@ export class GitDirectoryService {
       };
     }
 
-    const repoRoot = await runGit(directoryPath, ["rev-parse", "--show-toplevel"]);
+    const repoRoot = await readGitRoot(directoryPath);
+    if (!repoRoot) {
+      return {
+        cwd: directoryPath,
+        workMode: "local",
+      };
+    }
+
     const baseBranch =
       sanitizeBranchName(launchpad.branchName ?? "") ||
       sanitizeBranchName(await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"])) ||

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2493,6 +2493,21 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:new:workspace:worktree") {
+      const directory = nextSession.selectedProject
+        ? directoryForProjectSelection(navigation, nextSession.selectedProject)
+        : undefined;
+      if (!canCreateNewThreadWorktree(directory)) {
+        await this.presentNewThreadPromptGate(
+          {
+            ...nextSession,
+            workMode: "local",
+            branchName: undefined,
+          },
+          event,
+          navigation,
+        );
+        return;
+      }
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -2505,6 +2520,21 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:new:base-branch") {
+      const directory = nextSession.selectedProject
+        ? directoryForProjectSelection(navigation, nextSession.selectedProject)
+        : undefined;
+      if (!canCreateNewThreadWorktree(directory)) {
+        await this.presentNewThreadPromptGate(
+          {
+            ...nextSession,
+            workMode: "local",
+            branchName: undefined,
+          },
+          event,
+          navigation,
+        );
+        return;
+      }
       await this.presentNewThreadBranchPicker(nextSession, navigation, event);
       return;
     }
@@ -2524,6 +2554,21 @@ export class MessagingController {
       const branchName = readStringValue(event.value, "branchName");
       if (!branchName) {
         await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      const directory = nextSession.selectedProject
+        ? directoryForProjectSelection(navigation, nextSession.selectedProject)
+        : undefined;
+      if (!canCreateNewThreadWorktree(directory)) {
+        await this.presentNewThreadPromptGate(
+          {
+            ...nextSession,
+            workMode: "local",
+            branchName: undefined,
+          },
+          event,
+          navigation,
+        );
         return;
       }
       await this.presentNewThreadPromptGate(
@@ -2801,17 +2846,21 @@ export class MessagingController {
     }
 
     const directory = directoryForProjectSelection(navigation, project);
+    const workMode = resolveNewThreadWorkMode({
+      requestedWorkMode:
+        session.workMode ??
+        directory?.launchpad?.workMode ??
+        navigation.launchpadDefaults.workMode ??
+        "local",
+      directory,
+    });
     await this.presentNewThreadPromptGate(
       {
         ...session,
         mode: "new_thread_options",
         pageIndex: 0,
-        workMode:
-          session.workMode ??
-          directory?.launchpad?.workMode ??
-          navigation.launchpadDefaults.workMode ??
-          "local",
-        branchName: session.branchName,
+        workMode,
+        branchName: workMode === "worktree" ? session.branchName : undefined,
         selectedProject: project,
         updatedAt: this.now(),
         expiresAt: this.now() + this.pendingIntentTtlMs,
@@ -2838,6 +2887,7 @@ export class MessagingController {
       directory,
       this.streamingResponsesDefault,
     );
+    const canCreateWorktree = canCreateNewThreadWorktree(directory);
     await this.options.store.upsertBrowseSession(session);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -2861,12 +2911,20 @@ export class MessagingController {
           style: options.workMode === "local" ? "primary" : "secondary",
           fallbackText: "local",
         },
-        {
-          id: "browse:new:workspace:worktree",
-          label: options.workMode === "worktree" ? "New Worktree ✓" : "New Worktree",
-          style: options.workMode === "worktree" ? "primary" : "secondary",
-          fallbackText: "worktree",
-        },
+        ...(canCreateWorktree
+          ? [
+              {
+                id: "browse:new:workspace:worktree",
+                label:
+                  options.workMode === "worktree" ? "New Worktree ✓" : "New Worktree",
+                style:
+                  options.workMode === "worktree"
+                    ? "primary" as const
+                    : "secondary" as const,
+                fallbackText: "worktree",
+              },
+            ]
+          : []),
         ...(options.workMode === "worktree"
           ? [
               {
@@ -2929,6 +2987,8 @@ export class MessagingController {
 
     const updatedSession = {
       ...session,
+      workMode: options.workMode,
+      branchName: options.workMode === "worktree" ? options.branchName : undefined,
       surface: result.surface,
       updatedAt: this.now(),
     };
@@ -5487,11 +5547,14 @@ function newThreadOptionsForSession(
   directory: NavigationDirectorySummary | undefined,
   streamingResponsesDefault: boolean,
 ): NewThreadOptionsSummary {
-  const workMode =
-    session.workMode ??
-    directory?.launchpad?.workMode ??
-    navigation.launchpadDefaults.workMode ??
-    "local";
+  const workMode = resolveNewThreadWorkMode({
+    requestedWorkMode:
+      session.workMode ??
+      directory?.launchpad?.workMode ??
+      navigation.launchpadDefaults.workMode ??
+      "local",
+    directory,
+  });
   const streamingMode = session.preferences?.streamingResponses ?? "inherit";
   return {
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
@@ -5511,6 +5574,27 @@ function newThreadOptionsForSession(
         : streamingMode === "enabled",
     workMode,
   };
+}
+
+function canCreateNewThreadWorktree(
+  directory: NavigationDirectorySummary | undefined,
+): boolean {
+  return Boolean(
+    directory?.path &&
+      directory.kind === "directory" &&
+      (directory.gitStatus?.currentBranch ||
+        (directory.gitStatus?.branches?.length ?? 0) > 0),
+  );
+}
+
+function resolveNewThreadWorkMode(params: {
+  requestedWorkMode: LaunchpadWorkMode;
+  directory: NavigationDirectorySummary | undefined;
+}): LaunchpadWorkMode {
+  return params.requestedWorkMode === "worktree" &&
+    canCreateNewThreadWorktree(params.directory)
+    ? "worktree"
+    : "local";
 }
 
 function newThreadPromptGateBody(

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -336,7 +336,12 @@ function projectsForSession(
   session: MessagingBrowseSessionRecord,
 ): NavigationDirectorySummary[] {
   const query = session.query?.trim().toLowerCase();
-  return [...navigation.directories]
+  const directories =
+    session.launchAction === "start_new_thread"
+      ? collapseWorkspaceScratchpadDirectories(navigation.directories)
+      : navigation.directories;
+
+  return [...directories]
     .filter((directory) => {
       if (!query) {
         return true;
@@ -361,6 +366,45 @@ function projectsForSession(
       const updatedDelta = (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0);
       return updatedDelta !== 0 ? updatedDelta : left.label.localeCompare(right.label);
     });
+}
+
+function collapseWorkspaceScratchpadDirectories(
+  directories: NavigationDirectorySummary[],
+): NavigationDirectorySummary[] {
+  const scratchpads = directories.filter(isWorkspaceScratchpadDirectory);
+  if (scratchpads.length <= 1) {
+    return directories;
+  }
+
+  const preferred = [...scratchpads].sort(compareWorkspaceScratchpadPreference)[0]!;
+  const threadKeys = new Set<string>();
+  let needsAttentionCount = 0;
+  let latestUpdatedAt = 0;
+  for (const scratchpad of scratchpads) {
+    for (const threadKey of scratchpad.threadKeys) {
+      threadKeys.add(threadKey);
+    }
+    needsAttentionCount += scratchpad.needsAttentionCount;
+    latestUpdatedAt = Math.max(latestUpdatedAt, scratchpad.latestUpdatedAt ?? 0);
+  }
+
+  return [
+    {
+      ...preferred,
+      threadKeys: [...threadKeys],
+      needsAttentionCount,
+      latestUpdatedAt,
+    },
+    ...directories.filter((directory) => !isWorkspaceScratchpadDirectory(directory)),
+  ];
+}
+
+function compareWorkspaceScratchpadPreference(
+  left: NavigationDirectorySummary,
+  right: NavigationDirectorySummary,
+): number {
+  const updatedDelta = (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0);
+  return updatedDelta !== 0 ? updatedDelta : left.key.localeCompare(right.key);
 }
 
 function isWorkspaceScratchpadDirectory(directory: NavigationDirectorySummary): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -22,6 +22,7 @@ import { capabilityProfilePageSize } from "@pwragent/messaging-interface";
 
 export const RESUME_BROWSER_PAGE_SIZE = 8;
 const RESUME_BROWSER_NAV_ACTION_COUNT = 5;
+const WORKSPACES_SCRATCHPAD_LABEL = "Workspaces Scratchpad";
 
 export function resumeBrowserPageSize(
   profile?: MessagingCapabilityProfile,
@@ -242,9 +243,10 @@ function buildProjectPickerIntent(params: {
   const page = paginate(allProjects, params.session.pageIndex, params.session.pageSize);
   const actions: MessagingSurfaceAction[] = [
     ...page.items.map((project, index) => {
+      const projectLabel = formatProjectPickerLabel(project, params.session);
       const value: Record<string, MessagingJsonValue> = {
         directoryKey: project.key,
-        label: project.label,
+        label: projectLabel,
       };
       if (typeof project.path === "string") {
         value.path = project.path;
@@ -252,7 +254,7 @@ function buildProjectPickerIntent(params: {
 
       return {
         id: "browse:select-project",
-        label: `${page.startIndex + index + 1}. ${project.label} (${project.threadKeys.length})`,
+        label: `${page.startIndex + index + 1}. ${projectLabel} (${project.threadKeys.length})`,
         style: "primary" as const,
         fallbackText: String(index + 1),
         value,
@@ -339,14 +341,40 @@ function projectsForSession(
       if (!query) {
         return true;
       }
-      return [directory.label, directory.path, directory.key]
+      return [
+        formatProjectPickerLabel(directory, session),
+        directory.label,
+        directory.path,
+        directory.key,
+      ]
         .filter(Boolean)
         .some((value) => value!.toLowerCase().includes(query));
     })
     .sort((left, right) => {
+      if (session.launchAction === "start_new_thread") {
+        const leftRank = isWorkspaceScratchpadDirectory(left) ? 0 : 1;
+        const rightRank = isWorkspaceScratchpadDirectory(right) ? 0 : 1;
+        if (leftRank !== rightRank) {
+          return leftRank - rightRank;
+        }
+      }
       const updatedDelta = (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0);
       return updatedDelta !== 0 ? updatedDelta : left.label.localeCompare(right.label);
     });
+}
+
+function isWorkspaceScratchpadDirectory(directory: NavigationDirectorySummary): boolean {
+  return directory.kind === "workspace";
+}
+
+function formatProjectPickerLabel(
+  project: NavigationDirectorySummary,
+  session: MessagingBrowseSessionRecord,
+): string {
+  return session.launchAction === "start_new_thread" &&
+    isWorkspaceScratchpadDirectory(project)
+    ? WORKSPACES_SCRATCHPAD_LABEL
+    : project.label;
 }
 
 // Explicit row sentinels for the resume browser footer. Items above are
@@ -505,10 +533,10 @@ function projectPickerFallbackText(
   ].filter(Boolean);
   return [
     projectPickerPromptText(session, page.totalPages, page.totalItems),
-    ...page.items.map(
-      (project, index) =>
-        `${page.startIndex + index + 1}. ${project.label} (${project.threadKeys.length})`,
-    ),
+    ...page.items.map((project, index) => {
+      const projectLabel = formatProjectPickerLabel(project, session);
+      return `${page.startIndex + index + 1}. ${projectLabel} (${project.threadKeys.length})`;
+    }),
     page.totalItems > 0
       ? `Reply with a number, or reply ${formatControlList(controls)}.`
       : `Reply ${formatControlList(controls)}.`,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2380,6 +2380,11 @@ export function Composer(props: ComposerProps) {
   const launchpadWorkspaceOptions = props.launchpad
     ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
     : [];
+  const launchpadWorkspaceValue =
+    props.launchpad &&
+    launchpadWorkspaceOptions.some((option) => option.value === props.launchpad?.workMode)
+      ? props.launchpad.workMode
+      : "local";
   const threadWorkspace = props.thread ? getThreadWorkspace(props.thread) : undefined;
   const workspaceOpenPath = getComposerWorkspaceOpenPath({
     directory: props.directory,
@@ -3265,7 +3270,7 @@ export function Composer(props: ComposerProps) {
                 !props.onUpdateLaunchpad ||
                 launchpadWorkspaceOptions.length <= 1
               }
-              value={props.launchpad.workMode}
+              value={launchpadWorkspaceValue}
               options={launchpadWorkspaceOptions.map((option) => ({
                 label: option.label,
                 value: option.value,
@@ -3327,7 +3332,7 @@ export function Composer(props: ComposerProps) {
           ) : null}
 
           {props.launchpad &&
-          props.launchpad.workMode === "worktree" &&
+          launchpadWorkspaceValue === "worktree" &&
           (props.directory?.gitStatus?.branches?.length ?? 0) > 0 ? (
             <ComposerDropdown
               ariaLabel="Base branch"
@@ -4044,7 +4049,7 @@ function buildLaunchpadWorkspaceOptions(
     { value: "local", label: localLabel ?? "Local" },
   ];
 
-  if (canCreateWorktree || launchpad.workMode === "worktree") {
+  if (canCreateWorktree) {
     options.push({ value: "worktree", label: "New worktree" });
   }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2291,6 +2291,46 @@ describe("Composer", () => {
     });
   });
 
+  it("does not offer worktree launchpad mode for non-git directories", () => {
+    render(
+      <Composer
+        backends={[
+          backendSummary("codex"),
+        ]}
+        directory={{
+          key: "directory:/Users/huntharo/.pwragent/projects",
+          kind: "directory",
+          label: "Projects",
+          path: "/Users/huntharo/.pwragent/projects",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/.pwragent/projects",
+          directoryKind: "directory",
+          directoryLabel: "Projects",
+          directoryPath: "/Users/huntharo/.pwragent/projects",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    const workspaceMode = screen.getByLabelText("Workspace mode");
+    expect(workspaceMode).toBeDisabled();
+    expect(workspaceMode).toHaveValue("local");
+    expect(workspaceMode).toHaveTextContent("Local");
+    fireEvent.click(workspaceMode);
+    expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
+  });
+
   it("renders the worktree base branch menu as a branch chooser", () => {
     render(
       <Composer


### PR DESCRIPTION
## Summary

I fixed the desktop launchpad/worktree startup path so directories that are not Git repositories no longer hard-fail when the selected launch mode says `worktree`. I also made the messaging new-thread picker stop presenting worktree mode for non-git directories and keep the scratchpad option stable at the top without duplicate scratchpad rows.

## Changes

- Treat `git rev-parse --show-toplevel` "not a git repository" failures as a local-mode fallback in `GitDirectoryService.prepareLaunchpadWorkspace`.
- Carry the prepared workspace's effective mode through `DesktopBackendRegistry.startThread`, so local fallbacks get local linked-directory metadata and skip Codex worktree owner recording.
- Hide or normalize the messaging and desktop launchpad worktree option when the selected directory has no Git branch status.
- Rename the scratch workspace grouping to `Workspaces Scratchpad` in the messaging new-thread picker and sort it before recency-ranked project rows.
- Collapse multiple scratch workspace roots into one `Workspaces Scratchpad` picker row with the combined thread count.
- Added regression coverage for service fallback, thread-start metadata, non-git worktree option gating, scratchpad picker ordering, and duplicate scratchpad row collapse.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts -t "pins the Workspaces Scratchpad"`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
- `pnpm test`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
