### PR TITLE
feat(messaging): surface startup bot metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1793,8 +1793,18 @@ describe("DesktopMessagingRuntime", () => {
 
   it("hot-applies config by stopping disabled channels and restarting changed credentials", async () => {
     await prepareRuntimeStore();
-    const firstTelegramAdapter = createAdapter("telegram");
-    const secondTelegramAdapter = createAdapter("telegram");
+    const firstTelegramAdapter = createAdapter("telegram", {
+      readCredentialMetadata: () => ({
+        account: "@old_bot",
+        detail: "api.telegram.org",
+      }),
+    });
+    const secondTelegramAdapter = createAdapter("telegram", {
+      readCredentialMetadata: () => ({
+        account: "@new_bot",
+        detail: "api.telegram.org",
+      }),
+    });
     const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => {
       if (!config.telegram) return [];
       return [
@@ -1842,11 +1852,18 @@ describe("DesktopMessagingRuntime", () => {
         health: "suspended",
       }),
     ]);
+    expect(runtime.getPlatformStatuses()[0]).not.toHaveProperty("account");
+    expect(runtime.getPlatformCredentialMetadata("telegram")).toBeUndefined();
   });
 
   it("preserves errored health when a hot restart replacement fails", async () => {
     await prepareRuntimeStore();
-    const firstTelegramAdapter = createAdapter("telegram");
+    const firstTelegramAdapter = createAdapter("telegram", {
+      readCredentialMetadata: () => ({
+        account: "@old_bot",
+        detail: "api.telegram.org",
+      }),
+    });
     const failingTelegramAdapter = createAdapter("telegram", {
       start: vi.fn(async () => {
         throw new Error("new token rejected");
@@ -1895,6 +1912,8 @@ describe("DesktopMessagingRuntime", () => {
         reason: "new token rejected",
       }),
     ]);
+    expect(runtime.getPlatformStatuses()[0]).not.toHaveProperty("account");
+    expect(runtime.getPlatformCredentialMetadata("telegram")).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -72,6 +72,34 @@ describe("DesktopMessagingRuntime", () => {
     });
   });
 
+  it("surfaces adapter startup credential metadata in platform status", async () => {
+    const { runtime } = await createRuntimeHarness({
+      adapter: createAdapter("telegram", {
+        readCredentialMetadata: () => ({
+          account: "@pwragent_bot",
+          detail: "api.telegram.org",
+        }),
+      }),
+    });
+
+    await runtime.start();
+
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        account: "@pwragent_bot",
+        detail: "api.telegram.org",
+        health: "enabled",
+        platform: "telegram",
+      }),
+    ]);
+    expect(runtime.getPlatformCredentialMetadata("telegram")).toEqual(
+      expect.objectContaining({
+        account: "@pwragent_bot",
+        detail: "api.telegram.org",
+      }),
+    );
+  });
+
   it("routes adversarial Telegram inbound text literally without mutating SQLite state", async () => {
     const { runtime, adapter, bridge } = await createRuntimeHarness();
     const { getAppStateDb } = await import("../state/app-state");
@@ -1870,7 +1898,9 @@ describe("DesktopMessagingRuntime", () => {
   });
 });
 
-async function createRuntimeHarness(): Promise<{
+async function createRuntimeHarness(options: {
+  adapter?: ReturnType<typeof createAdapter>;
+} = {}): Promise<{
   DesktopMessagingRuntime: typeof DesktopMessagingRuntime;
   adapter: ReturnType<typeof createAdapter>;
   bridge: ReturnType<typeof createBackendBridge>;
@@ -1879,7 +1909,7 @@ async function createRuntimeHarness(): Promise<{
 }> {
   await prepareRuntimeStore();
 
-  const adapter = createAdapter("telegram");
+  const adapter = options.adapter ?? createAdapter("telegram");
   const bridge = createBackendBridge();
   const { DesktopMessagingRuntime: Runtime } = await import(
     "../messaging/messaging-runtime"

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -16,6 +16,7 @@ const providerMocks = vi.hoisted(() => ({
 }));
 const runtimeMock = vi.hoisted(() => ({
   applyConfig: vi.fn(async () => undefined),
+  getPlatformCredentialMetadata: vi.fn(),
   isEnabled: vi.fn(() => false),
   requestCredentialValidation: vi.fn(),
 }));
@@ -93,6 +94,7 @@ describe("settings ipc", () => {
     providerMocks.resolveSlackContact.mockReset();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
     runtimeMock.applyConfig.mockClear();
+    runtimeMock.getPlatformCredentialMetadata.mockReset();
     runtimeMock.isEnabled.mockClear();
     runtimeMock.requestCredentialValidation.mockReset();
   });
@@ -165,6 +167,39 @@ describe("settings ipc", () => {
 
     disposeSettingsIpcHandlers();
     expect(handlers.has(SETTINGS_READ_CHANNEL)).toBe(false);
+  });
+
+  it("uses startup messaging identity as the last credential result when no manual test ran", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-settings-ipc-"));
+    tempRoots.push(tempRoot);
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+    runtimeMock.getPlatformCredentialMetadata.mockReturnValue({
+      account: "@pwragent_bot",
+      detail: "api.telegram.org",
+      observedAt: 1234,
+    });
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL } = await import("../../shared/ipc");
+
+    registerSettingsIpcHandlers(service);
+
+    await expect(
+      handlers.get(SETTINGS_LAST_CREDENTIAL_TEST_CHANNEL)?.(
+        {},
+        { kind: "telegram" },
+      ),
+    ).resolves.toMatchObject({
+      account: "@pwragent_bot",
+      detail: "api.telegram.org",
+      kind: "telegram",
+      status: "ok",
+      testedAt: 1234,
+    });
   });
 
   it("disposes backend clients after model settings change", async () => {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -259,6 +259,29 @@ function getCredentialTester(
   return credentialTesterInstance;
 }
 
+function startupCredentialResult(
+  kind: SettingsCredentialTestKind,
+): SettingsCredentialTestResult | undefined {
+  if (
+    kind !== "telegram"
+    && kind !== "discord"
+    && kind !== "mattermost"
+    && kind !== "slack"
+  ) {
+    return undefined;
+  }
+  const metadata = getDesktopMessagingRuntime().getPlatformCredentialMetadata(kind);
+  if (!metadata) return undefined;
+  return {
+    kind,
+    status: "ok",
+    testedAt: metadata.observedAt,
+    durationMs: 0,
+    ...(metadata.account !== undefined ? { account: metadata.account } : {}),
+    ...(metadata.detail !== undefined ? { detail: metadata.detail } : {}),
+  };
+}
+
 /** For tests / shutdown — reset the singleton tester. */
 function disposeCredentialTester(): void {
   credentialTesterInstance = undefined;
@@ -412,7 +435,7 @@ export function registerSettingsIpcHandlers(
       request: { kind: SettingsCredentialTestKind },
     ): Promise<SettingsCredentialTestResult | undefined> => {
       const tester = getCredentialTester(service);
-      return tester.lastResult(request.kind);
+      return tester.lastResult(request.kind) ?? startupCredentialResult(request.kind);
     },
   );
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -70,6 +70,7 @@ export type DesktopMessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   channel: MessagingChannelKind;
   clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
+  readCredentialMetadata?(): MessagingCredentialMetadata | undefined;
   deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult>;
   resolveDeliveryScope?(intent: MessagingSurfaceIntent): MessagingDeliveryScope | undefined;
   downloadAttachment?: MessagingAdapter["downloadAttachment"];
@@ -94,6 +95,11 @@ export type DesktopMessagingAdapter = {
   ): Promise<MessagingConversationTitleUpdateResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
+};
+
+export type MessagingCredentialMetadata = {
+  account?: string;
+  detail?: string;
 };
 
 export type DesktopMessagingAdapterFactory = (params: {
@@ -222,6 +228,10 @@ export class DesktopMessagingRuntime {
   private readonly platformStatuses = new Map<
     MessagingChannelKind,
     MessagingPlatformStatus
+  >();
+  private readonly platformCredentialMetadata = new Map<
+    MessagingChannelKind,
+    MessagingCredentialMetadata & { observedAt: number }
   >();
   private readonly platformDegradationReasons = new Map<
     MessagingChannelKind,
@@ -475,6 +485,12 @@ export class DesktopMessagingRuntime {
       this.clearExpiredDegradationReasons(platform);
     }
     return [...this.platformStatuses.values()];
+  }
+
+  getPlatformCredentialMetadata(
+    platform: MessagingChannelKind,
+  ): (MessagingCredentialMetadata & { observedAt: number }) | undefined {
+    return this.platformCredentialMetadata.get(platform);
   }
 
   /**
@@ -906,7 +922,9 @@ export class DesktopMessagingRuntime {
       unsubscribeRuntimeError,
     });
     this.syncRunningAdapterLists();
-    this.setPlatformHealth(adapter.channel, "enabled");
+    this.setPlatformHealth(adapter.channel, "enabled", {
+      credentialMetadata: adapter.readCredentialMetadata?.(),
+    });
     messagingLog.info(`${adapter.channel}: adapter started successfully`, {
       channel: adapter.channel,
     });
@@ -1130,10 +1148,23 @@ export class DesktopMessagingRuntime {
   private setPlatformHealth(
     platform: MessagingChannelKind,
     health: MessagingPlatformHealth,
-    options: { reason?: string } = {},
+    options: {
+      credentialMetadata?: MessagingCredentialMetadata;
+      reason?: string;
+    } = {},
   ): void {
     const at = Date.now();
     const previous = this.platformStatuses.get(platform);
+    if (
+      options.credentialMetadata
+      && (options.credentialMetadata.account || options.credentialMetadata.detail)
+    ) {
+      this.platformCredentialMetadata.set(platform, {
+        ...definedCredentialMetadata(options.credentialMetadata),
+        observedAt: at,
+      });
+    }
+    const credentialMetadata = this.platformCredentialMetadata.get(platform);
     if (health === "enabled" || health === "suspended" || health === "errored") {
       if (health !== "enabled") {
         this.clearPlatformDegradationReasons(platform, { broadcast: false });
@@ -1149,6 +1180,10 @@ export class DesktopMessagingRuntime {
       platform,
       health: effectiveHealth,
       changedAt: at,
+      ...definedCredentialMetadata({
+        account: credentialMetadata?.account ?? previous?.account,
+        detail: credentialMetadata?.detail ?? previous?.detail,
+      }),
       reason: options.reason,
       degradationReasons,
       // Preserve the existing activity timestamp through health
@@ -1161,6 +1196,7 @@ export class DesktopMessagingRuntime {
       kind: "health-changed",
       platform,
       health: effectiveHealth,
+      ...definedCredentialMetadata(next),
       reason: options.reason,
       degradationReasons,
       at,
@@ -1937,6 +1973,15 @@ function streamingResponsesDefaultForChannel(
     default:
       return false;
   }
+}
+
+function definedCredentialMetadata(
+  metadata: MessagingCredentialMetadata,
+): MessagingCredentialMetadata {
+  return {
+    ...(metadata.account !== undefined ? { account: metadata.account } : {}),
+    ...(metadata.detail !== undefined ? { detail: metadata.detail } : {}),
+  };
 }
 
 function degradationTimerKey(

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -490,6 +490,13 @@ export class DesktopMessagingRuntime {
   getPlatformCredentialMetadata(
     platform: MessagingChannelKind,
   ): (MessagingCredentialMetadata & { observedAt: number }) | undefined {
+    const status = this.platformStatuses.get(platform);
+    if (
+      !this.runningAdapters.has(platform)
+      || (status?.health !== "enabled" && status?.health !== "degraded")
+    ) {
+      return undefined;
+    }
     return this.platformCredentialMetadata.get(platform);
   }
 
@@ -1163,8 +1170,15 @@ export class DesktopMessagingRuntime {
         ...definedCredentialMetadata(options.credentialMetadata),
         observedAt: at,
       });
+    } else if (health !== "enabled") {
+      this.platformCredentialMetadata.delete(platform);
     }
     const credentialMetadata = this.platformCredentialMetadata.get(platform);
+    const {
+      account: _previousAccount,
+      detail: _previousDetail,
+      ...previousWithoutCredentialMetadata
+    } = previous ?? {};
     if (health === "enabled" || health === "suspended" || health === "errored") {
       if (health !== "enabled") {
         this.clearPlatformDegradationReasons(platform, { broadcast: false });
@@ -1176,14 +1190,11 @@ export class DesktopMessagingRuntime {
     const effectiveHealth =
       health === "enabled" && degradationReasons.length > 0 ? "degraded" : health;
     const next: MessagingPlatformStatus = {
-      ...previous,
+      ...previousWithoutCredentialMetadata,
       platform,
       health: effectiveHealth,
       changedAt: at,
-      ...definedCredentialMetadata({
-        account: credentialMetadata?.account ?? previous?.account,
-        detail: credentialMetadata?.detail ?? previous?.detail,
-      }),
+      ...definedCredentialMetadata(credentialMetadata ?? {}),
       reason: options.reason,
       degradationReasons,
       // Preserve the existing activity timestamp through health

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -1,7 +1,10 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { MessagingPlatformStatus } from "@pwragent/shared";
+import type {
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { MessagingStatusBar } from "./MessagingStatusBar";
 
@@ -54,5 +57,52 @@ describe("MessagingStatusBar", () => {
     expect(chip).toHaveTextContent("Telegram group -100123");
     expect(chip).toHaveTextContent("Bot: @pwragent_bot");
     expect(chip).toHaveTextContent("Account detail: api.telegram.org");
+  });
+
+  it("clears credential identity when health event omits account metadata", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+        account: "@pwragent_bot",
+        detail: "api.telegram.org",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    let emitStatusEvent: ((event: MessagingPlatformStatusEvent) => void) | null =
+      null;
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn((listener) => {
+        emitStatusEvent = listener;
+        return () => {};
+      }),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    const chip = await screen.findByRole("group", {
+      name: "Messaging platform status",
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
+    });
+    expect(chip).toHaveTextContent("Bot: @pwragent_bot");
+    expect(chip).toHaveTextContent("Account detail: api.telegram.org");
+
+    act(() => {
+      emitStatusEvent?.({
+        at: 2000,
+        health: "suspended",
+        kind: "health-changed",
+        platform: "telegram",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Telegram: Suspended/)).toBeInTheDocument();
+    });
+    expect(chip).not.toHaveTextContent("Bot: @pwragent_bot");
+    expect(chip).not.toHaveTextContent("Account detail: api.telegram.org");
   });
 });

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -31,6 +31,8 @@ describe("MessagingStatusBar", () => {
         ],
         health: "degraded",
         platform: "telegram",
+        account: "@pwragent_bot",
+        detail: "api.telegram.org",
       },
     ] satisfies MessagingPlatformStatus[];
     const desktopApi: DesktopApi = {
@@ -50,5 +52,7 @@ describe("MessagingStatusBar", () => {
     });
     expect(chip).toHaveTextContent("Rate limited");
     expect(chip).toHaveTextContent("Telegram group -100123");
+    expect(chip).toHaveTextContent("Bot: @pwragent_bot");
+    expect(chip).toHaveTextContent("Account detail: api.telegram.org");
   });
 });

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -88,6 +88,8 @@ function PlatformChip(props: {
   const Icon = ICONS[status.platform];
   const labelLines = [
     `${formatPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
+    status.account ? `Bot: ${status.account}` : undefined,
+    status.detail ? `Account detail: ${status.detail}` : undefined,
     status.reason,
     ...formatDegradationReasons(status.degradationReasons ?? []),
   ]

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -100,6 +100,8 @@ function upsertHealth(
     ...existing,
     platform,
     health: event.health,
+    account: event.account ?? existing?.account,
+    detail: event.detail ?? existing?.detail,
     changedAt: event.at,
     reason: event.reason,
     degradationReasons: event.degradationReasons,

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -96,12 +96,17 @@ function upsertHealth(
 ): MessagingPlatformStatus[] {
   const platform: MessagingChannelKind = event.platform;
   const existing = current.find((entry) => entry.platform === platform);
+  const {
+    account: _existingAccount,
+    detail: _existingDetail,
+    ...existingWithoutCredentialMetadata
+  } = existing ?? {};
   const next: MessagingPlatformStatus = {
-    ...existing,
+    ...existingWithoutCredentialMetadata,
     platform,
     health: event.health,
-    account: event.account ?? existing?.account,
-    detail: event.detail ?? existing?.detail,
+    ...(event.account !== undefined ? { account: event.account } : {}),
+    ...(event.detail !== undefined ? { detail: event.detail } : {}),
     changedAt: event.at,
     reason: event.reason,
     degradationReasons: event.degradationReasons,

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -392,6 +392,15 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     return this.authorizedActorIdsValue;
   }
 
+  readCredentialMetadata(): { account?: string; detail?: string } | undefined {
+    if (!this.botUsername && !this.botUserId) return undefined;
+    const account = this.botUsername ?? this.botUserId;
+    return {
+      ...(account ? { account } : {}),
+      detail: hostFromUrl(this.config.serverUrl),
+    };
+  }
+
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
     this.authorizedActorIdsValue = [...update.authorizedActorIds];
     this.config.authorizedActorIds = mattermostContactsFromIds(
@@ -2440,6 +2449,14 @@ function clampHeader(text: string): string {
   return text.length > MATTERMOST_CHANNEL_HEADER_LIMIT
     ? text.slice(0, MATTERMOST_CHANNEL_HEADER_LIMIT)
     : text;
+}
+
+function hostFromUrl(serverUrl: string): string {
+  try {
+    return new URL(serverUrl).host;
+  } catch {
+    return serverUrl;
+  }
 }
 
 /**

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -286,6 +286,8 @@ export class SlackAdapter implements SlackProviderAdapter {
   private readonly recentInboundMessageEvents = new Map<string, number>();
   private readonly threadTitleCache = new Map<string, string | undefined>();
   private readonly userDisplayNameCache = new Map<string, string | undefined>();
+  private botAccount: string | undefined;
+  private botAccountDetail: string | undefined;
   private botUserId: string | undefined;
   private conversationInfoLookupDisabled = false;
   private threadInfoLookupDisabled = false;
@@ -316,6 +318,14 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   get authorizedActorIds(): readonly string[] {
     return this.authorizedActorIdsValue;
+  }
+
+  readCredentialMetadata(): { account?: string; detail?: string } | undefined {
+    if (!this.botAccount && !this.botAccountDetail) return undefined;
+    return {
+      ...(this.botAccount ? { account: this.botAccount } : {}),
+      ...(this.botAccountDetail ? { detail: this.botAccountDetail } : {}),
+    };
   }
 
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
@@ -366,6 +376,8 @@ export class SlackAdapter implements SlackProviderAdapter {
     this.listener = listener;
     const auth = await this.api.authTest();
     this.botUserId = auth.user_id;
+    this.botAccount = auth.user ?? auth.user_id;
+    this.botAccountDetail = auth.team ?? hostFromUrl(auth.url) ?? auth.team_id;
 
     if (this.config.inboundMode === "events") {
       throw new Error("Slack Events API mode is not implemented yet; use Socket Mode");
@@ -1529,6 +1541,15 @@ export function createSlackSocketClient(
     appToken,
     autoReconnectEnabled: true,
   }) as SlackSocketClient;
+}
+
+function hostFromUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
 }
 
 export function stripBotMention(text: string, botUserId: string | undefined): string {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -478,6 +478,14 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     return this.options.config.authorizedActorIds.map((contact) => contact.id);
   }
 
+  readCredentialMetadata(): { account?: string; detail?: string } | undefined {
+    if (!this.botUsername) return undefined;
+    return {
+      account: `@${this.botUsername}`,
+      detail: "api.telegram.org",
+    };
+  }
+
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
     this.options.config.authorizedActorIds = telegramContactsFromIds(
       update.authorizedActorIds,

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -143,6 +143,10 @@ export type MessagingPlatformStatus = {
   health: MessagingPlatformHealth;
   /** Wall-clock ms when the health last changed. */
   changedAt: number;
+  /** Public identity observed at adapter startup, e.g. bot username. */
+  account?: string;
+  /** Short public detail for the identity, e.g. API host or workspace. */
+  detail?: string;
   /** When errored, a human-readable reason for the UI tooltip. */
   reason?: string;
   /** Transient provider/runtime reasons that make an enabled platform degraded. */
@@ -160,6 +164,8 @@ export type MessagingPlatformStatusEvent =
       kind: "health-changed";
       platform: MessagingChannelKind;
       health: MessagingPlatformHealth;
+      account?: string;
+      detail?: string;
       reason?: string;
       degradationReasons?: MessagingDegradationReason[];
       at: number;


### PR DESCRIPTION
## Summary

I surfaced public messaging bot metadata captured during adapter startup so Settings and status tooltips can show the resolved bot/account identity without requiring a manual Test click every time.

## What Changed

- Added optional startup credential metadata to messaging platform status events and snapshots.
- Reused that metadata as the Settings connection-test fallback when no manual test result exists.
- Displayed the bot/account identity in messaging status tooltips.
- Added Telegram, Mattermost, and Slack adapter metadata readers using identity already fetched during startup.
- Fixed the stale metadata path so cleared credentials or failed restarts do not continue to show the old bot as connected.
- Rebased onto the current Telegram General-topic fix and authorized that test fixture's supergroup so the routing assertion exercises the intended path.

## Verification

I verified:

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx`
- `pnpm typecheck`
- `pnpm lint:boundaries`
