### PR TITLE
test(messaging): authorize Telegram General topic fixture

### DIFF
--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2276,6 +2276,7 @@ describe("TelegramAdapter", () => {
         channel: "telegram",
         botToken: "telegram-token",
         authorizedActorIds: [{ id: "42", displayName: "" }],
+        authorizedSupergroupIds: [{ id: "-1003711601984", displayName: "PwrDrvr" }],
       },
       pollOnStart: false,
     });


### PR DESCRIPTION
## Summary

I cherry-picked `8c3e8b6841e07b6cc1b6aefc5b8fb45377d876af` onto current `main` to restore the Telegram General-topic test fixture authorization.

The recent `main` CI failure was in the `Test` job for `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`, specifically `TelegramAdapter > preserves Telegram General topic id in opaque routing state`, where the test received `[]` instead of the expected command event. The same failure showed up in nearby `ci.yml` PR runs, and the source branch went green after this one-line fixture fix.

## Verification

I verified this locally with:

- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
- `pnpm test`

I also checked that the cherry-picked commit is signed and includes the original commit reference.
