### PR TITLE
fix(desktop): surface Git discovery failures

### DIFF
--- a/apps/desktop/src/main/__tests__/git-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/git-discovery.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const accessMock = vi.fn();
+const execFileMock = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+  access: accessMock,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    command: string,
+    args: string[],
+    options: Record<string, unknown>,
+    callback: (
+      error: Error | null,
+      result?: { stdout: string; stderr?: string },
+    ) => void,
+  ) => {
+    execFileMock(command, args, options, callback);
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  accessMock.mockReset();
+  execFileMock.mockReset();
+});
+
+describe("Git discovery", () => {
+  it("selects a working Homebrew git when Apple git is blocked by Xcode license", async () => {
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    const xcodeError = new Error(
+      "You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license'",
+    );
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/usr/bin/git" || candidate === "/opt/homebrew/bin/git") {
+        return undefined;
+      }
+      throw missingError;
+    });
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (command === "/usr/bin/git") {
+          callback(xcodeError);
+          return;
+        }
+        if (command === "/opt/homebrew/bin/git") {
+          callback(null, { stdout: "git version 2.39.1\n" });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    const { discoverGitCommands, isXcodeLicenseFailure } = await import(
+      "../settings/git-discovery"
+    );
+
+    const snapshot = await discoverGitCommands({ env: { PATH: "/usr/bin" } });
+
+    expect(snapshot.selectedCommand).toBe("/opt/homebrew/bin/git");
+    expect(snapshot.selectedSource).toBe("homebrew");
+    expect(snapshot.candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          command: "/usr/bin/git",
+          executable: false,
+          selected: false,
+          source: "path",
+          failureReason: expect.stringContaining("Xcode license"),
+        }),
+        expect.objectContaining({
+          command: "/opt/homebrew/bin/git",
+          executable: true,
+          selected: true,
+          source: "homebrew",
+          version: "2.39.1",
+        }),
+      ]),
+    );
+    expect(isXcodeLicenseFailure(snapshot.candidates[0]?.failureReason)).toBe(true);
+  });
+
+  it("parses git --version output", async () => {
+    const { parseGitVersionOutput } = await import("../settings/git-discovery");
+
+    expect(parseGitVersionOutput("git version 2.39.1\n")).toBe("2.39.1");
+    expect(parseGitVersionOutput("git version 2.45.0.windows.1\n")).toBe(
+      "2.45.0.windows.1",
+    );
+  });
+
+  it("uses user git paths in the app-server executor", async () => {
+    const homeGit = "/Users/test/bin/git";
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (command === homeGit) {
+          callback(null, { stdout: "git version 2.48.0\n" });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    vi.doMock("node:os", () => ({
+      default: {
+        homedir: () => "/Users/test",
+      },
+    }));
+    const { resolveGitExecutable } = await import("../app-server/git-executable");
+
+    await expect(resolveGitExecutable()).resolves.toBe(homeGit);
+  });
+
+  it("retries app-server git resolution after an initial failure", async () => {
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    let failAll = true;
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (!failAll && command === "/opt/homebrew/bin/git") {
+          callback(null, { stdout: "git version 2.39.1\n" });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    const { resolveGitExecutable } = await import("../app-server/git-executable");
+
+    await expect(resolveGitExecutable()).rejects.toThrow("Git executable unavailable");
+
+    failAll = false;
+
+    await expect(resolveGitExecutable()).resolves.toBe("/opt/homebrew/bin/git");
+  });
+});

--- a/apps/desktop/src/main/app-server/directory-registration-service.ts
+++ b/apps/desktop/src/main/app-server/directory-registration-service.ts
@@ -1,15 +1,12 @@
-import { execFile as execFileCallback } from "node:child_process";
 import { stat as fsStat } from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import type {
   AppServerBackendKind,
   EnsureDirectoryLaunchpadResponse,
   RegisterDirectoryFromDiskFailureReason,
   RegisterDirectoryFromDiskResponse,
 } from "@pwragent/shared";
-
-const execFile = promisify(execFileCallback);
+import { runGitCommand } from "./git-executable";
 
 /**
  * Validate `path` and seed a launchpad for the project-directory
@@ -51,10 +48,7 @@ export type DirectoryRegistrationDeps = {
 };
 
 async function defaultRunGit(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFile("git", ["-C", cwd, ...args], {
-    env: process.env,
-  });
-  return stdout.trim();
+  return (await runGitCommand(cwd, args)).stdout;
 }
 
 async function defaultStat(

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,8 +1,6 @@
-import { execFile as execFileCallback } from "node:child_process";
 import { access, mkdir, rmdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import type {
   AppServerThreadSummary,
   AppServerBackendKind,
@@ -15,14 +13,10 @@ import type {
 } from "@pwragent/shared";
 import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
 import { userHomeWorktreesRoot } from "../settings/desktop-config";
-
-const execFile = promisify(execFileCallback);
+import { runGitCommand } from "./git-executable";
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
-  const { stdout } = await execFile("git", ["-C", cwd, ...args], {
-    env: process.env,
-  });
-  return stdout.trim();
+  return (await runGitCommand(cwd, args)).stdout;
 }
 
 function errorText(error: unknown): string {
@@ -360,20 +354,25 @@ export class GitDirectoryService {
   private async loadDirectoryStatus(
     cwd: string,
   ): Promise<NavigationDirectoryGitStatus | undefined> {
+    const repoRoot = await readGitRoot(cwd);
+    if (!repoRoot) {
+      return undefined;
+    }
+
     const [currentBranch, branchesOutput, remoteHead, worktreeList] = await Promise.all([
-      runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
-      runGit(cwd, [
+      runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]),
+      runGit(repoRoot, [
         "for-each-ref",
         "refs/heads",
         "--sort=-committerdate",
         "--format=%(refname:short)",
       ]).catch(() => ""),
-      runGit(cwd, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
+      runGit(repoRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
         () => "",
       ),
-      runGit(cwd, ["worktree", "list", "--porcelain"]).catch(() => ""),
+      runGit(repoRoot, ["worktree", "list", "--porcelain"]).catch(() => ""),
     ]);
-    const upstreamBranch = await runGit(cwd, [
+    const upstreamBranch = await runGit(repoRoot, [
       "rev-parse",
       "--abbrev-ref",
       "--symbolic-full-name",

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,0 +1,78 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { gitCandidateInputs } from "../settings/git-discovery";
+
+const execFile = promisify(execFileCallback);
+
+let resolvedGitExecutable: string | undefined;
+let resolvingGitExecutable: Promise<string> | undefined;
+
+function gitExecutableCandidates(): string[] {
+  const candidates = gitCandidateInputs(process.env).flatMap((candidate) => {
+    const normalized = candidate.command?.trim();
+    return normalized ? [normalized] : [];
+  });
+  return [...new Set(candidates)];
+}
+
+function errorText(error: unknown): string {
+  const parts = [error instanceof Error ? error.message : String(error)];
+  const stderr = (error as { stderr?: unknown })?.stderr;
+  if (typeof stderr === "string" && stderr.trim()) {
+    parts.push(stderr.trim());
+  }
+  return parts.join("\n");
+}
+
+async function canRunGit(
+  candidate: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await execFile(candidate, ["--version"], {
+      encoding: "utf8",
+      env: process.env,
+    });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: errorText(error) };
+  }
+}
+
+export async function resolveGitExecutable(): Promise<string> {
+  if (resolvedGitExecutable) {
+    return resolvedGitExecutable;
+  }
+
+  resolvingGitExecutable ??= (async () => {
+    const failures: string[] = [];
+    for (const candidate of gitExecutableCandidates()) {
+      const result = await canRunGit(candidate);
+      if (result.ok) {
+        resolvedGitExecutable = candidate;
+        return candidate;
+      }
+      failures.push(`${candidate}: ${result.error}`);
+    }
+
+    throw new Error(`Git executable unavailable. Tried:\n${failures.join("\n")}`);
+  })().finally(() => {
+    resolvingGitExecutable = undefined;
+  });
+
+  return await resolvingGitExecutable;
+}
+
+export async function runGitCommand(cwd: string, args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  const git = await resolveGitExecutable();
+  const { stdout, stderr } = await execFile(git, ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: process.env,
+  });
+  return {
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+  };
+}

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -283,6 +283,9 @@ export async function discoverDesktopApplications(params?: {
       path: { value: "", source: "default" },
       discovery: { candidates: [] },
     },
+    git: {
+      discovery: { candidates: [] },
+    },
   };
 }
 

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -78,6 +78,7 @@ import {
   resolveCodexHomeForProfile,
 } from "./codex-profiles";
 import { discoverDesktopApplications } from "./application-discovery";
+import { discoverGitCommands } from "./git-discovery";
 import { discoverGhCommands } from "./gh-discovery";
 import { getMainLogger } from "../log";
 
@@ -174,6 +175,7 @@ export class DesktopSettingsService {
       configuredCommand: config.applications?.gh?.path,
       env: this.env,
     });
+    const gitDiscovery = await discoverGitCommands({ env: this.env });
     const applications = await discoverDesktopApplications({ env: this.env });
     const preferredEditorId = this.resolveConfigString(
       config.applications?.editor?.preferredId,
@@ -388,6 +390,9 @@ export class DesktopSettingsService {
         gh: {
           path: this.resolveString(config.applications?.gh?.path, GH_COMMAND_ENV),
           discovery: ghDiscovery,
+        },
+        git: {
+          discovery: gitDiscovery,
         },
       },
       worktrees: this.resolveWorktrees(config.worktrees?.storage),

--- a/apps/desktop/src/main/settings/git-discovery.ts
+++ b/apps/desktop/src/main/settings/git-discovery.ts
@@ -1,0 +1,123 @@
+import os from "node:os";
+import path from "node:path";
+import type {
+  DesktopGitCandidateSource,
+  DesktopGitDiscoveryCandidate,
+  DesktopGitDiscoverySnapshot,
+} from "@pwragent/shared";
+import { buildCommandDiscoveryCandidate } from "./command-discovery";
+
+export const GIT_COMMAND_ENV = "PWRAGENT_GIT_PATH";
+const XCODE_LICENSE_COMMAND = "sudo xcodebuild -license";
+
+export function parseGitVersionOutput(output: string): string | undefined {
+  return output.match(/\bgit version\s+([^\s]+)/i)?.[1]
+    ?? output.match(/\b([0-9]+(?:\.[0-9]+){1,2}(?:-[0-9A-Za-z.-]+)?)\b/)?.[1];
+}
+
+export function isXcodeLicenseFailure(reason?: string): boolean {
+  return Boolean(
+    reason?.includes("Xcode license")
+      || reason?.includes("license agreements")
+      || reason?.includes("xcodebuild -license"),
+  );
+}
+
+export function xcodeLicenseRemediationCommand(): string {
+  return XCODE_LICENSE_COMMAND;
+}
+
+export function gitCandidateInputs(env: NodeJS.ProcessEnv): Array<{
+  command: string | undefined;
+  source: DesktopGitCandidateSource;
+}> {
+  return [
+    { command: env[GIT_COMMAND_ENV]?.trim(), source: "env" },
+    { command: "git", source: "path" },
+    { command: "/opt/homebrew/bin/git", source: "homebrew" },
+    { command: "/usr/local/bin/git", source: "homebrew" },
+    { command: path.join(os.homedir(), ".local/bin/git"), source: "user" },
+    { command: path.join(os.homedir(), "bin/git"), source: "user" },
+    { command: "/usr/bin/git", source: "xcode" },
+  ];
+}
+
+async function buildGitCandidate(
+  input: { command: string | undefined; source: DesktopGitCandidateSource },
+  options: {
+    env: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  },
+): Promise<DesktopGitDiscoveryCandidate | undefined> {
+  const candidate = await buildCommandDiscoveryCandidate<DesktopGitCandidateSource>(
+    input,
+    {
+      env: options.env,
+      platform: options.platform,
+      parseVersion: parseGitVersionOutput,
+    },
+  );
+  if (!candidate) {
+    return undefined;
+  }
+
+  if (candidate.version) {
+    return candidate;
+  }
+
+  const failureReason =
+    candidate.versionFailureReason
+    ?? candidate.failureReason
+    ?? "version_not_reported";
+  return {
+    ...candidate,
+    executable: false,
+    failureReason,
+    versionFailureReason: undefined,
+  };
+}
+
+function dedupeGitCandidates(
+  candidates: Array<DesktopGitDiscoveryCandidate | undefined>,
+): DesktopGitDiscoveryCandidate[] {
+  const deduped: DesktopGitDiscoveryCandidate[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate.command)) {
+      continue;
+    }
+    seen.add(candidate.command);
+    deduped.push(candidate);
+  }
+  return deduped;
+}
+
+export async function discoverGitCommands(params?: {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}): Promise<DesktopGitDiscoverySnapshot> {
+  const env = params?.env ?? process.env;
+  const candidates = dedupeGitCandidates(
+    await Promise.all(
+      gitCandidateInputs(env).map((candidate) =>
+        buildGitCandidate(candidate, {
+          env,
+          platform: params?.platform,
+        }),
+      ),
+    ),
+  );
+  const selected =
+    candidates.find((candidate) => candidate.source === "env" && candidate.executable)
+    ?? candidates.find((candidate) => candidate.executable);
+
+  if (selected) {
+    selected.selected = true;
+  }
+
+  return {
+    selectedCommand: selected?.command,
+    selectedSource: selected?.source,
+    candidates,
+  };
+}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -180,6 +180,9 @@ describe("App", () => {
           path: { value: "", source: "default" },
           discovery: { candidates: [] },
         },
+        git: {
+          discovery: { candidates: [] },
+        },
       },
       worktrees: {
         storage: { value: "user-home", source: "default" },

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -240,6 +240,9 @@ describe("Composer", () => {
             path: { value: "", source: "default" },
             discovery: { candidates: [] },
           },
+          git: {
+            discovery: { candidates: [] },
+          },
         }}
         backends={[backendSummary("codex")]}
         desktopApi={{ openApplication }}
@@ -2404,6 +2407,9 @@ describe("Composer", () => {
             path: { value: "", source: "default" },
             discovery: { candidates: [] },
           },
+          git: {
+            discovery: { candidates: [] },
+          },
         }}
         backends={[backendSummary("codex")]}
         desktopApi={{ openApplication }}
@@ -2486,6 +2492,9 @@ describe("Composer", () => {
           preferredTerminalId: { value: "", source: "default" },
           gh: {
             path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
             discovery: { candidates: [] },
           },
         }}

--- a/apps/desktop/src/renderer/src/features/settings/ApplicationsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ApplicationsSettings.tsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useState } from "react";
 import type {
   DesktopApplicationDiscoveryCandidate,
   DesktopApplicationKind,
+  DesktopGitDiscoveryCandidate,
   DesktopGhDiscoveryCandidate,
   DesktopSettingsSnapshot,
   GhStatus,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { copyText } from "../../lib/copy-text";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -26,6 +28,7 @@ export function ApplicationsSettings(props: {
     kind: DesktopApplicationKind,
     preferredId: string,
   ) => Promise<void>;
+  onRefresh: () => Promise<void>;
   onSaveGhPath: (path: string) => Promise<void>;
 }) {
   return (
@@ -54,6 +57,12 @@ export function ApplicationsSettings(props: {
         title="Terminal"
         onPreferredApplicationChange={props.onPreferredApplicationChange}
       />
+      <GitStatusPanel
+        desktopApi={props.desktopApi}
+        saving={props.saving}
+        snapshot={props.snapshot}
+        onRefresh={props.onRefresh}
+      />
       <GhStatusPanel
         desktopApi={props.desktopApi}
         saving={props.saving}
@@ -61,6 +70,135 @@ export function ApplicationsSettings(props: {
         onSaveGhPath={props.onSaveGhPath}
       />
     </SettingsSectionStack>
+  );
+}
+
+const XCODE_LICENSE_REMEDIATION_COMMAND = "sudo xcodebuild -license";
+
+function GitStatusPanel(props: {
+  desktopApi?: DesktopApi;
+  saving: boolean;
+  snapshot: DesktopSettingsSnapshot;
+  onRefresh: () => Promise<void>;
+}) {
+  const [loading, setLoading] = useState(false);
+  const discovery = props.snapshot.applications.git.discovery;
+  const selected = discovery.candidates.find((candidate) => candidate.selected);
+  const hasWorkingGit = discovery.candidates.some((candidate) => candidate.executable);
+  const visibleCandidates = discovery.candidates.filter(
+    (candidate) =>
+      candidate.executable || isXcodeLicenseCandidate(candidate) || !hasWorkingGit,
+  );
+  const xcodeLicenseCandidate = discovery.candidates.find((candidate) =>
+    isXcodeLicenseCandidate(candidate)
+  );
+  const pill = describeGitStatusPill(discovery, xcodeLicenseCandidate);
+
+  const refresh = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      await props.onRefresh();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      eyebrow="Applications"
+      title="Git"
+      description={
+        <>
+          PwrAgent uses <code>git</code> to inspect repositories and create
+          worktrees for new threads.
+        </>
+      }
+    >
+      <div className="settings-fields">
+        <SettingsField
+          label="Command status"
+          sub="Checks the git command PwrAgent will use for repository and worktree operations."
+          source={selected?.source ?? "auto"}
+          control={
+            <div className="settings-gh-status">
+              <span className={`settings-pill settings-pill--${pill.tone}`}>
+                {pill.label}
+              </span>
+              {selected?.command ? (
+                <span className="settings-pathrow__path">
+                  Path: <code>{selected.command}</code>
+                </span>
+              ) : null}
+              {selected?.version ? (
+                <span className="settings-pathrow__path">
+                  Version: <code>{selected.version}</code>
+                </span>
+              ) : null}
+              {xcodeLicenseCandidate ? (
+                <div className="settings-gh-status">
+                  <span className="settings-pathrow__path settings-error">
+                    Apple&apos;s Git at <code>{xcodeLicenseCandidate.command}</code>{" "}
+                    is blocked by the Xcode license check.
+                  </span>
+                  <span className="settings-pathrow__path">
+                    Run this in Terminal, then follow the prompts:
+                  </span>
+                  <span className="settings-pathrow__path">
+                    <code>{XCODE_LICENSE_REMEDIATION_COMMAND}</code>
+                  </span>
+                  <div className="settings-inline-actions">
+                    <button
+                      className="button button--secondary"
+                      type="button"
+                      onClick={() =>
+                        void copyText(
+                          XCODE_LICENSE_REMEDIATION_COMMAND,
+                          props.desktopApi,
+                        )
+                      }
+                    >
+                      Copy command
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--secondary"
+                  disabled={loading || props.saving}
+                  type="button"
+                  onClick={() => void refresh()}
+                >
+                  {loading ? "Checking…" : "Re-check"}
+                </button>
+              </div>
+            </div>
+          }
+        />
+        <SettingsField
+          label="Available paths"
+          sub={
+            hasWorkingGit
+              ? "Detected on this machine. The selected path is used."
+              : "No working git executable was found. These are the paths PwrAgent checked."
+          }
+          control={
+            <div className="settings-paths" aria-label="Git discovery">
+              {visibleCandidates.length === 0 ? (
+                <p className="settings-empty">No git candidates found.</p>
+              ) : (
+                visibleCandidates.map((candidate) => (
+                  <GitCandidateRow
+                    key={`${candidate.source}:${candidate.command}`}
+                    candidate={candidate}
+                  />
+                ))
+              )}
+            </div>
+          }
+        />
+      </div>
+    </SettingsSection>
   );
 }
 
@@ -247,6 +385,36 @@ function GhStatusPanel(props: {
   );
 }
 
+function GitCandidateRow(props: {
+  candidate: DesktopGitDiscoveryCandidate;
+}) {
+  const candidate = props.candidate;
+  const failureLabel = describeCommandDiscoveryFailure(candidate.failureReason);
+  const chips: SettingsPathRowChip[] = [
+    { label: describeGitCandidateSource(candidate.source), tone: "muted" },
+  ];
+  if (candidate.executable) {
+    chips.push({
+      label: candidate.version ?? "version unknown",
+      tone: candidate.version ? "muted" : "err",
+    });
+  } else {
+    chips.push({
+      label: failureLabel ?? "Unavailable",
+      tone: isXcodeLicenseCandidate(candidate) ? "warn" : "err",
+    });
+  }
+
+  return (
+    <SettingsPathRow
+      title={candidate.command}
+      chips={chips}
+      selected={candidate.selected}
+      disabled
+    />
+  );
+}
+
 function GhCandidateRow(props: {
   candidate: DesktopGhDiscoveryCandidate;
   disabled?: boolean;
@@ -289,12 +457,56 @@ function GhCandidateRow(props: {
   );
 }
 
+function describeGitStatusPill(
+  discovery: DesktopSettingsSnapshot["applications"]["git"]["discovery"],
+  xcodeLicenseCandidate?: DesktopGitDiscoveryCandidate,
+): {
+  tone: "ok" | "warn" | "bad" | "neutral";
+  label: string;
+} {
+  if (discovery.selectedCommand) {
+    return xcodeLicenseCandidate
+      ? { tone: "warn", label: "Available" }
+      : { tone: "ok", label: "Available" };
+  }
+  if (xcodeLicenseCandidate) {
+    return { tone: "bad", label: "Xcode license required" };
+  }
+  return { tone: "bad", label: "Not available" };
+}
+
+function describeGitCandidateSource(
+  source: DesktopGitDiscoveryCandidate["source"],
+): string {
+  if (source === "xcode") return "Apple Git";
+  if (source === "homebrew") return "Homebrew";
+  if (source === "env") return "env";
+  if (source === "path") return "PATH";
+  return source;
+}
+
 function describeCommandDiscoveryFailure(reason?: string): string | undefined {
   if (!reason) return undefined;
   if (reason === "not_found") return "Missing";
   if (reason === "not_executable") return "Not executable";
   if (reason === "version_not_reported") return "Version unknown";
+  if (isXcodeLicenseFailure(reason)) return "Xcode license";
   return reason;
+}
+
+function isXcodeLicenseCandidate(
+  candidate: DesktopGitDiscoveryCandidate,
+): boolean {
+  return candidate.command === "/usr/bin/git"
+    && isXcodeLicenseFailure(candidate.failureReason ?? candidate.versionFailureReason);
+}
+
+function isXcodeLicenseFailure(reason?: string): boolean {
+  return Boolean(
+    reason?.includes("Xcode license")
+      || reason?.includes("license agreements")
+      || reason?.includes("xcodebuild -license"),
+  );
 }
 
 function describeGhStatusPill(status: GhStatus | undefined): {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -317,6 +317,7 @@ function SettingsSectionBody(props: {
                 : { terminal: { preferredId } },
           });
         }}
+        onRefresh={props.settings.refresh}
         onSaveGhPath={async (path) => {
           await props.settings.writeConfig({
             applications: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -200,6 +200,21 @@ function createSnapshot(
         path: { value: "", source: "default" },
         discovery: { candidates: [] },
       },
+      git: {
+        discovery: {
+          selectedCommand: "/opt/homebrew/bin/git",
+          selectedSource: "homebrew",
+          candidates: [
+            {
+              command: "/opt/homebrew/bin/git",
+              source: "homebrew",
+              executable: true,
+              selected: true,
+              version: "2.39.1",
+            },
+          ],
+        },
+      },
     },
     worktrees: {
       storage: { value: "user-home", source: "default" },
@@ -446,6 +461,63 @@ describe("SettingsScreen", () => {
       });
     });
     expect(getGhStatus).toHaveBeenCalledWith({ recheck: true });
+  });
+
+  it("shows Git discovery and Xcode license remediation", async () => {
+    const snapshot = createSnapshot();
+    snapshot.applications.git = {
+      discovery: {
+        selectedCommand: "/opt/homebrew/bin/git",
+        selectedSource: "homebrew",
+        candidates: [
+          {
+            command: "/opt/homebrew/bin/git",
+            executable: true,
+            selected: true,
+            source: "homebrew",
+            version: "2.39.1",
+          },
+          {
+            command: "/usr/bin/git",
+            executable: false,
+            selected: false,
+            source: "xcode",
+            failureReason:
+              "You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license'",
+          },
+          {
+            command: "/usr/local/bin/git",
+            executable: false,
+            selected: false,
+            source: "homebrew",
+            failureReason: "not_found",
+          },
+        ],
+      },
+    };
+    const settings = createSettingsState(snapshot);
+    const copyTextMock = vi.fn(async () => undefined);
+
+    render(
+      <SettingsScreen
+        desktopApi={{ copyText: copyTextMock }}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    const gitPanel = screen.getByRole("heading", { name: "Git" }).closest("section")!;
+    expect(within(gitPanel).getAllByText("/opt/homebrew/bin/git").length).toBeGreaterThanOrEqual(1);
+    expect(within(gitPanel).getByText(/Apple's Git at/)).toBeInTheDocument();
+    expect(within(gitPanel).queryByText("/usr/local/bin/git")).not.toBeInTheDocument();
+    expect(
+      within(gitPanel).getByText("sudo xcodebuild -license"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(gitPanel).getByRole("button", { name: "Copy command" }));
+    await waitFor(() => {
+      expect(copyTextMock).toHaveBeenCalledWith("sudo xcodebuild -license");
+    });
   });
 
   it("renders the Mattermost section and saves edits via writeConfig", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1488,7 +1488,12 @@ export function ThreadView(props: ThreadViewProps) {
             </div>
             <div>
               <dt>Current branch</dt>
-              <dd>{props.selectedDirectory.gitStatus?.currentBranch ?? "Not a Git repo"}</dd>
+              <dd>
+                {props.selectedDirectory.gitStatus?.currentBranch ??
+                  (props.selectedDirectory.gitStatus?.syncState === "status-unavailable"
+                    ? "Unavailable"
+                    : "Not a Git repo")}
+              </dd>
             </div>
             <div>
               <dt>Upstream</dt>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -49,6 +49,9 @@ describe("ThreadMarkdown", () => {
             path: { value: "", source: "default" },
             discovery: { candidates: [] },
           },
+          git: {
+            discovery: { candidates: [] },
+          },
         }}
         desktopApi={{ openApplication }}
         text={"I updated [AGENTS.md](/repo/PwrAgent/AGENTS.md:17)."}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -298,6 +298,9 @@ describe("TranscriptList", () => {
             path: { value: "", source: "default" },
             discovery: { candidates: [] },
           },
+          git: {
+            discovery: { candidates: [] },
+          },
         }}
         desktopApi={{ openApplication }}
         entries={[

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -156,6 +156,9 @@ describe("desktop settings contracts", () => {
           path: { value: "", source: "default" },
           discovery: { candidates: [] },
         },
+        git: {
+          discovery: { candidates: [] },
+        },
       },
       worktrees: {
         storage: { value: "user-home", source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -176,6 +176,30 @@ export type DesktopGhDiscoverySnapshot = {
   error?: string;
 };
 
+export type DesktopGitCandidateSource =
+  | "env"
+  | "path"
+  | "homebrew"
+  | "xcode"
+  | "user";
+
+export type DesktopGitDiscoveryCandidate = {
+  command: string;
+  source: DesktopGitCandidateSource;
+  executable: boolean;
+  selected: boolean;
+  version?: string;
+  versionFailureReason?: string;
+  failureReason?: string;
+};
+
+export type DesktopGitDiscoverySnapshot = {
+  selectedCommand?: string;
+  selectedSource?: DesktopGitCandidateSource;
+  candidates: DesktopGitDiscoveryCandidate[];
+  error?: string;
+};
+
 export type DesktopApplicationKind = "editor" | "terminal";
 
 export type DesktopApplicationSource = "application" | "path";
@@ -199,6 +223,9 @@ export type DesktopApplicationsSnapshot = {
   gh: {
     path: DesktopSettingsValue<string>;
     discovery: DesktopGhDiscoverySnapshot;
+  };
+  git: {
+    discovery: DesktopGitDiscoverySnapshot;
   };
 };
 


### PR DESCRIPTION
## Summary
- add Git command discovery to Settings -> Applications with a dedicated Git health panel
- prefer a working Git binary for repo/worktree operations instead of failing on Apple Git first
- detect the Xcode license failure for /usr/bin/git and show a copyable remediation command
- keep normal missing Git candidates hidden when a working Git is already available

## Verification
- node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/main/__tests__/git-discovery.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
- node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json
- apps/desktop/node_modules/.bin/electron-vite build