### PR TITLE
fix(desktop): skip helper thread name sync

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3560,6 +3560,19 @@ describe("CodexAppServerClient", () => {
 
     transport!.emitInbound({
       jsonrpc: "2.0",
+      method: "thread/started",
+      params: {
+        thread: {
+          id: "thread-title-helper",
+          preview: "",
+          ephemeral: true,
+          name: null,
+        },
+      },
+    });
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
       method: "turn/completed",
       params: {
         threadId: "thread-title-helper",
@@ -3612,6 +3625,14 @@ describe("CodexAppServerClient", () => {
           outputSchema: expect.objectContaining({
             type: "object",
           }),
+        }),
+      })
+    );
+    expect(requests).not.toContainEqual(
+      expect.objectContaining({
+        method: "thread/name/set",
+        params: expect.objectContaining({
+          threadId: "thread-title-helper",
         }),
       })
     );

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2471,7 +2471,7 @@ function extractThreadNameRecordFromValue(
 
   const threadRecord = asRecord(record.thread) ?? asRecord(record.session);
   const threadId = extractThreadIdFromValue(value);
-  if (!threadId) {
+  if (!threadId || record.ephemeral === true || threadRecord?.ephemeral === true) {
     return undefined;
   }
 
@@ -3424,10 +3424,6 @@ export class CodexAppServerClient {
         });
       }
 
-      if (method === "thread/started") {
-        await this.recordThreadNameWithCodex(params);
-      }
-
       const normalized = normalizeServerNotification(
         method,
         params,
@@ -3436,6 +3432,10 @@ export class CodexAppServerClient {
       if (helperThreadId && this.helperThreadIds.has(helperThreadId)) {
         this.handleHelperThreadNotification(method, normalized);
         return;
+      }
+
+      if (method === "thread/started") {
+        await this.recordThreadNameWithCodex(params);
       }
 
       for (const listener of this.notificationListeners) {


### PR DESCRIPTION
## Summary

- I fixed Codex thread title generation so ephemeral helper threads do not get `thread/name/set` calls.
- I moved helper-thread notification filtering ahead of generic `thread/started` name sync.
- I added focused Codex client coverage that simulates an ephemeral helper `thread/started` notification and asserts no helper rename request is sent.

## Verification

- I ran `pnpm install` to hydrate this worktree's workspace dependencies.
- I ran `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` and it passed with 62 tests.

## Notes

- Root cause: title generation starts an internal ephemeral Codex helper thread. Its `thread/started` notification was being handled by the normal thread-name sync path before the helper filter saw it, which could produce a `thread/name/set` call for the helper thread ID.
