### PR TITLE
fix(desktop): keep accepted branch drift state stable

### DIFF
--- a/apps/desktop/e2e/fixtures/branch-drift-fixture.ts
+++ b/apps/desktop/e2e/fixtures/branch-drift-fixture.ts
@@ -5,11 +5,14 @@ import path from "node:path";
 import { expect } from "@playwright/test";
 import Database from "better-sqlite3";
 
-export async function createBranchDriftFixture(): Promise<{
+export async function createBranchDriftFixture(options: {
+  expectedBranch?: string;
+} = {}): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
   homeDir: string;
 }> {
+  const expectedBranch = options.expectedBranch ?? "codex/expected-branch";
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-branch-drift-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
   // Use the legacy "pwragnt" directory name because the migration code in
@@ -59,7 +62,7 @@ export async function createBranchDriftFixture(): Promise<{
             backend: "codex",
             threadId: "thread-branch-drift",
             executionMode: "default",
-            observedGitBranch: "codex/expected-branch",
+            observedGitBranch: expectedBranch,
             extraLinkedDirectories: [
               {
                 id: "pwragent-handoff:codex:thread-branch-drift",
@@ -112,7 +115,7 @@ export async function createBranchDriftFixture(): Promise<{
                 summary: "A thread whose checkout changed branch.",
                 source: "codex",
                 executionMode: "default",
-                gitBranch: "codex/expected-branch",
+                gitBranch: expectedBranch,
                 linkedDirectories: [],
                 updatedAt: 1_760_000_000_000,
               },

--- a/apps/desktop/e2e/thread-branch-drift.spec.ts
+++ b/apps/desktop/e2e/thread-branch-drift.spec.ts
@@ -118,3 +118,54 @@ test("updates the expected branch when the user accepts the current branch", asy
     await fixture.cleanup();
   }
 });
+
+test("does not reopen a HEAD drift warning after accepting the current branch", async () => {
+  const fixture = await createBranchDriftFixture({ expectedBranch: "HEAD" });
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      HOME: fixture.homeDir,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", {
+        name: "Accept current branch as correct. Continue working on codex/current-branch without further warnings",
+      })
+      .click();
+
+    const dialog = app.window.getByRole("dialog", {
+      name: "Thread branch changed",
+    });
+    await expect(dialog).toBeHidden();
+    expect(readThreadPayload(fixture.homeDir)).toMatchObject({
+      gitBranch: "codex/current-branch",
+      observedGitBranch: "codex/current-branch",
+    });
+
+    const staleRendererCheck = await app.window.evaluate(async () =>
+      await (window as any).pwragent.checkThreadBranchDrift({
+        backend: "codex",
+        expectedBranch: "HEAD",
+        threadId: "thread-branch-drift",
+      })
+    );
+    expect(staleRendererCheck).toMatchObject({
+      drifted: false,
+      expectedBranch: "codex/current-branch",
+      observedBranch: "codex/current-branch",
+    });
+
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0]?.webContents.send("window:focus-sync", {
+        focusedAt: Date.now(),
+      });
+    });
+
+    await expect(dialog).toBeHidden();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2649,8 +2649,10 @@ export class DesktopBackendRegistry {
       callerReason: "branch-drift",
       threadId: params.threadId,
     });
+    const overlayExpectedBranch = overlay?.gitBranch?.trim();
     const requestedExpectedBranch = params.expectedBranch?.trim();
     const expectedBranch =
+      overlayExpectedBranch ||
       requestedExpectedBranch ||
       resolveExpectedThreadBranch({
         overlay,


### PR DESCRIPTION
## Summary

- I reproduced the accepted-HEAD branch drift popup with an Electron E2E regression.
- I made persisted overlay branch metadata authoritative over stale renderer-supplied expected branch values during drift checks.
- I kept the existing branch-drift behavior for active drift and retained warnings intact.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` and it passed: 80 tests.
- I ran `pnpm --filter @pwragent/desktop test:e2e -- thread-branch-drift.spec.ts` and it passed: 4 tests.

## Notes

- The regression covers the case where a thread originally expected `HEAD`, the user accepts the current named branch, and a later stale `expectedBranch: "HEAD"` check should not reopen the warning.
