### PR TITLE
fix(desktop): hydrate Codex app-server PATH

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -290,6 +290,22 @@ describe("DesktopBackendRegistry replay isolation", () => {
 
     await registry.close();
   });
+
+  it("sets the Codex command shell PATH from the live client env", async () => {
+    settingsState.codexEnv = {
+      PATH: "/opt/homebrew/bin:/usr/bin:/bin",
+    } as NodeJS.ProcessEnv;
+
+    const registry = new DesktopBackendRegistry({
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    expect(constructorState.codexArgs[0]).toContain(
+      'shell_environment_policy.set.PATH="/opt/homebrew/bin:/usr/bin:/bin"',
+    );
+
+    await registry.close();
+  });
 });
 
 function writeFixture(fixture: unknown): string {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -440,6 +440,22 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("adds login shell PATH entries to the Codex app-server spawn env", () => {
+    const service = new DesktopSettingsService({
+      env: { PATH: "/usr/bin:/bin" } as NodeJS.ProcessEnv,
+      secretStore: new MemoryDesktopSecretStore(),
+      resolveCodexShellEnv: () => ({
+        NVM_DIR: "/Users/alice/.nvm",
+        PATH: "/Users/alice/.sdkman/candidates/sbt/current/bin:/usr/bin",
+      }),
+    });
+
+    expect(service.resolveCodexSpawnEnv().PATH).toBe(
+      "/Users/alice/.sdkman/candidates/sbt/current/bin:/usr/bin",
+    );
+    expect(service.resolveCodexSpawnEnv().NVM_DIR).toBe("/Users/alice/.nvm");
+  });
+
   it("applies env overrides above TOML and keeps the Grok API key in keychain", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/shell-environment.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-environment.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  mergeLoginShellEnvIntoEnv,
+  resolveInteractiveLoginShellEnv,
+} from "../shell-environment";
+
+describe("shell environment", () => {
+  it("reads the environment from an interactive login shell so zshrc-managed tools are visible", () => {
+    const execFileSync = vi.fn(() =>
+      [
+        "oh-my-zsh startup noise",
+        "__PWRAGENT_ENV_START__",
+        "PATH=/Users/alice/.sdkman/candidates/sbt/current/bin:/opt/homebrew/bin:/usr/bin",
+        "NVM_DIR=/Users/alice/.nvm",
+        "IGNORED-NAME=value",
+        "__PWRAGENT_ENV_END__",
+      ].join("\n"),
+    );
+
+    const shellEnv = resolveInteractiveLoginShellEnv({
+      env: {
+        PATH: "/usr/bin",
+        SHELL: "/bin/zsh",
+      } as NodeJS.ProcessEnv,
+      platform: "darwin",
+      execFileSync,
+      shellCandidates: ["/bin/zsh"],
+    });
+
+    expect(shellEnv?.PATH).toBe(
+      "/Users/alice/.sdkman/candidates/sbt/current/bin:/opt/homebrew/bin:/usr/bin",
+    );
+    expect(shellEnv?.NVM_DIR).toBe("/Users/alice/.nvm");
+    expect(shellEnv?.["IGNORED-NAME"]).toBeUndefined();
+    expect(execFileSync).toHaveBeenCalledWith(
+      "/bin/zsh",
+      [
+        "-ilc",
+        "command printf '__PWRAGENT_ENV_START__\\n'; command env; command printf '__PWRAGENT_ENV_END__\\n'",
+      ],
+      expect.objectContaining({
+        env: {
+          PATH: "/usr/bin",
+          SHELL: "/bin/zsh",
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    );
+  });
+
+  it("tries the next shell candidate when the first one cannot report PATH", () => {
+    const execFileSync = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("shell failed");
+      })
+      .mockImplementationOnce(
+        () => "__PWRAGENT_ENV_START__\nPATH=/bin\n__PWRAGENT_ENV_END__\n",
+      );
+
+    expect(
+      resolveInteractiveLoginShellEnv({
+        env: {} as NodeJS.ProcessEnv,
+        platform: "darwin",
+        execFileSync,
+        shellCandidates: ["/missing/zsh", "/bin/bash"],
+      })?.PATH,
+    ).toBe("/bin");
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not try to hydrate PATH on Windows", () => {
+    const execFileSync = vi.fn();
+
+    expect(
+      resolveInteractiveLoginShellEnv({
+        env: {} as NodeJS.ProcessEnv,
+        platform: "win32",
+        execFileSync,
+      }),
+    ).toBeUndefined();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns a copied env with the login shell env without mutating the input", () => {
+    const env = {
+      PATH: "/usr/bin:/bin",
+      SHELL: "/bin/zsh",
+    } as NodeJS.ProcessEnv;
+
+    const mergedEnv = mergeLoginShellEnvIntoEnv(env, {
+      platform: "darwin",
+      resolveShellEnv: () => ({
+        NVM_DIR: "/Users/alice/.nvm",
+        PATH: "/Users/alice/.sdkman/candidates/sbt/current/bin:/usr/bin",
+      }),
+    });
+
+    expect(mergedEnv).not.toBe(env);
+    expect(mergedEnv.PATH).toBe(
+      "/Users/alice/.sdkman/candidates/sbt/current/bin:/usr/bin",
+    );
+    expect(mergedEnv.NVM_DIR).toBe("/Users/alice/.nvm");
+    expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.NVM_DIR).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -557,13 +557,25 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
   };
 }
 
-function buildCodexClientArgs(): string[] {
-  return [
+function buildCodexClientArgs(env?: NodeJS.ProcessEnv): string[] {
+  const args = [
     "-c",
     'approval_policy="on-request"',
     "-c",
     'sandbox_mode="workspace-write"',
   ];
+  const pathValue = env?.PATH?.trim();
+  if (pathValue) {
+    args.push(
+      "-c",
+      `shell_environment_policy.set.PATH=${formatTomlString(pathValue)}`,
+    );
+  }
+  return args;
+}
+
+function formatTomlString(value: string): string {
+  return JSON.stringify(value);
 }
 
 function buildPendingRequestKey(params: {
@@ -1180,7 +1192,7 @@ export class DesktopBackendRegistry {
       options?.codexClient ??
       replayClients?.codexClient ??
       new CodexAppServerClient({
-        args: buildCodexClientArgs(),
+        args: buildCodexClientArgs(codexEnv),
         command: codexCommand,
         connectionObserver: codexObserver,
         env: codexEnv,

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -81,6 +81,7 @@ import { discoverDesktopApplications } from "./application-discovery";
 import { discoverGitCommands } from "./git-discovery";
 import { discoverGhCommands } from "./gh-discovery";
 import { getMainLogger } from "../log";
+import { mergeLoginShellEnvIntoEnv } from "../shell-environment";
 
 type DesktopSettingsServiceOptions = {
   configPath?: string;
@@ -88,6 +89,9 @@ type DesktopSettingsServiceOptions = {
   argv?: readonly string[];
   secretStore: DesktopSecretStore;
   now?: () => number;
+  resolveCodexShellEnv?: (
+    env: NodeJS.ProcessEnv
+  ) => NodeJS.ProcessEnv | undefined;
 };
 
 type ConfigReadResult = {
@@ -495,9 +499,12 @@ export class DesktopSettingsService {
     const codexHome = resolveCodexHomeForProfile(configuredProfile, {
       env: this.env,
     });
-    if (!codexHome) return this.env;
+    const spawnEnv = mergeLoginShellEnvIntoEnv(this.env, {
+      resolveShellEnv: this.options.resolveCodexShellEnv,
+    });
+    if (!codexHome) return spawnEnv;
     return {
-      ...this.env,
+      ...spawnEnv,
       CODEX_HOME: codexHome,
     };
   }

--- a/apps/desktop/src/main/shell-environment.ts
+++ b/apps/desktop/src/main/shell-environment.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+type ExecFileSyncLike = (
+  file: string,
+  args: string[],
+  options: {
+    encoding: BufferEncoding;
+    env: NodeJS.ProcessEnv;
+    stdio: ["ignore", "pipe", "ignore"];
+    timeout: number;
+  },
+) => string;
+
+type ShellPathOptions = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  execFileSync?: ExecFileSyncLike;
+  shellCandidates?: string[];
+  timeoutMs?: number;
+};
+
+type MergeLoginShellEnvOptions = ShellPathOptions & {
+  resolveShellEnv?: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv | undefined;
+};
+
+const ENV_MARKER_START = "__PWRAGENT_ENV_START__";
+const ENV_MARKER_END = "__PWRAGENT_ENV_END__";
+const DEFAULT_SHELL_PATH_TIMEOUT_MS = 5_000;
+
+export function mergeLoginShellEnvIntoEnv(
+  env: NodeJS.ProcessEnv,
+  options: MergeLoginShellEnvOptions = {},
+): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const shellEnv = options.resolveShellEnv
+    ? options.resolveShellEnv(env)
+    : resolveInteractiveLoginShellEnv({
+        ...options,
+        env,
+        platform,
+      });
+  if (!shellEnv || Object.keys(shellEnv).length === 0) {
+    return env;
+  }
+  return {
+    ...env,
+    ...shellEnv,
+  };
+}
+
+export function resolveInteractiveLoginShellEnv(
+  options: ShellPathOptions = {},
+): NodeJS.ProcessEnv | undefined {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    return undefined;
+  }
+
+  const env = options.env ?? process.env;
+  const exec: ExecFileSyncLike =
+    options.execFileSync
+    ?? ((file, args, execOptions) =>
+      String(execFileSync(file, args, execOptions)));
+  const timeout = options.timeoutMs ?? DEFAULT_SHELL_PATH_TIMEOUT_MS;
+  const command = [
+    `command printf '${ENV_MARKER_START}\\n'`,
+    "command env",
+    `command printf '${ENV_MARKER_END}\\n'`,
+  ].join("; ");
+
+  for (const shell of options.shellCandidates ?? defaultShellCandidates(env)) {
+    try {
+      const output = exec(shell, ["-ilc", command], {
+        encoding: "utf8",
+        env,
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout,
+      });
+      const shellEnv = extractMarkedEnv(output);
+      if (shellEnv) {
+        return shellEnv;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+function defaultShellCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates = [env.SHELL, readUserShell(), "/bin/zsh", "/bin/bash"];
+  return [...new Set(candidates.filter(isUsableShellPath))];
+}
+
+function readUserShell(): string | undefined {
+  try {
+    return os.userInfo().shell ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isUsableShellPath(value: string | undefined): value is string {
+  if (!value?.trim()) {
+    return false;
+  }
+  return path.isAbsolute(value);
+}
+
+function extractMarkedEnv(output: string): NodeJS.ProcessEnv | undefined {
+  const start = output.indexOf(ENV_MARKER_START);
+  if (start === -1) {
+    return undefined;
+  }
+  const valueStart = start + ENV_MARKER_START.length;
+  const end = output.indexOf(ENV_MARKER_END, valueStart);
+  if (end === -1) {
+    return undefined;
+  }
+  const env: NodeJS.ProcessEnv = {};
+  for (const line of output.slice(valueStart, end).split(/\r?\n/)) {
+    const separator = line.indexOf("=");
+    if (separator <= 0) {
+      continue;
+    }
+    const key = line.slice(0, separator);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      continue;
+    }
+    env[key] = line.slice(separator + 1);
+  }
+  return Object.keys(env).length > 0 ? env : undefined;
+}


### PR DESCRIPTION
Fixes desktop launches where Codex app-server inherits a minimal macOS app environment and then cannot find user-installed tools like SDKMAN `sbt`, Homebrew tools, or NVM-managed Node tools.

PwrAgent now mirrors Codex Desktop's startup shape more closely by running the user's interactive login shell once, capturing the exported shell environment, and merging that into the Codex app-server spawn env before preserving any selected `CODEX_HOME` profile. PwrAgent also passes the hydrated PATH into Codex app-server via `shell_environment_policy.set.PATH`, because Codex applies its own environment policy when it runs user shell commands.

This keeps the broad shell-env hydration scoped to the Codex app-server process while avoiding `shell_environment_policy.inherit=all` for every command.

Tests cover noisy zsh startup output, full login-shell env capture, shell fallback behavior, Windows skip behavior, non-mutating env merges, Codex spawn env integration, and the app-server args that set Codex's command PATH policy.

Verification:
- `pnpm test apps/desktop/src/main/__tests__/shell-environment.test.ts apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)