### PR TITLE
fix(desktop): release queued turns reliably

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
+import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 
 export function App() {
   const desktopApi = useDesktopApi();
@@ -79,6 +80,13 @@ function DesktopAppShell(props: {
     selectedThread: navigation.selectedThread,
   });
   const composerDraftStore = useComposerDraftStore();
+  useQueuedTurnRelease({
+    backends: backendSummaries.backends,
+    composerDraftStore,
+    desktopApi,
+    selectedThread: navigation.selectedThread,
+    threads: navigation.threads,
+  });
   const session = useThreadSessionState({
     desktopApi,
     thread: navigation.selectedThread,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -162,6 +162,7 @@ type ComposerDropdownOption = {
 };
 
 type QueuedTurnDraft = {
+  id: string;
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
   text: string;
@@ -223,6 +224,13 @@ type ReviewConfigState = {
 };
 
 const DEFAULT_REASONING_EFFORT = "medium";
+
+let queuedTurnIdSequence = 0;
+
+function createQueuedTurnId(): string {
+  queuedTurnIdSequence += 1;
+  return `queued-turn-${Date.now().toString(36)}-${queuedTurnIdSequence.toString(36)}`;
+}
 
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
   {
@@ -1098,10 +1106,12 @@ export function Composer(props: ComposerProps) {
   };
   const removeQueuedTurn = (queued: QueuedTurnDraft): void => {
     setQueuedTurnsState((current) => {
-      const removeIndex = current.findIndex((candidate) => candidate === queued);
-      const nextQueuedTurns = current.filter((_, candidateIndex) => {
-        return candidateIndex !== (removeIndex === -1 ? 0 : removeIndex);
+      const nextQueuedTurns = current.filter((candidate) => {
+        return candidate.id !== queued.id;
       });
+      if (nextQueuedTurns.length === current.length) {
+        return current;
+      }
       saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
       return nextQueuedTurns;
     });
@@ -1535,6 +1545,7 @@ export function Composer(props: ComposerProps) {
             setImageAttachments(pendingSteer.imageAttachments);
           } else {
             setQueuedTurn({
+              id: createQueuedTurnId(),
               text: pendingSteer.text,
               imageAttachments: pendingSteer.imageAttachments,
             });
@@ -1830,6 +1841,7 @@ export function Composer(props: ComposerProps) {
       setImageAttachments(pendingSteer.imageAttachments);
     } else {
       setQueuedTurn({
+        id: createQueuedTurnId(),
         text: pendingSteer.text,
         imageAttachments: pendingSteer.imageAttachments,
       });
@@ -1848,6 +1860,7 @@ export function Composer(props: ComposerProps) {
     }
 
     enqueueQueuedTurn({
+      id: createQueuedTurnId(),
       input: payload.input,
       text: canonicalDraft,
       imageAttachments,
@@ -1899,6 +1912,7 @@ export function Composer(props: ComposerProps) {
           setImageAttachments(pending.imageAttachments);
         } else {
           setQueuedTurn({
+            id: createQueuedTurnId(),
             text: pending.text,
             imageAttachments: pending.imageAttachments,
           });
@@ -1938,6 +1952,7 @@ export function Composer(props: ComposerProps) {
 
     setSendError(undefined);
     setPendingSteer({
+      id: pending.id,
       text: pending.text,
       imageAttachments: pending.imageAttachments,
       status: "pending",
@@ -1962,6 +1977,7 @@ export function Composer(props: ComposerProps) {
     }
 
     createPendingSteer({
+      id: createQueuedTurnId(),
       text: canonicalDraft,
       imageAttachments,
     });

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -162,6 +162,7 @@ type ComposerDropdownOption = {
 };
 
 type QueuedTurnDraft = {
+  input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
   text: string;
 };
@@ -860,8 +861,8 @@ export function Composer(props: ComposerProps) {
   const localDraftStore = useComposerDraftStore();
   const draftStore = props.draftStore ?? localDraftStore;
   const savedInitialDraft = draftStore.get(composerScopeKey);
-  const savedInitialQueuedTurn = props.thread
-    ? draftStore.getQueuedTurn(composerScopeKey)
+  const savedInitialQueuedTurns = props.thread
+    ? draftStore.getQueuedTurns(composerScopeKey)
     : undefined;
   const savedInitialPendingSteer = props.thread
     ? draftStore.getPendingSteer(composerScopeKey)
@@ -915,8 +916,8 @@ export function Composer(props: ComposerProps) {
   const [sending, setSending] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
   const [steering, setSteering] = useState(false);
-  const [queuedTurn, setQueuedTurnState] = useState<QueuedTurnDraft | undefined>(
-    savedInitialQueuedTurn
+  const [queuedTurns, setQueuedTurnsState] = useState<QueuedTurnDraft[]>(
+    savedInitialQueuedTurns ?? []
   );
   const [pendingSteer, setPendingSteerState] = useState<
     PendingSteerDraft | undefined
@@ -968,6 +969,7 @@ export function Composer(props: ComposerProps) {
   );
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
+  const queuedTurn = queuedTurns[0];
   launchpadUpdateRef.current = props.onUpdateLaunchpad;
   latestDraftSnapshotRef.current = {
     scopeKey: composerScopeKey,
@@ -1051,24 +1053,58 @@ export function Composer(props: ComposerProps) {
 
     draftStore.setPendingSteer(scopeKey, state);
   };
-  const saveQueuedTurnSnapshot = (
+  const saveQueuedTurnSnapshots = (
     scopeKey: string,
-    state?: ComposerQueuedTurnSnapshot,
+    state: ComposerQueuedTurnSnapshot[],
   ): void => {
     if (!isQueuedTurnStoreScope(scopeKey)) {
       return;
     }
 
-    if (!state || (!state.text.trim() && state.imageAttachments.length === 0)) {
+    const snapshots = state.filter(
+      (entry) =>
+        entry.text.trim() || entry.imageAttachments.length > 0 || entry.input?.length,
+    );
+
+    if (snapshots.length === 0) {
       draftStore.deleteQueuedTurn(scopeKey);
       return;
     }
 
-    draftStore.setQueuedTurn(scopeKey, state);
+    draftStore.setQueuedTurns(scopeKey, snapshots);
+  };
+  const setQueuedTurns = (nextQueuedTurns: QueuedTurnDraft[]): void => {
+    saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
+    setQueuedTurnsState(nextQueuedTurns);
   };
   const setQueuedTurn = (nextQueuedTurn?: QueuedTurnDraft): void => {
-    saveQueuedTurnSnapshot(composerScopeKey, nextQueuedTurn);
-    setQueuedTurnState(nextQueuedTurn);
+    setQueuedTurns(nextQueuedTurn ? [nextQueuedTurn] : []);
+  };
+  const enqueueQueuedTurn = (nextQueuedTurn: QueuedTurnDraft): void => {
+    setQueuedTurnsState((current) => {
+      const nextQueuedTurns = [...current, nextQueuedTurn];
+      saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
+      return nextQueuedTurns;
+    });
+  };
+  const removeQueuedTurnAt = (index: number): void => {
+    setQueuedTurnsState((current) => {
+      const nextQueuedTurns = current.filter((_, candidateIndex) => {
+        return candidateIndex !== index;
+      });
+      saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
+      return nextQueuedTurns;
+    });
+  };
+  const removeQueuedTurn = (queued: QueuedTurnDraft): void => {
+    setQueuedTurnsState((current) => {
+      const removeIndex = current.findIndex((candidate) => candidate === queued);
+      const nextQueuedTurns = current.filter((_, candidateIndex) => {
+        return candidateIndex !== (removeIndex === -1 ? 0 : removeIndex);
+      });
+      saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
+      return nextQueuedTurns;
+    });
   };
   const setPendingSteer = (nextPendingSteer?: PendingSteerDraft): void => {
     if (nextPendingSteer?.status === "pending") {
@@ -1269,7 +1305,7 @@ export function Composer(props: ComposerProps) {
     if (props.thread) {
       const saved = draftStore.get(composerScopeKey);
       const savedPendingSteer = draftStore.getPendingSteer(composerScopeKey);
-      const savedQueuedTurn = draftStore.getQueuedTurn(composerScopeKey);
+      const savedQueuedTurns = draftStore.getQueuedTurns(composerScopeKey);
       setDraft(saved?.draft ?? "");
       setEditorDocument(saved?.editorDocument);
       setImageAttachments(saved?.imageAttachments ?? []);
@@ -1277,10 +1313,10 @@ export function Composer(props: ComposerProps) {
       setPendingSteerState(
         savedPendingSteer ? { ...savedPendingSteer, status: "pending" } : undefined
       );
-      setQueuedTurnState(savedQueuedTurn);
+      setQueuedTurnsState(savedQueuedTurns);
     } else {
       setPendingSteerState(undefined);
-      setQueuedTurnState(undefined);
+      setQueuedTurnsState([]);
     }
     setSending(false);
     setInterrupting(false);
@@ -1389,7 +1425,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-    setQueuedTurnState(undefined);
+    setQueuedTurnsState([]);
     setPendingSteer(undefined);
     window.setTimeout(() => {
       inputRef.current?.focus();
@@ -1744,7 +1780,7 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
       if (queued) {
-        setQueuedTurn(undefined);
+        removeQueuedTurn(queued);
       } else {
         clearComposerDraftSnapshot(composerScopeKey);
         clearComposerDraft();
@@ -1805,12 +1841,14 @@ export function Composer(props: ComposerProps) {
     if (!hasComposerContent && imageAttachments.length === 0) {
       return;
     }
-    if (queuedTurn) {
-      setSendError("A message is already queued.");
+
+    const payload = buildTurnPayload(canonicalDraft, imageAttachments);
+    if (payload.input.length === 0) {
       return;
     }
 
-    setQueuedTurn({
+    enqueueQueuedTurn({
+      input: payload.input,
       text: canonicalDraft,
       imageAttachments,
     });
@@ -1933,7 +1971,7 @@ export function Composer(props: ComposerProps) {
     if (!createPendingSteer(queued)) {
       return;
     }
-    setQueuedTurn(undefined);
+    removeQueuedTurn(queued);
     if (activeTurnIdRef.current) {
       void submitPendingSteer(queued);
     }
@@ -2824,15 +2862,21 @@ export function Composer(props: ComposerProps) {
         </div>
       ) : null}
 
-      {queuedTurn ? (
-        <div className="composer__queued" aria-label="Queued message">
+      {queuedTurns.map((queued, index) => (
+        <div
+          className="composer__queued"
+          aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
+          key={`${index}:${queued.text}:${queued.imageAttachments.length}`}
+        >
           <div className="composer__queued-copy">
-            <span className="composer__queued-label">Queued next</span>
+            <span className="composer__queued-label">
+              {index === 0 ? "Queued next" : `Queued #${index + 1}`}
+            </span>
             <span className="composer__queued-text">
-              {formatDraftPreview(queuedTurn)}
+              {formatDraftPreview(queued)}
             </span>
           </div>
-          <QueuedImageAttachments attachments={queuedTurn.imageAttachments} />
+          <QueuedImageAttachments attachments={queued.imageAttachments} />
           <div className="composer__queued-actions">
             {supportsSteering ? (
               <button
@@ -2840,7 +2884,7 @@ export function Composer(props: ComposerProps) {
                 disabled={props.disabled || steering || !activeTurnId}
                 type="button"
                 onClick={() => {
-                  steerQueuedTurn(queuedTurn);
+                  steerQueuedTurn(queued);
                 }}
               >
                 {steering ? "Steering..." : "Steer"}
@@ -2850,9 +2894,9 @@ export function Composer(props: ComposerProps) {
               className="composer__secondary-action"
               type="button"
               onClick={() => {
-                setComposerDraftFromCanonical(queuedTurn.text);
-                setImageAttachments(queuedTurn.imageAttachments);
-                setQueuedTurn(undefined);
+                setComposerDraftFromCanonical(queued.text);
+                setImageAttachments(queued.imageAttachments);
+                removeQueuedTurnAt(index);
                 requestAnimationFrame(() => inputRef.current?.focus());
               }}
             >
@@ -2862,14 +2906,14 @@ export function Composer(props: ComposerProps) {
               className="composer__secondary-action"
               type="button"
               onClick={() => {
-                setQueuedTurn(undefined);
+                removeQueuedTurnAt(index);
               }}
             >
               Delete
             </button>
           </div>
         </div>
-      ) : null}
+      ))}
 
       <div className="composer__input-wrap" ref={inputWrapRef}>
         {isReviewComposerOpen ? (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -77,7 +77,7 @@ function chooseDropdownOption(label: string, optionName: string): void {
 function createComposerDraftStore(): ComposerDraftStore {
   const drafts = new Map<string, ComposerDraftSnapshot>();
   const pendingSteers = new Map<string, ComposerPendingSteerSnapshot>();
-  const queuedTurns = new Map<string, ComposerQueuedTurnSnapshot>();
+  const queuedTurns = new Map<string, ComposerQueuedTurnSnapshot[]>();
   return {
     delete: (scopeKey) => {
       drafts.delete(scopeKey);
@@ -90,12 +90,41 @@ function createComposerDraftStore(): ComposerDraftStore {
       queuedTurns.delete(scopeKey);
     },
     getPendingSteer: (scopeKey) => pendingSteers.get(scopeKey),
-    getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey),
+    getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey)?.[0],
+    getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
+    removeQueuedTurnAt: (scopeKey, index) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const next = [...current];
+      const [removed] = next.splice(index, 1);
+      if (next.length > 0) {
+        queuedTurns.set(scopeKey, next);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return removed;
+    },
+    shiftQueuedTurn: (scopeKey) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const [first, ...rest] = current;
+      if (rest.length > 0) {
+        queuedTurns.set(scopeKey, rest);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return first;
+    },
     setPendingSteer: (scopeKey, snapshot) => {
       pendingSteers.set(scopeKey, snapshot);
     },
     setQueuedTurn: (scopeKey, snapshot) => {
-      queuedTurns.set(scopeKey, snapshot);
+      queuedTurns.set(scopeKey, [snapshot]);
+    },
+    setQueuedTurns: (scopeKey, snapshots) => {
+      if (snapshots.length > 0) {
+        queuedTurns.set(scopeKey, snapshots);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
     },
     set: (scopeKey, snapshot) => {
       drafts.set(scopeKey, snapshot);
@@ -579,6 +608,68 @@ describe("Composer", () => {
         })
       );
     });
+  });
+
+  it("keeps active-turn messages in oldest-first queue order", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Active turn",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "First queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Second queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "First queued reply"
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Second queued reply"
+    );
+    expect(screen.queryByText("A message is already queued.")).not.toBeInTheDocument();
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "First queued reply" }],
+        })
+      );
+    });
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Second queued reply"
+    );
   });
 
   it("restores a queued active-turn message after navigating away and back", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -103,6 +103,21 @@ function createComposerDraftStore(): ComposerDraftStore {
       }
       return removed;
     },
+    removeQueuedTurnById: (scopeKey, id) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const index = current.findIndex((entry) => entry.id === id);
+      if (index === -1) {
+        return undefined;
+      }
+      const next = [...current];
+      const [removed] = next.splice(index, 1);
+      if (next.length > 0) {
+        queuedTurns.set(scopeKey, next);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return removed;
+    },
     shiftQueuedTurn: (scopeKey) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const [first, ...rest] = current;
@@ -667,6 +682,85 @@ describe("Composer", () => {
         })
       );
     });
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Second queued reply"
+    );
+  });
+
+  it("does not remove the next queued message when the in-flight queued chip is edited", async () => {
+    let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
+    const startTurn = vi.fn(
+      (request: StartTurnRequest) =>
+        new Promise<StartTurnResponse>((resolve) => {
+          resolveStartTurn = () =>
+            resolve({
+              backend: request.backend,
+              threadId: request.threadId,
+              turnId: "turn-2",
+            });
+        })
+    );
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Active turn",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "First queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Second queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ type: "text", text: "First queued reply" }],
+        })
+      );
+    });
+
+    fireEvent.click(
+      within(screen.getByLabelText("Queued message")).getByRole("button", {
+        name: "Edit",
+      })
+    );
+
+    expect(textarea).toHaveValue("First queued reply");
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Second queued reply"
+    );
+
+    await act(async () => {
+      resolveStartTurn?.({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-2",
+      });
+    });
+
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Second queued reply"
     );

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -14,12 +14,14 @@ export type ComposerDraftSnapshot = {
 };
 
 export type ComposerQueuedTurnSnapshot = {
+  id: string;
   input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
 };
 
 export type ComposerPendingSteerSnapshot = {
+  id: string;
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
 };
@@ -33,6 +35,7 @@ export type ComposerDraftStore = {
   getQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
   getQueuedTurns(scopeKey: string): ComposerQueuedTurnSnapshot[];
   removeQueuedTurnAt(scopeKey: string, index: number): ComposerQueuedTurnSnapshot | undefined;
+  removeQueuedTurnById(scopeKey: string, id: string): ComposerQueuedTurnSnapshot | undefined;
   shiftQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
   setPendingSteer(scopeKey: string, snapshot: ComposerPendingSteerSnapshot): void;
   setQueuedTurn(scopeKey: string, snapshot: ComposerQueuedTurnSnapshot): void;
@@ -63,6 +66,21 @@ export function useComposerDraftStore(): ComposerDraftStore {
       removeQueuedTurnAt: (scopeKey, index) => {
         const current = queuedTurnStoreRef.current.get(scopeKey) ?? [];
         if (index < 0 || index >= current.length) {
+          return undefined;
+        }
+        const next = [...current];
+        const [removed] = next.splice(index, 1);
+        if (next.length === 0) {
+          queuedTurnStoreRef.current.delete(scopeKey);
+        } else {
+          queuedTurnStoreRef.current.set(scopeKey, next);
+        }
+        return removed;
+      },
+      removeQueuedTurnById: (scopeKey, id) => {
+        const current = queuedTurnStoreRef.current.get(scopeKey) ?? [];
+        const index = current.findIndex((entry) => entry.id === id);
+        if (index === -1) {
           return undefined;
         }
         const next = [...current];

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -1,6 +1,9 @@
 import { useMemo, useRef } from "react";
 import type { JSONContent } from "@tiptap/react";
-import type { NavigationLaunchpadImageAttachment } from "@pwragent/shared";
+import type {
+  AppServerTurnInputItem,
+  NavigationLaunchpadImageAttachment,
+} from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerInputTypes";
 
 export type ComposerDraftSnapshot = {
@@ -11,6 +14,7 @@ export type ComposerDraftSnapshot = {
 };
 
 export type ComposerQueuedTurnSnapshot = {
+  input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
 };
@@ -27,15 +31,19 @@ export type ComposerDraftStore = {
   deleteQueuedTurn(scopeKey: string): void;
   getPendingSteer(scopeKey: string): ComposerPendingSteerSnapshot | undefined;
   getQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
+  getQueuedTurns(scopeKey: string): ComposerQueuedTurnSnapshot[];
+  removeQueuedTurnAt(scopeKey: string, index: number): ComposerQueuedTurnSnapshot | undefined;
+  shiftQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
   setPendingSteer(scopeKey: string, snapshot: ComposerPendingSteerSnapshot): void;
   setQueuedTurn(scopeKey: string, snapshot: ComposerQueuedTurnSnapshot): void;
+  setQueuedTurns(scopeKey: string, snapshots: ComposerQueuedTurnSnapshot[]): void;
   set(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
 };
 
 export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
   const pendingSteerStoreRef = useRef(new Map<string, ComposerPendingSteerSnapshot>());
-  const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot>());
+  const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot[]>());
 
   return useMemo(
     () => ({
@@ -50,12 +58,47 @@ export function useComposerDraftStore(): ComposerDraftStore {
         queuedTurnStoreRef.current.delete(scopeKey);
       },
       getPendingSteer: (scopeKey) => pendingSteerStoreRef.current.get(scopeKey),
-      getQueuedTurn: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey),
+      getQueuedTurn: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey)?.[0],
+      getQueuedTurns: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey) ?? [],
+      removeQueuedTurnAt: (scopeKey, index) => {
+        const current = queuedTurnStoreRef.current.get(scopeKey) ?? [];
+        if (index < 0 || index >= current.length) {
+          return undefined;
+        }
+        const next = [...current];
+        const [removed] = next.splice(index, 1);
+        if (next.length === 0) {
+          queuedTurnStoreRef.current.delete(scopeKey);
+        } else {
+          queuedTurnStoreRef.current.set(scopeKey, next);
+        }
+        return removed;
+      },
+      shiftQueuedTurn: (scopeKey) => {
+        const current = queuedTurnStoreRef.current.get(scopeKey) ?? [];
+        const [first, ...rest] = current;
+        if (!first) {
+          return undefined;
+        }
+        if (rest.length === 0) {
+          queuedTurnStoreRef.current.delete(scopeKey);
+        } else {
+          queuedTurnStoreRef.current.set(scopeKey, rest);
+        }
+        return first;
+      },
       setPendingSteer: (scopeKey, snapshot) => {
         pendingSteerStoreRef.current.set(scopeKey, snapshot);
       },
       setQueuedTurn: (scopeKey, snapshot) => {
-        queuedTurnStoreRef.current.set(scopeKey, snapshot);
+        queuedTurnStoreRef.current.set(scopeKey, [snapshot]);
+      },
+      setQueuedTurns: (scopeKey, snapshots) => {
+        if (snapshots.length === 0) {
+          queuedTurnStoreRef.current.delete(scopeKey);
+        } else {
+          queuedTurnStoreRef.current.set(scopeKey, [...snapshots]);
+        }
       },
       set: (scopeKey, snapshot) => {
         storeRef.current.set(scopeKey, snapshot);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -35,6 +35,21 @@ function createComposerDraftStore(): ComposerDraftStore {
       }
       return removed;
     },
+    removeQueuedTurnById: (scopeKey, id) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const index = current.findIndex((entry) => entry.id === id);
+      if (index === -1) {
+        return undefined;
+      }
+      const next = [...current];
+      const [removed] = next.splice(index, 1);
+      if (next.length > 0) {
+        queuedTurns.set(scopeKey, next);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return removed;
+    },
     shiftQueuedTurn: (scopeKey) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const [first, ...rest] = current;
@@ -123,11 +138,13 @@ describe("useQueuedTurnRelease", () => {
     const composerDraftStore = createComposerDraftStore();
     composerDraftStore.setQueuedTurns("thread:codex:thread-a", [
       {
+        id: "queued-1",
         text: "First background reply",
         imageAttachments: [],
         input: [{ type: "text", text: "First background reply" }],
       },
       {
+        id: "queued-2",
         text: "Second background reply",
         imageAttachments: [],
         input: [{ type: "text", text: "Second background reply" }],
@@ -178,6 +195,102 @@ describe("useQueuedTurnRelease", () => {
     ).toBe("Second background reply");
   });
 
+  it("does not remove the next background queued message when the started item changed while in flight", async () => {
+    let resolveStartTurn: (() => void) | undefined;
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(
+      () =>
+        new Promise<{
+          backend: "codex";
+          threadId: string;
+          turnId: string;
+        }>((resolve) => {
+          resolveStartTurn = () => {
+            resolve({
+              backend: "codex",
+              threadId: "thread-a",
+              turnId: "turn-next",
+            });
+          };
+        })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurns("thread:codex:thread-a", [
+      {
+        id: "queued-1",
+        text: "First background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "First background reply" }],
+      },
+      {
+        id: "queued-2",
+        text: "Second background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Second background reply" }],
+      },
+    ]);
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ type: "text", text: "First background reply" }],
+        })
+      );
+    });
+
+    composerDraftStore.removeQueuedTurnAt("thread:codex:thread-a", 0);
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("Second background reply");
+
+    await act(async () => {
+      resolveStartTurn?.();
+    });
+
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("Second background reply");
+  });
+
   it("leaves the focused thread queue for the mounted composer to release", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn();
@@ -192,6 +305,7 @@ describe("useQueuedTurnRelease", () => {
     };
     const composerDraftStore = createComposerDraftStore();
     composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-1",
       text: "Focused reply",
       imageAttachments: [],
       input: [{ type: "text", text: "Focused reply" }],

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -102,7 +102,10 @@ function backendSummary(): BackendSummary {
   };
 }
 
-function thread(id: string): NavigationThreadSummary {
+function thread(
+  id: string,
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
   return {
     id,
     title: `Thread ${id}`,
@@ -111,6 +114,7 @@ function thread(id: string): NavigationThreadSummary {
     executionMode: "default",
     linkedDirectories: [],
     inbox: { inInbox: false },
+    ...overrides,
   };
 }
 
@@ -289,6 +293,68 @@ describe("useQueuedTurnRelease", () => {
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Second background reply");
+  });
+
+  it("does not background-release a branch-tracked thread that needs the drift guard", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn();
+    const checkThreadBranchDrift = vi.fn();
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-branch",
+      text: "Guarded background reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Guarded background reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", { gitBranch: "feature/expected" }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(checkThreadBranchDrift).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("Guarded background reply");
   });
 
   it("leaves the focused thread queue for the mounted composer to release", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -1,0 +1,235 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type {
+  AgentEvent,
+  BackendSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComposerDraftStore } from "../../features/composer/useComposerDraftStore";
+import type { DesktopApi } from "../desktop-api";
+import { useQueuedTurnRelease } from "../useQueuedTurnRelease";
+
+function createComposerDraftStore(): ComposerDraftStore {
+  const queuedTurns = new Map<
+    string,
+    ReturnType<ComposerDraftStore["getQueuedTurns"]>
+  >();
+  return {
+    delete: vi.fn(),
+    get: vi.fn(),
+    deletePendingSteer: vi.fn(),
+    deleteQueuedTurn: (scopeKey) => {
+      queuedTurns.delete(scopeKey);
+    },
+    getPendingSteer: vi.fn(),
+    getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey)?.[0],
+    getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
+    removeQueuedTurnAt: (scopeKey, index) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const next = [...current];
+      const [removed] = next.splice(index, 1);
+      if (next.length > 0) {
+        queuedTurns.set(scopeKey, next);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return removed;
+    },
+    shiftQueuedTurn: (scopeKey) => {
+      const current = queuedTurns.get(scopeKey) ?? [];
+      const [first, ...rest] = current;
+      if (rest.length > 0) {
+        queuedTurns.set(scopeKey, rest);
+      } else {
+        queuedTurns.delete(scopeKey);
+      }
+      return first;
+    },
+    setPendingSteer: vi.fn(),
+    setQueuedTurn: (scopeKey, snapshot) => {
+      queuedTurns.set(scopeKey, [snapshot]);
+    },
+    setQueuedTurns: (scopeKey, snapshots) => {
+      queuedTurns.set(scopeKey, snapshots);
+    },
+    set: vi.fn(),
+  };
+}
+
+function backendSummary(): BackendSummary {
+  return {
+    kind: "codex",
+    label: "Codex",
+    available: true,
+    methods: ["turn/start"],
+    capabilities: {
+      listThreads: true,
+      createThread: true,
+      resumeThread: true,
+      renameThread: false,
+      readThread: true,
+      startTurn: true,
+      interruptTurn: true,
+      steerTurn: false,
+      transcriptPagination: true,
+      toolUse: false,
+      approvalRequests: true,
+      multiDirectoryThreads: true,
+    },
+    executionModes: [
+      {
+        mode: "default",
+        label: "Default Access",
+        available: true,
+        isDefault: true,
+      },
+    ],
+  };
+}
+
+function thread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: `Thread ${id}`,
+    titleSource: "explicit",
+    source: "codex",
+    executionMode: "default",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+  };
+}
+
+describe("useQueuedTurnRelease", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("releases the oldest queued message for a non-focused thread when its turn completes", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-next",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurns("thread:codex:thread-a", [
+      {
+        text: "First background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "First background reply" }],
+      },
+      {
+        text: "Second background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Second background reply" }],
+      },
+    ]);
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-a",
+          input: [{ type: "text", text: "First background reply" }],
+        })
+      );
+    });
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("Second background reply");
+  });
+
+  it("leaves the focused thread queue for the mounted composer to release", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      text: "Focused reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Focused reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-a"),
+        threads: [thread("thread-a")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("Focused reply");
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -130,7 +130,7 @@ export function useQueuedTurnRelease(params: {
 
       const input = buildQueuedTurnInput(queuedTurn);
       if (input.length === 0) {
-        current.composerDraftStore.shiftQueuedTurn(scopeKey);
+        current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
         return;
       }
 
@@ -172,7 +172,7 @@ export function useQueuedTurnRelease(params: {
             : undefined,
       })
         .then(() => {
-          current.composerDraftStore.shiftQueuedTurn(scopeKey);
+          current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
         })
         .finally(() => {
           inFlightScopeKeysRef.current.delete(scopeKey);

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -128,6 +128,10 @@ export function useQueuedTurnRelease(params: {
         return;
       }
 
+      if (thread.gitBranch && current.desktopApi?.checkThreadBranchDrift) {
+        return;
+      }
+
       const input = buildQueuedTurnInput(queuedTurn);
       if (input.length === 0) {
         current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -1,0 +1,182 @@
+import { useEffect, useRef } from "react";
+import type {
+  AgentEvent,
+  AppServerTurnInputItem,
+  BackendSummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type {
+  ComposerDraftStore,
+  ComposerQueuedTurnSnapshot,
+} from "../features/composer/useComposerDraftStore";
+import type { DesktopApi } from "./desktop-api";
+
+type ModelOption = NonNullable<
+  NonNullable<BackendSummary["launchpadOptions"]>["models"]
+>[number];
+
+const TERMINAL_TURN_METHODS = new Set([
+  "turn/completed",
+  "turn/failed",
+  "turn/cancelled",
+]);
+
+function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
+  const models = backend?.launchpadOptions?.models ?? [];
+  return (
+    models.find((model) => model.current) ??
+    models.find((model) => model.supportsReasoning) ??
+    models[0]
+  );
+}
+
+function getDefaultReasoningEffort(backend?: BackendSummary): string | undefined {
+  const reasoningEfforts = backend?.launchpadOptions?.reasoningEfforts ?? [];
+  return reasoningEfforts.includes("medium") ? "medium" : reasoningEfforts[0];
+}
+
+function getReasoningEffortValue(
+  backend: BackendSummary | undefined,
+  currentValue: string | undefined,
+): string | undefined {
+  const reasoningEfforts = backend?.launchpadOptions?.reasoningEfforts ?? [];
+  return reasoningEfforts.includes(currentValue ?? "")
+    ? currentValue
+    : getDefaultReasoningEffort(backend);
+}
+
+function buildQueuedTurnInput(
+  queuedTurn: ComposerQueuedTurnSnapshot,
+): AppServerTurnInputItem[] {
+  if (queuedTurn.input?.length) {
+    return queuedTurn.input;
+  }
+
+  return [
+    ...(queuedTurn.text.trim()
+      ? [{ type: "text" as const, text: queuedTurn.text.trim() }]
+      : []),
+    ...queuedTurn.imageAttachments.map((attachment) => ({
+      type: "image" as const,
+      url: attachment.url,
+    })),
+  ];
+}
+
+function readNotificationThreadId(event: AgentEvent): string | undefined {
+  const params = event.notification.params;
+  return "threadId" in params && typeof params.threadId === "string"
+    ? params.threadId
+    : undefined;
+}
+
+function getThreadScopeKey(thread: Pick<NavigationThreadSummary, "id" | "source">): string {
+  return `thread:${thread.source}:${thread.id}`;
+}
+
+export function useQueuedTurnRelease(params: {
+  backends: BackendSummary[];
+  composerDraftStore: ComposerDraftStore;
+  desktopApi?: DesktopApi;
+  selectedThread?: NavigationThreadSummary;
+  threads: NavigationThreadSummary[];
+}): void {
+  const paramsRef = useRef(params);
+  const inFlightScopeKeysRef = useRef(new Set<string>());
+  paramsRef.current = params;
+
+  useEffect(() => {
+    const desktopApi = params.desktopApi;
+    const startTurn = desktopApi?.startTurn;
+    if (!desktopApi?.onAgentEvent || !startTurn) {
+      return;
+    }
+
+    return desktopApi.onAgentEvent((event) => {
+      const current = paramsRef.current;
+      if (!TERMINAL_TURN_METHODS.has(event.notification.method)) {
+        return;
+      }
+
+      const threadId = readNotificationThreadId(event);
+      if (!threadId) {
+        return;
+      }
+
+      if (
+        current.selectedThread?.source === event.backend &&
+        current.selectedThread.id === threadId
+      ) {
+        return;
+      }
+
+      const thread = current.threads.find(
+        (candidate) =>
+          candidate.source === event.backend && candidate.id === threadId,
+      );
+      if (!thread) {
+        return;
+      }
+
+      const scopeKey = getThreadScopeKey(thread);
+      if (inFlightScopeKeysRef.current.has(scopeKey)) {
+        return;
+      }
+
+      const queuedTurn = current.composerDraftStore.getQueuedTurn(scopeKey);
+      if (!queuedTurn) {
+        return;
+      }
+
+      const input = buildQueuedTurnInput(queuedTurn);
+      if (input.length === 0) {
+        current.composerDraftStore.shiftQueuedTurn(scopeKey);
+        return;
+      }
+
+      const backend = current.backends.find(
+        (candidate) => candidate.kind === thread.source,
+      );
+      if (!backend?.available || !backend.capabilities.startTurn) {
+        return;
+      }
+
+      const selectedModelOption =
+        backend.launchpadOptions?.models?.find((option) => option.id === thread.model) ??
+        getDefaultModelOption(backend);
+      const supportsReasoning =
+        selectedModelOption?.supportsReasoning ??
+        Boolean(backend.launchpadOptions?.reasoningEfforts?.length);
+      const supportsFast =
+        backend.kind === "codex"
+          ? selectedModelOption?.supportsFast ??
+            backend.launchpadOptions?.supportsFastMode ??
+            false
+          : false;
+
+      inFlightScopeKeysRef.current.add(scopeKey);
+      void startTurn({
+        backend: thread.source,
+        threadId: thread.id,
+        input,
+        executionMode: thread.executionMode,
+        model: selectedModelOption?.id,
+        reasoningEffort: supportsReasoning
+          ? getReasoningEffortValue(backend, thread.reasoningEffort)
+          : undefined,
+        serviceTier:
+          thread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
+        fastMode:
+          thread.source === "codex" && supportsFast
+            ? Boolean(thread.fastMode)
+            : undefined,
+      })
+        .then(() => {
+          current.composerDraftStore.shiftQueuedTurn(scopeKey);
+        })
+        .finally(() => {
+          inFlightScopeKeysRef.current.delete(scopeKey);
+        });
+    });
+  }, [params.desktopApi]);
+}


### PR DESCRIPTION
## Summary

- I fixed queued composer messages so background threads release the next queued turn as soon as their active turn ends, instead of waiting until the thread is focused again.
- I changed queued messages from a single slot into an oldest-first queue, with stable queued-turn IDs so edit/delete/send races do not drop the wrong message.
- I kept branch-drift safety intact by leaving queued messages parked for branch-tracked background threads; when the user focuses the thread, the existing Composer path runs the drift confirmation before starting work.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- I used temporary local `node_modules` symlinks from the existing checkout for verification in this worktree, then removed them before committing.
