### PR TITLE
fix(desktop): queue review starts during active turns

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -501,6 +501,7 @@ class MockBackendClient {
       startTurnError?: Error;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
+      setThreadPermissionsDelay?: Promise<unknown>;
     }
   ) {}
 
@@ -677,6 +678,7 @@ class MockBackendClient {
   }): Promise<{ threadId: string }> {
     this.lastSetThreadPermissionsParams = params;
     this.setThreadPermissionsCallCount += 1;
+    await this.options.setThreadPermissionsDelay;
     if (this.options.setThreadPermissionsError) {
       throw this.options.setThreadPermissionsError;
     }
@@ -2490,6 +2492,37 @@ describe("DesktopBackendRegistry", () => {
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
     });
+
+    await registry.close();
+  });
+
+  it("rejects Codex review start while the thread has an active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Keep working" }],
+    });
+
+    await expect(
+      registry.startReview({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      }),
+    ).rejects.toThrow("Thread already has an active turn in progress: thread-1");
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
 
     await registry.close();
   });
@@ -4727,6 +4760,75 @@ describe("DesktopBackendRegistry", () => {
 
       const log = await getLog(overlayStore, "thread-1");
       expect(log.map((entry) => entry.status)).toContain("applied");
+
+      await registry.close();
+    });
+
+    it("startReview waits for an in-flight permission queue flush before review/start", async () => {
+      const permissionFlush = createDeferred<void>();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start", "review/start", "thread/resume"] },
+        setThreadPermissionsDelay: permissionFlush.promise,
+      });
+      const overlayStore = createOverlayStoreMock({
+        executionMode: "default",
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok unavailable"),
+        }),
+        overlayStore,
+      });
+      const turnId = await startActiveTurn(registry, "thread-1");
+
+      await registry.setThreadExecutionMode({
+        backend: "codex",
+        threadId: "thread-1",
+        executionMode: "full-access",
+      });
+      expect(codexClient.lastSetThreadPermissionsParams).toBeUndefined();
+
+      await codexClient.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId,
+          turn: { id: turnId, status: "completed", output: [] },
+        },
+      });
+
+      await waitForCondition(
+        () => codexClient.lastSetThreadPermissionsParams !== undefined,
+      );
+
+      const reviewPromise = registry.startReview({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+      await flushAsync();
+
+      expect(codexClient.lastStartReviewParams).toBeUndefined();
+      permissionFlush.resolve();
+      await reviewPromise;
+
+      expect(codexClient.lastSetThreadPermissionsParams).toEqual({
+        threadId: "thread-1",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      });
+      expect(codexClient.lastStartReviewParams).toEqual({
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+      const overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+      expect(overlay?.executionMode).toBe("full-access");
 
       await registry.close();
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1122,6 +1122,7 @@ export class DesktopBackendRegistry {
       flushAttempts: number;
     }
   >();
+  private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
   private readonly attemptedTitleGenerations = new Set<string>();
   private titleGenerationSequence = 0;
 
@@ -1998,6 +1999,13 @@ export class DesktopBackendRegistry {
   }
 
   async startReview(params: StartReviewRequest): Promise<StartReviewResponse> {
+    if (params.backend === "codex" && this.threadHasActiveTurn(params.threadId)) {
+      throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
+    }
+    if (params.backend === "codex") {
+      await this.flushQueuedExecutionModeIfPresent(params.threadId);
+    }
+
     const startWithClient = async (
       client: BackendClient,
     ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
@@ -2524,8 +2532,9 @@ export class DesktopBackendRegistry {
    * Called from two places:
    *  - the `emit()` listener when codex reports `thread/status/changed
    *    → idle` (or `turn/completed`), as the natural turn-end signal.
-   *  - the top of `startTurn` for codex, to guarantee the queue
-   *    applies BEFORE the next turn fires (race-safe ordering).
+   *  - the top of `startTurn`/`startReview` for codex, to guarantee
+   *    the queue applies BEFORE the next turn or review fires
+   *    (race-safe ordering).
    *
    * Idempotent: a no-op when no queue is present. On apply error, the
    * queue is retained and the failure counter is incremented; after
@@ -2535,6 +2544,12 @@ export class DesktopBackendRegistry {
   private async flushQueuedExecutionModeIfPresent(
     threadId: string,
   ): Promise<void> {
+    const activeFlush = this.queuedExecutionModeFlushes.get(threadId);
+    if (activeFlush) {
+      await activeFlush;
+      return;
+    }
+
     const queue = this.queuedExecutionModes.get(threadId);
     if (!queue) return;
     // Atomic claim: in JS's single-threaded event loop, `Map.delete`
@@ -2547,6 +2562,27 @@ export class DesktopBackendRegistry {
     if (!this.queuedExecutionModes.delete(threadId)) {
       return;
     }
+
+    const flush = this.applyClaimedQueuedExecutionMode(threadId, queue);
+    this.queuedExecutionModeFlushes.set(threadId, flush);
+    try {
+      await flush;
+    } finally {
+      if (this.queuedExecutionModeFlushes.get(threadId) === flush) {
+        this.queuedExecutionModeFlushes.delete(threadId);
+      }
+    }
+  }
+
+  private async applyClaimedQueuedExecutionMode(
+    threadId: string,
+    queue: {
+      mode: ThreadExecutionMode;
+      queuedAt: number;
+      queueId: string;
+      flushAttempts: number;
+    },
+  ): Promise<void> {
     try {
       await this.applyThreadExecutionMode(
         {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -165,6 +165,10 @@ type QueuedTurnDraft = {
   id: string;
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
+  reviewCommand?: {
+    displayText: string;
+    target: AppServerReviewTarget;
+  };
   text: string;
 };
 
@@ -398,6 +402,10 @@ function findSlashCommandTrigger(text: string, caret: number): {
 }
 
 function formatDraftPreview(draft: QueuedTurnDraft): string {
+  if (draft.reviewCommand) {
+    return draft.reviewCommand.displayText;
+  }
+
   const text = draft.text.trim();
   if (text) {
     return text;
@@ -497,6 +505,22 @@ function parseStaleSteerError(
   }
 
   return undefined;
+}
+
+function reviewCommandToDraftText(command: {
+  target: AppServerReviewTarget;
+}): string {
+  const target = command.target;
+  if (target.type === "uncommittedChanges") {
+    return "/review";
+  }
+  if (target.type === "baseBranch") {
+    return `/review ${target.branch}`;
+  }
+  if (target.type === "commit") {
+    return `/review --commit ${[target.sha, target.title].filter(Boolean).join(" ")}`;
+  }
+  return `/review --custom ${target.instructions}`;
 }
 
 function HighlightedAutocompleteLabel(props: {
@@ -921,7 +945,12 @@ export function Composer(props: ComposerProps) {
   const [leaveLocalBranch, setLeaveLocalBranch] = useState("");
   const [handoffError, setHandoffError] = useState<string | undefined>();
   const [handoffSubmitting, setHandoffSubmitting] = useState(false);
-  const [sending, setSending] = useState(false);
+  const [sending, setSendingState] = useState(false);
+  const sendingRef = useRef(false);
+  const updateSending = (nextSending: boolean): void => {
+    sendingRef.current = nextSending;
+    setSendingState(nextSending);
+  };
   const [interrupting, setInterrupting] = useState(false);
   const [steering, setSteering] = useState(false);
   const [queuedTurns, setQueuedTurnsState] = useState<QueuedTurnDraft[]>(
@@ -1071,7 +1100,10 @@ export function Composer(props: ComposerProps) {
 
     const snapshots = state.filter(
       (entry) =>
-        entry.text.trim() || entry.imageAttachments.length > 0 || entry.input?.length,
+        entry.reviewCommand ||
+        entry.text.trim() ||
+        entry.imageAttachments.length > 0 ||
+        entry.input?.length,
     );
 
     if (snapshots.length === 0) {
@@ -1328,7 +1360,7 @@ export function Composer(props: ComposerProps) {
       setPendingSteerState(undefined);
       setQueuedTurnsState([]);
     }
-    setSending(false);
+    updateSending(false);
     setInterrupting(false);
     setSteering(false);
     updateActiveTurnId(undefined);
@@ -1429,7 +1461,7 @@ export function Composer(props: ComposerProps) {
       );
       setImageAttachments(props.launchpad?.imageAttachments ?? []);
     }
-    setSending(false);
+    updateSending(false);
     setInterrupting(false);
     setSteering(false);
     updateActiveTurnId(undefined);
@@ -1461,7 +1493,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(props.activeTurnId);
 
     if (!props.activeTurnId) {
-      setSending(false);
+      updateSending(false);
       setInterrupting(false);
       setSteering(false);
     }
@@ -1536,7 +1568,7 @@ export function Composer(props: ComposerProps) {
           props.removeOptimisticMessage?.(activeOptimisticMessageId);
         }
         props.onPendingStatusChange?.(undefined);
-        setSending(false);
+        updateSending(false);
         setInterrupting(false);
         setSteering(false);
         if (pendingSteer?.status === "pending") {
@@ -1567,7 +1599,7 @@ export function Composer(props: ComposerProps) {
         }
 
         props.onPendingStatusChange?.(undefined);
-        setSending(false);
+        updateSending(false);
         setInterrupting(false);
         setSteering(false);
         setPendingSteer(undefined);
@@ -1625,17 +1657,21 @@ export function Composer(props: ComposerProps) {
   const submitReviewCommand = async (reviewCommand: {
     displayText: string;
     target: AppServerReviewTarget;
-  }): Promise<void> => {
+  }, options?: { queued?: QueuedTurnDraft }): Promise<void> => {
     if (props.disabled) {
       return;
     }
-    if (imageAttachments.length > 0) {
+    if (!options?.queued && imageAttachments.length > 0) {
       setSendError("/review does not accept image attachments.");
+      return;
+    }
+    if (!options?.queued && shouldQueueThreadSubmit()) {
+      queueReviewCommand(reviewCommand);
       return;
     }
 
     setSendError(undefined);
-    setSending(true);
+    updateSending(true);
     props.onPendingStatusChange?.("Reviewing");
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
@@ -1655,14 +1691,14 @@ export function Composer(props: ComposerProps) {
         props.onPendingStatusChange?.(undefined);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
-        setSending(false);
+        updateSending(false);
       }
       return;
     }
 
     if (!props.thread || !props.desktopApi?.startReview) {
       props.onPendingStatusChange?.(undefined);
-      setSending(false);
+      updateSending(false);
       return;
     }
 
@@ -1679,15 +1715,19 @@ export function Composer(props: ComposerProps) {
       });
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
-      clearComposerDraftSnapshot(composerScopeKey);
-      clearComposerDraft();
-      setReviewConfig(undefined);
+      if (options?.queued) {
+        removeQueuedTurn(options.queued);
+      } else {
+        clearComposerDraftSnapshot(composerScopeKey);
+        clearComposerDraft();
+        setReviewConfig(undefined);
+      }
     } catch (error) {
       if (optimisticReviewId) {
         props.removeOptimisticMessage?.(optimisticReviewId);
       }
       props.onPendingStatusChange?.(undefined);
-      setSending(false);
+      updateSending(false);
       setInterrupting(false);
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
@@ -1762,7 +1802,7 @@ export function Composer(props: ComposerProps) {
         : undefined;
 
     if (props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
-      setSending(false);
+      updateSending(false);
       return;
     }
 
@@ -1805,7 +1845,7 @@ export function Composer(props: ComposerProps) {
         props.removeOptimisticMessage?.(optimisticMessageId);
       }
       props.onPendingStatusChange?.(undefined);
-      setSending(false);
+      updateSending(false);
       setInterrupting(false);
       setSteering(false);
       updateActiveTurnId(undefined);
@@ -1815,14 +1855,23 @@ export function Composer(props: ComposerProps) {
     }
   };
 
+  const sendQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
+    if (queued.reviewCommand) {
+      await submitReviewCommand(queued.reviewCommand, { queued });
+      return;
+    }
+
+    await sendThreadTurn(queued);
+  };
+
   useEffect(() => {
     if (!queuedTurn || activeTurnId || sending || props.launchpad || props.disabled) {
       return;
     }
 
-    setSending(true);
-    void sendThreadTurn(queuedTurn).finally(() => {
-      setSending(false);
+    updateSending(true);
+    void sendQueuedTurn(queuedTurn).finally(() => {
+      updateSending(false);
     });
   }, [activeTurnId, queuedTurn, sending, props.disabled, props.launchpad]);
 
@@ -1871,6 +1920,26 @@ export function Composer(props: ComposerProps) {
     setReviewConfig(undefined);
     setSendError(undefined);
   };
+
+  const queueReviewCommand = (reviewCommand: {
+    displayText: string;
+    target: AppServerReviewTarget;
+  }): void => {
+    enqueueQueuedTurn({
+      id: createQueuedTurnId(),
+      text: reviewCommandToDraftText(reviewCommand),
+      imageAttachments: [],
+      reviewCommand,
+    });
+    clearComposerDraftSnapshot(composerScopeKey);
+    clearComposerDraft();
+    setImageAttachments([]);
+    setReviewConfig(undefined);
+    setSendError(undefined);
+  };
+
+  const shouldQueueThreadSubmit = (): boolean =>
+    !props.launchpad && (Boolean(activeTurnIdRef.current) || sendingRef.current);
 
   const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
     const turnId = activeTurnIdRef.current;
@@ -1995,9 +2064,24 @@ export function Composer(props: ComposerProps) {
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
     const reviewCommand = parseReviewCommand(draft);
-    if (activeTurnIdRef.current && !props.launchpad) {
-      if (mode === "steer") {
+    if (shouldQueueThreadSubmit()) {
+      if (activeTurnIdRef.current && mode === "steer") {
         steerCurrentDraft();
+      } else if (reviewCommand && isBareReviewCommand) {
+        setReviewConfig(
+          reviewConfig ??
+            createReviewConfig({
+              directory: props.directory,
+              thread: props.thread,
+            })
+        );
+        setSendError(undefined);
+      } else if (reviewCommand) {
+        if (imageAttachments.length > 0) {
+          setSendError("/review does not accept image attachments.");
+          return;
+        }
+        queueReviewCommand(reviewCommand);
       } else {
         queueCurrentDraft();
       }
@@ -2041,7 +2125,7 @@ export function Composer(props: ComposerProps) {
     }
 
     setSendError(undefined);
-    setSending(true);
+    updateSending(true);
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
       const submittedScopeKey = composerScopeKey;
@@ -2060,13 +2144,13 @@ export function Composer(props: ComposerProps) {
         unmarkComposerDraftSubmitted(submittedScopeKey);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
-        setSending(false);
+        updateSending(false);
       }
       return;
     }
 
     if (!props.thread || !props.desktopApi?.startTurn) {
-      setSending(false);
+      updateSending(false);
       return;
     }
 
@@ -2162,6 +2246,11 @@ export function Composer(props: ComposerProps) {
 
     if (command.id === "review-current") {
       enterReviewComposer();
+      return;
+    }
+
+    if (shouldQueueThreadSubmit()) {
+      queueCurrentDraft();
       return;
     }
 
@@ -2894,7 +2983,7 @@ export function Composer(props: ComposerProps) {
           </div>
           <QueuedImageAttachments attachments={queued.imageAttachments} />
           <div className="composer__queued-actions">
-            {supportsSteering ? (
+            {supportsSteering && !queued.reviewCommand ? (
               <button
                 className="composer__secondary-action"
                 disabled={props.disabled || steering || !activeTurnId}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@pwragent/shared";
 import type { JSONContent } from "@tiptap/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
 import { normalizeImageFile } from "../../../lib/image-normalization";
 import { Composer } from "../Composer";
 import type {
@@ -572,6 +573,202 @@ describe("Composer", () => {
         turnId: "turn-1",
       });
     });
+  });
+
+  it("queues submits while a turn start is pending", async () => {
+    let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
+    const startTurn = vi.fn(
+      (request: StartTurnRequest) =>
+        new Promise<StartTurnResponse>((resolve) => {
+          resolveStartTurn = () =>
+            resolve({
+              backend: request.backend,
+              threadId: request.threadId,
+              turnId: "turn-1",
+            });
+        })
+    );
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Slow send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "did CI pass" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.change(textarea, { target: { value: "follow up next" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent("follow up next");
+
+    await act(async () => {
+      resolveStartTurn?.({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    });
+  });
+
+  it("queues slash review submits while a turn start is pending", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const startTurn = vi.fn(
+      (request: StartTurnRequest) =>
+        new Promise<StartTurnResponse>((resolve) => {
+          resolveStartTurn = () =>
+            resolve({
+              backend: request.backend,
+              threadId: request.threadId,
+              turnId: "turn-1",
+            });
+        })
+    );
+
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: (callback: NonNullable<DesktopApi["onAgentEvent"]> extends (
+          listener: infer Listener,
+        ) => unknown
+          ? Listener
+          : never) => {
+          agentEventHandler = callback as typeof agentEventHandler;
+          return () => undefined;
+        },
+        startReview,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Slow send",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(<Composer {...baseProps} />);
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "did CI pass" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.change(textarea, { target: { value: "/review main" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+
+    await act(async () => {
+      resolveStartTurn?.({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+    });
+    rerender(<Composer {...baseProps} activeTurnId="turn-1" />);
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("keeps the review target picker for bare reviews while a turn start is pending", async () => {
+    const startReview = vi.fn();
+    const startTurn = vi.fn(
+      (request: StartTurnRequest) =>
+        new Promise<StartTurnResponse>(() => {
+          void request;
+        })
+    );
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Slow send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "did CI pass" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    fireEvent.change(textarea, { target: { value: "/review" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByText("Queued next")).not.toBeInTheDocument();
   });
 
   it("queues Enter during an active turn and sends it after the turn clears", async () => {
@@ -1918,6 +2115,234 @@ describe("Composer", () => {
     });
     expect(addOptimisticReviewEntry).toHaveBeenCalledWith("Review changes against main");
     expect(startTurn).not.toHaveBeenCalled();
+  });
+
+  it("queues review target submissions while a turn is active", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const baseProps = {
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startReview,
+      },
+      backends: [
+        {
+          ...backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                supportsReasoning: true,
+                supportsSteering: true,
+              },
+            ],
+          }),
+          capabilities: {
+            ...backendSummary("codex").capabilities,
+            steerTurn: true,
+          },
+        },
+      ],
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Review thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(<Composer {...baseProps} />);
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/review" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+
+    rerender(<Composer {...baseProps} activeTurnId="turn-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+    expect(screen.getByText("Review changes against main")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Steer" })).not.toBeInTheDocument();
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("keeps the review target picker for bare review commands during an active turn", async () => {
+    const startReview = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByText("Queued next")).not.toBeInTheDocument();
+  });
+
+  it("starts a queued review without clearing the next live draft", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "next-draft.png", {
+      type: "image/png",
+    });
+    const baseProps = {
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startReview,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Review thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(<Composer {...baseProps} activeTurnId="turn-1" />);
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("next-draft.png")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "keep this next draft" },
+    });
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+    expect(
+      screen.queryByText("/review does not accept image attachments.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toHaveValue("keep this next draft");
+    expect(screen.getByAltText("next-draft.png")).toBeInTheDocument();
+  });
+
+  it("rejects review queue attempts with live image attachments", async () => {
+    const startReview = vi.fn();
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "review-image.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+    expect(await screen.findByAltText("review-image.png")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.queryByText("Queued next")).not.toBeInTheDocument();
+    expect(screen.getByText("/review does not accept image attachments.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Reply")).toHaveValue("/review main");
+    expect(screen.getByAltText("review-image.png")).toBeInTheDocument();
   });
 
   it("asks for a review target before submitting bare slash review commands", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from "react";
 import type { JSONContent } from "@tiptap/react";
 import type {
+  AppServerReviewTarget,
   AppServerTurnInputItem,
   NavigationLaunchpadImageAttachment,
 } from "@pwragent/shared";
@@ -18,6 +19,10 @@ export type ComposerQueuedTurnSnapshot = {
   input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  reviewCommand?: {
+    displayText: string;
+    target: AppServerReviewTarget;
+  };
 };
 
 export type ComposerPendingSteerSnapshot = {


### PR DESCRIPTION
## Summary

Fixes a review-start race where submitting `/review` from the review target picker while a turn is already running could call Codex `review/start` immediately. Codex may then interrupt the existing turn or start review work in parallel on the same thread.

This changes the desktop composer to preserve review commands as queued turn drafts when an active turn exists, then submit the structured `review/start` request once the active turn clears. It also adds a registry-side Codex admission guard so stale renderer state cannot send `review/start` into a thread the registry already knows is active.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
