### PR TITLE
fix(desktop): improve markdown table rendering

### DIFF
--- a/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/markdown-findings-table/replay.fixture.json
@@ -1,0 +1,97 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "markdown-findings-table",
+    "sourceCaptureId": "synthetic-sanitized-2026-05-11",
+    "threadId": "thread-markdown-findings-table"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-markdown-findings-table",
+          "title": "Sanitized Markdown table",
+          "titleSource": "explicit",
+          "summary": "Synthetic assistant response with a wide review findings table",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1778500906000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-user-1",
+            "role": "user",
+            "text": "Review the billing pacing change and present the findings in a compact table."
+          },
+          {
+            "type": "message",
+            "id": "message-assistant-1",
+            "role": "assistant",
+            "text": "**Verdict: Not ready for enforcement.** The shadow path is close, but enforcement has correctness and lifecycle risks. I'd fix P1/P2 before enabling `billing.pacing.enforce`.\n\n## Findings\n\n| # | Sev | File | Issue | Fix |\n|---:|:---:|---|---|---|\n| 1 | P1 | [InvoiceDispatcher.scala (line 48)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48) | A retry-suppressed invoice falls through to the standard path because fallback only checks `queuedInvoices.isEmpty`. Why it matters: `enforce=true` can still make a second provider call and emit a duplicate notice after suppression was explicitly requested, so throttling does not reliably reduce calls or preserve invoice semantics. | Distinguish \"normal no invoice ready\" from terminal states like `Retry suppressed`; only fallback on intentional misses. |\n| 2 | P2 | [LedgerWindow.scala (line 16)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerWindow.scala:16) | `LedgerIdentity` drops `tenantId` when normalizing matched cache items. Why it matters: the existing cache counting treats `(tenantId, accountId, periodId, bucketId)` as the unique ledger identity, so two tenants with the same period/bucket ids are merged and can cross-throttle each other. | Include `tenantId` in `LedgerIdentity`, `stableKey`, sorting, and tests. |\n| 3 | P2 | [AttemptObservation.scala (line 56)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/AttemptObservation.scala:56) | `observedCalls` excludes failures, while `Failure` still counts as an attempted provider call. Why it matters: `minObservedCalls` is based on wins and losses only, so a failure-heavy bucket can remain sparse indefinitely and continue sending 100% of traffic during an outage pattern. | Use `attempts` for the minimum call threshold and keep win-ratio math on wins/losses, or rename the threshold and test failure-heavy behavior explicitly. |\n| 4 | P2 | [InvoiceDispatcher.scala (line 87)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:87) | The no-cache path always gives pacing an empty matched-account set, which becomes an allow-without-bucket decision. Why it matters: `billing.enforce=true` silently has no effect for `createWithoutCache` and no observations are accumulated even though pacing is enabled. | Fail fast or disable enforcement when the active-account cache is unavailable, or introduce a deliberate fallback bucket if no-cache pacing is expected to work. |\n| 5 | P3 | [LedgerController.scala (line 72)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerController.scala:72) | The deterministic sampling key is customer/page scoped and has no per-opportunity component. Why it matters: repeated requests from the same customer for the same bucket in one interval all make the same allow/throttle decision, and missing/shared customer ids can turn a configured probability into all-or-nothing behavior. | Include a stable opportunity/request identifier, or at least the full targeting tuple, in the sampling key and add tests for repeated same-customer requests. |"
+          },
+          {
+            "type": "message",
+            "id": "message-assistant-2",
+            "role": "assistant",
+            "text": "Compact summary:\n\n| Key | Value |\n|---|---|\n| Mode | Shadow |\n| Owner | Billing |\n\nOversized regional matrix:\n\n| Metric | North America | Europe | Asia Pacific | South America | Middle East | Reliability Notes |\n|---|---|---|---|---|---|---|\n| Request fingerprint | `north-america-invoice-pacing-window-retry-suppressed-001` | `europe-invoice-pacing-window-retry-suppressed-002` | `asia-pacific-invoice-pacing-window-retry-suppressed-003` | `south-america-invoice-pacing-window-retry-suppressed-004` | `middle-east-invoice-pacing-window-retry-suppressed-005` | Keep this table horizontally scrollable rather than compressing regional token cells into unreadable slivers. |"
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-user-1",
+            "role": "user",
+            "text": "Review the billing pacing change and present the findings in a compact table."
+          },
+          {
+            "id": "message-assistant-1",
+            "role": "assistant",
+            "text": "**Verdict: Not ready for enforcement.** The shadow path is close, but enforcement has correctness and lifecycle risks. I'd fix P1/P2 before enabling `billing.pacing.enforce`.\n\n## Findings\n\n| # | Sev | File | Issue | Fix |\n|---:|:---:|---|---|---|\n| 1 | P1 | [InvoiceDispatcher.scala (line 48)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48) | A retry-suppressed invoice falls through to the standard path because fallback only checks `queuedInvoices.isEmpty`. Why it matters: `enforce=true` can still make a second provider call and emit a duplicate notice after suppression was explicitly requested, so throttling does not reliably reduce calls or preserve invoice semantics. | Distinguish \"normal no invoice ready\" from terminal states like `Retry suppressed`; only fallback on intentional misses. |\n| 2 | P2 | [LedgerWindow.scala (line 16)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerWindow.scala:16) | `LedgerIdentity` drops `tenantId` when normalizing matched cache items. Why it matters: the existing cache counting treats `(tenantId, accountId, periodId, bucketId)` as the unique ledger identity, so two tenants with the same period/bucket ids are merged and can cross-throttle each other. | Include `tenantId` in `LedgerIdentity`, `stableKey`, sorting, and tests. |\n| 3 | P2 | [AttemptObservation.scala (line 56)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/AttemptObservation.scala:56) | `observedCalls` excludes failures, while `Failure` still counts as an attempted provider call. Why it matters: `minObservedCalls` is based on wins and losses only, so a failure-heavy bucket can remain sparse indefinitely and continue sending 100% of traffic during an outage pattern. | Use `attempts` for the minimum call threshold and keep win-ratio math on wins/losses, or rename the threshold and test failure-heavy behavior explicitly. |\n| 4 | P2 | [InvoiceDispatcher.scala (line 87)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:87) | The no-cache path always gives pacing an empty matched-account set, which becomes an allow-without-bucket decision. Why it matters: `billing.enforce=true` silently has no effect for `createWithoutCache` and no observations are accumulated even though pacing is enabled. | Fail fast or disable enforcement when the active-account cache is unavailable, or introduce a deliberate fallback bucket if no-cache pacing is expected to work. |\n| 5 | P3 | [LedgerController.scala (line 72)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerController.scala:72) | The deterministic sampling key is customer/page scoped and has no per-opportunity component. Why it matters: repeated requests from the same customer for the same bucket in one interval all make the same allow/throttle decision, and missing/shared customer ids can turn a configured probability into all-or-nothing behavior. | Include a stable opportunity/request identifier, or at least the full targeting tuple, in the sampling key and add tests for repeated same-customer requests. |"
+          },
+          {
+            "id": "message-assistant-2",
+            "role": "assistant",
+            "text": "Compact summary:\n\n| Key | Value |\n|---|---|\n| Mode | Shadow |\n| Owner | Billing |\n\nOversized regional matrix:\n\n| Metric | North America | Europe | Asia Pacific | South America | Middle East | Reliability Notes |\n|---|---|---|---|---|---|---|\n| Request fingerprint | `north-america-invoice-pacing-window-retry-suppressed-001` | `europe-invoice-pacing-window-retry-suppressed-002` | `asia-pacific-invoice-pacing-window-retry-suppressed-003` | `south-america-invoice-pacing-window-retry-suppressed-004` | `middle-east-invoice-pacing-window-retry-suppressed-005` | Keep this table horizontally scrollable rather than compressing regional token cells into unreadable slivers. |"
+          }
+        ],
+        "lastUserMessage": "Review the billing pacing change and present the findings in a compact table.",
+        "lastAssistantMessage": "**Verdict: Not ready for enforcement.** The shadow path is close, but enforcement has correctness and lifecycle risks. I'd fix P1/P2 before enabling `billing.pacing.enforce`.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/markdown-findings-table.spec.ts
+++ b/apps/desktop/e2e/markdown-findings-table.spec.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+test("renders a wide assistant markdown findings table without crushing the columns", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/markdown-findings-table/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1440,
+      height: 900,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Sanitized Markdown table/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Sanitized Markdown table",
+      })
+    ).toBeVisible();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const proseMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Verdict: Not ready for enforcement" })
+      .first();
+    const wideTableMessage = transcript
+      .locator(".transcript-message--table-wide")
+      .filter({ hasText: "InvoiceDispatcher.scala" })
+      .first();
+    const tableScroll = wideTableMessage.locator(".thread-markdown__table-scroll");
+    const table = tableScroll.locator("table.thread-markdown__table");
+
+    await expect(proseMessage).toBeVisible();
+    await expect(proseMessage).not.toHaveClass(/transcript-message--table-wide/);
+    await expect(wideTableMessage).toBeVisible();
+    await expect(tableScroll).toBeVisible();
+    await expect(table).toBeVisible();
+    await expect(table.getByRole("columnheader", { name: "#" })).toBeVisible();
+    await expect(table.getByRole("columnheader", { name: "Sev" })).toBeVisible();
+    await expect(table.getByRole("columnheader", { name: "File" })).toBeVisible();
+    await expect(table.getByRole("columnheader", { name: "Issue" })).toBeVisible();
+    await expect(table.getByRole("columnheader", { name: "Fix" })).toBeVisible();
+    await expect(table.locator("tbody tr")).toHaveCount(5);
+    await expect(table.getByRole("link", { name: "InvoiceDispatcher.scala (line 48)" })).toBeVisible();
+    await expect(table).toContainText("Retry suppressed");
+    await expect(table).toContainText("failure-heavy behavior explicitly");
+
+    const dimensions = await tableScroll.evaluate((node) => {
+      const tableNode = node.querySelector("table");
+      const linkNode = node.querySelector("tbody tr:first-child td:nth-child(3) a");
+      const issueCell = node.querySelector("tbody tr:first-child td:nth-child(4)");
+      return {
+        clientWidth: node.clientWidth,
+        scrollWidth: node.scrollWidth,
+        assistantWidth: node.closest(".transcript-message")?.getBoundingClientRect().width ?? 0,
+        tableWidth: tableNode?.getBoundingClientRect().width ?? 0,
+        fileLinkWidth: linkNode?.getBoundingClientRect().width ?? 0,
+        issueCellWidth: issueCell?.getBoundingClientRect().width ?? 0,
+      };
+    });
+
+    expect(dimensions.assistantWidth).toBeGreaterThan(880);
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 8);
+    expect(dimensions.tableWidth).toBeLessThanOrEqual(dimensions.clientWidth + 8);
+    expect(dimensions.fileLinkWidth).toBeGreaterThan(120);
+    expect(dimensions.issueCellWidth).toBeGreaterThan(280);
+
+    const compactTableMessage = transcript
+      .locator(".transcript-message--assistant")
+      .filter({ hasText: "Compact summary:" })
+      .first();
+    await expect(compactTableMessage).toBeVisible();
+    await expect(compactTableMessage).not.toHaveClass(/transcript-message--table/);
+    await expect(compactTableMessage).not.toHaveClass(/transcript-message--table-wide/);
+    await expect(compactTableMessage.locator("table")).toContainText("Billing");
+
+    const oversizedTableScroll = transcript
+      .locator(".transcript-message--table-wide")
+      .filter({ hasText: "north-america-invoice-pacing-window-retry-suppressed-001" })
+      .locator(".thread-markdown__table-scroll")
+      .first();
+    await expect(oversizedTableScroll).toBeVisible();
+    const oversizedDimensions = await oversizedTableScroll.evaluate((node) => {
+      const headers = Array.from(node.querySelectorAll("thead th")).map((header) =>
+        header.getBoundingClientRect()
+      );
+
+      return {
+        clientWidth: node.clientWidth,
+        scrollWidth: node.scrollWidth,
+        tableWidth: node.querySelector("table")?.getBoundingClientRect().width ?? 0,
+        metricWidth: headers[0]?.width ?? 0,
+        northAmericaWidth: headers[1]?.width ?? 0,
+        metricRight: headers[0]?.right ?? 0,
+        northAmericaLeft: headers[1]?.left ?? 0,
+        northAmericaRight: headers[1]?.right ?? 0,
+        europeLeft: headers[2]?.left ?? 0,
+      };
+    });
+    expect(oversizedDimensions.scrollWidth).toBeGreaterThan(
+      oversizedDimensions.clientWidth + 120
+    );
+    expect(oversizedDimensions.tableWidth).toBeGreaterThan(
+      oversizedDimensions.clientWidth + 120
+    );
+    expect(oversizedDimensions.metricWidth).toBeGreaterThan(120);
+    expect(oversizedDimensions.northAmericaWidth).toBeGreaterThan(140);
+    expect(oversizedDimensions.metricRight).toBeLessThanOrEqual(
+      oversizedDimensions.northAmericaLeft + 1
+    );
+    expect(oversizedDimensions.northAmericaRight).toBeLessThanOrEqual(
+      oversizedDimensions.europeLeft + 1
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -165,6 +165,47 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       pre(preProps) {
         return <pre className="transcript-message__pre">{preProps.children}</pre>;
       },
+      table(tableProps) {
+        const tableKind = classifyMarkdownTable(sourceForNode(props.text, tableProps.node));
+
+        return (
+          <div
+            className={[
+              "thread-markdown__table-scroll",
+              tableKind ? `thread-markdown__table-scroll--${tableKind}` : undefined,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            tabIndex={0}
+          >
+            <table
+              className={[
+                "thread-markdown__table",
+                tableKind ? `thread-markdown__table--${tableKind}` : undefined,
+              ]
+              .filter(Boolean)
+              .join(" ")}
+            >
+              {tableProps.children}
+            </table>
+          </div>
+        );
+      },
+      tbody(tableBodyProps) {
+        return <tbody className="thread-markdown__tbody">{tableBodyProps.children}</tbody>;
+      },
+      td(tableCellProps) {
+        return <td className="thread-markdown__td">{tableCellProps.children}</td>;
+      },
+      th(tableHeaderCellProps) {
+        return <th className="thread-markdown__th">{tableHeaderCellProps.children}</th>;
+      },
+      thead(tableHeadProps) {
+        return <thead className="thread-markdown__thead">{tableHeadProps.children}</thead>;
+      },
+      tr(tableRowProps) {
+        return <tr className="thread-markdown__tr">{tableRowProps.children}</tr>;
+      },
       ul(listProps) {
         return <ul className="transcript-message__list">{listProps.children}</ul>;
       },
@@ -275,6 +316,35 @@ function sourceForNode(
   }
 
   return markdown.slice(start, end);
+}
+
+function classifyMarkdownTable(source?: string): "review-findings" | undefined {
+  const header = source?.split("\n")[0];
+  if (!header) {
+    return undefined;
+  }
+
+  const cells = splitMarkdownTableCells(header).map((cell) => cell.toLowerCase());
+  if (
+    cells[0] === "#" &&
+    cells[1] === "sev" &&
+    cells[2] === "file" &&
+    cells[3] === "issue" &&
+    cells[4] === "fix"
+  ) {
+    return "review-findings";
+  }
+
+  return undefined;
+}
+
+function splitMarkdownTableCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
 }
 
 function normalizeSkillPath(href: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -25,38 +25,49 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
       : props.message.text
         ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
         : [];
+  const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
+
+  if (messageSegments.length === 0) {
+    return (
+      <article
+        className={`transcript-message transcript-message--${props.message.role}`}
+      >
+        {renderMessageHeader(props.message, false)}
+      </article>
+    );
+  }
+
   return (
-    <article
-      className={`transcript-message transcript-message--${props.message.role}`}
-    >
-      <header className="transcript-message__header">
-        <span className="transcript-message__role">{labelForRole(props.message.role)}</span>
-        {props.message.createdAt ? (
-          <time className="transcript-message__time">
-            {new Intl.DateTimeFormat(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "numeric",
-              minute: "2-digit"
-            }).format(props.message.createdAt)}
-          </time>
-        ) : null}
-      </header>
-      {contentParts.length > 0 ? (
-        <div className="transcript-message__text">
-          {groupMessageParts(contentParts).map((segment, index) =>
-            renderMessageSegment({
+    <>
+      {messageSegments.map((segment, index) => (
+        <article
+          className={[
+            "transcript-message",
+            `transcript-message--${props.message.role}`,
+            segment.type === "table" ? "transcript-message--table" : undefined,
+            segment.type === "table" && segment.wide
+              ? "transcript-message--table-wide"
+              : undefined,
+            index > 0 ? "transcript-message--continuation" : undefined,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          key={`${props.message.id}:${index}`}
+        >
+          {renderMessageHeader(props.message, index > 0)}
+          <div className="transcript-message__text">
+            {renderMessageSegment({
               segment,
               index,
               applications: props.applications,
               desktopApi: props.desktopApi,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
-            })
-          )}
-        </div>
-      ) : null}
-    </article>
+            })}
+          </div>
+        </article>
+      ))}
+    </>
   );
 });
 
@@ -64,6 +75,7 @@ TranscriptMessage.displayName = "TranscriptMessage";
 
 type MessagePartSegment =
   | { type: "text"; part: Exclude<AppServerThreadMessagePart, AppServerThreadImagePart> }
+  | { type: "table"; text: string; wide: boolean }
   | { type: "images"; parts: AppServerThreadImagePart[]; startIndex: number };
 
 function groupMessageParts(parts: AppServerThreadMessagePart[]): MessagePartSegment[] {
@@ -93,6 +105,185 @@ function groupMessageParts(parts: AppServerThreadMessagePart[]): MessagePartSegm
   }
 
   return segments;
+}
+
+function splitMarkdownTableSegment(segment: MessagePartSegment): MessagePartSegment[] {
+  if (segment.type !== "text") {
+    return [segment];
+  }
+
+  const referenceDefinitions = extractMarkdownReferenceDefinitions(segment.part.text);
+  const blocks = splitMarkdownTableBlocks(segment.part.text);
+  if (blocks.length === 1 && blocks[0]?.type === "text") {
+    return [segment];
+  }
+
+  const segments: MessagePartSegment[] = [];
+  for (const block of blocks) {
+    if (block.type === "table" && isWideMarkdownTable(block.text)) {
+      segments.push({
+        type: "table",
+        text: withMarkdownReferenceDefinitions(block.text, referenceDefinitions),
+        wide: true,
+      });
+      continue;
+    }
+
+    if (isOnlyMarkdownReferenceDefinitions(block.text)) {
+      continue;
+    }
+
+    appendTextSegment(segments, block.text);
+  }
+
+  return segments;
+}
+
+type MarkdownBlock = { type: "text" | "table"; text: string };
+
+function splitMarkdownTableBlocks(markdown: string): MarkdownBlock[] {
+  const lines = markdown.split("\n");
+  const blocks: MarkdownBlock[] = [];
+  let textBuffer: string[] = [];
+  let inFence = false;
+  let fenceMarker: string | undefined;
+  let index = 0;
+
+  const flushText = (): void => {
+    const text = trimBlankMarkdownLines(textBuffer).join("\n");
+    textBuffer = [];
+    if (text) {
+      blocks.push({ type: "text", text });
+    }
+  };
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    const fence = line.match(/^\s{0,3}(```+|~~~+)/);
+    if (fence) {
+      const marker = fence[1]?.[0];
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = marker;
+      } else if (marker === fenceMarker) {
+        inFence = false;
+        fenceMarker = undefined;
+      }
+      textBuffer.push(line);
+      index += 1;
+      continue;
+    }
+
+    if (
+      !inFence &&
+      isMarkdownTableHeader(line) &&
+      isMarkdownTableDelimiter(lines[index + 1] ?? "")
+    ) {
+      flushText();
+      const tableLines = [line, lines[index + 1] ?? ""];
+      index += 2;
+      while (index < lines.length && isMarkdownTableRow(lines[index] ?? "")) {
+        tableLines.push(lines[index] ?? "");
+        index += 1;
+      }
+      blocks.push({ type: "table", text: tableLines.join("\n") });
+      continue;
+    }
+
+    textBuffer.push(line);
+    index += 1;
+  }
+
+  flushText();
+  return blocks;
+}
+
+function isMarkdownTableHeader(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.includes("|") && splitTableCells(trimmed).length >= 2;
+}
+
+function isMarkdownTableDelimiter(line: string): boolean {
+  const cells = splitTableCells(line.trim());
+  return (
+    cells.length >= 2 &&
+    cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()))
+  );
+}
+
+function isMarkdownTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed !== "" &&
+    trimmed.includes("|") &&
+    splitTableCells(trimmed).length >= 2
+  );
+}
+
+function splitTableCells(line: string): string[] {
+  return line
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function isWideMarkdownTable(table: string): boolean {
+  const [header = "", , ...rows] = table.split("\n");
+  const columnCount = splitTableCells(header).length;
+  const longestRowLength = rows.reduce(
+    (longest, row) => Math.max(longest, row.length),
+    header.length
+  );
+  return columnCount >= 4 || longestRowLength > 140;
+}
+
+function trimBlankMarkdownLines(lines: string[]): string[] {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start]?.trim() === "") {
+    start += 1;
+  }
+  while (end > start && lines[end - 1]?.trim() === "") {
+    end -= 1;
+  }
+
+  return lines.slice(start, end);
+}
+
+function extractMarkdownReferenceDefinitions(markdown: string): string[] {
+  return markdown
+    .split("\n")
+    .filter((line) => /^\s{0,3}\[[^\]]+\]:\s+\S/.test(line));
+}
+
+function withMarkdownReferenceDefinitions(table: string, definitions: string[]): string {
+  if (definitions.length === 0) {
+    return table;
+  }
+
+  return `${table}\n\n${definitions.join("\n")}`;
+}
+
+function isOnlyMarkdownReferenceDefinitions(markdown: string): boolean {
+  const meaningfulLines = markdown
+    .split("\n")
+    .filter((line) => line.trim() !== "");
+
+  return (
+    meaningfulLines.length > 0 &&
+    meaningfulLines.every((line) => /^\s{0,3}\[[^\]]+\]:\s+\S/.test(line))
+  );
+}
+
+function appendTextSegment(segments: MessagePartSegment[], text: string): void {
+  const previous = segments[segments.length - 1];
+  if (previous?.type === "text") {
+    previous.part.text = `${previous.part.text}\n\n${text}`;
+    return;
+  }
+
+  segments.push({ type: "text", part: { type: "text", text } });
 }
 
 function renderMessageSegment(params: {
@@ -137,8 +328,33 @@ function renderMessageSegment(params: {
       className="transcript-message__text-block"
       desktopApi={params.desktopApi}
       skills={params.skills}
-      text={params.segment.part.text}
+      text={params.segment.type === "table" ? params.segment.text : params.segment.part.text}
     />
+  );
+}
+
+function renderMessageHeader(
+  message: AppServerThreadMessageEntry,
+  continuation: boolean
+): ReactNode {
+  if (continuation) {
+    return null;
+  }
+
+  return (
+    <header className="transcript-message__header">
+      <span className="transcript-message__role">{labelForRole(message.role)}</span>
+      {message.createdAt ? (
+        <time className="transcript-message__time">
+          {new Intl.DateTimeFormat(undefined, {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit"
+          }).format(message.createdAt)}
+        </time>
+      ) : null}
+    </header>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -3,6 +3,14 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ThreadMarkdown } from "../ThreadMarkdown";
 
+const sanitizedReviewFindingsTable = `| # | Sev | File | Issue | Fix |
+|---:|:---:|---|---|---|
+| 1 | P1 | [InvoiceDispatcher.scala (line 48)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48) | A retry-suppressed invoice falls through to the standard path because fallback only checks \`queuedInvoices.isEmpty\`. Why it matters: \`enforce=true\` can still make a second provider call and emit a duplicate notice after suppression was explicitly requested, so throttling does not reliably reduce calls or preserve invoice semantics. | Distinguish "normal no invoice ready" from terminal states like \`Retry suppressed\`; only fallback on intentional misses. |
+| 2 | P2 | [LedgerWindow.scala (line 16)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerWindow.scala:16) | \`LedgerIdentity\` drops \`tenantId\` when normalizing matched cache items. Why it matters: the existing cache counting treats \`(tenantId, accountId, periodId, bucketId)\` as the unique ledger identity, so two tenants with the same period/bucket ids are merged and can cross-throttle each other. | Include \`tenantId\` in \`LedgerIdentity\`, \`stableKey\`, sorting, and tests. |
+| 3 | P2 | [AttemptObservation.scala (line 56)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/AttemptObservation.scala:56) | \`observedCalls\` excludes failures, while \`Failure\` still counts as an attempted provider call. Why it matters: \`minObservedCalls\` is based on wins and losses only, so a failure-heavy bucket can remain sparse indefinitely and continue sending 100% of traffic during an outage pattern. | Use \`attempts\` for the minimum call threshold and keep win-ratio math on wins/losses, or rename the threshold and test failure-heavy behavior explicitly. |
+| 4 | P2 | [InvoiceDispatcher.scala (line 87)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:87) | The no-cache path always gives pacing an empty matched-account set, which becomes an allow-without-bucket decision. Why it matters: \`billing.enforce=true\` silently has no effect for \`createWithoutCache\` and no observations are accumulated even though pacing is enabled. | Fail fast or disable enforcement when the active-account cache is unavailable, or introduce a deliberate fallback bucket if no-cache pacing is expected to work. |
+| 5 | P3 | [LedgerController.scala (line 72)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/window/LedgerController.scala:72) | The deterministic sampling key is customer/page scoped and has no per-opportunity component. Why it matters: repeated requests from the same customer for the same bucket in one interval all make the same allow/throttle decision, and missing/shared customer ids can turn a configured probability into all-or-nothing behavior. | Include a stable opportunity/request identifier, or at least the full targeting tuple, in the sampling key and add tests for repeated same-customer requests. |`;
+
 describe("ThreadMarkdown", () => {
   it("renders markdown formatting and local file links", () => {
     render(
@@ -204,6 +212,54 @@ describe("ThreadMarkdown", () => {
     expect(container.textContent).toContain(
       "![Transcript preview](https://example.com/preview.png)"
     );
+  });
+
+  it("renders wide review-style markdown tables with transcript table chrome", () => {
+    const { container } = render(
+      <ThreadMarkdown text={`## Findings\n\n${sanitizedReviewFindingsTable}`} />
+    );
+
+    const tableScroll = container.querySelector<HTMLDivElement>(
+      ".thread-markdown__table-scroll"
+    );
+    const table = container.querySelector<HTMLTableElement>(".thread-markdown__table");
+
+    expect(tableScroll).not.toBeNull();
+    expect(table).not.toBeNull();
+    expect(tableScroll).toContainElement(table);
+    expect(tableScroll).toHaveClass("thread-markdown__table-scroll--review-findings");
+    expect(table).toHaveClass("thread-markdown__table--review-findings");
+    expect(container.querySelectorAll("th.thread-markdown__th")).toHaveLength(5);
+    expect(container.querySelectorAll("td.thread-markdown__td")).toHaveLength(25);
+    expect(screen.getByRole("columnheader", { name: "Issue" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Fix" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "InvoiceDispatcher.scala (line 48)" })
+    ).toHaveAttribute(
+      "href",
+      "file:///Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48"
+    );
+    expect(container).toHaveTextContent("Retry suppressed");
+    expect(container).toHaveTextContent("failure-heavy behavior explicitly");
+  });
+
+  it("does not apply review findings table sizing to unrelated wide tables", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={`| Metric | North America | Europe | Asia Pacific |
+|---|---|---|---|
+| Request fingerprint | \`north-america-invoice-pacing-window-retry-suppressed-001\` | \`europe-invoice-pacing-window-retry-suppressed-002\` | \`asia-pacific-invoice-pacing-window-retry-suppressed-003\` |`}
+      />
+    );
+
+    expect(container.querySelector(".thread-markdown__table-scroll")).not.toHaveClass(
+      "thread-markdown__table-scroll--review-findings"
+    );
+    expect(container.querySelector(".thread-markdown__table")).not.toHaveClass(
+      "thread-markdown__table--review-findings"
+    );
+    expect(screen.getByRole("columnheader", { name: "Metric" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "North America" })).toBeInTheDocument();
   });
 
   it("skips raw html parsing for oversized html-like messages", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3,6 +3,19 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptList } from "../TranscriptList";
 
+const compactMarkdownTable = `| Key | Value |
+|---|---|
+| Mode | Shadow |
+| Owner | Billing |`;
+
+const wideMarkdownTable = `| # | Sev | File | Issue | Fix |
+|---:|:---:|---|---|---|
+| 1 | P1 | [InvoiceDispatcher.scala (line 48)](/Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48) | A retry-suppressed invoice falls through to the standard path because fallback only checks \`queuedInvoices.isEmpty\`. | Distinguish terminal states like \`Retry suppressed\`; only fallback on intentional misses. |`;
+
+const oversizedMarkdownTable = `| Metric | North America | Europe | Asia Pacific | South America | Middle East | Reliability Notes |
+|---|---|---|---|---|---|---|
+| Request fingerprint | \`north-america-invoice-pacing-window-retry-suppressed-001\` | \`europe-invoice-pacing-window-retry-suppressed-002\` | \`asia-pacific-invoice-pacing-window-retry-suppressed-003\` | \`south-america-invoice-pacing-window-retry-suppressed-004\` | \`middle-east-invoice-pacing-window-retry-suppressed-005\` | Keep the table horizontally scrollable rather than compressing prose or token cells into unreadable slivers. |`;
+
 describe("TranscriptList", () => {
   let scrollHeight = 480;
   let clientHeight = 240;
@@ -265,6 +278,169 @@ describe("TranscriptList", () => {
     expect(
       screen.getByText("$frontend-design").closest("article")
     ).toHaveClass("transcript-message--user");
+  });
+
+  it("keeps prose in readable bubbles while wide markdown tables get their own wide bubble", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-table",
+            role: "assistant",
+            text: `Intro prose should stay in the normal readable assistant bubble.\n\n${wideMarkdownTable}\n\nFollow-up prose should not inherit the table width.`,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    expect(articles).toHaveLength(3);
+    expect(articles[0]).not.toHaveClass("transcript-message--table");
+    expect(articles[0]).not.toHaveClass("transcript-message--table-wide");
+    expect(articles[1]).toHaveClass("transcript-message--table");
+    expect(articles[1]).toHaveClass("transcript-message--table-wide");
+    expect(articles[2]).not.toHaveClass("transcript-message--table");
+    expect(articles[2]).not.toHaveClass("transcript-message--table-wide");
+    expect(screen.getAllByText("Assistant")).toHaveLength(1);
+    expect(screen.getByText("Intro prose should stay", { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "InvoiceDispatcher.scala (line 48)" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Follow-up prose should not inherit", { exact: false })).toBeInTheDocument();
+  });
+
+  it("preserves reference-style links inside split wide markdown tables", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-reference-table",
+            role: "assistant",
+            text: `Review summary.\n\n| # | Sev | File | Issue | Fix |
+|---:|:---:|---|---|---|
+| 1 | P1 | [Invoice dispatcher][invoice-dispatcher] | A retry-suppressed invoice falls through to the standard path because fallback only checks \`queuedInvoices.isEmpty\`. | Keep reference-style file links clickable after table splitting. |
+
+[invoice-dispatcher]: /Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48`,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    expect(articles).toHaveLength(2);
+    expect(articles[1]).toHaveClass("transcript-message--table-wide");
+    expect(screen.getByRole("link", { name: "Invoice dispatcher" })).toHaveAttribute(
+      "href",
+      "file:///Users/ana/signal-shop/src/jvm/shared/public-api/src/main/scala/billing/invoice/InvoiceDispatcher.scala:48"
+    );
+    expect(container).not.toHaveTextContent("[invoice-dispatcher]:");
+  });
+
+  it("preserves indented code blocks around split wide markdown tables", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-indented-code-table",
+            role: "assistant",
+            text: `Before:\n\n    pnpm test before\n\n${wideMarkdownTable}\n\nAfter:\n\n    pnpm test after`,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    expect(articles).toHaveLength(3);
+    expect(articles[1]).toHaveClass("transcript-message--table-wide");
+    expect(container.querySelectorAll("pre code")).toHaveLength(2);
+    expect(screen.getByText("pnpm test before", { selector: "pre code" })).toBeInTheDocument();
+    expect(screen.getByText("pnpm test after", { selector: "pre code" })).toBeInTheDocument();
+  });
+
+  it("leaves compact markdown tables inside normal readable bubbles", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-compact-table",
+            role: "assistant",
+            text: `Compact summary:\n\n${compactMarkdownTable}`,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const articles = container.querySelectorAll("article.transcript-message--assistant");
+    expect(articles).toHaveLength(1);
+    expect(articles[0]).not.toHaveClass("transcript-message--table");
+    expect(articles[0]).not.toHaveClass("transcript-message--table-wide");
+    expect(container.querySelector("table.thread-markdown__table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Key" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Billing" })).toBeInTheDocument();
+  });
+
+  it("marks oversized markdown tables as wide so they can scroll inside the table bubble", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-oversized-table",
+            role: "assistant",
+            text: oversizedMarkdownTable,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const tableArticle = container.querySelector("article.transcript-message--table");
+    expect(tableArticle).toHaveClass("transcript-message--table-wide");
+    expect(container.querySelector(".thread-markdown__table-scroll")).toBeInTheDocument();
+    expect(
+      screen.getByText("north-america-invoice-pacing-window-retry-suppressed-001")
+    ).toBeInTheDocument();
+  });
+
+  it("does not split table-looking text inside fenced code blocks", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-code-table",
+            role: "assistant",
+            text: "```md\n| Key | Value |\n|---|---|\n| Mode | Shadow |\n```",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(container.querySelectorAll("article.transcript-message--assistant")).toHaveLength(1);
+    expect(container.querySelector("article.transcript-message--table")).toBeNull();
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelector("pre code")).toHaveTextContent("| Key | Value |");
   });
 
   it("opens transcript file links in the configured editor", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4004,6 +4004,15 @@ textarea,
   background: var(--bg-panel);
 }
 
+.transcript-message--table-wide {
+  width: 100%;
+  max-width: 100%;
+}
+
+.transcript-message--continuation .transcript-message__text {
+  margin-top: 0;
+}
+
 .transcript-work-phase-group {
   display: contents;
 }
@@ -4211,6 +4220,119 @@ textarea,
 
 .transcript-message__link:hover {
   text-decoration-color: currentColor;
+}
+
+.thread-markdown__table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-app);
+}
+
+.thread-markdown__table-scroll:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.thread-markdown__table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.thread-markdown__thead {
+  background: var(--bg-panel-elevated);
+}
+
+.thread-markdown__th,
+.thread-markdown__td {
+  min-width: 150px;
+  max-width: 42ch;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  border-left: 1px solid var(--border-subtle);
+  text-align: left;
+  vertical-align: top;
+}
+
+.thread-markdown__th:first-child,
+.thread-markdown__td:first-child {
+  border-left: 0;
+}
+
+.thread-markdown__tr:last-child .thread-markdown__td {
+  border-bottom: 0;
+}
+
+.thread-markdown__th {
+  color: var(--text-primary);
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.thread-markdown__td {
+  color: var(--text-secondary);
+}
+
+.thread-markdown__th:first-child,
+.thread-markdown__td:first-child {
+  min-width: 132px;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__th:nth-child(1),
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(1) {
+  width: 40px;
+  min-width: 40px;
+  max-width: 40px;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__th:nth-child(2),
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(2) {
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__th:nth-child(3),
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(3) {
+  width: 190px;
+  min-width: 190px;
+  max-width: 190px;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__th:nth-child(4),
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(4) {
+  width: 310px;
+  min-width: 310px;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__th:nth-child(5),
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(5) {
+  width: 312px;
+  min-width: 312px;
+}
+
+.thread-markdown__table--review-findings .thread-markdown__td:nth-child(n + 4) {
+  min-width: 280px;
+}
+
+.thread-markdown__td .transcript-message__code {
+  display: inline;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.thread-markdown__td .transcript-message__link {
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .transcript-message__image-button {


### PR DESCRIPTION
## Summary
- split markdown table blocks into dedicated continuation bubbles so prose keeps normal readable width
- render markdown tables with table chrome, tuned narrow columns, wide-table layout, and horizontal overflow for oversized cases
- add a sanitized replay fixture plus unit/E2E coverage for compact, wide, oversized, and fenced-code table cases

## Tests
- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- pnpm --filter @pwragent/desktop test:e2e -- markdown-findings-table.spec.ts