### PR TITLE
fix(desktop): wrap review result paths / review cards (finally)

### DIFF
--- a/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-output-rendering/replay.fixture.json
@@ -33,10 +33,18 @@
           "title": "Composer image paste reset E2E",
           "titleSource": "explicit",
           "summary": "Captured review output rendering regression",
+          "projectKey": "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz",
           "source": "codex",
           "executionMode": "default",
           "gitBranch": "fix/composer-image-thread-switch-race",
-          "linkedDirectories": [],
+          "linkedDirectories": [
+            {
+              "id": "directory:/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz",
+              "label": "PwrAgent",
+              "path": "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz",
+              "kind": "local"
+            }
+          ],
           "inbox": {
             "inInbox": true,
             "reason": "new-thread"
@@ -140,7 +148,7 @@
           "item": {
             "type": "exitedReviewMode",
             "id": "019dd6d5-91fa-7820-acb5-8ebd37da76e4",
-            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes.\n\nReview comment:\n\n- [P2] Preserve async pasted images for launchpad scopes — /Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz/apps/desktop/src/renderer/src/features/composer/Composer.tsx:971-979\n  When an image paste starts from a new-thread launchpad and the user switches away before `normalizeImageFile` resolves, this branch runs with a `launchpad:*` `pasteScope.key`; `saveThreadComposerDraft` ignores non-thread scopes, so the completed attachment is dropped instead of being persisted back to the launchpad draft. This makes large pasted images silently disappear for launchpad composers under the same switch-away race this change is trying to fix."
+            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes."
           }
         }
       }
@@ -156,7 +164,7 @@
           "item": {
             "type": "exitedReviewMode",
             "id": "019dd6d5-91fa-7820-acb5-8ebd37da76e4",
-            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes.\n\nReview comment:\n\n- [P2] Preserve async pasted images for launchpad scopes — /Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz/apps/desktop/src/renderer/src/features/composer/Composer.tsx:971-979\n  When an image paste starts from a new-thread launchpad and the user switches away before `normalizeImageFile` resolves, this branch runs with a `launchpad:*` `pasteScope.key`; `saveThreadComposerDraft` ignores non-thread scopes, so the completed attachment is dropped instead of being persisted back to the launchpad draft. This makes large pasted images silently disappear for launchpad composers under the same switch-away race this change is trying to fix."
+            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes."
           }
         }
       }
@@ -234,7 +242,7 @@
             "type": "review",
             "id": "review-exited-1",
             "displayText": "Code review",
-            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes.\n\nReview comment:\n\n- [P2] Preserve async pasted images for launchpad scopes — /Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz/apps/desktop/src/renderer/src/features/composer/Composer.tsx:971-979\n  When an image paste starts from a new-thread launchpad and the user switches away before `normalizeImageFile` resolves, this branch runs with a `launchpad:*` `pasteScope.key`; `saveThreadComposerDraft` ignores non-thread scopes, so the completed attachment is dropped instead of being persisted back to the launchpad draft. This makes large pasted images silently disappear for launchpad composers under the same switch-away race this change is trying to fix."
+            "review": "The thread draft preservation path fixes the covered scenario, but the new async paste handling drops completed image attachments for launchpad composers if the user navigates away before normalization finishes."
           },
           {
             "type": "message",

--- a/apps/desktop/e2e/fixtures/review-path-wrapping/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/review-path-wrapping/replay.fixture.json
@@ -1,0 +1,75 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "review-path-wrapping",
+    "threadId": "thread-review-path-wrapping"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-review-path-wrapping",
+          "title": "Review path wrapping",
+          "titleSource": "explicit",
+          "summary": "Review renderer path wrapping regression",
+          "projectKey": "/Users/huntharo/work/PwrAgent",
+          "source": "codex",
+          "executionMode": "default",
+          "gitBranch": "fix/review-path-wrapping",
+          "linkedDirectories": [
+            {
+              "id": "directory:/Users/huntharo/work/PwrAgent",
+              "label": "PwrAgent",
+              "path": "/Users/huntharo/work/PwrAgent",
+              "kind": "local"
+            }
+          ],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1777425951000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "review",
+            "id": "review-path-wrapping-result",
+            "displayText": "Code review",
+            "review": "The review renderer should keep file locations readable without widening the transcript.\n\nFull review comments:\n\n- [P3] Keep linked directory paths compact — /Users/huntharo/work/PwrAgent/apps/desktop/src/renderer/src/features/composer/Composer.tsx:2013-2014\n  Paths inside the thread directory should render relative to that directory and keep the full absolute target in the link destination.\n\n- [P0] Wrap external review file paths — /Volumes/ExternalReviewArchive/OutsideRepositoryPathWithAnExcessivelyLongSingleFilenameSegmentThatMustWrapInsideTheReviewRendererBecauseItCannotBeReducedByTheCurrentWorkingDirectoryBoundary.tsx:88-91\n  Paths outside the current working directory cannot be shortened by prefix stripping, so the location row must wrap the long linked filename instead of overflowing horizontally."
+          }
+        ],
+        "messages": [],
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -71,3 +71,60 @@ test("renders captured Codex review findings once in the review card", async () 
     await app.close();
   }
 });
+
+test("wraps unstripped long review paths and strips paths inside the thread directory", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/review-path-wrapping/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 900,
+      height: 720,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Review path wrapping/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Review path wrapping",
+      })
+    ).toBeVisible();
+
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const reviewCard = transcript.getByRole("group", { name: "Code review" }).last();
+    await expect(reviewCard).toBeVisible();
+    await expect(reviewCard).toContainText(
+      "apps/desktop/src/renderer/src/features/composer/Composer.tsx"
+    );
+    await expect(reviewCard).not.toContainText(
+      "/Users/huntharo/work/PwrAgent/apps/desktop"
+    );
+
+    const outsidePathLink = reviewCard.getByRole("link", {
+      name: /OutsideRepositoryPathWithAnExcessivelyLongSingleFilenameSegment/,
+    });
+    await expect(outsidePathLink).toBeVisible();
+    await expect(outsidePathLink).toHaveAttribute(
+      "href",
+      /\/Volumes\/ExternalReviewArchive\//
+    );
+
+    const linkBox = await outsidePathLink.boundingBox();
+    const cardBox = await reviewCard.boundingBox();
+    expect(linkBox).not.toBeNull();
+    expect(cardBox).not.toBeNull();
+    expect(linkBox!.height).toBeGreaterThan(24);
+    expect(linkBox!.x + linkBox!.width).toBeLessThanOrEqual(
+      cardBox!.x + cardBox!.width + 1
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -57,6 +57,9 @@ test("renders captured Codex review findings once in the review card", async () 
       "Preserve async pasted images for launchpad scopes"
     );
     await expect(reviewCard).toContainText("features/composer/Composer.tsx");
+    await expect(reviewCard).not.toContainText(
+      "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main-moja6ucz"
+    );
     await expect(reviewCard).toContainText("Lines 971-979");
 
     await expect(

--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -49,6 +49,11 @@ test("renders captured Codex review findings once in the review card", async () 
 
     const reviewCard = transcript.getByRole("group", { name: "Code review" }).last();
     await expect(reviewCard).toBeVisible();
+    const reviewTime = reviewCard.locator("time").first();
+    await expect(reviewTime).toBeVisible();
+    const reviewTimeBox = await reviewTime.boundingBox();
+    expect(reviewTimeBox).not.toBeNull();
+    expect(reviewTimeBox!.height).toBeLessThanOrEqual(18);
     await expect(reviewCard).toContainText(
       "The thread draft preservation path fixes the covered scenario"
     );

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2379,6 +2379,57 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("merges review-shaped assistant findings into summary-only exited review events", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const reviewSummary =
+      "The queued-review behavior introduces draft/attachment loss in realistic active-turn workflows.";
+    const reviewText = `${reviewSummary}\n\nFull review comments:\n\n- [P2] Preserve the live draft after starting a queued review — /Users/huntharo/.codex/worktrees/mp1febj4/PwrAgnt/apps/desktop/src/renderer/src/features/composer/Composer.tsx:1673-1677\n  When this path is reached from sendQueuedTurn, the user may already have started composing another reply while the review waited in the queue.`;
+    MockTransport.readThreadResultByThreadId.set("thread-summary-review", {
+      thread: {
+        turns: [
+          {
+            id: "turn-review",
+            status: "completed",
+            startedAt: 1_763_509_850,
+            items: [
+              {
+                type: "exitedReviewMode",
+                id: "exited-review",
+                review: reviewSummary,
+              },
+              {
+                type: "agentMessage",
+                id: "review-answer",
+                text: reviewText,
+                phase: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-summary-review",
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "review",
+        id: "exited-review",
+        review: reviewText,
+      }),
+    ]);
+    expect(replay.messages).toEqual([]);
+
+    await client.close();
+  });
+
   it("suppresses review prompts without legacy image metadata", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-review-prompt", {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -926,6 +926,31 @@ function isReviewActionText(text: string): boolean {
   return text.includes("<user_action>") && text.includes("<action>review</action>");
 }
 
+function isPlainReviewFindingText(text: string): boolean {
+  return (
+    /\b(?:full\s+)?review comments?:/i.test(text) &&
+    /(?:^|\n)\s*-\s*\[P[0-3]\]\s+.+(?:\s+—\s+|\s+-\s+).+:\d+/u.test(text)
+  );
+}
+
+function shouldUseAssistantReviewText(params: {
+  assistantText: string;
+  reviewText: string;
+}): boolean {
+  if (!isPlainReviewFindingText(params.assistantText)) {
+    return false;
+  }
+
+  const normalizedAssistant = normalizeSuppressionText(params.assistantText);
+  const normalizedReview = normalizeSuppressionText(params.reviewText);
+  return (
+    !normalizedReview ||
+    normalizedAssistant === normalizedReview ||
+    normalizedAssistant.startsWith(normalizedReview) ||
+    normalizedAssistant.includes(normalizedReview)
+  );
+}
+
 function isCodexInternalReviewPrompt(
   record: Record<string, unknown>,
   text: string
@@ -958,6 +983,16 @@ function collectReviewSuppressionTexts(value: unknown): Set<string> {
     const record = asRecord(node);
     if (!record) {
       return;
+    }
+
+    const role = normalizeConversationRole(
+      pickString(record, ["role", "author", "speaker", "source", "type"])
+    );
+    if (role === "assistant") {
+      const text = collectLegacyMessageText(record);
+      if (isPlainReviewFindingText(text)) {
+        output.add(normalizeSuppressionText(text));
+      }
     }
 
     const reviewOutput = normalizeReviewOutput(record);
@@ -994,6 +1029,33 @@ function collectReviewSuppressionTexts(value: unknown): Set<string> {
   };
 
   visit(value);
+  return output;
+}
+
+function collectAssistantReviewTexts(items: Record<string, unknown>[]): string[] {
+  const output: string[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const role = normalizeConversationRole(
+      pickString(item, ["role", "author", "speaker", "source", "type"])
+    );
+    if (role !== "assistant") {
+      continue;
+    }
+
+    const text = buildMessageContent(item).text;
+    if (!isPlainReviewFindingText(text)) {
+      continue;
+    }
+
+    const key = normalizeSuppressionText(text);
+    if (!seen.has(key)) {
+      seen.add(key);
+      output.push(text);
+    }
+  }
+
   return output;
 }
 
@@ -2320,7 +2382,11 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
           .map((entry) => asRecord(entry))
           .filter((entry): entry is Record<string, unknown> => entry !== null)
       : [];
+    const assistantReviewTexts = collectAssistantReviewTexts(rawItems);
     const suppressedAssistantTexts = collectReviewSuppressionTexts(rawItems);
+    for (const text of assistantReviewTexts) {
+      suppressedAssistantTexts.add(normalizeSuppressionText(text));
+    }
     const pendingActivityItems: Record<string, unknown>[] = [];
 
     const flushActivityItems = (): void => {
@@ -2373,7 +2439,23 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
       const reviewEntry = extractReviewEntryFromItem(item, createdAt, turnMetadata);
       if (reviewEntry) {
         flushActivityItems();
-        entries.push(reviewEntry);
+        const assistantReviewText =
+          reviewEntry.displayText === undefined
+            ? assistantReviewTexts.find((text) =>
+                shouldUseAssistantReviewText({
+                  assistantText: text,
+                  reviewText: reviewEntry.review,
+                })
+              )
+            : undefined;
+        entries.push(
+          assistantReviewText
+            ? {
+                ...reviewEntry,
+                review: assistantReviewText,
+              }
+            : reviewEntry
+        );
         continue;
       }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1577,6 +1577,7 @@ export function ThreadView(props: ThreadViewProps) {
               activeTurnId={props.activeTurnId}
               activeTurnStartedAt={props.activeTurnStartedAt}
               applications={props.applications}
+              directoryPaths={threadDirectoryPaths(selectedThread!)}
               desktopApi={props.desktopApi}
               error={props.transcriptError}
               loading={props.loading}
@@ -1968,4 +1969,15 @@ function formatDirectorySync(directory: NavigationDirectorySummary): string | un
   }
 
   return undefined;
+}
+
+function threadDirectoryPaths(thread: NavigationThreadSummary): string[] {
+  const linkedDirectoryPaths = thread.linkedDirectories.flatMap((directory) => {
+    const paths = [directory.path];
+    if (directory.worktreePath && directory.worktreePath !== directory.path) {
+      paths.push(directory.worktreePath);
+    }
+    return paths;
+  });
+  return thread.projectKey ? [thread.projectKey, ...linkedDirectoryPaths] : linkedDirectoryPaths;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -46,6 +46,7 @@ type TranscriptListProps = {
   activeTurnStartedAt?: number;
   applications?: DesktopApplicationsSnapshot;
   desktopApi?: Pick<DesktopApi, "openApplication">;
+  directoryPaths?: string[];
   entries: AppServerThreadEntry[];
   error?: string;
   loading: boolean;
@@ -708,6 +709,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   key={item.id}
                   applications={props.applications}
                   collapsible={item.collapsible}
+                  directoryPaths={props.directoryPaths}
                   desktopApi={props.desktopApi}
                   entries={item.entries}
                   expanded={expandedCommentaryGroupIds.has(item.id)}
@@ -735,6 +737,7 @@ export function TranscriptList(props: TranscriptListProps) {
               <TranscriptReview
                 key={entry.id}
                 applications={props.applications}
+                directoryPaths={props.directoryPaths}
                 desktopApi={props.desktopApi}
                 entry={entry}
               />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -3,12 +3,14 @@ import type {
   AppServerThreadReviewEntry,
   DesktopApplicationsSnapshot,
 } from "@pwragent/shared";
+import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptReviewProps = {
   applications?: DesktopApplicationsSnapshot;
+  directoryPaths?: string[];
   desktopApi?: Pick<DesktopApi, "openApplication">;
   entry: AppServerThreadReviewEntry;
 };
@@ -21,14 +23,33 @@ function formatConfidence(value: number | undefined): string | undefined {
   return `${Math.round(value * 100)}% confidence`;
 }
 
-function formatPath(path: string): string {
-  const normalized = path.replace(/\\/g, "/");
-  const parts = normalized.split("/").filter(Boolean);
-  return parts.slice(-3).join("/") || path;
+function formatPath(path: string, directoryPaths: string[] | undefined): string {
+  const normalized = normalizePath(path);
+  const matchingDirectory = normalizedDirectoryPaths(directoryPaths)
+    .filter(
+      (directoryPath) =>
+        normalized === directoryPath || normalized.startsWith(`${directoryPath}/`)
+    )
+    .sort((left, right) => right.length - left.length)[0];
+
+  if (!matchingDirectory) {
+    return normalized || path;
+  }
+
+  return normalized.slice(matchingDirectory.length).replace(/^\//, "") || normalized;
 }
 
 function priorityLabel(priority: number | undefined): string {
   return typeof priority === "number" ? `P${priority}` : "P?";
+}
+
+function priorityClassName(priority: number | undefined): string {
+  const normalizedPriority =
+    typeof priority === "number" && priority >= 0 && priority <= 3
+      ? `p${priority}`
+      : "unknown";
+
+  return `transcript-review__priority transcript-review__priority--${normalizedPriority}`;
 }
 
 function shouldHideReviewBody(summary: string, review: string): boolean {
@@ -99,6 +120,34 @@ function parsePlainReview(review: string): {
 }
 
 export function TranscriptReview(props: TranscriptReviewProps) {
+  const editorApplication = useMemo(
+    () =>
+      props.applications?.editors.find(
+        (application) =>
+          application.canOpenWorkspace &&
+          application.id === props.applications?.preferredEditorId.value
+      ) ?? props.applications?.editors.find((application) => application.canOpenWorkspace),
+    [props.applications]
+  );
+  const openLocalFile = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, targetPath: string): void => {
+      if (!editorApplication || !props.desktopApi?.openApplication) {
+        return;
+      }
+
+      event.preventDefault();
+      void props.desktopApi
+        .openApplication({
+          applicationId: editorApplication.id,
+          kind: "editor",
+          targetPath,
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to open review file link", error);
+        });
+    },
+    [editorApplication, props.desktopApi]
+  );
   const output = props.entry.output;
   const plainReview = output ? undefined : parsePlainReview(props.entry.review);
   const findings = output?.findings ?? plainReview?.findings ?? [];
@@ -172,13 +221,15 @@ export function TranscriptReview(props: TranscriptReviewProps) {
         <ol className="transcript-review__findings">
           {findings.map((finding, index) => {
             const range = finding.code_location.line_range;
+            const absoluteFilePath = normalizePath(finding.code_location.absolute_file_path);
+            const displayPath = formatPath(absoluteFilePath, props.directoryPaths);
             return (
               <li
                 className="transcript-review__finding"
                 key={`${finding.code_location.absolute_file_path}:${range.start}:${index}`}
               >
                 <div className="transcript-review__finding-head">
-                  <span className="transcript-review__priority">
+                  <span className={priorityClassName(finding.priority)}>
                     {priorityLabel(finding.priority)}
                   </span>
                   <span className="transcript-review__finding-title">
@@ -192,8 +243,19 @@ export function TranscriptReview(props: TranscriptReviewProps) {
                   text={finding.body}
                 />
                 <div className="transcript-review__location">
-                  <span>{formatPath(finding.code_location.absolute_file_path)}</span>
-                  <span>
+                  <a
+                    className="transcript-review__location-path"
+                    href={fileHref(absoluteFilePath, range.start)}
+                    onClick={(event) => {
+                      openLocalFile(event, absoluteFilePath);
+                    }}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title={`${absoluteFilePath}:${range.start}`}
+                  >
+                    {displayPath}
+                  </a>
+                  <span className="transcript-review__location-line">
                     {range.start === range.end
                       ? `Line ${range.start}`
                       : `Lines ${range.start}-${range.end}`}
@@ -208,4 +270,22 @@ export function TranscriptReview(props: TranscriptReviewProps) {
       ) : null}
     </aside>
   );
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function normalizedDirectoryPaths(paths: string[] | undefined): string[] {
+  return (paths ?? [])
+    .map((path) => normalizePath(path))
+    .filter((path) => path.startsWith("/"));
+}
+
+function fileHref(path: string, line: number): string {
+  const encodedPath = path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `file://${encodedPath}:${line}`;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -14,6 +14,7 @@ import { TranscriptReview } from "./TranscriptReview";
 type TranscriptWorkPhaseGroupProps = {
   applications?: DesktopApplicationsSnapshot;
   collapsible: boolean;
+  directoryPaths?: string[];
   desktopApi?: Pick<DesktopApi, "openApplication">;
   entries: AppServerThreadEntry[];
   expanded: boolean;
@@ -36,6 +37,7 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
       {props.entries.map((entry) =>
         renderEntry({
           applications: props.applications,
+          directoryPaths: props.directoryPaths,
           desktopApi: props.desktopApi,
           entry,
           onOpenImage: props.onOpenImage,
@@ -72,6 +74,7 @@ TranscriptWorkPhaseGroup.displayName = "TranscriptWorkPhaseGroup";
 
 function renderEntry(params: {
   applications?: DesktopApplicationsSnapshot;
+  directoryPaths?: string[];
   desktopApi?: Pick<DesktopApi, "openApplication">;
   entry: AppServerThreadEntry;
   skills: AppServerSkillSummary[];
@@ -91,6 +94,7 @@ function renderEntry(params: {
     <TranscriptReview
       key={entry.id}
       applications={params.applications}
+      directoryPaths={params.directoryPaths}
       desktopApi={params.desktopApi}
       entry={entry}
     />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -11,6 +11,7 @@ describe("TranscriptReview", () => {
   it("renders review summary metadata and prioritized findings", () => {
     render(
       <TranscriptReview
+        directoryPaths={["/repo/apps/desktop/src/renderer"]}
         entry={{
           type: "review",
           id: "review-1",
@@ -47,8 +48,15 @@ describe("TranscriptReview", () => {
     expect(screen.getByText("1 finding")).toBeInTheDocument();
     expect(screen.getByText("87% confidence")).toBeInTheDocument();
     expect(screen.getByText("P1")).toBeInTheDocument();
+    expect(screen.getByText("P1")).toHaveClass("transcript-review__priority--p1");
     expect(screen.getByText("Hydrate review transcript items")).toBeInTheDocument();
-    expect(screen.getByText("src/lib/useThreadSessionState.ts")).toBeInTheDocument();
+    const fileLink = screen.getByRole("link", {
+      name: "src/lib/useThreadSessionState.ts",
+    });
+    expect(fileLink).toHaveAttribute(
+      "href",
+      "file:///repo/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts:845"
+    );
     expect(screen.getByText("Lines 845-848")).toBeInTheDocument();
   });
 
@@ -71,6 +79,7 @@ describe("TranscriptReview", () => {
   it("renders plain Codex review comments as review findings", () => {
     render(
       <TranscriptReview
+        directoryPaths={["/repo/apps/desktop/src/renderer/src"]}
         entry={{
           type: "review",
           id: "review-exited-1",
@@ -85,16 +94,23 @@ describe("TranscriptReview", () => {
       screen.getByText("The change fixes the covered scenario, but one edge case remains.")
     ).toBeInTheDocument();
     expect(screen.getByText("P2")).toBeInTheDocument();
+    expect(screen.getByText("P2")).toHaveClass("transcript-review__priority--p2");
     expect(
       screen.getByText("Preserve async pasted images for launchpad scopes")
     ).toBeInTheDocument();
-    expect(screen.getByText("features/composer/Composer.tsx")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "features/composer/Composer.tsx" })
+    ).toHaveAttribute(
+      "href",
+      "file:///repo/apps/desktop/src/renderer/src/features/composer/Composer.tsx:971"
+    );
     expect(screen.getByText("Lines 971-979")).toBeInTheDocument();
   });
 
   it("renders full review comments as separate finding cards", () => {
     render(
       <TranscriptReview
+        directoryPaths={["/repo/apps/desktop/src/renderer/src"]}
         entry={{
           type: "review",
           id: "review-exited-2",
@@ -115,5 +131,30 @@ describe("TranscriptReview", () => {
     expect(screen.getByText("Lines 618-622")).toBeInTheDocument();
     expect(screen.getByText("Lines 660-667")).toBeInTheDocument();
     expect(screen.queryByText("Full review comments:")).not.toBeInTheDocument();
+  });
+
+  it("colors every supported review severity and preserves absolute outside paths", () => {
+    render(
+      <TranscriptReview
+        directoryPaths={["/repo"]}
+        entry={{
+          type: "review",
+          id: "review-severity-paths",
+          displayText: "Code review",
+          review: "Review severities.\n\nFull review comments:\n\n- [P0] Critical issue — /outside/repository/VeryLongOutsideFileName.ts:1\n  Critical body.\n\n- [P1] High issue — /repo/packages/app/high.ts:2\n  High body.\n\n- [P2] Medium issue — /repo/packages/app/medium.ts:3\n  Medium body.\n\n- [P3] Low issue — /repo/packages/app/low.ts:4\n  Low body.",
+        }}
+      />
+    );
+
+    for (const priority of [0, 1, 2, 3]) {
+      expect(screen.getByText(`P${priority}`)).toHaveClass(
+        `transcript-review__priority--p${priority}`
+      );
+    }
+
+    expect(
+      screen.getByRole("link", { name: "/outside/repository/VeryLongOutsideFileName.ts" })
+    ).toHaveAttribute("href", "file:///outside/repository/VeryLongOutsideFileName.ts:1");
+    expect(screen.getByRole("link", { name: "packages/app/high.ts" })).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -558,6 +558,78 @@ function normalizeTranscriptText(value: string): string {
   return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
 }
 
+function isPlainReviewFindingText(text: string): boolean {
+  return (
+    /\b(?:full\s+)?review comments?:/i.test(text) &&
+    /(?:^|\n)\s*-\s*\[P[0-3]\]\s+.+(?:\s+—\s+|\s+-\s+).+:\d+/u.test(text)
+  );
+}
+
+function shouldUseAssistantReviewText(params: {
+  assistantText: string;
+  reviewText: string;
+}): boolean {
+  if (!isPlainReviewFindingText(params.assistantText)) {
+    return false;
+  }
+
+  const normalizedAssistant = normalizeTranscriptText(params.assistantText);
+  const normalizedReview = normalizeTranscriptText(params.reviewText);
+  return (
+    !normalizedReview ||
+    normalizedAssistant === normalizedReview ||
+    normalizedAssistant.startsWith(normalizedReview) ||
+    normalizedAssistant.includes(normalizedReview)
+  );
+}
+
+function coalesceReviewAssistantMessages(
+  entries: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  const output: AppServerThreadEntry[] = [];
+
+  for (const entry of entries) {
+    if (
+      entry.type === "message" &&
+      entry.role === "assistant" &&
+      shouldUseAssistantReviewText({
+        assistantText: entry.text,
+        reviewText: "",
+      })
+    ) {
+      const matchingReviewIndex = output.findLastIndex((candidate) => {
+        if (candidate.type !== "review") {
+          return false;
+        }
+        if (
+          entry.turn?.id &&
+          candidate.turn?.id &&
+          entry.turn.id !== candidate.turn.id
+        ) {
+          return false;
+        }
+        return shouldUseAssistantReviewText({
+          assistantText: entry.text,
+          reviewText: candidate.review,
+        });
+      });
+
+      if (matchingReviewIndex !== -1) {
+        const reviewEntry = output[matchingReviewIndex] as AppServerThreadReviewEntry;
+        output[matchingReviewIndex] = {
+          ...reviewEntry,
+          review: entry.text,
+        };
+        continue;
+      }
+    }
+
+    output.push(entry);
+  }
+
+  return output;
+}
+
 function reviewResultTexts(entries: AppServerThreadEntry[]): Set<string> {
   const output = new Set<string>();
   for (const entry of entries) {
@@ -2847,9 +2919,10 @@ export function useThreadSessionState(params: {
         selectedSession?.response?.replay.entries ?? [],
         visibleOptimisticEntries
       );
+      const coalescedEntries = coalesceReviewAssistantMessages(mergedEntries);
       return suppressReviewDuplicateMessages(
-        mergedEntries,
-        reviewResultTexts(mergedEntries)
+        coalescedEntries,
+        reviewResultTexts(coalescedEntries)
       );
     },
     [selectedSession?.response?.replay.entries, visibleOptimisticEntries]

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1478,6 +1478,13 @@ textarea,
   font-weight: 500;
 }
 
+.transcript-message__time {
+  flex: 0 0 auto;
+  line-height: 1.2;
+  text-align: right;
+  white-space: nowrap;
+}
+
 .thread-row__time {
   transition: opacity 120ms ease;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4483,11 +4483,41 @@ textarea,
 }
 
 .transcript-review__priority {
-  color: var(--accent-bright);
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: rgba(247, 243, 235, 0.04);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 700;
-  line-height: 1.4;
+  line-height: 1.3;
+}
+
+.transcript-review__priority--p0 {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
+.transcript-review__priority--p1 {
+  border-color: rgba(196, 90, 58, 0.42);
+  background: rgba(196, 90, 58, 0.16);
+  color: #ffba8a;
+}
+
+.transcript-review__priority--p2 {
+  border-color: color-mix(in srgb, var(--status-warning) 48%, transparent);
+  background: color-mix(in srgb, var(--status-warning) 18%, transparent);
+  color: var(--status-warning);
+}
+
+.transcript-review__priority--p3 {
+  border-color: var(--info-border);
+  background: var(--info-soft);
+  color: var(--info-text);
 }
 
 .transcript-review__finding-title {
@@ -4517,10 +4547,32 @@ textarea,
   display: flex;
   flex-wrap: wrap;
   gap: 6px 10px;
+  min-width: 0;
+  max-width: 100%;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.4;
+}
+
+.transcript-review__location-path {
+  min-width: 0;
+  max-width: 100%;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+  text-decoration-color: rgba(184, 176, 165, 0.42);
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.transcript-review__location-path:hover {
+  color: var(--accent-bright);
+  text-decoration-color: currentColor;
+}
+
+.transcript-review__location-line {
+  flex: none;
 }
 
 .transcript-review__empty {


### PR DESCRIPTION
## Summary

Fixes review result rendering so file locations stay readable in desktop transcripts. Review findings now show P0-P3 severity badges, link locations to the full absolute path, and display paths relative to the selected thread directory when possible while still wrapping long external paths inside the card.

## Testing

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e -- review-output-rendering.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)