### PR TITLE
fix(desktop): use Slack icon in activity rows

### DIFF
--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -1,9 +1,16 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactElement } from "react";
 import type {
   MessagingActivityEntry,
   MessagingActivityKind,
 } from "@pwragent/shared";
-import { DiscordIcon, LineIcon, MattermostIcon, TelegramIcon } from "../../icons";
+import {
+  DiscordIcon,
+  LineIcon,
+  MattermostIcon,
+  SlackIcon,
+  TelegramIcon,
+  type IconProps,
+} from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
@@ -25,6 +32,15 @@ const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "mut
   outbound: "muted",
   binding: "ok",
   diagnostic: "warning",
+};
+const PLATFORM_ICONS: Partial<
+  Record<MessagingActivityEntry["platform"], (props: IconProps) => ReactElement>
+> = {
+  telegram: ({ size }) => <TelegramIcon size={size} variant="color" />,
+  discord: ({ size }) => <DiscordIcon size={size} variant="white" />,
+  mattermost: ({ size }) => <MattermostIcon size={size} />,
+  slack: ({ size }) => <SlackIcon size={size} />,
+  line: ({ size }) => <LineIcon size={size} />,
 };
 
 /**
@@ -157,17 +173,12 @@ function ActivityRow(props: { entry: MessagingActivityEntry }) {
   const tone = KIND_TONE[entry.kind];
   const [copiedKey, setCopiedKey] = useState<string | undefined>(undefined);
   const copyFields = copyFieldsForEntry(entry);
+  const Icon = PLATFORM_ICONS[entry.platform];
   return (
     <li className="messaging-activity-row">
       <span className={`messaging-activity-row__icon messaging-activity-row__icon--${tone}`}>
-        {entry.platform === "telegram" ? (
-          <TelegramIcon size={14} variant="color" />
-        ) : entry.platform === "discord" ? (
-          <DiscordIcon size={14} variant="white" />
-        ) : entry.platform === "mattermost" ? (
-          <MattermostIcon size={14} />
-        ) : entry.platform === "line" ? (
-          <LineIcon size={14} />
+        {Icon ? (
+          <Icon size={14} />
         ) : (
           <span>{entry.platform.slice(0, 2)}</span>
         )}

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -113,5 +113,8 @@ describe("MessagingActivityScreen", () => {
       .toHaveTextContent("Workspace ID");
     expect(screen.getByText("C079K80HTGS").closest("button"))
       .toHaveTextContent("Channel ID");
+    const row = screen.getByText("Observed pairing token").closest("li");
+    expect(row).not.toHaveTextContent("sl");
+    expect(row?.querySelector("img")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Render Slack activity rows with the existing `SlackIcon` asset instead of the generic two-letter platform fallback.
- Keep the fallback only for future platforms without a dedicated icon.
- Add a Messaging Activity regression assertion that Slack rows render an image and do not show `sl` text.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

The remaining two-letter fallbacks in `MessagingStatusBar` and `ThreadRow` are behind platform icon maps that already include Slack, so they are not used for Slack.
