### PR TITLE
fix(desktop): stop navigation refresh loop

### DIFF
--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -134,6 +134,39 @@ describe("usePullRequestRefresh", () => {
     expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
   });
 
+  it("does not refresh again when only the navigation refresh callback changes", async () => {
+    const response = buildResponse({ prs: [] });
+    const refreshThreadPullRequests = vi.fn(async () => response);
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { rerender } = renderHook(
+      ({ onRefreshNavigation }: { onRefreshNavigation: () => Promise<void> }) =>
+        usePullRequestRefresh({
+          desktopApi,
+          onRefreshNavigation,
+          selectedThread: buildThread({ prs: [] }),
+        }),
+      {
+        initialProps: {
+          onRefreshNavigation: vi.fn(async () => undefined),
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+    });
+
+    rerender({
+      onRefreshNavigation: vi.fn(async () => undefined),
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 20));
+    expect(refreshThreadPullRequests).toHaveBeenCalledOnce();
+  });
+
   it("refreshes again when the selected thread PR request changes", async () => {
     const response = buildResponse({ prs: [] });
     const refreshThreadPullRequests = vi.fn(async () => response);

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -29,6 +29,11 @@ export function usePullRequestRefresh(params: {
 }): { prefetch: (thread: NavigationThreadSummary) => void } {
   const desktopApi = params.desktopApi;
   const onRefreshNavigation = params.onRefreshNavigation;
+  const onRefreshNavigationRef = useRef(onRefreshNavigation);
+  useEffect(() => {
+    onRefreshNavigationRef.current = onRefreshNavigation;
+  }, [onRefreshNavigation]);
+
   const refresh = useCallback(
     (thread: NavigationThreadSummary): void => {
       if (!desktopApi?.refreshThreadPullRequests) return;
@@ -47,13 +52,13 @@ export function usePullRequestRefresh(params: {
           if (prSummariesEqual(thread.prs, response.prs)) {
             return;
           }
-          void onRefreshNavigation?.();
+          void onRefreshNavigationRef.current?.();
         })
         .catch(() => {
           // Logged in main — keep the renderer silent.
         });
     },
-    [desktopApi, onRefreshNavigation],
+    [desktopApi],
   );
 
   const selected = params.selectedThread;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1872,6 +1872,38 @@ describe("useThreadNavigation", () => {
     ).toBe("discord");
   });
 
+  it("keeps the public refresh callback stable across navigation renders", async () => {
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    const initialRefresh = result.current.refresh;
+
+    act(() => {
+      result.current.setBrowseMode("directories");
+    });
+
+    expect(result.current.refresh).toBe(initialRefresh);
+  });
+
   describe("pickAndRegisterDirectory (issue #223)", () => {
     function buildBaseDesktopApi(
       overrides: Partial<DesktopApi> = {},

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1338,6 +1338,9 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     },
     [performRefresh]
   );
+  const refreshNavigation = useCallback(async (): Promise<void> => {
+    await refresh();
+  }, [refresh]);
 
   const scheduleRefresh = useCallback(
     (
@@ -2706,7 +2709,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     renameThreadError,
     loading: state.loading,
     refreshing: state.refreshing,
-    refresh: async () => await refresh(),
+    refresh: refreshNavigation,
     materializeDirectoryLaunchpad,
     openDirectoryLaunchpad,
     pickAndRegisterDirectory,


### PR DESCRIPTION
## Summary

Fixes a renderer-side refresh loop that could repeatedly call `getNavigationSnapshot` even when the main process reported `unchanged=true`.

The loop came from callback identity churn: `useThreadNavigation` returned a fresh public `refresh` function every render, and `usePullRequestRefresh` included the navigation refresh callback in the dependency chain for its selected-thread PR probe. A navigation refresh could therefore change callback identity, restart the PR probe effect, and trigger another navigation refresh.

## Changes

- Stabilize the public `navigation.refresh` callback returned by `useThreadNavigation`.
- Store `onRefreshNavigation` in a ref inside `usePullRequestRefresh` so callback prop changes do not restart selected-thread PR polling.
- Add regression coverage for both callback-stability cases.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
