### PR TITLE
feat(desktop): warn before enabling Full Access

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -129,6 +129,13 @@ test("stops the active turn after a queued access-mode change", async () => {
     await expect(accessMode).toHaveAttribute("data-value", "default");
     await accessMode.click();
     await app.window.getByRole("option", { name: "Full Access" }).click();
+    const fullAccessWarning = app.window.getByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    await expect(fullAccessWarning).toContainText("network access");
+    await fullAccessWarning
+      .getByRole("button", { name: "I Understand and Accept the Risks" })
+      .click();
 
     // Toggling access mode mid-turn queues the change at the resume
     // boundary instead of flipping immediately. The applied executionMode

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -644,6 +644,14 @@ test("directory launchpad keeps full access as the sticky default after user cha
       window: app.window,
       option: "Full Access",
     });
+    const fullAccessWarning = app.window.getByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    await expect(fullAccessWarning).toContainText("network access");
+    await expect(fullAccessWarning).toContainText("read/write access");
+    await fullAccessWarning
+      .getByRole("button", { name: "I Understand and Accept the Risks" })
+      .click();
     await expect(accessMode).toHaveAttribute("data-value", "full-access");
 
     await app.window

--- a/apps/desktop/e2e/execution-mode-routing.spec.ts
+++ b/apps/desktop/e2e/execution-mode-routing.spec.ts
@@ -53,6 +53,14 @@ test("applies the correct per-turn permission policy after execution mode toggle
     await app.window
       .getByRole("option", { name: "Full Access" })
       .click();
+    const fullAccessWarning = app.window.getByRole("dialog", {
+      name: "Enable Full Access?",
+    });
+    await expect(fullAccessWarning).toContainText("network access");
+    await expect(fullAccessWarning).toContainText("read/write access");
+    await fullAccessWarning
+      .getByRole("button", { name: "I Understand and Accept the Risks" })
+      .click();
     await expect(accessMode).toHaveAttribute("data-value", "full-access");
 
     await app.window

--- a/apps/desktop/e2e/execution-mode-routing.spec.ts
+++ b/apps/desktop/e2e/execution-mode-routing.spec.ts
@@ -58,6 +58,20 @@ test("applies the correct per-turn permission policy after execution mode toggle
     });
     await expect(fullAccessWarning).toContainText("network access");
     await expect(fullAccessWarning).toContainText("read/write access");
+    const [viewportSize, dialogBox] = await Promise.all([
+      app.window.evaluate(() => ({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      })),
+      fullAccessWarning.boundingBox(),
+    ]);
+    expect(dialogBox).not.toBeNull();
+    expect(
+      Math.abs(dialogBox!.x + dialogBox!.width / 2 - viewportSize.width / 2),
+    ).toBeLessThan(2);
+    await app.window.mouse.click(20, 20);
+    await expect(fullAccessWarning).toBeVisible();
+    await expect(accessMode).toHaveAttribute("data-value", "default");
     await fullAccessWarning
       .getByRole("button", { name: "I Understand and Accept the Risks" })
       .click();

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 import { desktopSettingsPatchToEdits } from "../settings/desktop-config";
 import { parseTomlTables } from "../settings/toml-editor";
 
+describe("desktopSettingsPatchToEdits — experimental", () => {
+  it("writes the Full Access risk warning dismissal flag", () => {
+    const edits = desktopSettingsPatchToEdits({
+      experimental: {
+        fullAccessRiskWarningDismissed: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["experimental", "full_access_risk_warning_dismissed"],
+        value: true,
+      },
+    ]);
+  });
+});
+
 describe("desktopSettingsPatchToEdits — Mattermost", () => {
   it("emits one set op per defined Mattermost field with the correct snake_case key", () => {
     const edits = desktopSettingsPatchToEdits({

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -908,6 +908,37 @@ describe("DesktopSettingsService", () => {
     expect(reverted.experimental.diffCondensation.enabled.value).toBe(true);
   });
 
+  it("defaults Full Access risk warning dismissal to false and persists it", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.experimental.fullAccessRiskWarningDismissed).toEqual({
+      value: false,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      experimental: {
+        fullAccessRiskWarningDismissed: true,
+      },
+    });
+
+    const updated = await service.readSettings();
+    expect(updated.experimental.fullAccessRiskWarningDismissed).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "full_access_risk_warning_dismissed = true",
+    );
+  });
+
   it("preserves unknown sections written by other builds when saving a patch", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -41,6 +41,7 @@ type StoredChatReplyComposer =
 export type DesktopSettingsConfig = {
   experimental?: {
     chatReplyComposer?: StoredChatReplyComposer;
+    fullAccessRiskWarningDismissed?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       model?: string;
@@ -273,6 +274,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "diff_condensation", "enabled"],
       patch.experimental.diffCondensation.enabled,
+    );
+  }
+  if (patch.experimental?.fullAccessRiskWarningDismissed !== undefined) {
+    set(
+      ["experimental", "full_access_risk_warning_dismissed"],
+      patch.experimental.fullAccessRiskWarningDismissed,
     );
   }
   if (patch.experimental?.diffCondensation?.model !== undefined) {
@@ -549,6 +556,9 @@ function normalizeDesktopConfig(
   return pruneEmptyConfig({
     experimental: {
       chatReplyComposer: readComposer(experimental?.chat_reply_composer),
+      fullAccessRiskWarningDismissed: readBoolean(
+        experimental?.full_access_risk_warning_dismissed,
+      ),
       diffCondensation: {
         enabled: readBoolean(diffCondensation?.enabled),
         model: readString(diffCondensation?.model),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -230,6 +230,10 @@ export class DesktopSettingsService {
         chatReplyComposer: this.resolveComposer(
           config.experimental?.chatReplyComposer,
         ),
+        fullAccessRiskWarningDismissed: this.resolveConfigBoolean(
+          config.experimental?.fullAccessRiskWarningDismissed,
+          false,
+        ),
         diffCondensation: {
           enabled: this.resolveDiffCondensationEnabled(
             config.experimental?.diffCondensation?.enabled,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -210,6 +210,10 @@ function DesktopAppShell(props: {
           selectedLaunchpad={navigation.selectedLaunchpad}
           selectedThread={navigation.selectedThread}
           directories={navigation.directories}
+          fullAccessRiskWarningDismissed={
+            settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ??
+            false
+          }
           pickDirectoryError={navigation.pickDirectoryError}
           pickingDirectory={navigation.pickingDirectory}
           onSelectDirectoryFromPicker={(directory) => {
@@ -232,6 +236,16 @@ function DesktopAppShell(props: {
           onActiveTurnIdChange={session.setActiveTurnId}
           onArchiveWorktree={navigation.archiveWorktree}
           onEnsureSkillsLoaded={skills.ensureLoaded}
+          onDismissFullAccessRiskWarning={async () => {
+            const saved = await settings.writeConfig({
+              experimental: {
+                fullAccessRiskWarningDismissed: true,
+              },
+            });
+            if (!saved) {
+              throw new Error("Could not save the Full Access warning preference.");
+            }
+          }}
           onOpenMessagingActivity={openMessagingActivityWindow}
           onHandoffThreadWorkspace={
             navigation.selectedThread

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -97,6 +97,10 @@ describe("App", () => {
           value: "tiptap-wysiwyg-markdown-chips",
           source: "default",
         },
+        fullAccessRiskWarningDismissed: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -84,7 +84,9 @@ type ComposerProps = {
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
   onActiveTurnIdChange?: (turnId?: string) => void;
+  fullAccessRiskWarningDismissed?: boolean;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
+  onDismissFullAccessRiskWarning?: () => Promise<void>;
   pendingRequestActive?: boolean;
   pendingUserInputActive?: boolean;
   onMaterializeLaunchpad?: (
@@ -978,6 +980,12 @@ export function Composer(props: ComposerProps) {
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
+  const [fullAccessRiskDialogOpen, setFullAccessRiskDialogOpen] =
+    useState(false);
+  const [fullAccessRiskDontWarnAgain, setFullAccessRiskDontWarnAgain] =
+    useState(false);
+  const [fullAccessRiskSaving, setFullAccessRiskSaving] = useState(false);
+  const [fullAccessRiskError, setFullAccessRiskError] = useState<string>();
   const [autocompleteLayout, setAutocompleteLayout] = useState<{
     maxHeight: number;
     placement: "above" | "below";
@@ -2471,6 +2479,61 @@ export function Composer(props: ComposerProps) {
     }, 0);
   };
 
+  const applyExecutionModeSelection = (
+    executionMode: ThreadExecutionMode,
+  ): void => {
+    if (props.launchpad) {
+      if (props.launchpad.executionMode !== executionMode) {
+        handleLaunchpadPatch({ executionMode });
+      }
+      return;
+    }
+
+    if (
+      props.thread &&
+      props.thread.executionMode !== executionMode &&
+      !props.updatingExecutionMode
+    ) {
+      setSendError(undefined);
+      void props.onSetExecutionMode?.(executionMode);
+    }
+  };
+
+  const requestExecutionModeSelection = (
+    executionMode: ThreadExecutionMode,
+  ): void => {
+    const currentExecutionMode =
+      props.launchpad?.executionMode ?? props.thread?.executionMode ?? "default";
+    if (
+      currentExecutionMode === "default" &&
+      executionMode === "full-access" &&
+      !props.fullAccessRiskWarningDismissed
+    ) {
+      setFullAccessRiskDontWarnAgain(false);
+      setFullAccessRiskError(undefined);
+      setFullAccessRiskDialogOpen(true);
+      return;
+    }
+
+    applyExecutionModeSelection(executionMode);
+  };
+
+  const confirmFullAccessRisk = async (): Promise<void> => {
+    setFullAccessRiskSaving(true);
+    setFullAccessRiskError(undefined);
+    try {
+      if (fullAccessRiskDontWarnAgain) {
+        await props.onDismissFullAccessRiskWarning?.();
+      }
+      setFullAccessRiskDialogOpen(false);
+      applyExecutionModeSelection("full-access");
+    } catch (error) {
+      setFullAccessRiskError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setFullAccessRiskSaving(false);
+    }
+  };
+
   const handleThreadModelSettingsPatch = (
     patch: Partial<
       Pick<
@@ -3363,20 +3426,7 @@ export function Composer(props: ComposerProps) {
               }))}
               onChange={(value) => {
                 const executionMode = value as ThreadExecutionMode;
-                if (props.launchpad) {
-                  if (props.launchpad.executionMode !== executionMode) {
-                    handleLaunchpadPatch({ executionMode });
-                  }
-                  return;
-                }
-
-                if (
-                  props.thread &&
-                  props.thread.executionMode !== executionMode &&
-                  !props.updatingExecutionMode
-                ) {
-                  void props.onSetExecutionMode?.(executionMode);
-                }
+                requestExecutionModeSelection(executionMode);
               }}
             />
           ) : null}
@@ -3876,6 +3926,80 @@ export function Composer(props: ComposerProps) {
           </button>
         </div>
       </div>
+
+      {fullAccessRiskDialogOpen ? (
+        <div className="full-access-warning-modal">
+          <div
+            aria-labelledby="full-access-warning-title"
+            aria-modal="true"
+            className="full-access-warning-dialog"
+            role="dialog"
+          >
+            <div className="full-access-warning-dialog__header">
+              <h2 id="full-access-warning-title">Enable Full Access?</h2>
+              <button
+                aria-label="Cancel Full Access warning"
+                className="workspace-handoff-dialog__close"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  setFullAccessRiskDialogOpen(false);
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <p>
+              Full Access allows network access and read/write access to almost
+              all files on this machine.
+            </p>
+            <p>
+              That means data can be exfiltrated unintentionally, or by
+              malicious code the agent downloads and executes through a supply
+              chain attack on npm, PyPI, Rust crates, Go modules, or a similar
+              dependency source.
+            </p>
+            <label className="composer__checkbox full-access-warning-dialog__checkbox">
+              <input
+                checked={fullAccessRiskDontWarnAgain}
+                disabled={fullAccessRiskSaving}
+                type="checkbox"
+                onChange={(event) =>
+                  setFullAccessRiskDontWarnAgain(event.currentTarget.checked)
+                }
+              />
+              <span>Do not warn me again on this desktop.</span>
+            </label>
+            {fullAccessRiskError ? (
+              <p className="full-access-warning-dialog__error" role="alert">
+                {fullAccessRiskError}
+              </p>
+            ) : null}
+            <div className="full-access-warning-dialog__actions">
+              <button
+                className="button button--secondary"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  setFullAccessRiskDialogOpen(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--primary"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  void confirmFullAccessRisk();
+                }}
+              >
+                I Understand and Accept the Risks
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </form>
   );
 }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { flushSync } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 import type { JSONContent } from "@tiptap/react";
 import type {
   AppServerCollaborationModeRequest,
@@ -2938,16 +2938,94 @@ export function Composer(props: ComposerProps) {
     handlePlainComposerKeyDown(event);
   };
 
+  const fullAccessRiskDialog = fullAccessRiskDialogOpen
+    ? createPortal(
+        <div className="full-access-warning-modal">
+          <div
+            aria-labelledby="full-access-warning-title"
+            aria-modal="true"
+            className="full-access-warning-dialog"
+            role="dialog"
+          >
+            <div className="full-access-warning-dialog__header">
+              <h2 id="full-access-warning-title">Enable Full Access?</h2>
+              <button
+                aria-label="Cancel Full Access warning"
+                className="workspace-handoff-dialog__close"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  setFullAccessRiskDialogOpen(false);
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <p>
+              Full Access allows network access and read/write access to almost
+              all files on this machine.
+            </p>
+            <p>
+              That means data can be exfiltrated unintentionally, or by
+              malicious code the agent downloads and executes through a supply
+              chain attack on npm, PyPI, Rust crates, Go modules, or a similar
+              dependency source.
+            </p>
+            <label className="composer__checkbox full-access-warning-dialog__checkbox">
+              <input
+                checked={fullAccessRiskDontWarnAgain}
+                disabled={fullAccessRiskSaving}
+                type="checkbox"
+                onChange={(event) =>
+                  setFullAccessRiskDontWarnAgain(event.currentTarget.checked)
+                }
+              />
+              <span>Do not warn me again on this desktop.</span>
+            </label>
+            {fullAccessRiskError ? (
+              <p className="full-access-warning-dialog__error" role="alert">
+                {fullAccessRiskError}
+              </p>
+            ) : null}
+            <div className="full-access-warning-dialog__actions">
+              <button
+                className="button button--secondary"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  setFullAccessRiskDialogOpen(false);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--primary"
+                disabled={fullAccessRiskSaving}
+                type="button"
+                onClick={() => {
+                  void confirmFullAccessRisk();
+                }}
+              >
+                I Understand and Accept the Risks
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
+
   return (
-    <form
-      className="composer"
-      data-composer-implementation="tiptap-wysiwyg-markdown-chips"
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submitTurn();
-      }}
-    >
-      {/* Issue #240: removed the visible "Reply" / "New thread" /
+    <>
+      <form
+        className="composer"
+        data-composer-implementation="tiptap-wysiwyg-markdown-chips"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submitTurn();
+        }}
+      >
+        {/* Issue #240: removed the visible "Reply" / "New thread" /
           "Review" eyebrow that used to sit above the composer. The
           input itself carries the same name through its `aria-label`
           (the `label` prop on the inner ComposerRichInput /
@@ -3926,81 +4004,9 @@ export function Composer(props: ComposerProps) {
           </button>
         </div>
       </div>
-
-      {fullAccessRiskDialogOpen ? (
-        <div className="full-access-warning-modal">
-          <div
-            aria-labelledby="full-access-warning-title"
-            aria-modal="true"
-            className="full-access-warning-dialog"
-            role="dialog"
-          >
-            <div className="full-access-warning-dialog__header">
-              <h2 id="full-access-warning-title">Enable Full Access?</h2>
-              <button
-                aria-label="Cancel Full Access warning"
-                className="workspace-handoff-dialog__close"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  setFullAccessRiskDialogOpen(false);
-                }}
-              >
-                ×
-              </button>
-            </div>
-            <p>
-              Full Access allows network access and read/write access to almost
-              all files on this machine.
-            </p>
-            <p>
-              That means data can be exfiltrated unintentionally, or by
-              malicious code the agent downloads and executes through a supply
-              chain attack on npm, PyPI, Rust crates, Go modules, or a similar
-              dependency source.
-            </p>
-            <label className="composer__checkbox full-access-warning-dialog__checkbox">
-              <input
-                checked={fullAccessRiskDontWarnAgain}
-                disabled={fullAccessRiskSaving}
-                type="checkbox"
-                onChange={(event) =>
-                  setFullAccessRiskDontWarnAgain(event.currentTarget.checked)
-                }
-              />
-              <span>Do not warn me again on this desktop.</span>
-            </label>
-            {fullAccessRiskError ? (
-              <p className="full-access-warning-dialog__error" role="alert">
-                {fullAccessRiskError}
-              </p>
-            ) : null}
-            <div className="full-access-warning-dialog__actions">
-              <button
-                className="button button--secondary"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  setFullAccessRiskDialogOpen(false);
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                className="button button--primary"
-                disabled={fullAccessRiskSaving}
-                type="button"
-                onClick={() => {
-                  void confirmFullAccessRisk();
-                }}
-              >
-                I Understand and Accept the Risks
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </form>
+      </form>
+      {fullAccessRiskDialog}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2754,6 +2754,8 @@ describe("Composer", () => {
     chooseDropdownOption("Access mode", "Full Access");
 
     const dialog = screen.getByRole("dialog", { name: "Enable Full Access?" });
+    expect(dialog.closest(".composer")).toBeNull();
+    expect(dialog.closest(".full-access-warning-modal")).not.toBeNull();
     expect(dialog).toHaveTextContent("network access");
     expect(dialog).toHaveTextContent("read/write access to almost all files");
     expect(dialog).toHaveTextContent("supply chain attack");

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2635,6 +2635,7 @@ describe("Composer", () => {
           }),
         }}
         disabled={false}
+        fullAccessRiskWarningDismissed
         directory={{
           key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
           kind: "directory",
@@ -2705,6 +2706,118 @@ describe("Composer", () => {
 
     chooseDropdownOption("Access mode", "Full Access");
 
+    await waitFor(() => {
+      expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
+  it("requires confirmation before switching a thread from Default Access to Full Access", async () => {
+    const onSetExecutionMode = vi.fn(async () => undefined);
+    const onDismissFullAccessRiskWarning = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("codex"),
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        disabled={false}
+        onDismissFullAccessRiskWarning={onDismissFullAccessRiskWarning}
+        onSetExecutionMode={onSetExecutionMode}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Risky switch",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    chooseDropdownOption("Access mode", "Full Access");
+
+    const dialog = screen.getByRole("dialog", { name: "Enable Full Access?" });
+    expect(dialog).toHaveTextContent("network access");
+    expect(dialog).toHaveTextContent("read/write access to almost all files");
+    expect(dialog).toHaveTextContent("supply chain attack");
+    expect(onSetExecutionMode).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      within(dialog).getByLabelText("Do not warn me again on this desktop."),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "I Understand and Accept the Risks",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onDismissFullAccessRiskWarning).toHaveBeenCalledTimes(1);
+      expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
+  it("skips the Full Access warning after it has been dismissed", async () => {
+    const onSetExecutionMode = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("codex"),
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        disabled={false}
+        fullAccessRiskWarningDismissed
+        onSetExecutionMode={onSetExecutionMode}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Risk accepted",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    chooseDropdownOption("Access mode", "Full Access");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Enable Full Access?" }),
+    ).not.toBeInTheDocument();
     await waitFor(() => {
       expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -51,6 +51,10 @@ function createSnapshot(
         value: "tiptap-wysiwyg-markdown-chips",
         source: "default",
       },
+      fullAccessRiskWarningDismissed: {
+        value: false,
+        source: "default",
+      },
       diffCondensation: {
         enabled: { value: false, source: "default" },
         model: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -604,6 +604,7 @@ type ThreadViewProps = {
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
+  fullAccessRiskWarningDismissed?: boolean;
   /**
    * Project-directory picker (issue #223) — surfaced in the launchpad
    * composer when no thread is selected yet. Rendering happens inside
@@ -627,6 +628,7 @@ type ThreadViewProps = {
   updatingExecutionMode?: ThreadExecutionMode;
   onActiveTurnIdChange?: (turnId?: string) => void;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
+  onDismissFullAccessRiskWarning?: () => Promise<void>;
   /** Forwarded to ThreadHeader → MessagingStatusBar — opens the Activity screen. */
   onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
   onLoadOlder: () => Promise<void>;
@@ -1530,7 +1532,13 @@ export function ThreadView(props: ThreadViewProps) {
               disabled={!launchpadBackend?.available}
               launchpad={selectedLaunchpad}
               launchpadError={props.launchpadError}
+              fullAccessRiskWarningDismissed={
+                props.fullAccessRiskWarningDismissed
+              }
               onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+              onDismissFullAccessRiskWarning={
+                props.onDismissFullAccessRiskWarning
+              }
               onMaterializeLaunchpad={handleMaterializeLaunchpad}
               onUpdateLaunchpad={props.onUpdateLaunchpad}
               onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
@@ -1626,7 +1634,13 @@ export function ThreadView(props: ThreadViewProps) {
             directory={props.selectedDirectory}
             disabled={props.composerDisabled}
             contextWindow={props.contextWindow}
+            fullAccessRiskWarningDismissed={
+              props.fullAccessRiskWarningDismissed
+            }
             onActiveTurnIdChange={props.onActiveTurnIdChange}
+            onDismissFullAccessRiskWarning={
+              props.onDismissFullAccessRiskWarning
+            }
             onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
             onPendingStatusChange={props.onPendingStatusChange}
             onHandoffThreadWorkspace={props.onHandoffThreadWorkspace}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7050,15 +7050,26 @@ textarea,
   justify-content: center;
   padding: 24px;
   background: rgb(0 0 0 / 62%);
+  isolation: isolate;
 }
 
 .full-access-warning-dialog {
-  width: min(560px, 100%);
+  position: relative;
+  overflow: hidden;
+  width: min(560px, calc(100vw - 48px));
   padding: 16px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+}
+
+.full-access-warning-dialog::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--accent);
+  content: "";
 }
 
 .full-access-warning-dialog__header {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7041,6 +7041,62 @@ textarea,
   line-height: 1.25;
 }
 
+.full-access-warning-modal {
+  position: fixed;
+  z-index: 110;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgb(0 0 0 / 62%);
+}
+
+.full-access-warning-dialog {
+  width: min(560px, 100%);
+  padding: 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.full-access-warning-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.full-access-warning-dialog h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.full-access-warning-dialog p {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.full-access-warning-dialog__checkbox {
+  margin-top: 14px;
+}
+
+.full-access-warning-dialog__error {
+  color: var(--danger-text);
+}
+
+.full-access-warning-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
 .composer__checkbox {
   display: inline-flex;
   align-items: center;

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -23,6 +23,10 @@ describe("desktop settings contracts", () => {
           value: "tiptap-wysiwyg-markdown-chips",
           source: "default",
         },
+        fullAccessRiskWarningDismissed: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -248,6 +248,7 @@ export type DesktopSettingsSnapshot = {
   secretStorage: DesktopSettingsSecretStorageState;
   experimental: {
     chatReplyComposer: DesktopSettingsValue<DesktopChatReplyComposer>;
+    fullAccessRiskWarningDismissed: DesktopSettingsValue<boolean>;
     /**
      * Diff condensation (a.k.a. "diff eliding") gates whether we send
      * focused-diff requests to xAI. When enabled, less-relevant diff
@@ -343,6 +344,7 @@ export type DesktopSettingsSnapshot = {
 
 export type DesktopSettingsConfigPatch = {
   experimental?: {
+    fullAccessRiskWarningDismissed?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       /** "auto" or a specific model id. Empty string is coerced to "auto". */


### PR DESCRIPTION
## Summary

- I added a desktop confirmation dialog before switching a thread or launchpad from Default Access to Full Access.
- I made the dialog spell out the network, filesystem, exfiltration, and supply-chain risks, and require the user to accept them before Full Access is applied.
- I added a persisted desktop setting for "do not warn me again" and wired it through the settings snapshot, config writer, renderer shell, and composer.
- I moved the warning dialog into a body-level portal so it stays centered over the viewport, added the left warning rail, and covered outside-click behavior in E2E.
- I filed the messaging controls follow-up as #347.

## Verification

- I verified the focused desktop/settings test coverage passes:
  `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts packages/shared/src/contracts/__tests__/settings.test.ts`
- I verified the full workspace typecheck passes:
  `pnpm typecheck`
- I verified dependency boundaries pass:
  `pnpm lint:boundaries`
- I verified the affected replay-backed desktop E2E flows pass:
  `pnpm --filter @pwragent/desktop build && pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/approval-pending.spec.ts:116 e2e/directory-launchpad-workspace.spec.ts:627 e2e/execution-mode-routing.spec.ts`
- I verified the focused positioning/outside-click E2E assertion passes:
  `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/execution-mode-routing.spec.ts`

## Notes

- The commit is signed with the configured SSH signing key.
