### PR TITLE
chore(skills): add dev profile launcher

### DIFF
--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -29,6 +29,12 @@ Check whether the dev-profile app is running:
 .agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh status --root "$PWD"
 ```
 
+List the profile's recorded app instances and messaging lease owner:
+
+```bash
+.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh leases
+```
+
 Verify that a previously started instance is still up:
 
 ```bash
@@ -38,13 +44,14 @@ Verify that a previously started instance is still up:
 ## Workflow
 
 1. Run `status` first when the user asks what is running or when closing processes may be surprising.
-2. Run `restart` when the user asks to start the dev profile; it closes the prior managed dev-profile instance, starts `PWRAGENT_PROFILE=dev pnpm dev` detached from the checkout, and waits until the Electron dev process is visible.
+2. Run `restart` when the user asks to start the dev profile; it closes the prior managed dev-profile instance, starts `PWRAGENT_PROFILE=dev PWRAGENT_INSTANCE_ROOT="$PWD" pnpm dev` detached from the checkout, and waits until the app writes a matching profile runtime record.
 3. Run `close` when the user only wants the dev-profile app stopped.
 4. Relay the script output and the log path to the user. The default log is `.local/pwragent-dev-profile.log`.
 
 ## Script Notes
 
 - The script defaults to `--profile dev`, `--root "$PWD"`, `.local/pwragent-dev-profile.pid`, and `.local/pwragent-dev-profile.log`.
-- Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script records a PID file and makes later cleanup deterministic.
-- The script only targets the managed PID tree and root-scoped development commands such as `pnpm dev`, `electron-vite dev`, and Electron descendants. It does not kill arbitrary processes just because they are running under the same checkout.
+- Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script passes `PWRAGENT_INSTANCE_ROOT`, then uses the app's lease-backed runtime metadata in `~/.pwragent/profiles/dev/state/state.db` to find the Electron owner process.
+- The script only targets the app instance whose recorded root hash matches the requested checkout, plus that instance's bounded `pnpm dev` / `electron-vite` parent chain.
+- Use `leases` when debugging which process owns the profile messaging lease.
 - If verification fails, inspect the last log lines printed by the script before retrying.

--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pwragent-dev-profile
+description: Start, stop, restart, and verify the local PwrAgent Electron development app with `PWRAGENT_PROFILE=dev` from the current checkout. Use when Codex needs to close any running dev-profile PwrAgent instance, launch `pnpm dev` in the current working directory, or confirm the dev-profile app came up.
+---
+
+# PwrAgent Dev Profile
+
+Use this skill to manage the local PwrAgent Electron app for the `dev` profile from the checkout Codex is currently working in.
+
+## Commands
+
+Run commands from the repository root unless the user asks for a different checkout.
+
+Start or restart the dev-profile app:
+
+```bash
+.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh restart --root "$PWD"
+```
+
+Close the dev-profile app if it is running:
+
+```bash
+.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh close --root "$PWD"
+```
+
+Check whether the dev-profile app is running:
+
+```bash
+.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh status --root "$PWD"
+```
+
+Verify that a previously started instance is still up:
+
+```bash
+.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh verify --root "$PWD"
+```
+
+## Workflow
+
+1. Run `status` first when the user asks what is running or when closing processes may be surprising.
+2. Run `restart` when the user asks to start the dev profile; it closes the prior managed dev-profile instance, starts `PWRAGENT_PROFILE=dev pnpm dev` detached from the checkout, and waits until the Electron dev process is visible.
+3. Run `close` when the user only wants the dev-profile app stopped.
+4. Relay the script output and the log path to the user. The default log is `.local/pwragent-dev-profile.log`.
+
+## Script Notes
+
+- The script defaults to `--profile dev`, `--root "$PWD"`, `.local/pwragent-dev-profile.pid`, and `.local/pwragent-dev-profile.log`.
+- Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script records a PID file and makes later cleanup deterministic.
+- The script only targets the managed PID tree and root-scoped development commands such as `pnpm dev`, `electron-vite dev`, and Electron descendants. It does not kill arbitrary processes just because they are running under the same checkout.
+- If verification fails, inspect the last log lines printed by the script before retrying.

--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -51,7 +51,8 @@ Verify that a previously started instance is still up:
 ## Script Notes
 
 - The script defaults to `--profile dev`, `--root "$PWD"`, `.local/pwragent-dev-profile.pid`, and `.local/pwragent-dev-profile.log`.
-- Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script passes `PWRAGENT_INSTANCE_ROOT`, then uses the app's lease-backed runtime metadata in `~/.pwragent/profiles/dev/state/state.db` to find the Electron owner process.
+- Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script passes `PWRAGENT_INSTANCE_ROOT`, starts a detached daemon helper, then uses the app's lease-backed runtime metadata in `~/.pwragent/profiles/dev/state/state.db` to find the Electron owner process.
+- The detached daemon helper stops the `pnpm dev` supervisor when the first lease-backed Electron instance it started exits, so closing the spawned app does not leave a dev supervisor relaunching it.
 - The script only targets the app instance whose recorded root hash matches the requested checkout, plus that instance's bounded `pnpm dev` / `electron-vite` parent chain.
 - Use `leases` when debugging which process owns the profile messaging lease.
 - If verification fails, inspect the last log lines printed by the script before retrying.

--- a/.agents/skills/pwragent-dev-profile/agents/openai.yaml
+++ b/.agents/skills/pwragent-dev-profile/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PwrAgent Dev Profile"
+  short_description: "Start the local dev profile app"
+  default_prompt: "Use $pwragent-dev-profile to restart the PwrAgent app in the dev profile from this checkout."

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+
+const INSTANCE_ROOT_ENV = "PWRAGENT_INSTANCE_ROOT";
+
+function parseArgs(argv) {
+  const options = { daemonize: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--daemonize") {
+      options.daemonize = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) throw new Error(`unknown argument: ${arg}`);
+    const key = arg.slice(2).replace(/-([a-z])/g, (_match, value) => value.toUpperCase());
+    const value = argv[index + 1];
+    if (!value) throw new Error(`${arg} requires a value`);
+    options[key] = value;
+    index += 1;
+  }
+  for (const key of ["root", "profile", "rootHash", "stateDb", "log", "pidFile", "startedAfter"]) {
+    if (!options[key]) throw new Error(`missing --${key.replace(/[A-Z]/g, (value) => `-${value.toLowerCase()}`)}`);
+  }
+  return options;
+}
+
+function appendLog(logPath, message) {
+  fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`);
+}
+
+function daemonize(options) {
+  const args = process.argv.slice(1).filter((arg) => arg !== "--daemonize");
+  const out = fs.openSync(options.log, "a");
+  const child = spawn(process.execPath, args, {
+    cwd: options.root,
+    detached: true,
+    env: process.env,
+    stdio: ["ignore", out, out],
+  });
+  child.unref();
+  fs.writeFileSync(options.pidFile, `${child.pid}\n`);
+  process.stdout.write(`${child.pid}\n`);
+}
+
+function sqliteValue(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+function readStartedInstance(options, trackedInstanceId) {
+  if (!fs.existsSync(options.stateDb)) return null;
+  const selector = trackedInstanceId
+    ? `instance_id = '${sqliteValue(trackedInstanceId)}'`
+    : `profile_name = '${sqliteValue(options.profile)}' AND cwd_hash = '${sqliteValue(options.rootHash)}' AND heartbeat_at >= ${Number(options.startedAfter)} AND exited_at IS NULL`;
+  const sql = `SELECT instance_id, process_id, coalesce(exited_at, '') FROM app_runtime_instances WHERE ${selector} ORDER BY heartbeat_at DESC LIMIT 1;`;
+  const result = spawnSync("sqlite3", ["-readonly", "-separator", "\t", options.stateDb, sql], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) return null;
+  const line = result.stdout.trim();
+  if (!line) return null;
+  const [instanceId, processId, exitedAt] = line.split("\t");
+  return { instanceId, processId: Number(processId), exitedAt };
+}
+
+function pidIsLive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function terminateProcessGroup(pid, signal) {
+  if (!pid) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+async function run(options) {
+  appendLog(options.log, `daemon start root=${options.root} profile=${options.profile} rootHash=${options.rootHash}`);
+  fs.writeFileSync(options.pidFile, `${process.pid}\n`);
+
+  const out = fs.openSync(options.log, "a");
+  const child = spawn("/bin/zsh", ["-lc", "exec pnpm dev"], {
+    cwd: options.root,
+    detached: true,
+    env: {
+      ...process.env,
+      PWRAGENT_PROFILE: options.profile,
+      [INSTANCE_ROOT_ENV]: options.root,
+    },
+    stdio: ["ignore", out, out],
+  });
+
+  let stopping = false;
+  const stop = (reason) => {
+    if (stopping) return;
+    stopping = true;
+    appendLog(options.log, `daemon stopping reason=${reason} childPid=${child.pid}`);
+    terminateProcessGroup(child.pid, "SIGTERM");
+    setTimeout(() => {
+      terminateProcessGroup(child.pid, "SIGKILL");
+      process.exit(0);
+    }, 5_000).unref();
+  };
+
+  process.on("SIGTERM", () => stop("sigterm"));
+  process.on("SIGINT", () => stop("sigint"));
+  process.on("SIGHUP", () => stop("sighup"));
+  child.on("exit", (code, signal) => {
+    appendLog(options.log, `pnpm dev exited code=${code ?? ""} signal=${signal ?? ""}`);
+    process.exit(code ?? 0);
+  });
+
+  let trackedInstanceId = null;
+  let trackedProcessId = null;
+  const monitor = setInterval(() => {
+    const instance = readStartedInstance(options, trackedInstanceId);
+    if (!instance) return;
+    if (!trackedInstanceId) {
+      trackedInstanceId = instance.instanceId;
+      trackedProcessId = instance.processId;
+      appendLog(options.log, `tracking app instance id=${trackedInstanceId} pid=${trackedProcessId}`);
+      return;
+    }
+    if (instance.exitedAt) {
+      stop(`app-exited instance=${trackedInstanceId}`);
+      return;
+    }
+    if (trackedProcessId && !pidIsLive(trackedProcessId)) {
+      stop(`app-pid-exited instance=${trackedInstanceId} pid=${trackedProcessId}`);
+    }
+  }, 500);
+  monitor.unref();
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  fs.mkdirSync(path.dirname(options.log), { recursive: true });
+  fs.mkdirSync(path.dirname(options.pidFile), { recursive: true });
+  if (options.daemonize) {
+    daemonize(options);
+  } else {
+    await run(options);
+  }
+} catch (error) {
+  console.error(`pwragent-dev-profile-daemon: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
@@ -50,9 +50,11 @@ function sqliteValue(value) {
 
 function readStartedInstance(options, trackedInstanceId) {
   if (!fs.existsSync(options.stateDb)) return null;
+  const candidatePids = trackedInstanceId ? [] : electronDescendantPids(Number(options.childPid));
+  if (!trackedInstanceId && candidatePids.length === 0) return null;
   const selector = trackedInstanceId
     ? `instance_id = '${sqliteValue(trackedInstanceId)}'`
-    : `profile_name = '${sqliteValue(options.profile)}' AND cwd_hash = '${sqliteValue(options.rootHash)}' AND heartbeat_at >= ${Number(options.startedAfter)} AND exited_at IS NULL`;
+    : `profile_name = '${sqliteValue(options.profile)}' AND cwd_hash = '${sqliteValue(options.rootHash)}' AND heartbeat_at >= ${Number(options.startedAfter)} AND process_id IN (${candidatePids.join(",")}) AND exited_at IS NULL`;
   const sql = `SELECT instance_id, process_id, coalesce(exited_at, '') FROM app_runtime_instances WHERE ${selector} ORDER BY heartbeat_at DESC LIMIT 1;`;
   const result = spawnSync("sqlite3", ["-readonly", "-separator", "\t", options.stateDb, sql], {
     encoding: "utf8",
@@ -62,6 +64,27 @@ function readStartedInstance(options, trackedInstanceId) {
   if (!line) return null;
   const [instanceId, processId, exitedAt] = line.split("\t");
   return { instanceId, processId: Number(processId), exitedAt };
+}
+
+function electronDescendantPids(rootPid) {
+  return descendantPids(rootPid).filter((pid) => {
+    const result = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf8",
+    });
+    return result.status === 0
+      && result.stdout.includes("Electron.app/Contents/MacOS/Electron");
+  });
+}
+
+function descendantPids(rootPid) {
+  if (!rootPid) return [];
+  const result = spawnSync("pgrep", ["-P", String(rootPid)], { encoding: "utf8" });
+  if (result.status !== 0) return [];
+  return result.stdout
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((value) => Number(value))
+    .flatMap((pid) => [pid, ...descendantPids(pid)]);
 }
 
 function pidIsLive(pid) {
@@ -102,6 +125,7 @@ async function run(options) {
     },
     stdio: ["ignore", out, out],
   });
+  options.childPid = child.pid;
 
   let stopping = false;
   const stop = (reason) => {

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -2,6 +2,8 @@
 set -u
 
 INSTANCE_ROOT_ENV="PWRAGENT_INSTANCE_ROOT"
+SCRIPT_SOURCE="${(%):-%x}"
+SCRIPT_DIR="${SCRIPT_SOURCE:A:h}"
 
 usage() {
   cat <<'USAGE'
@@ -106,6 +108,7 @@ is_dev_command() {
   local command="$1"
   [[ "$command" == *"pnpm dev"* ]] && return 0
   [[ "$command" == *"pnpm --filter @pwragent/desktop dev"* ]] && return 0
+  [[ "$command" == *"pwragent-dev-profile-daemon.mjs"* ]] && return 0
   [[ "$command" == *"electron-vite"* && "$command" == *"dev"* ]] && return 0
   [[ "$command" == *"scripts/rebuild-native-for-electron.mjs"* ]] && return 0
   [[ "$command" == *"Electron.app"* && "$command" == *"apps/desktop"* ]] && return 0
@@ -456,30 +459,23 @@ verify_app() {
 }
 
 start_app() {
-  local start_pid command
+  local start_pid helper_path started_after
 
   [[ -f "$root/package.json" ]] || die "root does not look like the PwrAgent repository root: $root"
   mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
+  helper_path="$SCRIPT_DIR/pwragent-dev-profile-daemon.mjs"
+  [[ -f "$helper_path" ]] || die "missing daemon helper: $helper_path"
 
   close_app
 
+  started_after="$(( $(date +%s) * 1000 ))"
   log_line "start root=$root profile=$profile rootHash=$root_hash_value command=PWRAGENT_PROFILE=$profile $INSTANCE_ROOT_ENV=$root pnpm dev" >> "$log_path"
-  command="trap '' HUP TERM; cd $(shell_quote "$root") && exec env PWRAGENT_PROFILE=$(shell_quote "$profile") $INSTANCE_ROOT_ENV=$(shell_quote "$root") pnpm dev"
-
-  if [[ "$(uname -s)" == "Darwin" ]] && command -v launchctl >/dev/null 2>&1; then
-    launchctl submit -l "$(launch_job_label)" -o "$log_path" -e "$log_path" -- /bin/zsh -lc "$command" \
-      || die "failed to submit launchd job: $(launch_job_label)"
-    sleep 1
-    start_pid="$(launch_job_pid)"
-  else
-    nohup /bin/zsh -lc "$command" </dev/null >> "$log_path" 2>&1 &
-    start_pid="$!"
-    disown "$start_pid" 2>/dev/null || true
-  fi
+  start_pid="$(node "$helper_path" --daemonize --root "$root" --profile "$profile" --root-hash "$root_hash_value" --state-db "$state_db" --log "$log_path" --pid-file "$pid_file" --started-after "$started_after")" \
+    || die "failed to start detached daemon helper"
 
   print -r -- "$start_pid" > "$pid_file"
 
-  say "started $profile profile dev app supervisor pid=${start_pid:-unknown} label=$(launch_job_label)"
+  say "started $profile profile dev app daemon pid=${start_pid:-unknown}"
   say "log: $log_path"
   verify_app
 }

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -1,0 +1,364 @@
+#!/bin/zsh
+set -u
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  pwragent-dev-profile.zsh start   [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH] [--timeout SECONDS]
+  pwragent-dev-profile.zsh restart [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH] [--timeout SECONDS]
+  pwragent-dev-profile.zsh close   [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
+  pwragent-dev-profile.zsh status  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
+  pwragent-dev-profile.zsh verify  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH] [--timeout SECONDS]
+
+Manages a detached local PwrAgent Electron dev app with PWRAGENT_PROFILE=dev.
+The default root is the current working directory.
+USAGE
+}
+
+timestamp() {
+  date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+shell_quote() {
+  printf "%q" "$1"
+}
+
+say() {
+  print -r -- "pwragent-dev-profile: $*"
+}
+
+log_line() {
+  print -r -- "[$(timestamp)] $*"
+}
+
+die() {
+  print -u2 -r -- "pwragent-dev-profile: $*"
+  exit 1
+}
+
+process_command() {
+  ps -p "$1" -o command= 2>/dev/null
+}
+
+process_with_env() {
+  ps eww -p "$1" -o command= 2>/dev/null
+}
+
+parent_pid() {
+  ps -p "$1" -o ppid= 2>/dev/null | tr -d ' '
+}
+
+cwd_of_pid() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
+is_live_pid() {
+  [[ -n "${1:-}" ]] && kill -0 "$1" 2>/dev/null
+}
+
+is_self_or_parent() {
+  [[ "$1" == "$$" || "$1" == "$PPID" ]]
+}
+
+is_under_root() {
+  local value="$1"
+  [[ "$value" == "$root" || "$value" == "$root/"* ]]
+}
+
+command_mentions_root() {
+  [[ "$1" == *"$root"* ]]
+}
+
+process_has_profile() {
+  local command_with_env
+
+  command_with_env="$(process_with_env "$1")"
+  [[ "$command_with_env" == *"PWRAGENT_PROFILE=$profile"* ]]
+}
+
+is_dev_command() {
+  local command="$1"
+  [[ "$command" == *"pnpm dev"* ]] && return 0
+  [[ "$command" == *"pnpm --filter @pwragent/desktop dev"* ]] && return 0
+  [[ "$command" == *"electron-vite"* && "$command" == *"dev"* ]] && return 0
+  [[ "$command" == *"scripts/rebuild-native-for-electron.mjs"* ]] && return 0
+  [[ "$command" == *"Electron.app"* && "$command" == *"apps/desktop"* ]] && return 0
+  [[ "$command" == *"PwrAgent"* && "$command" == *"apps/desktop"* ]] && return 0
+  return 1
+}
+
+pid_is_root_scoped_dev() {
+  local pid="$1"
+  local command cwd
+
+  is_self_or_parent "$pid" && return 1
+
+  command="$(process_command "$pid")"
+  [[ -n "$command" ]] || return 1
+  is_dev_command "$command" || return 1
+  process_has_profile "$pid" || return 1
+
+  cwd="$(cwd_of_pid "$pid")"
+  if [[ -n "$cwd" ]] && is_under_root "$cwd"; then
+    return 0
+  fi
+
+  command_mentions_root "$command"
+}
+
+descendants_of() {
+  local parent="$1"
+  local child
+
+  pgrep -P "$parent" 2>/dev/null | while read -r child; do
+    [[ -z "$child" ]] && continue
+    print -r -- "$child"
+    descendants_of "$child"
+  done
+}
+
+pid_file_pids() {
+  local managed_pid
+
+  [[ -f "$pid_file" ]] || return 0
+  managed_pid="$(tr -dc '0-9' < "$pid_file")"
+  [[ -n "$managed_pid" ]] || return 0
+  is_self_or_parent "$managed_pid" && return 0
+
+  if is_live_pid "$managed_pid" && pid_is_root_scoped_dev "$managed_pid"; then
+    print -r -- "$managed_pid"
+    descendants_of "$managed_pid"
+  fi
+}
+
+matching_dev_pids() {
+  local pid parent command
+
+  {
+    pid_file_pids
+    pgrep -f 'pnpm.*dev|electron-vite.*dev|scripts/rebuild-native-for-electron.mjs|Electron.app|PwrAgent' 2>/dev/null | while read -r pid; do
+      [[ -z "$pid" ]] && continue
+      if pid_is_root_scoped_dev "$pid"; then
+        print -r -- "$pid"
+        descendants_of "$pid"
+
+        parent="$(parent_pid "$pid")"
+        while [[ -n "$parent" && "$parent" != "0" && "$parent" != "1" ]]; do
+          is_self_or_parent "$parent" && break
+          command="$(process_command "$parent")"
+          if [[ -n "$command" ]] && is_dev_command "$command"; then
+            print -r -- "$parent"
+            parent="$(parent_pid "$parent")"
+          else
+            break
+          fi
+        done
+      fi
+    done
+  } | sort -rnu
+}
+
+describe_pids() {
+  local pid
+
+  for pid in $(matching_dev_pids); do
+    ps -p "$pid" -o pid=,ppid=,command= 2>/dev/null || true
+  done
+}
+
+write_status() {
+  local rows
+
+  rows="$(describe_pids)"
+  if [[ -z "$rows" ]]; then
+    say "no $profile profile dev app processes found for $root"
+    return 1
+  fi
+
+  say "$profile profile dev app processes for $root:"
+  print -r -- "$rows"
+  return 0
+}
+
+stop_matches() {
+  local signal="$1"
+  local pid
+
+  for pid in $(matching_dev_pids); do
+    log_line "$signal pid=$pid"
+    kill "-$signal" "$pid" 2>/dev/null || true
+  done
+}
+
+close_app() {
+  local remaining
+
+  mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
+  log_line "close root=$root profile=$profile" >> "$log_path"
+
+  if [[ -z "$(matching_dev_pids)" ]]; then
+    rm -f "$pid_file"
+    say "no $profile profile dev app processes found for $root"
+    return 0
+  fi
+
+  stop_matches TERM >> "$log_path"
+  sleep 5
+
+  remaining="$(matching_dev_pids)"
+  if [[ -n "$remaining" ]]; then
+    stop_matches KILL >> "$log_path"
+  fi
+
+  rm -f "$pid_file"
+  say "closed $profile profile dev app for $root"
+}
+
+has_started_process() {
+  local pid command
+
+  for pid in $(matching_dev_pids); do
+    command="$(process_command "$pid")"
+    [[ "$command" == *"electron-vite"* && "$command" == *"dev"* ]] && return 0
+    [[ "$command" == *"Electron.app"* ]] && return 0
+    [[ "$command" == *"PwrAgent"* && "$command" == *"apps/desktop"* ]] && return 0
+  done
+
+  return 1
+}
+
+tail_log() {
+  if [[ -f "$log_path" ]]; then
+    tail -80 "$log_path"
+  else
+    say "log does not exist yet: $log_path"
+  fi
+}
+
+verify_app() {
+  local elapsed=0
+  local sleep_step=2
+  local managed_pid=""
+
+  [[ -f "$pid_file" ]] && managed_pid="$(tr -dc '0-9' < "$pid_file")"
+
+  while (( elapsed <= timeout )); do
+    if [[ -n "$managed_pid" ]] && ! is_live_pid "$managed_pid"; then
+      say "managed process exited before verification completed (pid=$managed_pid)"
+      tail_log
+      return 1
+    fi
+
+    if has_started_process; then
+      sleep 3
+      if [[ -z "$managed_pid" ]] || is_live_pid "$managed_pid"; then
+        say "$profile profile dev app is running for $root"
+        say "log: $log_path"
+        return 0
+      fi
+    fi
+
+    sleep "$sleep_step"
+    elapsed=$((elapsed + sleep_step))
+  done
+
+  say "timed out waiting ${timeout}s for $profile profile dev app to come up"
+  tail_log
+  return 1
+}
+
+start_app() {
+  local start_pid command
+
+  [[ -f "$root/package.json" ]] || die "root does not look like the PwrAgent repository root: $root"
+  mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
+
+  close_app
+
+  log_line "start root=$root profile=$profile command=PWRAGENT_PROFILE=$profile pnpm dev" >> "$log_path"
+  command="cd $(shell_quote "$root") && exec env PWRAGENT_PROFILE=$(shell_quote "$profile") pnpm dev"
+  nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &
+  start_pid="$!"
+  print -r -- "$start_pid" > "$pid_file"
+
+  say "started $profile profile dev app supervisor pid=$start_pid"
+  say "log: $log_path"
+  verify_app
+}
+
+mode="${1:-}"
+if [[ -z "$mode" || "$mode" == "--help" || "$mode" == "-h" ]]; then
+  usage
+  exit 0
+fi
+shift
+
+root="${PWD:A}"
+profile="dev"
+log_path=""
+pid_file=""
+timeout="120"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      [[ $# -ge 2 ]] || die "--root requires a path"
+      root="$2"
+      shift 2
+      ;;
+    --profile)
+      [[ $# -ge 2 ]] || die "--profile requires a name"
+      profile="$2"
+      shift 2
+      ;;
+    --log)
+      [[ $# -ge 2 ]] || die "--log requires a path"
+      log_path="$2"
+      shift 2
+      ;;
+    --pid-file)
+      [[ $# -ge 2 ]] || die "--pid-file requires a path"
+      pid_file="$2"
+      shift 2
+      ;;
+    --timeout)
+      [[ $# -ge 2 ]] || die "--timeout requires seconds"
+      timeout="$2"
+      shift 2
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$mode" == "start" || "$mode" == "restart" || "$mode" == "close" || "$mode" == "status" || "$mode" == "verify" ]] || die "unknown mode: $mode"
+[[ "$timeout" == <-> ]] || die "--timeout must be an integer number of seconds"
+
+root="${root:A}"
+[[ -d "$root" ]] || die "root does not exist: $root"
+
+if [[ -z "$log_path" ]]; then
+  log_path="$root/.local/pwragent-dev-profile.log"
+fi
+if [[ -z "$pid_file" ]]; then
+  pid_file="$root/.local/pwragent-dev-profile.pid"
+fi
+
+case "$mode" in
+  start)
+    start_app
+    ;;
+  restart)
+    start_app
+    ;;
+  close)
+    close_app
+    ;;
+  status)
+    write_status
+    ;;
+  verify)
+    verify_app
+    ;;
+esac

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -9,6 +9,7 @@ Usage:
   pwragent-dev-profile.zsh close   [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
   pwragent-dev-profile.zsh status  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
   pwragent-dev-profile.zsh verify  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH] [--timeout SECONDS]
+  pwragent-dev-profile.zsh self-test
 
 Manages a detached local PwrAgent Electron dev app with PWRAGENT_PROFILE=dev.
 The default root is the current working directory.
@@ -66,14 +67,51 @@ is_under_root() {
 }
 
 command_mentions_root() {
-  [[ "$1" == *"$root"* ]]
+  local command="$1"
+  local rest="$command"
+  local before after previous next
+
+  while [[ "$rest" == *"$root"* ]]; do
+    before="${rest%%"$root"*}"
+    after="${rest#*"$root"}"
+    previous="${before[-1]:-}"
+    next="${after[1]:-}"
+
+    if is_path_boundary_before "$previous" && is_path_boundary_after "$next"; then
+      return 0
+    fi
+
+    rest="$after"
+  done
+
+  return 1
+}
+
+is_path_boundary_before() {
+  local character="${1:-}"
+
+  [[ -z "$character" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' || "$character" == "=" ]]
+}
+
+is_path_boundary_after() {
+  local character="${1:-}"
+
+  [[ -z "$character" || "$character" == "/" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' ]]
+}
+
+env_has_assignment() {
+  local env_text="$1"
+  local name="$2"
+  local value="$3"
+
+  [[ " $env_text " == *" $name=$value "* ]]
 }
 
 process_has_profile() {
   local command_with_env
 
   command_with_env="$(process_with_env "$1")"
-  [[ "$command_with_env" == *"PWRAGENT_PROFILE=$profile"* ]]
+  env_has_assignment "$command_with_env" "PWRAGENT_PROFILE" "$profile"
 }
 
 is_dev_command() {
@@ -99,8 +137,9 @@ pid_is_root_scoped_dev() {
   process_has_profile "$pid" || return 1
 
   cwd="$(cwd_of_pid "$pid")"
-  if [[ -n "$cwd" ]] && is_under_root "$cwd"; then
-    return 0
+  if [[ -n "$cwd" ]]; then
+    is_under_root "$cwd"
+    return $?
   fi
 
   command_mentions_root "$command"
@@ -235,6 +274,39 @@ tail_log() {
   fi
 }
 
+assert_success() {
+  local description="$1"
+  shift
+
+  "$@" || die "self-test failed: expected success for $description"
+}
+
+assert_failure() {
+  local description="$1"
+  shift
+
+  if "$@"; then
+    die "self-test failed: expected failure for $description"
+  fi
+}
+
+run_self_test() {
+  root="/Users/example/PwrAgnt"
+  profile="dev"
+
+  assert_success "exact root command" command_mentions_root "cd /Users/example/PwrAgnt && pnpm dev"
+  assert_success "root child path" command_mentions_root "/Users/example/PwrAgnt/apps/desktop"
+  assert_success "root env-style assignment" command_mentions_root "PWD=/Users/example/PwrAgnt"
+  assert_failure "sibling checkout prefix" command_mentions_root "/Users/example/PwrAgnt-old/apps/desktop"
+  assert_failure "sibling checkout suffix" command_mentions_root "/Users/example/PwrAgnt2/apps/desktop"
+
+  assert_success "exact profile assignment" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=dev SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
+  assert_failure "profile prefix dev2" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=dev2 SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
+  assert_failure "profile prefix development" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=development SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
+
+  say "self-test passed"
+}
+
 verify_app() {
   local elapsed=0
   local sleep_step=2
@@ -332,7 +404,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$mode" == "start" || "$mode" == "restart" || "$mode" == "close" || "$mode" == "status" || "$mode" == "verify" ]] || die "unknown mode: $mode"
+[[ "$mode" == "start" || "$mode" == "restart" || "$mode" == "close" || "$mode" == "status" || "$mode" == "verify" || "$mode" == "self-test" ]] || die "unknown mode: $mode"
 [[ "$timeout" == <-> ]] || die "--timeout must be an integer number of seconds"
 
 root="${root:A}"
@@ -360,5 +432,8 @@ case "$mode" in
     ;;
   verify)
     verify_app
+    ;;
+  self-test)
+    run_self_test
     ;;
 esac

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -187,6 +187,12 @@ remove_launch_job() {
   launchctl remove "$(launch_job_label)" >/dev/null 2>&1
 }
 
+cleanup_exited_launch_job() {
+  launch_job_exists || return 1
+  [[ -n "$(launch_job_pid)" ]] && return 1
+  remove_launch_job
+}
+
 runtime_tables_ready() {
   [[ -f "$state_db" ]] || return 1
   sqlite3 -readonly "$state_db" "SELECT cwd_hash FROM app_runtime_instances LIMIT 0;" >/dev/null 2>&1
@@ -314,12 +320,14 @@ write_status() {
   rows="$(query_root_instances 2>/dev/null || true)"
   if [[ -z "$rows" ]]; then
     say "no lease-backed $profile profile app instances found for $root"
+    cleanup_exited_launch_job >/dev/null 2>&1 || true
     describe_active_lease >/dev/null || true
     return 1
   fi
 
   if ! has_live_root_instance; then
     say "only stale lease-backed $profile profile app instances found for $root"
+    cleanup_exited_launch_job >/dev/null 2>&1 || true
     describe_root_instances
     describe_active_lease || true
     return 1
@@ -432,6 +440,7 @@ verify_app() {
 
     if [[ -n "$managed_pid" ]] && ! is_live_pid "$managed_pid"; then
       say "managed process exited before lease-backed verification completed (pid=$managed_pid)"
+      cleanup_exited_launch_job >/dev/null 2>&1 || true
       tail_log
       return 1
     fi
@@ -441,6 +450,7 @@ verify_app() {
   done
 
   say "timed out waiting ${timeout}s for lease-backed $profile profile app record"
+  cleanup_exited_launch_job >/dev/null 2>&1 || true
   tail_log
   return 1
 }

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -1,6 +1,8 @@
 #!/bin/zsh
 set -u
 
+INSTANCE_ROOT_ENV="PWRAGENT_INSTANCE_ROOT"
+
 usage() {
   cat <<'USAGE'
 Usage:
@@ -9,10 +11,11 @@ Usage:
   pwragent-dev-profile.zsh close   [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
   pwragent-dev-profile.zsh status  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH]
   pwragent-dev-profile.zsh verify  [--root PATH] [--profile NAME] [--log PATH] [--pid-file PATH] [--timeout SECONDS]
+  pwragent-dev-profile.zsh leases  [--profile NAME]
   pwragent-dev-profile.zsh self-test
 
 Manages a detached local PwrAgent Electron dev app with PWRAGENT_PROFILE=dev.
-The default root is the current working directory.
+Process ownership is resolved from the app's profile runtime lease records.
 USAGE
 }
 
@@ -41,10 +44,6 @@ process_command() {
   ps -p "$1" -o command= 2>/dev/null
 }
 
-process_with_env() {
-  ps eww -p "$1" -o command= 2>/dev/null
-}
-
 parent_pid() {
   ps -p "$1" -o ppid= 2>/dev/null | tr -d ' '
 }
@@ -61,9 +60,25 @@ is_self_or_parent() {
   [[ "$1" == "$$" || "$1" == "$PPID" ]]
 }
 
+is_valid_profile() {
+  [[ "$1" =~ '^[a-z0-9][a-z0-9_-]{0,31}$' && "$1" != "." && "$1" != ".." && "$1" != "con" && "$1" != "nul" && "$1" != "aux" && "$1" != "prn" ]]
+}
+
 is_under_root() {
   local value="$1"
   [[ "$value" == "$root" || "$value" == "$root/"* ]]
+}
+
+is_path_boundary_before() {
+  local character="${1:-}"
+
+  [[ -z "$character" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' || "$character" == "=" ]]
+}
+
+is_path_boundary_after() {
+  local character="${1:-}"
+
+  [[ -z "$character" || "$character" == "/" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' ]]
 }
 
 command_mentions_root() {
@@ -87,33 +102,6 @@ command_mentions_root() {
   return 1
 }
 
-is_path_boundary_before() {
-  local character="${1:-}"
-
-  [[ -z "$character" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' || "$character" == "=" ]]
-}
-
-is_path_boundary_after() {
-  local character="${1:-}"
-
-  [[ -z "$character" || "$character" == "/" || "$character" == " " || "$character" == $'\t' || "$character" == "'" || "$character" == '"' ]]
-}
-
-env_has_assignment() {
-  local env_text="$1"
-  local name="$2"
-  local value="$3"
-
-  [[ " $env_text " == *" $name=$value "* ]]
-}
-
-process_has_profile() {
-  local command_with_env
-
-  command_with_env="$(process_with_env "$1")"
-  env_has_assignment "$command_with_env" "PWRAGENT_PROFILE" "$profile"
-}
-
 is_dev_command() {
   local command="$1"
   [[ "$command" == *"pnpm dev"* ]] && return 0
@@ -125,7 +113,7 @@ is_dev_command() {
   return 1
 }
 
-pid_is_root_scoped_dev() {
+root_scoped_dev_pid() {
   local pid="$1"
   local command cwd
 
@@ -134,7 +122,6 @@ pid_is_root_scoped_dev() {
   command="$(process_command "$pid")"
   [[ -n "$command" ]] || return 1
   is_dev_command "$command" || return 1
-  process_has_profile "$pid" || return 1
 
   cwd="$(cwd_of_pid "$pid")"
   if [[ -n "$cwd" ]]; then
@@ -156,6 +143,108 @@ descendants_of() {
   done
 }
 
+dev_parent_chain_of() {
+  local parent command
+
+  parent="$(parent_pid "$1")"
+  while [[ -n "$parent" && "$parent" != "0" && "$parent" != "1" ]]; do
+    is_self_or_parent "$parent" && break
+    command="$(process_command "$parent")"
+    if [[ -n "$command" ]] && is_dev_command "$command" && root_scoped_dev_pid "$parent"; then
+      print -r -- "$parent"
+      parent="$(parent_pid "$parent")"
+    else
+      break
+    fi
+  done
+}
+
+compute_root_hash() {
+  printf '%s' "${1:A}" | shasum -a 256 | awk '{ print substr($1, 1, 16) }'
+}
+
+state_db_path() {
+  local pwragent_home="${PWRAGENT_HOME:-$HOME/.pwragent}"
+  print -r -- "${pwragent_home:A}/profiles/$profile/state/state.db"
+}
+
+launch_job_label() {
+  print -r -- "local.pwragent.dev-profile.$profile.$root_hash_value"
+}
+
+launch_job_pid() {
+  command -v launchctl >/dev/null 2>&1 || return 1
+  launchctl list 2>/dev/null | awk -v label="$(launch_job_label)" '$3 == label && $1 ~ /^[0-9]+$/ { print $1; exit }'
+}
+
+launch_job_exists() {
+  command -v launchctl >/dev/null 2>&1 || return 1
+  launchctl list 2>/dev/null | awk -v label="$(launch_job_label)" '$3 == label { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+remove_launch_job() {
+  launch_job_exists || return 1
+  launchctl remove "$(launch_job_label)" >/dev/null 2>&1
+}
+
+runtime_tables_ready() {
+  [[ -f "$state_db" ]] || return 1
+  sqlite3 -readonly "$state_db" "SELECT cwd_hash FROM app_runtime_instances LIMIT 0;" >/dev/null 2>&1
+}
+
+query_root_instances() {
+  runtime_tables_ready || return 1
+  sqlite3 -readonly -separator $'\t' "$state_db" \
+    "SELECT instance_id, process_id, coalesce(cwd_hint, ''), heartbeat_at,
+            desired_messaging_enabled, effective_messaging_enabled,
+            coalesce(disabled_reason, '')
+     FROM app_runtime_instances
+     WHERE profile_name = '$profile'
+       AND cwd_hash = '$root_hash_value'
+       AND exited_at IS NULL
+     ORDER BY heartbeat_at DESC;"
+}
+
+query_profile_instances() {
+  runtime_tables_ready || return 1
+  sqlite3 -readonly -separator $'\t' "$state_db" \
+    "SELECT instance_id, process_id, coalesce(cwd_hint, ''), coalesce(cwd_hash, ''),
+            heartbeat_at, desired_messaging_enabled, effective_messaging_enabled,
+            coalesce(disabled_reason, ''), coalesce(exited_at, '')
+     FROM app_runtime_instances
+     WHERE profile_name = '$profile'
+     ORDER BY heartbeat_at DESC
+     LIMIT 20;"
+}
+
+query_active_lease() {
+  runtime_tables_ready || return 1
+  sqlite3 -readonly -separator $'\t' "$state_db" \
+    "SELECT l.owner_instance_id, l.heartbeat_at, l.expires_at,
+            coalesce(i.process_id, ''), coalesce(i.cwd_hint, ''),
+            coalesce(i.cwd_hash, ''), coalesce(i.effective_messaging_enabled, 0)
+     FROM messaging_runtime_lease l
+     LEFT JOIN app_runtime_instances i
+       ON i.instance_id = l.owner_instance_id
+     WHERE l.lease_key = 'profile-messaging'
+       AND l.status = 'active'
+       AND l.expires_at > CAST(strftime('%s', 'now') AS INTEGER) * 1000
+     LIMIT 1;"
+}
+
+managed_app_pids() {
+  local instance_id pid cwd_hint heartbeat desired effective disabled
+
+  query_root_instances 2>/dev/null | while IFS=$'\t' read -r instance_id pid cwd_hint heartbeat desired effective disabled; do
+    [[ -n "$pid" ]] || continue
+    if is_live_pid "$pid"; then
+      print -r -- "$pid"
+      descendants_of "$pid"
+      dev_parent_chain_of "$pid"
+    fi
+  done
+}
+
 pid_file_pids() {
   local managed_pid
 
@@ -164,40 +253,20 @@ pid_file_pids() {
   [[ -n "$managed_pid" ]] || return 0
   is_self_or_parent "$managed_pid" && return 0
 
-  if is_live_pid "$managed_pid" && pid_is_root_scoped_dev "$managed_pid"; then
+  if is_live_pid "$managed_pid" && root_scoped_dev_pid "$managed_pid"; then
     print -r -- "$managed_pid"
     descendants_of "$managed_pid"
   fi
 }
 
 matching_dev_pids() {
-  local pid parent command
-
   {
+    managed_app_pids
     pid_file_pids
-    pgrep -f 'pnpm.*dev|electron-vite.*dev|scripts/rebuild-native-for-electron.mjs|Electron.app|PwrAgent' 2>/dev/null | while read -r pid; do
-      [[ -z "$pid" ]] && continue
-      if pid_is_root_scoped_dev "$pid"; then
-        print -r -- "$pid"
-        descendants_of "$pid"
-
-        parent="$(parent_pid "$pid")"
-        while [[ -n "$parent" && "$parent" != "0" && "$parent" != "1" ]]; do
-          is_self_or_parent "$parent" && break
-          command="$(process_command "$parent")"
-          if [[ -n "$command" ]] && is_dev_command "$command"; then
-            print -r -- "$parent"
-            parent="$(parent_pid "$parent")"
-          else
-            break
-          fi
-        done
-      fi
-    done
   } | sort -rnu
 }
 
-describe_pids() {
+describe_matching_processes() {
   local pid
 
   for pid in $(matching_dev_pids); do
@@ -205,18 +274,85 @@ describe_pids() {
   done
 }
 
-write_status() {
-  local rows
+describe_root_instances() {
+  local instance_id pid cwd_hint heartbeat desired effective disabled live
 
-  rows="$(describe_pids)"
-  if [[ -z "$rows" ]]; then
-    say "no $profile profile dev app processes found for $root"
+  query_root_instances 2>/dev/null | while IFS=$'\t' read -r instance_id pid cwd_hint heartbeat desired effective disabled; do
+    live="stale"
+    is_live_pid "$pid" && live="live"
+    say "instance id=$instance_id pid=$pid $live cwd=$cwd_hint heartbeat=$heartbeat desiredMessaging=$desired effectiveMessaging=$effective disabledReason=${disabled:-none}"
+  done
+}
+
+describe_active_lease() {
+  local owner heartbeat expires pid cwd_hint cwd_hash effective live
+  local row
+
+  row="$(query_active_lease 2>/dev/null || true)"
+  if [[ -z "$row" ]]; then
+    say "no active $profile profile messaging lease"
     return 1
   fi
 
-  say "$profile profile dev app processes for $root:"
-  print -r -- "$rows"
+  IFS=$'\t' read -r owner heartbeat expires pid cwd_hint cwd_hash effective <<< "$row"
+  live="unknown"
+  if [[ -n "$pid" ]]; then
+    live="stale"
+    is_live_pid "$pid" && live="live"
+  fi
+  say "active messaging lease owner=$owner pid=${pid:-unknown} $live cwd=${cwd_hint:-unknown} cwdHash=${cwd_hash:-unknown} effectiveMessaging=$effective expiresAt=$expires"
+}
+
+write_status() {
+  local rows processes
+
+  if ! runtime_tables_ready; then
+    say "no lease metadata yet for profile $profile at $state_db"
+    return 1
+  fi
+
+  rows="$(query_root_instances 2>/dev/null || true)"
+  if [[ -z "$rows" ]]; then
+    say "no lease-backed $profile profile app instances found for $root"
+    describe_active_lease >/dev/null || true
+    return 1
+  fi
+
+  if ! has_live_root_instance; then
+    say "only stale lease-backed $profile profile app instances found for $root"
+    describe_root_instances
+    describe_active_lease || true
+    return 1
+  fi
+
+  say "$profile profile app instances for $root:"
+  describe_root_instances
+  describe_active_lease || true
+
+  processes="$(describe_matching_processes)"
+  if [[ -n "$processes" ]]; then
+    say "managed process tree:"
+    print -r -- "$processes"
+  fi
   return 0
+}
+
+write_leases() {
+  local instance_id pid cwd_hint cwd_hash heartbeat desired effective disabled exited live
+
+  if ! runtime_tables_ready; then
+    say "no lease metadata yet for profile $profile at $state_db"
+    return 1
+  fi
+
+  describe_active_lease || true
+  say "recent $profile profile app instances:"
+  query_profile_instances | while IFS=$'\t' read -r instance_id pid cwd_hint cwd_hash heartbeat desired effective disabled exited; do
+    live="stale"
+    [[ -n "$exited" ]] && live="exited"
+    [[ -z "$exited" ]] && is_live_pid "$pid" && live="live"
+    say "instance id=$instance_id pid=$pid $live cwd=${cwd_hint:-unknown} cwdHash=${cwd_hash:-unknown} heartbeat=$heartbeat desiredMessaging=$desired effectiveMessaging=$effective disabledReason=${disabled:-none}"
+  done
 }
 
 stop_matches() {
@@ -230,14 +366,18 @@ stop_matches() {
 }
 
 close_app() {
-  local remaining
+  local remaining removed_job=0
 
   mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
-  log_line "close root=$root profile=$profile" >> "$log_path"
+  log_line "close root=$root profile=$profile rootHash=$root_hash_value" >> "$log_path"
+  if remove_launch_job; then
+    removed_job=1
+    log_line "removed launchd job label=$(launch_job_label)" >> "$log_path"
+  fi
 
-  if [[ -z "$(matching_dev_pids)" ]]; then
+  if [[ -z "$(matching_dev_pids)" && "$removed_job" == "0" ]]; then
     rm -f "$pid_file"
-    say "no $profile profile dev app processes found for $root"
+    say "no lease-backed $profile profile app processes found for $root"
     return 0
   fi
 
@@ -250,28 +390,88 @@ close_app() {
   fi
 
   rm -f "$pid_file"
-  say "closed $profile profile dev app for $root"
+  say "closed $profile profile app for $root"
 }
 
-has_started_process() {
-  local pid command
+tail_log() {
+  if [[ -f "$log_path" ]]; then
+    tail -100 "$log_path"
+  else
+    say "log does not exist yet: $log_path"
+  fi
+}
 
-  for pid in $(matching_dev_pids); do
-    command="$(process_command "$pid")"
-    [[ "$command" == *"electron-vite"* && "$command" == *"dev"* ]] && return 0
-    [[ "$command" == *"Electron.app"* ]] && return 0
-    [[ "$command" == *"PwrAgent"* && "$command" == *"apps/desktop"* ]] && return 0
+has_live_root_instance() {
+  local instance_id pid cwd_hint heartbeat desired effective disabled
+
+  query_root_instances 2>/dev/null | while IFS=$'\t' read -r instance_id pid cwd_hint heartbeat desired effective disabled; do
+    [[ -n "$pid" ]] || continue
+    if is_live_pid "$pid"; then
+      return 0
+    fi
   done
 
   return 1
 }
 
-tail_log() {
-  if [[ -f "$log_path" ]]; then
-    tail -80 "$log_path"
+verify_app() {
+  local elapsed=0
+  local sleep_step=2
+  local managed_pid=""
+
+  [[ -f "$pid_file" ]] && managed_pid="$(tr -dc '0-9' < "$pid_file")"
+
+  while (( elapsed <= timeout )); do
+    if has_live_root_instance; then
+      say "$profile profile app is running for $root"
+      say "log: $log_path"
+      describe_root_instances
+      describe_active_lease || true
+      return 0
+    fi
+
+    if [[ -n "$managed_pid" ]] && ! is_live_pid "$managed_pid"; then
+      say "managed process exited before lease-backed verification completed (pid=$managed_pid)"
+      tail_log
+      return 1
+    fi
+
+    sleep "$sleep_step"
+    elapsed=$((elapsed + sleep_step))
+  done
+
+  say "timed out waiting ${timeout}s for lease-backed $profile profile app record"
+  tail_log
+  return 1
+}
+
+start_app() {
+  local start_pid command
+
+  [[ -f "$root/package.json" ]] || die "root does not look like the PwrAgent repository root: $root"
+  mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
+
+  close_app
+
+  log_line "start root=$root profile=$profile rootHash=$root_hash_value command=PWRAGENT_PROFILE=$profile $INSTANCE_ROOT_ENV=$root pnpm dev" >> "$log_path"
+  command="trap '' HUP TERM; cd $(shell_quote "$root") && exec env PWRAGENT_PROFILE=$(shell_quote "$profile") $INSTANCE_ROOT_ENV=$(shell_quote "$root") pnpm dev"
+
+  if [[ "$(uname -s)" == "Darwin" ]] && command -v launchctl >/dev/null 2>&1; then
+    launchctl submit -l "$(launch_job_label)" -o "$log_path" -e "$log_path" -- /bin/zsh -lc "$command" \
+      || die "failed to submit launchd job: $(launch_job_label)"
+    sleep 1
+    start_pid="$(launch_job_pid)"
   else
-    say "log does not exist yet: $log_path"
+    nohup /bin/zsh -lc "$command" </dev/null >> "$log_path" 2>&1 &
+    start_pid="$!"
+    disown "$start_pid" 2>/dev/null || true
   fi
+
+  print -r -- "$start_pid" > "$pid_file"
+
+  say "started $profile profile dev app supervisor pid=${start_pid:-unknown} label=$(launch_job_label)"
+  say "log: $log_path"
+  verify_app
 }
 
 assert_success() {
@@ -292,70 +492,19 @@ assert_failure() {
 
 run_self_test() {
   root="/Users/example/PwrAgnt"
+  root_hash_value="$(compute_root_hash "$root")"
   profile="dev"
 
+  assert_success "valid profile" is_valid_profile "dev"
+  assert_failure "profile prefix" is_valid_profile "Dev"
   assert_success "exact root command" command_mentions_root "cd /Users/example/PwrAgnt && pnpm dev"
   assert_success "root child path" command_mentions_root "/Users/example/PwrAgnt/apps/desktop"
   assert_success "root env-style assignment" command_mentions_root "PWD=/Users/example/PwrAgnt"
   assert_failure "sibling checkout prefix" command_mentions_root "/Users/example/PwrAgnt-old/apps/desktop"
   assert_failure "sibling checkout suffix" command_mentions_root "/Users/example/PwrAgnt2/apps/desktop"
-
-  assert_success "exact profile assignment" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=dev SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
-  assert_failure "profile prefix dev2" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=dev2 SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
-  assert_failure "profile prefix development" env_has_assignment "PATH=/bin PWRAGENT_PROFILE=development SHELL=/bin/zsh" "PWRAGENT_PROFILE" "dev"
+  [[ "$root_hash_value" == "c976f17804e892f9" ]] || die "self-test failed: unexpected root hash $root_hash_value"
 
   say "self-test passed"
-}
-
-verify_app() {
-  local elapsed=0
-  local sleep_step=2
-  local managed_pid=""
-
-  [[ -f "$pid_file" ]] && managed_pid="$(tr -dc '0-9' < "$pid_file")"
-
-  while (( elapsed <= timeout )); do
-    if [[ -n "$managed_pid" ]] && ! is_live_pid "$managed_pid"; then
-      say "managed process exited before verification completed (pid=$managed_pid)"
-      tail_log
-      return 1
-    fi
-
-    if has_started_process; then
-      sleep 3
-      if [[ -z "$managed_pid" ]] || is_live_pid "$managed_pid"; then
-        say "$profile profile dev app is running for $root"
-        say "log: $log_path"
-        return 0
-      fi
-    fi
-
-    sleep "$sleep_step"
-    elapsed=$((elapsed + sleep_step))
-  done
-
-  say "timed out waiting ${timeout}s for $profile profile dev app to come up"
-  tail_log
-  return 1
-}
-
-start_app() {
-  local start_pid command
-
-  [[ -f "$root/package.json" ]] || die "root does not look like the PwrAgent repository root: $root"
-  mkdir -p "${log_path:h}" || die "failed to create log directory: ${log_path:h}"
-
-  close_app
-
-  log_line "start root=$root profile=$profile command=PWRAGENT_PROFILE=$profile pnpm dev" >> "$log_path"
-  command="cd $(shell_quote "$root") && exec env PWRAGENT_PROFILE=$(shell_quote "$profile") pnpm dev"
-  nohup /bin/zsh -lc "$command" >> "$log_path" 2>&1 &
-  start_pid="$!"
-  print -r -- "$start_pid" > "$pid_file"
-
-  say "started $profile profile dev app supervisor pid=$start_pid"
-  say "log: $log_path"
-  verify_app
 }
 
 mode="${1:-}"
@@ -404,11 +553,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$mode" == "start" || "$mode" == "restart" || "$mode" == "close" || "$mode" == "status" || "$mode" == "verify" || "$mode" == "self-test" ]] || die "unknown mode: $mode"
+[[ "$mode" == "start" || "$mode" == "restart" || "$mode" == "close" || "$mode" == "status" || "$mode" == "verify" || "$mode" == "leases" || "$mode" == "self-test" ]] || die "unknown mode: $mode"
 [[ "$timeout" == <-> ]] || die "--timeout must be an integer number of seconds"
+is_valid_profile "$profile" || die "invalid profile: $profile"
 
 root="${root:A}"
 [[ -d "$root" ]] || die "root does not exist: $root"
+root_hash_value="$(compute_root_hash "$root")"
+state_db="$(state_db_path)"
 
 if [[ -z "$log_path" ]]; then
   log_path="$root/.local/pwragent-dev-profile.log"
@@ -432,6 +584,9 @@ case "$mode" in
     ;;
   verify)
     verify_app
+    ;;
+  leases)
+    write_leases
     ;;
   self-test)
     run_self_test

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -41,13 +41,13 @@ The desktop style guide defines:
 To launch the desktop app with live threads and real user state, run from the **repo root** (or worktree root):
 
 ```bash
-pnpm --filter @pwragent/desktop dev:no-messaging
+pnpm --filter @pwragent/desktop dev
 ```
 
 - Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
-- `dev:no-messaging` disables the Telegram/Discord messaging interface, which avoids bot-token prompts and Keychain access issues during development.
-- For visual verification of UI changes, use this command so you can see real threads in the sidebar and thread detail pane.
-- The `dev` script (without `no-messaging`) also works but will attempt to connect messaging providers.
+- Messaging adapters are guarded by a profile-scoped sqlite lease. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
+- Use `pnpm --filter @pwragent/desktop dev:no-messaging` when you explicitly want to guarantee that this app process never starts messaging adapters.
+- For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
 - If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
 
 ## Inspecting Branch Drift Dialog E2E

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -343,4 +343,37 @@ describe("AppRuntimeInstanceStore", () => {
       cwdHash: "c976f17804e892f9",
     });
   });
+
+  it("removes exited runtime instance rows after one hour", () => {
+    const now = 2 * 60 * 60 * 1000;
+    store.recordInstanceStart({
+      instanceId: "recent-exited",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      startedAt: now - 59 * 60 * 1000,
+      desiredMessagingEnabled: true,
+    });
+    store.markInstanceExited({
+      instanceId: "recent-exited",
+      now: now - 59 * 60 * 1000,
+    });
+    store.recordInstanceStart({
+      instanceId: "old-exited",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt",
+      startedAt: now - 61 * 60 * 1000,
+      desiredMessagingEnabled: true,
+    });
+    store.markInstanceExited({
+      instanceId: "old-exited",
+      now: now - 61 * 60 * 1000,
+    });
+
+    stateDb.cleanupExpired(now);
+
+    expect(store.getInstance("recent-exited")).toBeDefined();
+    expect(store.getInstance("old-exited")).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -45,6 +45,7 @@ describe("AppRuntimeInstanceStore", () => {
       profileName: "dev",
       processId: 123,
       cwdHint: "PwrAgnt",
+      cwdHash: "c976f17804e892f9",
       startedAt: 1_000,
       heartbeatAt: 1_000,
       desiredMessagingEnabled: true,
@@ -57,6 +58,29 @@ describe("AppRuntimeInstanceStore", () => {
       expiresAt: 31_000,
       status: "active",
     });
+  });
+
+  it("stores the same cwd hash for equivalent absolute paths", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: path.join(tempDir, "..", path.basename(tempDir)),
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: tempDir,
+      startedAt: 2_000,
+      desiredMessagingEnabled: true,
+    });
+
+    expect(store.getInstance("instance-a")?.cwdHash).toBe(
+      store.getInstance("instance-b")?.cwdHash,
+    );
   });
 
   it("renews the current holder lease without changing the original acquisition time", () => {
@@ -291,6 +315,32 @@ describe("AppRuntimeInstanceStore", () => {
     expect(store.getMessagingLease()).toMatchObject({
       ownerInstanceId: "instance-b",
       status: "active",
+    });
+  });
+
+  it("repairs missing runtime lease tables when user_version already advanced", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.exec(`
+      DROP TABLE IF EXISTS messaging_runtime_lease;
+      DROP TABLE IF EXISTS app_runtime_instances;
+      PRAGMA user_version = 4;
+    `);
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath, { profileName: "dev" });
+    store = new AppRuntimeInstanceStore(stateDb);
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/Users/example/PwrAgnt",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+
+    expect(store.getInstance("instance-a")).toMatchObject({
+      instanceId: "instance-a",
+      cwdHash: "c976f17804e892f9",
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -1,0 +1,296 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: AppRuntimeInstanceStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-runtime-instance-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+  store = new AppRuntimeInstanceStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("AppRuntimeInstanceStore", () => {
+  it("records startup and acquires the profile messaging lease", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/Users/example/PwrAgnt",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result.acquired).toBe(true);
+    expect(store.getInstance("instance-a")).toMatchObject({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwdHint: "PwrAgnt",
+      startedAt: 1_000,
+      heartbeatAt: 1_000,
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: true,
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      acquiredAt: 1_000,
+      heartbeatAt: 1_000,
+      expiresAt: 31_000,
+      status: "active",
+    });
+  });
+
+  it("renews the current holder lease without changing the original acquisition time", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    expect(
+      store.acquireMessagingLease({
+        instanceId: "instance-a",
+        now: 1_000,
+        ttlMs: 30_000,
+      }).acquired,
+    ).toBe(true);
+
+    expect(
+      store.renewMessagingLease({
+        instanceId: "instance-a",
+        now: 11_000,
+        ttlMs: 30_000,
+      }),
+    ).toBe(true);
+
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      acquiredAt: 1_000,
+      heartbeatAt: 11_000,
+      expiresAt: 41_000,
+      status: "active",
+    });
+    expect(store.getInstance("instance-a")).toMatchObject({
+      heartbeatAt: 11_000,
+      effectiveMessagingEnabled: true,
+    });
+  });
+
+  it("denies a second instance while the current lease holder is live", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 2_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 2_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result).toMatchObject({
+      acquired: false,
+      reason: "held",
+      holder: {
+        ownerInstanceId: "instance-a",
+        expiresAt: 31_000,
+      },
+    });
+    expect(store.getInstance("instance-b")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+  });
+
+  it("lets another instance acquire after the previous holder expires", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 40_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 40_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result.acquired).toBe(true);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      acquiredAt: 40_000,
+      heartbeatAt: 40_000,
+      expiresAt: 70_000,
+      status: "active",
+    });
+    const instance = store.getInstance("instance-b");
+    expect(instance).toMatchObject({
+      effectiveMessagingEnabled: true,
+    });
+    expect(instance).not.toHaveProperty("disabledReason");
+  });
+
+  it("does not release a live holder when a non-holder asks to release", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 2_000,
+      desiredMessagingEnabled: false,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    expect(
+      store.releaseMessagingLease({
+        instanceId: "instance-b",
+        now: 2_000,
+      }),
+    ).toBe(false);
+
+    const lease = store.getMessagingLease();
+    expect(lease).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+    expect(lease).not.toHaveProperty("releasedAt");
+  });
+
+  it("sanitizes instance metadata instead of storing raw paths or secrets", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/Users/example/Projects/token-secret-value",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+      disabledReason: "PWRAGENT_DISABLE_MESSAGING=token-secret-value",
+    });
+
+    const row = stateDb.raw
+      .prepare(
+        "SELECT cwd_hint, disabled_reason FROM app_runtime_instances WHERE instance_id = ?",
+      )
+      .get("instance-a") as {
+      cwd_hint: string;
+      disabled_reason: string;
+    };
+
+    expect(row.cwd_hint).toBe("token-secret-value");
+    expect(row.cwd_hint).not.toContain("/Users/example");
+    expect(row.disabled_reason).toBe("explicit_override");
+    expect(row.disabled_reason).not.toContain("token-secret-value");
+  });
+
+  it("preserves rows across database reopen and still uses expiry as authority", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath, { profileName: "dev" });
+    store = new AppRuntimeInstanceStore(stateDb);
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 40_000,
+      desiredMessagingEnabled: true,
+    });
+
+    expect(
+      store.acquireMessagingLease({
+        instanceId: "instance-b",
+        now: 40_000,
+        ttlMs: 30_000,
+      }).acquired,
+    ).toBe(true);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -633,6 +633,7 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.runtime.messaging).toEqual({
       disabled: true,
       overrideActive: true,
+      disabledReasonKind: "explicit_override",
       disabledReason: "--disable-messaging was provided at startup",
     });
   });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -30,6 +30,8 @@ const mainLogInfoMock = vi.fn();
 const mainLogWarnMock = vi.fn();
 const mainLogErrorMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
+const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
+const messagingLeaseShutdownSyncMock = vi.fn();
 const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
@@ -169,6 +171,13 @@ vi.mock("../messaging/messaging-runtime", () => ({
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
 }));
 
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => ({
+    start: messagingLeaseStartMock,
+    shutdownSync: messagingLeaseShutdownSyncMock,
+  })),
+}));
+
 vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
@@ -218,6 +227,9 @@ describe("bootstrapApp", () => {
     mainLogErrorMock.mockReset();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
+    messagingLeaseStartMock.mockReset();
+    messagingLeaseStartMock.mockResolvedValue();
+    messagingLeaseShutdownSyncMock.mockReset();
     requestBindingRevokeAllForThreadMock.mockReset();
     setMessagingArchiveCleanerMock.mockReset();
     disposeDesktopMessagingRuntimeMock.mockReset();
@@ -266,7 +278,7 @@ describe("bootstrapApp", () => {
     resolveStart();
     await flushMicrotasks();
 
-    expect(messagingRuntimeStartMock).toHaveBeenCalledTimes(1);
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
     });
@@ -298,12 +310,12 @@ describe("bootstrapApp", () => {
 
   it("creates the first window without waiting for messaging startup", async () => {
     startupProfilerInstance.start.mockResolvedValue();
-    messagingRuntimeStartMock.mockReturnValue(new Promise(() => {}));
+    messagingLeaseStartMock.mockReturnValue(new Promise(() => {}));
 
     await import("../index");
     await flushMicrotasks();
 
-    expect(messagingRuntimeStartMock).toHaveBeenCalledTimes(1);
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(registerMessagingStatusIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
@@ -312,7 +324,7 @@ describe("bootstrapApp", () => {
 
   it("logs unexpected background messaging startup failures", async () => {
     startupProfilerInstance.start.mockResolvedValue();
-    messagingRuntimeStartMock.mockRejectedValue(new Error("config load failed"));
+    messagingLeaseStartMock.mockRejectedValue(new Error("config load failed"));
 
     await import("../index");
     await flushMicrotasks();
@@ -374,6 +386,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(messagingRuntimeStartMock).not.toHaveBeenCalled();
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(mainLogInfoMock).toHaveBeenCalledWith(
       "messaging runtime disabled for this app instance",
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const runtimeMock = vi.hoisted(() => ({
-  applyConfig: vi.fn(async () => undefined),
+  applyConfig: vi.fn(async (_config: unknown, _options?: unknown) => undefined),
   deliverPairingOutcome: vi.fn(async () => undefined),
   getPlatformStatuses: vi.fn(() => []),
   isEnabled: vi.fn(() => true),
@@ -27,6 +27,23 @@ const messagingConfigMocks = vi.hoisted(() => ({
     enabled: true,
     inputDebounceMs: 500,
   })),
+}));
+const leaseCoordinatorMock = vi.hoisted(() => ({
+  applyLatestConfig: vi.fn(
+    async (
+      runtime: typeof runtimeMock,
+      loadConfig: (options: unknown) => Promise<unknown>,
+      options: unknown,
+    ) => {
+      const config = await loadConfig(options);
+      await runtime.applyConfig(config, { allowStart: true });
+      return { enabled: true };
+    },
+  ),
+  disableForSession: vi.fn(async (runtime: typeof runtimeMock) => {
+    await runtime.stop();
+    return { enabled: false, disabledReasonKind: "runtime_stopped" };
+  }),
 }));
 
 vi.mock("electron", () => ({
@@ -53,6 +70,10 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
 vi.mock("../messaging/messaging-config", () => ({
   loadDesktopMessagingConfigFromSettings:
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings,
+}));
+
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => leaseCoordinatorMock),
 }));
 
 vi.mock("../messaging/desktop-messaging-pairing-store", () => ({
@@ -101,6 +122,8 @@ describe("messaging status ipc", () => {
     pairingStoreMock.markStatus.mockReset();
     activityLogMock.record.mockClear();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
+    leaseCoordinatorMock.applyLatestConfig.mockClear();
+    leaseCoordinatorMock.disableForSession.mockClear();
   });
 
   it("loads startup eligibility diagnostics when enabling messaging at runtime", async () => {
@@ -121,6 +144,14 @@ describe("messaging status ipc", () => {
       logStartupEligibility: true,
       messagingEnabledOverride: true,
     });
+    expect(leaseCoordinatorMock.applyLatestConfig).toHaveBeenCalledWith(
+      runtimeMock,
+      expect.any(Function),
+      {
+        logStartupEligibility: true,
+        messagingEnabledOverride: true,
+      },
+    );
     expect(runtimeMock.applyConfig).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),
       { allowStart: true },
@@ -164,6 +195,11 @@ describe("messaging status ipc", () => {
       },
     });
     expect(runtimeMock.deliverPairingOutcome).toHaveBeenCalledWith(consumed, "approved");
+    expect(leaseCoordinatorMock.applyLatestConfig).toHaveBeenCalledWith(
+      runtimeMock,
+      expect.any(Function),
+      { logStartupEligibility: true },
+    );
   });
 
   it("approves LINE group and room pairing into separate bucket lists", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
+import {
+  MESSAGING_LEASE_HEARTBEAT_MS,
+  RuntimeMessagingLeaseCoordinator,
+} from "../runtime-messaging-lease";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 import type { DesktopMessagingConfig } from "../messaging/messaging-config";
@@ -12,10 +15,11 @@ let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
 
-function createRuntime(): DesktopMessagingRuntime {
+function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingRuntime {
   let enabled = false;
   return {
     applyConfig: vi.fn(async () => {
+      if (options.failApply) throw new Error("apply failed");
       enabled = true;
     }),
     isEnabled: vi.fn(() => enabled),
@@ -34,6 +38,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -217,6 +222,101 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       status: "active",
     });
     second.shutdownSync();
+  });
+
+  it("stops runtime when the heartbeat loses the lease", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => now,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => now,
+      store,
+    });
+
+    await first.applyResolvedConfig(firstRuntime, config);
+    now = 32_000;
+    await second.applyResolvedConfig(secondRuntime, config);
+    now = 33_000;
+    await vi.advanceTimersByTimeAsync(MESSAGING_LEASE_HEARTBEAT_MS);
+
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.isEnabled()).toBe(false);
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+    second.shutdownSync();
+  });
+
+  it("releases the lease when runtime startup fails", async () => {
+    const runtime = createRuntime({ failApply: true });
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+        telegram: {
+          channel: "telegram",
+          enabled: true,
+          botToken: "token",
+          streamingResponses: false,
+          authorizedActorIds: [],
+          authorizedSupergroupIds: [],
+        },
+      }),
+    ).rejects.toThrow("apply failed");
+
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "released",
+      releasedAt: 1_000,
+    });
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "startup_error",
+    });
   });
 
   it("releases the lease when the session disables messaging", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+import type { DesktopMessagingConfig } from "../messaging/messaging-config";
+import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
+
+let stateDb: StateDb;
+let store: AppRuntimeInstanceStore;
+let tempDir: string;
+
+function createRuntime(): DesktopMessagingRuntime {
+  let enabled = false;
+  return {
+    applyConfig: vi.fn(async () => {
+      enabled = true;
+    }),
+    isEnabled: vi.fn(() => enabled),
+    stop: vi.fn(async () => {
+      enabled = false;
+    }),
+  } as unknown as DesktopMessagingRuntime;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-lease-coordinator-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+  store = new AppRuntimeInstanceStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("RuntimeMessagingLeaseCoordinator", () => {
+  it("records explicit no-messaging overrides without loading config", async () => {
+    const runtime = createRuntime();
+    const loadConfig = vi.fn(async () => ({
+      enabled: true,
+      inputDebounceMs: 500,
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    }));
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+      env: { PWRAGENT_DISABLE_MESSAGING: "1" } as NodeJS.ProcessEnv,
+    });
+
+    await expect(coordinator.start(runtime, loadConfig)).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "explicit_override",
+    });
+
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(runtime.applyConfig).not.toHaveBeenCalled();
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: false,
+      effectiveMessagingEnabled: false,
+      disabledReason: "explicit_override",
+    });
+    expect(store.getMessagingLease()).toBeUndefined();
+  });
+
+  it("does not claim the lease when no adapters are runnable", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+      }),
+    ).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "no_runnable_adapters",
+    });
+
+    expect(runtime.applyConfig).not.toHaveBeenCalled();
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toBeUndefined();
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "no_runnable_adapters",
+    });
+  });
+
+  it("starts runtime only for the profile lease holder", async () => {
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => 1_000,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => 2_000,
+      store,
+    });
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+
+    await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
+      .toMatchObject({ enabled: true });
+    await expect(second.applyResolvedConfig(secondRuntime, config)).resolves
+      .toMatchObject({
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        leaseHolder: { instanceId: "instance-a" },
+      });
+
+    expect(firstRuntime.applyConfig).toHaveBeenCalledTimes(1);
+    expect(secondRuntime.applyConfig).not.toHaveBeenCalled();
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+    expect(store.getInstance("instance-b")).toMatchObject({
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    first.shutdownSync();
+  });
+
+  it("stops runtime when another live instance holds the lease", async () => {
+    let now = 1_000;
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => now,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => now,
+      store,
+    });
+
+    await first.applyResolvedConfig(firstRuntime, config);
+    now = 32_000;
+    await second.applyResolvedConfig(secondRuntime, config);
+    now = 33_000;
+    await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
+      .toMatchObject({
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        leaseHolder: { instanceId: "instance-b" },
+      });
+
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.isEnabled()).toBe(false);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+    second.shutdownSync();
+  });
+
+  it("releases the lease when the session disables messaging", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await coordinator.applyResolvedConfig(runtime, {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram",
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    });
+    await expect(coordinator.disableForSession(runtime)).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "runtime_stopped",
+    });
+
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "released",
+      releasedAt: 1_000,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -153,6 +153,48 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
     });
   });
 
+  it("treats Feishu-only config as runnable", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+        feishu: {
+          channel: "feishu" as const,
+          enabled: true,
+          appId: "cli_xxx",
+          appSecret: "secret",
+          inboundMode: "persistent",
+          tenantRegion: "feishu",
+          tenantUrl: "https://open.feishu.cn",
+          callbackBaseUrl: "https://example.test/feishu",
+          streamingResponses: false,
+          authorizedActorIds: [],
+          authorizedChatIds: [],
+          authorizedTenantKeys: [],
+        },
+      }),
+    ).resolves.toMatchObject({ enabled: true });
+
+    expect(runtime.applyConfig).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+
+    coordinator.shutdownSync();
+  });
+
   it("starts runtime only for the profile lease holder", async () => {
     const firstRuntime = createRuntime();
     const secondRuntime = createRuntime();

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MESSAGING_LEASE_HEARTBEAT_MS,
+  PWRAGENT_INSTANCE_ROOT_ENV,
   RuntimeMessagingLeaseCoordinator,
 } from "../runtime-messaging-lease";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
@@ -81,6 +82,43 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       disabledReason: "explicit_override",
     });
     expect(store.getMessagingLease()).toBeUndefined();
+  });
+
+  it("uses the launch root env var for lease owner identity", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      now: () => 1_000,
+      store,
+      env: {
+        [PWRAGENT_INSTANCE_ROOT_ENV]: "/Users/example/PwrAgnt",
+      } as NodeJS.ProcessEnv,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+        telegram: {
+          channel: "telegram" as const,
+          enabled: true,
+          botToken: "token",
+          streamingResponses: false,
+          authorizedActorIds: [],
+          authorizedSupergroupIds: [],
+        },
+      }),
+    ).resolves.toMatchObject({ enabled: true });
+
+    expect(store.getInstance("instance-a")).toMatchObject({
+      cwdHint: "PwrAgnt",
+      cwdHash: "c976f17804e892f9",
+    });
+
+    coordinator.shutdownSync();
   });
 
   it("does not claim the lease when no adapters are runnable", async () => {

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -18,13 +18,35 @@ const providerMocks = vi.hoisted(() => ({
   resolveSlackContact: vi.fn(),
 }));
 const runtimeMock = vi.hoisted(() => ({
-  applyConfig: vi.fn(async () => undefined),
+  applyConfig: vi.fn(async (_config: unknown, _options?: unknown) => undefined),
   getPlatformCredentialMetadata: vi.fn(),
   isEnabled: vi.fn(() => false),
   requestCredentialValidation: vi.fn(),
 }));
 const messagingConfigMocks = vi.hoisted(() => ({
   loadDesktopMessagingConfigFromSettings: vi.fn(),
+}));
+const leaseCoordinatorMock = vi.hoisted(() => ({
+  applyLatestConfig: vi.fn(
+    async (
+      runtime: typeof runtimeMock,
+      loadConfig: (options: unknown) => Promise<unknown>,
+      options: { allowStart?: boolean },
+    ) => {
+      const config = await loadConfig({
+        logStartupEligibility: true,
+      });
+      await runtime.applyConfig(config, {
+        allowStart: options.allowStart ?? true,
+      });
+      return { enabled: runtime.isEnabled() };
+    },
+  ),
+  snapshot: vi.fn(() => ({
+    instanceId: "test-instance",
+    effectiveMessagingEnabled: false,
+    leaseHeld: false,
+  })),
 }));
 
 vi.mock("electron", () => ({
@@ -68,6 +90,10 @@ vi.mock("../messaging/messaging-config", async (importOriginal) => {
   };
 });
 
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => leaseCoordinatorMock),
+}));
+
 vi.mock("@pwragent/messaging-provider-telegram", () => ({
   resolveContact: providerMocks.resolveTelegramContact,
 }));
@@ -100,6 +126,8 @@ describe("settings ipc", () => {
     providerMocks.resolveMattermostContact.mockReset();
     providerMocks.resolveSlackContact.mockReset();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
+    leaseCoordinatorMock.applyLatestConfig.mockClear();
+    leaseCoordinatorMock.snapshot.mockClear();
     runtimeMock.applyConfig.mockClear();
     runtimeMock.getPlatformCredentialMetadata.mockReset();
     runtimeMock.isEnabled.mockClear();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -50,6 +50,7 @@ import {
 } from "./messaging/messaging-runtime";
 import { loadDesktopMessagingConfigFromSettings } from "./messaging/messaging-config";
 import { resolveRuntimeMessagingOverride } from "./runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "./runtime-messaging-lease";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import { disposeAppState, initializeAppState } from "./state/app-state";
 import { createMainWindow } from "./window";
@@ -156,12 +157,33 @@ export function bootstrapApp(): void {
       mainLog.info("messaging runtime disabled for this app instance", {
         reason: messagingOverride.reason,
       });
-    } else {
-      void messagingRuntime.start().catch((error) => {
-        mainLog.error("messaging runtime failed during background startup", {
-          error: error instanceof Error ? error.message : String(error),
+      void getRuntimeMessagingLeaseCoordinator()
+        .start(messagingRuntime, (options) =>
+          loadDesktopMessagingConfigFromSettings(
+            getDesktopSettingsService(),
+            process.env,
+            options,
+          ),
+        )
+        .catch((error) => {
+          mainLog.error("messaging runtime lease recording failed during startup", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+    } else {
+      void getRuntimeMessagingLeaseCoordinator()
+        .start(messagingRuntime, (options) =>
+          loadDesktopMessagingConfigFromSettings(
+            getDesktopSettingsService(),
+            process.env,
+            options,
+          ),
+        )
+        .catch((error) => {
+          mainLog.error("messaging runtime failed during background startup", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
     }
     // Register status IPC after the runtime is constructed so the
     // initial subscriber attaches before the renderer asks for the
@@ -204,6 +226,7 @@ export function bootstrapApp(): void {
       disposeRuntimeIdentityIpcHandlers();
     }
     void disposeMessagingStatusIpcHandlers();
+    getRuntimeMessagingLeaseCoordinator().shutdownSync();
     void disposeDesktopMessagingRuntime();
     void disposeAppServerIpcHandlers();
     disposeAppState();

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -29,6 +29,7 @@ import { getMainLogger } from "../log";
 import { showMessagingActivityWindow } from "../messaging-activity-window";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
 import { subscribersForChannel } from "../window-channels";
 import {
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
@@ -360,11 +361,12 @@ export function registerMessagingStatusIpcHandlers(): void {
       if (!pairing) throw new Error("Pairing request not found.");
       const approval = buildPairingApprovalPatch(pairing, await service.readSettings());
       const next = await service.writeConfigPatch(approval.patch);
-      await runtime.applyConfig(
-        await loadDesktopMessagingConfigFromSettings(service, process.env, {
+      await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+        runtime,
+        (options) => loadDesktopMessagingConfigFromSettings(service, process.env, options),
+        {
           logStartupEligibility: true,
-        }),
-        { allowStart: true },
+        },
       );
       const consumed = markPairingConsumed(request.entryId);
       recordPairingActivity(consumed ?? pairing, "Approved pairing request");
@@ -430,27 +432,43 @@ export function registerMessagingStatusIpcHandlers(): void {
       request: SetMessagingEnabledRequest,
     ): Promise<SetMessagingEnabledResponse> => {
       if (request.enabled) {
-        await runtime.applyConfig(
-          await loadDesktopMessagingConfigFromSettings(
+        const result = await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+          runtime,
+          (options) => loadDesktopMessagingConfigFromSettings(
             getDesktopSettingsService(),
             process.env,
-            {
-              logStartupEligibility: true,
-              messagingEnabledOverride: true,
-            },
+            options,
           ),
-          { allowStart: true },
+          {
+            logStartupEligibility: true,
+            messagingEnabledOverride: true,
+          },
         );
+        const override = resolveRuntimeMessagingOverride();
+        return {
+          enabled: result.enabled,
+          overridden: override.disabled || result.disabledReasonKind === "lease_held",
+          ...(override.reason ? { overrideReason: override.reason } : {}),
+          ...(result.disabledReason ? { disabledReason: result.disabledReason } : {}),
+          ...(result.disabledReasonKind
+            ? { disabledReasonKind: result.disabledReasonKind }
+            : {}),
+          ...(result.leaseHolder ? { leaseHolder: result.leaseHolder } : {}),
+        };
       } else {
-        await runtime.stop();
+        const result = await getRuntimeMessagingLeaseCoordinator()
+          .disableForSession(runtime);
+        const override = resolveRuntimeMessagingOverride();
+        return {
+          enabled: result.enabled,
+          overridden: override.disabled,
+          ...(override.reason ? { overrideReason: override.reason } : {}),
+          ...(result.disabledReason ? { disabledReason: result.disabledReason } : {}),
+          ...(result.disabledReasonKind
+            ? { disabledReasonKind: result.disabledReasonKind }
+            : {}),
+        };
       }
-
-      const override = resolveRuntimeMessagingOverride();
-      return {
-        enabled: runtime.isEnabled(),
-        overridden: override.disabled,
-        ...(override.reason ? { overrideReason: override.reason } : {}),
-      };
     },
   );
 

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -39,6 +39,7 @@ import { CredentialTester } from "../credential-tester/credential-tester";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
 import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-config";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
 import { validateGhCommand } from "../settings/gh-discovery";
 
 function getService(service?: DesktopSettingsService): DesktopSettingsService {
@@ -85,11 +86,12 @@ async function applyLatestMessagingRuntimeConfig(
 ): Promise<void> {
   const runtime = getDesktopMessagingRuntime();
   const runtimeOverride = resolveRuntimeMessagingOverride();
-  await runtime.applyConfig(
-    await loadDesktopMessagingConfigFromSettings(service, process.env, {
-      logStartupEligibility: true,
-    }),
+  await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+    runtime,
+    (options) =>
+      loadDesktopMessagingConfigFromSettings(service, process.env, options),
     {
+      logStartupEligibility: true,
       allowStart: !runtimeOverride.disabled || runtime.isEnabled(),
     },
   );
@@ -98,10 +100,18 @@ async function applyLatestMessagingRuntimeConfig(
 function applyRuntimeMessagingSnapshot(
   snapshot: DesktopSettingsSnapshot,
 ): DesktopSettingsSnapshot {
-  const overrideActive = snapshot.runtime.messaging.overrideActive === true;
+  const leaseSnapshot = getRuntimeMessagingLeaseCoordinator().snapshot();
+  const leaseOverrideActive = leaseSnapshot.disabledReasonKind === "lease_held";
+  const overrideActive =
+    snapshot.runtime.messaging.overrideActive === true || leaseOverrideActive;
   const runtimeEnabled = overrideActive
     ? getDesktopMessagingRuntime().isEnabled()
     : snapshot.messaging.enabled.value;
+  const disabledReason =
+    leaseSnapshot.disabledReason ?? snapshot.runtime.messaging.disabledReason;
+  const disabledReasonKind =
+    leaseSnapshot.disabledReasonKind
+    ?? snapshot.runtime.messaging.disabledReasonKind;
   return {
     ...snapshot,
     runtime: {
@@ -111,6 +121,12 @@ function applyRuntimeMessagingSnapshot(
         disabled: overrideActive
           ? !runtimeEnabled
           : snapshot.messaging.enabled.value === false,
+        overrideActive,
+        ...(disabledReason ? { disabledReason } : {}),
+        ...(disabledReasonKind ? { disabledReasonKind } : {}),
+        ...(leaseSnapshot.leaseHolder
+          ? { leaseHolder: leaseSnapshot.leaseHolder }
+          : {}),
       },
     },
   };

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -326,6 +326,7 @@ export function desktopMessagingConfigHasRunnableAdapters(
       || config.discord
       || config.mattermost
       || config.slack
+      || config.feishu
       || config.line,
   );
 }

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -318,6 +318,18 @@ export type DesktopMessagingConfigLoadOptions = {
   messagingEnabledOverride?: boolean;
 };
 
+export function desktopMessagingConfigHasRunnableAdapters(
+  config: DesktopMessagingConfig,
+): boolean {
+  return Boolean(
+    config.telegram
+      || config.discord
+      || config.mattermost
+      || config.slack
+      || config.line,
+  );
+}
+
 export function classifyDesktopMessagingChannelConfigUpdate(
   previous: DesktopMessagingConfig,
   next: DesktopMessagingConfig,

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -1,0 +1,369 @@
+import { randomUUID } from "node:crypto";
+import {
+  resolveActiveProfileName,
+} from "./profile";
+import { getAppRuntimeInstanceStore } from "./state/app-state";
+import type {
+  AppRuntimeMessagingDisabledReason,
+  AppRuntimeInstanceStore,
+  MessagingRuntimeLeaseRecord,
+} from "./state/app-runtime-instance-store";
+import type {
+  DesktopMessagingConfig,
+} from "./messaging/messaging-config";
+import {
+  desktopMessagingConfigHasRunnableAdapters,
+  type DesktopMessagingConfigLoadOptions,
+} from "./messaging/messaging-config";
+import type {
+  DesktopMessagingConfigLoader,
+  DesktopMessagingRuntime,
+} from "./messaging/messaging-runtime";
+import {
+  resolveRuntimeMessagingOverride,
+  type RuntimeMessagingOverride,
+} from "./runtime-flags";
+
+export const MESSAGING_LEASE_TTL_MS = 30_000;
+export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
+
+export type RuntimeMessagingDisabledReasonKind =
+  | AppRuntimeMessagingDisabledReason
+  | "saved_disabled";
+
+export type RuntimeMessagingLeaseSnapshot = {
+  instanceId: string;
+  disabledReasonKind?: RuntimeMessagingDisabledReasonKind;
+  disabledReason?: string;
+  effectiveMessagingEnabled: boolean;
+  leaseHeld: boolean;
+  leaseHolder?: {
+    instanceId: string;
+    processId?: number;
+    cwdHint?: string;
+    startedAt?: number;
+    expiresAt: number;
+  };
+};
+
+export type RuntimeMessagingLeaseApplyResult = {
+  enabled: boolean;
+  disabledReasonKind?: RuntimeMessagingDisabledReasonKind;
+  disabledReason?: string;
+  leaseHolder?: RuntimeMessagingLeaseSnapshot["leaseHolder"];
+};
+
+type RuntimeMessagingLeaseCoordinatorOptions = {
+  instanceId?: string;
+  profileName?: string;
+  processId?: number;
+  cwd?: string;
+  now?: () => number;
+  store?: AppRuntimeInstanceStore;
+  env?: NodeJS.ProcessEnv;
+  argv?: readonly string[];
+};
+
+export class RuntimeMessagingLeaseCoordinator {
+  private readonly instanceId: string;
+  private readonly profileName: string;
+  private readonly processId: number;
+  private readonly cwd: string;
+  private readonly now: () => number;
+  private readonly store: AppRuntimeInstanceStore;
+  private readonly env?: NodeJS.ProcessEnv;
+  private readonly argv?: readonly string[];
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private startedRecorded = false;
+  private leaseHeld = false;
+
+  constructor(options: RuntimeMessagingLeaseCoordinatorOptions = {}) {
+    this.instanceId = options.instanceId ?? randomUUID();
+    this.profileName = options.profileName ?? resolveActiveProfileName();
+    this.processId = options.processId ?? process.pid;
+    this.cwd = options.cwd ?? process.cwd();
+    this.now = options.now ?? Date.now;
+    this.store = options.store ?? getAppRuntimeInstanceStore();
+    this.env = options.env;
+    this.argv = options.argv;
+  }
+
+  get id(): string {
+    return this.instanceId;
+  }
+
+  async start(
+    runtime: DesktopMessagingRuntime,
+    loadConfig: DesktopMessagingConfigLoader,
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const override = resolveRuntimeMessagingOverride({
+      env: this.env,
+      argv: this.argv,
+    });
+    if (override.disabled) {
+      this.recordStart({
+        desiredMessagingEnabled: false,
+        effectiveMessagingEnabled: false,
+        disabledReason: "explicit_override",
+      });
+      return {
+        enabled: false,
+        disabledReasonKind: "explicit_override",
+        ...(override.reason ? { disabledReason: override.reason } : {}),
+      };
+    }
+
+    const config = await loadConfig({ logStartupEligibility: true });
+    return this.applyResolvedConfig(runtime, config, { allowStart: true });
+  }
+
+  async applyLatestConfig(
+    runtime: DesktopMessagingRuntime,
+    loadConfig: DesktopMessagingConfigLoader,
+    options: DesktopMessagingConfigLoadOptions & { allowStart?: boolean } = {},
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const config = await loadConfig({
+      logStartupEligibility: options.logStartupEligibility,
+      messagingEnabledOverride: options.messagingEnabledOverride,
+    });
+    return this.applyResolvedConfig(runtime, config, {
+      allowStart: options.allowStart ?? true,
+    });
+  }
+
+  async applyResolvedConfig(
+    runtime: DesktopMessagingRuntime,
+    config: DesktopMessagingConfig,
+    options: { allowStart?: boolean } = {},
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const now = this.now();
+    const desiredMessagingEnabled = config.enabled !== false;
+    this.recordStart({
+      desiredMessagingEnabled,
+      effectiveMessagingEnabled: false,
+      disabledReason: desiredMessagingEnabled ? undefined : "runtime_stopped",
+    });
+
+    if (config.enabled === false) {
+      await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+      return {
+        enabled: false,
+        disabledReasonKind: "saved_disabled",
+        disabledReason: "Messaging is disabled in saved settings.",
+      };
+    }
+
+    if (!desktopMessagingConfigHasRunnableAdapters(config)) {
+      await this.stopRuntimeAndRelease(runtime, now, "no_runnable_adapters");
+      return {
+        enabled: false,
+        disabledReasonKind: "no_runnable_adapters",
+        disabledReason: "No messaging platforms are configured for this profile.",
+      };
+    }
+
+    if (options.allowStart === false && !this.leaseHeld && !runtime.isEnabled()) {
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "runtime_stopped",
+        now,
+      });
+      return {
+        enabled: false,
+        disabledReasonKind: "runtime_stopped",
+        disabledReason: "Messaging is stopped for this app instance.",
+      };
+    }
+
+    const acquire = this.store.acquireMessagingLease({
+      instanceId: this.instanceId,
+      now,
+      ttlMs: MESSAGING_LEASE_TTL_MS,
+    });
+    if (!acquire.acquired) {
+      this.stopHeartbeat();
+      await runtime.stop();
+      this.leaseHeld = false;
+      const leaseHolder = this.describeLeaseHolder(acquire.holder);
+      return {
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        disabledReason: "Messaging is already active in another PwrAgent instance for this profile.",
+        ...(leaseHolder ? { leaseHolder } : {}),
+      };
+    }
+
+    this.leaseHeld = true;
+    this.startHeartbeat();
+    await runtime.applyConfig(config, { allowStart: true });
+    return { enabled: runtime.isEnabled() };
+  }
+
+  async disableForSession(
+    runtime: DesktopMessagingRuntime,
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const now = this.now();
+    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+    return {
+      enabled: false,
+      disabledReasonKind: "runtime_stopped",
+      disabledReason: "Messaging is stopped for this app instance.",
+    };
+  }
+
+  async shutdown(runtime: DesktopMessagingRuntime): Promise<void> {
+    const now = this.now();
+    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+    this.store.markInstanceExited({ instanceId: this.instanceId, now });
+  }
+
+  shutdownSync(): void {
+    const now = this.now();
+    this.stopHeartbeat();
+    if (this.leaseHeld) {
+      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+    }
+    this.store.markInstanceExited({ instanceId: this.instanceId, now });
+    this.leaseHeld = false;
+  }
+
+  snapshot(): RuntimeMessagingLeaseSnapshot {
+    const instance = this.store.getInstance(this.instanceId);
+    const lease = this.store.getMessagingLease();
+    const leaseHolder =
+      lease
+      && lease.status === "active"
+      && lease.ownerInstanceId !== this.instanceId
+      && lease.expiresAt > this.now()
+        ? this.describeLeaseHolder(lease)
+        : undefined;
+    return {
+      instanceId: this.instanceId,
+      effectiveMessagingEnabled: instance?.effectiveMessagingEnabled ?? false,
+      disabledReasonKind: instance?.disabledReason,
+      ...(instance?.disabledReason
+        ? { disabledReason: runtimeDisabledReasonMessage(instance.disabledReason) }
+        : {}),
+      leaseHeld: this.leaseHeld,
+      ...(leaseHolder ? { leaseHolder } : {}),
+    };
+  }
+
+  private recordStart(params: {
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled: boolean;
+    disabledReason?: AppRuntimeMessagingDisabledReason;
+  }): void {
+    const now = this.now();
+    if (this.startedRecorded) {
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: params.desiredMessagingEnabled,
+        effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+        disabledReason: params.disabledReason,
+        now,
+      });
+      return;
+    }
+    this.store.recordInstanceStart({
+      instanceId: this.instanceId,
+      profileName: this.profileName,
+      processId: this.processId,
+      cwd: this.cwd,
+      startedAt: now,
+      desiredMessagingEnabled: params.desiredMessagingEnabled,
+      effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+      disabledReason: params.disabledReason,
+    });
+    this.startedRecorded = true;
+  }
+
+  private async stopRuntimeAndRelease(
+    runtime: DesktopMessagingRuntime,
+    now: number,
+    disabledReason: AppRuntimeMessagingDisabledReason,
+  ): Promise<void> {
+    this.stopHeartbeat();
+    await runtime.stop();
+    if (this.leaseHeld) {
+      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+    }
+    this.store.markDesiredMessaging({
+      instanceId: this.instanceId,
+      desiredMessagingEnabled: disabledReason !== "runtime_stopped",
+      effectiveMessagingEnabled: false,
+      disabledReason,
+      now,
+    });
+    this.leaseHeld = false;
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+    this.heartbeatTimer = setInterval(() => {
+      const renewed = this.store.renewMessagingLease({
+        instanceId: this.instanceId,
+        now: this.now(),
+        ttlMs: MESSAGING_LEASE_TTL_MS,
+      });
+      if (!renewed) {
+        this.leaseHeld = false;
+        this.stopHeartbeat();
+      }
+    }, MESSAGING_LEASE_HEARTBEAT_MS);
+    if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private describeLeaseHolder(
+    lease: MessagingRuntimeLeaseRecord,
+  ): RuntimeMessagingLeaseSnapshot["leaseHolder"] {
+    const holder = this.store.getInstance(lease.ownerInstanceId);
+    return {
+      instanceId: lease.ownerInstanceId,
+      ...(holder?.processId ? { processId: holder.processId } : {}),
+      ...(holder?.cwdHint ? { cwdHint: holder.cwdHint } : {}),
+      ...(holder?.startedAt ? { startedAt: holder.startedAt } : {}),
+      expiresAt: lease.expiresAt,
+    };
+  }
+}
+
+let coordinator: RuntimeMessagingLeaseCoordinator | null = null;
+
+export function getRuntimeMessagingLeaseCoordinator(): RuntimeMessagingLeaseCoordinator {
+  if (!coordinator) {
+    coordinator = new RuntimeMessagingLeaseCoordinator();
+  }
+  return coordinator;
+}
+
+export function setRuntimeMessagingLeaseCoordinatorForTests(
+  next: RuntimeMessagingLeaseCoordinator | null,
+): void {
+  coordinator = next;
+}
+
+function runtimeDisabledReasonMessage(
+  reason: AppRuntimeMessagingDisabledReason,
+): string {
+  switch (reason) {
+    case "explicit_override":
+      return "Messaging is disabled for this app instance.";
+    case "lease_held":
+      return "Messaging is already active in another PwrAgent instance for this profile.";
+    case "no_runnable_adapters":
+      return "No messaging platforms are configured for this profile.";
+    case "startup_error":
+      return "Messaging failed during startup for this app instance.";
+    case "runtime_stopped":
+      return "Messaging is stopped for this app instance.";
+  }
+}

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -27,6 +27,7 @@ import { getMainLogger } from "./log";
 
 export const MESSAGING_LEASE_TTL_MS = 30_000;
 export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
+export const PWRAGENT_INSTANCE_ROOT_ENV = "PWRAGENT_INSTANCE_ROOT";
 
 const leaseLog = getMainLogger("pwragent:messaging-lease");
 
@@ -84,7 +85,11 @@ export class RuntimeMessagingLeaseCoordinator {
     this.instanceId = options.instanceId ?? randomUUID();
     this.profileName = options.profileName ?? resolveActiveProfileName();
     this.processId = options.processId ?? process.pid;
-    this.cwd = options.cwd ?? process.cwd();
+    this.cwd =
+      options.cwd
+      ?? options.env?.[PWRAGENT_INSTANCE_ROOT_ENV]
+      ?? process.env[PWRAGENT_INSTANCE_ROOT_ENV]
+      ?? process.cwd();
     this.now = options.now ?? Date.now;
     this.store = options.store ?? getAppRuntimeInstanceStore();
     this.env = options.env;

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -23,9 +23,12 @@ import {
   resolveRuntimeMessagingOverride,
   type RuntimeMessagingOverride,
 } from "./runtime-flags";
+import { getMainLogger } from "./log";
 
 export const MESSAGING_LEASE_TTL_MS = 30_000;
 export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
+
+const leaseLog = getMainLogger("pwragent:messaging-lease");
 
 export type RuntimeMessagingDisabledReasonKind =
   | AppRuntimeMessagingDisabledReason
@@ -196,8 +199,13 @@ export class RuntimeMessagingLeaseCoordinator {
     }
 
     this.leaseHeld = true;
-    this.startHeartbeat();
-    await runtime.applyConfig(config, { allowStart: true });
+    this.startHeartbeat(runtime);
+    try {
+      await runtime.applyConfig(config, { allowStart: true });
+    } catch (error) {
+      await this.releaseAfterStartupFailure(runtime, now);
+      throw error;
+    }
     return { enabled: runtime.isEnabled() };
   }
 
@@ -300,7 +308,7 @@ export class RuntimeMessagingLeaseCoordinator {
     this.leaseHeld = false;
   }
 
-  private startHeartbeat(): void {
+  private startHeartbeat(runtime: DesktopMessagingRuntime): void {
     if (this.heartbeatTimer) return;
     this.heartbeatTimer = setInterval(() => {
       const renewed = this.store.renewMessagingLease({
@@ -309,11 +317,65 @@ export class RuntimeMessagingLeaseCoordinator {
         ttlMs: MESSAGING_LEASE_TTL_MS,
       });
       if (!renewed) {
-        this.leaseHeld = false;
-        this.stopHeartbeat();
+        void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {
+          leaseLog.error("messaging runtime stop failed after lease loss", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
       }
     }, MESSAGING_LEASE_HEARTBEAT_MS);
     if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
+  }
+
+  private async releaseAfterStartupFailure(
+    runtime: DesktopMessagingRuntime,
+    now: number,
+  ): Promise<void> {
+    this.stopHeartbeat();
+    try {
+      await runtime.stop();
+    } catch (error) {
+      leaseLog.warn("messaging runtime stop failed during startup cleanup", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      if (this.leaseHeld) {
+        this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+      }
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "startup_error",
+        now,
+      });
+      this.leaseHeld = false;
+    }
+  }
+
+  private async stopRuntimeAfterLeaseLoss(
+    runtime: DesktopMessagingRuntime,
+  ): Promise<void> {
+    const now = this.now();
+    this.stopHeartbeat();
+    this.leaseHeld = false;
+    try {
+      await runtime.stop();
+    } finally {
+      const lease = this.store.getMessagingLease();
+      const heldByAnotherInstance =
+        lease
+        && lease.status === "active"
+        && lease.ownerInstanceId !== this.instanceId
+        && lease.expiresAt > now;
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: heldByAnotherInstance ? "lease_held" : "runtime_stopped",
+        now,
+      });
+    }
   }
 
   private stopHeartbeat(): void {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -261,6 +261,9 @@ export class DesktopSettingsService {
         messaging: {
           disabled: messagingOverride.disabled,
           overrideActive: messagingOverride.disabled,
+          ...(messagingOverride.disabled
+            ? { disabledReasonKind: "explicit_override" as const }
+            : {}),
           ...(messagingOverride.reason
             ? { disabledReason: messagingOverride.reason }
             : {}),

--- a/apps/desktop/src/main/state/app-runtime-instance-store.ts
+++ b/apps/desktop/src/main/state/app-runtime-instance-store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import type { StateDb } from "./state-db.js";
 
@@ -15,6 +16,7 @@ export type AppRuntimeInstanceRecord = {
   profileName: string;
   processId: number;
   cwdHint?: string;
+  cwdHash?: string;
   startedAt: number;
   heartbeatAt: number;
   exitedAt?: number;
@@ -45,6 +47,7 @@ type InstanceRow = {
   profile_name: string;
   process_id: number;
   cwd_hint: string | null;
+  cwd_hash: string | null;
   started_at: number;
   heartbeat_at: number;
   exited_at: number | null;
@@ -70,6 +73,7 @@ export class AppRuntimeInstanceStore {
     profileName: string;
     processId: number;
     cwd?: string;
+    cwdHash?: string;
     startedAt: number;
     desiredMessagingEnabled: boolean;
     effectiveMessagingEnabled?: boolean;
@@ -82,16 +86,17 @@ export class AppRuntimeInstanceStore {
     this.stateDb.raw
       .prepare(
         `INSERT OR REPLACE INTO app_runtime_instances(
-           instance_id, profile_name, process_id, cwd_hint, started_at,
+           instance_id, profile_name, process_id, cwd_hint, cwd_hash, started_at,
            heartbeat_at, exited_at, desired_messaging_enabled,
            effective_messaging_enabled, disabled_reason
-         ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
       )
       .run(
         params.instanceId,
         params.profileName,
         params.processId,
         sanitizeCwdHint(params.cwd),
+        params.cwdHash ?? hashCwd(params.cwd),
         params.startedAt,
         params.startedAt,
         booleanToSql(params.desiredMessagingEnabled),
@@ -302,6 +307,7 @@ function mapInstanceRow(row: InstanceRow): AppRuntimeInstanceRecord {
     profileName: row.profile_name,
     processId: row.process_id,
     ...(row.cwd_hint ? { cwdHint: row.cwd_hint } : {}),
+    ...(row.cwd_hash ? { cwdHash: row.cwd_hash } : {}),
     startedAt: row.started_at,
     heartbeatAt: row.heartbeat_at,
     ...(row.exited_at !== null ? { exitedAt: row.exited_at } : {}),
@@ -335,6 +341,12 @@ function sanitizeCwdHint(cwd: string | undefined): string | null {
   const value = cwd?.trim();
   if (!value) return null;
   return path.basename(value).slice(0, 120) || null;
+}
+
+export function hashCwd(cwd: string | undefined): string | null {
+  const value = cwd?.trim();
+  if (!value) return null;
+  return createHash("sha256").update(path.resolve(value)).digest("hex").slice(0, 16);
 }
 
 function normalizeDisabledReason(

--- a/apps/desktop/src/main/state/app-runtime-instance-store.ts
+++ b/apps/desktop/src/main/state/app-runtime-instance-store.ts
@@ -1,0 +1,353 @@
+import path from "node:path";
+import type { StateDb } from "./state-db.js";
+
+const MESSAGING_LEASE_KEY = "profile-messaging";
+
+export type AppRuntimeMessagingDisabledReason =
+  | "explicit_override"
+  | "lease_held"
+  | "no_runnable_adapters"
+  | "runtime_stopped"
+  | "startup_error";
+
+export type AppRuntimeInstanceRecord = {
+  instanceId: string;
+  profileName: string;
+  processId: number;
+  cwdHint?: string;
+  startedAt: number;
+  heartbeatAt: number;
+  exitedAt?: number;
+  desiredMessagingEnabled: boolean;
+  effectiveMessagingEnabled: boolean;
+  disabledReason?: AppRuntimeMessagingDisabledReason;
+};
+
+export type MessagingRuntimeLeaseRecord = {
+  ownerInstanceId: string;
+  acquiredAt: number;
+  heartbeatAt: number;
+  expiresAt: number;
+  releasedAt?: number;
+  status: "active" | "released" | "expired";
+};
+
+export type MessagingLeaseAcquireResult =
+  | { acquired: true; lease: MessagingRuntimeLeaseRecord }
+  | {
+      acquired: false;
+      reason: "held";
+      holder: MessagingRuntimeLeaseRecord;
+    };
+
+type InstanceRow = {
+  instance_id: string;
+  profile_name: string;
+  process_id: number;
+  cwd_hint: string | null;
+  started_at: number;
+  heartbeat_at: number;
+  exited_at: number | null;
+  desired_messaging_enabled: number;
+  effective_messaging_enabled: number;
+  disabled_reason: string | null;
+};
+
+type LeaseRow = {
+  owner_instance_id: string;
+  acquired_at: number;
+  heartbeat_at: number;
+  expires_at: number;
+  released_at: number | null;
+  status: "active" | "released" | "expired";
+};
+
+export class AppRuntimeInstanceStore {
+  constructor(private readonly stateDb: StateDb) {}
+
+  recordInstanceStart(params: {
+    instanceId: string;
+    profileName: string;
+    processId: number;
+    cwd?: string;
+    startedAt: number;
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled?: boolean;
+    disabledReason?: string;
+  }): AppRuntimeInstanceRecord {
+    const disabledReason = normalizeDisabledReason(params.disabledReason);
+    const effectiveMessagingEnabled =
+      params.effectiveMessagingEnabled ?? (disabledReason ? false : false);
+
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO app_runtime_instances(
+           instance_id, profile_name, process_id, cwd_hint, started_at,
+           heartbeat_at, exited_at, desired_messaging_enabled,
+           effective_messaging_enabled, disabled_reason
+         ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+      )
+      .run(
+        params.instanceId,
+        params.profileName,
+        params.processId,
+        sanitizeCwdHint(params.cwd),
+        params.startedAt,
+        params.startedAt,
+        booleanToSql(params.desiredMessagingEnabled),
+        booleanToSql(effectiveMessagingEnabled),
+        disabledReason ?? null,
+      );
+
+    return this.getInstance(params.instanceId)!;
+  }
+
+  getInstance(instanceId: string): AppRuntimeInstanceRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM app_runtime_instances WHERE instance_id = ?")
+      .get(instanceId) as InstanceRow | undefined;
+    return row ? mapInstanceRow(row) : undefined;
+  }
+
+  markDesiredMessaging(params: {
+    instanceId: string;
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled: boolean;
+    disabledReason?: AppRuntimeMessagingDisabledReason;
+    now: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE app_runtime_instances
+         SET desired_messaging_enabled = ?,
+             effective_messaging_enabled = ?,
+             disabled_reason = ?,
+             heartbeat_at = ?
+         WHERE instance_id = ?`,
+      )
+      .run(
+        booleanToSql(params.desiredMessagingEnabled),
+        booleanToSql(params.effectiveMessagingEnabled),
+        params.disabledReason ?? null,
+        params.now,
+        params.instanceId,
+      );
+  }
+
+  heartbeatInstance(params: { instanceId: string; now: number }): void {
+    this.stateDb.raw
+      .prepare(
+        "UPDATE app_runtime_instances SET heartbeat_at = ? WHERE instance_id = ?",
+      )
+      .run(params.now, params.instanceId);
+  }
+
+  markInstanceExited(params: { instanceId: string; now: number }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE app_runtime_instances
+         SET exited_at = ?, heartbeat_at = ?
+         WHERE instance_id = ?`,
+      )
+      .run(params.now, params.now, params.instanceId);
+  }
+
+  acquireMessagingLease(params: {
+    instanceId: string;
+    now: number;
+    ttlMs: number;
+  }): MessagingLeaseAcquireResult {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        existing
+        && existing.status === "active"
+        && existing.ownerInstanceId !== params.instanceId
+        && existing.expiresAt > params.now
+      ) {
+        this.markDesiredMessaging({
+          instanceId: params.instanceId,
+          desiredMessagingEnabled: true,
+          effectiveMessagingEnabled: false,
+          disabledReason: "lease_held",
+          now: params.now,
+        });
+        return { acquired: false as const, reason: "held" as const, holder: existing };
+      }
+
+      const acquiredAt =
+        existing?.status === "active"
+        && existing.ownerInstanceId === params.instanceId
+        && existing.expiresAt > params.now
+          ? existing.acquiredAt
+          : params.now;
+      const lease = this.upsertActiveLease({
+        instanceId: params.instanceId,
+        acquiredAt,
+        now: params.now,
+        ttlMs: params.ttlMs,
+      });
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: true,
+        now: params.now,
+      });
+      return { acquired: true as const, lease };
+    })();
+  }
+
+  renewMessagingLease(params: {
+    instanceId: string;
+    now: number;
+    ttlMs: number;
+  }): boolean {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        !existing
+        || existing.status !== "active"
+        || existing.ownerInstanceId !== params.instanceId
+      ) {
+        return false;
+      }
+
+      this.upsertActiveLease({
+        instanceId: params.instanceId,
+        acquiredAt: existing.acquiredAt,
+        now: params.now,
+        ttlMs: params.ttlMs,
+      });
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: true,
+        now: params.now,
+      });
+      return true;
+    })();
+  }
+
+  releaseMessagingLease(params: { instanceId: string; now: number }): boolean {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        !existing
+        || existing.status !== "active"
+        || existing.ownerInstanceId !== params.instanceId
+      ) {
+        return false;
+      }
+
+      this.stateDb.raw
+        .prepare(
+          `UPDATE messaging_runtime_lease
+           SET released_at = ?, status = 'released'
+           WHERE lease_key = ? AND owner_instance_id = ?`,
+        )
+        .run(params.now, MESSAGING_LEASE_KEY, params.instanceId);
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "runtime_stopped",
+        now: params.now,
+      });
+      return true;
+    })();
+  }
+
+  getMessagingLease(): MessagingRuntimeLeaseRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM messaging_runtime_lease WHERE lease_key = ?")
+      .get(MESSAGING_LEASE_KEY) as LeaseRow | undefined;
+    return row ? mapLeaseRow(row) : undefined;
+  }
+
+  private upsertActiveLease(params: {
+    instanceId: string;
+    acquiredAt: number;
+    now: number;
+    ttlMs: number;
+  }): MessagingRuntimeLeaseRecord {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO messaging_runtime_lease(
+           lease_key, owner_instance_id, acquired_at, heartbeat_at,
+           expires_at, released_at, status
+         ) VALUES (?, ?, ?, ?, ?, NULL, 'active')
+         ON CONFLICT(lease_key) DO UPDATE SET
+           owner_instance_id = excluded.owner_instance_id,
+           acquired_at = excluded.acquired_at,
+           heartbeat_at = excluded.heartbeat_at,
+           expires_at = excluded.expires_at,
+           released_at = NULL,
+           status = 'active'`,
+      )
+      .run(
+        MESSAGING_LEASE_KEY,
+        params.instanceId,
+        params.acquiredAt,
+        params.now,
+        params.now + params.ttlMs,
+      );
+    this.heartbeatInstance({ instanceId: params.instanceId, now: params.now });
+    return this.getMessagingLease()!;
+  }
+}
+
+function mapInstanceRow(row: InstanceRow): AppRuntimeInstanceRecord {
+  return {
+    instanceId: row.instance_id,
+    profileName: row.profile_name,
+    processId: row.process_id,
+    ...(row.cwd_hint ? { cwdHint: row.cwd_hint } : {}),
+    startedAt: row.started_at,
+    heartbeatAt: row.heartbeat_at,
+    ...(row.exited_at !== null ? { exitedAt: row.exited_at } : {}),
+    desiredMessagingEnabled: row.desired_messaging_enabled === 1,
+    effectiveMessagingEnabled: row.effective_messaging_enabled === 1,
+    ...(row.disabled_reason
+      ? {
+          disabledReason:
+            normalizeDisabledReason(row.disabled_reason) ?? "runtime_stopped",
+        }
+      : {}),
+  };
+}
+
+function mapLeaseRow(row: LeaseRow): MessagingRuntimeLeaseRecord {
+  return {
+    ownerInstanceId: row.owner_instance_id,
+    acquiredAt: row.acquired_at,
+    heartbeatAt: row.heartbeat_at,
+    expiresAt: row.expires_at,
+    ...(row.released_at !== null ? { releasedAt: row.released_at } : {}),
+    status: row.status,
+  };
+}
+
+function booleanToSql(value: boolean): number {
+  return value ? 1 : 0;
+}
+
+function sanitizeCwdHint(cwd: string | undefined): string | null {
+  const value = cwd?.trim();
+  if (!value) return null;
+  return path.basename(value).slice(0, 120) || null;
+}
+
+function normalizeDisabledReason(
+  value: string | undefined,
+): AppRuntimeMessagingDisabledReason | undefined {
+  switch (value) {
+    case "explicit_override":
+    case "lease_held":
+    case "no_runnable_adapters":
+    case "runtime_stopped":
+    case "startup_error":
+      return value;
+    default:
+      return value ? "explicit_override" : undefined;
+  }
+}

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -3,6 +3,7 @@ import {
   resolveActiveProfilePath,
   updateLastUsed,
 } from "../profile";
+import { AppRuntimeInstanceStore } from "./app-runtime-instance-store.js";
 import { migrateIfNeeded } from "./migration.js";
 import { SqliteMessagingStore } from "./messaging-store-sqlite.js";
 import { SqliteOverlayStore } from "./overlay-store-sqlite.js";
@@ -11,14 +12,21 @@ import { StateDb } from "./state-db.js";
 let stateDb: StateDb | null = null;
 let messagingStore: SqliteMessagingStore | null = null;
 let overlayStore: SqliteOverlayStore | null = null;
+let runtimeInstanceStore: AppRuntimeInstanceStore | null = null;
 
 export function initializeAppState(): {
   stateDb: StateDb;
   messagingStore: SqliteMessagingStore;
   overlayStore: SqliteOverlayStore;
+  runtimeInstanceStore: AppRuntimeInstanceStore;
 } {
   if (stateDb) {
-    return { stateDb, messagingStore: messagingStore!, overlayStore: overlayStore! };
+    return {
+      stateDb,
+      messagingStore: messagingStore!,
+      overlayStore: overlayStore!,
+      runtimeInstanceStore: runtimeInstanceStore!,
+    };
   }
 
   const { profileName } = ensureProfileExists();
@@ -32,8 +40,9 @@ export function initializeAppState(): {
 
   messagingStore = new SqliteMessagingStore(stateDb);
   overlayStore = new SqliteOverlayStore(stateDb);
+  runtimeInstanceStore = new AppRuntimeInstanceStore(stateDb);
 
-  return { stateDb, messagingStore, overlayStore };
+  return { stateDb, messagingStore, overlayStore, runtimeInstanceStore };
 }
 
 export function getAppStateDb(): StateDb {
@@ -51,12 +60,18 @@ export function getAppOverlayStore(): SqliteOverlayStore {
   return overlayStore;
 }
 
+export function getAppRuntimeInstanceStore(): AppRuntimeInstanceStore {
+  if (!runtimeInstanceStore) throw new Error("App state not initialized. Call initializeAppState() first.");
+  return runtimeInstanceStore;
+}
+
 export function disposeAppState(): void {
   if (stateDb) {
     stateDb.close();
     stateDb = null;
     messagingStore = null;
     overlayStore = null;
+    runtimeInstanceStore = null;
   }
 }
 
@@ -64,4 +79,5 @@ export function resetAppStateForTests(): void {
   stateDb = null;
   messagingStore = null;
   overlayStore = null;
+  runtimeInstanceStore = null;
 }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -155,10 +155,38 @@ CREATE TABLE IF NOT EXISTS monitor_subscriptions (
 );
 CREATE INDEX IF NOT EXISTS idx_monitor_subscriptions_channel
   ON monitor_subscriptions(channel_kind, channel_id);
+
+CREATE TABLE IF NOT EXISTS app_runtime_instances (
+  instance_id                 TEXT PRIMARY KEY,
+  profile_name                TEXT NOT NULL,
+  process_id                  INTEGER NOT NULL,
+  cwd_hint                    TEXT,
+  started_at                  INTEGER NOT NULL,
+  heartbeat_at                INTEGER NOT NULL,
+  exited_at                   INTEGER,
+  desired_messaging_enabled   INTEGER NOT NULL,
+  effective_messaging_enabled INTEGER NOT NULL,
+  disabled_reason             TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_heartbeat
+  ON app_runtime_instances(profile_name, heartbeat_at DESC);
+
+CREATE TABLE IF NOT EXISTS messaging_runtime_lease (
+  lease_key         TEXT PRIMARY KEY,
+  owner_instance_id TEXT NOT NULL,
+  acquired_at       INTEGER NOT NULL,
+  heartbeat_at      INTEGER NOT NULL,
+  expires_at        INTEGER NOT NULL,
+  released_at       INTEGER,
+  status            TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messaging_runtime_lease_status_expires
+  ON messaging_runtime_lease(status, expires_at);
 `;
 
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const APP_RUNTIME_INSTANCE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 /**
  * Per-platform cap for the messaging activity log. Older rows are
  * evicted FIFO so the table stays small even on busy platforms. Tuned
@@ -264,6 +292,16 @@ export class StateDb {
           "UPDATE messaging_pairing_tokens SET status = 'expired' WHERE status IN ('pending', 'observed') AND expires_at < ?",
         )
         .run(now);
+      this.db
+        .prepare(
+          "UPDATE messaging_runtime_lease SET status = 'expired' WHERE status = 'active' AND expires_at < ?",
+        )
+        .run(now);
+      this.db
+        .prepare(
+          "DELETE FROM app_runtime_instances WHERE heartbeat_at < ? AND exited_at IS NOT NULL",
+        )
+        .run(now - APP_RUNTIME_INSTANCE_RETENTION_MS);
       this.db
         .prepare("DELETE FROM deliveries WHERE created_at < ?")
         .run(now - DELIVERIES_RETENTION_MS);

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -187,7 +187,7 @@ CREATE INDEX IF NOT EXISTS idx_messaging_runtime_lease_status_expires
 
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
-const APP_RUNTIME_INSTANCE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
 /**
  * Per-platform cap for the messaging activity log. Older rows are
  * evicted FIFO so the table stays small even on busy platforms. Tuned

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -161,6 +161,7 @@ CREATE TABLE IF NOT EXISTS app_runtime_instances (
   profile_name                TEXT NOT NULL,
   process_id                  INTEGER NOT NULL,
   cwd_hint                    TEXT,
+  cwd_hash                    TEXT,
   started_at                  INTEGER NOT NULL,
   heartbeat_at                INTEGER NOT NULL,
   exited_at                   INTEGER,
@@ -250,6 +251,11 @@ export class StateDb {
       })();
     }
     ensureCurrentSchema(db);
+    if ((db.pragma("user_version", { simple: true }) as number) < 5) {
+      db.transaction(() => {
+        db.pragma("user_version = 5");
+      })();
+    }
 
     return new StateDb(db);
   }
@@ -378,4 +384,23 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
       db.pragma("user_version = 4");
     }
   })();
+
+  if (!columnExists(db, "app_runtime_instances", "cwd_hash")) {
+    db.exec("ALTER TABLE app_runtime_instances ADD COLUMN cwd_hash TEXT");
+  }
+  db.exec(`
+CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_cwd_hash
+  ON app_runtime_instances(profile_name, cwd_hash, heartbeat_at DESC);
+`);
+}
+
+function columnExists(
+  db: BetterSqlite3.Database,
+  tableName: string,
+  columnName: string,
+): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name: string;
+  }>;
+  return rows.some((row) => row.name === columnName);
 }

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -97,6 +97,22 @@ export function MessagingSettings(props: {
     ? !runtimeMessaging.disabled
     : messagingEnabled.value;
   const platformControlsDisabled = props.saving || !masterEnabled;
+  const leaseHolderLabel = runtimeMessaging.leaseHolder
+    ? [
+        runtimeMessaging.leaseHolder.cwdHint,
+        runtimeMessaging.leaseHolder.processId
+          ? `pid ${runtimeMessaging.leaseHolder.processId}`
+          : undefined,
+      ].filter(Boolean).join(" - ")
+    : undefined;
+  const runtimeWarningTitle =
+    runtimeMessaging.disabledReasonKind === "lease_held"
+      ? "Messaging active in another app instance"
+      : "Messaging disabled for this app instance";
+  const runtimeWarningBody =
+    runtimeMessaging.disabledReasonKind === "lease_held"
+      ? `Messaging is off here because another PwrAgent instance holds this profile's messaging lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance or wait for its lease to expire, then flip the master toggle to try again.`
+      : "Messaging is off because the app was launched with the no-messaging flag. You can override this for the current session by flipping the master toggle below, but make sure messaging is off in any other PwrAgent instances first. The override applies to this session only; the saved default is unchanged.";
 
   return (
     <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
@@ -111,15 +127,11 @@ export function MessagingSettings(props: {
           <div className="settings-panel__header">
             <div>
               <p className="eyebrow">Runtime Override</p>
-              <h2>Messaging disabled for this app instance</h2>
+              <h2>{runtimeWarningTitle}</h2>
             </div>
           </div>
           <p className="settings-row__description">
-            Messaging is off because the app was launched with the no-messaging
-            flag. You can override this for the current session by flipping the
-            master toggle below, but make sure messaging is off in any other
-            PwrAgent instances first. The override applies to this session only;
-            the saved default is unchanged.
+            {runtimeWarningBody}
           </p>
         </section>
       ) : null}
@@ -141,7 +153,9 @@ export function MessagingSettings(props: {
             }
             source={
               runtimeMessaging.overrideActive
-                ? "session"
+                ? runtimeMessaging.disabledReasonKind === "lease_held"
+                  ? "lease"
+                  : "session"
                 : sourceBadge(messagingEnabled)
             }
             onChange={(enabled) => {

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -249,6 +249,12 @@ This disables messaging only for that app process. It does not rewrite the
 settings file or remove stored bot credentials. The Settings > Messaging screen
 shows when this runtime override is active.
 
+Normal `pnpm dev` launches are protected by a profile-scoped messaging lease:
+only one live app instance for a profile starts messaging adapters. A second
+instance stays usable for desktop work and leaves messaging stopped until the
+holder exits or its heartbeat expires. Keep `dev:no-messaging` for work where
+the current process should never attempt messaging, even if the lease is free.
+
 Default 1Password item:
 
 - Vault: `Private`

--- a/docs/plans/2026-05-12-001-feat-dev-profile-messaging-leases-plan.md
+++ b/docs/plans/2026-05-12-001-feat-dev-profile-messaging-leases-plan.md
@@ -1,0 +1,352 @@
+---
+title: feat: Add dev profile messaging leases
+type: feat
+status: completed
+date: 2026-05-12
+deepened: 2026-05-12
+---
+
+# feat: Add dev profile messaging leases
+
+## Overview
+
+Add a profile-scoped messaging lease so multiple PwrAgent desktop instances can share one profile without every instance trying to start Telegram, Discord, Slack, Mattermost, or LINE adapters. Each app instance records itself in the profile `state.db`, one instance at a time may hold the messaging lease, and stale holders expire when their heartbeat stops. This keeps `dev:no-messaging` available as an explicit opt-out, but makes normal dev launches safer.
+
+## Problem Frame
+
+Today `pnpm dev:no-messaging` exists because `pnpm dev` can start real messaging adapters against the same profile credentials. A second desktop process can collide with the first, causing provider conflicts such as duplicate bot polling or confusing runtime status. The user wants this solved as developer/runtime infrastructure rather than a broad user-facing feature: log instance starts, know whether messaging is effective for that instance, and let a new process take over when the old holder is gone.
+
+## Requirements Trace
+
+- R1. Record every desktop app instance startup in the profile database with enough safe metadata to identify it during development.
+- R2. Record both desired and effective messaging state for each instance so a process can show "wanted messaging, lease held elsewhere" distinctly from "messaging explicitly disabled."
+- R3. Allow at most one active messaging-enabled lease holder per profile.
+- R4. Expire stale messaging leases after the holder stops heartbeating, so crashed or killed dev instances do not require manual cleanup.
+- R5. Keep explicit `--disable-messaging` / `PWRAGENT_DISABLE_MESSAGING` behavior as a stronger session-only opt-out.
+- R6. Keep provider packages persistence-free; lease ownership belongs to desktop main process state/orchestration.
+- R7. Do not persist secrets, raw env, or full command lines in instance/lease rows.
+- R8. Keep second instances useful for desktop browsing and editing even when messaging is suspended by another holder.
+
+## Scope Boundaries
+
+- In scope: desktop main-process instance logging, profile-scoped lease persistence, heartbeat/release lifecycle, settings/status wording for lease-held-disabled state, tests, and developer docs.
+- Out of scope: changing provider adapter contracts, adding cross-machine distributed locking, changing profile selection semantics, changing messaging credentials/config shape, or removing `dev:no-messaging`.
+- Out of scope for first pass: a force-takeover UI. Lease takeover should happen only when the prior holder is expired.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/index.ts` initializes profile state, constructs `DesktopMessagingRuntime`, and currently decides between `resolveRuntimeMessagingOverride()` and `messagingRuntime.start()`.
+- `apps/desktop/src/main/runtime-flags.ts` defines the explicit no-messaging override.
+- `apps/desktop/src/main/state/app-state.ts` opens the profile `state/state.db`, starts SQLite GC, and exposes `getAppStateDb()`.
+- `apps/desktop/src/main/state/state-db.ts` owns SQLite schema migrations, WAL setup, busy timeout, GC, and small state helpers.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` owns adapter lifecycle, platform health, runtime start/stop, and status snapshots.
+- `apps/desktop/src/main/ipc/messaging-status.ts` already lets Settings start/stop messaging for the current session without changing saved config when a runtime override is active.
+- `apps/desktop/src/main/settings/desktop-settings-service.ts` and `packages/shared/src/contracts/settings.ts` expose `runtime.messaging` to the renderer.
+- `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx` already has a runtime warning panel for session-only messaging disablement.
+- `docs/state-layout.md` currently states multiple instances can share the same profile DB safely via SQLite WAL, but it does not account for singleton messaging adapters.
+- `packages/messaging/AGENTS.md` requires providers to stay persistence-free and puts orchestration in `apps/desktop/src/main/messaging`.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` reinforces that singleton ownership can simplify runtime behavior when multiple processes would otherwise create conflicting state.
+- Existing messaging plans establish that desktop owns messaging orchestration and providers should remain isolated behind the generic interface.
+
+### External References
+
+- External research skipped. The core problem is repo-local runtime coordination over SQLite, and the repository already has the relevant architectural patterns.
+
+## Key Technical Decisions
+
+- Use the profile `state.db` as the lease authority. It is already the shared per-profile coordination point and is opened with WAL plus a busy timeout, so no extra lockfile or process-global IPC is needed.
+- Use heartbeat expiry, not PID liveness, as the correctness mechanism. PID and cwd are useful diagnostics, but PID reuse and cross-platform behavior make process checks a weak authority. A lease is valid only while `expires_at` is in the future and the owner keeps renewing it.
+- Acquire the lease before starting provider adapters. The second process should never import/load/start configured providers when another live holder owns messaging for that profile.
+- Keep explicit no-messaging overrides stronger than leases. If `--disable-messaging` or `PWRAGENT_DISABLE_MESSAGING` is set, the instance logs desired/effective messaging as disabled and does not attempt acquisition.
+- Represent lease-held-disabled as runtime state, not saved config. The user's `[messaging] enabled` setting remains the desired default; the lease only affects this process.
+- Release only the current holder's lease on orderly shutdown or session stop. Do not delete another instance's row, and do not release the lease merely because one provider adapter fails after startup.
+- Keep the first pass passive for second instances. They should show messaging as unavailable because another live instance holds the lease, and should acquire automatically only after expiry or when the user toggles messaging after the lease is free.
+- Do not claim the lease when the resolved messaging config has no configured adapters. A profile with the master switch on but no eligible provider credentials should record that messaging was desired but had no runnable platforms; it should not block another instance unnecessarily.
+- Centralize lease gating in one desktop main-process coordinator used by startup, `applyLatestConfig`, and Settings IPC. Bootstrap and Settings should not each invent slightly different acquisition/release rules.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be limited to development builds? No. The implementation is a safe profile invariant that prevents duplicate adapter starts anywhere. The feature is developer-motivated, but the invariant protects production-like multi-instance use too.
+- Should provider packages participate? No. The lease guards desktop runtime startup before provider loading, preserving the provider persistence boundary.
+- Should a second process force-steal the lease? No for the first pass. Stale expiry is enough to reduce `dev:no-messaging` use without adding destructive takeover behavior.
+
+### Deferred to Implementation
+
+- Exact names for the store class and shared DTO fields: choose names that fit nearby desktop state/settings conventions during implementation.
+- Exact heartbeat interval constants: the plan recommends a 10-second heartbeat and 30-second lease TTL, but implementation can tune slightly if tests or existing timer conventions suggest better values.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant App as Desktop instance
+    participant State as Profile state.db
+    participant Runtime as DesktopMessagingRuntime
+    participant Providers as Provider adapters
+
+    App->>State: record instance start
+    App->>State: resolve desired messaging config + explicit override
+    alt explicit no-messaging override
+        App->>State: mark effective messaging disabled
+        App-->>Runtime: keep runtime constructed but stopped
+    else no runnable adapters
+        App->>State: mark effective messaging disabled: no configured platforms
+        App-->>Runtime: keep runtime constructed but stopped
+    else lease free or expired
+        App->>State: atomically acquire profile messaging lease
+        App->>State: heartbeat instance + lease
+        App->>Runtime: start messaging
+        Runtime->>Providers: load and start configured adapters
+    else live holder owns lease
+        App->>State: mark effective messaging disabled: lease held elsewhere
+        App-->>Runtime: keep runtime constructed but stopped
+    end
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add profile instance and lease persistence**
+
+**Goal:** Create the SQLite schema and desktop main-process store that records app instances and manages the single messaging lease for the active profile.
+
+**Requirements:** R1, R2, R3, R4, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/state/state-db.ts`
+- Modify: `apps/desktop/src/main/state/app-state.ts`
+- Create: `apps/desktop/src/main/state/app-runtime-instance-store.ts`
+- Test: `apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts`
+
+**Approach:**
+- Add a new schema migration with an `app_runtime_instances` table and a singleton/profile-scoped `messaging_runtime_lease` table.
+- Instance rows should include a generated instance id, profile name, process id, safe cwd/worktree hint, start timestamp, heartbeat timestamp, optional exit timestamp, desired messaging boolean, effective messaging boolean, and safe disabled reason.
+- Lease rows should include the owner instance id, acquired timestamp, last heartbeat timestamp, expires timestamp, and released timestamp or status.
+- Implement atomic acquire/renew/release operations inside transactions. Acquisition succeeds when no active lease exists, the existing lease is expired, or the existing owner is the current instance.
+- Keep SQL parameterized and keep generated SQL fragments limited to hardcoded structure.
+- Add GC for old instance rows and released/expired lease history if the chosen schema retains history.
+
+**Execution note:** Implement the store test-first because the lease race/expiry behavior is the correctness core.
+
+**Patterns to follow:**
+- `StateDb.open()` migration style and `cleanupExpired()` retention patterns in `apps/desktop/src/main/state/state-db.ts`.
+- `apps/desktop/src/main/messaging/messaging-pairing-store.ts` for focused SQLite store methods around a small table.
+- SQLite query rules in `apps/desktop/AGENTS.md`.
+
+**Test scenarios:**
+- Happy path: first instance records startup and acquires the messaging lease with effective messaging enabled.
+- Happy path: the same instance renews its lease and extends `expires_at`.
+- Edge case: a second instance cannot acquire while the first holder's `expires_at` is in the future and records effective messaging disabled with a lease-held reason.
+- Edge case: a second instance can acquire after the first holder's lease is expired.
+- Edge case: releasing a lease from a non-holder leaves the live holder intact.
+- Error path: malformed or missing profile metadata does not persist secrets or raw env values.
+- Integration: reopening `state.db` preserves instance/lease rows and allows expiry-based acquisition across processes.
+
+**Verification:**
+- The store can deterministically prove single-holder semantics with concurrent-like sequential transactions.
+- The schema migration is idempotent for existing profile databases.
+
+- [x] **Unit 2: Gate messaging startup through the lease**
+
+**Goal:** Change desktop bootstrap and runtime lifecycle so provider adapters start only when this instance holds the profile messaging lease.
+
+**Requirements:** R2, R3, R4, R5, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/index.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Modify: `apps/desktop/src/main/runtime-flags.ts` only if the override type needs a broader disabled-reason model.
+- Test: `apps/desktop/src/main/__tests__/index.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Test: `apps/desktop/src/main/__tests__/runtime-flags.test.ts` if the override type changes.
+
+**Approach:**
+- Generate the instance id after `initializeAppState()` and record startup before making the messaging startup decision.
+- Resolve explicit no-messaging override first. If present, mark the instance as disabled and skip lease acquisition.
+- Load the desktop messaging config before acquisition so the coordinator can distinguish "master enabled with runnable adapters" from "master enabled but no configured platforms."
+- If desired messaging is enabled, at least one adapter config is present, and no explicit override is active, attempt lease acquisition before calling `messagingRuntime.start()` or `messagingRuntime.applyConfig()`.
+- Put this preflight in a shared coordinator path that startup and Settings IPC both use; avoid duplicating lease conditions in two call sites.
+- Start a heartbeat timer only for the current lease holder. The heartbeat should renew both the instance heartbeat and lease expiry.
+- On `before-quit`, stop messaging and release the lease only when this process is the holder; mark the instance exited before closing `state.db`.
+- If lease acquisition fails, keep the runtime constructed and status IPC registered, but do not load providers or start adapters.
+- Preserve the existing `messagingRuntime.start().catch(...)` background-start behavior, but ensure failed startup updates instance effective state without corrupting another holder's lease.
+
+**Patterns to follow:**
+- Existing bootstrap order in `apps/desktop/src/main/index.ts`.
+- Runtime lifecycle queue in `DesktopMessagingRuntime`.
+- Existing explicit override behavior in `resolveRuntimeMessagingOverride()`.
+
+**Test scenarios:**
+- Happy path: without override and with a free lease, bootstrap attempts messaging startup.
+- Happy path: with `PWRAGENT_DISABLE_MESSAGING`, bootstrap records disabled state and never calls runtime start or lease acquire.
+- Edge case: with the master switch enabled but no configured adapter credentials, bootstrap records no runnable platforms and does not claim the lease.
+- Edge case: when lease acquisition fails because another live holder exists, provider loading is not invoked and the app still registers messaging status IPC.
+- Edge case: when a stale lease exists, bootstrap acquires and starts messaging.
+- Error path: if runtime start fails after lease acquisition, the error is logged and the lease remains owned until the runtime/instance stops.
+- Integration: before-quit releases only the current holder's lease and marks the instance exited.
+
+**Verification:**
+- A second desktop instance with the same profile no longer starts provider adapters while the first holder is live.
+- Explicit no-messaging behavior remains unchanged except for instance logging.
+
+- [x] **Unit 3: Make session enable/disable lease-aware**
+
+**Goal:** Keep the Settings master toggle and IPC behavior correct when messaging is disabled because another instance holds the lease.
+
+**Requirements:** R2, R3, R4, R5, R8
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/ipc/messaging-status.ts`
+- Modify: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Modify: `packages/shared/src/contracts/settings.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+
+**Approach:**
+- Extend runtime messaging snapshot data with a disabled reason category that can distinguish explicit override from lease-held-disabled.
+- When Settings calls `setMessagingEnabled({ enabled: true })`, attempt lease acquisition before applying config with `allowStart: true`.
+- Reuse the same coordinator path as startup so a config with no runnable adapters does not claim the lease and a config with runnable adapters cannot bypass the lease.
+- If acquisition succeeds, start/renew heartbeat and apply config as today.
+- If acquisition fails because a live holder exists, return effective disabled state and the holder metadata that is safe to show or log.
+- When Settings disables messaging for the session, stop the runtime and release this instance's lease if held; do not change saved config when the disabled state is lease/session-only.
+
+**Patterns to follow:**
+- Existing `MESSAGING_SET_ENABLED_CHANNEL` flow in `apps/desktop/src/main/ipc/messaging-status.ts`.
+- Existing runtime messaging snapshot shape in `DesktopSettingsSnapshot`.
+- Current session-only override handling in `MessagingSettings.tsx`.
+
+**Test scenarios:**
+- Happy path: enabling messaging from a lease-disabled instance acquires a now-free lease and starts runtime.
+- Happy path: enabling messaging when no adapters are configured returns a coherent disabled/no-platforms state without claiming the lease.
+- Edge case: enabling messaging while another live holder exists returns disabled state with a lease-held reason and does not start providers.
+- Edge case: disabling messaging from the lease holder stops runtime and releases the lease.
+- Edge case: disabling messaging from a non-holder is a no-op for the lease and still returns a coherent effective disabled state.
+- Integration: `readSettings()` reports explicit no-messaging and lease-held-disabled as distinct runtime conditions.
+
+**Verification:**
+- Settings can recover automatically once the prior holder expires, without requiring `dev:no-messaging`.
+- Saved `config.toml` messaging settings are unchanged by lease-only state.
+
+- [x] **Unit 4: Surface lease-held state in developer-facing UI/status**
+
+**Goal:** Make lease-disabled state understandable without turning it into a prominent end-user feature.
+
+**Requirements:** R2, R8
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx` only if the master toggle callback needs adjusted state handling.
+- Modify: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx` only if status chips need a suspended-by-lease tooltip.
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts` only if preload contract types change locally.
+- Modify: `apps/desktop/src/preload/index.ts` if IPC response fields change.
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx` if status chip behavior changes.
+
+**Approach:**
+- Reuse the existing runtime warning panel shape in Messaging Settings, but change copy and source labeling when disabled because another profile instance holds the lease.
+- Keep the master toggle semantics effective-state based: on means this instance is the holder and runtime is started; off can mean explicit override, lease held elsewhere, or user stopped the session.
+- Avoid broad new navigation or dashboard surfaces. This is developer/runtime status, not a new product workflow.
+- If safe holder metadata is exposed, show only coarse information such as start time, pid, or cwd basename/worktree hint, not raw env or full argv.
+
+**Patterns to follow:**
+- Existing `MessagingSettings.tsx` runtime override panel and source badges.
+- Desktop style guidance in `apps/desktop/AGENTS.md`: no placeholder or implementation-status narration in user-facing UI.
+
+**Test scenarios:**
+- Happy path: Settings shows the existing explicit no-messaging warning when launched with `dev:no-messaging`.
+- Happy path: Settings shows a distinct lease-held message when another live instance owns messaging.
+- Edge case: the master toggle is disabled or returns to off when an enable attempt cannot acquire the lease.
+- Edge case: once IPC reports enabled after acquisition, the warning disappears and platform controls become enabled.
+
+**Verification:**
+- Developers can tell why messaging is off in the current process and whether retrying after the other instance exits should work.
+- No provider-specific wording leaks into the generic messaging settings panel.
+
+- [x] **Unit 5: Update docs and operational guidance**
+
+**Goal:** Document the new lease behavior so developers know when `dev`, `dev:no-messaging`, and profile isolation are appropriate.
+
+**Requirements:** R1, R3, R4, R5, R8
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/state-layout.md`
+- Modify: `apps/desktop/AGENTS.md`
+- Modify: `docs/messaging-platform-integration.md` if its dev commands still imply `dev:no-messaging` is the default safest path.
+- Test: `apps/desktop/src/main/__tests__/messaging-docs-links.test.ts` if docs links are added or changed.
+
+**Approach:**
+- Update the multi-instance section to state that SQLite still supports shared profile access, but messaging adapters are single-holder per profile.
+- Keep `dev:no-messaging` documented as an explicit opt-out for visual/UI work or when the developer never wants adapters to start.
+- Document that stale leases expire automatically after missed heartbeats and that deleting rows manually should not be normal workflow.
+- Do not imply cross-machine safety; the lease coordinates processes sharing the same local profile database.
+
+**Patterns to follow:**
+- Current `docs/state-layout.md` profile and dev profile sections.
+- Existing concise dev-command guidance in `apps/desktop/AGENTS.md`.
+
+**Test scenarios:**
+- Test expectation: none for prose itself, except existing documentation link tests if modified docs introduce links.
+
+**Verification:**
+- Developer docs no longer present `dev:no-messaging` as required for every normal dev launch.
+- Multi-instance behavior is documented with the same state layout vocabulary used elsewhere.
+
+## System-Wide Impact
+
+- **Interaction graph:** Bootstrap, app state, messaging runtime, settings IPC, renderer settings, and status chips are affected. Provider packages should be unaffected except that they load less often.
+- **Error propagation:** Lease acquisition failures should produce an effective disabled state, not startup crashes. Runtime adapter errors after acquisition should continue through existing platform health/error logging.
+- **State lifecycle risks:** The main risk is a stale lease that blocks messaging too long or expires too quickly. Use a heartbeat interval substantially shorter than TTL and test expiry deterministically with injected clocks.
+- **API surface parity:** Shared settings/messaging contracts may gain reason fields; preload and renderer DTOs must stay aligned.
+- **Integration coverage:** Unit tests should cover persistence and IPC behavior. A manual two-instance check should verify that only the first live profile instance starts messaging adapters and the second can acquire after the first exits or the lease expires.
+- **Unchanged invariants:** Messaging providers remain persistence-free, renderer imports remain limited by desktop boundaries, saved messaging config remains the desired default, and explicit no-messaging overrides continue to work.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Lease expiry is too short and causes duplicate adapter starts during brief event-loop stalls | Use a conservative TTL such as 30 seconds with a faster heartbeat such as 10 seconds, and renew from a lightweight timer. |
+| Lease expiry is too long and crashed dev instances block messaging annoyingly | Keep TTL short enough for developer recovery and expose a clear lease-held reason in Settings. |
+| Instance rows accidentally persist secrets or sensitive command-line data | Store only allowlisted metadata; never store env values, tokens, or raw argv. |
+| A provider conflict can still happen with another profile or an external bot process using the same token | Treat this lease as same-profile coordination only; keep existing adapter runtime error health handling for external conflicts. |
+| Shutdown ordering closes SQLite before lease release | Release/mark exited before `disposeAppState()` closes `state.db`, and make release best-effort/logged. |
+| Settings toggle appears to save config when it only changes session state | Keep lease-disabled and override-disabled states under `runtime.messaging`, not persisted `messaging.enabled`. |
+
+## Documentation / Operational Notes
+
+- Update developer guidance so `pnpm --filter @pwragent/desktop dev` becomes reasonable when a profile already has a live holder; `dev:no-messaging` remains useful when the developer wants to guarantee no adapter startup.
+- Avoid adding manual SQL cleanup guidance unless implementation discovers a real recovery need.
+- Logs should include instance id and safe reason fields so developers can correlate startup/lease decisions without inspecting SQLite.
+
+## Sources & References
+
+- Related code: `apps/desktop/src/main/index.ts`
+- Related code: `apps/desktop/src/main/runtime-flags.ts`
+- Related code: `apps/desktop/src/main/state/state-db.ts`
+- Related code: `apps/desktop/src/main/state/app-state.ts`
+- Related code: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Related code: `apps/desktop/src/main/ipc/messaging-status.ts`
+- Related code: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Related code: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`
+- Related docs: `docs/state-layout.md`
+- Related docs: `docs/messaging-architecture.md`
+- Related docs: `packages/messaging/AGENTS.md`
+- Institutional learning: `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -93,10 +93,21 @@ Single database containing all persistent state. Opened with WAL mode, `synchron
 | `directory_launchpads` | Per-directory launchpad drafts and settings |
 | `threads` | Thread overlay state (seen timestamps, git branch, linked dirs) |
 | `secrets` | `safeStorage`-encrypted secrets (bot tokens, API keys) |
+| `app_runtime_instances` | Per-process startup/heartbeat records for instances using this profile |
+| `messaging_runtime_lease` | Singleton profile lease that allows only one live instance to run messaging adapters |
 
 ## Multi-Instance Access
 
-Multiple desktop instances can share the same profile's `state.db` safely. sqlite WAL mode serializes writes automatically. No external lockfile is required.
+Multiple desktop instances can share the same profile's `state.db` safely. sqlite WAL mode serializes writes automatically. No external lockfile is required for normal state access.
+
+Messaging adapters are single-holder per profile. Each desktop process records
+an `app_runtime_instances` heartbeat, and only the process holding the
+`messaging_runtime_lease` starts provider adapters. If the holder exits cleanly,
+it releases the lease during shutdown. If it crashes or is killed, the lease
+expires after missed heartbeats and another instance can acquire it. This lease
+coordinates local processes that share the same profile database; it is not a
+cross-machine distributed lock for two different profile directories or two
+external bot deployments using the same token.
 
 ## Migration
 

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -239,10 +239,26 @@ export type SetMessagingEnabledRequest = {
 export type SetMessagingEnabledResponse = {
   /** Effective runtime state after the toggle. */
   enabled: boolean;
-  /** True when the process was launched with a no-messaging override. */
+  /** True when this process cannot use saved messaging as-is. */
   overridden: boolean;
   /** Human-readable explanation of the launch override, when applicable. */
   overrideReason?: string;
+  /** Effective runtime-disabled reason after the toggle, when applicable. */
+  disabledReason?: string;
+  disabledReasonKind?:
+    | "explicit_override"
+    | "lease_held"
+    | "no_runnable_adapters"
+    | "runtime_stopped"
+    | "startup_error"
+    | "saved_disabled";
+  leaseHolder?: {
+    instanceId: string;
+    processId?: number;
+    cwdHint?: string;
+    startedAt?: number;
+    expiresAt: number;
+  };
 };
 
 export type MessagingPairingScope = "user_dm" | "bucket" | "user_in_group";

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -249,7 +249,21 @@ export type DesktopSettingsSnapshot = {
     messaging: {
       disabled: boolean;
       disabledReason?: string;
+      disabledReasonKind?:
+        | "explicit_override"
+        | "lease_held"
+        | "no_runnable_adapters"
+        | "runtime_stopped"
+        | "startup_error"
+        | "saved_disabled";
       overrideActive?: boolean;
+      leaseHolder?: {
+        instanceId: string;
+        processId?: number;
+        cwdHint?: string;
+        startedAt?: number;
+        expiresAt: number;
+      };
     };
   };
   secretStorage: DesktopSettingsSecretStorageState;


### PR DESCRIPTION
## Summary

- I added a project-local `$pwragent-dev-profile` skill for managing the PwrAgent Electron app with `PWRAGENT_PROFILE=dev` from the current checkout.
- I cherry-picked the profile messaging lease mechanism from `feat/dev-profile-messaging-leases` and wired the launcher to use lease-backed runtime rows instead of broad process-name matching.
- I added a root hash to runtime instance records so the skill can target the exact checkout, repair missing lease tables in already-advanced profile databases, and inspect the active lease owner with `leases`.
- I replaced the macOS `launchctl submit` launcher with a detached Node daemon helper that owns `pnpm dev` and stops the dev supervisor when the spawned Electron instance exits.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `zsh -n .agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh`.
- I ran `.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh self-test`.
- I ran `uv run --with pyyaml /Users/huntharo/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/pwragent-dev-profile`.
- I ran `.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh restart --root "$PWD" --timeout 120` and verified the dev profile app wrote a live lease-backed instance row for this checkout.
- I ran `.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh status --root "$PWD"` after the heartbeat interval and verified it still found the live Electron process and active lease owner.
- I ran `.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh close --root "$PWD"` and verified a follow-up `status` reported only stale rows.
- I relaunched the dev profile app with `restart --root "$PWD" --timeout 120`, terminated the spawned Electron PID, and verified no process from this checkout remained afterward.

## Notes

- The launcher no longer registers a launchd job. It uses the detached daemon helper plus the app-authored lease rows as the ownership source of truth.
