### PR TITLE
feat(desktop): add profile messaging leases

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -41,13 +41,13 @@ The desktop style guide defines:
 To launch the desktop app with live threads and real user state, run from the **repo root** (or worktree root):
 
 ```bash
-pnpm --filter @pwragent/desktop dev:no-messaging
+pnpm --filter @pwragent/desktop dev
 ```
 
 - Do **not** override `HOME` or set `NODE_ENV` — the app needs the real user data directory to load saved threads and Keychain secrets.
-- `dev:no-messaging` disables the Telegram/Discord messaging interface, which avoids bot-token prompts and Keychain access issues during development.
-- For visual verification of UI changes, use this command so you can see real threads in the sidebar and thread detail pane.
-- The `dev` script (without `no-messaging`) also works but will attempt to connect messaging providers.
+- Messaging adapters are guarded by a profile-scoped sqlite lease. If another live instance already owns messaging for the active profile, this process stays usable but leaves messaging stopped.
+- Use `pnpm --filter @pwragent/desktop dev:no-messaging` when you explicitly want to guarantee that this app process never starts messaging adapters.
+- For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
 - If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
 
 ## Inspecting Branch Drift Dialog E2E

--- a/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
+++ b/apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts
@@ -1,0 +1,296 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: AppRuntimeInstanceStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-runtime-instance-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+  store = new AppRuntimeInstanceStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("AppRuntimeInstanceStore", () => {
+  it("records startup and acquires the profile messaging lease", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/Users/example/PwrAgnt",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result.acquired).toBe(true);
+    expect(store.getInstance("instance-a")).toMatchObject({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwdHint: "PwrAgnt",
+      startedAt: 1_000,
+      heartbeatAt: 1_000,
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: true,
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      acquiredAt: 1_000,
+      heartbeatAt: 1_000,
+      expiresAt: 31_000,
+      status: "active",
+    });
+  });
+
+  it("renews the current holder lease without changing the original acquisition time", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    expect(
+      store.acquireMessagingLease({
+        instanceId: "instance-a",
+        now: 1_000,
+        ttlMs: 30_000,
+      }).acquired,
+    ).toBe(true);
+
+    expect(
+      store.renewMessagingLease({
+        instanceId: "instance-a",
+        now: 11_000,
+        ttlMs: 30_000,
+      }),
+    ).toBe(true);
+
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      acquiredAt: 1_000,
+      heartbeatAt: 11_000,
+      expiresAt: 41_000,
+      status: "active",
+    });
+    expect(store.getInstance("instance-a")).toMatchObject({
+      heartbeatAt: 11_000,
+      effectiveMessagingEnabled: true,
+    });
+  });
+
+  it("denies a second instance while the current lease holder is live", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 2_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 2_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result).toMatchObject({
+      acquired: false,
+      reason: "held",
+      holder: {
+        ownerInstanceId: "instance-a",
+        expiresAt: 31_000,
+      },
+    });
+    expect(store.getInstance("instance-b")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+  });
+
+  it("lets another instance acquire after the previous holder expires", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 40_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    const result = store.acquireMessagingLease({
+      instanceId: "instance-b",
+      now: 40_000,
+      ttlMs: 30_000,
+    });
+
+    expect(result.acquired).toBe(true);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      acquiredAt: 40_000,
+      heartbeatAt: 40_000,
+      expiresAt: 70_000,
+      status: "active",
+    });
+    const instance = store.getInstance("instance-b");
+    expect(instance).toMatchObject({
+      effectiveMessagingEnabled: true,
+    });
+    expect(instance).not.toHaveProperty("disabledReason");
+  });
+
+  it("does not release a live holder when a non-holder asks to release", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 2_000,
+      desiredMessagingEnabled: false,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+
+    expect(
+      store.releaseMessagingLease({
+        instanceId: "instance-b",
+        now: 2_000,
+      }),
+    ).toBe(false);
+
+    const lease = store.getMessagingLease();
+    expect(lease).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+    expect(lease).not.toHaveProperty("releasedAt");
+  });
+
+  it("sanitizes instance metadata instead of storing raw paths or secrets", () => {
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/Users/example/Projects/token-secret-value",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+      disabledReason: "PWRAGENT_DISABLE_MESSAGING=token-secret-value",
+    });
+
+    const row = stateDb.raw
+      .prepare(
+        "SELECT cwd_hint, disabled_reason FROM app_runtime_instances WHERE instance_id = ?",
+      )
+      .get("instance-a") as {
+      cwd_hint: string;
+      disabled_reason: string;
+    };
+
+    expect(row.cwd_hint).toBe("token-secret-value");
+    expect(row.cwd_hint).not.toContain("/Users/example");
+    expect(row.disabled_reason).toBe("explicit_override");
+    expect(row.disabled_reason).not.toContain("token-secret-value");
+  });
+
+  it("preserves rows across database reopen and still uses expiry as authority", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    store.recordInstanceStart({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      startedAt: 1_000,
+      desiredMessagingEnabled: true,
+    });
+    store.acquireMessagingLease({
+      instanceId: "instance-a",
+      now: 1_000,
+      ttlMs: 30_000,
+    });
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath, { profileName: "dev" });
+    store = new AppRuntimeInstanceStore(stateDb);
+    store.recordInstanceStart({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      startedAt: 40_000,
+      desiredMessagingEnabled: true,
+    });
+
+    expect(
+      store.acquireMessagingLease({
+        instanceId: "instance-b",
+        now: 40_000,
+        ttlMs: 30_000,
+      }).acquired,
+    ).toBe(true);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -633,6 +633,7 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.runtime.messaging).toEqual({
       disabled: true,
       overrideActive: true,
+      disabledReasonKind: "explicit_override",
       disabledReason: "--disable-messaging was provided at startup",
     });
   });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -29,6 +29,8 @@ const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const mainLogErrorMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
+const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
+const messagingLeaseShutdownSyncMock = vi.fn();
 const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
@@ -154,6 +156,13 @@ vi.mock("../messaging/messaging-runtime", () => ({
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
 }));
 
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => ({
+    start: messagingLeaseStartMock,
+    shutdownSync: messagingLeaseShutdownSyncMock,
+  })),
+}));
+
 vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
@@ -202,6 +211,9 @@ describe("bootstrapApp", () => {
     mainLogErrorMock.mockReset();
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
+    messagingLeaseStartMock.mockReset();
+    messagingLeaseStartMock.mockResolvedValue();
+    messagingLeaseShutdownSyncMock.mockReset();
     requestBindingRevokeAllForThreadMock.mockReset();
     setMessagingArchiveCleanerMock.mockReset();
     disposeDesktopMessagingRuntimeMock.mockReset();
@@ -245,7 +257,7 @@ describe("bootstrapApp", () => {
     resolveStart();
     await flushMicrotasks();
 
-    expect(messagingRuntimeStartMock).toHaveBeenCalledTimes(1);
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
     });
@@ -262,12 +274,12 @@ describe("bootstrapApp", () => {
 
   it("creates the first window without waiting for messaging startup", async () => {
     startupProfilerInstance.start.mockResolvedValue();
-    messagingRuntimeStartMock.mockReturnValue(new Promise(() => {}));
+    messagingLeaseStartMock.mockReturnValue(new Promise(() => {}));
 
     await import("../index");
     await flushMicrotasks();
 
-    expect(messagingRuntimeStartMock).toHaveBeenCalledTimes(1);
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(registerMessagingStatusIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
@@ -276,7 +288,7 @@ describe("bootstrapApp", () => {
 
   it("logs unexpected background messaging startup failures", async () => {
     startupProfilerInstance.start.mockResolvedValue();
-    messagingRuntimeStartMock.mockRejectedValue(new Error("config load failed"));
+    messagingLeaseStartMock.mockRejectedValue(new Error("config load failed"));
 
     await import("../index");
     await flushMicrotasks();
@@ -338,6 +350,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(messagingRuntimeStartMock).not.toHaveBeenCalled();
+    expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(mainLogInfoMock).toHaveBeenCalledWith(
       "messaging runtime disabled for this app instance",
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const runtimeMock = vi.hoisted(() => ({
-  applyConfig: vi.fn(async () => undefined),
+  applyConfig: vi.fn(async (_config: unknown, _options?: unknown) => undefined),
   deliverPairingOutcome: vi.fn(async () => undefined),
   getPlatformStatuses: vi.fn(() => []),
   isEnabled: vi.fn(() => true),
@@ -27,6 +27,23 @@ const messagingConfigMocks = vi.hoisted(() => ({
     enabled: true,
     inputDebounceMs: 500,
   })),
+}));
+const leaseCoordinatorMock = vi.hoisted(() => ({
+  applyLatestConfig: vi.fn(
+    async (
+      runtime: typeof runtimeMock,
+      loadConfig: (options: unknown) => Promise<unknown>,
+      options: unknown,
+    ) => {
+      const config = await loadConfig(options);
+      await runtime.applyConfig(config, { allowStart: true });
+      return { enabled: true };
+    },
+  ),
+  disableForSession: vi.fn(async (runtime: typeof runtimeMock) => {
+    await runtime.stop();
+    return { enabled: false, disabledReasonKind: "runtime_stopped" };
+  }),
 }));
 
 vi.mock("electron", () => ({
@@ -53,6 +70,10 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
 vi.mock("../messaging/messaging-config", () => ({
   loadDesktopMessagingConfigFromSettings:
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings,
+}));
+
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => leaseCoordinatorMock),
 }));
 
 vi.mock("../messaging/desktop-messaging-pairing-store", () => ({
@@ -101,6 +122,8 @@ describe("messaging status ipc", () => {
     pairingStoreMock.markStatus.mockReset();
     activityLogMock.record.mockClear();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
+    leaseCoordinatorMock.applyLatestConfig.mockClear();
+    leaseCoordinatorMock.disableForSession.mockClear();
   });
 
   it("loads startup eligibility diagnostics when enabling messaging at runtime", async () => {
@@ -121,6 +144,14 @@ describe("messaging status ipc", () => {
       logStartupEligibility: true,
       messagingEnabledOverride: true,
     });
+    expect(leaseCoordinatorMock.applyLatestConfig).toHaveBeenCalledWith(
+      runtimeMock,
+      expect.any(Function),
+      {
+        logStartupEligibility: true,
+        messagingEnabledOverride: true,
+      },
+    );
     expect(runtimeMock.applyConfig).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),
       { allowStart: true },
@@ -164,6 +195,11 @@ describe("messaging status ipc", () => {
       },
     });
     expect(runtimeMock.deliverPairingOutcome).toHaveBeenCalledWith(consumed, "approved");
+    expect(leaseCoordinatorMock.applyLatestConfig).toHaveBeenCalledWith(
+      runtimeMock,
+      expect.any(Function),
+      { logStartupEligibility: true },
+    );
   });
 
   it("approves LINE group and room pairing into separate bucket lists", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
+import {
+  MESSAGING_LEASE_HEARTBEAT_MS,
+  RuntimeMessagingLeaseCoordinator,
+} from "../runtime-messaging-lease";
 import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 import type { DesktopMessagingConfig } from "../messaging/messaging-config";
@@ -12,10 +15,11 @@ let stateDb: StateDb;
 let store: AppRuntimeInstanceStore;
 let tempDir: string;
 
-function createRuntime(): DesktopMessagingRuntime {
+function createRuntime(options: { failApply?: boolean } = {}): DesktopMessagingRuntime {
   let enabled = false;
   return {
     applyConfig: vi.fn(async () => {
+      if (options.failApply) throw new Error("apply failed");
       enabled = true;
     }),
     isEnabled: vi.fn(() => enabled),
@@ -34,6 +38,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -217,6 +222,101 @@ describe("RuntimeMessagingLeaseCoordinator", () => {
       status: "active",
     });
     second.shutdownSync();
+  });
+
+  it("stops runtime when the heartbeat loses the lease", async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => now,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => now,
+      store,
+    });
+
+    await first.applyResolvedConfig(firstRuntime, config);
+    now = 32_000;
+    await second.applyResolvedConfig(secondRuntime, config);
+    now = 33_000;
+    await vi.advanceTimersByTimeAsync(MESSAGING_LEASE_HEARTBEAT_MS);
+
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.isEnabled()).toBe(false);
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+    second.shutdownSync();
+  });
+
+  it("releases the lease when runtime startup fails", async () => {
+    const runtime = createRuntime({ failApply: true });
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+        telegram: {
+          channel: "telegram",
+          enabled: true,
+          botToken: "token",
+          streamingResponses: false,
+          authorizedActorIds: [],
+          authorizedSupergroupIds: [],
+        },
+      }),
+    ).rejects.toThrow("apply failed");
+
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "released",
+      releasedAt: 1_000,
+    });
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "startup_error",
+    });
   });
 
   it("releases the lease when the session disables messaging", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-messaging-lease.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+import type { DesktopMessagingConfig } from "../messaging/messaging-config";
+import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
+
+let stateDb: StateDb;
+let store: AppRuntimeInstanceStore;
+let tempDir: string;
+
+function createRuntime(): DesktopMessagingRuntime {
+  let enabled = false;
+  return {
+    applyConfig: vi.fn(async () => {
+      enabled = true;
+    }),
+    isEnabled: vi.fn(() => enabled),
+    stop: vi.fn(async () => {
+      enabled = false;
+    }),
+  } as unknown as DesktopMessagingRuntime;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-lease-coordinator-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+  store = new AppRuntimeInstanceStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("RuntimeMessagingLeaseCoordinator", () => {
+  it("records explicit no-messaging overrides without loading config", async () => {
+    const runtime = createRuntime();
+    const loadConfig = vi.fn(async () => ({
+      enabled: true,
+      inputDebounceMs: 500,
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    }));
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+      env: { PWRAGENT_DISABLE_MESSAGING: "1" } as NodeJS.ProcessEnv,
+    });
+
+    await expect(coordinator.start(runtime, loadConfig)).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "explicit_override",
+    });
+
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(runtime.applyConfig).not.toHaveBeenCalled();
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: false,
+      effectiveMessagingEnabled: false,
+      disabledReason: "explicit_override",
+    });
+    expect(store.getMessagingLease()).toBeUndefined();
+  });
+
+  it("does not claim the lease when no adapters are runnable", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await expect(
+      coordinator.applyResolvedConfig(runtime, {
+        enabled: true,
+        inputDebounceMs: 500,
+        toolUpdateDefaultMode: "show_some",
+      }),
+    ).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "no_runnable_adapters",
+    });
+
+    expect(runtime.applyConfig).not.toHaveBeenCalled();
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toBeUndefined();
+    expect(store.getInstance("instance-a")).toMatchObject({
+      desiredMessagingEnabled: true,
+      effectiveMessagingEnabled: false,
+      disabledReason: "no_runnable_adapters",
+    });
+  });
+
+  it("starts runtime only for the profile lease holder", async () => {
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => 1_000,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => 2_000,
+      store,
+    });
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+
+    await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
+      .toMatchObject({ enabled: true });
+    await expect(second.applyResolvedConfig(secondRuntime, config)).resolves
+      .toMatchObject({
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        leaseHolder: { instanceId: "instance-a" },
+      });
+
+    expect(firstRuntime.applyConfig).toHaveBeenCalledTimes(1);
+    expect(secondRuntime.applyConfig).not.toHaveBeenCalled();
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "active",
+    });
+    expect(store.getInstance("instance-b")).toMatchObject({
+      effectiveMessagingEnabled: false,
+      disabledReason: "lease_held",
+    });
+    first.shutdownSync();
+  });
+
+  it("stops runtime when another live instance holds the lease", async () => {
+    let now = 1_000;
+    const firstRuntime = createRuntime();
+    const secondRuntime = createRuntime();
+    const config: DesktopMessagingConfig = {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram" as const,
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    };
+    const first = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt-a",
+      now: () => now,
+      store,
+    });
+    const second = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-b",
+      profileName: "dev",
+      processId: 456,
+      cwd: "/tmp/PwrAgnt-b",
+      now: () => now,
+      store,
+    });
+
+    await first.applyResolvedConfig(firstRuntime, config);
+    now = 32_000;
+    await second.applyResolvedConfig(secondRuntime, config);
+    now = 33_000;
+    await expect(first.applyResolvedConfig(firstRuntime, config)).resolves
+      .toMatchObject({
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        leaseHolder: { instanceId: "instance-b" },
+      });
+
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.isEnabled()).toBe(false);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-b",
+      status: "active",
+    });
+    second.shutdownSync();
+  });
+
+  it("releases the lease when the session disables messaging", async () => {
+    const runtime = createRuntime();
+    const coordinator = new RuntimeMessagingLeaseCoordinator({
+      instanceId: "instance-a",
+      profileName: "dev",
+      processId: 123,
+      cwd: "/tmp/PwrAgnt",
+      now: () => 1_000,
+      store,
+    });
+
+    await coordinator.applyResolvedConfig(runtime, {
+      enabled: true,
+      inputDebounceMs: 500,
+      toolUpdateDefaultMode: "show_some",
+      telegram: {
+        channel: "telegram",
+        enabled: true,
+        botToken: "token",
+        streamingResponses: false,
+        authorizedActorIds: [],
+        authorizedSupergroupIds: [],
+      },
+    });
+    await expect(coordinator.disableForSession(runtime)).resolves.toMatchObject({
+      enabled: false,
+      disabledReasonKind: "runtime_stopped",
+    });
+
+    expect(runtime.stop).toHaveBeenCalledTimes(1);
+    expect(store.getMessagingLease()).toMatchObject({
+      ownerInstanceId: "instance-a",
+      status: "released",
+      releasedAt: 1_000,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -15,13 +15,35 @@ const providerMocks = vi.hoisted(() => ({
   resolveSlackContact: vi.fn(),
 }));
 const runtimeMock = vi.hoisted(() => ({
-  applyConfig: vi.fn(async () => undefined),
+  applyConfig: vi.fn(async (_config: unknown, _options?: unknown) => undefined),
   getPlatformCredentialMetadata: vi.fn(),
   isEnabled: vi.fn(() => false),
   requestCredentialValidation: vi.fn(),
 }));
 const messagingConfigMocks = vi.hoisted(() => ({
   loadDesktopMessagingConfigFromSettings: vi.fn(),
+}));
+const leaseCoordinatorMock = vi.hoisted(() => ({
+  applyLatestConfig: vi.fn(
+    async (
+      runtime: typeof runtimeMock,
+      loadConfig: (options: unknown) => Promise<unknown>,
+      options: { allowStart?: boolean },
+    ) => {
+      const config = await loadConfig({
+        logStartupEligibility: true,
+      });
+      await runtime.applyConfig(config, {
+        allowStart: options.allowStart ?? true,
+      });
+      return { enabled: runtime.isEnabled() };
+    },
+  ),
+  snapshot: vi.fn(() => ({
+    instanceId: "test-instance",
+    effectiveMessagingEnabled: false,
+    leaseHeld: false,
+  })),
 }));
 
 vi.mock("electron", () => ({
@@ -61,6 +83,10 @@ vi.mock("../messaging/messaging-config", async (importOriginal) => {
   };
 });
 
+vi.mock("../runtime-messaging-lease", () => ({
+  getRuntimeMessagingLeaseCoordinator: vi.fn(() => leaseCoordinatorMock),
+}));
+
 vi.mock("@pwragent/messaging-provider-telegram", () => ({
   resolveContact: providerMocks.resolveTelegramContact,
 }));
@@ -93,6 +119,8 @@ describe("settings ipc", () => {
     providerMocks.resolveMattermostContact.mockReset();
     providerMocks.resolveSlackContact.mockReset();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
+    leaseCoordinatorMock.applyLatestConfig.mockClear();
+    leaseCoordinatorMock.snapshot.mockClear();
     runtimeMock.applyConfig.mockClear();
     runtimeMock.getPlatformCredentialMetadata.mockReset();
     runtimeMock.isEnabled.mockClear();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -49,6 +49,7 @@ import {
 } from "./messaging/messaging-runtime";
 import { loadDesktopMessagingConfigFromSettings } from "./messaging/messaging-config";
 import { resolveRuntimeMessagingOverride } from "./runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "./runtime-messaging-lease";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import { disposeAppState, initializeAppState } from "./state/app-state";
 import { createMainWindow } from "./window";
@@ -139,12 +140,33 @@ export function bootstrapApp(): void {
       mainLog.info("messaging runtime disabled for this app instance", {
         reason: messagingOverride.reason,
       });
-    } else {
-      void messagingRuntime.start().catch((error) => {
-        mainLog.error("messaging runtime failed during background startup", {
-          error: error instanceof Error ? error.message : String(error),
+      void getRuntimeMessagingLeaseCoordinator()
+        .start(messagingRuntime, (options) =>
+          loadDesktopMessagingConfigFromSettings(
+            getDesktopSettingsService(),
+            process.env,
+            options,
+          ),
+        )
+        .catch((error) => {
+          mainLog.error("messaging runtime lease recording failed during startup", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+    } else {
+      void getRuntimeMessagingLeaseCoordinator()
+        .start(messagingRuntime, (options) =>
+          loadDesktopMessagingConfigFromSettings(
+            getDesktopSettingsService(),
+            process.env,
+            options,
+          ),
+        )
+        .catch((error) => {
+          mainLog.error("messaging runtime failed during background startup", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
     }
     // Register status IPC after the runtime is constructed so the
     // initial subscriber attaches before the renderer asks for the
@@ -187,6 +209,7 @@ export function bootstrapApp(): void {
       disposeRuntimeIdentityIpcHandlers();
     }
     void disposeMessagingStatusIpcHandlers();
+    getRuntimeMessagingLeaseCoordinator().shutdownSync();
     void disposeDesktopMessagingRuntime();
     void disposeAppServerIpcHandlers();
     disposeAppState();

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -29,6 +29,7 @@ import { getMainLogger } from "../log";
 import { showMessagingActivityWindow } from "../messaging-activity-window";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
 import { subscribersForChannel } from "../window-channels";
 import {
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
@@ -310,11 +311,12 @@ export function registerMessagingStatusIpcHandlers(): void {
       if (!pairing) throw new Error("Pairing request not found.");
       const approval = buildPairingApprovalPatch(pairing, await service.readSettings());
       const next = await service.writeConfigPatch(approval.patch);
-      await runtime.applyConfig(
-        await loadDesktopMessagingConfigFromSettings(service, process.env, {
+      await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+        runtime,
+        (options) => loadDesktopMessagingConfigFromSettings(service, process.env, options),
+        {
           logStartupEligibility: true,
-        }),
-        { allowStart: true },
+        },
       );
       const consumed = markPairingConsumed(request.entryId);
       recordPairingActivity(consumed ?? pairing, "Approved pairing request");
@@ -380,27 +382,43 @@ export function registerMessagingStatusIpcHandlers(): void {
       request: SetMessagingEnabledRequest,
     ): Promise<SetMessagingEnabledResponse> => {
       if (request.enabled) {
-        await runtime.applyConfig(
-          await loadDesktopMessagingConfigFromSettings(
+        const result = await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+          runtime,
+          (options) => loadDesktopMessagingConfigFromSettings(
             getDesktopSettingsService(),
             process.env,
-            {
-              logStartupEligibility: true,
-              messagingEnabledOverride: true,
-            },
+            options,
           ),
-          { allowStart: true },
+          {
+            logStartupEligibility: true,
+            messagingEnabledOverride: true,
+          },
         );
+        const override = resolveRuntimeMessagingOverride();
+        return {
+          enabled: result.enabled,
+          overridden: override.disabled || result.disabledReasonKind === "lease_held",
+          ...(override.reason ? { overrideReason: override.reason } : {}),
+          ...(result.disabledReason ? { disabledReason: result.disabledReason } : {}),
+          ...(result.disabledReasonKind
+            ? { disabledReasonKind: result.disabledReasonKind }
+            : {}),
+          ...(result.leaseHolder ? { leaseHolder: result.leaseHolder } : {}),
+        };
       } else {
-        await runtime.stop();
+        const result = await getRuntimeMessagingLeaseCoordinator()
+          .disableForSession(runtime);
+        const override = resolveRuntimeMessagingOverride();
+        return {
+          enabled: result.enabled,
+          overridden: override.disabled,
+          ...(override.reason ? { overrideReason: override.reason } : {}),
+          ...(result.disabledReason ? { disabledReason: result.disabledReason } : {}),
+          ...(result.disabledReasonKind
+            ? { disabledReasonKind: result.disabledReasonKind }
+            : {}),
+        };
       }
-
-      const override = resolveRuntimeMessagingOverride();
-      return {
-        enabled: runtime.isEnabled(),
-        overridden: override.disabled,
-        ...(override.reason ? { overrideReason: override.reason } : {}),
-      };
     },
   );
 

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -39,6 +39,7 @@ import { CredentialTester } from "../credential-tester/credential-tester";
 import { getDesktopMessagingRuntime } from "../messaging/messaging-runtime";
 import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-config";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
+import { getRuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
 import { validateGhCommand } from "../settings/gh-discovery";
 
 function getService(service?: DesktopSettingsService): DesktopSettingsService {
@@ -81,11 +82,12 @@ async function applyLatestMessagingRuntimeConfig(
 ): Promise<void> {
   const runtime = getDesktopMessagingRuntime();
   const runtimeOverride = resolveRuntimeMessagingOverride();
-  await runtime.applyConfig(
-    await loadDesktopMessagingConfigFromSettings(service, process.env, {
-      logStartupEligibility: true,
-    }),
+  await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
+    runtime,
+    (options) =>
+      loadDesktopMessagingConfigFromSettings(service, process.env, options),
     {
+      logStartupEligibility: true,
       allowStart: !runtimeOverride.disabled || runtime.isEnabled(),
     },
   );
@@ -94,10 +96,18 @@ async function applyLatestMessagingRuntimeConfig(
 function applyRuntimeMessagingSnapshot(
   snapshot: DesktopSettingsSnapshot,
 ): DesktopSettingsSnapshot {
-  const overrideActive = snapshot.runtime.messaging.overrideActive === true;
+  const leaseSnapshot = getRuntimeMessagingLeaseCoordinator().snapshot();
+  const leaseOverrideActive = leaseSnapshot.disabledReasonKind === "lease_held";
+  const overrideActive =
+    snapshot.runtime.messaging.overrideActive === true || leaseOverrideActive;
   const runtimeEnabled = overrideActive
     ? getDesktopMessagingRuntime().isEnabled()
     : snapshot.messaging.enabled.value;
+  const disabledReason =
+    leaseSnapshot.disabledReason ?? snapshot.runtime.messaging.disabledReason;
+  const disabledReasonKind =
+    leaseSnapshot.disabledReasonKind
+    ?? snapshot.runtime.messaging.disabledReasonKind;
   return {
     ...snapshot,
     runtime: {
@@ -107,6 +117,12 @@ function applyRuntimeMessagingSnapshot(
         disabled: overrideActive
           ? !runtimeEnabled
           : snapshot.messaging.enabled.value === false,
+        overrideActive,
+        ...(disabledReason ? { disabledReason } : {}),
+        ...(disabledReasonKind ? { disabledReasonKind } : {}),
+        ...(leaseSnapshot.leaseHolder
+          ? { leaseHolder: leaseSnapshot.leaseHolder }
+          : {}),
       },
     },
   };

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -260,6 +260,18 @@ export type DesktopMessagingConfigLoadOptions = {
   messagingEnabledOverride?: boolean;
 };
 
+export function desktopMessagingConfigHasRunnableAdapters(
+  config: DesktopMessagingConfig,
+): boolean {
+  return Boolean(
+    config.telegram
+      || config.discord
+      || config.mattermost
+      || config.slack
+      || config.line,
+  );
+}
+
 export function classifyDesktopMessagingChannelConfigUpdate(
   previous: DesktopMessagingConfig,
   next: DesktopMessagingConfig,

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -1,0 +1,369 @@
+import { randomUUID } from "node:crypto";
+import {
+  resolveActiveProfileName,
+} from "./profile";
+import { getAppRuntimeInstanceStore } from "./state/app-state";
+import type {
+  AppRuntimeMessagingDisabledReason,
+  AppRuntimeInstanceStore,
+  MessagingRuntimeLeaseRecord,
+} from "./state/app-runtime-instance-store";
+import type {
+  DesktopMessagingConfig,
+} from "./messaging/messaging-config";
+import {
+  desktopMessagingConfigHasRunnableAdapters,
+  type DesktopMessagingConfigLoadOptions,
+} from "./messaging/messaging-config";
+import type {
+  DesktopMessagingConfigLoader,
+  DesktopMessagingRuntime,
+} from "./messaging/messaging-runtime";
+import {
+  resolveRuntimeMessagingOverride,
+  type RuntimeMessagingOverride,
+} from "./runtime-flags";
+
+export const MESSAGING_LEASE_TTL_MS = 30_000;
+export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
+
+export type RuntimeMessagingDisabledReasonKind =
+  | AppRuntimeMessagingDisabledReason
+  | "saved_disabled";
+
+export type RuntimeMessagingLeaseSnapshot = {
+  instanceId: string;
+  disabledReasonKind?: RuntimeMessagingDisabledReasonKind;
+  disabledReason?: string;
+  effectiveMessagingEnabled: boolean;
+  leaseHeld: boolean;
+  leaseHolder?: {
+    instanceId: string;
+    processId?: number;
+    cwdHint?: string;
+    startedAt?: number;
+    expiresAt: number;
+  };
+};
+
+export type RuntimeMessagingLeaseApplyResult = {
+  enabled: boolean;
+  disabledReasonKind?: RuntimeMessagingDisabledReasonKind;
+  disabledReason?: string;
+  leaseHolder?: RuntimeMessagingLeaseSnapshot["leaseHolder"];
+};
+
+type RuntimeMessagingLeaseCoordinatorOptions = {
+  instanceId?: string;
+  profileName?: string;
+  processId?: number;
+  cwd?: string;
+  now?: () => number;
+  store?: AppRuntimeInstanceStore;
+  env?: NodeJS.ProcessEnv;
+  argv?: readonly string[];
+};
+
+export class RuntimeMessagingLeaseCoordinator {
+  private readonly instanceId: string;
+  private readonly profileName: string;
+  private readonly processId: number;
+  private readonly cwd: string;
+  private readonly now: () => number;
+  private readonly store: AppRuntimeInstanceStore;
+  private readonly env?: NodeJS.ProcessEnv;
+  private readonly argv?: readonly string[];
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private startedRecorded = false;
+  private leaseHeld = false;
+
+  constructor(options: RuntimeMessagingLeaseCoordinatorOptions = {}) {
+    this.instanceId = options.instanceId ?? randomUUID();
+    this.profileName = options.profileName ?? resolveActiveProfileName();
+    this.processId = options.processId ?? process.pid;
+    this.cwd = options.cwd ?? process.cwd();
+    this.now = options.now ?? Date.now;
+    this.store = options.store ?? getAppRuntimeInstanceStore();
+    this.env = options.env;
+    this.argv = options.argv;
+  }
+
+  get id(): string {
+    return this.instanceId;
+  }
+
+  async start(
+    runtime: DesktopMessagingRuntime,
+    loadConfig: DesktopMessagingConfigLoader,
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const override = resolveRuntimeMessagingOverride({
+      env: this.env,
+      argv: this.argv,
+    });
+    if (override.disabled) {
+      this.recordStart({
+        desiredMessagingEnabled: false,
+        effectiveMessagingEnabled: false,
+        disabledReason: "explicit_override",
+      });
+      return {
+        enabled: false,
+        disabledReasonKind: "explicit_override",
+        ...(override.reason ? { disabledReason: override.reason } : {}),
+      };
+    }
+
+    const config = await loadConfig({ logStartupEligibility: true });
+    return this.applyResolvedConfig(runtime, config, { allowStart: true });
+  }
+
+  async applyLatestConfig(
+    runtime: DesktopMessagingRuntime,
+    loadConfig: DesktopMessagingConfigLoader,
+    options: DesktopMessagingConfigLoadOptions & { allowStart?: boolean } = {},
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const config = await loadConfig({
+      logStartupEligibility: options.logStartupEligibility,
+      messagingEnabledOverride: options.messagingEnabledOverride,
+    });
+    return this.applyResolvedConfig(runtime, config, {
+      allowStart: options.allowStart ?? true,
+    });
+  }
+
+  async applyResolvedConfig(
+    runtime: DesktopMessagingRuntime,
+    config: DesktopMessagingConfig,
+    options: { allowStart?: boolean } = {},
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const now = this.now();
+    const desiredMessagingEnabled = config.enabled !== false;
+    this.recordStart({
+      desiredMessagingEnabled,
+      effectiveMessagingEnabled: false,
+      disabledReason: desiredMessagingEnabled ? undefined : "runtime_stopped",
+    });
+
+    if (config.enabled === false) {
+      await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+      return {
+        enabled: false,
+        disabledReasonKind: "saved_disabled",
+        disabledReason: "Messaging is disabled in saved settings.",
+      };
+    }
+
+    if (!desktopMessagingConfigHasRunnableAdapters(config)) {
+      await this.stopRuntimeAndRelease(runtime, now, "no_runnable_adapters");
+      return {
+        enabled: false,
+        disabledReasonKind: "no_runnable_adapters",
+        disabledReason: "No messaging platforms are configured for this profile.",
+      };
+    }
+
+    if (options.allowStart === false && !this.leaseHeld && !runtime.isEnabled()) {
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "runtime_stopped",
+        now,
+      });
+      return {
+        enabled: false,
+        disabledReasonKind: "runtime_stopped",
+        disabledReason: "Messaging is stopped for this app instance.",
+      };
+    }
+
+    const acquire = this.store.acquireMessagingLease({
+      instanceId: this.instanceId,
+      now,
+      ttlMs: MESSAGING_LEASE_TTL_MS,
+    });
+    if (!acquire.acquired) {
+      this.stopHeartbeat();
+      await runtime.stop();
+      this.leaseHeld = false;
+      const leaseHolder = this.describeLeaseHolder(acquire.holder);
+      return {
+        enabled: false,
+        disabledReasonKind: "lease_held",
+        disabledReason: "Messaging is already active in another PwrAgent instance for this profile.",
+        ...(leaseHolder ? { leaseHolder } : {}),
+      };
+    }
+
+    this.leaseHeld = true;
+    this.startHeartbeat();
+    await runtime.applyConfig(config, { allowStart: true });
+    return { enabled: runtime.isEnabled() };
+  }
+
+  async disableForSession(
+    runtime: DesktopMessagingRuntime,
+  ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const now = this.now();
+    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+    return {
+      enabled: false,
+      disabledReasonKind: "runtime_stopped",
+      disabledReason: "Messaging is stopped for this app instance.",
+    };
+  }
+
+  async shutdown(runtime: DesktopMessagingRuntime): Promise<void> {
+    const now = this.now();
+    await this.stopRuntimeAndRelease(runtime, now, "runtime_stopped");
+    this.store.markInstanceExited({ instanceId: this.instanceId, now });
+  }
+
+  shutdownSync(): void {
+    const now = this.now();
+    this.stopHeartbeat();
+    if (this.leaseHeld) {
+      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+    }
+    this.store.markInstanceExited({ instanceId: this.instanceId, now });
+    this.leaseHeld = false;
+  }
+
+  snapshot(): RuntimeMessagingLeaseSnapshot {
+    const instance = this.store.getInstance(this.instanceId);
+    const lease = this.store.getMessagingLease();
+    const leaseHolder =
+      lease
+      && lease.status === "active"
+      && lease.ownerInstanceId !== this.instanceId
+      && lease.expiresAt > this.now()
+        ? this.describeLeaseHolder(lease)
+        : undefined;
+    return {
+      instanceId: this.instanceId,
+      effectiveMessagingEnabled: instance?.effectiveMessagingEnabled ?? false,
+      disabledReasonKind: instance?.disabledReason,
+      ...(instance?.disabledReason
+        ? { disabledReason: runtimeDisabledReasonMessage(instance.disabledReason) }
+        : {}),
+      leaseHeld: this.leaseHeld,
+      ...(leaseHolder ? { leaseHolder } : {}),
+    };
+  }
+
+  private recordStart(params: {
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled: boolean;
+    disabledReason?: AppRuntimeMessagingDisabledReason;
+  }): void {
+    const now = this.now();
+    if (this.startedRecorded) {
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: params.desiredMessagingEnabled,
+        effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+        disabledReason: params.disabledReason,
+        now,
+      });
+      return;
+    }
+    this.store.recordInstanceStart({
+      instanceId: this.instanceId,
+      profileName: this.profileName,
+      processId: this.processId,
+      cwd: this.cwd,
+      startedAt: now,
+      desiredMessagingEnabled: params.desiredMessagingEnabled,
+      effectiveMessagingEnabled: params.effectiveMessagingEnabled,
+      disabledReason: params.disabledReason,
+    });
+    this.startedRecorded = true;
+  }
+
+  private async stopRuntimeAndRelease(
+    runtime: DesktopMessagingRuntime,
+    now: number,
+    disabledReason: AppRuntimeMessagingDisabledReason,
+  ): Promise<void> {
+    this.stopHeartbeat();
+    await runtime.stop();
+    if (this.leaseHeld) {
+      this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+    }
+    this.store.markDesiredMessaging({
+      instanceId: this.instanceId,
+      desiredMessagingEnabled: disabledReason !== "runtime_stopped",
+      effectiveMessagingEnabled: false,
+      disabledReason,
+      now,
+    });
+    this.leaseHeld = false;
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+    this.heartbeatTimer = setInterval(() => {
+      const renewed = this.store.renewMessagingLease({
+        instanceId: this.instanceId,
+        now: this.now(),
+        ttlMs: MESSAGING_LEASE_TTL_MS,
+      });
+      if (!renewed) {
+        this.leaseHeld = false;
+        this.stopHeartbeat();
+      }
+    }, MESSAGING_LEASE_HEARTBEAT_MS);
+    if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private describeLeaseHolder(
+    lease: MessagingRuntimeLeaseRecord,
+  ): RuntimeMessagingLeaseSnapshot["leaseHolder"] {
+    const holder = this.store.getInstance(lease.ownerInstanceId);
+    return {
+      instanceId: lease.ownerInstanceId,
+      ...(holder?.processId ? { processId: holder.processId } : {}),
+      ...(holder?.cwdHint ? { cwdHint: holder.cwdHint } : {}),
+      ...(holder?.startedAt ? { startedAt: holder.startedAt } : {}),
+      expiresAt: lease.expiresAt,
+    };
+  }
+}
+
+let coordinator: RuntimeMessagingLeaseCoordinator | null = null;
+
+export function getRuntimeMessagingLeaseCoordinator(): RuntimeMessagingLeaseCoordinator {
+  if (!coordinator) {
+    coordinator = new RuntimeMessagingLeaseCoordinator();
+  }
+  return coordinator;
+}
+
+export function setRuntimeMessagingLeaseCoordinatorForTests(
+  next: RuntimeMessagingLeaseCoordinator | null,
+): void {
+  coordinator = next;
+}
+
+function runtimeDisabledReasonMessage(
+  reason: AppRuntimeMessagingDisabledReason,
+): string {
+  switch (reason) {
+    case "explicit_override":
+      return "Messaging is disabled for this app instance.";
+    case "lease_held":
+      return "Messaging is already active in another PwrAgent instance for this profile.";
+    case "no_runnable_adapters":
+      return "No messaging platforms are configured for this profile.";
+    case "startup_error":
+      return "Messaging failed during startup for this app instance.";
+    case "runtime_stopped":
+      return "Messaging is stopped for this app instance.";
+  }
+}

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -23,9 +23,12 @@ import {
   resolveRuntimeMessagingOverride,
   type RuntimeMessagingOverride,
 } from "./runtime-flags";
+import { getMainLogger } from "./log";
 
 export const MESSAGING_LEASE_TTL_MS = 30_000;
 export const MESSAGING_LEASE_HEARTBEAT_MS = 10_000;
+
+const leaseLog = getMainLogger("pwragent:messaging-lease");
 
 export type RuntimeMessagingDisabledReasonKind =
   | AppRuntimeMessagingDisabledReason
@@ -196,8 +199,13 @@ export class RuntimeMessagingLeaseCoordinator {
     }
 
     this.leaseHeld = true;
-    this.startHeartbeat();
-    await runtime.applyConfig(config, { allowStart: true });
+    this.startHeartbeat(runtime);
+    try {
+      await runtime.applyConfig(config, { allowStart: true });
+    } catch (error) {
+      await this.releaseAfterStartupFailure(runtime, now);
+      throw error;
+    }
     return { enabled: runtime.isEnabled() };
   }
 
@@ -300,7 +308,7 @@ export class RuntimeMessagingLeaseCoordinator {
     this.leaseHeld = false;
   }
 
-  private startHeartbeat(): void {
+  private startHeartbeat(runtime: DesktopMessagingRuntime): void {
     if (this.heartbeatTimer) return;
     this.heartbeatTimer = setInterval(() => {
       const renewed = this.store.renewMessagingLease({
@@ -309,11 +317,65 @@ export class RuntimeMessagingLeaseCoordinator {
         ttlMs: MESSAGING_LEASE_TTL_MS,
       });
       if (!renewed) {
-        this.leaseHeld = false;
-        this.stopHeartbeat();
+        void this.stopRuntimeAfterLeaseLoss(runtime).catch((error) => {
+          leaseLog.error("messaging runtime stop failed after lease loss", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
       }
     }, MESSAGING_LEASE_HEARTBEAT_MS);
     if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
+  }
+
+  private async releaseAfterStartupFailure(
+    runtime: DesktopMessagingRuntime,
+    now: number,
+  ): Promise<void> {
+    this.stopHeartbeat();
+    try {
+      await runtime.stop();
+    } catch (error) {
+      leaseLog.warn("messaging runtime stop failed during startup cleanup", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      if (this.leaseHeld) {
+        this.store.releaseMessagingLease({ instanceId: this.instanceId, now });
+      }
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "startup_error",
+        now,
+      });
+      this.leaseHeld = false;
+    }
+  }
+
+  private async stopRuntimeAfterLeaseLoss(
+    runtime: DesktopMessagingRuntime,
+  ): Promise<void> {
+    const now = this.now();
+    this.stopHeartbeat();
+    this.leaseHeld = false;
+    try {
+      await runtime.stop();
+    } finally {
+      const lease = this.store.getMessagingLease();
+      const heldByAnotherInstance =
+        lease
+        && lease.status === "active"
+        && lease.ownerInstanceId !== this.instanceId
+        && lease.expiresAt > now;
+      this.store.markDesiredMessaging({
+        instanceId: this.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: heldByAnotherInstance ? "lease_held" : "runtime_stopped",
+        now,
+      });
+    }
   }
 
   private stopHeartbeat(): void {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -220,6 +220,9 @@ export class DesktopSettingsService {
         messaging: {
           disabled: messagingOverride.disabled,
           overrideActive: messagingOverride.disabled,
+          ...(messagingOverride.disabled
+            ? { disabledReasonKind: "explicit_override" as const }
+            : {}),
           ...(messagingOverride.reason
             ? { disabledReason: messagingOverride.reason }
             : {}),

--- a/apps/desktop/src/main/state/app-runtime-instance-store.ts
+++ b/apps/desktop/src/main/state/app-runtime-instance-store.ts
@@ -1,0 +1,353 @@
+import path from "node:path";
+import type { StateDb } from "./state-db.js";
+
+const MESSAGING_LEASE_KEY = "profile-messaging";
+
+export type AppRuntimeMessagingDisabledReason =
+  | "explicit_override"
+  | "lease_held"
+  | "no_runnable_adapters"
+  | "runtime_stopped"
+  | "startup_error";
+
+export type AppRuntimeInstanceRecord = {
+  instanceId: string;
+  profileName: string;
+  processId: number;
+  cwdHint?: string;
+  startedAt: number;
+  heartbeatAt: number;
+  exitedAt?: number;
+  desiredMessagingEnabled: boolean;
+  effectiveMessagingEnabled: boolean;
+  disabledReason?: AppRuntimeMessagingDisabledReason;
+};
+
+export type MessagingRuntimeLeaseRecord = {
+  ownerInstanceId: string;
+  acquiredAt: number;
+  heartbeatAt: number;
+  expiresAt: number;
+  releasedAt?: number;
+  status: "active" | "released" | "expired";
+};
+
+export type MessagingLeaseAcquireResult =
+  | { acquired: true; lease: MessagingRuntimeLeaseRecord }
+  | {
+      acquired: false;
+      reason: "held";
+      holder: MessagingRuntimeLeaseRecord;
+    };
+
+type InstanceRow = {
+  instance_id: string;
+  profile_name: string;
+  process_id: number;
+  cwd_hint: string | null;
+  started_at: number;
+  heartbeat_at: number;
+  exited_at: number | null;
+  desired_messaging_enabled: number;
+  effective_messaging_enabled: number;
+  disabled_reason: string | null;
+};
+
+type LeaseRow = {
+  owner_instance_id: string;
+  acquired_at: number;
+  heartbeat_at: number;
+  expires_at: number;
+  released_at: number | null;
+  status: "active" | "released" | "expired";
+};
+
+export class AppRuntimeInstanceStore {
+  constructor(private readonly stateDb: StateDb) {}
+
+  recordInstanceStart(params: {
+    instanceId: string;
+    profileName: string;
+    processId: number;
+    cwd?: string;
+    startedAt: number;
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled?: boolean;
+    disabledReason?: string;
+  }): AppRuntimeInstanceRecord {
+    const disabledReason = normalizeDisabledReason(params.disabledReason);
+    const effectiveMessagingEnabled =
+      params.effectiveMessagingEnabled ?? (disabledReason ? false : false);
+
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO app_runtime_instances(
+           instance_id, profile_name, process_id, cwd_hint, started_at,
+           heartbeat_at, exited_at, desired_messaging_enabled,
+           effective_messaging_enabled, disabled_reason
+         ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+      )
+      .run(
+        params.instanceId,
+        params.profileName,
+        params.processId,
+        sanitizeCwdHint(params.cwd),
+        params.startedAt,
+        params.startedAt,
+        booleanToSql(params.desiredMessagingEnabled),
+        booleanToSql(effectiveMessagingEnabled),
+        disabledReason ?? null,
+      );
+
+    return this.getInstance(params.instanceId)!;
+  }
+
+  getInstance(instanceId: string): AppRuntimeInstanceRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM app_runtime_instances WHERE instance_id = ?")
+      .get(instanceId) as InstanceRow | undefined;
+    return row ? mapInstanceRow(row) : undefined;
+  }
+
+  markDesiredMessaging(params: {
+    instanceId: string;
+    desiredMessagingEnabled: boolean;
+    effectiveMessagingEnabled: boolean;
+    disabledReason?: AppRuntimeMessagingDisabledReason;
+    now: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE app_runtime_instances
+         SET desired_messaging_enabled = ?,
+             effective_messaging_enabled = ?,
+             disabled_reason = ?,
+             heartbeat_at = ?
+         WHERE instance_id = ?`,
+      )
+      .run(
+        booleanToSql(params.desiredMessagingEnabled),
+        booleanToSql(params.effectiveMessagingEnabled),
+        params.disabledReason ?? null,
+        params.now,
+        params.instanceId,
+      );
+  }
+
+  heartbeatInstance(params: { instanceId: string; now: number }): void {
+    this.stateDb.raw
+      .prepare(
+        "UPDATE app_runtime_instances SET heartbeat_at = ? WHERE instance_id = ?",
+      )
+      .run(params.now, params.instanceId);
+  }
+
+  markInstanceExited(params: { instanceId: string; now: number }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE app_runtime_instances
+         SET exited_at = ?, heartbeat_at = ?
+         WHERE instance_id = ?`,
+      )
+      .run(params.now, params.now, params.instanceId);
+  }
+
+  acquireMessagingLease(params: {
+    instanceId: string;
+    now: number;
+    ttlMs: number;
+  }): MessagingLeaseAcquireResult {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        existing
+        && existing.status === "active"
+        && existing.ownerInstanceId !== params.instanceId
+        && existing.expiresAt > params.now
+      ) {
+        this.markDesiredMessaging({
+          instanceId: params.instanceId,
+          desiredMessagingEnabled: true,
+          effectiveMessagingEnabled: false,
+          disabledReason: "lease_held",
+          now: params.now,
+        });
+        return { acquired: false as const, reason: "held" as const, holder: existing };
+      }
+
+      const acquiredAt =
+        existing?.status === "active"
+        && existing.ownerInstanceId === params.instanceId
+        && existing.expiresAt > params.now
+          ? existing.acquiredAt
+          : params.now;
+      const lease = this.upsertActiveLease({
+        instanceId: params.instanceId,
+        acquiredAt,
+        now: params.now,
+        ttlMs: params.ttlMs,
+      });
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: true,
+        now: params.now,
+      });
+      return { acquired: true as const, lease };
+    })();
+  }
+
+  renewMessagingLease(params: {
+    instanceId: string;
+    now: number;
+    ttlMs: number;
+  }): boolean {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        !existing
+        || existing.status !== "active"
+        || existing.ownerInstanceId !== params.instanceId
+      ) {
+        return false;
+      }
+
+      this.upsertActiveLease({
+        instanceId: params.instanceId,
+        acquiredAt: existing.acquiredAt,
+        now: params.now,
+        ttlMs: params.ttlMs,
+      });
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: true,
+        now: params.now,
+      });
+      return true;
+    })();
+  }
+
+  releaseMessagingLease(params: { instanceId: string; now: number }): boolean {
+    return this.stateDb.raw.transaction(() => {
+      const existing = this.getMessagingLease();
+      if (
+        !existing
+        || existing.status !== "active"
+        || existing.ownerInstanceId !== params.instanceId
+      ) {
+        return false;
+      }
+
+      this.stateDb.raw
+        .prepare(
+          `UPDATE messaging_runtime_lease
+           SET released_at = ?, status = 'released'
+           WHERE lease_key = ? AND owner_instance_id = ?`,
+        )
+        .run(params.now, MESSAGING_LEASE_KEY, params.instanceId);
+      this.markDesiredMessaging({
+        instanceId: params.instanceId,
+        desiredMessagingEnabled: true,
+        effectiveMessagingEnabled: false,
+        disabledReason: "runtime_stopped",
+        now: params.now,
+      });
+      return true;
+    })();
+  }
+
+  getMessagingLease(): MessagingRuntimeLeaseRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM messaging_runtime_lease WHERE lease_key = ?")
+      .get(MESSAGING_LEASE_KEY) as LeaseRow | undefined;
+    return row ? mapLeaseRow(row) : undefined;
+  }
+
+  private upsertActiveLease(params: {
+    instanceId: string;
+    acquiredAt: number;
+    now: number;
+    ttlMs: number;
+  }): MessagingRuntimeLeaseRecord {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO messaging_runtime_lease(
+           lease_key, owner_instance_id, acquired_at, heartbeat_at,
+           expires_at, released_at, status
+         ) VALUES (?, ?, ?, ?, ?, NULL, 'active')
+         ON CONFLICT(lease_key) DO UPDATE SET
+           owner_instance_id = excluded.owner_instance_id,
+           acquired_at = excluded.acquired_at,
+           heartbeat_at = excluded.heartbeat_at,
+           expires_at = excluded.expires_at,
+           released_at = NULL,
+           status = 'active'`,
+      )
+      .run(
+        MESSAGING_LEASE_KEY,
+        params.instanceId,
+        params.acquiredAt,
+        params.now,
+        params.now + params.ttlMs,
+      );
+    this.heartbeatInstance({ instanceId: params.instanceId, now: params.now });
+    return this.getMessagingLease()!;
+  }
+}
+
+function mapInstanceRow(row: InstanceRow): AppRuntimeInstanceRecord {
+  return {
+    instanceId: row.instance_id,
+    profileName: row.profile_name,
+    processId: row.process_id,
+    ...(row.cwd_hint ? { cwdHint: row.cwd_hint } : {}),
+    startedAt: row.started_at,
+    heartbeatAt: row.heartbeat_at,
+    ...(row.exited_at !== null ? { exitedAt: row.exited_at } : {}),
+    desiredMessagingEnabled: row.desired_messaging_enabled === 1,
+    effectiveMessagingEnabled: row.effective_messaging_enabled === 1,
+    ...(row.disabled_reason
+      ? {
+          disabledReason:
+            normalizeDisabledReason(row.disabled_reason) ?? "runtime_stopped",
+        }
+      : {}),
+  };
+}
+
+function mapLeaseRow(row: LeaseRow): MessagingRuntimeLeaseRecord {
+  return {
+    ownerInstanceId: row.owner_instance_id,
+    acquiredAt: row.acquired_at,
+    heartbeatAt: row.heartbeat_at,
+    expiresAt: row.expires_at,
+    ...(row.released_at !== null ? { releasedAt: row.released_at } : {}),
+    status: row.status,
+  };
+}
+
+function booleanToSql(value: boolean): number {
+  return value ? 1 : 0;
+}
+
+function sanitizeCwdHint(cwd: string | undefined): string | null {
+  const value = cwd?.trim();
+  if (!value) return null;
+  return path.basename(value).slice(0, 120) || null;
+}
+
+function normalizeDisabledReason(
+  value: string | undefined,
+): AppRuntimeMessagingDisabledReason | undefined {
+  switch (value) {
+    case "explicit_override":
+    case "lease_held":
+    case "no_runnable_adapters":
+    case "runtime_stopped":
+    case "startup_error":
+      return value;
+    default:
+      return value ? "explicit_override" : undefined;
+  }
+}

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -3,6 +3,7 @@ import {
   resolveActiveProfilePath,
   updateLastUsed,
 } from "../profile";
+import { AppRuntimeInstanceStore } from "./app-runtime-instance-store.js";
 import { migrateIfNeeded } from "./migration.js";
 import { SqliteMessagingStore } from "./messaging-store-sqlite.js";
 import { SqliteOverlayStore } from "./overlay-store-sqlite.js";
@@ -11,14 +12,21 @@ import { StateDb } from "./state-db.js";
 let stateDb: StateDb | null = null;
 let messagingStore: SqliteMessagingStore | null = null;
 let overlayStore: SqliteOverlayStore | null = null;
+let runtimeInstanceStore: AppRuntimeInstanceStore | null = null;
 
 export function initializeAppState(): {
   stateDb: StateDb;
   messagingStore: SqliteMessagingStore;
   overlayStore: SqliteOverlayStore;
+  runtimeInstanceStore: AppRuntimeInstanceStore;
 } {
   if (stateDb) {
-    return { stateDb, messagingStore: messagingStore!, overlayStore: overlayStore! };
+    return {
+      stateDb,
+      messagingStore: messagingStore!,
+      overlayStore: overlayStore!,
+      runtimeInstanceStore: runtimeInstanceStore!,
+    };
   }
 
   const { profileName } = ensureProfileExists();
@@ -32,8 +40,9 @@ export function initializeAppState(): {
 
   messagingStore = new SqliteMessagingStore(stateDb);
   overlayStore = new SqliteOverlayStore(stateDb);
+  runtimeInstanceStore = new AppRuntimeInstanceStore(stateDb);
 
-  return { stateDb, messagingStore, overlayStore };
+  return { stateDb, messagingStore, overlayStore, runtimeInstanceStore };
 }
 
 export function getAppStateDb(): StateDb {
@@ -51,12 +60,18 @@ export function getAppOverlayStore(): SqliteOverlayStore {
   return overlayStore;
 }
 
+export function getAppRuntimeInstanceStore(): AppRuntimeInstanceStore {
+  if (!runtimeInstanceStore) throw new Error("App state not initialized. Call initializeAppState() first.");
+  return runtimeInstanceStore;
+}
+
 export function disposeAppState(): void {
   if (stateDb) {
     stateDb.close();
     stateDb = null;
     messagingStore = null;
     overlayStore = null;
+    runtimeInstanceStore = null;
   }
 }
 
@@ -64,4 +79,5 @@ export function resetAppStateForTests(): void {
   stateDb = null;
   messagingStore = null;
   overlayStore = null;
+  runtimeInstanceStore = null;
 }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -142,8 +142,38 @@ CREATE INDEX idx_messaging_pairing_status
   ON messaging_pairing_tokens(status, expires_at);
 `;
 
+const SCHEMA_V4 = `
+CREATE TABLE app_runtime_instances (
+  instance_id                 TEXT PRIMARY KEY,
+  profile_name                TEXT NOT NULL,
+  process_id                  INTEGER NOT NULL,
+  cwd_hint                    TEXT,
+  started_at                  INTEGER NOT NULL,
+  heartbeat_at                INTEGER NOT NULL,
+  exited_at                   INTEGER,
+  desired_messaging_enabled   INTEGER NOT NULL,
+  effective_messaging_enabled INTEGER NOT NULL,
+  disabled_reason             TEXT
+);
+CREATE INDEX idx_app_runtime_instances_profile_heartbeat
+  ON app_runtime_instances(profile_name, heartbeat_at DESC);
+
+CREATE TABLE messaging_runtime_lease (
+  lease_key         TEXT PRIMARY KEY,
+  owner_instance_id TEXT NOT NULL,
+  acquired_at       INTEGER NOT NULL,
+  heartbeat_at      INTEGER NOT NULL,
+  expires_at        INTEGER NOT NULL,
+  released_at       INTEGER,
+  status            TEXT NOT NULL
+);
+CREATE INDEX idx_messaging_runtime_lease_status_expires
+  ON messaging_runtime_lease(status, expires_at);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const APP_RUNTIME_INSTANCE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 /**
  * Per-platform cap for the messaging activity log. Older rows are
  * evicted FIFO so the table stays small even on busy platforms. Tuned
@@ -200,6 +230,12 @@ export class StateDb {
         db.pragma("user_version = 3");
       })();
     }
+    if ((db.pragma("user_version", { simple: true }) as number) < 4) {
+      db.transaction(() => {
+        db.exec(SCHEMA_V4);
+        db.pragma("user_version = 4");
+      })();
+    }
 
     return new StateDb(db);
   }
@@ -242,6 +278,16 @@ export class StateDb {
           "UPDATE messaging_pairing_tokens SET status = 'expired' WHERE status IN ('pending', 'observed') AND expires_at < ?",
         )
         .run(now);
+      this.db
+        .prepare(
+          "UPDATE messaging_runtime_lease SET status = 'expired' WHERE status = 'active' AND expires_at < ?",
+        )
+        .run(now);
+      this.db
+        .prepare(
+          "DELETE FROM app_runtime_instances WHERE heartbeat_at < ? AND exited_at IS NOT NULL",
+        )
+        .run(now - APP_RUNTIME_INSTANCE_RETENTION_MS);
       this.db
         .prepare("DELETE FROM deliveries WHERE created_at < ?")
         .run(now - DELIVERIES_RETENTION_MS);

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -90,6 +90,22 @@ export function MessagingSettings(props: {
     ? !runtimeMessaging.disabled
     : messagingEnabled.value;
   const platformControlsDisabled = props.saving || !masterEnabled;
+  const leaseHolderLabel = runtimeMessaging.leaseHolder
+    ? [
+        runtimeMessaging.leaseHolder.cwdHint,
+        runtimeMessaging.leaseHolder.processId
+          ? `pid ${runtimeMessaging.leaseHolder.processId}`
+          : undefined,
+      ].filter(Boolean).join(" - ")
+    : undefined;
+  const runtimeWarningTitle =
+    runtimeMessaging.disabledReasonKind === "lease_held"
+      ? "Messaging active in another app instance"
+      : "Messaging disabled for this app instance";
+  const runtimeWarningBody =
+    runtimeMessaging.disabledReasonKind === "lease_held"
+      ? `Messaging is off here because another PwrAgent instance holds this profile's messaging lease${leaseHolderLabel ? ` (${leaseHolderLabel})` : ""}. Close that instance or wait for its lease to expire, then flip the master toggle to try again.`
+      : "Messaging is off because the app was launched with the no-messaging flag. You can override this for the current session by flipping the master toggle below, but make sure messaging is off in any other PwrAgent instances first. The override applies to this session only; the saved default is unchanged.";
 
   return (
     <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
@@ -104,15 +120,11 @@ export function MessagingSettings(props: {
           <div className="settings-panel__header">
             <div>
               <p className="eyebrow">Runtime Override</p>
-              <h2>Messaging disabled for this app instance</h2>
+              <h2>{runtimeWarningTitle}</h2>
             </div>
           </div>
           <p className="settings-row__description">
-            Messaging is off because the app was launched with the no-messaging
-            flag. You can override this for the current session by flipping the
-            master toggle below, but make sure messaging is off in any other
-            PwrAgent instances first. The override applies to this session only;
-            the saved default is unchanged.
+            {runtimeWarningBody}
           </p>
         </section>
       ) : null}
@@ -134,7 +146,9 @@ export function MessagingSettings(props: {
             }
             source={
               runtimeMessaging.overrideActive
-                ? "session"
+                ? runtimeMessaging.disabledReasonKind === "lease_held"
+                  ? "lease"
+                  : "session"
                 : sourceBadge(messagingEnabled)
             }
             onChange={(enabled) => {

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -242,6 +242,12 @@ This disables messaging only for that app process. It does not rewrite the
 settings file or remove stored bot credentials. The Settings > Messaging screen
 shows when this runtime override is active.
 
+Normal `pnpm dev` launches are protected by a profile-scoped messaging lease:
+only one live app instance for a profile starts messaging adapters. A second
+instance stays usable for desktop work and leaves messaging stopped until the
+holder exits or its heartbeat expires. Keep `dev:no-messaging` for work where
+the current process should never attempt messaging, even if the lease is free.
+
 Default 1Password item:
 
 - Vault: `Private`

--- a/docs/plans/2026-05-12-001-feat-dev-profile-messaging-leases-plan.md
+++ b/docs/plans/2026-05-12-001-feat-dev-profile-messaging-leases-plan.md
@@ -1,0 +1,352 @@
+---
+title: feat: Add dev profile messaging leases
+type: feat
+status: completed
+date: 2026-05-12
+deepened: 2026-05-12
+---
+
+# feat: Add dev profile messaging leases
+
+## Overview
+
+Add a profile-scoped messaging lease so multiple PwrAgent desktop instances can share one profile without every instance trying to start Telegram, Discord, Slack, Mattermost, or LINE adapters. Each app instance records itself in the profile `state.db`, one instance at a time may hold the messaging lease, and stale holders expire when their heartbeat stops. This keeps `dev:no-messaging` available as an explicit opt-out, but makes normal dev launches safer.
+
+## Problem Frame
+
+Today `pnpm dev:no-messaging` exists because `pnpm dev` can start real messaging adapters against the same profile credentials. A second desktop process can collide with the first, causing provider conflicts such as duplicate bot polling or confusing runtime status. The user wants this solved as developer/runtime infrastructure rather than a broad user-facing feature: log instance starts, know whether messaging is effective for that instance, and let a new process take over when the old holder is gone.
+
+## Requirements Trace
+
+- R1. Record every desktop app instance startup in the profile database with enough safe metadata to identify it during development.
+- R2. Record both desired and effective messaging state for each instance so a process can show "wanted messaging, lease held elsewhere" distinctly from "messaging explicitly disabled."
+- R3. Allow at most one active messaging-enabled lease holder per profile.
+- R4. Expire stale messaging leases after the holder stops heartbeating, so crashed or killed dev instances do not require manual cleanup.
+- R5. Keep explicit `--disable-messaging` / `PWRAGENT_DISABLE_MESSAGING` behavior as a stronger session-only opt-out.
+- R6. Keep provider packages persistence-free; lease ownership belongs to desktop main process state/orchestration.
+- R7. Do not persist secrets, raw env, or full command lines in instance/lease rows.
+- R8. Keep second instances useful for desktop browsing and editing even when messaging is suspended by another holder.
+
+## Scope Boundaries
+
+- In scope: desktop main-process instance logging, profile-scoped lease persistence, heartbeat/release lifecycle, settings/status wording for lease-held-disabled state, tests, and developer docs.
+- Out of scope: changing provider adapter contracts, adding cross-machine distributed locking, changing profile selection semantics, changing messaging credentials/config shape, or removing `dev:no-messaging`.
+- Out of scope for first pass: a force-takeover UI. Lease takeover should happen only when the prior holder is expired.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/index.ts` initializes profile state, constructs `DesktopMessagingRuntime`, and currently decides between `resolveRuntimeMessagingOverride()` and `messagingRuntime.start()`.
+- `apps/desktop/src/main/runtime-flags.ts` defines the explicit no-messaging override.
+- `apps/desktop/src/main/state/app-state.ts` opens the profile `state/state.db`, starts SQLite GC, and exposes `getAppStateDb()`.
+- `apps/desktop/src/main/state/state-db.ts` owns SQLite schema migrations, WAL setup, busy timeout, GC, and small state helpers.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` owns adapter lifecycle, platform health, runtime start/stop, and status snapshots.
+- `apps/desktop/src/main/ipc/messaging-status.ts` already lets Settings start/stop messaging for the current session without changing saved config when a runtime override is active.
+- `apps/desktop/src/main/settings/desktop-settings-service.ts` and `packages/shared/src/contracts/settings.ts` expose `runtime.messaging` to the renderer.
+- `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx` already has a runtime warning panel for session-only messaging disablement.
+- `docs/state-layout.md` currently states multiple instances can share the same profile DB safely via SQLite WAL, but it does not account for singleton messaging adapters.
+- `packages/messaging/AGENTS.md` requires providers to stay persistence-free and puts orchestration in `apps/desktop/src/main/messaging`.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` reinforces that singleton ownership can simplify runtime behavior when multiple processes would otherwise create conflicting state.
+- Existing messaging plans establish that desktop owns messaging orchestration and providers should remain isolated behind the generic interface.
+
+### External References
+
+- External research skipped. The core problem is repo-local runtime coordination over SQLite, and the repository already has the relevant architectural patterns.
+
+## Key Technical Decisions
+
+- Use the profile `state.db` as the lease authority. It is already the shared per-profile coordination point and is opened with WAL plus a busy timeout, so no extra lockfile or process-global IPC is needed.
+- Use heartbeat expiry, not PID liveness, as the correctness mechanism. PID and cwd are useful diagnostics, but PID reuse and cross-platform behavior make process checks a weak authority. A lease is valid only while `expires_at` is in the future and the owner keeps renewing it.
+- Acquire the lease before starting provider adapters. The second process should never import/load/start configured providers when another live holder owns messaging for that profile.
+- Keep explicit no-messaging overrides stronger than leases. If `--disable-messaging` or `PWRAGENT_DISABLE_MESSAGING` is set, the instance logs desired/effective messaging as disabled and does not attempt acquisition.
+- Represent lease-held-disabled as runtime state, not saved config. The user's `[messaging] enabled` setting remains the desired default; the lease only affects this process.
+- Release only the current holder's lease on orderly shutdown or session stop. Do not delete another instance's row, and do not release the lease merely because one provider adapter fails after startup.
+- Keep the first pass passive for second instances. They should show messaging as unavailable because another live instance holds the lease, and should acquire automatically only after expiry or when the user toggles messaging after the lease is free.
+- Do not claim the lease when the resolved messaging config has no configured adapters. A profile with the master switch on but no eligible provider credentials should record that messaging was desired but had no runnable platforms; it should not block another instance unnecessarily.
+- Centralize lease gating in one desktop main-process coordinator used by startup, `applyLatestConfig`, and Settings IPC. Bootstrap and Settings should not each invent slightly different acquisition/release rules.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be limited to development builds? No. The implementation is a safe profile invariant that prevents duplicate adapter starts anywhere. The feature is developer-motivated, but the invariant protects production-like multi-instance use too.
+- Should provider packages participate? No. The lease guards desktop runtime startup before provider loading, preserving the provider persistence boundary.
+- Should a second process force-steal the lease? No for the first pass. Stale expiry is enough to reduce `dev:no-messaging` use without adding destructive takeover behavior.
+
+### Deferred to Implementation
+
+- Exact names for the store class and shared DTO fields: choose names that fit nearby desktop state/settings conventions during implementation.
+- Exact heartbeat interval constants: the plan recommends a 10-second heartbeat and 30-second lease TTL, but implementation can tune slightly if tests or existing timer conventions suggest better values.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant App as Desktop instance
+    participant State as Profile state.db
+    participant Runtime as DesktopMessagingRuntime
+    participant Providers as Provider adapters
+
+    App->>State: record instance start
+    App->>State: resolve desired messaging config + explicit override
+    alt explicit no-messaging override
+        App->>State: mark effective messaging disabled
+        App-->>Runtime: keep runtime constructed but stopped
+    else no runnable adapters
+        App->>State: mark effective messaging disabled: no configured platforms
+        App-->>Runtime: keep runtime constructed but stopped
+    else lease free or expired
+        App->>State: atomically acquire profile messaging lease
+        App->>State: heartbeat instance + lease
+        App->>Runtime: start messaging
+        Runtime->>Providers: load and start configured adapters
+    else live holder owns lease
+        App->>State: mark effective messaging disabled: lease held elsewhere
+        App-->>Runtime: keep runtime constructed but stopped
+    end
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add profile instance and lease persistence**
+
+**Goal:** Create the SQLite schema and desktop main-process store that records app instances and manages the single messaging lease for the active profile.
+
+**Requirements:** R1, R2, R3, R4, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/state/state-db.ts`
+- Modify: `apps/desktop/src/main/state/app-state.ts`
+- Create: `apps/desktop/src/main/state/app-runtime-instance-store.ts`
+- Test: `apps/desktop/src/main/__tests__/app-runtime-instance-store.test.ts`
+
+**Approach:**
+- Add a new schema migration with an `app_runtime_instances` table and a singleton/profile-scoped `messaging_runtime_lease` table.
+- Instance rows should include a generated instance id, profile name, process id, safe cwd/worktree hint, start timestamp, heartbeat timestamp, optional exit timestamp, desired messaging boolean, effective messaging boolean, and safe disabled reason.
+- Lease rows should include the owner instance id, acquired timestamp, last heartbeat timestamp, expires timestamp, and released timestamp or status.
+- Implement atomic acquire/renew/release operations inside transactions. Acquisition succeeds when no active lease exists, the existing lease is expired, or the existing owner is the current instance.
+- Keep SQL parameterized and keep generated SQL fragments limited to hardcoded structure.
+- Add GC for old instance rows and released/expired lease history if the chosen schema retains history.
+
+**Execution note:** Implement the store test-first because the lease race/expiry behavior is the correctness core.
+
+**Patterns to follow:**
+- `StateDb.open()` migration style and `cleanupExpired()` retention patterns in `apps/desktop/src/main/state/state-db.ts`.
+- `apps/desktop/src/main/messaging/messaging-pairing-store.ts` for focused SQLite store methods around a small table.
+- SQLite query rules in `apps/desktop/AGENTS.md`.
+
+**Test scenarios:**
+- Happy path: first instance records startup and acquires the messaging lease with effective messaging enabled.
+- Happy path: the same instance renews its lease and extends `expires_at`.
+- Edge case: a second instance cannot acquire while the first holder's `expires_at` is in the future and records effective messaging disabled with a lease-held reason.
+- Edge case: a second instance can acquire after the first holder's lease is expired.
+- Edge case: releasing a lease from a non-holder leaves the live holder intact.
+- Error path: malformed or missing profile metadata does not persist secrets or raw env values.
+- Integration: reopening `state.db` preserves instance/lease rows and allows expiry-based acquisition across processes.
+
+**Verification:**
+- The store can deterministically prove single-holder semantics with concurrent-like sequential transactions.
+- The schema migration is idempotent for existing profile databases.
+
+- [x] **Unit 2: Gate messaging startup through the lease**
+
+**Goal:** Change desktop bootstrap and runtime lifecycle so provider adapters start only when this instance holds the profile messaging lease.
+
+**Requirements:** R2, R3, R4, R5, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/index.ts`
+- Modify: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Modify: `apps/desktop/src/main/runtime-flags.ts` only if the override type needs a broader disabled-reason model.
+- Test: `apps/desktop/src/main/__tests__/index.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
+- Test: `apps/desktop/src/main/__tests__/runtime-flags.test.ts` if the override type changes.
+
+**Approach:**
+- Generate the instance id after `initializeAppState()` and record startup before making the messaging startup decision.
+- Resolve explicit no-messaging override first. If present, mark the instance as disabled and skip lease acquisition.
+- Load the desktop messaging config before acquisition so the coordinator can distinguish "master enabled with runnable adapters" from "master enabled but no configured platforms."
+- If desired messaging is enabled, at least one adapter config is present, and no explicit override is active, attempt lease acquisition before calling `messagingRuntime.start()` or `messagingRuntime.applyConfig()`.
+- Put this preflight in a shared coordinator path that startup and Settings IPC both use; avoid duplicating lease conditions in two call sites.
+- Start a heartbeat timer only for the current lease holder. The heartbeat should renew both the instance heartbeat and lease expiry.
+- On `before-quit`, stop messaging and release the lease only when this process is the holder; mark the instance exited before closing `state.db`.
+- If lease acquisition fails, keep the runtime constructed and status IPC registered, but do not load providers or start adapters.
+- Preserve the existing `messagingRuntime.start().catch(...)` background-start behavior, but ensure failed startup updates instance effective state without corrupting another holder's lease.
+
+**Patterns to follow:**
+- Existing bootstrap order in `apps/desktop/src/main/index.ts`.
+- Runtime lifecycle queue in `DesktopMessagingRuntime`.
+- Existing explicit override behavior in `resolveRuntimeMessagingOverride()`.
+
+**Test scenarios:**
+- Happy path: without override and with a free lease, bootstrap attempts messaging startup.
+- Happy path: with `PWRAGENT_DISABLE_MESSAGING`, bootstrap records disabled state and never calls runtime start or lease acquire.
+- Edge case: with the master switch enabled but no configured adapter credentials, bootstrap records no runnable platforms and does not claim the lease.
+- Edge case: when lease acquisition fails because another live holder exists, provider loading is not invoked and the app still registers messaging status IPC.
+- Edge case: when a stale lease exists, bootstrap acquires and starts messaging.
+- Error path: if runtime start fails after lease acquisition, the error is logged and the lease remains owned until the runtime/instance stops.
+- Integration: before-quit releases only the current holder's lease and marks the instance exited.
+
+**Verification:**
+- A second desktop instance with the same profile no longer starts provider adapters while the first holder is live.
+- Explicit no-messaging behavior remains unchanged except for instance logging.
+
+- [x] **Unit 3: Make session enable/disable lease-aware**
+
+**Goal:** Keep the Settings master toggle and IPC behavior correct when messaging is disabled because another instance holds the lease.
+
+**Requirements:** R2, R3, R4, R5, R8
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/ipc/messaging-status.ts`
+- Modify: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Modify: `packages/shared/src/contracts/settings.ts`
+- Modify: `packages/shared/src/contracts/messaging.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+
+**Approach:**
+- Extend runtime messaging snapshot data with a disabled reason category that can distinguish explicit override from lease-held-disabled.
+- When Settings calls `setMessagingEnabled({ enabled: true })`, attempt lease acquisition before applying config with `allowStart: true`.
+- Reuse the same coordinator path as startup so a config with no runnable adapters does not claim the lease and a config with runnable adapters cannot bypass the lease.
+- If acquisition succeeds, start/renew heartbeat and apply config as today.
+- If acquisition fails because a live holder exists, return effective disabled state and the holder metadata that is safe to show or log.
+- When Settings disables messaging for the session, stop the runtime and release this instance's lease if held; do not change saved config when the disabled state is lease/session-only.
+
+**Patterns to follow:**
+- Existing `MESSAGING_SET_ENABLED_CHANNEL` flow in `apps/desktop/src/main/ipc/messaging-status.ts`.
+- Existing runtime messaging snapshot shape in `DesktopSettingsSnapshot`.
+- Current session-only override handling in `MessagingSettings.tsx`.
+
+**Test scenarios:**
+- Happy path: enabling messaging from a lease-disabled instance acquires a now-free lease and starts runtime.
+- Happy path: enabling messaging when no adapters are configured returns a coherent disabled/no-platforms state without claiming the lease.
+- Edge case: enabling messaging while another live holder exists returns disabled state with a lease-held reason and does not start providers.
+- Edge case: disabling messaging from the lease holder stops runtime and releases the lease.
+- Edge case: disabling messaging from a non-holder is a no-op for the lease and still returns a coherent effective disabled state.
+- Integration: `readSettings()` reports explicit no-messaging and lease-held-disabled as distinct runtime conditions.
+
+**Verification:**
+- Settings can recover automatically once the prior holder expires, without requiring `dev:no-messaging`.
+- Saved `config.toml` messaging settings are unchanged by lease-only state.
+
+- [x] **Unit 4: Surface lease-held state in developer-facing UI/status**
+
+**Goal:** Make lease-disabled state understandable without turning it into a prominent end-user feature.
+
+**Requirements:** R2, R8
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx` only if the master toggle callback needs adjusted state handling.
+- Modify: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx` only if status chips need a suspended-by-lease tooltip.
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts` only if preload contract types change locally.
+- Modify: `apps/desktop/src/preload/index.ts` if IPC response fields change.
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx` if status chip behavior changes.
+
+**Approach:**
+- Reuse the existing runtime warning panel shape in Messaging Settings, but change copy and source labeling when disabled because another profile instance holds the lease.
+- Keep the master toggle semantics effective-state based: on means this instance is the holder and runtime is started; off can mean explicit override, lease held elsewhere, or user stopped the session.
+- Avoid broad new navigation or dashboard surfaces. This is developer/runtime status, not a new product workflow.
+- If safe holder metadata is exposed, show only coarse information such as start time, pid, or cwd basename/worktree hint, not raw env or full argv.
+
+**Patterns to follow:**
+- Existing `MessagingSettings.tsx` runtime override panel and source badges.
+- Desktop style guidance in `apps/desktop/AGENTS.md`: no placeholder or implementation-status narration in user-facing UI.
+
+**Test scenarios:**
+- Happy path: Settings shows the existing explicit no-messaging warning when launched with `dev:no-messaging`.
+- Happy path: Settings shows a distinct lease-held message when another live instance owns messaging.
+- Edge case: the master toggle is disabled or returns to off when an enable attempt cannot acquire the lease.
+- Edge case: once IPC reports enabled after acquisition, the warning disappears and platform controls become enabled.
+
+**Verification:**
+- Developers can tell why messaging is off in the current process and whether retrying after the other instance exits should work.
+- No provider-specific wording leaks into the generic messaging settings panel.
+
+- [x] **Unit 5: Update docs and operational guidance**
+
+**Goal:** Document the new lease behavior so developers know when `dev`, `dev:no-messaging`, and profile isolation are appropriate.
+
+**Requirements:** R1, R3, R4, R5, R8
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/state-layout.md`
+- Modify: `apps/desktop/AGENTS.md`
+- Modify: `docs/messaging-platform-integration.md` if its dev commands still imply `dev:no-messaging` is the default safest path.
+- Test: `apps/desktop/src/main/__tests__/messaging-docs-links.test.ts` if docs links are added or changed.
+
+**Approach:**
+- Update the multi-instance section to state that SQLite still supports shared profile access, but messaging adapters are single-holder per profile.
+- Keep `dev:no-messaging` documented as an explicit opt-out for visual/UI work or when the developer never wants adapters to start.
+- Document that stale leases expire automatically after missed heartbeats and that deleting rows manually should not be normal workflow.
+- Do not imply cross-machine safety; the lease coordinates processes sharing the same local profile database.
+
+**Patterns to follow:**
+- Current `docs/state-layout.md` profile and dev profile sections.
+- Existing concise dev-command guidance in `apps/desktop/AGENTS.md`.
+
+**Test scenarios:**
+- Test expectation: none for prose itself, except existing documentation link tests if modified docs introduce links.
+
+**Verification:**
+- Developer docs no longer present `dev:no-messaging` as required for every normal dev launch.
+- Multi-instance behavior is documented with the same state layout vocabulary used elsewhere.
+
+## System-Wide Impact
+
+- **Interaction graph:** Bootstrap, app state, messaging runtime, settings IPC, renderer settings, and status chips are affected. Provider packages should be unaffected except that they load less often.
+- **Error propagation:** Lease acquisition failures should produce an effective disabled state, not startup crashes. Runtime adapter errors after acquisition should continue through existing platform health/error logging.
+- **State lifecycle risks:** The main risk is a stale lease that blocks messaging too long or expires too quickly. Use a heartbeat interval substantially shorter than TTL and test expiry deterministically with injected clocks.
+- **API surface parity:** Shared settings/messaging contracts may gain reason fields; preload and renderer DTOs must stay aligned.
+- **Integration coverage:** Unit tests should cover persistence and IPC behavior. A manual two-instance check should verify that only the first live profile instance starts messaging adapters and the second can acquire after the first exits or the lease expires.
+- **Unchanged invariants:** Messaging providers remain persistence-free, renderer imports remain limited by desktop boundaries, saved messaging config remains the desired default, and explicit no-messaging overrides continue to work.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Lease expiry is too short and causes duplicate adapter starts during brief event-loop stalls | Use a conservative TTL such as 30 seconds with a faster heartbeat such as 10 seconds, and renew from a lightweight timer. |
+| Lease expiry is too long and crashed dev instances block messaging annoyingly | Keep TTL short enough for developer recovery and expose a clear lease-held reason in Settings. |
+| Instance rows accidentally persist secrets or sensitive command-line data | Store only allowlisted metadata; never store env values, tokens, or raw argv. |
+| A provider conflict can still happen with another profile or an external bot process using the same token | Treat this lease as same-profile coordination only; keep existing adapter runtime error health handling for external conflicts. |
+| Shutdown ordering closes SQLite before lease release | Release/mark exited before `disposeAppState()` closes `state.db`, and make release best-effort/logged. |
+| Settings toggle appears to save config when it only changes session state | Keep lease-disabled and override-disabled states under `runtime.messaging`, not persisted `messaging.enabled`. |
+
+## Documentation / Operational Notes
+
+- Update developer guidance so `pnpm --filter @pwragent/desktop dev` becomes reasonable when a profile already has a live holder; `dev:no-messaging` remains useful when the developer wants to guarantee no adapter startup.
+- Avoid adding manual SQL cleanup guidance unless implementation discovers a real recovery need.
+- Logs should include instance id and safe reason fields so developers can correlate startup/lease decisions without inspecting SQLite.
+
+## Sources & References
+
+- Related code: `apps/desktop/src/main/index.ts`
+- Related code: `apps/desktop/src/main/runtime-flags.ts`
+- Related code: `apps/desktop/src/main/state/state-db.ts`
+- Related code: `apps/desktop/src/main/state/app-state.ts`
+- Related code: `apps/desktop/src/main/messaging/messaging-runtime.ts`
+- Related code: `apps/desktop/src/main/ipc/messaging-status.ts`
+- Related code: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Related code: `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx`
+- Related docs: `docs/state-layout.md`
+- Related docs: `docs/messaging-architecture.md`
+- Related docs: `packages/messaging/AGENTS.md`
+- Institutional learning: `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -93,10 +93,21 @@ Single database containing all persistent state. Opened with WAL mode, `synchron
 | `directory_launchpads` | Per-directory launchpad drafts and settings |
 | `threads` | Thread overlay state (seen timestamps, git branch, linked dirs) |
 | `secrets` | `safeStorage`-encrypted secrets (bot tokens, API keys) |
+| `app_runtime_instances` | Per-process startup/heartbeat records for instances using this profile |
+| `messaging_runtime_lease` | Singleton profile lease that allows only one live instance to run messaging adapters |
 
 ## Multi-Instance Access
 
-Multiple desktop instances can share the same profile's `state.db` safely. sqlite WAL mode serializes writes automatically. No external lockfile is required.
+Multiple desktop instances can share the same profile's `state.db` safely. sqlite WAL mode serializes writes automatically. No external lockfile is required for normal state access.
+
+Messaging adapters are single-holder per profile. Each desktop process records
+an `app_runtime_instances` heartbeat, and only the process holding the
+`messaging_runtime_lease` starts provider adapters. If the holder exits cleanly,
+it releases the lease during shutdown. If it crashes or is killed, the lease
+expires after missed heartbeats and another instance can acquire it. This lease
+coordinates local processes that share the same profile database; it is not a
+cross-machine distributed lock for two different profile directories or two
+external bot deployments using the same token.
 
 ## Migration
 

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -239,10 +239,26 @@ export type SetMessagingEnabledRequest = {
 export type SetMessagingEnabledResponse = {
   /** Effective runtime state after the toggle. */
   enabled: boolean;
-  /** True when the process was launched with a no-messaging override. */
+  /** True when this process cannot use saved messaging as-is. */
   overridden: boolean;
   /** Human-readable explanation of the launch override, when applicable. */
   overrideReason?: string;
+  /** Effective runtime-disabled reason after the toggle, when applicable. */
+  disabledReason?: string;
+  disabledReasonKind?:
+    | "explicit_override"
+    | "lease_held"
+    | "no_runnable_adapters"
+    | "runtime_stopped"
+    | "startup_error"
+    | "saved_disabled";
+  leaseHolder?: {
+    instanceId: string;
+    processId?: number;
+    cwdHint?: string;
+    startedAt?: number;
+    expiresAt: number;
+  };
 };
 
 export type MessagingPairingScope = "user_dm" | "bucket" | "user_in_group";

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -242,7 +242,21 @@ export type DesktopSettingsSnapshot = {
     messaging: {
       disabled: boolean;
       disabledReason?: string;
+      disabledReasonKind?:
+        | "explicit_override"
+        | "lease_held"
+        | "no_runnable_adapters"
+        | "runtime_stopped"
+        | "startup_error"
+        | "saved_disabled";
       overrideActive?: boolean;
+      leaseHolder?: {
+        instanceId: string;
+        processId?: number;
+        cwdHint?: string;
+        startedAt?: number;
+        expiresAt: number;
+      };
     };
   };
   secretStorage: DesktopSettingsSecretStorageState;


### PR DESCRIPTION
## Summary

- Added profile-scoped runtime instance logging and a singleton messaging lease in the desktop profile SQLite DB.
- Routed desktop startup, settings runtime toggles, config hot-apply, and pairing approval through a lease coordinator so only one app instance per profile starts messaging adapters.
- Updated Settings runtime status, shared contracts, and developer docs so a second instance reports "lease held elsewhere" instead of requiring `dev:no-messaging`.

## Verification

- I ran `pnpm test`.
- I ran `pnpm lint`.
- I ran `pnpm -r --if-present typecheck`.
- I ran `git diff --check`.

## Notes

- `dev:no-messaging` remains available as an explicit session opt-out; normal `pnpm dev` now records the instance and only starts adapters after acquiring the profile lease.
- Lease takeover is passive: another instance can acquire messaging after the prior holder stops heartbeating and the lease expires.
