### PR TITLE
feat(messaging): add status skills browser

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  AppServerListSkillsResponse,
   AppServerPendingRequestNotification,
   CancelThreadExecutionModeQueueRequest,
   HandoffThreadWorkspaceRequest,
@@ -5038,6 +5039,187 @@ describe("MessagingController", () => {
     });
   });
 
+  it("opens, searches, selects, removes, and consumes skills from the status menu", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+
+    expect(harness.listSkills).toHaveBeenCalledWith({
+      backend: "codex",
+      cwds: ["/repo/pwragent"],
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Skills",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "skills:select",
+          label: "1. $ce:plan",
+        }),
+        expect.objectContaining({ id: "skills:search" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:search" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Search Skills",
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("work"));
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Skills matching \"work\""),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "skills:select",
+          label: "1. $ce:work",
+        }),
+      ]),
+    });
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    const workChoice = findChoice(harness.delivered.at(-1), "skills:select");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "skills:select",
+        value: workChoice.value,
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Skill Selected",
+      body: expect.stringContaining("Skill: $ce:work"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "skills:remove" }),
+      ]),
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.toMatchObject({
+      pendingSkillSelection: {
+        name: "ce:work",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:remove" }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.not.toHaveProperty("pendingSkillSelection");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "skills:select",
+        value: workChoice.value,
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.toMatchObject({
+      pendingSkillSelection: {
+        name: "ce:work",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("implement it"));
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Use [$ce:work](/skills/ce-work/SKILL.md)",
+          },
+          {
+            type: "text",
+            text: "implement it",
+          },
+        ],
+      }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.not.toHaveProperty("pendingSkillSelection");
+  });
+
+  it("reports skills as unavailable when the backend bridge cannot list them", async () => {
+    const harness = await createHarness({ listSkills: false });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Skills unavailable",
+    });
+  });
+
+  it("clears the skills browser pending intent when returning to status", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:refresh" }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("does not let the removed-skill notice block the next short request", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    const workChoice = findChoice(harness.delivered.at(-1), "skills:select");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "skills:select",
+        value: workChoice.value,
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:remove" }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
+      }),
+    );
+  });
+
   it("toggles fast mode and applies it to later free-form turns", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -6018,6 +6200,7 @@ async function createHarness(options?: {
   handoff?: false;
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
+  listSkills?: NonNullable<MessagingBackendBridge["listSkills"]> | false;
   navigation?: NavigationSnapshot;
   now?: () => number;
   channel?: MessagingChannelKind;
@@ -6051,6 +6234,7 @@ async function createHarness(options?: {
   getNavigationSnapshot: ReturnType<typeof vi.fn>;
   handoffThreadWorkspace: ReturnType<typeof vi.fn> | undefined;
   interruptTurn: ReturnType<typeof vi.fn>;
+  listSkills: ReturnType<typeof vi.fn> | undefined;
   listBackends: ReturnType<typeof vi.fn>;
   materializeDirectoryLaunchpad: ReturnType<typeof vi.fn>;
   onBindingChanged: ReturnType<typeof vi.fn>;
@@ -6145,6 +6329,39 @@ async function createHarness(options?: {
     itemId: "compact-item-1",
   }));
   const interruptTurn = vi.fn(async (request) => request);
+  const listSkills =
+    options?.listSkills === false
+      ? undefined
+      : vi.fn(
+          options?.listSkills ??
+            (async (): Promise<Pick<AppServerListSkillsResponse, "data">> => ({
+              data: [
+                {
+                  cwd: "/repo/pwragent",
+                  skills: [
+                    {
+                      name: "ce:plan",
+                      description: "Create implementation plans",
+                      enabled: true,
+                      path: "/skills/ce-plan/SKILL.md",
+                    },
+                    {
+                      name: "ce:work",
+                      description: "Execute implementation plans",
+                      enabled: true,
+                      path: "/skills/ce-work/SKILL.md",
+                    },
+                    {
+                      name: "review-pr",
+                      description: "Review pull requests",
+                      enabled: true,
+                      path: "/skills/review-pr/SKILL.md",
+                    },
+                  ],
+                },
+              ],
+            })),
+        );
   // Mirror the real BackendRegistry emit-after-mutation behavior: the
   // mutation methods also fan out a notification on the bus so the
   // controller's refreshStatusSurfacesForThread path runs end-to-end.
@@ -6242,6 +6459,7 @@ async function createHarness(options?: {
     getNavigationSnapshot,
     ...(handoffThreadWorkspace ? { handoffThreadWorkspace } : {}),
     interruptTurn,
+    ...(listSkills ? { listSkills } : {}),
     listBackends,
     materializeDirectoryLaunchpad,
     readThreadLastAssistantMessage,
@@ -6287,6 +6505,7 @@ async function createHarness(options?: {
     getNavigationSnapshot,
     handoffThreadWorkspace,
     interruptTurn,
+    listSkills,
     listBackends,
     materializeDirectoryLaunchpad,
     onBindingChanged,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5186,6 +5186,50 @@ describe("MessagingController", () => {
     ).resolves.not.toHaveProperty("pendingSkillSelection");
   });
 
+  it("lists skills from every linked directory on the bound thread", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      linkedDirectories: [
+        {
+          id: "directory:pwragent",
+          kind: "local",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+        {
+          id: "directory:secondary",
+          kind: "local",
+          label: "Secondary",
+          path: "/repo/secondary",
+        },
+        {
+          id: "directory:tools-worktree",
+          kind: "worktree",
+          label: "Tools",
+          path: "/repo/tools",
+          worktreePath: "/repo/tools/.worktrees/feature",
+        },
+      ],
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+
+    expect(harness.listSkills).toHaveBeenCalledWith({
+      backend: "codex",
+      cwds: [
+        "/repo/tools/.worktrees/feature",
+        "/repo/tools",
+        "/repo/pwragent",
+        "/repo/secondary",
+      ],
+    });
+  });
+
   it("reports skills as unavailable when the backend bridge cannot list them", async () => {
     const harness = await createHarness({ listSkills: false });
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5224,13 +5224,14 @@ describe("MessagingController", () => {
     });
   });
 
-  it("updates button-driven skills navigation but posts typed search results as latest messages", async () => {
+  it("updates the active skills message for button-driven navigation and typed search results", async () => {
     const harness = await createHarness();
     await bindThread(harness);
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:skills" }),
     );
+    const initialSkillsSurface = harness.delivered.at(-1)?.id;
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "skills:search" }),
     );
@@ -5241,20 +5242,28 @@ describe("MessagingController", () => {
         mode: "update",
       },
       targetSurface: {
-        id: expect.stringContaining("surface:skills-browser"),
+        id: `surface:${initialSkillsSurface}`,
       },
     });
+    const searchPromptIntent = await harness.store.findActivePendingIntentForChannel({
+      actorId: buildTextEvent("work").actor.platformUserId,
+      channel: buildTextEvent("work").channel,
+      now: 1000,
+    });
+    expect(searchPromptIntent?.surface).toBeDefined();
 
     await harness.controller.handleInboundEvent(buildTextEvent("work"));
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "single_select",
       delivery: {
-        mode: "present",
+        mode: "update",
       },
       prompt: expect.stringContaining('Skills matching "work"'),
+      targetSurface: {
+        id: searchPromptIntent?.surface?.id,
+      },
     });
-    expect(harness.delivered.at(-1)).not.toHaveProperty("targetSurface");
   });
 
   it("lists skills from every linked directory on the bound thread", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3055,6 +3055,41 @@ describe("MessagingController", () => {
     });
   });
 
+  it("clears a staged skill when backend concurrent-start rejection queues the prefixed request", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    const planChoice = findChoice(harness.delivered.at(-1), "skills:select");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "skills:select",
+        value: planChoice.value,
+      }),
+    );
+    harness.startTurn.mockRejectedValueOnce(
+      new Error("thread already has an active turn in progress"),
+    );
+
+    await harness.controller.handleInboundEvent(buildTextEvent("second turn"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.not.stringContaining("Pending skill: $ce:plan"),
+    });
+    const queuedNotice = harness.delivered
+      .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
+      .at(-1);
+    expect(queuedNotice).toMatchObject({
+      body: expect.stringContaining("> Use [$ce:plan](/skills/ce-plan/SKILL.md)"),
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.not.toHaveProperty("pendingSkillSelection");
+  });
+
   it("clears starting state when navigation lookup fails before retrying", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -5163,6 +5198,36 @@ describe("MessagingController", () => {
       kind: "error",
       title: "Skills unavailable",
     });
+  });
+
+  it("honors Back and Cancel text fallbacks from the skills search prompt", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:search" }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("back"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Skills",
+    });
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:search" }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("cancel"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Thread:"),
+    });
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("clears the skills browser pending intent when returning to status", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5186,6 +5186,77 @@ describe("MessagingController", () => {
     ).resolves.not.toHaveProperty("pendingSkillSelection");
   });
 
+  it("presents the skills browser as a current chat message instead of editing the status card", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
+    if (!binding) throw new Error("Expected an active binding");
+    await harness.store.upsertBinding({
+      ...binding,
+      statusSurface: {
+        channel: "telegram",
+        id: "status-surface",
+        state: { opaque: { messageId: "status-message" } },
+      },
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+
+    const skillsBrowser = harness.delivered.at(-1);
+    expect(skillsBrowser).toMatchObject({
+      kind: "single_select",
+      delivery: {
+        mode: "present",
+      },
+    });
+    expect(skillsBrowser).not.toHaveProperty("targetSurface");
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.toMatchObject({
+      statusSurface: {
+        id: "status-surface",
+      },
+    });
+  });
+
+  it("updates button-driven skills navigation but posts typed search results as latest messages", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:search" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      delivery: {
+        mode: "update",
+      },
+      targetSurface: {
+        id: expect.stringContaining("surface:skills-browser"),
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("work"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      delivery: {
+        mode: "present",
+      },
+      prompt: expect.stringContaining('Skills matching "work"'),
+    });
+    expect(harness.delivered.at(-1)).not.toHaveProperty("targetSurface");
+  });
+
   it("lists skills from every linked directory on the bound thread", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5348,13 +5348,53 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(buildTextEvent("cancel"));
 
     expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "status",
-      text: expect.stringContaining("Thread:"),
+      kind: "confirmation",
+      title: "Skills dismissed",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
     });
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
-  it("clears the skills browser pending intent when returning to status", async () => {
+  it("dismisses the skills browser and clears the pending intent on Cancel", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "skills:cancel" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Skills dismissed",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("dismisses older skills browser Cancel buttons that still send status refresh", async () => {
     const harness = await createHarness();
     await bindThread(harness);
 
@@ -5364,6 +5404,17 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:refresh" }),
     );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Skills dismissed",
+      actions: [],
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+    });
+
     await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
 
     expect(harness.startTurn).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3090,6 +3090,69 @@ describe("MessagingController", () => {
     ).resolves.not.toHaveProperty("pendingSkillSelection");
   });
 
+  it("does not restore a consumed skill when a queued turn starts later", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildTextEvent("first turn"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:skills" }),
+    );
+    const planChoice = findChoice(harness.delivered.at(-1), "skills:select");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "skills:select",
+        value: planChoice.value,
+      }),
+    );
+
+    await harness.controller.handleInboundEvent(buildTextEvent("second turn"));
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(1);
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
+    ).resolves.not.toHaveProperty("pendingSkillSelection");
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Use [$ce:plan](/skills/ce-plan/SKILL.md)",
+          },
+          {
+            type: "text",
+            text: "second turn",
+          },
+        ],
+      }),
+    );
+    const latestStatus = harness.delivered
+      .filter((intent) => intent.kind === "status")
+      .at(-1);
+    expect(latestStatus).toMatchObject({
+      kind: "status",
+      text: expect.not.stringContaining("Pending skill: $ce:plan"),
+    });
+  });
+
   it("clears starting state when navigation lookup fails before retrying", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
@@ -119,4 +119,51 @@ describe("messaging skills browser", () => {
       "alpha",
     ]);
   });
+
+  it("treats a leading dollar sign as skill mention syntax during search", () => {
+    const results = filterSkillEntries(
+      [
+        {
+          name: "ce:plan",
+          description: "Create implementation plans",
+          enabled: true,
+        },
+        {
+          name: "ce:work",
+          description: "Execute implementation plans",
+          enabled: true,
+        },
+        {
+          name: "review-pr",
+          description: "Review pull requests",
+          enabled: true,
+        },
+      ],
+      "$ce:",
+    );
+
+    expect(results.map((entry) => entry.name)).toEqual(["ce:plan", "ce:work"]);
+  });
+
+  it("keeps empty-result fallback from repeating the prompt", () => {
+    const intent = buildSkillsBrowserIntent({
+      binding,
+      createdAt: 1000,
+      entries: [
+        {
+          name: "ce:work",
+          description: "Execute implementation plans",
+          enabled: true,
+        },
+      ],
+      id: "skills-browser-1",
+      query: "missing",
+    });
+
+    expect(intent.prompt).toBe('Skills matching "missing"\nNo skills matched.');
+    expect(intent.fallbackText).toBe([
+      "No skills matched.",
+      "Reply Back, Search, or Cancel.",
+    ].join("\n"));
+  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
@@ -67,6 +67,34 @@ describe("messaging skills browser", () => {
       fallbackText: "1",
       label: "1. $ce:work",
     });
+    expect(intent.delivery).toMatchObject({
+      mode: "present",
+      fallback: "present_new",
+    });
+    expect(intent).not.toHaveProperty("targetSurface");
+  });
+
+  it("updates the active skills workflow surface when one is provided", () => {
+    const intent = buildSkillsBrowserIntent({
+      binding,
+      createdAt: 1000,
+      entries: [],
+      id: "skills-browser-1",
+      targetSurface: {
+        channel: "telegram",
+        id: "skills-surface",
+        state: { opaque: { messageId: "123" } },
+      },
+    });
+
+    expect(intent.delivery).toMatchObject({
+      mode: "update",
+      fallback: "present_new",
+      replaceMarkup: true,
+    });
+    expect(intent.targetSurface).toMatchObject({
+      id: "skills-surface",
+    });
   });
 
   it("keeps fallback text to choices and reply instructions", () => {

--- a/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
@@ -69,6 +69,28 @@ describe("messaging skills browser", () => {
     });
   });
 
+  it("keeps fallback text to choices and reply instructions", () => {
+    const intent = buildSkillsBrowserIntent({
+      binding,
+      createdAt: 1000,
+      entries: [
+        {
+          name: "ce:work",
+          description: "Execute implementation plans",
+          enabled: true,
+          path: "/skills/ce-work/SKILL.md",
+        },
+      ],
+      id: "skills-browser-1",
+    });
+
+    expect(intent.prompt).toBe("Skills");
+    expect(intent.fallbackText).toBe([
+      "1. $ce:work - Execute implementation plans",
+      "Reply with a number, Search, Back, Next, Prev, or Cancel.",
+    ].join("\n"));
+  });
+
   it("ranks name matches before description matches while preserving source order", () => {
     const results = filterSkillEntries(
       [

--- a/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type {
+  MessagingBindingRecord,
+  MessagingCapabilityProfile,
+} from "@pwragent/messaging-interface";
+import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
+import {
+  buildSkillsBrowserIntent,
+  filterSkillEntries,
+} from "../messaging/core/messaging-skills-browser";
+
+const binding: MessagingBindingRecord = {
+  id: "binding-1",
+  channel: {
+    channel: "telegram",
+    conversation: {
+      id: "chat-1",
+      kind: "dm",
+    },
+  },
+  backend: "codex",
+  threadId: "thread-1",
+  authorizedActorIds: ["user-1"],
+  createdAt: 1000,
+  updatedAt: 1000,
+};
+
+const tightProfile: MessagingCapabilityProfile = {
+  ...PERMISSIVE_CAPABILITY_PROFILE,
+  actions: {
+    ...PERMISSIVE_CAPABILITY_PROFILE.actions!,
+    maxActions: 3,
+    maxActionsPerRow: 3,
+    maxLabelLength: 32,
+  },
+};
+
+describe("messaging skills browser", () => {
+  it("keeps a selectable skill under tight action budgets", () => {
+    const intent = buildSkillsBrowserIntent({
+      binding,
+      capabilityProfile: tightProfile,
+      createdAt: 1000,
+      entries: [
+        {
+          name: "ce:work",
+          description: "Execute implementation plans",
+          enabled: true,
+          path: "/skills/ce-work/SKILL.md",
+        },
+        {
+          name: "review-pr",
+          description: "Review pull requests",
+          enabled: true,
+          path: "/skills/review-pr/SKILL.md",
+        },
+      ],
+      id: "skills-browser-1",
+    });
+
+    expect(intent.choices.map((choice) => choice.id)).toEqual([
+      "skills:select",
+      "skills:search",
+      "status:refresh",
+    ]);
+    expect(intent.choices[0]).toMatchObject({
+      fallbackText: "1",
+      label: "1. $ce:work",
+    });
+  });
+
+  it("ranks name matches before description matches while preserving source order", () => {
+    const results = filterSkillEntries(
+      [
+        {
+          name: "alpha",
+          description: "Run work plans",
+          enabled: true,
+        },
+        {
+          name: "workbench",
+          description: "Utilities",
+          enabled: true,
+        },
+        {
+          name: "team-work",
+          description: "Collaboration",
+          enabled: true,
+        },
+      ],
+      "work",
+    );
+
+    expect(results.map((entry) => entry.name)).toEqual([
+      "workbench",
+      "team-work",
+      "alpha",
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts
@@ -61,7 +61,7 @@ describe("messaging skills browser", () => {
     expect(intent.choices.map((choice) => choice.id)).toEqual([
       "skills:select",
       "skills:search",
-      "status:refresh",
+      "skills:cancel",
     ]);
     expect(intent.choices[0]).toMatchObject({
       fallbackText: "1",

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -57,6 +57,7 @@ describe("buildBindingStatusIntent", () => {
       status: "idle",
       actions: expect.arrayContaining([
         expect.objectContaining({ id: "status:model" }),
+        expect.objectContaining({ id: "status:skills" }),
         expect.objectContaining({ id: "status:detach" }),
       ]),
     });
@@ -76,6 +77,26 @@ describe("buildBindingStatusIntent", () => {
         fallbackText: "stream",
       }),
     );
+  });
+
+  it("renders a pending skill selection on the status card", () => {
+    const binding = {
+      ...buildBinding(),
+      pendingSkillSelection: {
+        name: "ce:plan",
+        path: "/skills/ce-plan/SKILL.md",
+        selectedAt: 1000,
+      },
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-pending-skill",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Pending skill: $ce:plan");
   });
 
   it("renders inherited streaming as on when the channel default is on", () => {

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -116,6 +116,29 @@ afterEach(async () => {
 });
 
 describe("SqliteMessagingStore", () => {
+  it("persists pending skill selections on bindings", async () => {
+    const store = await createStore();
+    await store.upsertBinding(
+      buildBinding({
+        pendingSkillSelection: {
+          cwd: "/repo/pwragent",
+          description: "Create implementation plans",
+          name: "ce:plan",
+          path: "/skills/ce-plan/SKILL.md",
+          selectedActorId: "user-1",
+          selectedAt: 1000,
+        },
+      }),
+    );
+
+    await expect(store.getBinding("binding-1")).resolves.toMatchObject({
+      pendingSkillSelection: {
+        name: "ce:plan",
+        path: "/skills/ce-plan/SKILL.md",
+      },
+    });
+  });
+
   it("sweeps binding and channel state when a binding is revoked", async () => {
     const store = await createStore();
     await store.upsertBinding(buildBinding());

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -190,6 +190,31 @@ describe("MessagingStore", () => {
     });
   });
 
+  it("persists pending skill selections on bindings", async () => {
+    const { filePath, store } = await createStore();
+    await store.upsertBinding(
+      buildBinding({
+        pendingSkillSelection: {
+          cwd: "/repo/pwragent",
+          description: "Create implementation plans",
+          name: "ce:plan",
+          path: "/skills/ce-plan/SKILL.md",
+          selectedActorId: "user-1",
+          selectedAt: 1000,
+        },
+      }),
+    );
+
+    const reloaded = new MessagingStore(filePath);
+
+    await expect(reloaded.getBinding("binding-1")).resolves.toMatchObject({
+      pendingSkillSelection: {
+        name: "ce:plan",
+        path: "/skills/ce-plan/SKILL.md",
+      },
+    });
+  });
+
   it("drops deprecated cached thread display and active turn data from bindings", async () => {
     const { filePath, store } = await createStore();
     await store.upsertBinding(

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -1,6 +1,8 @@
 import type {
   AgentEvent,
   AppServerBackendKind,
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
   AppServerThreadStatus,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
@@ -107,6 +109,9 @@ export type MessagingBackendBridge = {
   steerTurn?(request: SteerTurnRequest): Promise<SteerTurnResponse>;
   compactThread?(request: CompactThreadRequest): Promise<CompactThreadResponse>;
   interruptTurn?(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
+  listSkills?(
+    request?: AppServerListSkillsRequest,
+  ): Promise<Pick<AppServerListSkillsResponse, "data">>;
   listBackends?(request?: ListBackendsRequest): Promise<ListBackendsResponse>;
   setThreadExecutionMode?(
     request: SetThreadExecutionModeRequest,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -921,8 +921,8 @@ export class MessagingController {
         if (binding && !binding.revokedAt) {
           await this.presentSkillsBrowser(binding, event, {
             pageIndex: 0,
-            presentNew: true,
             query: event.text,
+            targetSurface: pendingIntent.surface,
           });
           return;
         }
@@ -3913,7 +3913,11 @@ export class MessagingController {
   private async presentSkillsBrowser(
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
-    options: { pageIndex?: number; presentNew?: boolean; query?: string } = {},
+    options: {
+      pageIndex?: number;
+      query?: string;
+      targetSurface?: MessagingSurfaceRef;
+    } = {},
   ): Promise<void> {
     if (!this.options.backend.listSkills) {
       await this.deliver(
@@ -3940,9 +3944,8 @@ export class MessagingController {
         backend: binding.backend,
         ...(cwds.length > 0 ? { cwds: [...new Set(cwds)] } : {}),
       });
-      const targetSurface = options.presentNew
-        ? undefined
-        : await this.findActiveSkillsWorkflowSurface(binding, event);
+      const targetSurface = options.targetSurface ??
+        await this.findActiveSkillsWorkflowSurface(binding, event);
       await this.deliverAndStoreSkillsWorkflow(
         buildSkillsBrowserIntent({
           id: this.newIntentId("skills-browser"),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3781,6 +3781,12 @@ export class MessagingController {
     }
 
     if (actionId === "status:refresh" || actionId === "handoff:back-to-status") {
+      if (
+        actionId === "status:refresh" &&
+        await this.dismissActiveSkillsWorkflow(binding, event)
+      ) {
+        return;
+      }
       // "Back" buttons from handoff sub-flows resolve to a status card
       // refresh, same as an explicit Refresh tap.
       await this.clearActiveBindingSubmodeIntent(event, binding);
@@ -3800,9 +3806,10 @@ export class MessagingController {
       await this.presentSkillsSearchPrompt(binding, event);
       return;
     }
-    if (actionId === "skills:search:cancel") {
-      await this.clearActiveBindingSubmodeIntent(event, binding);
-      await this.renderBindingStatus(binding, event);
+    if (actionId === "skills:cancel" || actionId === "skills:search:cancel") {
+      await this.dismissActiveSkillsWorkflow(binding, event, {
+        allowCallbackFallback: true,
+      });
       return;
     }
     if (actionId === "skills:select") {
@@ -4073,6 +4080,58 @@ export class MessagingController {
     ) {
       await this.options.store.deletePendingIntent(pendingIntent.id);
     }
+  }
+
+  private async dismissActiveSkillsWorkflow(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+    options: { allowCallbackFallback?: boolean } = {},
+  ): Promise<boolean> {
+    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    const activeSkillsIntent = pendingIntent &&
+      pendingIntent.bindingId === binding.id &&
+      isSkillsWorkflowIntent(pendingIntent.intent)
+      ? pendingIntent
+      : undefined;
+    const targetSurface = activeSkillsIntent?.surface ??
+      (event.kind === "callback" && (activeSkillsIntent || options.allowCallbackFallback)
+        ? event.interaction
+        : undefined);
+
+    if (activeSkillsIntent && !activeSkillsIntent.intent.requestContext) {
+      await this.options.store.deletePendingIntent(activeSkillsIntent.id);
+    }
+
+    if (!activeSkillsIntent && !targetSurface) {
+      return false;
+    }
+
+    if (targetSurface) {
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("skills-dismissed"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          title: "Skills dismissed",
+          body: "Use Skills from the status menu to choose a skill again.",
+          actions: [],
+          delivery: {
+            mode: "update",
+            replaceMarkup: true,
+            fallback: "present_new",
+          },
+          targetSurface,
+        }),
+        binding,
+        event,
+      );
+    }
+
+    return true;
   }
 
   private async findActiveSkillsWorkflowSurface(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1052,10 +1052,13 @@ export class MessagingController {
       prepared,
       currentBinding,
     );
+    const consumedSkillBinding = currentBinding.pendingSkillSelection
+      ? bindingWithoutPendingSkillSelection(currentBinding)
+      : currentBinding;
 
     if (await this.isTurnOccupied(currentBinding, bundle.threadKey)) {
       await this.queuePreparedInput({
-        binding: currentBinding,
+        binding: consumedSkillBinding,
         input: preparedWithSkill.input,
         preview: preparedWithSkill.preview,
         threadKey: bundle.threadKey,
@@ -1067,7 +1070,7 @@ export class MessagingController {
     }
 
     const startResult = await this.startPreparedInput({
-      binding: currentBinding,
+      binding: consumedSkillBinding,
       input: preparedWithSkill.input,
       preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
@@ -7721,6 +7724,13 @@ function skillSearchCwdsForThreadState(
   ].filter((cwd, index, candidates): cwd is string =>
     Boolean(cwd) && candidates.indexOf(cwd) === index,
   );
+}
+
+function bindingWithoutPendingSkillSelection(
+  binding: MessagingBindingRecord,
+): MessagingBindingRecord {
+  const { pendingSkillSelection: _pendingSkillSelection, ...rest } = binding;
+  return rest;
 }
 
 function isToolsFallbackText(text: string): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -117,7 +117,10 @@ import {
   skillSelectionFromValue,
   skillsBrowserPageFromValue,
 } from "./messaging-skills-browser.js";
-import { resolveMessagingThreadState } from "./messaging-thread-state.js";
+import {
+  resolveMessagingThreadState,
+  type MessagingResolvedThreadState,
+} from "./messaging-thread-state.js";
 import { summarizeToolActivityFromBackendEvent } from "./messaging-tool-activity.js";
 import {
   MessagingToolUpdatePolicy,
@@ -3930,10 +3933,7 @@ export class MessagingController {
         backend: "all",
       });
       const threadState = resolveMessagingThreadState({ binding, navigation });
-      const cwds = [
-        threadState.worktreePath,
-        threadState.directoryPath,
-      ].filter((cwd): cwd is string => Boolean(cwd));
+      const cwds = skillSearchCwdsForThreadState(threadState);
       const response = await this.options.backend.listSkills({
         backend: binding.backend,
         ...(cwds.length > 0 ? { cwds: [...new Set(cwds)] } : {}),
@@ -7584,6 +7584,21 @@ function parseTextCommandArgs(text: string): string[] {
   }
 
   return trimmed.slice(1).split(/\s+/).slice(1).filter(Boolean);
+}
+
+function skillSearchCwdsForThreadState(
+  threadState: MessagingResolvedThreadState,
+): string[] {
+  return [
+    threadState.worktreePath,
+    threadState.directoryPath,
+    ...(threadState.thread?.linkedDirectories ?? []).flatMap((directory) => [
+      directory.worktreePath,
+      directory.path,
+    ]),
+  ].filter((cwd, index, candidates): cwd is string =>
+    Boolean(cwd) && candidates.indexOf(cwd) === index,
+  );
 }
 
 function isToolsFallbackText(text: string): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -114,6 +114,7 @@ import {
   formatSkillInputPrefix,
   isSkillSelectionNoticeIntent,
   isSkillsSearchIntent,
+  isSkillsWorkflowIntent,
   skillSelectionFromValue,
   skillsBrowserPageFromValue,
 } from "./messaging-skills-browser.js";
@@ -920,6 +921,7 @@ export class MessagingController {
         if (binding && !binding.revokedAt) {
           await this.presentSkillsBrowser(binding, event, {
             pageIndex: 0,
+            presentNew: true,
             query: event.text,
           });
           return;
@@ -3911,7 +3913,7 @@ export class MessagingController {
   private async presentSkillsBrowser(
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
-    options: { pageIndex?: number; query?: string } = {},
+    options: { pageIndex?: number; presentNew?: boolean; query?: string } = {},
   ): Promise<void> {
     if (!this.options.backend.listSkills) {
       await this.deliver(
@@ -3938,7 +3940,10 @@ export class MessagingController {
         backend: binding.backend,
         ...(cwds.length > 0 ? { cwds: [...new Set(cwds)] } : {}),
       });
-      await this.deliverAndStoreStatusSubmode(
+      const targetSurface = options.presentNew
+        ? undefined
+        : await this.findActiveSkillsWorkflowSurface(binding, event);
+      await this.deliverAndStoreSkillsWorkflow(
         buildSkillsBrowserIntent({
           id: this.newIntentId("skills-browser"),
           binding,
@@ -3947,6 +3952,7 @@ export class MessagingController {
           entries: flattenSkillEntries(response.data),
           pageIndex: options.pageIndex,
           query: options.query,
+          targetSurface,
         }),
         binding,
         event,
@@ -3970,12 +3976,14 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    await this.deliverAndStoreStatusSubmode(
+    const targetSurface = await this.findActiveSkillsWorkflowSurface(binding, event);
+    await this.deliverAndStoreSkillsWorkflow(
       buildSkillsSearchPromptIntent({
         id: this.newIntentId("skills-search"),
         binding,
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
+        targetSurface,
       }),
       binding,
       event,
@@ -4001,13 +4009,15 @@ export class MessagingController {
       pendingSkillSelection: selection,
       updatedAt: this.now(),
     });
-    await this.deliverAndStoreStatusSubmode(
+    const targetSurface = await this.findActiveSkillsWorkflowSurface(binding, event);
+    await this.deliverAndStoreSkillsWorkflow(
       buildSkillSelectedIntent({
         id: this.newIntentId("skill-selected"),
         binding: updatedBinding,
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
         selection,
+        targetSurface,
       }),
       updatedBinding,
       event,
@@ -4020,12 +4030,14 @@ export class MessagingController {
   ): Promise<void> {
     const { pendingSkillSelection } = binding;
     const updatedBinding = await this.clearPendingSkillSelection(binding);
-    await this.deliverAndStoreStatusSubmode(
+    const targetSurface = await this.findActiveSkillsWorkflowSurface(binding, event);
+    await this.deliverAndStoreSkillsWorkflow(
       buildSkillRemovedIntent({
         id: this.newIntentId("skill-removed"),
         binding: updatedBinding,
         createdAt: this.now(),
         removed: pendingSkillSelection,
+        targetSurface,
       }),
       updatedBinding,
       event,
@@ -4058,6 +4070,25 @@ export class MessagingController {
     ) {
       await this.options.store.deletePendingIntent(pendingIntent.id);
     }
+  }
+
+  private async findActiveSkillsWorkflowSurface(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<MessagingSurfaceRef | undefined> {
+    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (
+      pendingIntent?.bindingId === binding.id &&
+      pendingIntent.surface &&
+      isSkillsWorkflowIntent(pendingIntent.intent)
+    ) {
+      return pendingIntent.surface;
+    }
+    return undefined;
   }
 
   private async presentHandoffOverview(
@@ -4335,6 +4366,35 @@ export class MessagingController {
       ...binding,
       statusSurface: result.surface,
       updatedAt: this.now(),
+    });
+  }
+
+  private async deliverAndStoreSkillsWorkflow(
+    intent: MessagingSurfaceIntent,
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const activeIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (
+      activeIntent &&
+      activeIntent.id !== intent.id &&
+      activeIntent.bindingId === binding.id &&
+      !activeIntent.intent.requestContext
+    ) {
+      await this.options.store.deletePendingIntent(activeIntent.id);
+    }
+    const pendingIntent = await this.storePendingIntent(intent, binding, event);
+    const result = await this.deliver(intent, binding, event);
+    if (!result.surface) {
+      return;
+    }
+    await this.options.store.upsertPendingIntent({
+      ...pendingIntent,
+      surface: result.surface,
     });
   }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -105,6 +105,18 @@ import {
   resolveMessagingToolUpdateMode,
   type MessagingWorkspaceHandoffContext,
 } from "./messaging-status-card.js";
+import {
+  buildSkillRemovedIntent,
+  buildSkillSelectedIntent,
+  buildSkillsBrowserIntent,
+  buildSkillsSearchPromptIntent,
+  flattenSkillEntries,
+  formatSkillInputPrefix,
+  isSkillSelectionNoticeIntent,
+  isSkillsSearchIntent,
+  skillSelectionFromValue,
+  skillsBrowserPageFromValue,
+} from "./messaging-skills-browser.js";
 import { resolveMessagingThreadState } from "./messaging-thread-state.js";
 import { summarizeToolActivityFromBackendEvent } from "./messaging-tool-activity.js";
 import {
@@ -877,41 +889,57 @@ export class MessagingController {
       now: this.now(),
     });
     if (pendingIntent) {
-      const mapped = await this.interactionMapper.mapText({
-        intent: pendingIntent.intent,
-        text: event.text,
-      });
-      if (mapped.kind === "matched") {
-        await this.handleCallback({
-          ...event,
-          kind: "callback",
-          interaction: {
-            channel: event.channel.channel,
-            id: mapped.action.id,
-          },
-          actionId: mapped.action.id,
-          value: mapped.action.value,
+      if (isSkillsSearchIntent(pendingIntent.intent)) {
+        await this.options.store.deletePendingIntent(pendingIntent.id);
+        const binding = pendingIntent.bindingId
+          ? await this.options.store.getBinding(pendingIntent.bindingId)
+          : undefined;
+        if (binding && !binding.revokedAt) {
+          await this.presentSkillsBrowser(binding, event, {
+            pageIndex: 0,
+            query: event.text,
+          });
+          return;
+        }
+      } else {
+        const mapped = await this.interactionMapper.mapText({
+          intent: pendingIntent.intent,
+          text: event.text,
         });
-        return;
-      }
-      if (pendingNewThread) {
-        await this.appendPendingNewThreadPrompt(pendingNewThread, event);
-        return;
-      }
-      if (mapped.kind === "ambiguous") {
-        await this.deliver(
-          buildConfirmationIntent({
-            id: this.newIntentId("ambiguous-reply"),
-            capabilityProfile: this.capabilityProfile,
-            createdAt: this.now(),
-            title: "Choose an option",
-            body: pendingIntent.intent.fallbackText ?? "Reply with one of the shown options.",
-            fallbackText: pendingIntent.intent.fallbackText,
-          }),
-          undefined,
-          event,
-        );
-        return;
+        if (mapped.kind === "matched") {
+          await this.handleCallback({
+            ...event,
+            kind: "callback",
+            interaction: {
+              channel: event.channel.channel,
+              id: mapped.action.id,
+            },
+            actionId: mapped.action.id,
+            value: mapped.action.value,
+          });
+          return;
+        }
+        if (pendingNewThread) {
+          await this.appendPendingNewThreadPrompt(pendingNewThread, event);
+          return;
+        }
+        if (isSkillSelectionNoticeIntent(pendingIntent.intent)) {
+          await this.options.store.deletePendingIntent(pendingIntent.id);
+        } else if (mapped.kind === "ambiguous") {
+          await this.deliver(
+            buildConfirmationIntent({
+              id: this.newIntentId("ambiguous-reply"),
+              capabilityProfile: this.capabilityProfile,
+              createdAt: this.now(),
+              title: "Choose an option",
+              body: pendingIntent.intent.fallbackText ?? "Reply with one of the shown options.",
+              fallbackText: pendingIntent.intent.fallbackText,
+            }),
+            undefined,
+            event,
+          );
+          return;
+        }
       }
     }
 
@@ -988,28 +1016,61 @@ export class MessagingController {
   private async handleAdmittedTurnBundle(
     bundle: MessagingTurnAdmissionBundle,
   ): Promise<void> {
-    const prepared = await this.prepareTurnInput(bundle.events, bundle.binding, bundle.events[0]);
+    const currentBinding = bundle.binding.pendingSkillSelection
+      ? await this.options.store.getBinding(bundle.binding.id) ?? bundle.binding
+      : bundle.binding;
+    const prepared = await this.prepareTurnInput(bundle.events, currentBinding, bundle.events[0]);
     if (!prepared) {
       return;
     }
+    const preparedWithSkill = this.prependPendingSkillSelection(
+      prepared,
+      currentBinding,
+    );
 
-    if (await this.isTurnOccupied(bundle.binding, bundle.threadKey)) {
+    if (await this.isTurnOccupied(currentBinding, bundle.threadKey)) {
       await this.queuePreparedInput({
-        binding: bundle.binding,
-        input: prepared.input,
-        preview: prepared.preview,
+        binding: currentBinding,
+        input: preparedWithSkill.input,
+        preview: preparedWithSkill.preview,
         threadKey: bundle.threadKey,
       });
+      if (currentBinding.pendingSkillSelection) {
+        await this.clearPendingSkillSelection(currentBinding);
+      }
       return;
     }
 
-    await this.startPreparedInput({
-      binding: bundle.binding,
-      input: prepared.input,
-      preview: prepared.preview,
+    const started = await this.startPreparedInput({
+      binding: currentBinding,
+      input: preparedWithSkill.input,
+      preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
       event: bundle.events[0],
     });
+    if (started && currentBinding.pendingSkillSelection) {
+      const updatedBinding = await this.clearPendingSkillSelection(currentBinding);
+      await this.renderBindingStatus(updatedBinding, bundle.events[0]);
+    }
+  }
+
+  private prependPendingSkillSelection(
+    prepared: { input: AppServerTurnInputItem[]; preview: string },
+    binding: MessagingBindingRecord,
+  ): { input: AppServerTurnInputItem[]; preview: string } {
+    const selection = binding.pendingSkillSelection;
+    if (!selection) return prepared;
+    const prefix = formatSkillInputPrefix(selection);
+    return {
+      input: [
+        {
+          type: "text",
+          text: prefix,
+        },
+        ...prepared.input,
+      ],
+      preview: `${prefix}\n${prepared.preview}`,
+    };
   }
 
   private async findPendingNewThreadSession(
@@ -3696,7 +3757,34 @@ export class MessagingController {
     if (actionId === "status:refresh" || actionId === "handoff:back-to-status") {
       // "Back" buttons from handoff sub-flows resolve to a status card
       // refresh, same as an explicit Refresh tap.
+      await this.clearActiveBindingSubmodeIntent(event, binding);
       await this.renderBindingStatus(binding, event);
+      return;
+    }
+    if (actionId === "status:skills") {
+      await this.presentSkillsBrowser(binding, event);
+      return;
+    }
+    if (actionId === "skills:next" || actionId === "skills:previous") {
+      const page = skillsBrowserPageFromValue(event.value);
+      await this.presentSkillsBrowser(binding, event, page);
+      return;
+    }
+    if (actionId === "skills:search") {
+      await this.presentSkillsSearchPrompt(binding, event);
+      return;
+    }
+    if (actionId === "skills:search:cancel") {
+      await this.clearActiveBindingSubmodeIntent(event, binding);
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+    if (actionId === "skills:select") {
+      await this.selectPendingSkill(binding, event);
+      return;
+    }
+    if (actionId === "skills:remove") {
+      await this.removePendingSkill(binding, event);
       return;
     }
     if (actionId === "status:handoff") {
@@ -3794,6 +3882,161 @@ export class MessagingController {
       }),
       binding,
     );
+  }
+
+  private async presentSkillsBrowser(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+    options: { pageIndex?: number; query?: string } = {},
+  ): Promise<void> {
+    if (!this.options.backend.listSkills) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("skills-unavailable"),
+          createdAt: this.now(),
+          title: "Skills unavailable",
+          body: "This runtime does not expose skill browsing through messaging.",
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+      return;
+    }
+
+    try {
+      const navigation = await this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+      const threadState = resolveMessagingThreadState({ binding, navigation });
+      const cwds = [
+        threadState.worktreePath,
+        threadState.directoryPath,
+      ].filter((cwd): cwd is string => Boolean(cwd));
+      const response = await this.options.backend.listSkills({
+        backend: binding.backend,
+        ...(cwds.length > 0 ? { cwds: [...new Set(cwds)] } : {}),
+      });
+      await this.deliverAndStoreStatusSubmode(
+        buildSkillsBrowserIntent({
+          id: this.newIntentId("skills-browser"),
+          binding,
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          entries: flattenSkillEntries(response.data),
+          pageIndex: options.pageIndex,
+          query: options.query,
+        }),
+        binding,
+        event,
+      );
+    } catch (error) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("skills-list-failed"),
+          createdAt: this.now(),
+          title: "Skills unavailable",
+          body: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+    }
+  }
+
+  private async presentSkillsSearchPrompt(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliverAndStoreStatusSubmode(
+      buildSkillsSearchPromptIntent({
+        id: this.newIntentId("skills-search"),
+        binding,
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+      }),
+      binding,
+      event,
+    );
+  }
+
+  private async selectPendingSkill(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const selection = skillSelectionFromValue(
+      event.value,
+      this.now(),
+      event.actor.platformUserId,
+    );
+    if (!selection) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+
+    const updatedBinding = await this.options.store.upsertBinding({
+      ...binding,
+      pendingSkillSelection: selection,
+      updatedAt: this.now(),
+    });
+    await this.deliverAndStoreStatusSubmode(
+      buildSkillSelectedIntent({
+        id: this.newIntentId("skill-selected"),
+        binding: updatedBinding,
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        selection,
+      }),
+      updatedBinding,
+      event,
+    );
+  }
+
+  private async removePendingSkill(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const { pendingSkillSelection } = binding;
+    const updatedBinding = await this.clearPendingSkillSelection(binding);
+    await this.deliverAndStoreStatusSubmode(
+      buildSkillRemovedIntent({
+        id: this.newIntentId("skill-removed"),
+        binding: updatedBinding,
+        createdAt: this.now(),
+        removed: pendingSkillSelection,
+      }),
+      updatedBinding,
+      event,
+    );
+  }
+
+  private async clearPendingSkillSelection(
+    binding: MessagingBindingRecord,
+  ): Promise<MessagingBindingRecord> {
+    const { pendingSkillSelection: _pendingSkillSelection, ...rest } = binding;
+    return await this.options.store.upsertBinding({
+      ...rest,
+      updatedAt: this.now(),
+    });
+  }
+
+  private async clearActiveBindingSubmodeIntent(
+    event: MessagingInboundEvent,
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (
+      pendingIntent &&
+      pendingIntent.bindingId === binding.id &&
+      !pendingIntent.intent.requestContext
+    ) {
+      await this.options.store.deletePendingIntent(pendingIntent.id);
+    }
   }
 
   private async presentHandoffOverview(
@@ -4045,6 +4288,19 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    const activeIntent = await this.options.store.findActivePendingIntentForChannel({
+      actorId: event.actor.platformUserId,
+      channel: event.channel,
+      now: this.now(),
+    });
+    if (
+      activeIntent &&
+      activeIntent.id !== intent.id &&
+      activeIntent.bindingId === binding.id &&
+      !activeIntent.intent.requestContext
+    ) {
+      await this.options.store.deletePendingIntent(activeIntent.id);
+    }
     const pendingIntent = await this.storePendingIntent(intent, binding, event);
     const result = await this.deliver(intent, binding, event);
     if (!result.surface) {
@@ -6022,7 +6278,9 @@ function readHelpPageIndex(event: MessagingInboundCallbackEvent): number {
 
 function readStatusAction(event: MessagingInboundCallbackEvent): string | undefined {
   const actionId = event.actionId ?? event.interaction.id;
-  return actionId.startsWith("status:") || actionId.startsWith("handoff:")
+  return actionId.startsWith("status:")
+    || actionId.startsWith("handoff:")
+    || actionId.startsWith("skills:")
     ? actionId
     : undefined;
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -149,6 +149,8 @@ const TYPING_ACTIVITY_CONTINUATION_REFRESH_MS = 9_000;
 const DEFAULT_INPUT_DEBOUNCE_MS = 500;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
+
+type PreparedInputStartResult = "failed" | "queued" | "started";
 // Provider adapters own stricter platform pacing; the generic layer only
 // coalesces noisy token deltas into human-visible refreshes.
 const STREAM_UPDATE_REFRESH_MS = 1_000;
@@ -890,10 +892,28 @@ export class MessagingController {
     });
     if (pendingIntent) {
       if (isSkillsSearchIntent(pendingIntent.intent)) {
-        await this.options.store.deletePendingIntent(pendingIntent.id);
+        const mapped = await this.interactionMapper.mapText({
+          intent: pendingIntent.intent,
+          text: event.text,
+        });
+        if (mapped.kind === "matched") {
+          await this.handleCallback({
+            ...event,
+            kind: "callback",
+            interaction: {
+              channel: event.channel.channel,
+              id: mapped.action.id,
+            },
+            actionId: mapped.action.id,
+            value: mapped.action.value,
+          });
+          return;
+        }
+
         const binding = pendingIntent.bindingId
           ? await this.options.store.getBinding(pendingIntent.bindingId)
           : undefined;
+        await this.options.store.deletePendingIntent(pendingIntent.id);
         if (binding && !binding.revokedAt) {
           await this.presentSkillsBrowser(binding, event, {
             pageIndex: 0,
@@ -1041,14 +1061,14 @@ export class MessagingController {
       return;
     }
 
-    const started = await this.startPreparedInput({
+    const startResult = await this.startPreparedInput({
       binding: currentBinding,
       input: preparedWithSkill.input,
       preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
       event: bundle.events[0],
     });
-    if (started && currentBinding.pendingSkillSelection) {
+    if (startResult !== "failed" && currentBinding.pendingSkillSelection) {
       const updatedBinding = await this.clearPendingSkillSelection(currentBinding);
       await this.renderBindingStatus(updatedBinding, bundle.events[0]);
     }
@@ -1298,7 +1318,7 @@ export class MessagingController {
     preview: string;
     queueOnConcurrentStart?: boolean;
     threadKey: string;
-  }): Promise<boolean> {
+  }): Promise<PreparedInputStartResult> {
     this.turnAdmission.markStarting(params.threadKey);
     let turnStarted = false;
 
@@ -1356,14 +1376,14 @@ export class MessagingController {
         force: true,
       });
       await this.renderBindingStatus(params.binding, undefined, navigation);
-      return true;
+      return "started";
     } catch (error) {
       if (turnStarted) {
         this.logger.debug?.("messaging post-start update failed", {
           error: error instanceof Error ? error.message : String(error),
           threadId: params.binding.threadId,
         });
-        return true;
+        return "started";
       }
       if (isTurnInProgressStartError(error)) {
         if (params.queueOnConcurrentStart !== false) {
@@ -1373,8 +1393,9 @@ export class MessagingController {
             preview: params.preview,
             threadKey: params.threadKey,
           });
+          return "queued";
         }
-        return false;
+        return "failed";
       }
       await this.deliver(
         buildErrorIntent({
@@ -1387,7 +1408,7 @@ export class MessagingController {
         params.binding,
         params.event,
       );
-      return false;
+      return "failed";
     } finally {
       this.turnAdmission.clearStarting(params.threadKey);
     }
@@ -1598,14 +1619,14 @@ export class MessagingController {
       return;
     }
 
-    const started = await this.startPreparedInput({
+    const startResult = await this.startPreparedInput({
       binding: entry.binding,
       input: entry.input,
       preview: entry.preview,
       queueOnConcurrentStart: false,
       threadKey,
     });
-    if (!started) {
+    if (startResult !== "started") {
       return;
     }
 

--- a/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
@@ -406,7 +406,6 @@ function skillsBrowserFallbackText(params: {
   totalPages: number;
 }): string {
   const lines = [
-    skillsBrowserPrompt(params),
     ...params.pageEntries.map((entry, index) => {
       const number = params.pageStart + index + 1;
       const description = skillDescription(entry);

--- a/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
@@ -9,6 +9,8 @@ import type {
   MessagingJsonValue,
   MessagingPendingSkillSelection,
   MessagingSingleSelectIntent,
+  MessagingSurfaceDeliveryPolicy,
+  MessagingSurfaceRef,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -80,6 +82,7 @@ export function buildSkillsBrowserIntent(params: {
   id: string;
   pageIndex?: number;
   query?: string;
+  targetSurface?: MessagingSurfaceRef;
 }): MessagingSingleSelectIntent {
   const filtered = filterSkillEntries(params.entries, params.query);
   const navActionCount = filtered.length > SKILLS_BROWSER_PAGE_SIZE ? 5 : 3;
@@ -167,8 +170,8 @@ export function buildSkillsBrowserIntent(params: {
     kind: "single_select",
     bindingId: params.binding.id,
     createdAt: params.createdAt,
-    delivery: statusSubmodeDelivery(params.binding),
-    targetSurface: params.binding.statusSurface,
+    delivery: skillWorkflowDelivery(params.targetSurface),
+    ...(params.targetSurface ? { targetSurface: params.targetSurface } : {}),
     fallbackText: skillsBrowserFallbackText({
       filteredCount: filtered.length,
       pageEntries,
@@ -192,14 +195,15 @@ export function buildSkillsSearchPromptIntent(params: {
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
   id: string;
+  targetSurface?: MessagingSurfaceRef;
 }): MessagingConfirmationIntent {
   return {
     id: params.id,
     kind: "confirmation",
     bindingId: params.binding.id,
     createdAt: params.createdAt,
-    delivery: statusSubmodeDelivery(params.binding),
-    targetSurface: params.binding.statusSurface,
+    delivery: skillWorkflowDelivery(params.targetSurface),
+    ...(params.targetSurface ? { targetSurface: params.targetSurface } : {}),
     title: "Search Skills",
     body: "Reply with search text. PwrAgent will search skill names, descriptions, paths, and workspaces.",
     fallbackText: "Reply with search text, Back, or Cancel.",
@@ -231,14 +235,15 @@ export function buildSkillSelectedIntent(params: {
   createdAt: number;
   id: string;
   selection: MessagingPendingSkillSelection;
+  targetSurface?: MessagingSurfaceRef;
 }): MessagingConfirmationIntent {
   return {
     id: params.id,
     kind: "confirmation",
     bindingId: params.binding.id,
     createdAt: params.createdAt,
-    delivery: statusSubmodeDelivery(params.binding),
-    targetSurface: params.binding.statusSurface,
+    delivery: skillWorkflowDelivery(params.targetSurface),
+    ...(params.targetSurface ? { targetSurface: params.targetSurface } : {}),
     title: "Skill Selected",
     body: formatSkillSelectionHelp(params.selection),
     fallbackText: "Reply Remove to clear this skill, or send your next request.",
@@ -269,14 +274,15 @@ export function buildSkillRemovedIntent(params: {
   createdAt: number;
   id: string;
   removed?: MessagingPendingSkillSelection;
+  targetSurface?: MessagingSurfaceRef;
 }): MessagingConfirmationIntent {
   return {
     id: params.id,
     kind: "confirmation",
     bindingId: params.binding.id,
     createdAt: params.createdAt,
-    delivery: statusSubmodeDelivery(params.binding),
-    targetSurface: params.binding.statusSurface,
+    delivery: skillWorkflowDelivery(params.targetSurface),
+    ...(params.targetSurface ? { targetSurface: params.targetSurface } : {}),
     title: "Skill Removed",
     body: params.removed
       ? `$${params.removed.name} will no longer be prepended to your next request.`
@@ -342,6 +348,16 @@ export function isSkillSelectionNoticeIntent(
   );
 }
 
+export function isSkillsWorkflowIntent(
+  intent: MessagingSurfaceIntent,
+): boolean {
+  return intent.bindingId !== undefined && (
+    intent.id.includes("skills-browser") ||
+    isSkillsSearchIntent(intent) ||
+    isSkillSelectionNoticeIntent(intent)
+  );
+}
+
 export function formatSkillSelectionHelp(
   selection: MessagingPendingSkillSelection,
 ): string {
@@ -366,11 +382,12 @@ export function formatSkillInputPrefix(
     : `Use $${selection.name}`;
 }
 
-function statusSubmodeDelivery(
-  binding: MessagingBindingRecord,
-): MessagingSingleSelectIntent["delivery"] {
+function skillWorkflowDelivery(
+  targetSurface?: MessagingSurfaceRef,
+): MessagingSurfaceDeliveryPolicy {
   return {
-    mode: binding.statusSurface ? "update" : "present",
+    mode: targetSurface ? "update" : "present",
+    replaceMarkup: Boolean(targetSurface),
     fallback: "present_new",
   };
 }

--- a/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
@@ -155,7 +155,7 @@ export function buildSkillsBrowserIntent(params: {
           ]
         : []),
       {
-        id: "status:refresh",
+        id: "skills:cancel",
         label: "Cancel",
         fallbackText: "cancel",
         style: "secondary" as const,

--- a/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
@@ -1,0 +1,490 @@
+import type {
+  AppServerListSkillsResponse,
+  AppServerSkillSummary,
+} from "@pwragent/shared";
+import type {
+  MessagingBindingRecord,
+  MessagingCapabilityProfile,
+  MessagingConfirmationIntent,
+  MessagingJsonValue,
+  MessagingPendingSkillSelection,
+  MessagingSingleSelectIntent,
+  MessagingSurfaceAction,
+  MessagingSurfaceIntent,
+} from "@pwragent/messaging-interface";
+import {
+  applyActionCapabilityLimits,
+  capabilityProfilePageSize,
+} from "@pwragent/messaging-interface";
+
+export const SKILLS_BROWSER_PAGE_SIZE = 8;
+
+export type MessagingSkillBrowserEntry = AppServerSkillSummary & {
+  cwd?: string;
+};
+
+export function flattenSkillEntries(
+  data: AppServerListSkillsResponse["data"],
+): MessagingSkillBrowserEntry[] {
+  const deduped = new Map<string, MessagingSkillBrowserEntry>();
+  for (const entry of data) {
+    for (const skill of entry.skills) {
+      const name = skill.name.trim();
+      if (!name) continue;
+      const key = name.toLowerCase();
+      if (deduped.has(key)) continue;
+      deduped.set(key, {
+        ...skill,
+        name,
+        ...(entry.cwd ? { cwd: entry.cwd } : {}),
+      });
+    }
+  }
+  return [...deduped.values()];
+}
+
+export function filterSkillEntries(
+  entries: MessagingSkillBrowserEntry[],
+  query?: string,
+): MessagingSkillBrowserEntry[] {
+  const normalized = normalizeQuery(query);
+  if (!normalized) return [...entries];
+
+  return entries
+    .map((entry, index) => ({
+      entry,
+      index,
+      score: scoreSkillEntry(entry, normalized),
+    }))
+    .filter(
+      (
+        item,
+      ): item is {
+        entry: MessagingSkillBrowserEntry;
+        index: number;
+        score: number;
+      } => item.score !== undefined,
+    )
+    .sort((left, right) => {
+      if (left.score !== right.score) return left.score - right.score;
+      return left.index - right.index;
+    })
+    .map((item) => item.entry);
+}
+
+export function buildSkillsBrowserIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  entries: MessagingSkillBrowserEntry[];
+  id: string;
+  pageIndex?: number;
+  query?: string;
+}): MessagingSingleSelectIntent {
+  const filtered = filterSkillEntries(params.entries, params.query);
+  const navActionCount = filtered.length > SKILLS_BROWSER_PAGE_SIZE ? 5 : 3;
+  const pageSize = params.capabilityProfile
+    ? capabilityProfilePageSize(
+        params.capabilityProfile,
+        navActionCount,
+        SKILLS_BROWSER_PAGE_SIZE,
+      )
+    : SKILLS_BROWSER_PAGE_SIZE;
+  const effectivePageSize = Math.max(1, pageSize);
+  const totalPages = Math.max(1, Math.ceil(filtered.length / effectivePageSize));
+  const pageIndex = clampPageIndex(params.pageIndex ?? 0, totalPages);
+  const pageStart = pageIndex * effectivePageSize;
+  const pageEntries = filtered.slice(pageStart, pageStart + effectivePageSize);
+  const choices = applyActionCapabilityLimits(
+    [
+      ...pageEntries.map((entry, index) => {
+        const skillNumber = pageStart + index + 1;
+        return {
+          id: "skills:select",
+          label: `${skillNumber}. $${entry.name}`,
+          description: skillDescription(entry),
+          fallbackText: String(skillNumber),
+          style: "secondary" as const,
+          priority: 1 + index,
+          value: skillSelectionValue(entry),
+        };
+      }),
+      ...(pageIndex > 0
+        ? [
+            {
+              id: "skills:previous",
+              label: "Prev",
+              fallbackText: "prev",
+              style: "secondary" as const,
+              priority: 50,
+              value: pageValue(pageIndex - 1, params.query),
+            },
+          ]
+        : []),
+      ...(pageIndex < totalPages - 1
+        ? [
+            {
+              id: "skills:next",
+              label: "Next",
+              fallbackText: "next",
+              style: "secondary" as const,
+              priority: 51,
+              value: pageValue(pageIndex + 1, params.query),
+            },
+          ]
+        : []),
+      {
+        id: "skills:search",
+        label: params.query ? "Search Again" : "Search",
+        fallbackText: "search",
+        style: "secondary" as const,
+        priority: 40,
+      },
+      ...(params.query
+        ? [
+            {
+              id: "status:skills",
+              label: "Back",
+              fallbackText: "back",
+              style: "secondary" as const,
+              priority: 41,
+            },
+          ]
+        : []),
+      {
+        id: "status:refresh",
+        label: "Cancel",
+        fallbackText: "cancel",
+        style: "secondary" as const,
+        priority: 42,
+      },
+    ],
+    params.capabilityProfile,
+  );
+
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: statusSubmodeDelivery(params.binding),
+    targetSurface: params.binding.statusSurface,
+    fallbackText: skillsBrowserFallbackText({
+      filteredCount: filtered.length,
+      pageEntries,
+      pageIndex,
+      pageStart,
+      query: params.query,
+      totalPages,
+    }),
+    prompt: skillsBrowserPrompt({
+      filteredCount: filtered.length,
+      pageIndex,
+      query: params.query,
+      totalPages,
+    }),
+    choices,
+  };
+}
+
+export function buildSkillsSearchPromptIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+}): MessagingConfirmationIntent {
+  return {
+    id: params.id,
+    kind: "confirmation",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: statusSubmodeDelivery(params.binding),
+    targetSurface: params.binding.statusSurface,
+    title: "Search Skills",
+    body: "Reply with search text. PwrAgent will search skill names, descriptions, paths, and workspaces.",
+    fallbackText: "Reply with search text, Back, or Cancel.",
+    actions: applyActionCapabilityLimits(
+      [
+        {
+          id: "status:skills",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary",
+          priority: 1,
+        },
+        {
+          id: "skills:search:cancel",
+          label: "Cancel",
+          fallbackText: "cancel",
+          style: "secondary",
+          priority: 2,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildSkillSelectedIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+  selection: MessagingPendingSkillSelection;
+}): MessagingConfirmationIntent {
+  return {
+    id: params.id,
+    kind: "confirmation",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: statusSubmodeDelivery(params.binding),
+    targetSurface: params.binding.statusSurface,
+    title: "Skill Selected",
+    body: formatSkillSelectionHelp(params.selection),
+    fallbackText: "Reply Remove to clear this skill, or send your next request.",
+    actions: applyActionCapabilityLimits(
+      [
+        {
+          id: "skills:remove",
+          label: "Remove",
+          fallbackText: "remove",
+          style: "danger",
+          priority: 1,
+        },
+        {
+          id: "status:skills",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary",
+          priority: 2,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildSkillRemovedIntent(params: {
+  binding: MessagingBindingRecord;
+  createdAt: number;
+  id: string;
+  removed?: MessagingPendingSkillSelection;
+}): MessagingConfirmationIntent {
+  return {
+    id: params.id,
+    kind: "confirmation",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: statusSubmodeDelivery(params.binding),
+    targetSurface: params.binding.statusSurface,
+    title: "Skill Removed",
+    body: params.removed
+      ? `$${params.removed.name} will no longer be prepended to your next request.`
+      : "No skill is currently selected.",
+    fallbackText: "Reply Skills to choose another skill, or send your next request.",
+    actions: [
+      {
+        id: "status:skills",
+        label: "Skills",
+        fallbackText: "skills",
+        style: "secondary",
+      },
+    ],
+  };
+}
+
+export function skillSelectionFromValue(
+  value: MessagingJsonValue | undefined,
+  selectedAt: number,
+  selectedActorId?: string,
+): MessagingPendingSkillSelection | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const name = readString(record, "name")?.trim();
+  if (!name) return undefined;
+  return {
+    name,
+    selectedAt,
+    ...(selectedActorId ? { selectedActorId } : {}),
+    ...optionalStringField(record, "path"),
+    ...optionalStringField(record, "description"),
+    ...optionalStringField(record, "shortDescription"),
+    ...optionalStringField(record, "cwd"),
+    ...(typeof record.enabled === "boolean" ? { enabled: record.enabled } : {}),
+  };
+}
+
+export function skillsBrowserPageFromValue(
+  value: MessagingJsonValue | undefined,
+): { pageIndex: number; query?: string } {
+  const record = asRecord(value);
+  const pageIndex =
+    typeof record?.pageIndex === "number" ? Math.trunc(record.pageIndex) : 0;
+  const query = readString(record, "query")?.trim();
+  return {
+    pageIndex: Number.isFinite(pageIndex) ? pageIndex : 0,
+    ...(query ? { query } : {}),
+  };
+}
+
+export function isSkillsSearchIntent(
+  intent: MessagingSurfaceIntent,
+): boolean {
+  return intent.bindingId !== undefined && intent.id.includes("skills-search");
+}
+
+export function isSkillSelectionNoticeIntent(
+  intent: MessagingSurfaceIntent,
+): boolean {
+  return intent.bindingId !== undefined && (
+    intent.id.includes("skill-selected") ||
+    intent.id.includes("skill-removed")
+  );
+}
+
+export function formatSkillSelectionHelp(
+  selection: MessagingPendingSkillSelection,
+): string {
+  const description = selection.description ?? selection.shortDescription;
+  return [
+    `Skill: $${selection.name}`,
+    description?.trim(),
+    selection.cwd ? `Workspace: ${selection.cwd}` : undefined,
+    selection.path ? `Path: ${selection.path}` : undefined,
+    selection.enabled === false ? "Status: disabled" : undefined,
+    "This skill will be prepended to your next request.",
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+export function formatSkillInputPrefix(
+  selection: MessagingPendingSkillSelection,
+): string {
+  return selection.path
+    ? `Use [$${selection.name}](${selection.path})`
+    : `Use $${selection.name}`;
+}
+
+function statusSubmodeDelivery(
+  binding: MessagingBindingRecord,
+): MessagingSingleSelectIntent["delivery"] {
+  return {
+    mode: binding.statusSurface ? "update" : "present",
+    fallback: "present_new",
+  };
+}
+
+function skillsBrowserPrompt(params: {
+  filteredCount: number;
+  pageIndex: number;
+  query?: string;
+  totalPages: number;
+}): string {
+  const header = params.query?.trim()
+    ? `Skills matching "${params.query.trim()}"`
+    : "Skills";
+  if (params.filteredCount === 0) {
+    return `${header}\nNo skills matched.`;
+  }
+  return [
+    header,
+    params.totalPages > 1
+      ? `Page ${params.pageIndex + 1}/${params.totalPages}.`
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
+
+function skillsBrowserFallbackText(params: {
+  filteredCount: number;
+  pageEntries: MessagingSkillBrowserEntry[];
+  pageIndex: number;
+  pageStart: number;
+  query?: string;
+  totalPages: number;
+}): string {
+  const lines = [
+    skillsBrowserPrompt(params),
+    ...params.pageEntries.map((entry, index) => {
+      const number = params.pageStart + index + 1;
+      const description = skillDescription(entry);
+      return `${number}. $${entry.name}${description ? ` - ${description}` : ""}`;
+    }),
+    params.filteredCount === 0 ? "Reply Back, Search, or Cancel." : "Reply with a number, Search, Back, Next, Prev, or Cancel.",
+  ];
+  return lines.join("\n");
+}
+
+function skillDescription(entry: MessagingSkillBrowserEntry): string | undefined {
+  return entry.description?.trim() || entry.shortDescription?.trim() || undefined;
+}
+
+function scoreSkillEntry(
+  entry: MessagingSkillBrowserEntry,
+  normalizedQuery: string,
+): number | undefined {
+  const name = entry.name.toLowerCase();
+  if (name.startsWith(normalizedQuery)) return 0;
+  if (name.includes(normalizedQuery)) return 1;
+  const haystack = [
+    entry.description,
+    entry.shortDescription,
+    entry.path,
+    entry.cwd,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+  return haystack.includes(normalizedQuery) ? 2 : undefined;
+}
+
+function skillSelectionValue(entry: MessagingSkillBrowserEntry): MessagingJsonValue {
+  return {
+    name: entry.name,
+    ...(entry.path ? { path: entry.path } : {}),
+    ...(entry.description ? { description: entry.description } : {}),
+    ...(entry.shortDescription ? { shortDescription: entry.shortDescription } : {}),
+    ...(entry.cwd ? { cwd: entry.cwd } : {}),
+    ...(typeof entry.enabled === "boolean" ? { enabled: entry.enabled } : {}),
+  };
+}
+
+function pageValue(pageIndex: number, query?: string): MessagingJsonValue {
+  return {
+    pageIndex,
+    ...(query?.trim() ? { query: query.trim() } : {}),
+  };
+}
+
+function normalizeQuery(query?: string): string {
+  return query?.trim().toLowerCase() ?? "";
+}
+
+function clampPageIndex(pageIndex: number, totalPages: number): number {
+  if (!Number.isFinite(pageIndex)) return 0;
+  return Math.min(Math.max(0, Math.trunc(pageIndex)), totalPages - 1);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalStringField(
+  record: Record<string, unknown>,
+  key: "cwd" | "description" | "path" | "shortDescription",
+): Partial<MessagingPendingSkillSelection> {
+  const value = readString(record, key)?.trim();
+  return value ? { [key]: value } : {};
+}

--- a/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-skills-browser.ts
@@ -406,6 +406,7 @@ function skillsBrowserFallbackText(params: {
   totalPages: number;
 }): string {
   const lines = [
+    params.filteredCount === 0 ? "No skills matched." : undefined,
     ...params.pageEntries.map((entry, index) => {
       const number = params.pageStart + index + 1;
       const description = skillDescription(entry);
@@ -413,7 +414,7 @@ function skillsBrowserFallbackText(params: {
     }),
     params.filteredCount === 0 ? "Reply Back, Search, or Cancel." : "Reply with a number, Search, Back, Next, Prev, or Cancel.",
   ];
-  return lines.join("\n");
+  return lines.filter((line): line is string => Boolean(line)).join("\n");
 }
 
 function skillDescription(entry: MessagingSkillBrowserEntry): string | undefined {
@@ -458,7 +459,7 @@ function pageValue(pageIndex: number, query?: string): MessagingJsonValue {
 }
 
 function normalizeQuery(query?: string): string {
-  return query?.trim().toLowerCase() ?? "";
+  return query?.trim().replace(/^\$+/, "").toLowerCase() ?? "";
 }
 
 function clampPageIndex(pageIndex: number, totalPages: number): number {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -122,6 +122,9 @@ export function buildBindingStatusIntent(params: {
       `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
+      params.binding.pendingSkillSelection
+        ? `Pending skill: $${params.binding.pendingSkillSelection.name}`
+        : undefined,
       "Context usage: unavailable",
       "Account: unavailable",
       "Rate limits: unavailable",
@@ -248,6 +251,13 @@ function buildStatusActions(params: {
       style: "secondary",
       fallbackText: "sync name",
       priority: 12,
+    },
+    {
+      id: "status:skills",
+      label: "Skills",
+      style: "secondary",
+      fallbackText: "skills",
+      priority: 13,
     },
     {
       id: "status:stop",

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,6 +1,8 @@
 import type {
   AgentEvent,
   AppServerBackendKind,
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
   AppServerThreadStatus,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
@@ -127,6 +129,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   async interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse> {
     return await this.registry.interruptTurn(request);
+  }
+
+  async listSkills(
+    request: AppServerListSkillsRequest = {},
+  ): Promise<Pick<AppServerListSkillsResponse, "data">> {
+    return await this.registry.listSkills(request);
   }
 
   async listBackends(request: ListBackendsRequest = {}): Promise<ListBackendsResponse> {

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -390,6 +390,7 @@ The full hands-on walkthrough — including a capability-profile workshop, the i
 | `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` | Canonical command catalog (verb + description), `matchMessagingCommandVerb` for dispatch lookup, `formatMessagingCommandHelpBody` for `/help` body generation, `paginateHelpCatalog` + `buildHelpActions` for the paginated command-button row |
 | `apps/desktop/src/main/messaging/core/messaging-renderer.ts` | Producers for thread picker, confirmation, questionnaire, error |
 | `apps/desktop/src/main/messaging/core/messaging-status-card.ts` | Producers for status card, model picker, reasoning picker, handoff overview/branch-picker/confirmation |
+| `apps/desktop/src/main/messaging/core/messaging-skills-browser.ts` | Producer/helpers for status-card skill browsing, search results, selected-skill confirmations, and skill-prefix formatting |
 | `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` | Producer for resume browser (`/resume`) — picker pagination, project/thread filtering |
 | `apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts` | Producer for approval prompts |
 | `apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts` | Inbound attachment normalization (size caps, MIME sniffing, image conversion) |

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -120,6 +120,20 @@ Effective streaming mode is resolved per binding first, then provider setting:
 Use the status card's `Stream: <mode>` action, or reply `stream` when actions
 are not available, to cycle a binding through `Default` -> `On` -> `Off`.
 
+## Skills Browser
+
+Bound conversations can stage a Codex skill from the status card. Choose
+`Skills` to open a paged browser, use `Search` to make the next free-text reply
+the skill query, then choose a skill from the results. PwrAgent posts a
+confirmation with the full `$skill` name and available metadata such as
+description, workspace, enabled status, and skill path.
+
+Selecting a skill does not start a turn. The selected skill is stored on the
+messaging binding and is prepended once to the next real user request, including
+requests that queue behind an active turn. Commands, browser navigation,
+callbacks, and skill-search replies do not consume it. Use `Remove` on the
+selection confirmation to clear the staged skill before sending the request.
+
 ## Tool Update Verbosity
 
 PwrAgent can send generated tool-use progress messages to bound conversations.
@@ -497,37 +511,40 @@ Telegram:
 4. Use Projects, select a project, then select a thread.
 5. Verify a pinned status card appears and updates in place.
 6. Use status buttons to change Model, Reasoning, Fast mode, and Permissions.
-7. For a bound Local thread with handoff branch metadata, choose Handoff from
+7. Choose Skills, search for a skill, select it, then send a short request.
+   Verify the turn starts with that skill prepended. Repeat once and use Remove
+   before sending to verify the staged skill clears.
+8. For a bound Local thread with handoff branch metadata, choose Handoff from
    `/status`, hand off to a new worktree, and verify the refreshed status shows
    the worktree path.
-8. For a bound worktree thread, choose Handoff from `/status`, hand off to
+9. For a bound worktree thread, choose Handoff from `/status`, hand off to
    Local, and verify the refreshed status no longer shows a worktree path.
-9. Repeat at least one handoff step by text fallback, such as replying `1` or
+10. Repeat at least one handoff step by text fallback, such as replying `1` or
    `confirm`.
-10. Try a stale or ineligible handoff prompt and verify the bot reports a
+11. Try a stale or ineligible handoff prompt and verify the bot reports a
    recoverable error without detaching the conversation.
-11. Send free-form text and verify a PwrAgent turn starts in the bound thread.
-12. Verify typing continues through an intermediate assistant update and stops at turn completion.
-13. With streaming disabled, trigger a long response and verify no live response message is created or edited before the final answer appears once.
-14. Enable Streaming Responses, trigger a long response, and verify Telegram creates then edits one in-progress response before the final answer appears once.
-15. Run a quiet command sequence and verify `Show Some` sends individual tool updates.
-16. Run a noisy command or file-read sequence and verify remaining tool updates batch before the final assistant response.
-17. Cycle Tools through `Show All`, `Show Less`, and `Show None`; verify all, batched, and suppressed behavior respectively.
-18. Trigger a Plan questionnaire and answer with both a button and text fallback.
-19. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
-20. Verify markdown, inline code, fenced code, long responses, and image output render.
-21. Restart PwrAgent and verify the same Telegram conversation still routes to the bound thread.
-22. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
-23. Send a small `.txt` attachment and verify a turn starts with the extracted text.
-24. Send an image attachment and verify a turn starts with normalized image input.
-25. Send an oversized file or voice message and verify it is rejected without model upload.
-26. Verify assistant image and file parts render as Telegram photo/document attachments.
-27. Send a long or split code-block request as two quick messages and verify only one turn starts.
-28. Send a text attachment and a follow-up text message inside the debounce window and verify one turn starts with both inputs.
-29. While a turn is active, send a follow-up message and verify the queued notice shows a quoted preview plus Steer and Cancel controls.
-30. Click Steer and verify the follow-up is sent into the active turn and the queued controls disappear.
-31. Repeat with Cancel and verify the queued input is not submitted after the active turn completes.
-32. Repeat without clicking either action and verify completion starts the queued input as the next turn.
+12. Send free-form text and verify a PwrAgent turn starts in the bound thread.
+13. Verify typing continues through an intermediate assistant update and stops at turn completion.
+14. With streaming disabled, trigger a long response and verify no live response message is created or edited before the final answer appears once.
+15. Enable Streaming Responses, trigger a long response, and verify Telegram creates then edits one in-progress response before the final answer appears once.
+16. Run a quiet command sequence and verify `Show Some` sends individual tool updates.
+17. Run a noisy command or file-read sequence and verify remaining tool updates batch before the final assistant response.
+18. Cycle Tools through `Show All`, `Show Less`, and `Show None`; verify all, batched, and suppressed behavior respectively.
+19. Trigger a Plan questionnaire and answer with both a button and text fallback.
+20. Trigger an approval request and test accept, session accept, decline, and cancel with both buttons and text.
+21. Verify markdown, inline code, fenced code, long responses, and image output render.
+22. Restart PwrAgent and verify the same Telegram conversation still routes to the bound thread.
+23. Send `/detach` and verify the status card is unpinned and free-form text asks for `/resume`.
+24. Send a small `.txt` attachment and verify a turn starts with the extracted text.
+25. Send an image attachment and verify a turn starts with normalized image input.
+26. Send an oversized file or voice message and verify it is rejected without model upload.
+27. Verify assistant image and file parts render as Telegram photo/document attachments.
+28. Send a long or split code-block request as two quick messages and verify only one turn starts.
+29. Send a text attachment and a follow-up text message inside the debounce window and verify one turn starts with both inputs.
+30. While a turn is active, send a follow-up message and verify the queued notice shows a quoted preview plus Steer and Cancel controls.
+31. Click Steer and verify the follow-up is sent into the active turn and the queued controls disappear.
+32. Repeat with Cancel and verify the queued input is not submitted after the active turn completes.
+33. Repeat without clicking either action and verify completion starts the queued input as the next turn.
 
 Discord:
 
@@ -841,19 +858,23 @@ should succeed before moving to the next:
 14. Click `Tools`, then `Permissions`. Each click cycles the value
     and the card updates inline. The desktop app's UI mirrors the
     change (cross-surface state bus).
+15. Click `Skills`, use `Search`, pick a skill, and verify the
+    confirmation offers `Remove`. Send a request and verify the skill
+    is prepended once; repeat with `Remove` and verify the next request
+    is not prefixed.
 
 **Detach:**
 
-15. Click `Detach` on the status card. The bot posts `Thread detached`
+16. Click `Detach` on the status card. The bot posts `Thread detached`
     and removes the status card's buttons. The desktop app's binding
     chip disappears for that thread.
-16. Send another message in the DM. The bot shows the command menu
+17. Send another message in the DM. The bot shows the command menu
     again; the offered `Resume` button still works to re-bind.
 
 **Cross-restart persistence (with env-var HMAC pinned):**
 
-17. Quit and relaunch PwrAgent.
-18. Click a button on a status card from a still-bound thread that
+18. Quit and relaunch PwrAgent.
+19. Click a button on a status card from a still-bound thread that
     was rendered before the restart. The click round-trips and the
     status updates. Without the env-var HMAC pinned, this step fails
     silently — the canary that says "you forgot to set the HMAC env

--- a/docs/plans/2026-05-12-001-feat-messaging-skills-browser-plan.md
+++ b/docs/plans/2026-05-12-001-feat-messaging-skills-browser-plan.md
@@ -1,0 +1,367 @@
+---
+title: feat: Add messaging Skills browser
+type: feat
+status: active
+date: 2026-05-12
+deepened: 2026-05-12
+---
+
+# feat: Add messaging Skills browser
+
+## Overview
+
+Add a Skills browser to the messaging thread status menu. The browser should let a user open Skills from the status card, page through available skills, search by sending the next free-text reply as the query, choose a skill, and have that skill prepended to the next user request. Selecting a skill should not immediately start a turn; it should post a confirmation with the full skill name, available help text, and a Remove button.
+
+## Problem Frame
+
+PwrAgent already supports skill metadata and desktop composer skill mentions, but remote messaging users do not have an ergonomic status-card path for browsing and staging a skill for their next instruction. OpenClaw had a useful predecessor in its status menu, with a Skills button, paged picker, search/filtering, and help mode. PwrAgent should recover that interaction while fitting the current channel-neutral messaging architecture, persistent binding store, pending-intent model, and status-card submode patterns.
+
+## Requirements Trace
+
+- R1. The bound thread status card exposes a Skills action when the channel capability profile has enough action budget.
+- R2. Clicking Skills opens a channel-neutral, paged Skills browser with navigation controls.
+- R3. The browser has a Search action that makes the next free-text response a skill search query rather than a normal turn instruction.
+- R4. Search results support navigation, empty-result feedback, and a Back action to return to unfiltered browsing.
+- R5. Selecting a skill posts a confirmation instead of starting a turn.
+- R6. The selection confirmation displays the full skill name and available help text, including description, workspace/context, status, and path when present.
+- R7. The selection confirmation includes a Remove action that clears the staged skill.
+- R8. The next user request sent to the bound thread consumes the staged skill once and prepends it to the turn input.
+- R9. The behavior works for text and media requests, respects existing turn admission/queueing behavior, and degrades to text fallback on low-capability channels.
+
+## Scope Boundaries
+
+- This plan covers messaging status-card interactions, not the desktop renderer composer autocomplete UI.
+- This plan does not add skill installation, enable/disable management, or config editing.
+- This plan does not add semantic search; search is lexical over skill name, description/help metadata, path, and cwd.
+- This plan does not require a new Codex app-server protocol method for reading full `SKILL.md` bodies. Use metadata returned by `skills/list`; preserve a future path for richer help if the protocol exposes it.
+- This plan stages one pending skill per messaging binding. Multi-skill staging is a future extension.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` builds status-card actions and existing status submodes such as model, reasoning, streaming, and handoff.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` handles inbound text, status callbacks, pending intents, status submode delivery, turn input preparation, and turn admission.
+- `apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts` maps free-text replies to pending actions, but currently lets likely new instructions pass through.
+- `apps/desktop/src/main/messaging/core/messaging-renderer.ts` already has generic confirmation/status builders that can carry channel-neutral actions.
+- `apps/desktop/src/main/messaging/core/messaging-adapter.ts` defines `MessagingBackendBridge`; it currently lacks `listSkills` even though `DesktopBackendRegistry` exposes it.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` forwards backend bridge calls to the registry and is the right desktop-side place to expose `listSkills`.
+- `packages/shared/src/contracts/normalized-app-server.ts` defines `AppServerSkillSummary`, `AppServerListSkillsRequest`, and `AppServerListSkillsResponse`.
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`, `apps/desktop/src/main/messaging/core/messaging-store.ts`, and `apps/desktop/src/main/messaging/core/messaging-migrations.ts` sanitize and migrate persisted binding payloads.
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`, `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`, and messaging store tests already cover status-card submodes, pending intents, and persisted binding behavior.
+- Reference repo `openclaw-app-server`: `src/controller.ts` implemented a status-card Skills button, paged skill picker, mode toggle, search/filter flow, and run/help callbacks; `src/format.ts` held skill filtering and help formatting helpers.
+- `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md` requires a real skills/plugins capability in the first milestone.
+- `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md` establishes that skills should load lazily and be cached after first use, which argues against eager loading outside the explicit Skills browser action.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is about permissions rather than skills, but the relevant lesson applies here: do not hide state transitions behind implicit side effects. The selected skill should be explicit binding state, consumed deterministically, and removable.
+
+### External References
+
+- External research is not needed. The feature is shaped by existing PwrAgent messaging architecture and the local OpenClaw reference implementation.
+
+## Key Technical Decisions
+
+- Add Skills as a channel-neutral status submode, not as provider-specific callback logic. This keeps Telegram, Discord, Slack, Mattermost, Line, and future providers on the same workflow path.
+- Add `listSkills` to `MessagingBackendBridge` and implement it in `DesktopMessagingBackendBridge` by delegating to `DesktopBackendRegistry.listSkills`. Providers must not call app-server skill APIs directly.
+- Store the selected skill on the `MessagingBindingRecord` as explicit pending skill state. A pending intent alone is too ephemeral for "prepend onto the next user request" and makes Remove harder to reason about.
+- Use pending intents for the interactive browser and search prompt. Represent search capture as a binding-scoped confirmation intent in the `skills:search` action namespace, then special-case that pending intent in `handleText` so the next free-text reply is captured as a query before `DeterministicInteractionMapper` can treat it as a normal instruction.
+- Prepend the selected skill using the same text-compatible skill mention shape the desktop composer already sends, such as `Use [$ce:plan](path)` when a path exists and `$ce:plan` when it does not. Defer a true `AppServerTurnInputItem` skill item until the normalized contract supports it.
+- Consume the staged skill only when a user request is admitted into a turn bundle or queue. Failed unsupported-media preparation should not silently clear the selection.
+- Keep skill help to metadata available from `skills/list`: full name, description or short description, cwd, path, and enabled status. Do not read arbitrary local `SKILL.md` paths from messaging workflow code in this slice.
+- Deduplicate skills by normalized name and keep deterministic ordering: name-prefix matches first during search, then description/path/cwd matches, preserving list order within equal match classes.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Was the old reference actually the user-mentioned codex-app-server checkout?** No. That checkout path is absent in this environment. The matching local predecessor is `openclaw-app-server`, which contains the status-card Skills picker behavior the request describes.
+- **Should selecting a skill start a turn immediately?** No. The user explicitly wants the skill prepended onto the next user request and a Remove button, so selection stages state rather than sending `$skill` as a prompt.
+- **Should the implementation read full skill files for help text?** No for this slice. The existing normalized API exposes metadata, not full skill bodies, and messaging workflow code should not grow local filesystem reads for app-server-owned skill discovery.
+
+### Deferred to Implementation
+
+- **Exact mention formatting:** If implementation discovers an existing shared helper for desktop composer skill mentions that can be used without violating renderer/main boundaries, use it. Otherwise keep a local formatter matching the current send payload shape.
+- **Exact action budget placement:** Final priorities for Skills relative to Handoff, Stream, and Sync name should be tuned against existing capability-profile tests.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Status["Bound thread status card"]
+    Skills["Skills browser submode"]
+    SearchPrompt["Search capture pending intent"]
+    Results["Filtered skills page"]
+    Selection["Pending skill on binding"]
+    Confirm["Selection confirmation with Remove"]
+    NextRequest["Next inbound text/media"]
+    TurnInput["Prepared turn input with skill prefix"]
+
+    Status --> Skills
+    Skills --> Results
+    Skills --> SearchPrompt
+    SearchPrompt --> Results
+    Results --> Selection
+    Selection --> Confirm
+    Confirm -->|Remove| Skills
+    NextRequest --> Selection
+    Selection --> TurnInput
+```
+
+The browser and search prompt are transient surfaces. The selected skill is durable binding state until it is removed or consumed by the next request.
+
+## Implementation Units
+
+- [ ] **Unit 1: Expose skills to messaging workflow**
+
+**Goal:** Let the messaging controller list skills through the desktop backend bridge without provider-specific app-server access.
+
+**Requirements:** R1, R2, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Modify: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Add an optional `listSkills` method to `MessagingBackendBridge` that accepts backend and cwd/cwds parameters compatible with `AppServerListSkillsRequest`.
+- Implement the bridge method by delegating to `DesktopBackendRegistry.listSkills`.
+- Update controller harness mocks to expose deterministic skills across one or more cwd buckets.
+- Treat a missing bridge method as a recoverable "Skills unavailable" message so non-Codex or future restricted backends fail cleanly.
+
+**Patterns to follow:**
+- `DesktopMessagingBackendBridge.getNavigationSnapshot`, `setThreadModelSettings`, and `startTurn` delegation patterns.
+- Existing status model/reasoning picker tests in `apps/desktop/src/main/__tests__/messaging-controller.test.ts`.
+
+**Test scenarios:**
+- Happy path: a controller harness with `listSkills` returns skills and the Skills browser can use them.
+- Error path: when `listSkills` is absent, clicking Skills delivers a recoverable unavailable message and does not throw.
+- Error path: when `listSkills` rejects, the controller posts a recoverable error and leaves the status card usable.
+
+**Verification:**
+- Messaging workflow code can list skill metadata without importing provider SDKs or crossing dependency boundaries.
+
+- [ ] **Unit 2: Build the Skills browser and search flow**
+
+**Goal:** Add the status-card Skills action and a paged browser with navigation, Search, result pages, Back, and Cancel.
+
+**Requirements:** R1, R2, R3, R4, R6, R9
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/messaging/core/messaging-skills-browser.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts`
+
+**Approach:**
+- Add `status:skills` to status actions with conservative priority so critical actions like Stop, Refresh, Detach, Permissions, and active handoff controls remain available first.
+- Build skill browser helpers that flatten `skills/list` entries into skill rows containing name, description/help metadata, path, cwd, enabled state, and match metadata.
+- Render browser pages as `single_select` or `confirmation` intents with skill choices plus navigation actions (`skills:previous`, `skills:next`, `skills:search`, `skills:back`, `skills:cancel`).
+- Use `targetSurface` and update delivery when the binding has a status surface, matching model/reasoning/handoff submode behavior.
+- When Search is clicked, store a binding-scoped pending confirmation intent whose id or action namespace is `skills:search`, with `skills:search:cancel` and `status:skills`/Back controls, and deliver a prompt explaining that the next reply is the search text.
+- In `handleText`, detect the active `skills:search` pending intent before normal interaction mapping and turn admission, consume that text as a query, delete the search pending intent, and render filtered results.
+- Keep filter matching lexical and deterministic: normalized name prefix, normalized name substring, then description/path/cwd substring.
+
+**Patterns to follow:**
+- Handoff branch picker pagination in `apps/desktop/src/main/messaging/core/messaging-status-card.ts`.
+- Existing pending intent lifecycle around `deliverAndStoreStatusSubmode` in `apps/desktop/src/main/messaging/core/messaging-controller.ts`.
+- OpenClaw reference repo `src/controller.ts` `buildSkillsPicker` and `src/format.ts` `filterSkillsByQuery` / `formatSkillsPickerText`, adapted to PwrAgent's generic intent model.
+
+**Test scenarios:**
+- Happy path: status card includes `status:skills` when capability limits allow it.
+- Happy path: clicking `status:skills` delivers a page containing skill choices and Search/Cancel actions.
+- Happy path: browser pagination moves between pages and preserves an active search query.
+- Happy path: clicking Search makes the next text reply `review` render filtered skills matching `review`.
+- Edge case: an empty search result renders "No skills matched" with Back and Search Again actions.
+- Edge case: Back from search results returns to unfiltered browsing.
+- Regression: a normal pending model/reasoning picker still treats likely new instructions as pass-through; only the skills search prompt captures free text.
+
+**Verification:**
+- Users can browse, page, search, and return without starting a turn or losing the bound status surface.
+
+- [ ] **Unit 3: Persist and display pending skill selection**
+
+**Goal:** Selecting a skill stores one pending skill on the binding and posts a confirmation with help text and a Remove button.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `packages/messaging/interface/src/index.ts`
+- Modify: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- Modify: `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Add a `pendingSkillSelection` field to `MessagingBindingRecord` with skill name, path, description/help text, cwd, enabled state, selected actor, and selected timestamp.
+- Preserve this field through binding sanitizers and migrations while continuing to strip deprecated `activeTurn` and `threadDisplay`.
+- Add a helper to format selected-skill confirmation text with the full `$name`, description/help metadata, cwd, path, enabled state, and "will be prepended to your next request" language.
+- Add `skills:select` to persist the selection and deliver a confirmation with `skills:remove` and `status:skills`/Back actions.
+- Add `skills:remove` to clear pending skill state and deliver an acknowledgement or refreshed browser/status submode.
+- Consider showing a short pending-skill line on the status card text while a skill is staged so users can see the state without reopening the browser.
+
+**Patterns to follow:**
+- Binding preference updates in `MessagingController.updateBindingPreferences`.
+- Store sanitizer tests that preserve intended binding state while dropping deprecated cached state.
+- Existing confirmation intents with actions, such as queued turn notices and handoff confirmations.
+
+**Test scenarios:**
+- Happy path: selecting `ce:plan` persists `pendingSkillSelection` on the active binding.
+- Happy path: the confirmation includes `$ce:plan`, description/help text, cwd/path when present, and a Remove action.
+- Happy path: the pending skill survives store reload in both JSON and sqlite stores.
+- Happy path: clicking Remove clears `pendingSkillSelection`.
+- Edge case: selecting a disabled skill either prevents staging with a clear message or stages it with explicit disabled status, based on the existing `enabled` metadata semantics.
+- Regression: sanitizers still remove deprecated `activeTurn` and `threadDisplay` without dropping `pendingSkillSelection`.
+
+**Verification:**
+- Pending skill state is visible, removable, and restart-safe.
+
+- [ ] **Unit 4: Prepend the staged skill to the next request**
+
+**Goal:** Consume the pending skill once when the next user request is accepted into normal turn flow, including queued-turn flow.
+
+**Requirements:** R8, R9
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- When preparing an admitted turn bundle, inspect the latest binding record for `pendingSkillSelection`.
+- Prepend a skill mention text item ahead of the user's text/media input using the selected skill name and path when available.
+- Include the pending skill in the queued-turn preview so users can tell the queued message will use that skill.
+- Clear the pending skill only after the request is successfully admitted into start or queue flow. If input preparation fails because attachments are unsupported, keep the selection.
+- For an active turn, attach the skill to the queued message rather than steering the currently running turn, because the requirement is "next user request."
+- Prevent commands such as `/status`, browser navigation callbacks, and search queries from consuming the pending skill.
+
+**Patterns to follow:**
+- `prepareTurnInput`, `handleAdmittedTurnBundle`, `queuePreparedInput`, and queued-turn preview construction in `apps/desktop/src/main/messaging/core/messaging-controller.ts`.
+- Desktop composer skill mention payload expectations in `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
+
+**Test scenarios:**
+- Happy path: after selecting `ce:plan`, the next text message starts a turn whose first text input contains the skill mention before the user instruction.
+- Happy path: after consumption, the binding no longer has `pendingSkillSelection`.
+- Happy path: when a thread is active, the next text message queues with the skill prefix and clears the selection once queued.
+- Integration: a media message with caption consumes the pending skill and preserves attachment input.
+- Edge case: `/status` after selecting a skill does not consume it.
+- Edge case: replying to a skills-search prompt after selecting a skill does not consume it as a turn request.
+- Error path: unsupported media does not clear the pending skill.
+
+**Verification:**
+- The selected skill is applied exactly once to the next real user request and never to status/browser control traffic.
+
+- [ ] **Unit 5: Cross-channel degradation and regression coverage**
+
+**Goal:** Ensure the browser works through the generic messaging contract and degrades cleanly on platforms with tighter action limits or text-only behavior.
+
+**Requirements:** R1, R2, R3, R4, R9
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- Modify: `packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts`
+- Modify: `packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts`
+- Modify: `packages/messaging/providers/line/src/__tests__/line-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/discord-adapter.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Keep browser and confirmation surfaces within existing `MessagingSurfaceIntent` and `MessagingSurfaceAction` primitives; the `skills:search` pending intent should be handled in controller workflow rather than by extending provider contracts.
+- Verify action labels and fallback text are useful when providers collapse buttons, truncate labels, or require typed replies.
+- Make Search, Back, Remove, and skill choices resolvable from fallback text where buttons are not available.
+- Confirm callback handle persistence still works for providers that sign or store callbacks externally.
+
+**Patterns to follow:**
+- Existing provider tests around status-card callbacks and generic action rendering.
+- Capability-profile truncation and action-budget helpers in `@pwragent/messaging-interface`.
+
+**Test scenarios:**
+- Happy path: Discord/Telegram callback action for a skill selection reaches `skills:select` with the expected value.
+- Happy path: Slack/Line formatting includes Search/Remove fallback labels in a usable form.
+- Edge case: low action-count capability profiles drop lower-priority browser actions before critical actions and still expose text fallback.
+- Regression: existing status actions for model, reasoning, permissions, tool updates, streaming, compact, stop, refresh, and detach still render or degrade as before.
+
+**Verification:**
+- The feature is channel-neutral and does not require provider-specific workflow branches.
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+    Status["Status card actions"]
+    Controller["MessagingController"]
+    Bridge["MessagingBackendBridge.listSkills"]
+    Registry["DesktopBackendRegistry.listSkills"]
+    Store["Binding store pendingSkillSelection"]
+    Mapper["Text interaction mapping"]
+    Admission["Turn admission and queue"]
+    Providers["Messaging providers"]
+
+    Status --> Controller
+    Controller --> Bridge
+    Bridge --> Registry
+    Controller --> Store
+    Controller --> Mapper
+    Controller --> Admission
+    Providers --> Controller
+    Controller --> Providers
+```
+
+- **Interaction graph:** Status callbacks route through `MessagingController.handleStatusCallback`; browser/search/selection flows update pending intents, binding state, and provider surfaces through the existing adapter delivery path.
+- **Error propagation:** Backend skill-list failures should become recoverable messaging errors. Search with zero results should be a normal browser state, not an error.
+- **State lifecycle risks:** Pending skill state must clear on remove, binding revoke, and successful next-request consumption. It must not clear on status refresh, search, unsupported input, or expired browser callbacks.
+- **API surface parity:** The bridge gains `listSkills`; providers stay on existing generic intent/action APIs.
+- **Integration coverage:** Controller tests must prove cross-layer behavior: status action -> skill list -> browser -> search -> select -> binding state -> next turn input.
+- **Unchanged invariants:** Providers do not import desktop/app-server code, renderer imports remain untouched, dependency-cruiser boundaries stay strict, and `skills/list` remains lazily called only when the user opens the browser or refreshes it.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Search prompt text is accidentally treated as a user turn instruction | Detect the active skills-search pending intent before normal text mapping and turn admission; cover with controller tests. |
+| Pending skill state becomes invisible stale state | Show it in the selection confirmation, provide Remove, consider a status-card line, and clear on binding revoke/next request. |
+| The skill prefix format drifts from desktop composer behavior | Reuse the composer-compatible markdown mention shape and test the exact `startTurn` input produced by messaging. |
+| Action budgets make Skills unreachable on some channels | Assign priorities deliberately and verify capability-profile truncation/fallback behavior. |
+| Disabled or duplicate skills confuse the browser | Deduplicate by normalized name and make disabled status explicit in text or prevent staging disabled entries. |
+| Adding binding state breaks store sanitization or migrations | Add contract, JSON store, and sqlite store tests that preserve `pendingSkillSelection`. |
+
+## Documentation / Operational Notes
+
+- Update `docs/messaging-platform-integration.md` after implementation to mention the status-card Skills browser, search flow, selection staging, and Remove action.
+- No operator config changes are expected.
+- No desktop visual design docs need updates because this is a messaging surface feature.
+
+## Sources & References
+
+- Related requirements: `docs/brainstorms/2026-04-16-thread-centric-agent-desktop-requirements.md`
+- Related requirements: `docs/brainstorms/2026-04-18-desktop-thread-refresh-model-requirements.md`
+- Related plan: `docs/plans/2026-05-02-001-fix-skill-autocomplete-regression-plan.md`
+- Related learning: `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts`
+- Related code: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Related code: `packages/shared/src/contracts/normalized-app-server.ts`
+- Reference repo: `openclaw-app-server` `src/controller.ts`
+- Reference repo: `openclaw-app-server` `src/format.ts`

--- a/docs/plans/2026-05-12-001-feat-messaging-skills-browser-plan.md
+++ b/docs/plans/2026-05-12-001-feat-messaging-skills-browser-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Add messaging Skills browser
 type: feat
-status: active
+status: completed
 date: 2026-05-12
 deepened: 2026-05-12
 ---
@@ -115,7 +115,7 @@ The browser and search prompt are transient surfaces. The selected skill is dura
 
 ## Implementation Units
 
-- [ ] **Unit 1: Expose skills to messaging workflow**
+- [x] **Unit 1: Expose skills to messaging workflow**
 
 **Goal:** Let the messaging controller list skills through the desktop backend bridge without provider-specific app-server access.
 
@@ -146,7 +146,7 @@ The browser and search prompt are transient surfaces. The selected skill is dura
 **Verification:**
 - Messaging workflow code can list skill metadata without importing provider SDKs or crossing dependency boundaries.
 
-- [ ] **Unit 2: Build the Skills browser and search flow**
+- [x] **Unit 2: Build the Skills browser and search flow**
 
 **Goal:** Add the status-card Skills action and a paged browser with navigation, Search, result pages, Back, and Cancel.
 
@@ -188,7 +188,7 @@ The browser and search prompt are transient surfaces. The selected skill is dura
 **Verification:**
 - Users can browse, page, search, and return without starting a turn or losing the bound status surface.
 
-- [ ] **Unit 3: Persist and display pending skill selection**
+- [x] **Unit 3: Persist and display pending skill selection**
 
 **Goal:** Selecting a skill stores one pending skill on the binding and posts a confirmation with help text and a Remove button.
 
@@ -233,7 +233,7 @@ The browser and search prompt are transient surfaces. The selected skill is dura
 **Verification:**
 - Pending skill state is visible, removable, and restart-safe.
 
-- [ ] **Unit 4: Prepend the staged skill to the next request**
+- [x] **Unit 4: Prepend the staged skill to the next request**
 
 **Goal:** Consume the pending skill once when the next user request is accepted into normal turn flow, including queued-turn flow.
 
@@ -269,7 +269,7 @@ The browser and search prompt are transient surfaces. The selected skill is dura
 **Verification:**
 - The selected skill is applied exactly once to the next real user request and never to status/browser control traffic.
 
-- [ ] **Unit 5: Cross-channel degradation and regression coverage**
+- [x] **Unit 5: Cross-channel degradation and regression coverage**
 
 **Goal:** Ensure the browser works through the generic messaging contract and degrades cleanly on platforms with tighter action limits or text-only behavior.
 

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -368,6 +368,48 @@ describe("messaging surface contract", () => {
     expect(JSON.stringify(intent)).not.toMatch(/callback_data|custom_id/);
   });
 
+  it("describes skill browsing as generic single-select actions", () => {
+    const intent = {
+      id: "skills-browser-1",
+      kind: "single_select",
+      createdAt: 1000,
+      bindingId: "binding-1",
+      prompt: "Skills",
+      fallbackText: "Reply with a number, Search, Back, Next, Prev, or Cancel.",
+      choices: [
+        {
+          id: "skills:select",
+          label: "1. $ce:work",
+          style: "secondary",
+          fallbackText: "1",
+          value: {
+            name: "ce:work",
+            path: "/skills/ce-work/SKILL.md",
+            description: "Execute implementation plans",
+          },
+        },
+        {
+          id: "skills:search",
+          label: "Search",
+          style: "secondary",
+          fallbackText: "search",
+        },
+        {
+          id: "status:refresh",
+          label: "Cancel",
+          style: "secondary",
+          fallbackText: "cancel",
+        },
+      ],
+    } satisfies MessagingSingleSelectIntent;
+
+    expect(intent.choices[0]?.value).toMatchObject({
+      name: "ce:work",
+      path: "/skills/ce-work/SKILL.md",
+    });
+    expect(JSON.stringify(intent)).not.toMatch(/callback_data|custom_id/);
+  });
+
   it("marks inbound media as unsupported by default", () => {
     const event = {
       id: "event-media",
@@ -503,6 +545,13 @@ describe("messaging surface contract", () => {
           },
         },
       },
+      pendingSkillSelection: {
+        name: "ce:work",
+        path: "/skills/ce-work/SKILL.md",
+        description: "Execute implementation plans",
+        selectedActorId: "telegram-user-1",
+        selectedAt: 1000,
+      },
     } satisfies MessagingBindingRecord;
     const browseSession = {
       id: "browse-1",
@@ -568,6 +617,7 @@ describe("messaging surface contract", () => {
     expect(monitorSubscription.monitor.recentThreadLimit).toBe(10);
     expect(monitorSubscription.monitor.showLastResponseSnippet).toBe(true);
     expect(monitorSubscription.monitorSurface?.id).toBe("monitor-message-1");
+    expect(binding.pendingSkillSelection?.name).toBe("ce:work");
   });
 
   it("defines callback handles as long-lived sqlite routes", () => {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -880,6 +880,17 @@ export type MessagingThreadDisplaySummary = {
   worktreePath?: string;
 };
 
+export type MessagingPendingSkillSelection = {
+  cwd?: string;
+  description?: string;
+  enabled?: boolean;
+  name: string;
+  path?: string;
+  selectedActorId?: string;
+  selectedAt: number;
+  shortDescription?: string;
+};
+
 export type MessagingBindingRecord = {
   id: string;
   channel: MessagingChannelRef;
@@ -899,6 +910,7 @@ export type MessagingBindingRecord = {
   monitor?: MessagingMonitorState;
   monitorSurface?: MessagingSurfaceRef;
   pinnedStatusSurface?: MessagingSurfaceRef;
+  pendingSkillSelection?: MessagingPendingSkillSelection;
   preferences?: MessagingBindingPreferences;
   statusSurface?: MessagingSurfaceRef;
   threadDisplay?: MessagingThreadDisplaySummary;


### PR DESCRIPTION
## Summary

Adds a channel-neutral Skills browser to messaging status cards so remote users can browse, search, stage, remove, and consume a Codex skill from Telegram, Discord, Slack, Mattermost, Line, or any provider that renders the existing generic messaging intents.

## What Changed

- Added a `Skills` status action plus a paged skill browser with Search, Back, Cancel, Prev/Next, and selectable skill rows.
- Added a search-capture state where the next free-text reply becomes the skill query instead of a turn instruction.
- Added durable per-binding `pendingSkillSelection` state with confirmation text, available skill metadata, and a Remove action.
- Prepends the selected skill once to the next real text/media request, including queued requests, while leaving commands, browser controls, and search replies alone.
- Exposed `listSkills` through the desktop messaging backend bridge rather than adding provider-specific skill access.
- Documented the operator smoke flow and marked the implementation plan complete.

## Review Notes

The workflow stays inside existing `MessagingSurfaceIntent` and `MessagingSurfaceAction` primitives. Providers do not gain new workflow logic; they only render the generic buttons/fallback text they already support. The selected skill is persisted on the binding instead of as a pending intent so it survives status refreshes and can be removed explicitly.

## Testing

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts apps/desktop/src/main/__tests__/messaging-skills-browser.test.ts packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
- `pnpm lint:boundaries`
- `git diff --check`

## Post-Deploy Monitoring & Validation

Validation window: first messaging smoke pass after merge. Owner: maintainer running the messaging smoke checklist.

Healthy signals:
- `/status` shows a `Skills` action on capable messaging providers.
- Clicking `Skills` lists skills for the bound thread workspace.
- `Search` captures one free-text reply and renders filtered skill results without starting a turn.
- Selecting a skill shows confirmation text with `$skill`, metadata, and `Remove`.
- The next real request starts or queues with the skill prefix exactly once.

Failure signals and mitigation:
- Messaging logs containing `Skills unavailable` or `skills-list-failed` for a normal Codex binding indicate backend bridge/listing failure; roll back this PR or disable use of the Skills action until investigated.
- Short follow-up messages after Cancel or Remove producing `Choose an option` indicate stale pending-intent handling; roll back this PR.
- Dependency boundary failures in CI indicate an architectural regression; block merge until fixed.

Suggested log searches:
- `pwragent:messaging Skills unavailable`
- `pwragent:messaging skills-list-failed`
- `messaging starting turn` with the expected skill-prefixed input during manual smoke testing.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)
