### PR TITLE
fix(desktop): release queued reviews after idle

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -80,7 +80,7 @@ function backendSummary(): BackendSummary {
     kind: "codex",
     label: "Codex",
     available: true,
-    methods: ["turn/start"],
+    methods: ["turn/start", "review/start"],
     capabilities: {
       listThreads: true,
       createThread: true,
@@ -88,6 +88,7 @@ function backendSummary(): BackendSummary {
       renameThread: false,
       readThread: true,
       startTurn: true,
+      startReview: true,
       interruptTurn: true,
       steerTurn: false,
       transcriptPagination: true,
@@ -124,6 +125,7 @@ function thread(
 
 describe("useQueuedTurnRelease", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -201,6 +203,67 @@ describe("useQueuedTurnRelease", () => {
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Second background reply");
+  });
+
+  it("releases a queued message for a non-focused thread when its status becomes idle", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-next",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-idle",
+      text: "Idle status reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Idle status reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-a",
+              status: { type: "idle" },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-a",
+          input: [{ type: "text", text: "Idle status reply" }],
+        })
+      );
+    });
+    expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
   });
 
   it("releases a queued review with review/start for a non-focused thread", async () => {
@@ -282,6 +345,73 @@ describe("useQueuedTurnRelease", () => {
     });
     expect(startTurn).not.toHaveBeenCalled();
     expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
+  });
+
+  it("keeps a queued review when review/start rejects", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startReview = vi.fn(async () => {
+      throw new Error("review unavailable");
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalled();
+    });
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.id
+    ).toBe("queued-review");
   });
 
   it("does not remove the next background queued message when the started item changed while in flight", async () => {
@@ -453,6 +583,420 @@ describe("useQueuedTurnRelease", () => {
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Guarded background reply");
+  });
+
+  it("releases a queued review for a non-focused thread when its turn completes", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-a",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")
+    ).toBeUndefined();
+  });
+
+  it("releases a branch-tracked queued review after a clean drift check", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "feature/review",
+      observedBranch: "feature/review",
+      drifted: false,
+      checkedAt: Date.now(),
+    }));
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", { gitBranch: "feature/review" }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalledWith({
+        backend: "codex",
+        expectedBranch: "feature/review",
+        threadId: "thread-a",
+      });
+      expect(startReview).toHaveBeenCalled();
+    });
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")
+    ).toBeUndefined();
+  });
+
+  it("keeps a branch-tracked queued review when the drift check blocks background release", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startReview = vi.fn();
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "feature/review",
+      observedBranch: "main",
+      drifted: true,
+      checkedAt: Date.now(),
+    }));
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", { gitBranch: "feature/review" }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalled();
+    });
+    expect(startReview).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("/review main");
+  });
+
+  it("releases a queued review when non-HEAD branch drift was retained", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "feature/review",
+      observedBranch: "main",
+      drifted: true,
+      checkedAt: Date.now(),
+    }));
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", {
+            gitBranch: "feature/review",
+            retainedBranchDriftPairs: [
+              {
+                expectedBranch: "feature/review",
+                observedBranch: "main",
+                retainedAt: 1,
+              },
+            ],
+          }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-a",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")
+    ).toBeUndefined();
+  });
+
+  it("keeps a queued review when a stale retained HEAD drift pair exists", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startReview = vi.fn();
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "HEAD",
+      observedBranch: "fix/review",
+      drifted: true,
+      checkedAt: Date.now(),
+    }));
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", {
+            gitBranch: "HEAD",
+            retainedBranchDriftPairs: [
+              {
+                expectedBranch: "HEAD",
+                observedBranch: "fix/review",
+                retainedAt: 1,
+              },
+            ],
+          }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalledWith({
+        backend: "codex",
+        expectedBranch: "HEAD",
+        threadId: "thread-a",
+      });
+    });
+    expect(startReview).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("/review main");
   });
 
   it("background-releases a branch-tracked thread when the drift guard passes", async () => {
@@ -762,5 +1306,217 @@ describe("useQueuedTurnRelease", () => {
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Focused reply");
+  });
+
+  it("leaves the focused thread queue to the mounted composer during the idle probe", async () => {
+    vi.useFakeTimers();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const readThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      threadId: "thread-a",
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          hasPreviousPage: false,
+          supportsPagination: true,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-a"),
+        threads: [thread("thread-a")],
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(readThread).not.toHaveBeenCalled();
+    expect(startReview).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
+    ).toBe("/review main");
+  });
+
+  it("does not release from the idle probe when the thread becomes focused mid-check", async () => {
+    vi.useFakeTimers();
+    let resolveReadThread:
+      | ((response: Awaited<ReturnType<NonNullable<DesktopApi["readThread"]>>>) => void)
+      | undefined;
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const readThread = vi.fn(
+      () =>
+        new Promise<
+          Awaited<ReturnType<NonNullable<DesktopApi["readThread"]>>>
+        >((resolve) => {
+          resolveReadThread = resolve;
+        })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    const { rerender } = renderHook(
+      ({ selectedThread }: { selectedThread: NavigationThreadSummary }) =>
+        useQueuedTurnRelease({
+          backends: [backendSummary()],
+          composerDraftStore,
+          desktopApi,
+          selectedThread,
+          threads: [thread("thread-a"), thread("thread-b")],
+        }),
+      { initialProps: { selectedThread: thread("thread-b") } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-a",
+      limit: 1,
+    });
+
+    rerender({ selectedThread: thread("thread-a") });
+
+    await act(async () => {
+      resolveReadThread?.({
+        backend: "codex",
+        fetchedAt: Date.now(),
+        threadId: "thread-a",
+        threadStatus: "idle",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            hasPreviousPage: false,
+            supportsPagination: true,
+          },
+        },
+      });
+    });
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.id
+    ).toBe("queued-review");
+  });
+
+  it("periodically releases a non-focused queued review after verifying the thread is idle", async () => {
+    vi.useFakeTimers();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const readThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: Date.now(),
+      threadId: "thread-a",
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          hasPreviousPage: false,
+          supportsPagination: true,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+      startReview,
+      startTurn: vi.fn(),
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: { type: "baseBranch", branch: "main" },
+      },
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-a",
+      limit: 1,
+    });
+    expect(startReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-a",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")
+    ).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -20,6 +20,7 @@ const TERMINAL_TURN_METHODS = new Set([
   "turn/failed",
   "turn/cancelled",
 ]);
+const BACKGROUND_QUEUE_RELEASE_INTERVAL_MS = 30_000;
 
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
@@ -70,8 +71,54 @@ function readNotificationThreadId(event: AgentEvent): string | undefined {
     : undefined;
 }
 
+function isIdleStatusNotification(event: AgentEvent): boolean {
+  if (event.notification.method !== "thread/status/changed") {
+    return false;
+  }
+
+  const status = event.notification.params.status;
+  return (
+    typeof status === "object" &&
+    status !== null &&
+    "type" in status &&
+    status.type === "idle"
+  );
+}
+
 function getThreadScopeKey(thread: Pick<NavigationThreadSummary, "id" | "source">): string {
   return `thread:${thread.source}:${thread.id}`;
+}
+
+function isThreadSelected(
+  current: { selectedThread?: NavigationThreadSummary },
+  thread: Pick<NavigationThreadSummary, "id" | "source">,
+): boolean {
+  return (
+    current.selectedThread?.source === thread.source &&
+    current.selectedThread.id === thread.id
+  );
+}
+
+function isRetainedBranchDrift(
+  thread: NavigationThreadSummary,
+  expectedBranch?: string,
+  observedBranch?: string,
+): boolean {
+  // Match ThreadView / registry retention semantics: the first named
+  // branch after detached HEAD is always a fresh context decision.
+  if (expectedBranch === "HEAD") {
+    return false;
+  }
+
+  if (!expectedBranch || !observedBranch) {
+    return false;
+  }
+
+  return (thread.retainedBranchDriftPairs ?? []).some(
+    (pair) =>
+      pair.expectedBranch === expectedBranch &&
+      pair.observedBranch === observedBranch,
+  );
 }
 
 export function useQueuedTurnRelease(params: {
@@ -85,142 +132,209 @@ export function useQueuedTurnRelease(params: {
   const inFlightScopeKeysRef = useRef(new Set<string>());
   paramsRef.current = params;
 
-  useEffect(() => {
-    const desktopApi = params.desktopApi;
-    const startTurn = desktopApi?.startTurn;
-    const startReview = desktopApi?.startReview;
-    if (!desktopApi?.onAgentEvent || (!startTurn && !startReview)) {
+  const releaseQueuedTurnForThread = async (
+    thread: NavigationThreadSummary,
+    options: { verifyIdle: boolean },
+  ): Promise<void> => {
+    const current = paramsRef.current;
+    const scopeKey = getThreadScopeKey(thread);
+    if (inFlightScopeKeysRef.current.has(scopeKey)) {
       return;
     }
 
-    const releaseQueuedTurn = async (
-      current: typeof params,
-      thread: NavigationThreadSummary,
-      queuedTurn: ComposerQueuedTurnSnapshot,
-      scopeKey: string,
-    ): Promise<void> => {
-      inFlightScopeKeysRef.current.add(scopeKey);
-      try {
-        let releaseState = current;
-        let releaseThread = thread;
-        let releaseQueuedSnapshot = queuedTurn;
+    const queuedTurn = current.composerDraftStore.getQueuedTurn(scopeKey);
+    if (!queuedTurn || isThreadSelected(current, thread)) {
+      return;
+    }
+    const queuedTurnId = queuedTurn.id;
 
-        if (thread.gitBranch && current.desktopApi?.checkThreadBranchDrift) {
-          const drift = await current.desktopApi.checkThreadBranchDrift({
-            backend: thread.source,
-            expectedBranch: thread.gitBranch,
-            threadId: thread.id,
-          });
-          if (drift.drifted) {
-            return;
-          }
+    const readReleaseCandidate = (candidateThread: NavigationThreadSummary) => {
+      const releaseState = paramsRef.current;
+      if (isThreadSelected(releaseState, candidateThread)) {
+        return undefined;
+      }
+
+      const releaseQueuedSnapshot =
+        releaseState.composerDraftStore.getQueuedTurn(scopeKey);
+      if (!releaseQueuedSnapshot || releaseQueuedSnapshot.id !== queuedTurnId) {
+        return undefined;
+      }
+
+      const releaseThread = releaseState.threads.find(
+        (candidate) =>
+          candidate.source === candidateThread.source &&
+          candidate.id === candidateThread.id,
+      );
+      if (!releaseThread) {
+        return undefined;
+      }
+
+      const backend = releaseState.backends.find(
+        (candidate) => candidate.kind === releaseThread.source,
+      );
+      if (!backend?.available) {
+        return undefined;
+      }
+
+      return {
+        backend,
+        desktopApi: releaseState.desktopApi,
+        releaseQueuedSnapshot,
+        releaseState,
+        releaseThread,
+      };
+    };
+
+    let releaseCandidate = readReleaseCandidate(thread);
+    if (!releaseCandidate) {
+      return;
+    }
+
+    inFlightScopeKeysRef.current.add(scopeKey);
+    try {
+      if (options.verifyIdle) {
+        const readThread = paramsRef.current.desktopApi?.readThread;
+        if (!readThread) {
+          return;
         }
 
-        releaseState = paramsRef.current;
+        const response = await readThread({
+          backend: thread.source,
+          threadId: thread.id,
+          limit: 1,
+        });
+        if (response.threadStatus !== "idle") {
+          return;
+        }
+      }
+
+      releaseCandidate = readReleaseCandidate(thread);
+      if (!releaseCandidate) {
+        return;
+      }
+
+      if (
+        releaseCandidate.releaseThread.gitBranch &&
+        releaseCandidate.desktopApi?.checkThreadBranchDrift
+      ) {
+        const drift = await releaseCandidate.desktopApi.checkThreadBranchDrift({
+          backend: releaseCandidate.releaseThread.source,
+          expectedBranch: releaseCandidate.releaseThread.gitBranch,
+          threadId: releaseCandidate.releaseThread.id,
+        });
         if (
-          releaseState.selectedThread?.source === thread.source &&
-          releaseState.selectedThread.id === thread.id
+          drift.drifted &&
+          !isRetainedBranchDrift(
+            releaseCandidate.releaseThread,
+            drift.expectedBranch,
+            drift.observedBranch,
+          )
         ) {
           return;
         }
+      }
 
-        const latestQueuedTurn = releaseState.composerDraftStore.getQueuedTurn(scopeKey);
-        if (!latestQueuedTurn || latestQueuedTurn.id !== queuedTurn.id) {
-          return;
-        }
-        releaseQueuedSnapshot = latestQueuedTurn;
+      releaseCandidate = readReleaseCandidate(thread);
+      if (!releaseCandidate) {
+        return;
+      }
 
-        const latestThread = releaseState.threads.find(
-          (candidate) =>
-            candidate.source === thread.source && candidate.id === thread.id,
-        );
-        if (!latestThread) {
-          return;
-        }
-        releaseThread = latestThread;
+      const {
+        backend,
+        desktopApi,
+        releaseQueuedSnapshot,
+        releaseState,
+        releaseThread,
+      } = releaseCandidate;
 
-        const backend = releaseState.backends.find(
-          (candidate) => candidate.kind === releaseThread.source,
-        );
-        if (!backend?.available) {
-          return;
-        }
-
-        if (releaseQueuedSnapshot.reviewCommand) {
-          const startReview = releaseState.desktopApi?.startReview;
-          if (!startReview || !backend.capabilities.startReview) {
-            return;
-          }
-
-          await startReview({
-            backend: releaseThread.source,
-            threadId: releaseThread.id,
-            target: releaseQueuedSnapshot.reviewCommand.target,
-            delivery: "inline",
-          });
-          releaseState.composerDraftStore.removeQueuedTurnById(
-            scopeKey,
-            releaseQueuedSnapshot.id,
-          );
+      if (releaseQueuedSnapshot.reviewCommand) {
+        const startReview = desktopApi?.startReview;
+        if (!startReview || !backend.capabilities.startReview) {
           return;
         }
 
-        const input = buildQueuedTurnInput(releaseQueuedSnapshot);
-        if (input.length === 0) {
-          releaseState.composerDraftStore.removeQueuedTurnById(
-            scopeKey,
-            releaseQueuedSnapshot.id,
-          );
-          return;
-        }
-
-        if (!startTurn || !backend.capabilities.startTurn) {
-          return;
-        }
-
-        const selectedModelOption =
-          backend.launchpadOptions?.models?.find(
-            (option) => option.id === releaseThread.model,
-          ) ??
-          getDefaultModelOption(backend);
-        const supportsReasoning =
-          selectedModelOption?.supportsReasoning ??
-          Boolean(backend.launchpadOptions?.reasoningEfforts?.length);
-        const supportsFast =
-          backend.kind === "codex"
-            ? selectedModelOption?.supportsFast ??
-              backend.launchpadOptions?.supportsFastMode ??
-              false
-            : false;
-
-        await startTurn({
+        await startReview({
           backend: releaseThread.source,
           threadId: releaseThread.id,
-          input,
-          executionMode: releaseThread.executionMode,
-          model: selectedModelOption?.id,
-          reasoningEffort: supportsReasoning
-            ? getReasoningEffortValue(backend, releaseThread.reasoningEffort)
-            : undefined,
-          serviceTier:
-            releaseThread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
-          fastMode:
-            releaseThread.source === "codex" && supportsFast
-              ? Boolean(releaseThread.fastMode)
-              : undefined,
+          target: releaseQueuedSnapshot.reviewCommand.target,
+          delivery: "inline",
         });
         releaseState.composerDraftStore.removeQueuedTurnById(
           scopeKey,
           releaseQueuedSnapshot.id,
         );
-      } finally {
-        inFlightScopeKeysRef.current.delete(scopeKey);
+        return;
       }
-    };
+
+      const input = buildQueuedTurnInput(releaseQueuedSnapshot);
+      if (input.length === 0) {
+        releaseState.composerDraftStore.removeQueuedTurnById(
+          scopeKey,
+          releaseQueuedSnapshot.id,
+        );
+        return;
+      }
+
+      const startTurn = desktopApi?.startTurn;
+      if (!startTurn || !backend.capabilities.startTurn) {
+        return;
+      }
+
+      const selectedModelOption =
+        backend.launchpadOptions?.models?.find(
+          (option) => option.id === releaseThread.model,
+        ) ??
+        getDefaultModelOption(backend);
+      const supportsReasoning =
+        selectedModelOption?.supportsReasoning ??
+        Boolean(backend.launchpadOptions?.reasoningEfforts?.length);
+      const supportsFast =
+        backend.kind === "codex"
+          ? selectedModelOption?.supportsFast ??
+            backend.launchpadOptions?.supportsFastMode ??
+            false
+          : false;
+
+      await startTurn({
+        backend: releaseThread.source,
+        threadId: releaseThread.id,
+        input,
+        executionMode: releaseThread.executionMode,
+        model: selectedModelOption?.id,
+        reasoningEffort: supportsReasoning
+          ? getReasoningEffortValue(backend, releaseThread.reasoningEffort)
+          : undefined,
+        serviceTier:
+          releaseThread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
+        fastMode:
+          releaseThread.source === "codex" && supportsFast
+            ? Boolean(releaseThread.fastMode)
+            : undefined,
+      });
+      releaseState.composerDraftStore.removeQueuedTurnById(
+        scopeKey,
+        releaseQueuedSnapshot.id,
+      );
+    } catch {
+      // Keep the queued entry. The next terminal/idle notification or
+      // periodic idle probe will retry without losing the user's request.
+    } finally {
+      inFlightScopeKeysRef.current.delete(scopeKey);
+    }
+  };
+
+  useEffect(() => {
+    const desktopApi = params.desktopApi;
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
 
     return desktopApi.onAgentEvent((event) => {
       const current = paramsRef.current;
-      if (!TERMINAL_TURN_METHODS.has(event.notification.method)) {
+      if (
+        !TERMINAL_TURN_METHODS.has(event.notification.method) &&
+        !isIdleStatusNotification(event)
+      ) {
         return;
       }
 
@@ -244,19 +358,27 @@ export function useQueuedTurnRelease(params: {
         return;
       }
 
-      const scopeKey = getThreadScopeKey(thread);
-      if (inFlightScopeKeysRef.current.has(scopeKey)) {
-        return;
-      }
-
-      const queuedTurn = current.composerDraftStore.getQueuedTurn(scopeKey);
-      if (!queuedTurn) {
-        return;
-      }
-
-      void releaseQueuedTurn(current, thread, queuedTurn, scopeKey).catch(() => {
-        inFlightScopeKeysRef.current.delete(scopeKey);
-      });
+      void releaseQueuedTurnForThread(thread, { verifyIdle: false });
     });
   }, [params.desktopApi]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      const current = paramsRef.current;
+      for (const thread of current.threads) {
+        if (
+          current.selectedThread?.source === thread.source &&
+          current.selectedThread.id === thread.id
+        ) {
+          continue;
+        }
+
+        void releaseQueuedTurnForThread(thread, { verifyIdle: true });
+      }
+    }, BACKGROUND_QUEUE_RELEASE_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
 }


### PR DESCRIPTION
## Summary

- Fix queued `/review` requests so they can be released by the global queued-turn release path instead of waiting for the thread composer to be focused.
- Add an idle recovery probe that checks `readThread(limit: 1)` before draining queued work, so stale "Thinking" UI state can recover without repeatedly calling start APIs while a turn is still active.
- Preserve the branch-drift guard for background release: clean or retained non-HEAD drift can proceed, unresolved drift leaves the queued item in place, and stale retained `HEAD -> branch` pairs still block as a fresh context decision.
- Re-check selected-thread ownership and the queued item id after async idle/drift probes so the background releaser does not steal work from a composer that became focused mid-check.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

## Notes

- Rebased on `origin/main`.
- Commit is signed: `05842d62 fix(desktop): release queued reviews after idle`.
