### PR TITLE
feat(messaging): add Full Access controls

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -30,6 +30,9 @@ describe("DesktopSettingsService", () => {
         'chat_reply_composer = "tiptap-chips"',
         "",
         "[messaging]",
+        "allow_full_access_thread_resume = false",
+        "allow_full_access_escalation = false",
+        'full_access_warning = "always"',
         "input_debounce_ms = 750",
         'tool_update_mode = "show_more"',
         "",
@@ -80,6 +83,18 @@ describe("DesktopSettingsService", () => {
     });
     expect(snapshot.messaging.inputDebounceMs).toEqual({
       value: 750,
+      source: "config",
+    });
+    expect(snapshot.messaging.allowFullAccessThreadResume).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(snapshot.messaging.allowFullAccessEscalation).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(snapshot.messaging.fullAccessWarning).toEqual({
+      value: "always",
       source: "config",
     });
     expect(snapshot.messaging.telegram.enabled).toEqual({
@@ -183,6 +198,8 @@ describe("DesktopSettingsService", () => {
         "[[messaging.telegram.authorized_users]]",
         'id = "111111111"',
         'display_name = "Harold"',
+        'full_access_warning = "always"',
+        "full_access_warning_dismissed = true",
         "",
         "[[messaging.telegram.authorized_supergroups]]",
         'id = "-1003841603622"',
@@ -200,7 +217,12 @@ describe("DesktopSettingsService", () => {
     const snapshot = await service.readSettings();
 
     expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
-      { id: "111111111", displayName: "Harold" },
+      {
+        id: "111111111",
+        displayName: "Harold",
+        fullAccessWarningOverride: "always",
+        fullAccessWarningDismissed: true,
+      },
     ]);
     expect(snapshot.messaging.telegram.authorizedSupergroups.value).toEqual([
       { id: "-1003841603622", displayName: "PwrAgent ops" },

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -61,6 +61,7 @@ describe("desktop messaging config", () => {
       "discord",
       "enabled",
       "feishu",
+      "fullAccessControls",
       "inputDebounceMs",
       "line",
       "mattermost",
@@ -225,6 +226,12 @@ describe("desktop messaging config", () => {
 
     expect(config).toEqual({
       enabled: true,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {},
+      },
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
       telegram: {
@@ -449,6 +456,20 @@ describe("desktop messaging config", () => {
         maxAttachmentBytes: 10485760,
         maxAttachmentCount: 4,
       },
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "111111111", displayName: "" }],
+          discord: [{ id: "222222222", displayName: "" }],
+          mattermost: [],
+          slack: [],
+          feishu: [],
+          line: [],
+        },
+        dismissWarning: expect.any(Function),
+      },
       telegram: {
         channel: "telegram",
         enabled: true,
@@ -545,6 +566,46 @@ describe("desktop messaging config", () => {
     expect(messagingLog.error).not.toHaveBeenCalledWith(
       expect.stringContaining("no authorized user IDs configured"),
       expect.anything(),
+    );
+  });
+
+  it("persists messaging Full Access warning dismissal for one authorized user", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "",
+        "[[messaging.telegram.authorized_users]]",
+        'id = "111111111"',
+        'display_name = "Harold"',
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const config = await loadDesktopMessagingConfigFromSettings(service, {});
+    await config.fullAccessControls?.dismissWarning?.({
+      actorId: "111111111",
+      channel: "telegram",
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
+      {
+        id: "111111111",
+        displayName: "Harold",
+        fullAccessWarningDismissed: true,
+      },
+    ]);
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "full_access_warning_dismissed = true",
     );
   });
 
@@ -674,6 +735,12 @@ describe("desktop messaging config", () => {
 
   it("redacts bot tokens while preserving useful diagnostics", () => {
     const redacted = redactDesktopMessagingConfig({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {},
+      },
       telegram: {
         channel: "telegram",
         botToken: "secret-token",
@@ -695,6 +762,11 @@ describe("desktop messaging config", () => {
     expect(JSON.stringify(redacted)).not.toContain("secret");
     expect(redacted).toEqual({
       enabled: true,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+      },
       telegram: {
         channel: "telegram",
         enabled: true,

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -469,6 +469,7 @@ describe("desktop messaging config", () => {
           line: [],
         },
         dismissWarning: expect.any(Function),
+        canDismissWarning: expect.any(Function),
       },
       telegram: {
         channel: "telegram",
@@ -606,6 +607,94 @@ describe("desktop messaging config", () => {
     ]);
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "full_access_warning_dismissed = true",
+    );
+  });
+
+  it("refuses to insert an authorized user while dismissing a Full Access warning", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[messaging.telegram]",
+        "enabled = true",
+        "",
+        "[[messaging.telegram.authorized_users]]",
+        'id = "111111111"',
+        'display_name = "Harold"',
+      ].join("\n"),
+      "utf8",
+    );
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const config = await loadDesktopMessagingConfigFromSettings(service, {});
+    expect(
+      await config.fullAccessControls?.canDismissWarning?.({
+        actorId: "222222222",
+        channel: "telegram",
+      }),
+    ).toBe(false);
+    await config.fullAccessControls?.dismissWarning?.({
+      actorId: "222222222",
+      channel: "telegram",
+    });
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.messaging.telegram.authorizedUserIds.value).toEqual([
+      {
+        id: "111111111",
+        displayName: "Harold",
+      },
+    ]);
+    expect(fs.readFileSync(configPath, "utf8")).not.toContain("222222222");
+    expect(messagingLog.error).toHaveBeenCalledWith(
+      "refusing to insert authorized user while dismissing Full Access warning",
+      {
+        actorId: "222222222",
+        channel: "telegram",
+        insertNewUser: false,
+      },
+    );
+  });
+
+  it("does not offer persistent Full Access warning dismissal for env-sourced contacts", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(configPath, "[messaging.telegram]\nenabled = true\n", "utf8");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {
+        [TELEGRAM_AUTHORIZED_USER_IDS_ENV]: "111111111",
+      },
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const config = await loadDesktopMessagingConfigFromSettings(service, {});
+    expect(
+      await config.fullAccessControls?.canDismissWarning?.({
+        actorId: "111111111",
+        channel: "telegram",
+      }),
+    ).toBe(false);
+    await config.fullAccessControls?.dismissWarning?.({
+      actorId: "111111111",
+      channel: "telegram",
+    });
+
+    expect(fs.readFileSync(configPath, "utf8")).not.toContain(
+      "full_access_warning_dismissed",
+    );
+    expect(messagingLog.error).toHaveBeenCalledWith(
+      "refusing to dismiss Full Access warning for non-config authorized user",
+      {
+        actorId: "111111111",
+        channel: "telegram",
+        source: "env",
+      },
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5721,6 +5721,82 @@ describe("MessagingController", () => {
     });
   });
 
+  it("omits the dismiss action when Full Access warning dismissal cannot persist", async () => {
+    const dismissWarning = vi.fn(async () => undefined);
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+        dismissWarning,
+        canDismissWarning: async () => false,
+      },
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    const warning = harness.delivered.at(-1);
+    expect(warning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+    expect(warning && "actions" in warning ? warning.actions : []).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "full-access-risk:dismiss" }),
+      ]),
+    );
+  });
+
+  it("rechecks escalation settings before honoring stale Full Access warning callbacks", async () => {
+    const onFullAccessPolicyViolation = vi.fn();
+    let allowEscalation = true;
+    const harness = await createHarness({
+      fullAccessControls: async () => ({
+        allowEscalation,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      }),
+      onFullAccessPolicyViolation,
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+    const warning = harness.delivered.at(-1);
+    allowEscalation = false;
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
+    expect(onFullAccessPolicyViolation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "user-1",
+        requestedAction: "messaging.full_access.escalate_thread",
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+      body: expect.stringContaining("Escalating to Full Access"),
+    });
+  });
+
   it("restores the status surface after accepting a Full Access warning", async () => {
     const harness = await createHarness({
       fullAccessControls: {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -753,7 +753,7 @@ describe("MessagingController", () => {
   });
 
   it("debounces split first prompts before creating a messaging-started thread", async () => {
-    const harness = await createHarness({ inputDebounceMs: 10 });
+    const harness = await createHarness({ inputDebounceMs: 100 });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
     await harness.controller.handleInboundEvent(
@@ -772,7 +772,7 @@ describe("MessagingController", () => {
     expect(harness.startThread).not.toHaveBeenCalled();
     expect(harness.materializeDirectoryLaunchpad).not.toHaveBeenCalled();
 
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setTimeout(resolve, 125));
 
     await vi.waitFor(() => {
       expect(harness.startThread).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5757,6 +5757,68 @@ describe("MessagingController", () => {
     });
   });
 
+  it("shows the new-thread Full Access warning on the existing picker surface", async () => {
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    const readyIntent = harness.delivered.at(-1);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
+    );
+
+    const warning = harness.delivered.at(-1);
+    expect(warning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+      targetSurface: {
+        id: `surface:${readyIntent?.id}`,
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Permissions: Full"),
+      delivery: expect.objectContaining({
+        mode: "update",
+      }),
+      targetSurface: {
+        id: `surface:${readyIntent?.id}`,
+      },
+    });
+  });
+
   it("posts a permissions-queue audit message with a Cancel button on thread/executionMode/queued", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -92,6 +92,61 @@ describe("MessagingController", () => {
       });
   });
 
+  it("filters Full Access threads out of messaging resume when disabled", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads = [
+      {
+        ...navigation.threads[0]!,
+        executionMode: "full-access",
+      },
+      {
+        id: "thread-2",
+        title: "Default thread",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [
+          {
+            id: "directory:pwragent",
+            kind: "local",
+            label: "PwrAgent",
+            path: "/repo/pwragent",
+          },
+        ],
+        inbox: {
+          inInbox: false,
+        },
+        executionMode: "default",
+        updatedAt: 900,
+      },
+    ];
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      threadKeys: ["codex:thread-1", "codex:thread-2"],
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: false,
+        warningPolicy: "dismissable",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "thread_picker",
+      page: {
+        items: [
+          expect.objectContaining({
+            id: "thread-2",
+          }),
+        ],
+      },
+    });
+    expect(JSON.stringify(harness.delivered[0])).not.toContain("thread-1");
+  });
+
   it("shows projects from /resume --projects and filters threads after a project click", async () => {
     const harness = await createHarness();
 
@@ -5571,6 +5626,137 @@ describe("MessagingController", () => {
     );
   });
 
+  it("blocks messaging Full Access escalation when the setting disallows it", async () => {
+    const onFullAccessPolicyViolation = vi.fn();
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: false,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+      },
+      onFullAccessPolicyViolation,
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
+    expect(onFullAccessPolicyViolation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "user-1",
+        backend: "codex",
+        bindingId: expect.any(String),
+        requestedAction: "messaging.full_access.escalate_thread",
+        threadId: "thread-1",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+      body: expect.stringContaining("Escalating to Full Access"),
+    });
+  });
+
+  it("requires a messaging risk acknowledgment before Full Access escalation", async () => {
+    const dismissWarning = vi.fn(async () => undefined);
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+        dismissWarning,
+      },
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
+    const warning = harness.delivered.at(-1);
+    expect(warning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+      body: expect.stringContaining("data can be exfiltrated"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "full-access-risk:accept", label: "Yes" }),
+        expect.objectContaining({
+          id: "full-access-risk:dismiss",
+          label: "Yes - and stop warning me",
+        }),
+        expect.objectContaining({ id: "full-access-risk:cancel", label: "Cancel" }),
+      ]),
+    });
+    const dismiss = findAction(warning, "full-access-risk:dismiss");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:dismiss",
+        value: dismiss.value,
+      }),
+    );
+
+    expect(dismissWarning).toHaveBeenCalledWith({
+      actorId: "user-1",
+      channel: "telegram",
+    });
+    expect(harness.setThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+  });
+
+  it("applies Full Access to a resumed Default Access thread after risk acknowledgment", async () => {
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --yolo"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
+    const warning = harness.delivered.at(-1);
+    expect(warning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.setThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+  });
+
   it("posts a permissions-queue audit message with a Cancel button on thread/executionMode/queued", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -6508,6 +6694,8 @@ async function createHarness(options?: {
   now?: () => number;
   channel?: MessagingChannelKind;
   capabilityProfile?: MessagingCapabilityProfile;
+  fullAccessControls?: MessagingControllerOptions["fullAccessControls"];
+  onFullAccessPolicyViolation?: MessagingControllerOptions["onFullAccessPolicyViolation"];
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
   materializeDirectoryLaunchpad?: NonNullable<
@@ -6786,7 +6974,13 @@ async function createHarness(options?: {
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),
+    fullAccessControls: options?.fullAccessControls ?? {
+      allowEscalation: true,
+      allowThreadResume: true,
+      warningPolicy: "never",
+    },
     onDeliveryBudgetEvent: options?.onDeliveryBudgetEvent,
+    onFullAccessPolicyViolation: options?.onFullAccessPolicyViolation,
     // Pass the spy by default so tests can assert on fan-out. The
     // `bindingChangedListener: false` opt-out exists for tests that
     // verify the nullish-callback guard — production wiring always

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5673,6 +5673,9 @@ describe("MessagingController", () => {
       },
     });
     await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
@@ -5684,6 +5687,11 @@ describe("MessagingController", () => {
       kind: "confirmation",
       title: "Enable Full Access?",
       body: expect.stringContaining("data can be exfiltrated"),
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+      targetSurface: binding?.statusSurface,
       actions: expect.arrayContaining([
         expect.objectContaining({ id: "full-access-risk:accept", label: "Yes" }),
         expect.objectContaining({
@@ -5710,6 +5718,93 @@ describe("MessagingController", () => {
       backend: "codex",
       threadId: "thread-1",
       executionMode: "full-access",
+    });
+  });
+
+  it("restores the status surface after accepting a Full Access warning", async () => {
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+    await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    const warning = harness.delivered.at(-1);
+    expect(warning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+      targetSurface: binding?.statusSurface,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      delivery: expect.objectContaining({
+        mode: "update",
+      }),
+      targetSurface: binding?.statusSurface,
+      text: expect.stringContaining("Permissions: Full Access"),
+    });
+  });
+
+  it("restores the status surface after cancelling a Full Access warning", async () => {
+    const harness = await createHarness({
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+    await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    const warning = harness.delivered.at(-1);
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:cancel",
+        value: findAction(warning, "full-access-risk:cancel").value,
+      }),
+    );
+
+    expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      delivery: expect.objectContaining({
+        mode: "update",
+      }),
+      targetSurface: binding?.statusSurface,
+      text: expect.stringContaining("Permissions: Default"),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1214,10 +1214,10 @@ describe("DesktopMessagingRuntime", () => {
         }),
       ]);
     } finally {
-      await runtime.stop();
       vi.useRealTimers();
+      await runtime.stop();
     }
-  });
+  }, 30_000);
 
   it("detaches adapter runtime-error listeners on stop so a graceful shutdown does not flip to errored", async () => {
     await prepareRuntimeStore();

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -395,6 +395,27 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Permissions: Full Access");
   });
 
+  it("hides the Full Access escalation action when messaging escalation is disabled", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.executionMode = "default";
+
+    const intent = buildBindingStatusIntent({
+      id: "status-no-escalation",
+      allowFullAccessEscalation: false,
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Permissions: Default Access");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({
+        id: "status:permissions",
+      }),
+    );
+  });
+
   it("adds the status handoff action when a handoff context is available", () => {
     const binding = buildBinding();
     const navigation = buildNavigationSnapshot();

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6,6 +6,8 @@ import type {
   AppServerBackendKind,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
+  DesktopAuthorizedContact,
+  DesktopMessagingFullAccessWarningGlobalPolicy,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
@@ -278,6 +280,66 @@ type MessagingToolUpdateDefaultModeResolver =
   | MessagingToolUpdateMode
   | (() => MessagingToolUpdateMode | Promise<MessagingToolUpdateMode>);
 
+type MessagingFullAccessControls = {
+  allowEscalation: boolean;
+  allowThreadResume: boolean;
+  warningPolicy: DesktopMessagingFullAccessWarningGlobalPolicy;
+  authorizedUsers?: Partial<Record<MessagingChannelKind, DesktopAuthorizedContact[]>>;
+  dismissWarning?: (params: {
+    actorId: string;
+    channel: MessagingChannelKind;
+  }) => Promise<void>;
+};
+
+type MessagingFullAccessControlsResolverFn = () =>
+  | MessagingFullAccessControls
+  | undefined
+  | Promise<MessagingFullAccessControls | undefined>;
+
+type MessagingFullAccessControlsResolver =
+  | MessagingFullAccessControls
+  | MessagingFullAccessControlsResolverFn;
+
+type FullAccessEscalationContext =
+  | {
+      backend: AppServerBackendKind;
+      binding?: MessagingBindingRecord;
+      kind: "thread";
+      threadId: ThreadIdentifier;
+    }
+  | {
+      kind: "new-thread";
+      session: MessagingBrowseSessionRecord;
+    }
+  | {
+      backend: AppServerBackendKind;
+      kind: "resume-thread";
+      session: MessagingBrowseSessionRecord;
+      threadId: ThreadIdentifier;
+    };
+
+type FullAccessRiskWarningContext =
+  | {
+      bindingId: string;
+      kind: "thread";
+      threadId: ThreadIdentifier;
+    }
+  | {
+      kind: "new-thread";
+      sessionId: string;
+    }
+  | {
+      backend: AppServerBackendKind;
+      kind: "resume-thread";
+      sessionId: string;
+      threadId: ThreadIdentifier;
+    };
+
+type FullAccessWarningResolution = {
+  canDismiss: boolean;
+  shouldWarn: boolean;
+};
+
 export type MessagingControllerDeliveryBudgetEvent = {
   at: number;
   backend?: AppServerBackendKind;
@@ -319,6 +381,7 @@ type PendingQueueAuditMessage = {
 };
 
 const PERMISSIONS_QUEUE_CANCEL_ACTION_PREFIX = "permissions:queue:cancel:";
+const FULL_ACCESS_RISK_ACTION_PREFIX = "full-access-risk:";
 
 type PendingNewThreadPromptWindow = {
   events: MessagingTurnInputEvent[];
@@ -345,8 +408,18 @@ export type MessagingControllerOptions = {
   store: MessagingStoreLike;
   streamingResponsesDefault?: boolean;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
+  fullAccessControls?: MessagingFullAccessControlsResolver;
   deliveryBudget?: MessagingDeliveryBudget;
   onDeliveryBudgetEvent?: (event: MessagingControllerDeliveryBudgetEvent) => void;
+  onFullAccessPolicyViolation?: (event: {
+    actorId: string;
+    actorDisplayName?: string;
+    backend?: AppServerBackendKind;
+    bindingId?: string;
+    channel: MessagingChannelRef;
+    requestedAction: string;
+    threadId?: ThreadIdentifier;
+  }) => void | Promise<void>;
   /**
    * Notification hook invoked after any binding mutation the
    * controller performs (create, conversation-metadata refresh,
@@ -1339,6 +1412,17 @@ export class MessagingController {
         params.binding,
         navigation,
       );
+      if (
+        turnSettings.executionMode === "full-access" &&
+        !(await this.canUseFullAccessThread(params.binding, navigation))
+      ) {
+        await this.deliverFullAccessPolicyError(
+          params.binding,
+          params.event,
+          "Full Access threads cannot be resumed from messaging with the current settings.",
+        );
+        return false;
+      }
       // Diagnostic for #203-class regressions: a turn that the UI shows
       // as Default Access but routes to the Full Access codex client is
       // a silent security bug — the user thinks they're sandboxed but
@@ -1688,6 +1772,12 @@ export class MessagingController {
       return;
     }
 
+    const fullAccessRiskAction = readFullAccessRiskAction(event);
+    if (fullAccessRiskAction) {
+      await this.handleFullAccessRiskCallback(event, fullAccessRiskAction);
+      return;
+    }
+
     const statusAction = readStatusAction(event);
     if (statusAction) {
       await this.handleStatusCallback(event, statusAction);
@@ -1702,6 +1792,25 @@ export class MessagingController {
 
     const bindingTarget = readBindingTarget(event);
     if (bindingTarget) {
+      const navigation = await this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+      const targetThread = navigation.threads.find(
+        (thread) =>
+          thread.source === bindingTarget.backend &&
+          thread.id === bindingTarget.threadId,
+      );
+      if (
+        targetThread?.executionMode === "full-access" &&
+        !(await this.canResumeFullAccessThreads())
+      ) {
+        await this.deliverFullAccessPolicyError(
+          undefined,
+          event,
+          "Full Access threads cannot be resumed from messaging with the current settings.",
+        );
+        return;
+      }
       const binding = await this.bindChannelToThread(event, bindingTarget);
       await this.deliver(
         buildConfirmationIntent({
@@ -2757,6 +2866,15 @@ export class MessagingController {
         nextSession.preferences?.executionMode ??
         navigation.launchpadDefaults.executionMode;
       const executionMode = currentMode === "full-access" ? "default" : "full-access";
+      if (executionMode === "full-access") {
+        const allowed = await this.ensureFullAccessEscalationAllowed(
+          { kind: "new-thread", session: nextSession },
+          event,
+        );
+        if (!allowed) {
+          return;
+        }
+      }
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -2873,10 +2991,49 @@ export class MessagingController {
         await this.deliverInvalidBrowseSelection(event);
         return;
       }
+      const targetThread = navigation.threads.find(
+        (thread) => thread.source === target.backend && thread.id === target.threadId,
+      );
+      if (
+        targetThread?.executionMode === "full-access" &&
+        !(await this.canResumeFullAccessThreads())
+      ) {
+        await this.deliverFullAccessPolicyError(
+          undefined,
+          event,
+          "Full Access threads cannot be resumed from messaging with the current settings.",
+        );
+        return;
+      }
+      const requestedExecutionMode = session.preferences?.executionMode;
+      const shouldEscalateTarget =
+        requestedExecutionMode === "full-access" &&
+        targetThread?.executionMode !== "full-access";
+      if (shouldEscalateTarget) {
+        const allowed = await this.ensureFullAccessEscalationAllowed(
+          {
+            backend: target.backend,
+            kind: "resume-thread",
+            session,
+            threadId: target.threadId,
+          },
+          event,
+        );
+        if (!allowed) {
+          return;
+        }
+      }
       const binding = await this.bindChannelToThread(event, target);
       const updatedBinding = session.preferences
         ? await this.updateBindingPreferences(binding, session.preferences)
         : binding;
+      if (shouldEscalateTarget) {
+        await this.options.backend.setThreadExecutionMode?.({
+          backend: target.backend,
+          threadId: target.threadId,
+          executionMode: "full-access",
+        });
+      }
       await this.options.store.deleteBrowseSession(session.id);
       await this.deliver(
         buildConfirmationIntent({
@@ -2972,10 +3129,11 @@ export class MessagingController {
     event: MessagingInboundEvent,
   ): Promise<void> {
     await this.options.store.upsertBrowseSession(session);
+    const browseNavigation = await this.navigationForResumeBrowser(session, navigation);
     const intent = buildResumeIntent({
       id: this.newIntentId("resume"),
       createdAt: this.now(),
-      navigation,
+      navigation: browseNavigation,
       session,
     });
     await this.storePendingIntent(intent, undefined, event);
@@ -3064,6 +3222,7 @@ export class MessagingController {
       this.streamingResponsesDefault,
     );
     const canCreateWorktree = canCreateNewThreadWorktree(directory);
+    const fullAccessControls = await this.resolveFullAccessControls();
     await this.options.store.upsertBrowseSession(session);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -3111,12 +3270,17 @@ export class MessagingController {
               },
             ]
           : []),
-        {
-          id: "browse:new:permissions",
-          label: `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
-          style: "secondary",
-          fallbackText: "permissions",
-        },
+        ...(options.executionMode === "full-access" ||
+        fullAccessControls.allowEscalation
+          ? [
+              {
+                id: "browse:new:permissions",
+                label: `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
+                style: "secondary" as const,
+                fallbackText: "permissions",
+              },
+            ]
+          : []),
         {
           id: "browse:new:fast",
           label: options.fastMode ? "Fast: on" : "Fast: off",
@@ -3414,6 +3578,16 @@ export class MessagingController {
       directory,
       this.streamingResponsesDefault,
     );
+    if (
+      options.executionMode === "full-access" &&
+      !(await this.isFullAccessRiskAcceptedForSession(bundle.session, event))
+    ) {
+      await this.presentFullAccessRiskWarning(
+        { kind: "new-thread", session: bundle.session },
+        event,
+      );
+      return;
+    }
     const materialized = this.options.backend.materializeDirectoryLaunchpad
       ? await this.options.backend.materializeDirectoryLaunchpad({
           directoryKey: messagingLaunchpadMaterializationKey(bundle.session),
@@ -3480,6 +3654,37 @@ export class MessagingController {
       event,
       navigation: optimisticNavigation,
     });
+  }
+
+  private async navigationForResumeBrowser(
+    session: MessagingBrowseSessionRecord,
+    navigation: NavigationSnapshot,
+  ): Promise<NavigationSnapshot> {
+    if (session.launchAction !== "resume_thread") {
+      return navigation;
+    }
+    if (await this.canResumeFullAccessThreads()) {
+      return navigation;
+    }
+    const threads = navigation.threads.filter(
+      (thread) => thread.executionMode !== "full-access",
+    );
+    const allowedThreadKeys = new Set(
+      threads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+    );
+    return {
+      ...navigation,
+      threads,
+      directories: navigation.directories.map((directory) => ({
+        ...directory,
+        threadKeys: directory.threadKeys.filter((threadKey) =>
+          allowedThreadKeys.has(threadKey)
+        ),
+      })),
+      inboxThreadKeys: navigation.inboxThreadKeys.filter((threadKey) =>
+        allowedThreadKeys.has(threadKey)
+      ),
+    };
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -4681,6 +4886,20 @@ export class MessagingController {
       "default";
     const nextMode = currentMode === "full-access" ? "default" : "full-access";
     const executionMode = nextMode;
+    if (executionMode === "full-access") {
+      const allowed = await this.ensureFullAccessEscalationAllowed(
+        {
+          backend: binding.backend,
+          binding,
+          kind: "thread",
+          threadId: binding.threadId,
+        },
+        event,
+      );
+      if (!allowed) {
+        return;
+      }
+    }
     // Update local binding prefs first so the bus-path render — which
     // fetches the binding fresh from the store — sees the new values
     // even if navigation snapshot hasn't reloaded yet. The registry
@@ -4701,6 +4920,355 @@ export class MessagingController {
     });
     // Refresh handled by the thread-state update bus on
     // thread/executionMode/updated — see refreshStatusSurfacesForThread.
+  }
+
+  private async ensureFullAccessEscalationAllowed(
+    context: FullAccessEscalationContext,
+    event: MessagingInboundEvent,
+  ): Promise<boolean> {
+    const controls = await this.resolveFullAccessControls();
+    if (!controls.allowEscalation) {
+      await this.recordFullAccessPolicyViolation(context, event);
+      await this.deliverFullAccessPolicyError(
+        context.kind === "thread" ? context.binding : undefined,
+        event,
+        "Escalating to Full Access from messaging is disabled in Settings.",
+      );
+      return false;
+    }
+
+    const warning = this.resolveFullAccessWarning(controls, event);
+    if (!warning.shouldWarn) {
+      return true;
+    }
+
+    await this.presentFullAccessRiskWarning(context, event);
+    return false;
+  }
+
+  private async presentFullAccessRiskWarning(
+    context: FullAccessEscalationContext,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const controls = await this.resolveFullAccessControls();
+    const warning = this.resolveFullAccessWarning(controls, event);
+    const actionContext: FullAccessRiskWarningContext =
+      context.kind === "thread"
+        ? {
+            kind: "thread",
+            bindingId: context.binding?.id ?? "",
+            threadId: context.threadId,
+          }
+        : context.kind === "new-thread"
+          ? {
+            kind: "new-thread",
+            sessionId: context.session.id,
+          }
+          : {
+              backend: context.backend,
+              kind: "resume-thread",
+              sessionId: context.session.id,
+              threadId: context.threadId,
+            };
+    const actions: MessagingConfirmationIntent["actions"] = [
+      {
+        id: `${FULL_ACCESS_RISK_ACTION_PREFIX}accept`,
+        label: "Yes",
+        style: "primary",
+        fallbackText: "yes",
+        value: actionContext,
+      },
+      ...(warning.canDismiss
+        ? [
+            {
+              id: `${FULL_ACCESS_RISK_ACTION_PREFIX}dismiss`,
+              label: "Yes - and stop warning me",
+              style: "primary" as const,
+              fallbackText: "yes and stop warning me",
+              value: actionContext,
+            },
+          ]
+        : []),
+      {
+        id: `${FULL_ACCESS_RISK_ACTION_PREFIX}cancel`,
+        label: "Cancel",
+        style: "secondary",
+        fallbackText: "cancel",
+        value: actionContext,
+      },
+    ];
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("full-access-risk"),
+      capabilityProfile: this.capabilityProfile,
+      createdAt: this.now(),
+      title: "Enable Full Access?",
+      body: [
+        "Full Access allows network access and read/write access to almost all files on this machine.",
+        "That means data can be exfiltrated unintentionally, or by malicious code the agent downloads and executes through a supply chain attack on npm, PyPI, Rust crates, Go modules, or a similar dependency source.",
+      ].join("\n\n"),
+      fallbackText: warning.canDismiss
+        ? "Reply Yes, Yes - and stop warning me, or Cancel."
+        : "Reply Yes or Cancel.",
+      actions,
+    });
+    await this.storePendingIntent(
+      intent,
+      context.kind === "thread" ? context.binding : undefined,
+      event,
+    );
+    await this.deliver(
+      intent,
+      context.kind === "thread" ? context.binding : undefined,
+      event,
+    );
+  }
+
+  private async handleFullAccessRiskCallback(
+    event: MessagingInboundCallbackEvent,
+    action: "accept" | "dismiss" | "cancel",
+  ): Promise<void> {
+    const context = readFullAccessRiskContext(event.value);
+    if (!context) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    if (action === "cancel") {
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("full-access-risk-cancelled"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          title: "Full Access cancelled",
+          body: "No Full Access change was made.",
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    if (action === "dismiss") {
+      const controls = await this.resolveFullAccessControls();
+      const warning = this.resolveFullAccessWarning(controls, event);
+      if (warning.canDismiss) {
+        await controls.dismissWarning?.({
+          actorId: event.actor.platformUserId,
+          channel: event.channel.channel,
+        });
+      }
+    }
+
+    if (context.kind === "new-thread") {
+      const session = await this.options.store.getBrowseSession(context.sessionId, {
+        now: this.now(),
+      });
+      if (!session) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      await this.presentNewThreadPromptGate(
+        {
+          ...session,
+          fullAccessRiskAcceptedAt: this.now(),
+          preferences: {
+            ...session.preferences,
+            executionMode: "full-access",
+            permissionsMode: "full-access",
+            updatedAt: this.now(),
+          },
+        },
+        event,
+      );
+      return;
+    }
+
+    if (context.kind === "resume-thread") {
+      const session = await this.options.store.getBrowseSession(context.sessionId, {
+        now: this.now(),
+      });
+      if (!session) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      const target = {
+        backend: context.backend,
+        threadId: context.threadId,
+      };
+      const binding = await this.bindChannelToThread(event, target);
+      const preferences = {
+        ...session.preferences,
+        executionMode: "full-access" as const,
+        permissionsMode: "full-access" as const,
+        updatedAt: this.now(),
+      };
+      const updatedBinding = await this.updateBindingPreferences(binding, preferences);
+      await this.options.backend.setThreadExecutionMode?.({
+        backend: context.backend,
+        threadId: context.threadId,
+        executionMode: "full-access",
+      });
+      await this.options.store.deleteBrowseSession(session.id);
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("bound"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          delivery: session.surface
+            ? {
+                mode: "update",
+                replaceMarkup: true,
+              }
+            : undefined,
+          title: "Thread bound",
+          body: "Messages in this conversation will route to the selected thread.",
+          fallbackText: "Send a message to continue the thread.",
+          targetSurface: session.surface,
+        }),
+        undefined,
+        event,
+      );
+      await this.renderBindingStatus(updatedBinding, event);
+      return;
+    }
+
+    const binding = await this.options.store.getBinding(context.bindingId);
+    if (!binding) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    await this.updateBindingPreferences(binding, {
+      executionMode: "full-access",
+      permissionsMode: "full-access",
+    });
+    await this.options.backend.setThreadExecutionMode?.({
+      backend: binding.backend,
+      threadId: context.threadId,
+      executionMode: "full-access",
+    });
+  }
+
+  private async canResumeFullAccessThreads(): Promise<boolean> {
+    return (await this.resolveFullAccessControls()).allowThreadResume;
+  }
+
+  private async canUseFullAccessThread(
+    binding: MessagingBindingRecord,
+    navigation: NavigationSnapshot,
+  ): Promise<boolean> {
+    const thread = findThreadForBinding(navigation, binding);
+    if (thread?.executionMode !== "full-access") {
+      return true;
+    }
+    return await this.canResumeFullAccessThreads();
+  }
+
+  private async isFullAccessRiskAcceptedForSession(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+  ): Promise<boolean> {
+    if (session.fullAccessRiskAcceptedAt) {
+      return true;
+    }
+    const controls = await this.resolveFullAccessControls();
+    if (!controls.allowEscalation) {
+      await this.recordFullAccessPolicyViolation(
+        { kind: "new-thread", session },
+        event,
+      );
+      await this.deliverFullAccessPolicyError(
+        undefined,
+        event,
+        "Starting a Full Access thread from messaging is disabled in Settings.",
+      );
+      return false;
+    }
+    const warning = this.resolveFullAccessWarning(controls, event);
+    return !warning.shouldWarn;
+  }
+
+  private async resolveFullAccessControls(): Promise<MessagingFullAccessControls> {
+    const controls = this.options.fullAccessControls;
+    const resolved =
+      typeof controls === "function" ? await controls() : controls;
+    return {
+      allowEscalation: resolved?.allowEscalation ?? true,
+      allowThreadResume: resolved?.allowThreadResume ?? true,
+      warningPolicy: resolved?.warningPolicy ?? "dismissable",
+      authorizedUsers: resolved?.authorizedUsers ?? {},
+      dismissWarning: resolved?.dismissWarning,
+    };
+  }
+
+  private resolveFullAccessWarning(
+    controls: MessagingFullAccessControls,
+    event: MessagingInboundEvent,
+  ): FullAccessWarningResolution {
+    const contact = controls.authorizedUsers?.[event.channel.channel]?.find(
+      (candidate) => candidate.id === event.actor.platformUserId,
+    );
+    const policy = contact?.fullAccessWarningOverride ?? "default";
+    const effectivePolicy =
+      policy === "default" ? controls.warningPolicy : policy;
+    if (effectivePolicy === "never") {
+      return { canDismiss: false, shouldWarn: false };
+    }
+    if (effectivePolicy === "always") {
+      return { canDismiss: false, shouldWarn: true };
+    }
+    return {
+      canDismiss: Boolean(controls.dismissWarning),
+      shouldWarn: contact?.fullAccessWarningDismissed !== true,
+    };
+  }
+
+  private async deliverFullAccessPolicyError(
+    binding: MessagingBindingRecord | undefined,
+    event: MessagingInboundEvent | undefined,
+    body: string,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("full-access-policy"),
+        createdAt: this.now(),
+        title: "Full Access blocked",
+        body,
+        recoverable: true,
+      }),
+      binding,
+      event,
+    );
+  }
+
+  private async recordFullAccessPolicyViolation(
+    context: FullAccessEscalationContext,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    try {
+      await this.options.onFullAccessPolicyViolation?.({
+        actorId: event.actor.platformUserId,
+        actorDisplayName: event.actor.displayName,
+        backend:
+          context.kind === "thread" || context.kind === "resume-thread"
+            ? context.backend
+            : undefined,
+        bindingId: context.kind === "thread" ? context.binding?.id : undefined,
+        channel: event.channel,
+        requestedAction:
+          context.kind === "thread"
+            ? "messaging.full_access.escalate_thread"
+            : context.kind === "resume-thread"
+              ? "messaging.full_access.resume_with_escalation"
+              : "messaging.full_access.start_new_thread",
+        threadId:
+          context.kind === "thread" || context.kind === "resume-thread"
+            ? context.threadId
+            : undefined,
+      });
+    } catch (error) {
+      this.logger.debug?.("messaging full-access policy log failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**
@@ -5218,6 +5786,8 @@ export class MessagingController {
     );
     const intent = buildBindingStatusIntent({
       id: this.newIntentId("status"),
+      allowFullAccessEscalation: (await this.resolveFullAccessControls())
+        .allowEscalation,
       binding,
       capabilityProfile: this.capabilityProfile,
       createdAt: this.now(),
@@ -6718,6 +7288,58 @@ function readPermissionsQueueCancelAction(
     return undefined;
   }
   return { queueId };
+}
+
+function readFullAccessRiskAction(
+  event: MessagingInboundCallbackEvent,
+): "accept" | "dismiss" | "cancel" | undefined {
+  const actionId = event.actionId ?? event.interaction.id;
+  if (!actionId.startsWith(FULL_ACCESS_RISK_ACTION_PREFIX)) {
+    return undefined;
+  }
+  const action = actionId.slice(FULL_ACCESS_RISK_ACTION_PREFIX.length);
+  return action === "accept" || action === "dismiss" || action === "cancel"
+    ? action
+    : undefined;
+}
+
+function readFullAccessRiskContext(
+  value: MessagingJsonValue | undefined,
+): FullAccessRiskWarningContext | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  if (value.kind === "new-thread" && typeof value.sessionId === "string") {
+    return {
+      kind: "new-thread",
+      sessionId: value.sessionId,
+    };
+  }
+  if (
+    value.kind === "resume-thread" &&
+    (value.backend === "codex" || value.backend === "grok") &&
+    typeof value.sessionId === "string" &&
+    typeof value.threadId === "string"
+  ) {
+    return {
+      backend: value.backend,
+      kind: "resume-thread",
+      sessionId: value.sessionId,
+      threadId: value.threadId,
+    };
+  }
+  if (
+    value.kind === "thread" &&
+    typeof value.bindingId === "string" &&
+    typeof value.threadId === "string"
+  ) {
+    return {
+      bindingId: value.bindingId,
+      kind: "thread",
+      threadId: value.threadId,
+    };
+  }
+  return undefined;
 }
 
 function readQueuedTurnAction(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -289,6 +289,10 @@ type MessagingFullAccessControls = {
     actorId: string;
     channel: MessagingChannelKind;
   }) => Promise<void>;
+  canDismissWarning?: (params: {
+    actorId: string;
+    channel: MessagingChannelKind;
+  }) => boolean | Promise<boolean>;
 };
 
 type MessagingFullAccessControlsResolverFn = () =>
@@ -1426,7 +1430,7 @@ export class MessagingController {
           params.event,
           "Full Access threads cannot be resumed from messaging with the current settings.",
         );
-        return false;
+        return "failed";
       }
       // Diagnostic for #203-class regressions: a turn that the UI shows
       // as Default Access but routes to the Full Access codex client is
@@ -4942,7 +4946,7 @@ export class MessagingController {
       return false;
     }
 
-    const warning = this.resolveFullAccessWarning(controls, event);
+    const warning = await this.resolveFullAccessWarning(controls, event);
     if (!warning.shouldWarn) {
       return true;
     }
@@ -4956,7 +4960,7 @@ export class MessagingController {
     event: MessagingInboundEvent,
   ): Promise<void> {
     const controls = await this.resolveFullAccessControls();
-    const warning = this.resolveFullAccessWarning(controls, event);
+    const warning = await this.resolveFullAccessWarning(controls, event);
     const actionContext: FullAccessRiskWarningContext =
       context.kind === "thread"
         ? {
@@ -5086,9 +5090,18 @@ export class MessagingController {
       return;
     }
 
+    const escalationContext =
+      await this.resolveFullAccessRiskCallbackContext(context, event);
+    if (!escalationContext) {
+      return;
+    }
+    if (!(await this.ensureFullAccessRiskCallbackAllowed(escalationContext, event))) {
+      return;
+    }
+
     if (action === "dismiss") {
       const controls = await this.resolveFullAccessControls();
-      const warning = this.resolveFullAccessWarning(controls, event);
+      const warning = await this.resolveFullAccessWarning(controls, event);
       if (warning.canDismiss) {
         await controls.dismissWarning?.({
           actorId: event.actor.platformUserId,
@@ -5097,14 +5110,8 @@ export class MessagingController {
       }
     }
 
-    if (context.kind === "new-thread") {
-      const session = await this.options.store.getBrowseSession(context.sessionId, {
-        now: this.now(),
-      });
-      if (!session) {
-        await this.deliverInvalidBrowseSelection(event);
-        return;
-      }
+    if (escalationContext.kind === "new-thread") {
+      const { session } = escalationContext;
       await this.presentNewThreadPromptGate(
         {
           ...session,
@@ -5121,17 +5128,11 @@ export class MessagingController {
       return;
     }
 
-    if (context.kind === "resume-thread") {
-      const session = await this.options.store.getBrowseSession(context.sessionId, {
-        now: this.now(),
-      });
-      if (!session) {
-        await this.deliverInvalidBrowseSelection(event);
-        return;
-      }
+    if (escalationContext.kind === "resume-thread") {
+      const { session } = escalationContext;
       const target = {
-        backend: context.backend,
-        threadId: context.threadId,
+        backend: escalationContext.backend,
+        threadId: escalationContext.threadId,
       };
       const binding = await this.bindChannelToThread(event, target);
       const preferences = {
@@ -5142,8 +5143,8 @@ export class MessagingController {
       };
       const updatedBinding = await this.updateBindingPreferences(binding, preferences);
       await this.options.backend.setThreadExecutionMode?.({
-        backend: context.backend,
-        threadId: context.threadId,
+        backend: escalationContext.backend,
+        threadId: escalationContext.threadId,
         executionMode: "full-access",
       });
       await this.options.store.deleteBrowseSession(session.id);
@@ -5170,7 +5171,7 @@ export class MessagingController {
       return;
     }
 
-    const binding = await this.options.store.getBinding(context.bindingId);
+    const { binding } = escalationContext;
     if (!binding) {
       await this.deliverInvalidStatusSelection(event);
       return;
@@ -5181,9 +5182,70 @@ export class MessagingController {
     });
     await this.options.backend.setThreadExecutionMode?.({
       backend: binding.backend,
-      threadId: context.threadId,
+      threadId: escalationContext.threadId,
       executionMode: "full-access",
     });
+  }
+
+  private async resolveFullAccessRiskCallbackContext(
+    context: FullAccessRiskWarningContext,
+    event: MessagingInboundEvent,
+  ): Promise<FullAccessEscalationContext | undefined> {
+    if (context.kind === "new-thread") {
+      const session = await this.options.store.getBrowseSession(context.sessionId, {
+        now: this.now(),
+      });
+      if (!session) {
+        await this.deliverInvalidBrowseSelection(event);
+        return undefined;
+      }
+      return { kind: "new-thread", session };
+    }
+
+    if (context.kind === "resume-thread") {
+      const session = await this.options.store.getBrowseSession(context.sessionId, {
+        now: this.now(),
+      });
+      if (!session) {
+        await this.deliverInvalidBrowseSelection(event);
+        return undefined;
+      }
+      return {
+        backend: context.backend,
+        kind: "resume-thread",
+        session,
+        threadId: context.threadId,
+      };
+    }
+
+    const binding = await this.options.store.getBinding(context.bindingId);
+    if (!binding) {
+      await this.deliverInvalidStatusSelection(event);
+      return undefined;
+    }
+    return {
+      backend: binding.backend,
+      binding,
+      kind: "thread",
+      threadId: context.threadId,
+    };
+  }
+
+  private async ensureFullAccessRiskCallbackAllowed(
+    context: FullAccessEscalationContext,
+    event: MessagingInboundEvent,
+  ): Promise<boolean> {
+    const controls = await this.resolveFullAccessControls();
+    if (!controls.allowEscalation) {
+      await this.recordFullAccessPolicyViolation(context, event);
+      await this.deliverFullAccessPolicyError(
+        context.kind === "thread" ? context.binding : undefined,
+        event,
+        "Escalating to Full Access from messaging is disabled in Settings.",
+      );
+      return false;
+    }
+    return true;
   }
 
   private async canResumeFullAccessThreads(): Promise<boolean> {
@@ -5221,7 +5283,7 @@ export class MessagingController {
       );
       return false;
     }
-    const warning = this.resolveFullAccessWarning(controls, event);
+    const warning = await this.resolveFullAccessWarning(controls, event);
     return !warning.shouldWarn;
   }
 
@@ -5235,13 +5297,14 @@ export class MessagingController {
       warningPolicy: resolved?.warningPolicy ?? "dismissable",
       authorizedUsers: resolved?.authorizedUsers ?? {},
       dismissWarning: resolved?.dismissWarning,
+      canDismissWarning: resolved?.canDismissWarning,
     };
   }
 
-  private resolveFullAccessWarning(
+  private async resolveFullAccessWarning(
     controls: MessagingFullAccessControls,
     event: MessagingInboundEvent,
-  ): FullAccessWarningResolution {
+  ): Promise<FullAccessWarningResolution> {
     const contact = controls.authorizedUsers?.[event.channel.channel]?.find(
       (candidate) => candidate.id === event.actor.platformUserId,
     );
@@ -5254,8 +5317,15 @@ export class MessagingController {
     if (effectivePolicy === "always") {
       return { canDismiss: false, shouldWarn: true };
     }
+    const canPersistDismissal =
+      controls.canDismissWarning
+        ? await controls.canDismissWarning({
+            actorId: event.actor.platformUserId,
+            channel: event.channel.channel,
+          })
+        : Boolean(controls.dismissWarning);
     return {
-      canDismiss: Boolean(controls.dismissWarning),
+      canDismiss: Boolean(controls.dismissWarning) && canPersistDismissal,
       shouldWarn: contact?.fullAccessWarningDismissed !== true,
     };
   }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -5063,6 +5063,15 @@ export class MessagingController {
         }
         return;
       }
+      const binding = await this.options.store.getBinding(context.bindingId);
+      if (!binding) {
+        await this.deliverInvalidStatusSelection(event);
+        return;
+      }
+      if (binding.statusSurface || binding.pinnedStatusSurface) {
+        await this.renderBindingStatus(binding, event);
+        return;
+      }
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("full-access-risk-cancelled"),
@@ -7376,7 +7385,10 @@ function fullAccessRiskPresentationForContext(
   context: FullAccessEscalationContext,
 ): FullAccessRiskPresentation {
   if (context.kind === "thread") {
-    return { binding: context.binding };
+    return {
+      binding: context.binding,
+      surface: context.binding?.statusSurface ?? context.binding?.pinnedStatusSurface,
+    };
   }
   return { surface: context.session.surface };
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -335,6 +335,11 @@ type FullAccessRiskWarningContext =
       threadId: ThreadIdentifier;
     };
 
+type FullAccessRiskPresentation = {
+  binding?: MessagingBindingRecord;
+  surface?: MessagingSurfaceRef;
+};
+
 type FullAccessWarningResolution = {
   canDismiss: boolean;
   shouldWarn: boolean;
@@ -3232,8 +3237,8 @@ export class MessagingController {
       delivery: session.surface
         ? {
             mode: "update",
-          replaceMarkup: true,
-        }
+            replaceMarkup: true,
+          }
         : undefined,
       title: "Ready to start",
       body: newThreadPromptGateBody(session, options),
@@ -4970,6 +4975,7 @@ export class MessagingController {
               sessionId: context.session.id,
               threadId: context.threadId,
             };
+    const presentation = fullAccessRiskPresentationForContext(context);
     const actions: MessagingConfirmationIntent["actions"] = [
       {
         id: `${FULL_ACCESS_RISK_ACTION_PREFIX}accept`,
@@ -5001,6 +5007,12 @@ export class MessagingController {
       id: this.newIntentId("full-access-risk"),
       capabilityProfile: this.capabilityProfile,
       createdAt: this.now(),
+      delivery: presentation.surface
+        ? {
+            mode: "update",
+            replaceMarkup: true,
+          }
+        : undefined,
       title: "Enable Full Access?",
       body: [
         "Full Access allows network access and read/write access to almost all files on this machine.",
@@ -5010,17 +5022,16 @@ export class MessagingController {
         ? "Reply Yes, Yes - and stop warning me, or Cancel."
         : "Reply Yes or Cancel.",
       actions,
+      targetSurface: presentation.surface,
     });
-    await this.storePendingIntent(
-      intent,
-      context.kind === "thread" ? context.binding : undefined,
-      event,
-    );
-    await this.deliver(
-      intent,
-      context.kind === "thread" ? context.binding : undefined,
-      event,
-    );
+    const pending = await this.storePendingIntent(intent, presentation.binding, event);
+    const result = await this.deliver(intent, presentation.binding, event);
+    if (result.surface) {
+      await this.options.store.upsertPendingIntent({
+        ...pending,
+        surface: result.surface,
+      });
+    }
   }
 
   private async handleFullAccessRiskCallback(
@@ -5033,6 +5044,25 @@ export class MessagingController {
       return;
     }
     if (action === "cancel") {
+      if (context.kind === "new-thread" || context.kind === "resume-thread") {
+        const session = await this.options.store.getBrowseSession(context.sessionId, {
+          now: this.now(),
+        });
+        if (!session) {
+          await this.deliverInvalidBrowseSelection(event);
+          return;
+        }
+        const navigation = await this.options.backend.getNavigationSnapshot({
+          backend: "all",
+          filter: session.query,
+        });
+        if (context.kind === "new-thread") {
+          await this.presentNewThreadPromptGate(session, event, navigation);
+        } else {
+          await this.renderResumeBrowser(session, navigation, event);
+        }
+        return;
+      }
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("full-access-risk-cancelled"),
@@ -7340,6 +7370,15 @@ function readFullAccessRiskContext(
     };
   }
   return undefined;
+}
+
+function fullAccessRiskPresentationForContext(
+  context: FullAccessEscalationContext,
+): FullAccessRiskPresentation {
+  if (context.kind === "thread") {
+    return { binding: context.binding };
+  }
+  return { surface: context.session.surface };
 }
 
 function readQueuedTurnAction(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -46,6 +46,7 @@ export const BRANCH_PICKER_PAGE_SIZE = 8;
 export const HANDOFF_BRANCH_PAGE_SIZE = BRANCH_PICKER_PAGE_SIZE;
 
 export function buildBindingStatusIntent(params: {
+  allowFullAccessEscalation?: boolean;
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
@@ -135,6 +136,7 @@ export function buildBindingStatusIntent(params: {
       .join("\n"),
     actions: buildStatusActions({
       capabilityProfile: params.capabilityProfile,
+      allowFullAccessEscalation: params.allowFullAccessEscalation,
       fastMode,
       handoff: params.handoff,
       permissionsMode,
@@ -162,6 +164,7 @@ function mentionRequiredLine(
 }
 
 function buildStatusActions(params: {
+  allowFullAccessEscalation?: boolean;
   capabilityProfile?: MessagingCapabilityProfile;
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
@@ -177,6 +180,21 @@ function buildStatusActions(params: {
     return [];
   }
 
+  const permissionsAction:
+    | MessagingSurfaceAction
+    | undefined =
+    params.permissionsMode === "full-access" || params.allowFullAccessEscalation !== false
+      ? {
+          id: "status:permissions",
+          label: formatPermissionsActionLabel(
+            params.permissionsMode,
+            params.queuedExecutionMode,
+          ),
+          style: "secondary",
+          fallbackText: "permissions",
+          priority: 7,
+        }
+      : undefined;
   const allActions: MessagingSurfaceAction[] = [
     {
       id: "status:model",
@@ -199,16 +217,7 @@ function buildStatusActions(params: {
       fallbackText: "fast",
       priority: 6,
     },
-    {
-      id: "status:permissions",
-      label: formatPermissionsActionLabel(
-        params.permissionsMode,
-        params.queuedExecutionMode,
-      ),
-      style: "secondary",
-      fallbackText: "permissions",
-      priority: 7,
-    },
+    ...(permissionsAction ? [permissionsAction] : []),
     ...(params.handoff
       ? [
           {

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -4,7 +4,12 @@ import type { LineMessagingConfig } from "@pwragent/messaging-provider-line";
 import type { MattermostMessagingConfig } from "@pwragent/messaging-provider-mattermost";
 import type { SlackMessagingConfig } from "@pwragent/messaging-provider-slack";
 import type { TelegramMessagingConfig } from "@pwragent/messaging-provider-telegram";
-import type { MessagingToolUpdateMode } from "@pwragent/shared";
+import type {
+  DesktopAuthorizedContact,
+  DesktopMessagingFullAccessWarningGlobalPolicy,
+  MessagingToolUpdateMode,
+  MessagingChannelKind,
+} from "@pwragent/shared";
 import type {
   MessagingAdapterAuthorizationUpdate,
   MessagingAdapterRenderingPreferencesUpdate,
@@ -154,12 +159,24 @@ export type DesktopMessagingConfig = {
   discord?: DiscordMessagingConfig;
   enabled?: boolean;
   feishu?: FeishuMessagingConfig;
+  fullAccessControls?: DesktopMessagingFullAccessControls;
   inputDebounceMs?: number;
   line?: LineMessagingConfig;
   mattermost?: MattermostMessagingConfig;
   slack?: SlackMessagingConfig;
   telegram?: TelegramMessagingConfig;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
+};
+
+export type DesktopMessagingFullAccessControls = {
+  allowEscalation: boolean;
+  allowThreadResume: boolean;
+  warningPolicy: DesktopMessagingFullAccessWarningGlobalPolicy;
+  authorizedUsers: Partial<Record<MessagingChannelKind, DesktopAuthorizedContact[]>>;
+  dismissWarning?: (params: {
+    actorId: string;
+    channel: MessagingChannelKind;
+  }) => Promise<void>;
 };
 
 export type DesktopMessagingConfigFieldImpact =
@@ -173,6 +190,7 @@ export const DESKTOP_MESSAGING_ROOT_CONFIG_FIELD_IMPACTS = {
   discord: "connection",
   enabled: "connection",
   feishu: "connection",
+  fullAccessControls: "irrelevant",
   inputDebounceMs: "connection",
   line: "connection",
   mattermost: "connection",
@@ -298,6 +316,7 @@ export type DesktopMessagingChannelConfigUpdate =
 export type DesktopMessagingSettingsSource = Pick<
   DesktopSettingsService,
   | "readSettings"
+  | "writeConfigPatch"
   | "resolveDiscordBotTokenSync"
   | "resolveTelegramBotTokenSync"
   | "resolveMattermostBotTokenSync"
@@ -501,6 +520,12 @@ export function loadDesktopMessagingConfig(
 
   return {
     enabled: true,
+    fullAccessControls: {
+      allowEscalation: true,
+      allowThreadResume: true,
+      warningPolicy: "dismissable",
+      authorizedUsers: {},
+    },
     inputDebounceMs: readInputDebounceMsFromEnv(env) ?? 500,
     toolUpdateDefaultMode: "show_some",
     ...(attachmentPolicy ? { attachmentPolicy } : {}),
@@ -1038,6 +1063,22 @@ export async function loadDesktopMessagingConfigFromSettings(
 
   return {
     enabled: messagingEnabled,
+    fullAccessControls: {
+      allowEscalation: snapshot.messaging.allowFullAccessEscalation.value,
+      allowThreadResume: snapshot.messaging.allowFullAccessThreadResume.value,
+      warningPolicy: snapshot.messaging.fullAccessWarning.value,
+      authorizedUsers: {
+        telegram: snapshot.messaging.telegram.authorizedUserIds.value,
+        discord: snapshot.messaging.discord.authorizedUserIds.value,
+        mattermost: snapshot.messaging.mattermost.authorizedUserIds.value,
+        slack: snapshot.messaging.slack.authorizedUserIds.value,
+        feishu: snapshot.messaging.feishu.authorizedUserIds.value,
+        line: snapshot.messaging.line.authorizedUserIds.value,
+      },
+      dismissWarning: async ({ actorId, channel }) => {
+        await dismissMessagingFullAccessWarning(settings, channel, actorId);
+      },
+    },
     inputDebounceMs: snapshot.messaging.inputDebounceMs.value,
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
     attachmentPolicy,
@@ -1120,6 +1161,13 @@ export function redactDesktopMessagingConfig(
         }
       : undefined,
     enabled: config.enabled !== false,
+    fullAccessControls: config.fullAccessControls
+      ? {
+          allowEscalation: config.fullAccessControls.allowEscalation,
+          allowThreadResume: config.fullAccessControls.allowThreadResume,
+          warningPolicy: config.fullAccessControls.warningPolicy,
+        }
+      : undefined,
     toolUpdateDefaultMode: config.toolUpdateDefaultMode ?? "show_some",
     inputDebounceMs: config.inputDebounceMs ?? 500,
     discord: config.discord
@@ -1209,6 +1257,80 @@ export function redactDesktopMessagingConfig(
       : undefined,
     attachmentPolicy: config.attachmentPolicy,
   };
+}
+
+async function dismissMessagingFullAccessWarning(
+  settings: DesktopMessagingSettingsSource,
+  channel: MessagingChannelKind,
+  actorId: string,
+): Promise<void> {
+  const snapshot = await settings.readSettings();
+  const contacts = contactsForFullAccessWarningChannel(snapshot, channel);
+  const nextContacts = contacts.map((contact) =>
+    contact.id === actorId
+      ? { ...contact, fullAccessWarningDismissed: true }
+      : contact,
+  );
+  if (!nextContacts.some((contact) => contact.id === actorId)) {
+    return;
+  }
+
+  switch (channel) {
+    case "telegram":
+      await settings.writeConfigPatch({
+        messaging: { telegram: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    case "discord":
+      await settings.writeConfigPatch({
+        messaging: { discord: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    case "mattermost":
+      await settings.writeConfigPatch({
+        messaging: { mattermost: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    case "slack":
+      await settings.writeConfigPatch({
+        messaging: { slack: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    case "feishu":
+      await settings.writeConfigPatch({
+        messaging: { feishu: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    case "line":
+      await settings.writeConfigPatch({
+        messaging: { line: { authorizedUserIds: nextContacts } },
+      });
+      return;
+    default:
+      return;
+  }
+}
+
+function contactsForFullAccessWarningChannel(
+  snapshot: Awaited<ReturnType<DesktopMessagingSettingsSource["readSettings"]>>,
+  channel: MessagingChannelKind,
+): DesktopAuthorizedContact[] {
+  switch (channel) {
+    case "telegram":
+      return snapshot.messaging.telegram.authorizedUserIds.value;
+    case "discord":
+      return snapshot.messaging.discord.authorizedUserIds.value;
+    case "mattermost":
+      return snapshot.messaging.mattermost.authorizedUserIds.value;
+    case "slack":
+      return snapshot.messaging.slack.authorizedUserIds.value;
+    case "feishu":
+      return snapshot.messaging.feishu.authorizedUserIds.value;
+    case "line":
+      return snapshot.messaging.line.authorizedUserIds.value;
+    default:
+      return [];
+  }
 }
 
 function readInputDebounceMsFromEnv(env: NodeJS.ProcessEnv): number | undefined {

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -7,6 +7,8 @@ import type { TelegramMessagingConfig } from "@pwragent/messaging-provider-teleg
 import type {
   DesktopAuthorizedContact,
   DesktopMessagingFullAccessWarningGlobalPolicy,
+  DesktopSettingsSnapshot,
+  DesktopSettingsValue,
   MessagingToolUpdateMode,
   MessagingChannelKind,
 } from "@pwragent/shared";
@@ -177,6 +179,10 @@ export type DesktopMessagingFullAccessControls = {
     actorId: string;
     channel: MessagingChannelKind;
   }) => Promise<void>;
+  canDismissWarning?: (params: {
+    actorId: string;
+    channel: MessagingChannelKind;
+  }) => boolean | Promise<boolean>;
 };
 
 export type DesktopMessagingConfigFieldImpact =
@@ -1078,6 +1084,8 @@ export async function loadDesktopMessagingConfigFromSettings(
       dismissWarning: async ({ actorId, channel }) => {
         await dismissMessagingFullAccessWarning(settings, channel, actorId);
       },
+      canDismissWarning: async ({ actorId, channel }) =>
+        await canPersistMessagingFullAccessWarningDismissal(settings, channel, actorId),
     },
     inputDebounceMs: snapshot.messaging.inputDebounceMs.value,
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
@@ -1265,13 +1273,28 @@ async function dismissMessagingFullAccessWarning(
   actorId: string,
 ): Promise<void> {
   const snapshot = await settings.readSettings();
-  const contacts = contactsForFullAccessWarningChannel(snapshot, channel);
+  const field = contactsForFullAccessWarningChannel(snapshot, channel);
+  const contacts = field.value;
+  const log = getMainLogger("pwragent:messaging");
+  if (field.source !== "config") {
+    log.error("refusing to dismiss Full Access warning for non-config authorized user", {
+      actorId,
+      channel,
+      source: field.source,
+    });
+    return;
+  }
   const nextContacts = contacts.map((contact) =>
     contact.id === actorId
       ? { ...contact, fullAccessWarningDismissed: true }
       : contact,
   );
   if (!nextContacts.some((contact) => contact.id === actorId)) {
+    log.error("refusing to insert authorized user while dismissing Full Access warning", {
+      actorId,
+      channel,
+      insertNewUser: false,
+    });
     return;
   }
 
@@ -1311,25 +1334,36 @@ async function dismissMessagingFullAccessWarning(
   }
 }
 
-function contactsForFullAccessWarningChannel(
-  snapshot: Awaited<ReturnType<DesktopMessagingSettingsSource["readSettings"]>>,
+async function canPersistMessagingFullAccessWarningDismissal(
+  settings: DesktopMessagingSettingsSource,
   channel: MessagingChannelKind,
-): DesktopAuthorizedContact[] {
+  actorId: string,
+): Promise<boolean> {
+  const snapshot = await settings.readSettings();
+  const field = contactsForFullAccessWarningChannel(snapshot, channel);
+  return field.source === "config"
+    && field.value.some((contact) => contact.id === actorId);
+}
+
+function contactsForFullAccessWarningChannel(
+  snapshot: DesktopSettingsSnapshot,
+  channel: MessagingChannelKind,
+): DesktopSettingsValue<DesktopAuthorizedContact[]> {
   switch (channel) {
     case "telegram":
-      return snapshot.messaging.telegram.authorizedUserIds.value;
+      return snapshot.messaging.telegram.authorizedUserIds;
     case "discord":
-      return snapshot.messaging.discord.authorizedUserIds.value;
+      return snapshot.messaging.discord.authorizedUserIds;
     case "mattermost":
-      return snapshot.messaging.mattermost.authorizedUserIds.value;
+      return snapshot.messaging.mattermost.authorizedUserIds;
     case "slack":
-      return snapshot.messaging.slack.authorizedUserIds.value;
+      return snapshot.messaging.slack.authorizedUserIds;
     case "feishu":
-      return snapshot.messaging.feishu.authorizedUserIds.value;
+      return snapshot.messaging.feishu.authorizedUserIds;
     case "line":
-      return snapshot.messaging.line.authorizedUserIds.value;
+      return snapshot.messaging.line.authorizedUserIds;
     default:
-      return [];
+      return { value: [], source: "default" };
   }
 }
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -836,8 +836,12 @@ export class DesktopMessagingRuntime {
       ),
       toolUpdateDefaultMode: async () =>
         (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
+      fullAccessControls: async () =>
+        (await this.loadConfig()).fullAccessControls,
       onBindingChanged: () => this.broadcastBindingsChanged(),
       onDeliveryBudgetEvent: (event) => this.handleDeliveryBudgetEvent(event),
+      onFullAccessPolicyViolation: (event) =>
+        this.recordFullAccessPolicyViolation(adapter.channel, event),
     });
 
     let unsubscribeDiagnostic: (() => void) | undefined;
@@ -1847,6 +1851,47 @@ export class DesktopMessagingRuntime {
           kind: event.kind,
         });
       }
+    }
+  }
+
+  private recordFullAccessPolicyViolation(
+    platform: MessagingChannelKind,
+    event: {
+      actorId: string;
+      actorDisplayName?: string;
+      backend?: MessagingBindingRecord["backend"];
+      bindingId?: string;
+      channel: MessagingInboundEvent["channel"];
+      requestedAction: string;
+      threadId?: MessagingBindingRecord["threadId"];
+    },
+  ): void {
+    try {
+      const conversation = event.channel.conversation;
+      getDesktopMessagingActivityLog().record({
+        platform,
+        kind: "inbound-rejected",
+        backend: event.backend,
+        threadId: event.threadId,
+        bindingId: event.bindingId,
+        conversationId: conversation.id,
+        conversationTitle: conversation.title,
+        actorId: event.actorId,
+        actorDisplayName: event.actorDisplayName,
+        summary: "Rejected Full Access escalation request from messaging",
+        payload: {
+          conversationKind: conversation.kind,
+          conversationParentId: conversation.parentId,
+          policyViolation: true,
+          requestedAction: event.requestedAction,
+        },
+      });
+    } catch (error) {
+      messagingLog.warn("messaging full-access policy activity write failed", {
+        actorId: event.actorId,
+        error: error instanceof Error ? error.message : String(error),
+        platform,
+      });
     }
   }
 

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import type {
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
+  DesktopMessagingFullAccessWarningGlobalPolicy,
+  DesktopMessagingFullAccessWarningUserPolicy,
   DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
   DesktopWorktreeStorageLocation,
@@ -49,6 +51,9 @@ export type DesktopSettingsConfig = {
   };
   messaging?: {
     enabled?: boolean;
+    allowFullAccessEscalation?: boolean;
+    allowFullAccessThreadResume?: boolean;
+    fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
     attachments?: {
@@ -276,6 +281,12 @@ export function desktopSettingsPatchToEdits(
       value: normalizedContacts.map((contact) => ({
         id: contact.id,
         display_name: contact.displayName,
+        ...(contact.fullAccessWarningOverride
+          ? { full_access_warning: contact.fullAccessWarningOverride }
+          : {}),
+        ...(contact.fullAccessWarningDismissed === true
+          ? { full_access_warning_dismissed: true }
+          : {}),
       })),
     });
   };
@@ -307,6 +318,21 @@ export function desktopSettingsPatchToEdits(
   }
   if (patch.messaging?.enabled !== undefined) {
     set(["messaging", "enabled"], patch.messaging.enabled);
+  }
+  if (patch.messaging?.allowFullAccessThreadResume !== undefined) {
+    set(
+      ["messaging", "allow_full_access_thread_resume"],
+      patch.messaging.allowFullAccessThreadResume,
+    );
+  }
+  if (patch.messaging?.allowFullAccessEscalation !== undefined) {
+    set(
+      ["messaging", "allow_full_access_escalation"],
+      patch.messaging.allowFullAccessEscalation,
+    );
+  }
+  if (patch.messaging?.fullAccessWarning !== undefined) {
+    set(["messaging", "full_access_warning"], patch.messaging.fullAccessWarning);
   }
   if (patch.messaging?.toolUpdateMode !== undefined) {
     set(["messaging", "tool_update_mode"], patch.messaging.toolUpdateMode);
@@ -634,6 +660,15 @@ function normalizeDesktopConfig(
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),
+      allowFullAccessEscalation: readBoolean(
+        messaging?.allow_full_access_escalation,
+      ),
+      allowFullAccessThreadResume: readBoolean(
+        messaging?.allow_full_access_thread_resume,
+      ),
+      fullAccessWarning: readFullAccessWarningGlobalPolicy(
+        messaging?.full_access_warning,
+      ),
       inputDebounceMs: readNumber(messaging?.input_debounce_ms),
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
       attachments: {
@@ -793,9 +828,15 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const line = config.messaging?.line;
   const inputDebounceMs = config.messaging?.inputDebounceMs;
   const enabled = config.messaging?.enabled;
+  const allowFullAccessEscalation = config.messaging?.allowFullAccessEscalation;
+  const allowFullAccessThreadResume = config.messaging?.allowFullAccessThreadResume;
+  const fullAccessWarning = config.messaging?.fullAccessWarning;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
   if (
     enabled !== undefined ||
+    allowFullAccessEscalation !== undefined ||
+    allowFullAccessThreadResume !== undefined ||
+    fullAccessWarning !== undefined ||
     inputDebounceMs !== undefined ||
     toolUpdateMode !== undefined ||
     (attachments && hasDefinedValue(attachments))
@@ -809,6 +850,15 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.messaging = {};
     if (enabled !== undefined) {
       pruned.messaging.enabled = enabled;
+    }
+    if (allowFullAccessEscalation !== undefined) {
+      pruned.messaging.allowFullAccessEscalation = allowFullAccessEscalation;
+    }
+    if (allowFullAccessThreadResume !== undefined) {
+      pruned.messaging.allowFullAccessThreadResume = allowFullAccessThreadResume;
+    }
+    if (fullAccessWarning !== undefined) {
+      pruned.messaging.fullAccessWarning = fullAccessWarning;
     }
     if (inputDebounceMs !== undefined) {
       pruned.messaging.inputDebounceMs = inputDebounceMs;
@@ -931,6 +981,25 @@ function readFeishuTenantRegion(
   return value === "feishu" || value === "lark" ? value : undefined;
 }
 
+function readFullAccessWarningGlobalPolicy(
+  value: TomlScalar | undefined,
+): DesktopMessagingFullAccessWarningGlobalPolicy | undefined {
+  return value === "always" || value === "dismissable" || value === "never"
+    ? value
+    : undefined;
+}
+
+function isFullAccessWarningUserPolicy(
+  value: unknown,
+): value is DesktopMessagingFullAccessWarningUserPolicy {
+  return (
+    value === "default" ||
+    value === "always" ||
+    value === "dismissable" ||
+    value === "never"
+  );
+}
+
 function readBoolean(value: TomlScalar | undefined): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
@@ -987,6 +1056,16 @@ function readAuthorizedContactArray(
           : typeof entry.displayName === "string"
             ? entry.displayName
             : "",
+      fullAccessWarningOverride: isFullAccessWarningUserPolicy(
+        entry.full_access_warning,
+      )
+        ? entry.full_access_warning
+        : isFullAccessWarningUserPolicy(entry.fullAccessWarningOverride)
+          ? entry.fullAccessWarningOverride
+          : undefined,
+      fullAccessWarningDismissed:
+        entry.full_access_warning_dismissed === true ||
+        entry.fullAccessWarningDismissed === true,
     })),
   );
 }
@@ -998,6 +1077,13 @@ function normalizeAuthorizedContacts(
     .map((contact) => ({
       id: contact.id.trim(),
       displayName: sanitizeMessagingContactLabel(contact.displayName),
+      ...(isFullAccessWarningUserPolicy(contact.fullAccessWarningOverride) &&
+      contact.fullAccessWarningOverride !== "default"
+        ? { fullAccessWarningOverride: contact.fullAccessWarningOverride }
+        : {}),
+      ...(contact.fullAccessWarningDismissed === true
+        ? { fullAccessWarningDismissed: true }
+        : {}),
     }))
     .filter((contact) => contact.id.length > 0);
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,6 +1,7 @@
 import type {
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
+  DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
   DesktopSettingsSecretName,
@@ -289,6 +290,17 @@ export class DesktopSettingsService {
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
+        allowFullAccessEscalation: this.resolveConfigBoolean(
+          config.messaging?.allowFullAccessEscalation,
+          true,
+        ),
+        allowFullAccessThreadResume: this.resolveConfigBoolean(
+          config.messaging?.allowFullAccessThreadResume,
+          true,
+        ),
+        fullAccessWarning: this.resolveConfigFullAccessWarningPolicy(
+          config.messaging?.fullAccessWarning,
+        ),
         inputDebounceMs: this.resolveClampedNumber(
           config.messaging?.inputDebounceMs,
           DEFAULT_MESSAGING_INPUT_DEBOUNCE_MS,
@@ -1039,6 +1051,15 @@ export class DesktopSettingsService {
   ): DesktopSettingsValue<MessagingToolUpdateMode> {
     return {
       value: configValue ?? "show_some",
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveConfigFullAccessWarningPolicy(
+    configValue: DesktopMessagingFullAccessWarningGlobalPolicy | undefined,
+  ): DesktopSettingsValue<DesktopMessagingFullAccessWarningGlobalPolicy> {
+    return {
+      value: configValue ?? "dismissable",
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -385,7 +385,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     }
   })();
 
-  if (!columnExists(db, "app_runtime_instances", "cwd_hash")) {
+  if (!appRuntimeInstancesColumnExists(db, "cwd_hash")) {
     db.exec("ALTER TABLE app_runtime_instances ADD COLUMN cwd_hash TEXT");
   }
   db.exec(`
@@ -394,12 +394,11 @@ CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_cwd_hash
 `);
 }
 
-function columnExists(
+function appRuntimeInstancesColumnExists(
   db: BetterSqlite3.Database,
-  tableName: string,
   columnName: string,
 ): boolean {
-  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+  const rows = db.prepare("PRAGMA table_info(app_runtime_instances)").all() as Array<{
     name: string;
   }>;
   return rows.some((row) => row.name === columnName);

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -108,6 +108,9 @@ describe("App", () => {
       },
       messaging: {
         enabled: { value: true, source: "default" },
+        allowFullAccessEscalation: { value: true, source: "default" },
+        allowFullAccessThreadResume: { value: true, source: "default" },
+        fullAccessWarning: { value: "dismissable", source: "default" },
         inputDebounceMs: { value: 500, source: "default" },
         toolUpdateMode: { value: "show_some", source: "default" },
         telegram: {

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -27,6 +27,8 @@ import {
   type IdentifierValidationResult,
   type DesktopSettingsSecretName,
   type DesktopSettingsSnapshot,
+  type DesktopMessagingFullAccessWarningGlobalPolicy,
+  type DesktopMessagingFullAccessWarningUserPolicy,
   type MessagingChannelKind,
   type MessagingPairingEntry,
   type MessagingPairingScope,
@@ -63,6 +65,11 @@ export function MessagingSettings(props: {
   onToolUpdateModeChange: (mode: MessagingToolUpdateMode) => Promise<void>;
   onInputDebounceMsChange: (value: number) => Promise<void>;
   onMessagingEnabledChange: (enabled: boolean) => Promise<void>;
+  onFullAccessEscalationChange: (enabled: boolean) => Promise<void>;
+  onFullAccessThreadResumeChange: (enabled: boolean) => Promise<void>;
+  onFullAccessWarningPolicyChange: (
+    policy: DesktopMessagingFullAccessWarningGlobalPolicy,
+  ) => Promise<void>;
   onPairingSettingsChanged?: () => Promise<void>;
   onSaveDiscord: (
     patch: NonNullable<DesktopSettingsSnapshot["messaging"]["discord"]>,
@@ -90,6 +97,11 @@ export function MessagingSettings(props: {
   const feishu = props.snapshot.messaging.feishu;
   const line = props.snapshot.messaging.line;
   const messagingEnabled = props.snapshot.messaging.enabled;
+  const allowFullAccessEscalation =
+    props.snapshot.messaging.allowFullAccessEscalation;
+  const allowFullAccessThreadResume =
+    props.snapshot.messaging.allowFullAccessThreadResume;
+  const fullAccessWarning = props.snapshot.messaging.fullAccessWarning;
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
   const runtimeMessaging = props.snapshot.runtime.messaging;
@@ -185,6 +197,37 @@ export function MessagingSettings(props: {
             value={inputDebounceMs.value}
             onSave={props.onInputDebounceMsChange}
           />
+          <ToggleField
+            checked={allowFullAccessThreadResume.value}
+            disabled={props.saving}
+            label="Resume Full Access threads"
+            sub="Allow messaging users to see and resume threads that are already in Full Access."
+            source={sourceBadge(allowFullAccessThreadResume)}
+            onChange={(enabled) => {
+              void props.onFullAccessThreadResumeChange(enabled);
+            }}
+          />
+          <ToggleField
+            checked={allowFullAccessEscalation.value}
+            disabled={props.saving}
+            label="Escalate to Full Access"
+            sub="Allow messaging users to switch Default Access threads or new threads into Full Access."
+            source={sourceBadge(allowFullAccessEscalation)}
+            onChange={(enabled) => {
+              void props.onFullAccessEscalationChange(enabled);
+            }}
+          />
+          <SegmentedField
+            disabled={props.saving}
+            label="Full Access warning"
+            sub="Controls whether messaging users see the Full Access risk warning before escalation."
+            options={FULL_ACCESS_WARNING_POLICY_OPTIONS}
+            source={sourceBadge(fullAccessWarning)}
+            value={fullAccessWarning.value}
+            onChange={(policy) => {
+              void props.onFullAccessWarningPolicyChange(policy);
+            }}
+          />
         </div>
       </SettingsSection>
 
@@ -268,6 +311,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(telegram.authorizedUserIds)}
             validateEntry={validateTelegramUserIdEntry}
             value={telegram.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveTelegram({
                 ...telegram,
@@ -399,6 +443,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(discord.authorizedUserIds)}
             validateEntry={validateDiscordUserIdEntry}
             value={discord.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveDiscord({
                 ...discord,
@@ -613,6 +658,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(mattermost.authorizedUserIds)}
             validateEntry={validateMattermostUserIdEntry}
             value={mattermost.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveMattermost({
                 ...mattermost,
@@ -819,6 +865,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(slack.authorizedUserIds)}
             validateEntry={validateSlackUserIdEntry}
             value={slack.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveSlack({
                 ...slack,
@@ -1055,6 +1102,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(feishu.authorizedUserIds)}
             validateEntry={validateFeishuOpenIdEntry}
             value={feishu.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveFeishu({
                 ...feishu,
@@ -1236,6 +1284,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(line.authorizedUserIds)}
             validateEntry={validateLineUserIdEntry}
             value={line.authorizedUserIds.value}
+            fullAccessWarningPolicy
             onSave={(authorizedUserIds) => {
               void props.onSaveLine({
                 ...line,
@@ -1299,6 +1348,25 @@ const TOOL_UPDATE_MODE_OPTIONS: Array<{
   { label: "Show Some", value: "show_some" },
   { label: "Show More", value: "show_more" },
   { label: "Show All", value: "show_all" },
+];
+
+const FULL_ACCESS_WARNING_POLICY_OPTIONS: Array<{
+  label: string;
+  value: DesktopMessagingFullAccessWarningGlobalPolicy;
+}> = [
+  { label: "Dismissable", value: "dismissable" },
+  { label: "Always", value: "always" },
+  { label: "Off", value: "never" },
+];
+
+const FULL_ACCESS_WARNING_USER_POLICY_OPTIONS: Array<{
+  label: string;
+  value: DesktopMessagingFullAccessWarningUserPolicy;
+}> = [
+  { label: "Default", value: "default" },
+  { label: "Yes - Always", value: "always" },
+  { label: "Yes - Dismissable", value: "dismissable" },
+  { label: "No", value: "never" },
 ];
 
 const SLACK_INBOUND_MODE_OPTIONS: Array<{
@@ -1790,6 +1858,7 @@ function pairingEntryDetails(entry: MessagingPairingEntry): string[] {
 
 function AuthorizedListField(props: {
   disabled?: boolean;
+  fullAccessWarningPolicy?: boolean;
   help?: ReactNode;
   label: string;
   lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
@@ -1918,7 +1987,11 @@ function AuthorizedListField(props: {
 
       const nextRows = latestRows.map((current, rowIndex) =>
         rowIndex === indexToLookup
-          ? { id: row.id, displayName: result.displayName ?? "" }
+          ? {
+              ...current,
+              id: row.id,
+              displayName: result.displayName ?? "",
+            }
           : current,
       );
       setRows(nextRows);
@@ -1970,7 +2043,11 @@ function AuthorizedListField(props: {
               return (
                 <div
                   key={index}
-                  className="settings-authorized-list__row"
+                  className={`settings-authorized-list__row${
+                    props.fullAccessWarningPolicy
+                      ? " settings-authorized-list__row--with-warning"
+                      : ""
+                  }`}
                 >
                   <input
                     aria-describedby={invalid ? descriptionId : undefined}
@@ -2016,6 +2093,39 @@ function AuthorizedListField(props: {
                       })
                     }
                   />
+                  {props.fullAccessWarningPolicy ? (
+                    <select
+                      aria-label={`${props.label} Full Access warning ${index + 1}`}
+                      className="settings-input settings-authorized-list__warning"
+                      disabled={props.disabled}
+                      value={row.fullAccessWarningOverride ?? "default"}
+                      onBlur={() => {
+                        const nextRows = rows.map((current, rowIndex) =>
+                          rowIndex === index
+                            ? normalizeAuthorizedContactRow(current)
+                            : current,
+                        );
+                        setRows(nextRows);
+                        saveIfValid(nextRows);
+                      }}
+                      onChange={(event) =>
+                        updateRow(index, {
+                          fullAccessWarningOverride: event.currentTarget
+                            .value as DesktopMessagingFullAccessWarningUserPolicy,
+                          fullAccessWarningDismissed:
+                            event.currentTarget.value === "default"
+                              ? row.fullAccessWarningDismissed
+                              : false,
+                        })
+                      }
+                    >
+                      {FULL_ACCESS_WARNING_USER_POLICY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
                   <button
                     aria-label={`Lookup ${props.label} row ${index + 1}`}
                     className="button button--ghost settings-authorized-list__lookup"
@@ -2046,7 +2156,13 @@ function AuthorizedListField(props: {
               onClick={() =>
                 setRows((current) => [
                   ...current,
-                  { id: "", displayName: "" },
+                  {
+                    id: "",
+                    displayName: "",
+                    ...(props.fullAccessWarningPolicy
+                      ? { fullAccessWarningOverride: "default" as const }
+                      : {}),
+                  },
                 ])
               }
             >
@@ -2143,6 +2259,13 @@ function normalizeAuthorizedContactRow(
   return {
     id: contact.id.trim(),
     displayName: sanitizeMessagingContactLabel(contact.displayName),
+    ...(contact.fullAccessWarningOverride &&
+    contact.fullAccessWarningOverride !== "default"
+      ? { fullAccessWarningOverride: contact.fullAccessWarningOverride }
+      : {}),
+    ...(contact.fullAccessWarningDismissed === true
+      ? { fullAccessWarningDismissed: true }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -261,6 +261,27 @@ function SettingsSectionBody(props: {
             },
           });
         }}
+        onFullAccessThreadResumeChange={async (allowFullAccessThreadResume) => {
+          await props.settings.writeConfig({
+            messaging: {
+              allowFullAccessThreadResume,
+            },
+          });
+        }}
+        onFullAccessEscalationChange={async (allowFullAccessEscalation) => {
+          await props.settings.writeConfig({
+            messaging: {
+              allowFullAccessEscalation,
+            },
+          });
+        }}
+        onFullAccessWarningPolicyChange={async (fullAccessWarning) => {
+          await props.settings.writeConfig({
+            messaging: {
+              fullAccessWarning,
+            },
+          });
+        }}
         onSaveDiscord={async (discord) => {
           const delta = buildDiscordPatchDelta(
             props.snapshot.messaging.discord,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -62,6 +62,9 @@ function createSnapshot(
     },
     messaging: {
       enabled: { value: true, source: "default" },
+      allowFullAccessEscalation: { value: true, source: "default" },
+      allowFullAccessThreadResume: { value: true, source: "default" },
+      fullAccessWarning: { value: "dismissable", source: "default" },
       inputDebounceMs: { value: 500, source: "default" },
       toolUpdateMode: { value: "show_some", source: "default" },
       telegram: {
@@ -1586,6 +1589,35 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: { enabled: false },
+      });
+    });
+  });
+
+  it("persists messaging Full Access policy controls", async () => {
+    const settings = createSettingsState();
+    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Resume Full Access threads" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: { allowFullAccessThreadResume: false },
+      });
+    });
+
+    fireEvent.click(screen.getByRole("switch", { name: "Escalate to Full Access" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: { allowFullAccessEscalation: false },
+      });
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "Always" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: { fullAccessWarning: "always" },
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -315,7 +315,12 @@ function authorizedContactArrayEqual(
 ): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
-    if (a[i]?.id !== b[i]?.id || a[i]?.displayName !== b[i]?.displayName) {
+    if (
+      a[i]?.id !== b[i]?.id ||
+      a[i]?.displayName !== b[i]?.displayName ||
+      a[i]?.fullAccessWarningOverride !== b[i]?.fullAccessWarningOverride ||
+      a[i]?.fullAccessWarningDismissed !== b[i]?.fullAccessWarningDismissed
+    ) {
       return false;
     }
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3158,8 +3158,18 @@ textarea,
   align-items: center;
 }
 
+.settings-authorized-list__row--with-warning {
+  grid-template-columns:
+    minmax(140px, 1fr)
+    minmax(140px, 1fr)
+    minmax(128px, 0.7fr)
+    auto
+    auto;
+}
+
 .settings-authorized-list__id,
-.settings-authorized-list__name {
+.settings-authorized-list__name,
+.settings-authorized-list__warning {
   min-width: 0;
 }
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -949,6 +949,7 @@ export type MessagingBrowseSessionRecord = {
   channel: MessagingChannelRef;
   createdAt: number;
   expiresAt: number;
+  fullAccessRiskAcceptedAt?: number;
   launchAction: MessagingBrowseLaunchAction;
   mode: MessagingBrowseMode;
   pageIndex: number;

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -37,6 +37,18 @@ describe("desktop settings contracts", () => {
           value: true,
           source: "default",
         },
+        allowFullAccessEscalation: {
+          value: true,
+          source: "default",
+        },
+        allowFullAccessThreadResume: {
+          value: true,
+          source: "default",
+        },
+        fullAccessWarning: {
+          value: "dismissable",
+          source: "default",
+        },
         inputDebounceMs: {
           value: 500,
           source: "default",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -37,7 +37,20 @@ export type DesktopSettingsValue<T> = {
 export type DesktopAuthorizedContact = {
   id: string;
   displayName: string;
+  fullAccessWarningDismissed?: boolean;
+  fullAccessWarningOverride?: DesktopMessagingFullAccessWarningUserPolicy;
 };
+
+export type DesktopMessagingFullAccessWarningGlobalPolicy =
+  | "always"
+  | "dismissable"
+  | "never";
+
+export type DesktopMessagingFullAccessWarningUserPolicy =
+  | "default"
+  | "always"
+  | "dismissable"
+  | "never";
 
 export type DesktopMessagingContactLookupPlatform =
   | "telegram"
@@ -288,6 +301,9 @@ export type DesktopSettingsSnapshot = {
   };
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
+    allowFullAccessEscalation: DesktopSettingsValue<boolean>;
+    allowFullAccessThreadResume: DesktopSettingsValue<boolean>;
+    fullAccessWarning: DesktopSettingsValue<DesktopMessagingFullAccessWarningGlobalPolicy>;
     inputDebounceMs: DesktopSettingsValue<number>;
     toolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
     attachments: DesktopMessagingAttachmentSettingsSnapshot;
@@ -391,6 +407,9 @@ export type DesktopSettingsConfigPatch = {
   };
   messaging?: {
     enabled?: boolean;
+    allowFullAccessEscalation?: boolean;
+    allowFullAccessThreadResume?: boolean;
+    fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
     attachments?: {


### PR DESCRIPTION
## Summary

- I added Messaging settings for allowing/disallowing Full Access thread resume, allowing/disallowing Messaging escalation to Full Access, and controlling the Messaging Full Access warning policy.
- I wired Messaging runtime/controller enforcement so Full Access threads can be filtered or blocked, escalation requests can be rejected and logged, and allowed escalations show the risk warning with Yes, Yes - and stop warning me, and Cancel actions.
- I persisted per-authorized-user warning dismissal/override state in desktop config and carried it through Settings, messaging config, and the controller workflow.

Closes #347

## Verification

- I verified the focused controller/config/settings coverage with `pnpm test apps/desktop/src/main/__tests__/messaging-status-card.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts packages/shared/src/contracts/__tests__/settings.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`.
- I verified the full test suite with `pnpm test`.
- I verified the full workspace typecheck with `pnpm typecheck`.
- I verified architecture and SQL guards with `pnpm lint:boundaries` and `pnpm lint:sql`.

## Notes

- I kept the default policy permissive for Messaging Full Access resume/escalation and dismissable for the warning, matching the issue defaults.
