### PR TITLE
fix(desktop): adopt active-turn branch changes

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4079,6 +4079,118 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("adopts a named branch change from an active turn before notifying listeners", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-active-turn-branch-"));
+    const repo = path.join(root, "app");
+    await mkdir(repo, { recursive: true });
+    await git(repo, ["init", "-b", "feature/old"]);
+    await git(repo, [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test User",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "init",
+    ]);
+
+    const thread: AppServerThreadSummary = {
+      id: "thread-branch",
+      title: "Active branch turn",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: `directory:${repo}`,
+          label: "app",
+          path: repo,
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "feature/old",
+      observedGitBranch: "feature/old",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-branch": {
+          backend: "codex",
+          threadId: "thread-branch",
+          executionMode: "default",
+          gitBranch: "feature/old",
+          observedGitBranch: "feature/old",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/metadata/update"] },
+      threads: [thread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    let overlayDuringTerminalEvent: ThreadOverlayState | undefined;
+    registry.onEvent(async (event) => {
+      if (event.notification.method !== "turn/completed") {
+        return;
+      }
+      overlayDuringTerminalEvent =
+        await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-branch",
+        });
+    });
+
+    try {
+      await codexClient.emit({
+        method: "turn/started",
+        params: {
+          threadId: "thread-branch",
+          turnId: "turn-branch",
+          turn: {
+            id: "turn-branch",
+            status: "in_progress",
+          },
+        },
+      });
+      await git(repo, ["switch", "-c", "fix/queued-review-release"]);
+
+      await codexClient.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-branch",
+          turnId: "turn-branch",
+          turn: {
+            id: "turn-branch",
+            status: "completed",
+            output: [],
+          },
+        },
+      });
+
+      expect(overlayDuringTerminalEvent).toMatchObject({
+        gitBranch: "fix/queued-review-release",
+        observedGitBranch: "fix/queued-review-release",
+      });
+      expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
+        threadId: "thread-branch",
+        gitInfo: {
+          branch: "fix/queued-review-release",
+        },
+      });
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not persist a retained branch drift pair when expected branch is HEAD", async () => {
     const overlayStore = createOverlayStoreMock({
       overlays: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4162,18 +4162,19 @@ describe("DesktopBackendRegistry", () => {
       });
       await git(repo, ["switch", "-c", "fix/queued-review-release"]);
 
-      await codexClient.emit({
-        method: "turn/completed",
-        params: {
-          threadId: "thread-branch",
-          turnId: "turn-branch",
-          turn: {
-            id: "turn-branch",
-            status: "completed",
-            output: [],
+      await codexClient.emit(
+        {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-branch",
+            turn: {
+              id: "turn-branch",
+              status: "completed",
+              output: [],
+            },
           },
-        },
-      });
+        } as unknown as AppServerNotification,
+      );
 
       expect(overlayDuringTerminalEvent).toMatchObject({
         gitBranch: "fix/queued-review-release",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2743,6 +2743,67 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private async adoptThreadBranchChangeFromActiveTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const thread = await this.findThreadForWorkspaceHandoff({
+      backend: params.backend,
+      callerReason: "active-turn-branch-adoption",
+      threadId: params.threadId,
+    });
+    const sourcePath = resolveThreadGitSourcePath(
+      thread,
+      overlay?.extraLinkedDirectories ?? [],
+    );
+    const observedBranch = sourcePath
+      ? await readCurrentGitBranch(sourcePath).catch(() => thread?.observedGitBranch)
+      : thread?.observedGitBranch;
+    const normalizedObservedBranch = observedBranch?.trim() || undefined;
+
+    if (!normalizedObservedBranch) {
+      return;
+    }
+
+    if (normalizedObservedBranch === "HEAD") {
+      await this.overlayStore.setThreadObservedBranch({
+        backend: params.backend,
+        threadId: params.threadId,
+        branch: normalizedObservedBranch,
+      });
+      return;
+    }
+
+    const previousExpectedBranch = resolveExpectedThreadBranch({
+      overlay,
+      thread,
+    });
+    await this.overlayStore.setThreadExpectedBranch({
+      backend: params.backend,
+      threadId: params.threadId,
+      branch: normalizedObservedBranch,
+    });
+    await this.updateThreadGitBranchMetadata({
+      backend: params.backend,
+      threadId: params.threadId,
+      branch: normalizedObservedBranch,
+    });
+
+    if (previousExpectedBranch !== normalizedObservedBranch) {
+      backendRegistryLog.info("adopted active-turn branch change", {
+        backend: params.backend,
+        observedBranch: normalizedObservedBranch,
+        previousExpectedBranch,
+        sourcePath,
+        threadId: params.threadId,
+      });
+    }
+  }
+
   async updateThreadExpectedBranch(
     params: UpdateThreadExpectedBranchRequest,
   ): Promise<UpdateThreadExpectedBranchResponse> {
@@ -4372,12 +4433,22 @@ export class DesktopBackendRegistry {
           turnId: string;
         };
       };
-      this.activeCodexTurnModes.delete(
-        buildActiveTurnModeKey(
-          notification.params.threadId,
-          notification.params.turnId,
-        ),
+      const activeTurnModeKey = buildActiveTurnModeKey(
+        notification.params.threadId,
+        notification.params.turnId,
       );
+      const wasKnownActiveTurn =
+        !notification.params.turnId.startsWith("pending:") &&
+        this.activeCodexTurnModes.has(activeTurnModeKey);
+      this.activeCodexTurnModes.delete(
+        activeTurnModeKey,
+      );
+      if (wasKnownActiveTurn) {
+        await this.adoptThreadBranchChangeFromActiveTurn({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+        });
+      }
       // Turn-end is the resume boundary — flush any queued mode change
       // now. Fire-and-forget; failures are logged + retried inside
       // flushQueuedExecutionModeIfPresent.
@@ -4392,10 +4463,20 @@ export class DesktopBackendRegistry {
       readStatusType(event.notification.params.status) !== "active"
     ) {
       const keyPrefix = `${event.notification.params.threadId}:`;
+      let hadKnownActiveTurn = false;
       for (const key of this.activeCodexTurnModes.keys()) {
         if (key.startsWith(keyPrefix)) {
+          if (!key.startsWith(`${keyPrefix}pending:`)) {
+            hadKnownActiveTurn = true;
+          }
           this.activeCodexTurnModes.delete(key);
         }
+      }
+      if (hadKnownActiveTurn) {
+        await this.adoptThreadBranchChangeFromActiveTurn({
+          backend: event.backend,
+          threadId: event.notification.params.threadId,
+        });
       }
       // Same resume-boundary flush, triggered from the
       // `thread/status/changed → idle` path (codex emits both, depending

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -621,6 +621,19 @@ function turnIdFromStartedNotification(
   return notification.params.turnId ?? notification.params.turn.id;
 }
 
+function turnIdFromTerminalNotification(
+  notification: {
+    params: {
+      turnId?: string;
+      turn?: {
+        id?: string;
+      };
+    };
+  },
+): string | undefined {
+  return notification.params.turnId ?? notification.params.turn?.id;
+}
+
 function logBackendLifecycleNotification(
   backend: AppServerBackendKind,
   notification: AppServerNotification,
@@ -4430,24 +4443,28 @@ export class DesktopBackendRegistry {
       const notification = event.notification as {
         params: {
           threadId: string;
-          turnId: string;
+          turnId?: string;
+          turn?: {
+            id?: string;
+          };
         };
       };
-      const activeTurnModeKey = buildActiveTurnModeKey(
-        notification.params.threadId,
-        notification.params.turnId,
-      );
-      const wasKnownActiveTurn =
-        !notification.params.turnId.startsWith("pending:") &&
-        this.activeCodexTurnModes.has(activeTurnModeKey);
-      this.activeCodexTurnModes.delete(
-        activeTurnModeKey,
-      );
-      if (wasKnownActiveTurn) {
-        await this.adoptThreadBranchChangeFromActiveTurn({
-          backend: event.backend,
-          threadId: notification.params.threadId,
-        });
+      const turnId = turnIdFromTerminalNotification(notification);
+      if (turnId) {
+        const activeTurnModeKey = buildActiveTurnModeKey(
+          notification.params.threadId,
+          turnId,
+        );
+        const wasKnownActiveTurn =
+          !turnId.startsWith("pending:") &&
+          this.activeCodexTurnModes.has(activeTurnModeKey);
+        this.activeCodexTurnModes.delete(activeTurnModeKey);
+        if (wasKnownActiveTurn) {
+          await this.adoptThreadBranchChangeFromActiveTurn({
+            backend: event.backend,
+            threadId: notification.params.threadId,
+          });
+        }
       }
       // Turn-end is the resume boundary — flush any queued mode change
       // now. Fire-and-forget; failures are logged + retried inside

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -295,10 +295,17 @@ describe("useQueuedTurnRelease", () => {
     ).toBe("Second background reply");
   });
 
-  it("does not background-release a branch-tracked thread that needs the drift guard", async () => {
+  it("does not background-release a branch-tracked thread when the drift guard reports drift", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn();
-    const checkThreadBranchDrift = vi.fn();
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "feature/expected",
+      observedBranch: "feature/actual",
+      drifted: true,
+      checkedAt: Date.now(),
+    }));
     const desktopApi: DesktopApi = {
       checkThreadBranchDrift,
       onAgentEvent: (listener) => {
@@ -351,10 +358,94 @@ describe("useQueuedTurnRelease", () => {
     });
 
     expect(startTurn).not.toHaveBeenCalled();
-    expect(checkThreadBranchDrift).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalledWith({
+        backend: "codex",
+        expectedBranch: "feature/expected",
+        threadId: "thread-a",
+      });
+    });
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Guarded background reply");
+  });
+
+  it("background-releases a branch-tracked thread when the drift guard passes", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-next",
+    }));
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      expectedBranch: "fix/queued-review-release",
+      observedBranch: "fix/queued-review-release",
+      drifted: false,
+      checkedAt: Date.now(),
+    }));
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-branch",
+      text: "Release background reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Release background reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", { gitBranch: "feature/expected" }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-a",
+          input: [{ type: "text", text: "Release background reply" }],
+        })
+      );
+    });
+    expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
   });
 
   it("leaves the focused thread queue for the mounted composer to release", async () => {

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -92,6 +92,73 @@ export function useQueuedTurnRelease(params: {
       return;
     }
 
+    const releaseQueuedTurn = async (
+      current: typeof params,
+      thread: NavigationThreadSummary,
+      queuedTurn: ComposerQueuedTurnSnapshot,
+      scopeKey: string,
+    ): Promise<void> => {
+      inFlightScopeKeysRef.current.add(scopeKey);
+      try {
+        if (thread.gitBranch && current.desktopApi?.checkThreadBranchDrift) {
+          const drift = await current.desktopApi.checkThreadBranchDrift({
+            backend: thread.source,
+            expectedBranch: thread.gitBranch,
+            threadId: thread.id,
+          });
+          if (drift.drifted) {
+            return;
+          }
+        }
+
+        const input = buildQueuedTurnInput(queuedTurn);
+        if (input.length === 0) {
+          current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
+          return;
+        }
+
+        const backend = current.backends.find(
+          (candidate) => candidate.kind === thread.source,
+        );
+        if (!backend?.available || !backend.capabilities.startTurn) {
+          return;
+        }
+
+        const selectedModelOption =
+          backend.launchpadOptions?.models?.find((option) => option.id === thread.model) ??
+          getDefaultModelOption(backend);
+        const supportsReasoning =
+          selectedModelOption?.supportsReasoning ??
+          Boolean(backend.launchpadOptions?.reasoningEfforts?.length);
+        const supportsFast =
+          backend.kind === "codex"
+            ? selectedModelOption?.supportsFast ??
+              backend.launchpadOptions?.supportsFastMode ??
+              false
+            : false;
+
+        await startTurn({
+          backend: thread.source,
+          threadId: thread.id,
+          input,
+          executionMode: thread.executionMode,
+          model: selectedModelOption?.id,
+          reasoningEffort: supportsReasoning
+            ? getReasoningEffortValue(backend, thread.reasoningEffort)
+            : undefined,
+          serviceTier:
+            thread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
+          fastMode:
+            thread.source === "codex" && supportsFast
+              ? Boolean(thread.fastMode)
+              : undefined,
+        });
+        current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
+      } finally {
+        inFlightScopeKeysRef.current.delete(scopeKey);
+      }
+    };
+
     return desktopApi.onAgentEvent((event) => {
       const current = paramsRef.current;
       if (!TERMINAL_TURN_METHODS.has(event.notification.method)) {
@@ -128,59 +195,9 @@ export function useQueuedTurnRelease(params: {
         return;
       }
 
-      if (thread.gitBranch && current.desktopApi?.checkThreadBranchDrift) {
-        return;
-      }
-
-      const input = buildQueuedTurnInput(queuedTurn);
-      if (input.length === 0) {
-        current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
-        return;
-      }
-
-      const backend = current.backends.find(
-        (candidate) => candidate.kind === thread.source,
-      );
-      if (!backend?.available || !backend.capabilities.startTurn) {
-        return;
-      }
-
-      const selectedModelOption =
-        backend.launchpadOptions?.models?.find((option) => option.id === thread.model) ??
-        getDefaultModelOption(backend);
-      const supportsReasoning =
-        selectedModelOption?.supportsReasoning ??
-        Boolean(backend.launchpadOptions?.reasoningEfforts?.length);
-      const supportsFast =
-        backend.kind === "codex"
-          ? selectedModelOption?.supportsFast ??
-            backend.launchpadOptions?.supportsFastMode ??
-            false
-          : false;
-
-      inFlightScopeKeysRef.current.add(scopeKey);
-      void startTurn({
-        backend: thread.source,
-        threadId: thread.id,
-        input,
-        executionMode: thread.executionMode,
-        model: selectedModelOption?.id,
-        reasoningEffort: supportsReasoning
-          ? getReasoningEffortValue(backend, thread.reasoningEffort)
-          : undefined,
-        serviceTier:
-          thread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
-        fastMode:
-          thread.source === "codex" && supportsFast
-            ? Boolean(thread.fastMode)
-            : undefined,
-      })
-        .then(() => {
-          current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
-        })
-        .finally(() => {
-          inFlightScopeKeysRef.current.delete(scopeKey);
-        });
+      void releaseQueuedTurn(current, thread, queuedTurn, scopeKey).catch(() => {
+        inFlightScopeKeysRef.current.delete(scopeKey);
+      });
     });
   }, [params.desktopApi]);
 }


### PR DESCRIPTION
## Summary

I fixed the queued turn/review release path so branch changes made by an active turn are adopted at the turn boundary instead of blocking queued work behind the branch-drift warning.

## What changed

- Adopt the currently observed named branch when a Codex turn reaches a terminal state, before renderer listeners receive the completion event.
- Keep detached `HEAD` behavior guarded by recording it as observed drift instead of adopting it as the expected branch.
- Let background queued-turn release run the branch-drift check and proceed when the guard reports clean, rather than blocking every branch-tracked thread.
- Add regression coverage for active-turn branch adoption and guarded queued release.

## Why

Queued reviews can be blocked after an active turn intentionally creates or switches to a PR branch. That branch change already happened while PwrAgent allowed the turn to keep operating, so warning only after the turn completes does not protect the user. It prevents the expected queued follow-up from starting.

Closes #358.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
- `pnpm --filter @pwragent/desktop test:e2e e2e/execution-mode-routing.spec.ts`
