### PR TITLE
fix(desktop): keep messaging status clear of context rail

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1549,7 +1549,14 @@ export function ThreadView(props: ThreadViewProps) {
   }
 
   return (
-    <section className="thread-view">
+    <section
+      className="thread-view"
+      style={
+        {
+          "--context-rail-width": `${contextRailWidth}px`,
+        } as CSSProperties
+      }
+    >
       <ThreadHeader
         desktopApi={props.desktopApi}
         thread={selectedThread!}
@@ -1560,11 +1567,6 @@ export function ThreadView(props: ThreadViewProps) {
         className={`thread-view__layout${
           contextRailEffectivePinned ? " has-pinned-context-rail" : ""
         }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
-        style={
-          {
-            "--context-rail-width": `${contextRailWidth}px`,
-          } as CSSProperties
-        }
       >
         <div className="thread-view__primary">
           <section className="transcript-panel" aria-label="Transcript">

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -185,6 +185,36 @@ describe("Tangerine Terminal theme contract", () => {
     expect(compactTitleRule).not.toContain("line-height: 1;");
   });
 
+  it("keeps messaging indicators ahead of thread header title overflow", () => {
+    const headerMainRule = extractRuleBody(css, ".thread-header__main");
+    const statusBarRule = extractRuleBody(css, ".messaging-status-bar");
+    const eyebrowRowRule = extractRuleBody(css, ".thread-header__eyebrow-row");
+    const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
+
+    expect(headerMainRule).toContain("flex: 1 1 0;");
+    expect(statusBarRule).toContain("flex: 0 0 auto;");
+    expect(statusBarRule).toContain("min-width: max-content;");
+    expect(eyebrowRowRule).toContain("min-width: 0;");
+    expect(compactTitleRule).toContain("flex: 1 1 auto;");
+    expect(compactTitleRule).toContain("overflow: hidden;");
+    expect(css).toMatch(
+      /\.thread-header__eyebrow-row > \.thread-row__chip\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?\}/
+    );
+  });
+
+  it("reserves opened context rail width for the thread header status area", () => {
+    expect(css).toMatch(
+      /\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), calc\(100% - 32px\)\) \+ 12px\);[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.thread-view:has\(\.context-rail\.is-pinned\) \.thread-header,\s*\.thread-view:has\(\.thread-view__layout\.has-pinned-context-rail\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), 42vw\) \+ 12px\);[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /@media \(max-width: 1100px\)\s*\{[\s\S]*?\.thread-view:has\(\.context-rail\.is-open\) \.thread-header,[\s\S]*?padding-right:\s*56px;[\s\S]*?\}/
+    );
+    expect(css).not.toContain("the header reclaims the space");
+  });
+
   it("keeps composer autocomplete visually separated from transcript surfaces", () => {
     const autocompleteRule = extractRuleBody(css, ".composer__autocomplete");
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -221,10 +221,18 @@ textarea,
   padding-right: 56px;
 }
 
+.thread-view:has(.context-rail.is-open) .thread-header {
+  /* The header sits above `.thread-view__layout`, so the layout's
+     pinned-rail padding does not protect the right-aligned messaging
+     indicators. Reserve the opened rail width here as well; the
+     title/chips shrink first and the status indicators keep their
+     visible slot. */
+  padding-right: calc(min(var(--context-rail-width, 380px), calc(100% - 32px)) + 12px);
+}
+
+.thread-view:has(.context-rail.is-pinned) .thread-header,
 .thread-view:has(.thread-view__layout.has-pinned-context-rail) .thread-header {
-  /* When the rail is pinned open, it pushes the layout left and is no
-     longer fixed at the screen edge — the header reclaims the space. */
-  padding-right: 0;
+  padding-right: calc(min(var(--context-rail-width, 380px), 42vw) + 12px);
 }
 
 .thread-header button,
@@ -238,7 +246,7 @@ textarea,
   display: flex;
   flex-direction: column;
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 1 1 0;
 }
 
 .messaging-status-bar {
@@ -246,6 +254,7 @@ textarea,
   align-items: center;
   gap: 6px;
   flex: 0 0 auto;
+  min-width: max-content;
   padding: 4px 8px;
   -webkit-app-region: no-drag;
 }
@@ -3609,9 +3618,12 @@ textarea,
   display: flex;
   align-items: center;
   gap: 8px;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .thread-header__compact-title {
+  flex: 1 1 auto;
   max-width: min(58vw, 520px);
   min-width: 0;
   margin: 0;
@@ -3623,6 +3635,11 @@ textarea,
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.thread-header__eyebrow-row > .thread-row__chip {
+  flex: 0 0 auto;
+  max-width: min(26ch, 28%);
 }
 
 .thread-header__warning {
@@ -7538,6 +7555,11 @@ textarea,
   .thread-view__layout {
     flex-direction: column;
     padding-right: 0;
+  }
+
+  .thread-view:has(.context-rail.is-open) .thread-header,
+  .thread-view:has(.thread-view__layout.has-pinned-context-rail) .thread-header {
+    padding-right: 56px;
   }
 
   .transcript-list__scroll-bottom {


### PR DESCRIPTION
## Summary

- I fixed the thread header so the messaging platform status indicators reserve visible space when the context rail auto-opens or is pinned.
- I moved the shared context rail width variable up to the thread view root so the header can reserve the same rail width as the transcript layout.
- I added CSS contract tests to lock the status indicators ahead of title/chip overflow and to keep open/pinned context rail header spacing from regressing.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `git diff --check`.

## Notes

- The worktree initially had no linked `node_modules`, so I ran `pnpm install --offline` before the focused renderer checks.
