### PR TITLE
fix(desktop): allow selecting review card text

### DIFF
--- a/apps/desktop/e2e/review-output-rendering.spec.ts
+++ b/apps/desktop/e2e/review-output-rendering.spec.ts
@@ -67,6 +67,28 @@ test("renders captured Codex review findings once in the review card", async () 
     );
     await expect(reviewCard).toContainText("Lines 971-979");
 
+    const findingTitle = reviewCard.getByText(
+      "Preserve async pasted images for launchpad scopes"
+    );
+    const findingTitleBox = await findingTitle.boundingBox();
+    expect(findingTitleBox).not.toBeNull();
+    await app.window.mouse.move(
+      findingTitleBox!.x + 4,
+      findingTitleBox!.y + findingTitleBox!.height / 2
+    );
+    await app.window.mouse.down();
+    await app.window.mouse.move(
+      findingTitleBox!.x + findingTitleBox!.width - 4,
+      findingTitleBox!.y + findingTitleBox!.height / 2,
+      { steps: 12 }
+    );
+    await app.window.mouse.up();
+    await expect
+      .poll(async () =>
+        app.window.evaluate(() => window.getSelection()?.toString() ?? "")
+      )
+      .toContain("Preserve async pasted images");
+
     await expect(
       transcript.getByText("Preserve async pasted images for launchpad scopes")
     ).toHaveCount(1);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4492,6 +4492,8 @@ textarea,
   background:
     linear-gradient(180deg, rgba(255, 138, 31, 0.08), rgba(255, 138, 31, 0.02)),
     var(--bg-panel-elevated);
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .transcript-review__header {


### PR DESCRIPTION
## Summary
- allow transcript review cards to opt back into browser text selection
- add replay-backed E2E coverage that drags over a review finding and verifies selected text is captured

## Verification
- pnpm --filter @pwragent/desktop test:e2e -- review-output-rendering.spec.ts
- pnpm --filter @pwragent/desktop typecheck