### PR TITLE
fix(desktop): reject stale Codex binaries before launch

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery.test.ts
@@ -79,6 +79,7 @@ describe("Codex discovery", () => {
       resolveCodexCommand({
         command: "codex",
         env: { PATH: "/opt/homebrew/bin" },
+        platform: "darwin",
       }),
     ).rejects.toThrow("older than the minimum supported version 0.125.0");
     expect(execFileMock).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/codex-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const accessMock = vi.fn();
 const execFileMock = vi.fn();
+const readFileMock = vi.fn();
+const realpathMock = vi.fn();
 
 vi.mock("node:fs/promises", () => ({
   access: accessMock,
+  readFile: readFileMock,
+  realpath: realpathMock,
 }));
 
 vi.mock("node:child_process", () => ({
@@ -19,8 +23,152 @@ vi.mock("node:child_process", () => ({
 }));
 
 describe("Codex discovery", () => {
+  beforeEach(() => {
+    accessMock.mockReset();
+    execFileMock.mockReset();
+    readFileMock.mockReset();
+    realpathMock.mockReset();
+  });
+
+  it("rejects old Homebrew Caskroom Codex versions without spawning them", async () => {
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/opt/homebrew/bin/codex") return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockResolvedValue(
+      "/opt/homebrew/Caskroom/codex/0.94.0/codex-aarch64-apple-darwin",
+    );
+    execFileMock.mockImplementation(() => {
+      throw new Error("old Codex should not be executed");
+    });
+    const { discoverCodexCommands } = await import("../settings/codex-discovery");
+
+    const snapshot = await discoverCodexCommands({
+      env: { PATH: "/opt/homebrew/bin" },
+      platform: "darwin",
+    });
+
+    expect(snapshot.selectedCommand).toBeUndefined();
+    expect(snapshot.candidates.find((candidate) => candidate.source === "path")).toMatchObject({
+      command: "/opt/homebrew/bin/codex",
+      executable: false,
+      failureReason: "codex_too_old",
+      version: "0.94.0",
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to spawning codex when the only resolved candidate is too old", async () => {
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/opt/homebrew/bin/codex") return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockResolvedValue(
+      "/opt/homebrew/Caskroom/codex/0.94.0/codex-aarch64-apple-darwin",
+    );
+    execFileMock.mockImplementation(() => {
+      throw new Error("old Codex should not be executed");
+    });
+    const { resolveCodexCommand } = await import("../settings/codex-discovery");
+
+    await expect(
+      resolveCodexCommand({
+        command: "codex",
+        env: { PATH: "/opt/homebrew/bin" },
+      }),
+    ).rejects.toThrow("older than the minimum supported version 0.125.0");
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("uses Homebrew Caskroom versions without a --version probe when they are new enough", async () => {
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/opt/homebrew/bin/codex") return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockResolvedValue(
+      "/opt/homebrew/Caskroom/codex/0.130.0/codex-aarch64-apple-darwin",
+    );
+    execFileMock.mockImplementation(() => {
+      throw new Error("Codex version should come from the Caskroom path");
+    });
+    const { discoverCodexCommands } = await import("../settings/codex-discovery");
+
+    const snapshot = await discoverCodexCommands({
+      env: { PATH: "/opt/homebrew/bin" },
+      platform: "darwin",
+    });
+
+    expect(snapshot.selectedCommand).toBe("/opt/homebrew/bin/codex");
+    expect(snapshot.candidates.find((candidate) => candidate.source === "path")).toMatchObject({
+      executable: true,
+      selected: true,
+      version: "0.130.0",
+    });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("uses Codex.app bundle versions before invoking the helper binary", async () => {
+    const appCommand = "/Applications/Codex.app/Contents/Resources/codex";
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === appCommand) return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    readFileMock.mockResolvedValue(`
+      <plist>
+        <dict>
+          <key>CFBundleShortVersionString</key>
+          <string>0.126.0</string>
+        </dict>
+      </plist>
+    `);
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: NodeJS.ErrnoException) => void,
+      ) => {
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error);
+      },
+    );
+    const { discoverCodexCommands } = await import("../settings/codex-discovery");
+
+    const snapshot = await discoverCodexCommands({
+      env: {},
+      platform: "darwin",
+    });
+
+    expect(snapshot.selectedCommand).toBe(appCommand);
+    expect(
+      snapshot.candidates.find((candidate) => candidate.source === "application"),
+    ).toMatchObject({
+      executable: true,
+      selected: true,
+      version: "0.126.0",
+    });
+    expect(execFileMock).not.toHaveBeenCalledWith(
+      appCommand,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("selects env overrides above configured and auto-discovered commands", async () => {
     accessMock.mockResolvedValue(undefined);
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         command: string,
@@ -56,6 +204,8 @@ describe("Codex discovery", () => {
     const missingError = new Error("missing") as NodeJS.ErrnoException;
     missingError.code = "ENOENT";
     accessMock.mockRejectedValue(missingError);
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    readFileMock.mockRejectedValue(missingError);
     execFileMock.mockImplementation(
       (
         _command: string,
@@ -83,6 +233,8 @@ describe("Codex discovery", () => {
 
   it("treats a successful version probe as executable when access fails", async () => {
     accessMock.mockRejectedValue(new Error("access denied"));
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         _command: string,
@@ -107,6 +259,8 @@ describe("Codex discovery", () => {
 
   it("reads Codex versions from stderr when needed", async () => {
     accessMock.mockResolvedValue(undefined);
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         _command: string,

--- a/apps/desktop/src/main/settings/codex-discovery.ts
+++ b/apps/desktop/src/main/settings/codex-discovery.ts
@@ -1,5 +1,8 @@
+import { execFile as execFileCallback } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { readFile, realpath } from "node:fs/promises";
+import { promisify } from "node:util";
 import type {
   DesktopCodexCandidateSource,
   DesktopCodexDiscoveryCandidate,
@@ -11,6 +14,9 @@ import {
   pathIsExecutable,
   type ResolvedCommandCandidate,
 } from "./command-discovery";
+
+const execFile = promisify(execFileCallback);
+export const MINIMUM_CODEX_CLI_VERSION = "0.125.0";
 
 export type ResolvedCodexCommandCandidate = {
   command: string;
@@ -115,6 +121,117 @@ function getCodexAppCandidatePaths(): string[] {
   ];
 }
 
+async function inspectCodexCandidateBeforeVersionProbe(params: {
+  command: string;
+  platform: NodeJS.Platform;
+}): Promise<{
+  version?: string;
+  failureReason?: string;
+  skipVersionProbe?: boolean;
+} | undefined> {
+  if (params.platform !== "darwin") {
+    return undefined;
+  }
+
+  const version = await readCodexVersionWithoutExecution(params.command);
+  if (!version) {
+    return undefined;
+  }
+
+  return {
+    version,
+    failureReason: compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0
+      ? "codex_too_old"
+      : undefined,
+    skipVersionProbe: true,
+  };
+}
+
+async function readCodexVersionWithoutExecution(command: string): Promise<string | undefined> {
+  const candidatePaths = [command];
+  try {
+    const resolved = await realpath(command);
+    if (resolved !== command) {
+      candidatePaths.push(resolved);
+    }
+  } catch {
+    // The caller already checked existence. If realpath fails, fall back to the
+    // original path and the normal version probe.
+  }
+
+  for (const candidatePath of candidatePaths) {
+    const homebrewVersion = readHomebrewCodexVersionFromPath(candidatePath);
+    if (homebrewVersion) {
+      return homebrewVersion;
+    }
+
+    const appVersion = await readCodexAppBundleVersion(candidatePath);
+    if (appVersion) {
+      return appVersion;
+    }
+  }
+
+  return undefined;
+}
+
+function readHomebrewCodexVersionFromPath(candidatePath: string): string | undefined {
+  const normalized = candidatePath.replace(/\\/g, "/");
+  const match = normalized.match(
+    /\/(?:Caskroom|Cellar)\/codex\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\/|$)/,
+  );
+  return match?.[1];
+}
+
+async function readCodexAppBundleVersion(candidatePath: string): Promise<string | undefined> {
+  const appPath = readContainingAppBundlePath(candidatePath);
+  if (!appPath) {
+    return undefined;
+  }
+
+  const plistPath = path.join(appPath, "Contents", "Info.plist");
+  const plutilVersion =
+    await readPlistString(plistPath, "CFBundleShortVersionString")
+    ?? await readPlistString(plistPath, "CFBundleVersion");
+  if (plutilVersion) {
+    return parseCodexVersionOutput(plutilVersion);
+  }
+
+  try {
+    const plist = await readFile(plistPath, "utf8");
+    const match = plist.match(
+      /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+    ) ?? plist.match(/<key>CFBundleVersion<\/key>\s*<string>([^<]+)<\/string>/);
+    return parseCodexVersionOutput(match?.[1] ?? "");
+  } catch {
+    return undefined;
+  }
+}
+
+async function readPlistString(
+  plistPath: string,
+  key: "CFBundleShortVersionString" | "CFBundleVersion",
+): Promise<string | undefined> {
+  try {
+    const result = await execFile(
+      "/usr/bin/plutil",
+      ["-extract", key, "raw", "-o", "-", plistPath],
+      { timeout: 2_000 },
+    );
+    return result.stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readContainingAppBundlePath(candidatePath: string): string | undefined {
+  const normalized = candidatePath.replace(/\\/g, "/");
+  const appSuffixIndex = normalized.indexOf(".app/");
+  if (appSuffixIndex === -1) {
+    return undefined;
+  }
+  return normalized.slice(0, appSuffixIndex + ".app".length);
+}
+
 export async function discoverCodexCommands(params?: {
   configuredCommand?: string;
   env?: NodeJS.ProcessEnv;
@@ -140,6 +257,8 @@ export async function discoverCodexCommands(params?: {
     ],
     parseVersion: parseCodexVersionOutput,
     compareVersions: compareCodexCliVersions,
+    preflightCandidate: ({ command, platform }) =>
+      inspectCodexCandidateBeforeVersionProbe({ command, platform }),
   }) as Promise<DesktopCodexDiscoverySnapshot>;
 }
 
@@ -156,15 +275,26 @@ export async function resolveCodexCommand(params: {
     env: params.env,
   });
   const selected = discovery.candidates.find((candidate) => candidate.selected);
+  const rejectedOldCodex = discovery.candidates.find(
+    (candidate) => candidate.failureReason === "codex_too_old",
+  );
 
-  return selected
-    ? {
-        command: selected.command,
-        source: selected.source,
-        version: selected.version,
-      }
-    : {
-        command: params.command.trim() || "codex",
-        source: "path",
-      };
+  if (selected) {
+    return {
+      command: selected.command,
+      source: selected.source,
+      version: selected.version,
+    };
+  }
+
+  if (rejectedOldCodex) {
+    throw new Error(
+      `Codex CLI ${rejectedOldCodex.version ?? "unknown"} is older than the minimum supported version ${MINIMUM_CODEX_CLI_VERSION}: ${rejectedOldCodex.command}`,
+    );
+  }
+
+  return {
+    command: params.command.trim() || "codex",
+    source: "path",
+  };
 }

--- a/apps/desktop/src/main/settings/codex-discovery.ts
+++ b/apps/desktop/src/main/settings/codex-discovery.ts
@@ -265,6 +265,7 @@ export async function discoverCodexCommands(params?: {
 export async function resolveCodexCommand(params: {
   command: string;
   env: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
 }): Promise<ResolvedCommandCandidate<DesktopCodexCandidateSource>> {
   const configuredCommand =
     params.command.trim() && params.command.trim() !== "codex"
@@ -273,6 +274,7 @@ export async function resolveCodexCommand(params: {
   const discovery = await discoverCodexCommands({
     configuredCommand,
     env: params.env,
+    platform: params.platform,
   });
   const selected = discovery.candidates.find((candidate) => candidate.selected);
   const rejectedOldCodex = discovery.candidates.find(

--- a/apps/desktop/src/main/settings/command-discovery.ts
+++ b/apps/desktop/src/main/settings/command-discovery.ts
@@ -36,7 +36,20 @@ export type DiscoverCommandOptions<Source extends string> = {
   versionArgs?: string[];
   parseVersion: (output: string) => string | undefined;
   compareVersions?: (left?: string, right?: string) => number;
+  preflightCandidate?: (params: {
+    command: string;
+    source: Source;
+    env: NodeJS.ProcessEnv;
+    platform: NodeJS.Platform;
+  }) => Promise<CommandDiscoveryPreflightResult | undefined>;
   includeFailedAutoCandidates?: boolean | "if-none-executable";
+};
+
+export type CommandDiscoveryPreflightResult = {
+  version?: string;
+  failureReason?: string;
+  versionFailureReason?: string;
+  skipVersionProbe?: boolean;
 };
 
 export type ResolvedCommandCandidate<Source extends string> = {
@@ -188,6 +201,12 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
     platform?: NodeJS.Platform;
     versionArgs?: string[];
     parseVersion: (output: string) => string | undefined;
+    preflightCandidate?: (params: {
+      command: string;
+      source: Source;
+      env: NodeJS.ProcessEnv;
+      platform: NodeJS.Platform;
+    }) => Promise<CommandDiscoveryPreflightResult | undefined>;
   },
 ): Promise<CommandDiscoveryCandidate<Source> | undefined> {
   const trimmedCommand = candidate.command?.trim();
@@ -207,13 +226,42 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
     resolvedCommand && existence !== "not_found"
       ? await pathIsExecutable(resolvedCommand)
       : false;
-  const versionResult = existence !== "not_found"
-    ? await readCommandVersion({
+  const preflightResult = existence !== "not_found"
+    ? await options.preflightCandidate?.({
         command: probeCommand,
+        source: candidate.source,
         env: options.env,
-        parseVersion: options.parseVersion,
-        versionArgs: options.versionArgs ?? ["--version"],
+        platform,
       })
+    : undefined;
+
+  if (preflightResult?.failureReason) {
+    return {
+      command: resolvedCommand || trimmedCommand,
+      source: candidate.source,
+      executable: false,
+      selected: false,
+      version: preflightResult.version,
+      versionFailureReason: preflightResult.versionFailureReason,
+      failureReason: preflightResult.failureReason,
+    };
+  }
+
+  const versionResult = existence !== "not_found"
+    ? preflightResult?.skipVersionProbe
+      ? {
+          ran: accessExecutable,
+          version: preflightResult.version,
+          failureReason: preflightResult.version
+            ? undefined
+            : (preflightResult.versionFailureReason ?? "version_not_reported"),
+        }
+      : await readCommandVersion({
+          command: probeCommand,
+          env: options.env,
+          parseVersion: options.parseVersion,
+          versionArgs: options.versionArgs ?? ["--version"],
+        })
     : { ran: false, failureReason: "not_found" };
   const executable = accessExecutable || versionResult.ran;
 
@@ -222,7 +270,7 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
     source: candidate.source,
     executable,
     selected: false,
-    version: versionResult.version,
+    version: versionResult.version ?? preflightResult?.version,
     versionFailureReason: executable ? versionResult.failureReason : undefined,
     failureReason: executable
       ? undefined
@@ -259,7 +307,9 @@ export async function discoverCommands<Source extends string>(
       ? executableAutoCandidates.length === 0
       : options.includeFailedAutoCandidates === true;
   const visibleAutoCandidates = autoCandidates
-    .filter((candidate) => includeFailedAutoCandidates || candidate.executable)
+    .filter((candidate) =>
+      includeFailedAutoCandidates || candidate.executable || candidate.version,
+    )
     .sort((left, right) =>
       options.compareVersions
         ? options.compareVersions(right.version, left.version)

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -355,5 +355,6 @@ function describeCommandDiscoveryFailure(reason?: string): string | undefined {
   if (reason === "not_found") return "Missing";
   if (reason === "not_executable") return "Not executable";
   if (reason === "version_not_reported") return "Version unknown";
+  if (reason === "codex_too_old") return "Codex too old";
   return reason;
 }


### PR DESCRIPTION
## Summary

- Refuse Codex CLI candidates older than `0.125.0` before launching them.
- Read safe pre-execution version metadata from Homebrew Caskroom/Cellar paths and `Codex.app` `Info.plist` metadata.
- Keep rejected old Codex candidates visible in Settings as `Codex too old` instead of selecting or spawning them.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-discovery.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- Generic standalone PATH binaries without Homebrew or app-bundle metadata still fall back to `codex --version`; macOS Mach-O binaries do not provide a reliable Windows-style product version field.
