### PR TITLE
fix(desktop): prevent hidden reaction action from resizing rows

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -162,6 +162,8 @@ export function ThreadRow(props: ThreadRowProps) {
       <button
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
+          canReact ? " thread-row--can-react" : ""
+        }${
           selected ? " is-selected" : ""
         }`}
         type="button"

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -162,8 +162,6 @@ export function ThreadRow(props: ThreadRowProps) {
       <button
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
-          canReact ? " thread-row--can-react" : ""
-        }${
           selected ? " is-selected" : ""
         }`}
         type="button"

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -195,9 +195,10 @@ export function ThreadRow(props: ThreadRowProps) {
         </span>
 
         {/* Single ordered chip flow: meta (agent/mode/dir/branch/drift)
-            → PR chips → messaging binding chips → reactions → add-
-            reaction. flex-wrap handles overflow naturally; every chip
-            is a sibling, no per-type containers. */}
+            → PR chips → messaging binding chips → reactions. flex-wrap
+            handles content overflow naturally; the hover-only add-
+            reaction affordance is positioned outside the flow so it
+            cannot reserve a phantom wrapped row while hidden. */}
         <span
           className="thread-row__chips"
           onMouseEnter={prs.length > 0 ? armHoverPrefetch : undefined}
@@ -245,15 +246,15 @@ export function ThreadRow(props: ThreadRowProps) {
               onToggle={() => toggleReaction(emoji)}
             />
           ))}
-
-          {canReact ? (
-            <AddReactionChip
-              anchorRef={addReactionRef}
-              open={pickerOpen}
-              onToggle={() => setPickerOpen((open) => !open)}
-            />
-          ) : null}
         </span>
+
+        {canReact ? (
+          <AddReactionChip
+            anchorRef={addReactionRef}
+            open={pickerOpen}
+            onToggle={() => setPickerOpen((open) => !open)}
+          />
+        ) : null}
       </button>
 
       {canReact ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -248,14 +248,15 @@ export function ThreadRow(props: ThreadRowProps) {
           ))}
         </span>
 
-        {canReact ? (
-          <AddReactionChip
-            anchorRef={addReactionRef}
-            open={pickerOpen}
-            onToggle={() => setPickerOpen((open) => !open)}
-          />
-        ) : null}
       </button>
+
+      {canReact ? (
+        <AddReactionChip
+          anchorRef={addReactionRef}
+          open={pickerOpen}
+          onToggle={() => setPickerOpen((open) => !open)}
+        />
+      ) : null}
 
       {canReact ? (
         <ReactionPicker

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -250,13 +250,34 @@ export function ThreadRow(props: ThreadRowProps) {
 
       </button>
 
-      {canReact ? (
-        <AddReactionChip
-          anchorRef={addReactionRef}
-          open={pickerOpen}
-          onToggle={() => setPickerOpen((open) => !open)}
-        />
-      ) : null}
+      <div className="thread-row__actions">
+        {canReact ? (
+          <AddReactionChip
+            anchorRef={addReactionRef}
+            open={pickerOpen}
+            onToggle={() => setPickerOpen((open) => !open)}
+          />
+        ) : null}
+
+        <button
+          aria-haspopup="menu"
+          aria-label="Open thread actions"
+          className="thread-row__overflow-button"
+          title={`Open thread actions for ${props.thread.title}`}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            const rect = event.currentTarget.getBoundingClientRect();
+            props.onOpenContextMenu(props.thread, {
+              x: rect.left,
+              y: rect.bottom + 4,
+              anchorTop: rect.top,
+            });
+          }}
+        >
+          ...
+        </button>
+      </div>
 
       {canReact ? (
         <ReactionPicker
@@ -270,25 +291,6 @@ export function ThreadRow(props: ThreadRowProps) {
           onDismiss={() => setPickerOpen(false)}
         />
       ) : null}
-
-      <button
-        aria-haspopup="menu"
-        aria-label="Open thread actions"
-        className="thread-row__overflow-button"
-        title={`Open thread actions for ${props.thread.title}`}
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          const rect = event.currentTarget.getBoundingClientRect();
-          props.onOpenContextMenu(props.thread, {
-            x: rect.left,
-            y: rect.bottom + 4,
-            anchorTop: rect.top,
-          });
-        }}
-      >
-        ...
-      </button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -92,13 +92,13 @@ describe("ThreadRow chip flow", () => {
 
   it("positions the add-reaction trigger outside the wrapping chip flow", () => {
     const { container } = renderRow();
-    const row = container.querySelector(".thread-row");
+    const shell = container.querySelector(".thread-row-shell");
     const flow = container.querySelector(".thread-row__chips");
     const addReaction = container.querySelector(".thread-row__chip--add-reaction");
-    expect(row).not.toBeNull();
+    expect(shell).not.toBeNull();
     expect(flow).not.toBeNull();
     expect(addReaction).not.toBeNull();
-    expect(addReaction?.parentElement).toBe(row);
+    expect(addReaction?.parentElement).toBe(shell);
     expect(flow?.contains(addReaction)).toBe(false);
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -102,17 +102,6 @@ describe("ThreadRow chip flow", () => {
     expect(flow?.contains(addReaction)).toBe(false);
   });
 
-  it("marks reactive rows so the chip flow can reserve an action gutter", () => {
-    const { container } = renderRow();
-    expect(container.querySelector(".thread-row")).toHaveClass("thread-row--can-react");
-  });
-
-  it("does not reserve the add-reaction gutter when reactions are unavailable", () => {
-    const { container } = renderRow({ onSetReaction: undefined });
-    expect(container.querySelector(".thread-row")).not.toHaveClass("thread-row--can-react");
-    expect(container.querySelector(".thread-row__chip--add-reaction")).toBeNull();
-  });
-
   it("uses span[role=button] for the binding chip (not nested <button>)", () => {
     const { container } = renderRow();
     const bindingChip = container.querySelector(".thread-row__chip--binding");

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -18,8 +18,10 @@ import { ThreadRow } from "../ThreadRow";
 //      instead of opening the binding menu.
 //
 // These tests freeze the contract that motivated the refactor:
-//   - Every chip is a sibling inside a single `.thread-row__chips`
-//     container — no per-type wrappers.
+//   - Content chips are siblings inside a single `.thread-row__chips`
+//     container — no per-type wrappers. The hover-only add-reaction
+//     trigger stays outside that flow so it cannot reserve hidden wrap
+//     space.
 //   - Interactive chips are `<span role="button">` (NOT `<button>`),
 //     and their click events do not propagate into the row's
 //     onSelectThread handler.
@@ -76,16 +78,28 @@ describe("ThreadRow chip flow", () => {
     return { ...utils, onSelectThread, onUnbindMessagingBinding, onSetReaction };
   }
 
-  it("renders every chip as a sibling inside a single .thread-row__chips container", () => {
+  it("renders content chips as siblings inside a single .thread-row__chips container", () => {
     const { container } = renderRow();
     const chipFlow = container.querySelectorAll(".thread-row__chips");
     expect(chipFlow.length).toBe(1);
-    // All known chip types should live inside that single container,
+    // Content chip types should live inside that single container,
     // not in any per-type wrapper.
     const flow = chipFlow[0]!;
     expect(flow.querySelector(".thread-row__chip--binding")).not.toBeNull();
     expect(flow.querySelector(".thread-row__chip--reaction")).not.toBeNull();
-    expect(flow.querySelector(".thread-row__chip--add-reaction")).not.toBeNull();
+    expect(flow.querySelector(".thread-row__chip--add-reaction")).toBeNull();
+  });
+
+  it("positions the add-reaction trigger outside the wrapping chip flow", () => {
+    const { container } = renderRow();
+    const row = container.querySelector(".thread-row");
+    const flow = container.querySelector(".thread-row__chips");
+    const addReaction = container.querySelector(".thread-row__chip--add-reaction");
+    expect(row).not.toBeNull();
+    expect(flow).not.toBeNull();
+    expect(addReaction).not.toBeNull();
+    expect(addReaction?.parentElement).toBe(row);
+    expect(flow?.contains(addReaction)).toBe(false);
   });
 
   it("uses span[role=button] for the binding chip (not nested <button>)", () => {
@@ -186,7 +200,7 @@ describe("ThreadRow chip flow", () => {
     expect(screen.queryByText("now fix/current")).not.toBeInTheDocument();
   });
 
-  it("orders chips: meta → PR → bindings → reactions → add-reaction", () => {
+  it("orders chips: meta → PR → bindings → reactions", () => {
     const threadWithEverything: NavigationThreadSummary = {
       ...baseThread,
       messagingBindings: [telegramBinding],
@@ -212,12 +226,8 @@ describe("ThreadRow chip flow", () => {
     const prIdx = indexOf(".thread-row__chip--pr, [data-pr-chip]");
     const bindingIdx = indexOf(".thread-row__chip--binding, .thread-row__chip-wrap");
     const reactionIdx = indexOf(".thread-row__chip--reaction");
-    const addReactionIdx = indexOf(".thread-row__chip--add-reaction");
     // Each chip type that's present comes after the previous one.
     if (prIdx >= 0 && bindingIdx >= 0) expect(prIdx).toBeLessThan(bindingIdx);
     if (bindingIdx >= 0 && reactionIdx >= 0) expect(bindingIdx).toBeLessThan(reactionIdx);
-    if (reactionIdx >= 0 && addReactionIdx >= 0) {
-      expect(reactionIdx).toBeLessThan(addReactionIdx);
-    }
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -92,14 +92,23 @@ describe("ThreadRow chip flow", () => {
 
   it("positions the add-reaction trigger outside the wrapping chip flow", () => {
     const { container } = renderRow();
-    const shell = container.querySelector(".thread-row-shell");
+    const actions = container.querySelector(".thread-row__actions");
     const flow = container.querySelector(".thread-row__chips");
     const addReaction = container.querySelector(".thread-row__chip--add-reaction");
-    expect(shell).not.toBeNull();
+    expect(actions).not.toBeNull();
     expect(flow).not.toBeNull();
     expect(addReaction).not.toBeNull();
-    expect(addReaction?.parentElement).toBe(shell);
+    expect(addReaction?.parentElement).toBe(actions);
     expect(flow?.contains(addReaction)).toBe(false);
+  });
+
+  it("keeps the add-reaction trigger left of the overflow action", () => {
+    const { container } = renderRow();
+    const actions = container.querySelector(".thread-row__actions");
+    expect(actions).not.toBeNull();
+    const actionChildren = Array.from(actions!.children) as HTMLElement[];
+    expect(actionChildren[0]).toHaveClass("thread-row__chip--add-reaction");
+    expect(actionChildren[1]).toHaveClass("thread-row__overflow-button");
   });
 
   it("uses span[role=button] for the binding chip (not nested <button>)", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -102,6 +102,17 @@ describe("ThreadRow chip flow", () => {
     expect(flow?.contains(addReaction)).toBe(false);
   });
 
+  it("marks reactive rows so the chip flow can reserve an action gutter", () => {
+    const { container } = renderRow();
+    expect(container.querySelector(".thread-row")).toHaveClass("thread-row--can-react");
+  });
+
+  it("does not reserve the add-reaction gutter when reactions are unavailable", () => {
+    const { container } = renderRow({ onSetReaction: undefined });
+    expect(container.querySelector(".thread-row")).not.toHaveClass("thread-row--can-react");
+    expect(container.querySelector(".thread-row__chip--add-reaction")).toBeNull();
+  });
+
   it("uses span[role=button] for the binding chip (not nested <button>)", () => {
     const { container } = renderRow();
     const bindingChip = container.querySelector(".thread-row__chip--binding");

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -215,6 +215,24 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toContain("the header reclaims the space");
   });
 
+  it("keeps hidden thread row actions from stealing row clicks", () => {
+    const actionsRule = extractRuleBody(css, ".thread-row__actions");
+
+    expect(actionsRule).toContain("pointer-events: none;");
+    expect(css).toMatch(
+      /\.thread-row-shell:hover \.thread-row__chip--add-reaction,\s*\.thread-row__chip--add-reaction:focus-visible,\s*\.thread-row__chip--add-reaction\.is-open\s*\{[\s\S]*?pointer-events:\s*auto;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.thread-row-shell:hover \.thread-row__overflow-button,\s*\.thread-row__overflow-button:focus-visible\s*\{[\s\S]*?pointer-events:\s*auto;[\s\S]*?\}/
+    );
+  });
+
+  it("hides thread row timestamps behind focused or open row actions", () => {
+    expect(css).toMatch(
+      /\.thread-row-shell:hover \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__overflow-button:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction:focus-visible\) \.thread-row__time,\s*\.thread-row-shell:has\(\.thread-row__chip--add-reaction\.is-open\) \.thread-row__time\s*\{[\s\S]*?opacity:\s*0;[\s\S]*?\}/
+    );
+  });
+
   it("keeps composer autocomplete visually separated from transcript surfaces", () => {
     const autocompleteRule = extractRuleBody(css, ".composer__autocomplete");
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1232,7 +1232,9 @@ textarea,
 }
 
 .thread-row-shell:hover .thread-row__time,
-.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time {
+.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
+.thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row__time,
+.thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row__time {
   opacity: 0;
 }
 
@@ -1284,8 +1286,8 @@ textarea,
 
 .thread-row__chip--add-reaction {
   position: absolute;
-  right: 14px;
-  bottom: 10px;
+  top: 10px;
+  right: 47px;
   z-index: 2;
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
@@ -1548,10 +1550,6 @@ textarea,
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-}
-
-.thread-row--can-react .thread-row__chips {
-  padding-right: 50px;
 }
 
 /* Focus ring for any role="button" chip in the flow (PR, binding,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1213,6 +1213,7 @@ textarea,
   display: flex;
   align-items: center;
   gap: 6px;
+  pointer-events: none;
 }
 
 .thread-row__overflow-button {
@@ -1239,7 +1240,9 @@ textarea,
 }
 
 .thread-row-shell:hover .thread-row__time,
-.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time {
+.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
+.thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row__time,
+.thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row__time {
   opacity: 0;
 }
 
@@ -1274,9 +1277,7 @@ textarea,
 }
 
 .thread-row__chip--reaction:hover,
-.thread-row__chip--reaction:focus-visible,
-.thread-row__chip--add-reaction:hover,
-.thread-row__chip--add-reaction.is-open {
+.thread-row__chip--reaction:focus-visible {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
   outline: none;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1232,9 +1232,7 @@ textarea,
 }
 
 .thread-row-shell:hover .thread-row__time,
-.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time,
-.thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row__time,
-.thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row__time {
+.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row__time {
   opacity: 0;
 }
 
@@ -1286,9 +1284,9 @@ textarea,
 
 .thread-row__chip--add-reaction {
   position: absolute;
-  top: 10px;
-  right: 47px;
-  z-index: 2;
+  right: 14px;
+  bottom: 10px;
+  z-index: 3;
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
   opacity: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1205,11 +1205,18 @@ textarea,
   pointer-events: none;
 }
 
-.thread-row__overflow-button {
+.thread-row__actions {
   position: absolute;
   top: 9px;
   right: 9px;
-  z-index: 1;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.thread-row__overflow-button {
+  position: static;
   display: grid;
   width: 30px;
   height: 26px;
@@ -1283,10 +1290,7 @@ textarea,
 }
 
 .thread-row__chip--add-reaction {
-  position: absolute;
-  right: 14px;
-  bottom: 10px;
-  z-index: 3;
+  position: static;
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
   opacity: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1249,10 +1249,10 @@ textarea,
   color: var(--accent-bright);
 }
 
-/* Reaction + add-reaction chips share the .thread-row__chip primitive
+/* Reaction + add-reaction controls share the .thread-row__chip primitive
    below; only their content (emoji glyph) differs from a meta chip.
-   These rules layer the per-variant tweaks (slightly larger glyph
-   font-size, hover-only visibility for the add chip) on top. */
+   The add control is a hover-only row affordance, positioned outside the
+   wrapping chip flow so it does not reserve hidden layout space. */
 
 .thread-row__chip--reaction,
 .thread-row__chip--add-reaction {
@@ -1269,17 +1269,28 @@ textarea,
 .thread-row__chip--reaction:hover,
 .thread-row__chip--reaction:focus-visible,
 .thread-row__chip--add-reaction:hover,
-.thread-row__chip--add-reaction:focus-visible,
 .thread-row__chip--add-reaction.is-open {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
   outline: none;
 }
 
+.thread-row__chip--add-reaction:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .thread-row__chip--add-reaction {
+  position: absolute;
+  right: 14px;
+  bottom: 10px;
+  z-index: 1;
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
   opacity: 0;
+  pointer-events: none;
   /* SVG glyph uses --text-secondary so it reads as a soft gray —
      matches the design and avoids competing with the actual reaction
      chips next to it. The reaction chips above still use
@@ -1306,6 +1317,7 @@ textarea,
 .thread-row__chip--add-reaction:focus-visible,
 .thread-row__chip--add-reaction.is-open {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .reaction-picker {
@@ -1527,11 +1539,10 @@ textarea,
   line-height: 1.45;
 }
 
-/* Single ordered chip flow per thread row. All chip types — meta
-   (agent/mode/dir/branch/drift), PR chips, messaging binding chips,
-   reactions, add-reaction — render as siblings in this one wrapping
-   flex container. flex-wrap handles overflow naturally; no per-type
-   container, no absolute positioning. */
+/* Single ordered content chip flow per thread row. Meta
+   (agent/mode/dir/branch/drift), PR chips, messaging binding chips, and
+   reactions render as siblings in this one wrapping flex container.
+   flex-wrap handles overflow naturally; no per-type containers. */
 .thread-row__chips {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1300,8 +1300,7 @@ textarea,
   transition:
     background 120ms ease,
     border-color 120ms ease,
-    color 120ms ease,
-    opacity 120ms ease;
+    color 120ms ease;
 }
 
 .thread-row__chip--add-reaction:hover,
@@ -1574,6 +1573,18 @@ textarea,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.thread-row__chip.thread-row__chip--add-reaction {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.thread-row__chip.thread-row__chip--add-reaction:hover,
+.thread-row__chip.thread-row__chip--add-reaction:focus-visible,
+.thread-row__chip.thread-row__chip--add-reaction.is-open {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
 }
 
 .thread-row__chip--backend {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1286,7 +1286,7 @@ textarea,
   position: absolute;
   right: 14px;
   bottom: 10px;
-  z-index: 1;
+  z-index: 2;
   /* Mute the add affordance until the user is interacting with the
      row; revealed on hover, focus, or while the picker is open. */
   opacity: 0;
@@ -1548,6 +1548,10 @@ textarea,
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
+}
+
+.thread-row--can-react .thread-row__chips {
+  padding-right: 50px;
 }
 
 /* Focus ring for any role="button" chip in the flow (PR, binding,


### PR DESCRIPTION
Fixes thread rows reserving layout space for the hidden add-reaction smiley, which could make tiles appear to have blank wrapped rows.

The add-reaction trigger now sits outside the wrapping chip flow as a hover/focus row affordance, while actual reaction chips remain inline content. This keeps row and chip-flow height stable before and after hover, and preserves keyboard focus visibility for the add-reaction control.

Verified with focused renderer tests, desktop typecheck/build, and a replay-backed Electron layout check confirming the smiley is outside the flow and row height is unchanged on hover.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.5 via [Codex](https://openai.com/codex)