### PR TITLE
fix(desktop): ignore Codex app bundle version

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery.test.ts
@@ -165,6 +165,58 @@ describe("Codex discovery", () => {
     );
   });
 
+  it("rejects old Codex.app helper versions after probing the helper binary", async () => {
+    const appCommand = "/Applications/Codex.app/Contents/Resources/codex";
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === appCommand) return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        if (command === appCommand) {
+          callback(null, { stdout: "codex-cli 0.94.0\n" });
+          return;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error);
+      },
+    );
+    const { discoverCodexCommands, resolveCodexCommand } = await import(
+      "../settings/codex-discovery"
+    );
+
+    const snapshot = await discoverCodexCommands({
+      env: {},
+      platform: "darwin",
+    });
+
+    expect(snapshot.selectedCommand).toBeUndefined();
+    expect(
+      snapshot.candidates.find((candidate) => candidate.source === "application"),
+    ).toMatchObject({
+      command: appCommand,
+      executable: false,
+      failureReason: "codex_too_old",
+      version: "0.94.0",
+    });
+    await expect(
+      resolveCodexCommand({
+        command: "codex",
+        env: {},
+        platform: "darwin",
+      }),
+    ).rejects.toThrow("older than the minimum supported version 0.125.0");
+  });
+
   it("selects env overrides above configured and auto-discovered commands", async () => {
     accessMock.mockResolvedValue(undefined);
     realpathMock.mockImplementation(async (candidate: string) => candidate);

--- a/apps/desktop/src/main/__tests__/codex-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery.test.ts
@@ -2,12 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const accessMock = vi.fn();
 const execFileMock = vi.fn();
-const readFileMock = vi.fn();
 const realpathMock = vi.fn();
 
 vi.mock("node:fs/promises", () => ({
   access: accessMock,
-  readFile: readFileMock,
   realpath: realpathMock,
 }));
 
@@ -26,7 +24,6 @@ describe("Codex discovery", () => {
   beforeEach(() => {
     accessMock.mockReset();
     execFileMock.mockReset();
-    readFileMock.mockReset();
     realpathMock.mockReset();
   });
 
@@ -114,7 +111,7 @@ describe("Codex discovery", () => {
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  it("uses Codex.app bundle versions before invoking the helper binary", async () => {
+  it("uses the Codex.app helper version instead of the Electron bundle version", async () => {
     const appCommand = "/Applications/Codex.app/Contents/Resources/codex";
     const notFoundError = new Error("missing") as NodeJS.ErrnoException;
     notFoundError.code = "ENOENT";
@@ -123,21 +120,17 @@ describe("Codex discovery", () => {
       throw notFoundError;
     });
     realpathMock.mockImplementation(async (candidate: string) => candidate);
-    readFileMock.mockResolvedValue(`
-      <plist>
-        <dict>
-          <key>CFBundleShortVersionString</key>
-          <string>0.126.0</string>
-        </dict>
-      </plist>
-    `);
     execFileMock.mockImplementation(
       (
-        _command: string,
+        command: string,
         _args: string[],
         _options: Record<string, unknown>,
-        callback: (error: NodeJS.ErrnoException) => void,
+        callback: (error: Error | null, result?: { stdout: string }) => void,
       ) => {
+        if (command === appCommand) {
+          callback(null, { stdout: "codex-cli 0.130.0-alpha.5\n" });
+          return;
+        }
         const error = new Error("missing") as NodeJS.ErrnoException;
         error.code = "ENOENT";
         callback(error);
@@ -156,10 +149,16 @@ describe("Codex discovery", () => {
     ).toMatchObject({
       executable: true,
       selected: true,
-      version: "0.126.0",
+      version: "0.130.0-alpha.5",
     });
-    expect(execFileMock).not.toHaveBeenCalledWith(
+    expect(execFileMock).toHaveBeenCalledWith(
       appCommand,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(execFileMock).not.toHaveBeenCalledWith(
+      "/usr/bin/plutil",
       expect.anything(),
       expect.anything(),
       expect.anything(),
@@ -169,7 +168,6 @@ describe("Codex discovery", () => {
   it("selects env overrides above configured and auto-discovered commands", async () => {
     accessMock.mockResolvedValue(undefined);
     realpathMock.mockImplementation(async (candidate: string) => candidate);
-    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         command: string,
@@ -206,7 +204,6 @@ describe("Codex discovery", () => {
     missingError.code = "ENOENT";
     accessMock.mockRejectedValue(missingError);
     realpathMock.mockImplementation(async (candidate: string) => candidate);
-    readFileMock.mockRejectedValue(missingError);
     execFileMock.mockImplementation(
       (
         _command: string,
@@ -235,7 +232,6 @@ describe("Codex discovery", () => {
   it("treats a successful version probe as executable when access fails", async () => {
     accessMock.mockRejectedValue(new Error("access denied"));
     realpathMock.mockImplementation(async (candidate: string) => candidate);
-    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         _command: string,
@@ -261,7 +257,6 @@ describe("Codex discovery", () => {
   it("reads Codex versions from stderr when needed", async () => {
     accessMock.mockResolvedValue(undefined);
     realpathMock.mockImplementation(async (candidate: string) => candidate);
-    readFileMock.mockRejectedValue(new Error("missing"));
     execFileMock.mockImplementation(
       (
         _command: string,

--- a/apps/desktop/src/main/__tests__/credential-tester.test.ts
+++ b/apps/desktop/src/main/__tests__/credential-tester.test.ts
@@ -270,6 +270,21 @@ describe("CredentialTester", () => {
       expect(result.detail).toBe("0.128.0-alpha.1");
     });
 
+    it("returns failed when the parsed Codex version is too old", async () => {
+      const { tester } = buildTester({
+        runCodexVersion: async () => ({
+          stdout: "codex 0.94.0\n",
+          stderr: "",
+        }),
+      });
+      const result = await tester.test("codex");
+      expect(result.status).toBe("failed");
+      expect(result.account).toBe("/usr/local/bin/codex");
+      expect(result.errorMessage).toBe(
+        "Codex CLI 0.94.0 is older than the minimum supported version 0.125.0",
+      );
+    });
+
     it("returns failed when the binary spawns but doesn't print a version", async () => {
       const { tester } = buildTester({
         runCodexVersion: async () => ({ stdout: "no version here\n", stderr: "" }),

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -8,6 +8,9 @@ import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const tempRoots: string[] = [];
 const disposeDesktopBackendRegistryMock = vi.fn(async () => undefined);
+const childProcessMocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
 const providerMocks = vi.hoisted(() => ({
   resolveTelegramContact: vi.fn(),
   resolveDiscordContact: vi.fn(),
@@ -38,6 +41,10 @@ vi.mock("electron", () => ({
     decryptString: vi.fn(),
     isEncryptionAvailable: vi.fn(() => false),
   },
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: childProcessMocks.execFile,
 }));
 
 vi.mock("../app-server/backend-registry", () => ({
@@ -97,6 +104,19 @@ describe("settings ipc", () => {
     runtimeMock.getPlatformCredentialMetadata.mockReset();
     runtimeMock.isEnabled.mockClear();
     runtimeMock.requestCredentialValidation.mockReset();
+    childProcessMocks.execFile.mockReset();
+    childProcessMocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: NodeJS.ErrnoException) => void,
+      ) => {
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error);
+      },
+    );
   });
 
   it("registers redacted read and write handlers", async () => {
@@ -239,6 +259,60 @@ describe("settings ipc", () => {
     );
 
     expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not run the saved Codex path when discovery rejected it", async () => {
+    const service = {
+      readSettings: vi.fn(async () => ({
+        models: {
+          codex: {
+            discovery: {
+              selectedCommand: undefined,
+              candidates: [
+                {
+                  command: "/opt/homebrew/bin/codex",
+                  executable: false,
+                  failureReason: "codex_too_old",
+                  selected: false,
+                  source: "path",
+                  version: "0.94.0",
+                },
+              ],
+            },
+            path: {
+              value: "/opt/homebrew/bin/codex",
+            },
+          },
+        },
+      })),
+      resolveTelegramBotTokenSync: vi.fn(),
+      resolveDiscordBotTokenSync: vi.fn(),
+      resolveMattermostBotTokenSync: vi.fn(),
+      resolveMattermostServerUrlSync: vi.fn(),
+      resolveSlackBotTokenSync: vi.fn(),
+      resolveLineChannelAccessTokenSync: vi.fn(),
+      resolveGrokApiKey: vi.fn(),
+    } as unknown as DesktopSettingsService;
+    const { registerSettingsIpcHandlers, disposeSettingsIpcHandlers } = await import(
+      "../ipc/settings"
+    );
+    const { SETTINGS_TEST_CREDENTIALS_CHANNEL } = await import("../../shared/ipc");
+
+    disposeSettingsIpcHandlers();
+    registerSettingsIpcHandlers(service);
+
+    await expect(
+      handlers.get(SETTINGS_TEST_CREDENTIALS_CHANNEL)?.(
+        {},
+        { kind: "codex" },
+      ),
+    ).resolves.toMatchObject({
+      kind: "codex",
+      status: "unset",
+    });
+    expect(childProcessMocks.execFile).not.toHaveBeenCalled();
+
+    disposeSettingsIpcHandlers();
   });
 
   it("hot-applies messaging config writes without defeating a launch disable override", async () => {

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -8,6 +8,10 @@ import type {
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import type { CredentialValidationRequest } from "../messaging/messaging-runtime";
+import {
+  compareCodexCliVersions,
+  MINIMUM_CODEX_CLI_VERSION,
+} from "../settings/codex-discovery";
 
 const execFileAsync = promisify(execFile);
 
@@ -339,13 +343,24 @@ export class CredentialTester {
       const output = `${stdout}\n${stderr}`;
       const match = output.match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/);
       if (match) {
+        const version = match[1];
+        if (compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0) {
+          return {
+            kind: "codex",
+            status: "failed",
+            testedAt,
+            durationMs,
+            account: command,
+            errorMessage: `Codex CLI ${version} is older than the minimum supported version ${MINIMUM_CODEX_CLI_VERSION}`,
+          };
+        }
         return {
           kind: "codex",
           status: "ok",
           testedAt,
           durationMs,
           account: command,
-          detail: match[1],
+          detail: version,
         };
       }
       return {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -251,11 +251,7 @@ function getCredentialTester(
       resolveGrokApiKey: () => resolveService().resolveGrokApiKey(),
       resolveCodexCommand: async () => {
         const snapshot = await resolveService().readSettings();
-        return (
-          snapshot.models.codex.discovery.selectedCommand
-          ?? snapshot.models.codex.path.value
-          ?? undefined
-        );
+        return snapshot.models.codex.discovery.selectedCommand ?? undefined;
       },
       validateMessagingCredentials: (request) =>
         getDesktopMessagingRuntime().requestCredentialValidation(request),

--- a/apps/desktop/src/main/settings/codex-discovery.ts
+++ b/apps/desktop/src/main/settings/codex-discovery.ts
@@ -111,6 +111,12 @@ export function compareCodexCliVersions(left?: string, right?: string): number {
   return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
 }
 
+function validateCodexCliVersion(version: string): string | undefined {
+  return compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0
+    ? "codex_too_old"
+    : undefined;
+}
+
 function getCodexAppCandidatePaths(): string[] {
   return [
     "/Applications/Codex.app/Contents/Resources/codex",
@@ -137,9 +143,7 @@ async function inspectCodexCandidateBeforeVersionProbe(params: {
 
   return {
     version,
-    failureReason: compareCodexCliVersions(version, MINIMUM_CODEX_CLI_VERSION) < 0
-      ? "codex_too_old"
-      : undefined,
+    failureReason: validateCodexCliVersion(version),
     skipVersionProbe: true,
   };
 }
@@ -199,6 +203,7 @@ export async function discoverCodexCommands(params?: {
     ],
     parseVersion: parseCodexVersionOutput,
     compareVersions: compareCodexCliVersions,
+    validateVersion: validateCodexCliVersion,
     preflightCandidate: ({ command, platform }) =>
       inspectCodexCandidateBeforeVersionProbe({ command, platform }),
   }) as Promise<DesktopCodexDiscoverySnapshot>;

--- a/apps/desktop/src/main/settings/codex-discovery.ts
+++ b/apps/desktop/src/main/settings/codex-discovery.ts
@@ -1,8 +1,6 @@
-import { execFile as execFileCallback } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { readFile, realpath } from "node:fs/promises";
-import { promisify } from "node:util";
+import { realpath } from "node:fs/promises";
 import type {
   DesktopCodexCandidateSource,
   DesktopCodexDiscoveryCandidate,
@@ -15,7 +13,6 @@ import {
   type ResolvedCommandCandidate,
 } from "./command-discovery";
 
-const execFile = promisify(execFileCallback);
 export const MINIMUM_CODEX_CLI_VERSION = "0.125.0";
 
 export type ResolvedCodexCommandCandidate = {
@@ -133,7 +130,7 @@ async function inspectCodexCandidateBeforeVersionProbe(params: {
     return undefined;
   }
 
-  const version = await readCodexVersionWithoutExecution(params.command);
+  const version = await readHomebrewCodexVersionWithoutExecution(params.command);
   if (!version) {
     return undefined;
   }
@@ -147,7 +144,7 @@ async function inspectCodexCandidateBeforeVersionProbe(params: {
   };
 }
 
-async function readCodexVersionWithoutExecution(command: string): Promise<string | undefined> {
+async function readHomebrewCodexVersionWithoutExecution(command: string): Promise<string | undefined> {
   const candidatePaths = [command];
   try {
     const resolved = await realpath(command);
@@ -164,11 +161,6 @@ async function readCodexVersionWithoutExecution(command: string): Promise<string
     if (homebrewVersion) {
       return homebrewVersion;
     }
-
-    const appVersion = await readCodexAppBundleVersion(candidatePath);
-    if (appVersion) {
-      return appVersion;
-    }
   }
 
   return undefined;
@@ -180,56 +172,6 @@ function readHomebrewCodexVersionFromPath(candidatePath: string): string | undef
     /\/(?:Caskroom|Cellar)\/codex\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\/|$)/,
   );
   return match?.[1];
-}
-
-async function readCodexAppBundleVersion(candidatePath: string): Promise<string | undefined> {
-  const appPath = readContainingAppBundlePath(candidatePath);
-  if (!appPath) {
-    return undefined;
-  }
-
-  const plistPath = path.join(appPath, "Contents", "Info.plist");
-  const plutilVersion =
-    await readPlistString(plistPath, "CFBundleShortVersionString")
-    ?? await readPlistString(plistPath, "CFBundleVersion");
-  if (plutilVersion) {
-    return parseCodexVersionOutput(plutilVersion);
-  }
-
-  try {
-    const plist = await readFile(plistPath, "utf8");
-    const match = plist.match(
-      /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
-    ) ?? plist.match(/<key>CFBundleVersion<\/key>\s*<string>([^<]+)<\/string>/);
-    return parseCodexVersionOutput(match?.[1] ?? "");
-  } catch {
-    return undefined;
-  }
-}
-
-async function readPlistString(
-  plistPath: string,
-  key: "CFBundleShortVersionString" | "CFBundleVersion",
-): Promise<string | undefined> {
-  try {
-    const result = await execFile(
-      "/usr/bin/plutil",
-      ["-extract", key, "raw", "-o", "-", plistPath],
-      { timeout: 2_000 },
-    );
-    return result.stdout.trim() || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function readContainingAppBundlePath(candidatePath: string): string | undefined {
-  const normalized = candidatePath.replace(/\\/g, "/");
-  const appSuffixIndex = normalized.indexOf(".app/");
-  if (appSuffixIndex === -1) {
-    return undefined;
-  }
-  return normalized.slice(0, appSuffixIndex + ".app".length);
 }
 
 export async function discoverCodexCommands(params?: {

--- a/apps/desktop/src/main/settings/command-discovery.ts
+++ b/apps/desktop/src/main/settings/command-discovery.ts
@@ -36,6 +36,7 @@ export type DiscoverCommandOptions<Source extends string> = {
   versionArgs?: string[];
   parseVersion: (output: string) => string | undefined;
   compareVersions?: (left?: string, right?: string) => number;
+  validateVersion?: (version: string) => string | undefined;
   preflightCandidate?: (params: {
     command: string;
     source: Source;
@@ -201,6 +202,7 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
     platform?: NodeJS.Platform;
     versionArgs?: string[];
     parseVersion: (output: string) => string | undefined;
+    validateVersion?: (version: string) => string | undefined;
     preflightCandidate?: (params: {
       command: string;
       source: Source;
@@ -263,6 +265,22 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
           versionArgs: options.versionArgs ?? ["--version"],
         })
     : { ran: false, failureReason: "not_found" };
+  const version = versionResult.version ?? preflightResult?.version;
+  const versionValidationFailure = version
+    ? options.validateVersion?.(version)
+    : undefined;
+  if (versionValidationFailure) {
+    return {
+      command: resolvedCommand || trimmedCommand,
+      source: candidate.source,
+      executable: false,
+      selected: false,
+      version,
+      versionFailureReason: undefined,
+      failureReason: versionValidationFailure,
+    };
+  }
+
   const executable = accessExecutable || versionResult.ran;
 
   return {
@@ -270,7 +288,7 @@ export async function buildCommandDiscoveryCandidate<Source extends string>(
     source: candidate.source,
     executable,
     selected: false,
-    version: versionResult.version ?? preflightResult?.version,
+    version,
     versionFailureReason: executable ? versionResult.failureReason : undefined,
     failureReason: executable
       ? undefined


### PR DESCRIPTION
## Summary

- Stop reading `Codex.app/Contents/Info.plist` as the Codex helper version because that value belongs to the Electron app shell.
- Let `Codex.app/Contents/Resources/codex` report its own CLI version through the existing `--version` probe.
- Keep the safe Homebrew Caskroom/Cellar path preflight for old Codex binaries before launch.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/codex-discovery.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The nested `Codex.app` helper binary does not expose a useful standalone app bundle version, so the reliable value is its own version banner.
