### PR TITLE
fix(desktop): revalidate queued release after drift guard

### DIFF
--- a/apps/desktop/e2e/queued-review-release.spec.ts
+++ b/apps/desktop/e2e/queued-review-release.spec.ts
@@ -1,0 +1,239 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createQueuedReviewReleaseFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-queued-review-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const fixturePath = path.join(rootDir, "queued-review-release.fixture.json");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const linkedDirectories = [
+    {
+      id: "fixture-repo",
+      label: "FixtureRepo",
+      path: repoDir,
+      kind: "local",
+    },
+  ];
+  const replay = {
+    entries: [],
+    messages: [],
+    pagination: {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    },
+  };
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "queued-review-release",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: [
+                "thread/list",
+                "thread/read",
+                "turn/start",
+                "review/start",
+              ],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-active",
+                title: "Active branch-changing turn",
+                titleSource: "explicit",
+                summary: "Queue a review here, then leave the thread",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "main",
+                linkedDirectories,
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-focused",
+                title: "Focused holding thread",
+                titleSource: "explicit",
+                summary: "Stay here while the active turn completes",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: replay,
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-active",
+              turnId: "turn-active",
+            },
+          },
+          {
+            id: "turn-started-1",
+            kind: "notification",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-active",
+                turnId: "turn-active",
+                turn: {
+                  id: "turn-active",
+                  status: "inProgress",
+                },
+              },
+            },
+          },
+          {
+            id: "turn-completed-1",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-active",
+                turnId: "turn-active",
+                turn: {
+                  id: "turn-active",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "review-start-1",
+            kind: "response",
+            method: "review/start",
+            result: {
+              threadId: "thread-active",
+              reviewThreadId: "thread-active",
+              turnId: "turn-review",
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    repoDir,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("background queued review releases after active turn branch adoption", async () => {
+  const fixture = await createQueuedReviewReleaseFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: { width: 1280, height: 820 },
+  });
+
+  try {
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Active branch-changing turn",
+      }),
+    ).toBeVisible();
+
+    await app.window.getByRole("textbox", { name: "Reply" }).fill("Make a PR");
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await expect
+      .poll(async () => await app.getLastStartTurn())
+      .toMatchObject({
+        threadId: "thread-active",
+        input: [{ type: "text", text: "Make a PR" }],
+      });
+
+    await app.advance({ stepId: "turn-started-1" });
+
+    await app.window.getByRole("textbox", { name: "Reply" }).fill("/review main");
+    await app.window.getByRole("button", { name: "Queue" }).click();
+    await expect(app.window.getByLabel("Queued message")).toContainText(
+      "Review changes against main",
+    );
+
+    await app.window
+      .getByRole("button", { name: /Focused holding thread/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Focused holding thread",
+      }),
+    ).toBeVisible();
+
+    execFileSync("git", ["checkout", "-B", "fix/queued-review-release"], {
+      cwd: fixture.repoDir,
+      stdio: "ignore",
+    });
+    await app.advance({ stepId: "turn-completed-1" });
+
+    await expect
+      .poll(async () => await app.getLastStartReview())
+      .toMatchObject({
+        threadId: "thread-active",
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+        delivery: "inline",
+      });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1150,6 +1150,243 @@ describe("App", () => {
     });
   });
 
+  it("releases a queued review for a thread after navigating away", async () => {
+    const agentEventListeners = new Set<
+      (event: {
+        backend: "codex";
+        notification: {
+          method: string;
+          params: Record<string, unknown>;
+        };
+      }) => void
+    >();
+    const startTurn = vi.fn<
+      (request: StartTurnRequest) => Promise<StartTurnResponse>
+    >(async (request) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-active",
+    }));
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "turn-review",
+    }));
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId
+      }: {
+        backend: "codex";
+        threadId: string;
+      }) => ({
+        backend,
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false
+          }
+        }
+      })
+    );
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          data: []
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start", "review/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: true,
+                startReview: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true
+                }
+              ]
+            }
+          ]
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all",
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-a", "codex:thread-b"],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex",
+            executionMode: "default",
+          },
+          threads: [
+            {
+              id: "thread-a",
+              title: "Active background thread",
+              titleSource: "explicit",
+              summary: "Has an active turn with a queued reply",
+              source: "codex",
+              executionMode: "default",
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread"
+              },
+              updatedAt: Date.now()
+            },
+            {
+              id: "thread-b",
+              title: "Focused thread",
+              titleSource: "explicit",
+              summary: "Selected while the first thread finishes",
+              source: "codex",
+              executionMode: "default",
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread"
+              },
+              updatedAt: Date.now() - 1000
+            }
+          ]
+        }),
+        markThreadSeen: async ({
+          backend,
+          threadId
+        }: {
+          backend: "codex";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now()
+        }),
+        onAgentEvent: (
+          listener: (event: {
+            backend: "codex";
+            notification: {
+              method: string;
+              params: Record<string, unknown>;
+            };
+          }) => void
+        ) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        onWindowFocus: () => () => undefined,
+        readThread,
+        startReview,
+        startTurn,
+        platform: "darwin",
+        versions: {
+          electron: "41.2.1"
+        }
+      }
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Active background thread"
+    });
+
+    pasteComposerText(
+      await screen.findByRole("textbox", { name: "Reply" }),
+      "Start the active turn",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-a",
+          input: [{ type: "text", text: "Start the active turn" }],
+        })
+      );
+    });
+
+    pasteComposerText(
+      await screen.findByRole("textbox", { name: "Reply" }),
+      "/review main",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+    expect(await screen.findByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Focused thread/i }));
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Focused thread"
+    });
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-active",
+              turn: {
+                id: "turn-active",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-a",
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+        delivery: "inline",
+      });
+    });
+    expect(startTurn).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps assistant response text out of the thread header", async () => {
     const response =
       'I don\'t have a built-in "X Search" tool or direct real-time access to the X/Twitter API with the available workspace tools.';

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -9,6 +9,10 @@ import type { ComposerDraftStore } from "../../features/composer/useComposerDraf
 import type { DesktopApi } from "../desktop-api";
 import { useQueuedTurnRelease } from "../useQueuedTurnRelease";
 
+type BranchDriftResult = Awaited<
+  ReturnType<NonNullable<DesktopApi["checkThreadBranchDrift"]>>
+>;
+
 function createComposerDraftStore(): ComposerDraftStore {
   const queuedTurns = new Map<
     string,
@@ -446,6 +450,181 @@ describe("useQueuedTurnRelease", () => {
       );
     });
     expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
+  });
+
+  it("does not background-release when the guarded thread becomes focused", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    let resolveDrift: ((value: BranchDriftResult) => void) | undefined;
+    const startTurn = vi.fn();
+    const checkThreadBranchDrift = vi.fn(
+      () =>
+        new Promise<BranchDriftResult>((resolve) => {
+          resolveDrift = resolve;
+        })
+    );
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-branch",
+      text: "Release background reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Release background reply" }],
+    });
+
+    const { rerender } = renderHook(
+      ({ selectedThread }: { selectedThread: NavigationThreadSummary }) =>
+        useQueuedTurnRelease({
+          backends: [backendSummary()],
+          composerDraftStore,
+          desktopApi,
+          selectedThread,
+          threads: [
+            thread("thread-a", { gitBranch: "feature/expected" }),
+            thread("thread-b"),
+          ],
+        }),
+      { initialProps: { selectedThread: thread("thread-b") } },
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalled();
+    });
+
+    rerender({
+      selectedThread: thread("thread-a", { gitBranch: "feature/expected" }),
+    });
+    await act(async () => {
+      resolveDrift?.({
+        backend: "codex",
+        threadId: "thread-a",
+        expectedBranch: "fix/queued-review-release",
+        observedBranch: "fix/queued-review-release",
+        drifted: false,
+        checkedAt: Date.now(),
+      });
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.id
+    ).toBe("queued-branch");
+  });
+
+  it("does not background-release when the queued item changes during the drift guard", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    let resolveDrift: ((value: BranchDriftResult) => void) | undefined;
+    const startTurn = vi.fn();
+    const checkThreadBranchDrift = vi.fn(
+      () =>
+        new Promise<BranchDriftResult>((resolve) => {
+          resolveDrift = resolve;
+        })
+    );
+    const desktopApi: DesktopApi = {
+      checkThreadBranchDrift,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-old",
+      text: "Stale background reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Stale background reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [
+          thread("thread-a", { gitBranch: "feature/expected" }),
+          thread("thread-b"),
+        ],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(checkThreadBranchDrift).toHaveBeenCalled();
+    });
+
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-new",
+      text: "Current background reply",
+      imageAttachments: [],
+      input: [{ type: "text", text: "Current background reply" }],
+    });
+    await act(async () => {
+      resolveDrift?.({
+        backend: "codex",
+        threadId: "thread-a",
+        expectedBranch: "fix/queued-review-release",
+        observedBranch: "fix/queued-review-release",
+        drifted: false,
+        checkedAt: Date.now(),
+      });
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.id
+    ).toBe("queued-new");
   });
 
   it("leaves the focused thread queue for the mounted composer to release", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -203,6 +203,87 @@ describe("useQueuedTurnRelease", () => {
     ).toBe("Second background reply");
   });
 
+  it("releases a queued review with review/start for a non-focused thread", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn();
+    const startReview = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      reviewThreadId: "thread-a",
+      turnId: "review-turn",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startReview,
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-review",
+      text: "/review main",
+      imageAttachments: [],
+      reviewCommand: {
+        displayText: "Review changes against main",
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+      },
+    });
+
+    const backend = backendSummary();
+    backend.capabilities.startReview = true;
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backend],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-a",
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+        delivery: "inline",
+      });
+    });
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
+  });
+
   it("does not remove the next background queued message when the started item changed while in flight", async () => {
     let resolveStartTurn: (() => void) | undefined;
     const listeners = new Set<(event: AgentEvent) => void>();

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -88,7 +88,8 @@ export function useQueuedTurnRelease(params: {
   useEffect(() => {
     const desktopApi = params.desktopApi;
     const startTurn = desktopApi?.startTurn;
-    if (!desktopApi?.onAgentEvent || !startTurn) {
+    const startReview = desktopApi?.startReview;
+    if (!desktopApi?.onAgentEvent || (!startTurn && !startReview)) {
       return;
     }
 
@@ -138,6 +139,32 @@ export function useQueuedTurnRelease(params: {
         }
         releaseThread = latestThread;
 
+        const backend = releaseState.backends.find(
+          (candidate) => candidate.kind === releaseThread.source,
+        );
+        if (!backend?.available) {
+          return;
+        }
+
+        if (releaseQueuedSnapshot.reviewCommand) {
+          const startReview = releaseState.desktopApi?.startReview;
+          if (!startReview || !backend.capabilities.startReview) {
+            return;
+          }
+
+          await startReview({
+            backend: releaseThread.source,
+            threadId: releaseThread.id,
+            target: releaseQueuedSnapshot.reviewCommand.target,
+            delivery: "inline",
+          });
+          releaseState.composerDraftStore.removeQueuedTurnById(
+            scopeKey,
+            releaseQueuedSnapshot.id,
+          );
+          return;
+        }
+
         const input = buildQueuedTurnInput(releaseQueuedSnapshot);
         if (input.length === 0) {
           releaseState.composerDraftStore.removeQueuedTurnById(
@@ -147,10 +174,7 @@ export function useQueuedTurnRelease(params: {
           return;
         }
 
-        const backend = releaseState.backends.find(
-          (candidate) => candidate.kind === releaseThread.source,
-        );
-        if (!backend?.available || !backend.capabilities.startTurn) {
+        if (!startTurn || !backend.capabilities.startTurn) {
           return;
         }
 

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -100,6 +100,10 @@ export function useQueuedTurnRelease(params: {
     ): Promise<void> => {
       inFlightScopeKeysRef.current.add(scopeKey);
       try {
+        let releaseState = current;
+        let releaseThread = thread;
+        let releaseQueuedSnapshot = queuedTurn;
+
         if (thread.gitBranch && current.desktopApi?.checkThreadBranchDrift) {
           const drift = await current.desktopApi.checkThreadBranchDrift({
             backend: thread.source,
@@ -111,21 +115,49 @@ export function useQueuedTurnRelease(params: {
           }
         }
 
-        const input = buildQueuedTurnInput(queuedTurn);
-        if (input.length === 0) {
-          current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
+        releaseState = paramsRef.current;
+        if (
+          releaseState.selectedThread?.source === thread.source &&
+          releaseState.selectedThread.id === thread.id
+        ) {
           return;
         }
 
-        const backend = current.backends.find(
-          (candidate) => candidate.kind === thread.source,
+        const latestQueuedTurn = releaseState.composerDraftStore.getQueuedTurn(scopeKey);
+        if (!latestQueuedTurn || latestQueuedTurn.id !== queuedTurn.id) {
+          return;
+        }
+        releaseQueuedSnapshot = latestQueuedTurn;
+
+        const latestThread = releaseState.threads.find(
+          (candidate) =>
+            candidate.source === thread.source && candidate.id === thread.id,
+        );
+        if (!latestThread) {
+          return;
+        }
+        releaseThread = latestThread;
+
+        const input = buildQueuedTurnInput(releaseQueuedSnapshot);
+        if (input.length === 0) {
+          releaseState.composerDraftStore.removeQueuedTurnById(
+            scopeKey,
+            releaseQueuedSnapshot.id,
+          );
+          return;
+        }
+
+        const backend = releaseState.backends.find(
+          (candidate) => candidate.kind === releaseThread.source,
         );
         if (!backend?.available || !backend.capabilities.startTurn) {
           return;
         }
 
         const selectedModelOption =
-          backend.launchpadOptions?.models?.find((option) => option.id === thread.model) ??
+          backend.launchpadOptions?.models?.find(
+            (option) => option.id === releaseThread.model,
+          ) ??
           getDefaultModelOption(backend);
         const supportsReasoning =
           selectedModelOption?.supportsReasoning ??
@@ -138,22 +170,25 @@ export function useQueuedTurnRelease(params: {
             : false;
 
         await startTurn({
-          backend: thread.source,
-          threadId: thread.id,
+          backend: releaseThread.source,
+          threadId: releaseThread.id,
           input,
-          executionMode: thread.executionMode,
+          executionMode: releaseThread.executionMode,
           model: selectedModelOption?.id,
           reasoningEffort: supportsReasoning
-            ? getReasoningEffortValue(backend, thread.reasoningEffort)
+            ? getReasoningEffortValue(backend, releaseThread.reasoningEffort)
             : undefined,
           serviceTier:
-            thread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
+            releaseThread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
           fastMode:
-            thread.source === "codex" && supportsFast
-              ? Boolean(thread.fastMode)
+            releaseThread.source === "codex" && supportsFast
+              ? Boolean(releaseThread.fastMode)
               : undefined,
         });
-        current.composerDraftStore.removeQueuedTurnById(scopeKey, queuedTurn.id);
+        releaseState.composerDraftStore.removeQueuedTurnById(
+          scopeKey,
+          releaseQueuedSnapshot.id,
+        );
       } finally {
         inFlightScopeKeysRef.current.delete(scopeKey);
       }


### PR DESCRIPTION
## Summary

I fixed the queued-turn release race that can happen after an async branch-drift check, and I fixed the missing background release path for queued `/review` commands.

## What changed

- Re-read the current queued-turn state after `checkThreadBranchDrift` resolves.
- Abort background release if the thread became focused while the drift check was pending.
- Abort background release if the queued item changed while the drift check was pending.
- Use the refreshed thread and queued snapshot before starting queued work.
- Release background queued reviews with `review/start` instead of treating them as normal text turns.
- Added app-shell and Electron replay coverage for queueing `/review main`, navigating away, adopting an active-turn branch change, and starting the queued review.

## Why

The branch drift guard introduced an async gap in the background queued-turn release path. During that gap, the user can focus the same thread and let the mounted composer release the queued turn. Without revalidation, the background continuation can still start stale queued work.

The earlier coverage also missed the full queued review workflow. Focused queued reviews use `review/start`; background release only used `turn/start`, so a queued `/review main` could fail to release as the same review workflow when the thread was not focused.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e apps/desktop/e2e/queued-review-release.spec.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
