### PR TITLE
fix(desktop): repair monitor schema on startup

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -384,6 +384,30 @@ describe("SqliteMessagingStore", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("repairs a missing monitor subscription table on reopen", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-sqlite-msg-"));
+    tempDirs.push(tempDir);
+    const dbPath = path.join(tempDir, "state.db");
+    const initialDb = StateDb.open(dbPath);
+    stateDbs.push(initialDb);
+
+    initialDb.raw.exec("DROP TABLE monitor_subscriptions");
+    initialDb.raw.pragma("user_version = 4");
+    initialDb.close();
+    stateDbs.pop();
+
+    const reopenedDb = StateDb.open(dbPath);
+    stateDbs.push(reopenedDb);
+    const store = new SqliteMessagingStore(reopenedDb);
+
+    await expect(
+      store.findActiveMonitorSubscriptionsForChannelKind({ channel: "telegram" }),
+    ).resolves.toEqual([]);
+    await expect(
+      store.findActiveMonitorSubscriptionForChannel(buildMonitorSubscription().channel),
+    ).resolves.toBeUndefined();
+  });
+
   it("can delete callback handles for a binding without revoking it", async () => {
     const store = await createStore();
     await store.upsertCallbackHandle(buildCallbackHandle());

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -143,7 +143,7 @@ CREATE INDEX idx_messaging_pairing_status
 `;
 
 const SCHEMA_V4 = `
-CREATE TABLE monitor_subscriptions (
+CREATE TABLE IF NOT EXISTS monitor_subscriptions (
   subscription_id  TEXT PRIMARY KEY,
   channel_kind     TEXT NOT NULL,
   channel_id       TEXT NOT NULL,
@@ -153,7 +153,7 @@ CREATE TABLE monitor_subscriptions (
   revoked_at       INTEGER,
   payload          TEXT NOT NULL
 );
-CREATE INDEX idx_monitor_subscriptions_channel
+CREATE INDEX IF NOT EXISTS idx_monitor_subscriptions_channel
   ON monitor_subscriptions(channel_kind, channel_id);
 `;
 
@@ -221,6 +221,7 @@ export class StateDb {
         db.pragma("user_version = 4");
       })();
     }
+    ensureCurrentSchema(db);
 
     return new StateDb(db);
   }
@@ -330,4 +331,13 @@ export class StateDb {
   deleteSecret(key: string): void {
     this.db.prepare("DELETE FROM secrets WHERE key = ?").run(key);
   }
+}
+
+function ensureCurrentSchema(db: BetterSqlite3.Database): void {
+  db.transaction(() => {
+    db.exec(SCHEMA_V4);
+    if ((db.pragma("user_version", { simple: true }) as number) < 4) {
+      db.pragma("user_version = 4");
+    }
+  })();
 }


### PR DESCRIPTION
## Summary

- Repair the monitor subscription schema during app DB open when an existing profile is missing `monitor_subscriptions`.
- Make the monitor subscription table/index creation idempotent so fresh and partially-upgraded profiles both start cleanly.
- Add a regression test for a v4 DB that is missing the monitor table.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/state-migration.test.ts`
- `pnpm lint`

## Notes

- Root cause: monitor rehydrate reads the new `monitor_subscriptions` table during adapter startup. If a profile DB reports the current schema version but lacks that table, startup logs noisy monitor rehydrate failures even though there are no monitors to rehydrate.
