### PR TITLE
fix(desktop): audit archived worktree cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3028,6 +3028,125 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("reports skipped cleanup when an archived thread has no linked worktrees", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archive local thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      gitBranch: "main",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+    });
+    const archiveWorktree = vi.fn();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(archiveWorktree).not.toHaveBeenCalled();
+    expect(response.cleanup).toEqual([
+      {
+        branch: "main",
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason: "No linked worktree directories were available for archive cleanup.",
+      },
+    ]);
+
+    await registry.close();
+  });
+
+  it("reports failed cleanup when a worktree directory remains after archive", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-sentinel-"));
+    const repoPath = path.join(root, "PwrAgnt");
+    const worktreePath = path.join(root, ".codex", "worktrees", "leaked", "PwrAgnt");
+
+    try {
+      await mkdir(worktreePath, { recursive: true });
+      const thread: AppServerThreadSummary = {
+        id: "thread-1",
+        title: "Archive me",
+        titleSource: "explicit",
+        linkedDirectories: [
+          {
+            id: `directory:${repoPath}`,
+            label: "PwrAgnt",
+            path: repoPath,
+            kind: "worktree",
+            worktreePath,
+          },
+        ],
+        source: "codex",
+        gitBranch: "codex/archive-me",
+        updatedAt: 2,
+      };
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/list", "thread/archive"] },
+        threads: [thread],
+      });
+      const archiveWorktree = vi.fn(async () => ({
+        id: "snapshot-1",
+        backend: "codex" as const,
+        threadId: "thread-1",
+        worktreePath,
+        repositoryPath: repoPath,
+        snapshotRef: "refs/codex/snapshots/snapshot-1",
+        snapshotCommit: "abc123",
+        sourceBranch: "codex/archive-me",
+        sourceHead: "def456",
+        createdAt: 1000,
+        archivedAt: 1000,
+        state: "archived" as const,
+        ignoredFilesExcluded: true,
+      }));
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        overlayStore: createOverlayStoreMock(),
+        worktreeArchiveService: {
+          archive: archiveWorktree,
+        } as unknown as WorktreeArchiveService,
+      });
+
+      const response = await registry.archiveThread({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+
+      expect(response.cleanup).toEqual([
+        {
+          worktreePath,
+          branch: "codex/archive-me",
+          removedWorktree: false,
+          deletedBranch: false,
+          error: "Worktree directory still exists after archive cleanup.",
+        },
+      ]);
+
+      await registry.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("revokes messaging bindings and clears pending intents when archiving a thread", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3028,7 +3028,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("reports skipped cleanup when an archived thread has no linked worktrees", async () => {
+  it("does not report a cleanup failure when an archived thread has no linked worktrees", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",
       title: "Archive local thread",
@@ -3060,14 +3060,7 @@ describe("DesktopBackendRegistry", () => {
     });
 
     expect(archiveWorktree).not.toHaveBeenCalled();
-    expect(response.cleanup).toEqual([
-      {
-        branch: "main",
-        removedWorktree: false,
-        deletedBranch: false,
-        skippedReason: "No linked worktree directories were available for archive cleanup.",
-      },
-    ]);
+    expect(response.cleanup).toEqual([]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -118,6 +118,7 @@ class MockTransport implements JsonRpcTransport {
           searchTerm?: string;
           query?: string;
           filter?: string;
+          cursor?: string;
           sortKey?: string;
           sourceKinds?: string[];
         };
@@ -254,6 +255,42 @@ class MockTransport implements JsonRpcTransport {
                       cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
                     },
                   ],
+            },
+          }),
+        );
+        return;
+      }
+
+      if (searchTerm === "paginated-archive") {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            result: {
+              data:
+                params.params?.archived && params.params?.cursor === "archive-page-2"
+                  ? [
+                      {
+                        id: "thread-archived-page-2",
+                        name: "Archived page two",
+                        updatedAt: 1_776_300_000,
+                        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+                      },
+                    ]
+                  : params.params?.archived
+                    ? [
+                        {
+                          id: "thread-archived-page-1",
+                          name: "Archived page one",
+                          updatedAt: 1_776_400_000,
+                          cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+                        },
+                      ]
+                    : [],
+              nextCursor:
+                params.params?.archived && params.params?.cursor !== "archive-page-2"
+                  ? "archive-page-2"
+                  : null,
             },
           }),
         );
@@ -1141,6 +1178,51 @@ describe("CodexAppServerClient", () => {
         }),
       ])
     );
+
+    await client.close();
+  });
+
+  it("follows thread/list pagination for archived codex threads", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const threads = await client.listThreads({
+      archived: true,
+      filter: "paginated-archive",
+    });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "thread-archived-page-1",
+      "thread-archived-page-2",
+    ]);
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const threadListRequests = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: { cursor?: string } })
+      .filter((payload) => payload.method === "thread/list");
+
+    expect(threadListRequests).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          archived: true,
+          limit: 50,
+          searchTerm: "paginated-archive",
+        }),
+      }),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          archived: true,
+          cursor: "archive-page-2",
+          limit: 50,
+          searchTerm: "paginated-archive",
+        }),
+      }),
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4155,14 +4155,7 @@ export class DesktopBackendRegistry {
         projectKey: params.thread.projectKey,
         gitBranch: params.thread.observedGitBranch ?? params.thread.gitBranch,
       });
-      return [
-        {
-          branch: params.thread.observedGitBranch ?? params.thread.gitBranch,
-          removedWorktree: false,
-          deletedBranch: false,
-          skippedReason: "No linked worktree directories were available for archive cleanup.",
-        },
-      ];
+      return [];
     }
 
     return await Promise.all(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import { execFile as execFileCallback } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
@@ -138,6 +139,19 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
   }
 
   backendRegistryLog.info(event, payload);
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 function assistantOutputForTurn(
@@ -4116,9 +4130,33 @@ export class DesktopBackendRegistry {
       ).values(),
     ];
 
+    if (uniqueCandidates.length === 0) {
+      backendRegistryLog.warn("archive thread worktree cleanup skipped: no worktree candidates", {
+        backend: params.backend,
+        threadId: params.thread.id,
+        linkedDirectoryCount: params.thread.linkedDirectories.length,
+        projectKey: params.thread.projectKey,
+        gitBranch: params.thread.observedGitBranch ?? params.thread.gitBranch,
+      });
+      return [
+        {
+          branch: params.thread.observedGitBranch ?? params.thread.gitBranch,
+          removedWorktree: false,
+          deletedBranch: false,
+          skippedReason: "No linked worktree directories were available for archive cleanup.",
+        },
+      ];
+    }
+
     return await Promise.all(
       uniqueCandidates.map(async (candidate): Promise<ArchiveThreadCleanupResult> => {
         try {
+          backendRegistryLog.info("archive thread worktree cleanup removing worktree", {
+            backend: params.backend,
+            threadId: params.thread.id,
+            repositoryPath: candidate.repositoryPath,
+            worktreePath: candidate.worktreePath,
+          });
           const snapshot = await this.worktreeArchiveService.archive({
             backend: params.backend,
             threadId: params.thread.id,
@@ -4130,6 +4168,49 @@ export class DesktopBackendRegistry {
             threadId: params.thread.id,
             snapshot,
           });
+
+          let worktreeStillExists = false;
+          try {
+            worktreeStillExists = await pathExists(snapshot.worktreePath);
+          } catch (sentinelError) {
+            const error =
+              sentinelError instanceof Error ? sentinelError.message : String(sentinelError);
+            backendRegistryLog.error("archive thread worktree cleanup sentinel failed", {
+              backend: params.backend,
+              threadId: params.thread.id,
+              repositoryPath: snapshot.repositoryPath,
+              worktreePath: snapshot.worktreePath,
+              error,
+            });
+            return {
+              worktreePath: snapshot.worktreePath,
+              branch: snapshot.sourceBranch,
+              removedWorktree: false,
+              deletedBranch: false,
+              error: `Unable to verify worktree removal: ${error}`,
+            };
+          }
+
+          if (worktreeStillExists) {
+            const error = "Worktree directory still exists after archive cleanup.";
+            backendRegistryLog.error("archive thread worktree cleanup left worktree directory", {
+              backend: params.backend,
+              threadId: params.thread.id,
+              repositoryPath: snapshot.repositoryPath,
+              worktreePath: snapshot.worktreePath,
+              branch: snapshot.sourceBranch,
+              snapshotRef: snapshot.snapshotRef,
+              snapshotCommit: snapshot.snapshotCommit,
+              error,
+            });
+            return {
+              worktreePath: snapshot.worktreePath,
+              branch: snapshot.sourceBranch,
+              removedWorktree: false,
+              deletedBranch: false,
+              error,
+            };
+          }
 
           return {
             worktreePath: snapshot.worktreePath,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1472,7 +1472,11 @@ export class DesktopBackendRegistry {
           backend,
           thread,
         })
-      : this.buildArchiveCleanupMetadataSkippedResult(cleanupMetadataError);
+      : this.buildArchiveCleanupMetadataSkippedResult({
+          backend,
+          threadId: result.threadId,
+          error: cleanupMetadataError,
+        });
 
     return {
       backend,
@@ -1482,15 +1486,28 @@ export class DesktopBackendRegistry {
     };
   }
 
-  private buildArchiveCleanupMetadataSkippedResult(
-    error?: string,
-  ): ArchiveThreadCleanupResult[] {
+  private buildArchiveCleanupMetadataSkippedResult(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    error?: string;
+  }): ArchiveThreadCleanupResult[] {
+    backendRegistryLog.warn(
+      "archive thread worktree cleanup skipped: metadata unavailable",
+      {
+        backend: params.backend,
+        threadId: params.threadId,
+        skippedReason: params.error
+          ? `Unable to load thread metadata for archive cleanup: ${params.error}`
+          : "Unable to load thread metadata for archive cleanup.",
+      },
+    );
+
     return [
       {
         removedWorktree: false,
         deletedBranch: false,
-        skippedReason: error
-          ? `Unable to load thread metadata for archive cleanup: ${error}`
+        skippedReason: params.error
+          ? `Unable to load thread metadata for archive cleanup: ${params.error}`
           : "Unable to load thread metadata for archive cleanup.",
       },
     ];

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -124,6 +124,11 @@ type RawCodexThreadSummary = Omit<
   gitOriginUrl?: string;
 };
 
+type RawCodexThreadListPage = {
+  nextCursor?: string;
+  threads: RawCodexThreadSummary[];
+};
+
 type SkillCatalogEntry = {
   cwd?: string;
   skills: AppServerSkillSummary[];
@@ -2911,13 +2916,25 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
   );
 }
 
+function extractThreadListPage(value: unknown): RawCodexThreadListPage {
+  const record = asRecord(value);
+  return {
+    nextCursor: record
+      ? pickString(record, ["nextCursor", "next_cursor", "after"])
+      : undefined,
+    threads: extractThreadsFromValue(value),
+  };
+}
+
 function buildThreadDiscoveryPayloads(
   filter?: string,
-  archived?: boolean
+  archived?: boolean,
+  cursor?: string
 ): CodexThreadListParams[] {
   const searchTerm = filter?.trim() || undefined;
   const baseParams: CodexThreadListParams = {
     archived,
+    cursor,
     limit: 50,
     sortKey: "updated_at",
     sourceKinds: ["cli", "vscode"],
@@ -2931,7 +2948,7 @@ function buildThreadDiscoveryPayloads(
     {
       ...baseParams,
     },
-    {}
+    cursor ? { cursor } : {}
   ];
 }
 
@@ -3428,6 +3445,41 @@ async function requestWithFallbacks(params: {
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+async function requestThreadListPages(params: {
+  archived?: boolean;
+  client: JsonRpcConnection;
+  diagnostics?: JsonRpcObserverDiagnostics;
+  filter?: string;
+  requestTimeoutMs: number;
+}): Promise<RawCodexThreadSummary[]> {
+  const pages: RawCodexThreadSummary[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    const result = await requestWithFallbacks({
+      client: params.client,
+      diagnostics: params.diagnostics,
+      methods: ["thread/list"] as CodexClientRequestMethod[],
+      payloads: buildThreadDiscoveryPayloads(params.filter, params.archived, cursor),
+      timeoutMs: params.requestTimeoutMs,
+    });
+    const page = extractThreadListPage(result);
+    pages.push(...page.threads);
+
+    const nextCursor = page.nextCursor?.trim();
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      cursor = undefined;
+      break;
+    }
+
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (cursor);
+
+  return mergeThreadSummaries(pages);
+}
+
 type HelperTurnResult =
   | {
       status: "ok";
@@ -3789,19 +3841,25 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     };
     if (params?.archived === true) {
-      const archivedResult = await requestWithFallbacks({
-        ...requestParams,
-        payloads: buildThreadDiscoveryPayloads(params?.filter, true),
+      const archivedThreads = await requestThreadListPages({
+        archived: true,
+        client: this.connection,
+        diagnostics,
+        filter: params?.filter,
+        requestTimeoutMs: requestParams.timeoutMs,
       });
-      return await this.enrichThreads(extractThreadsFromValue(archivedResult));
+      return await this.enrichThreads(archivedThreads);
     }
 
-    const activeResult = await requestWithFallbacks({
-      ...requestParams,
-      payloads: buildThreadDiscoveryPayloads(params?.filter, false),
+    const activeThreads = await requestThreadListPages({
+      archived: false,
+      client: this.connection,
+      diagnostics,
+      filter: params?.filter,
+      requestTimeoutMs: requestParams.timeoutMs,
     });
     const threads = mergeArchivedThreadMetadata({
-      activeThreads: extractThreadsFromValue(activeResult),
+      activeThreads,
       archivedThreads: this.getCachedArchivedThreadMetadata(params?.filter),
     });
     this.scheduleArchivedThreadMetadataRefresh(params?.filter, diagnostics);
@@ -3848,7 +3906,8 @@ export class CodexAppServerClient {
       return await inFlight;
     }
 
-    const requestPromise = requestWithFallbacks({
+    const requestPromise = requestThreadListPages({
+      archived: true,
       client: this.connection,
       diagnostics: diagnostics
         ? {
@@ -3856,12 +3915,10 @@ export class CodexAppServerClient {
             callerReason: `${diagnostics.callerReason ?? "thread-list"}:archived-metadata`,
           }
         : undefined,
-      methods: ["thread/list"] as CodexClientRequestMethod[],
-      payloads: buildThreadDiscoveryPayloads(filter, true),
-      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      filter,
+      requestTimeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     })
-      .then((result) => {
-        const threads = extractThreadsFromValue(result);
+      .then((threads) => {
         this.archivedThreadMetadataByFilter.set(cacheKey, threads);
         this.archivedThreadMetadataLastRefreshByFilter.set(cacheKey, Date.now());
         return threads;


### PR DESCRIPTION
## Summary

- I added archive cleanup logging for worktree removal attempts, skipped cleanup decisions, cleanup failures, and post-removal sentinel failures.
- I added a sentinel check after archive cleanup records a removed worktree, so the app logs an error and reports cleanup failure if the directory still exists.
- I fixed Codex thread listing to follow `thread/list` pagination, which makes archived-thread metadata lookups and audits see more than the first 50 threads.
- I kept benign non-worktree archives from surfacing false cleanup errors in the renderer.

## Verification

- I verified `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` passes.
- I verified `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` passes.
- I verified `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` passes.
- I verified `pnpm --filter @pwragent/desktop typecheck` passes.
- I verified `pnpm --filter @pwragent/desktop build` passes.
- I reran the archived worktree audit after pagination and confirmed the archived Codex count expands from the suspicious first page to 503 archived threads.

## Notes

- I did not delete any local worktrees as part of this change.
- The audit found two PwrAgnt archived worktree paths still present on disk: `/Users/huntharo/.codex/worktrees/moro7fen/PwrAgnt` and `/Users/huntharo/.codex/worktrees/mp0h91pd/PwrAgnt`.
