### PR TITLE
fix(desktop): make thread metadata chips copyable

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useState, type ReactNode } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { isBranchDrifted } from "@pwragent/shared";
 import { BranchIcon, FolderIcon, WorktreeIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
-import { copyText, formatCopyTooltip } from "../../lib/copy-text";
+import { copyText } from "../../lib/copy-text";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 type ThreadMetaChipsProps = {
   hasApprovalRequest?: boolean;
@@ -27,7 +29,7 @@ export function ThreadMetaChips({
               thread.linkedDirectories.map((directory) => [
                 directory.kind,
                 (
-                  <span
+                  <CopyableThreadChip
                     aria-label={
                       directory.kind === "worktree"
                         ? `Copy path for worktree ${directory.label}`
@@ -35,38 +37,14 @@ export function ThreadMetaChips({
                     }
                     key={`${thread.id}:${directory.kind}:location-kind`}
                     className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
-                    role="button"
-                    tabIndex={0}
-                    data-tooltip={formatCopyTooltip(
+                    value={
                       directory.kind === "worktree"
                         ? directory.worktreePath ?? directory.path
                         : directory.path
-                    )}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void copyText(
-                        directory.kind === "worktree"
-                          ? directory.worktreePath ?? directory.path
-                          : directory.path
-                      );
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter" && event.key !== " ") {
-                        return;
-                      }
-
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void copyText(
-                        directory.kind === "worktree"
-                          ? directory.worktreePath ?? directory.path
-                          : directory.path
-                      );
-                    }}
+                    }
                   >
                     {directory.kind}
-                  </span>
+                  </CopyableThreadChip>
                 ),
               ]),
             ).values(),
@@ -77,7 +55,7 @@ export function ThreadMetaChips({
                 ? directory.worktreePath ?? directory.path
                 : directory.path;
             return (
-              <span
+              <CopyableThreadChip
                 aria-label={
                   directory.kind === "worktree"
                     ? `Copy path for worktree ${directory.label}`
@@ -85,29 +63,13 @@ export function ThreadMetaChips({
                 }
                 key={`${thread.id}:${directory.id}:root`}
                 className="thread-row__chip path-copy-target tooltip-target"
-                role="button"
-                tabIndex={0}
-                data-tooltip={formatCopyTooltip(copyPath)}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  void copyText(copyPath);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") {
-                    return;
-                  }
-
-                  event.preventDefault();
-                  event.stopPropagation();
-                  void copyText(copyPath);
-                }}
+                value={copyPath}
               >
                 <span aria-hidden="true" className="thread-row__chip-icon">
                   {directory.kind === "worktree" ? <WorktreeIcon size={12} /> : <FolderIcon size={12} />}
                 </span>
                 {directory.label}
-              </span>
+              </CopyableThreadChip>
             );
           })
       : (
@@ -139,28 +101,91 @@ export function ThreadMetaChips({
       {linkedDirectoryChips}
 
       {branchChip ? (
-        <span
-          className="thread-row__chip thread-row__chip--mono"
-          title={thread.gitBranch ? undefined : `Current branch: ${branchChip}`}
+        <CopyableThreadChip
+          aria-label={
+            thread.gitBranch ? "Copy branch name" : "Copy current branch name"
+          }
+          className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+          value={branchChip}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
             <BranchIcon size={12} />
           </span>
           {branchChip}
-        </span>
+        </CopyableThreadChip>
       ) : null}
 
-      {branchDrifted ? (
-        <span
-          className="thread-row__chip thread-row__chip--muted thread-row__chip--mono"
-          title={`Current branch: ${thread.observedGitBranch}`}
+      {branchDrifted && thread.observedGitBranch ? (
+        <CopyableThreadChip
+          aria-label="Copy current branch name"
+          className="thread-row__chip path-copy-target tooltip-target thread-row__chip--muted thread-row__chip--mono"
+          value={thread.observedGitBranch}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
             !
           </span>
           now {thread.observedGitBranch}
-        </span>
+        </CopyableThreadChip>
       ) : null}
+    </>
+  );
+}
+
+function CopyableThreadChip(props: {
+  "aria-label": string;
+  children: ReactNode;
+  className: string;
+  value: string;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const [copied, setCopied] = useState(false);
+  const tooltipText = copied ? "Copied" : `${props.value}\nClick to copy to clipboard`;
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setCopied(false), 1200);
+    return () => window.clearTimeout(timeoutId);
+  }, [copied]);
+
+  const copy = (target: HTMLElement): void => {
+    void copyText(props.value).then(() => {
+      setCopied(true);
+      tooltip.show(target, "Copied");
+    });
+  };
+
+  return (
+    <>
+      <span
+        aria-label={props["aria-label"]}
+        className={props.className}
+        role="button"
+        tabIndex={0}
+        onBlur={tooltip.hide}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          copy(event.currentTarget);
+        }}
+        onFocus={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" && event.key !== " ") {
+            return;
+          }
+
+          event.preventDefault();
+          event.stopPropagation();
+          copy(event.currentTarget);
+        }}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseLeave={tooltip.hide}
+      >
+        {props.children}
+      </span>
+      {tooltip.tooltipNode}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -102,9 +102,10 @@ export function ThreadMetaChips({
 
       {branchChip ? (
         <CopyableThreadChip
-          aria-label={
-            thread.gitBranch ? "Copy branch name" : "Copy current branch name"
-          }
+          aria-label={formatBranchCopyLabel({
+            branch: branchChip,
+            kind: thread.gitBranch ? "expected" : "current",
+          })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
           value={branchChip}
         >
@@ -117,7 +118,10 @@ export function ThreadMetaChips({
 
       {branchDrifted && thread.observedGitBranch ? (
         <CopyableThreadChip
-          aria-label="Copy current branch name"
+          aria-label={formatBranchCopyLabel({
+            branch: thread.observedGitBranch,
+            kind: "current",
+          })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--muted thread-row__chip--mono"
           value={thread.observedGitBranch}
         >
@@ -129,6 +133,14 @@ export function ThreadMetaChips({
       ) : null}
     </>
   );
+}
+
+function formatBranchCopyLabel(params: {
+  branch: string;
+  kind: "current" | "expected";
+}): string {
+  const branchKind = params.kind === "current" ? "current branch" : "branch";
+  return `Copy ${branchKind} ${params.branch}`;
 }
 
 function CopyableThreadChip(props: {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -145,6 +145,7 @@ export function ThreadRow(props: ThreadRowProps) {
       }}
     >
       <button
+        aria-label={props.thread.title}
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
           selected ? " is-selected" : ""

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1263,7 +1263,7 @@ describe("Sidebar", () => {
     expect(screen.queryByText("▾")).not.toBeInTheDocument();
   });
 
-  it("copies a linked directory path from the recents chip", () => {
+  it("copies linked directory and branch metadata from recents chips", async () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragent", {
       configurable: true,
@@ -1291,9 +1291,29 @@ describe("Sidebar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy path for worktree PwrAgent" }));
+    const directoryChip = screen.getByRole("button", {
+      name: "Copy path for worktree PwrAgent",
+    });
+    fireEvent.mouseEnter(directoryChip);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "/Users/huntharo/.codex/worktrees/0f38/PwrAgent\nClick to copy to clipboard"
+    );
+    fireEvent.mouseLeave(directoryChip);
 
-    expect(copyText).toHaveBeenCalledWith("/Users/huntharo/.codex/worktrees/0f38/PwrAgent");
+    fireEvent.click(directoryChip);
+    const branchChip = screen.getByRole("button", { name: "Copy branch name" });
+    fireEvent.mouseEnter(branchChip);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "codex/thread-centric-ui\nClick to copy to clipboard"
+    );
+    fireEvent.mouseLeave(branchChip);
+    fireEvent.click(branchChip);
+
+    expect(copyText).toHaveBeenNthCalledWith(
+      1,
+      "/Users/huntharo/.codex/worktrees/0f38/PwrAgent"
+    );
+    expect(copyText).toHaveBeenNthCalledWith(2, "codex/thread-centric-ui");
     expect(
       screen.queryByText("Line up the desktop shell with the app server")
     ).not.toBeInTheDocument();
@@ -1342,7 +1362,10 @@ describe("Sidebar", () => {
     fireEvent.mouseLeave(cwdButton);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 
-    const branchButton = screen.getByRole("button", { name: "Copy branch name" });
+    const branchButton = within(screen.getByLabelText("Runtime identity")).getByRole(
+      "button",
+      { name: "Copy branch name" }
+    );
     fireEvent.mouseEnter(branchButton);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
       "codex/fix-thread-naming-ephemeral\nClick to copy to clipboard"

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1301,7 +1301,9 @@ describe("Sidebar", () => {
     fireEvent.mouseLeave(directoryChip);
 
     fireEvent.click(directoryChip);
-    const branchChip = screen.getByRole("button", { name: "Copy branch name" });
+    const branchChip = screen.getByRole("button", {
+      name: "Copy branch codex/thread-centric-ui",
+    });
     fireEvent.mouseEnter(branchChip);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
       "codex/thread-centric-ui\nClick to copy to clipboard"


### PR DESCRIPTION
## Summary

- I made the thread-row worktree/local and branch chips use the same portal tooltip style as the runtime identity chips.
- I made branch chips copyable with pointer/focus affordances and clipboard behavior.
- I fixed the branch chip accessible names so they include the branch value, while keeping the row button named by the thread title.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false`.
- I ran `git diff --check`.

## Notes

- I verified both commits are signed.
