### PR TITLE
fix(desktop): log codex skill invalidations

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4,6 +4,18 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
+const codexClientLogError = vi.hoisted(() => vi.fn());
+const codexClientLogInfo = vi.hoisted(() => vi.fn());
+const codexClientLogWarn = vi.hoisted(() => vi.fn());
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => ({
+    error: codexClientLogError,
+    info: codexClientLogInfo,
+    warn: codexClientLogWarn,
+  })),
+}));
+
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
   static readThreadErrorByThreadId = new Map<string, { code: number; message: string }>();
@@ -795,6 +807,9 @@ vi.mock("../codex-app-server/stdio-transport", () => {
 
 describe("CodexAppServerClient", () => {
   beforeEach(() => {
+    codexClientLogError.mockClear();
+    codexClientLogInfo.mockClear();
+    codexClientLogWarn.mockClear();
     MockTransport.instances.length = 0;
     MockTransport.readThreadErrorByThreadId.clear();
     MockTransport.readThreadResultByThreadId.clear();
@@ -2879,6 +2894,70 @@ describe("CodexAppServerClient", () => {
             status: "completed"
           })
         })
+      }
+    ]);
+
+    await client.close();
+  });
+
+  it("logs diagnostics for Codex skills changed notifications", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "skills/changed",
+      params: {
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+        reason: "fileChanged"
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(codexClientLogWarn).toHaveBeenCalledWith(
+      "codex skills changed notification received",
+      expect.objectContaining({
+        method: "skills/changed",
+        payloadType: "object",
+        payloadKeys: ["cwd", "reason"],
+        listenerCount: 1,
+        initialized: true,
+        serverAdvertisesSkillsList: false,
+        expectedFollowup: "call skills/list when refreshed skill metadata is needed",
+        payload: {
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+          reason: "fileChanged"
+        }
+      })
+    );
+    expect(codexClientLogWarn).not.toHaveBeenCalledWith(
+      "unknown codex notification",
+      expect.anything()
+    );
+    expect(notifications).toEqual([
+      {
+        method: "skills/changed",
+        params: {
+          cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+          reason: "fileChanged"
+        }
       }
     ]);
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -154,6 +154,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "thread/compacted",
   "thread/archived",
   "thread/unarchived",
+  "skills/changed",
   "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",
@@ -183,6 +184,7 @@ const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
   "thread/compacted",
   "thread/archived",
   "thread/unarchived",
+  "skills/changed",
   "thread/name/updated",
   "thread/status/changed",
   "thread/tokenUsage/updated",
@@ -236,6 +238,36 @@ function isRequestLikeMethod(method: string): boolean {
   return method.includes("/request");
 }
 
+function describePayloadShape(payload: unknown): {
+  payloadType: string;
+  payloadKeys?: string[];
+  payloadLength?: number;
+} {
+  if (payload === null) {
+    return { payloadType: "null" };
+  }
+
+  if (payload === undefined) {
+    return { payloadType: "undefined" };
+  }
+
+  if (Array.isArray(payload)) {
+    return {
+      payloadType: "array",
+      payloadLength: payload.length,
+    };
+  }
+
+  if (typeof payload === "object") {
+    return {
+      payloadType: "object",
+      payloadKeys: Object.keys(payload as Record<string, unknown>).sort(),
+    };
+  }
+
+  return { payloadType: typeof payload };
+}
+
 function logUnhandledCodexMessage(params: {
   kind: "notification" | "request";
   method: string;
@@ -259,6 +291,24 @@ function logUnhandledCodexMessage(params: {
 
   codexClientLog.warn("unknown codex notification", {
     method: params.method,
+    ...describePayloadShape(params.payload),
+    payload: params.payload,
+  });
+}
+
+function logSkillsChangedNotification(params: {
+  payload: unknown;
+  listenerCount: number;
+  initialized: boolean;
+  serverAdvertisesSkillsList: boolean;
+}): void {
+  codexClientLog.warn("codex skills changed notification received", {
+    method: "skills/changed",
+    ...describePayloadShape(params.payload),
+    listenerCount: params.listenerCount,
+    initialized: params.initialized,
+    serverAdvertisesSkillsList: params.serverAdvertisesSkillsList,
+    expectedFollowup: "call skills/list when refreshed skill metadata is needed",
     payload: params.payload,
   });
 }
@@ -3503,6 +3553,15 @@ export class CodexAppServerClient {
           kind: "notification",
           method,
           payload: params,
+        });
+      }
+      if (method === "skills/changed") {
+        logSkillsChangedNotification({
+          payload: params,
+          listenerCount: this.notificationListeners.size,
+          initialized: this.initialized,
+          serverAdvertisesSkillsList:
+            this.initializeResult?.methods?.includes("skills/list") ?? false,
         });
       }
 


### PR DESCRIPTION
## Summary

I added focused Codex client logging for `skills/changed` notifications so the desktop logs show this as a known skill invalidation signal instead of a generic unknown notification.

## Changes

- Recognize `skills/changed` as a generated Codex notification method.
- Log the notification payload shape, listener count, initialization state, and whether the server advertised `skills/list`.
- Include payload shape details on genuinely unknown Codex notification logs.
- Add a Codex client regression test that emits `skills/changed` and verifies it is not logged as unknown.

## Verification

- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
