### PR TITLE
feat(desktop): show thread drop targets

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -12,6 +12,11 @@ import {
   moveThreadKey,
 } from "@pwragent/shared";
 import { FolderIcon, UnlinkedDotIcon, WorkspaceIcon } from "../../icons";
+import {
+  didDragLeaveCurrentTarget,
+  getDropIndicatorPosition,
+  type DropIndicatorState,
+} from "./drag-drop";
 import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
@@ -64,6 +69,15 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
 
 export function DirectoriesList(props: DirectoriesListProps) {
   const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>({});
+  const [dropIndicator, setDropIndicator] = useState<
+    DropIndicatorState | undefined
+  >(undefined);
+  const [dividerDropTarget, setDividerDropTarget] = useState<
+    string | undefined
+  >(undefined);
+  const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
+    undefined,
+  );
   const threadsByKey = useMemo(
     () =>
       new Map(
@@ -310,11 +324,17 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {directoryPinnedThreads.map((thread) => {
                       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+                      const rowDropKey = `${directory.key}:${threadKey}`;
                       return (
                         <ThreadRow
                           key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                           compact
+                          dropIndicator={
+                            dropIndicator?.targetKey === rowDropKey
+                              ? dropIndicator.position
+                              : undefined
+                          }
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode="kind"
@@ -323,19 +343,50 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           thread={thread}
                           onDragOverThread={(event) => {
                             event.preventDefault();
+                            const draggedThread = draggedThreadKey
+                              ? threadsByKey.get(draggedThreadKey)
+                              : undefined;
+                            if (
+                              !draggedThreadKey ||
+                              !draggedThread ||
+                              !directory.threadKeys.includes(draggedThreadKey) ||
+                              draggedThread.source !== thread.source
+                            ) {
+                              event.dataTransfer.dropEffect = "none";
+                              setDropIndicator(undefined);
+                              return;
+                            }
+
+                            event.dataTransfer.dropEffect = "move";
+                            setDropIndicator({
+                              targetKey: rowDropKey,
+                              position: getDropIndicatorPosition(event),
+                            });
+                            setDividerDropTarget(undefined);
                           }}
                           onDragStartThread={(event) => {
+                            setDraggedThreadKey(threadKey);
                             event.dataTransfer.effectAllowed = "move";
                             event.dataTransfer.setData("text/plain", threadKey);
                           }}
+                          onDragLeaveThread={(event) => {
+                            if (didDragLeaveCurrentTarget(event)) {
+                              setDropIndicator(undefined);
+                            }
+                          }}
+                          onDragEndThread={() => {
+                            setDraggedThreadKey(undefined);
+                            setDropIndicator(undefined);
+                            setDividerDropTarget(undefined);
+                          }}
                           onDropOnThread={(event) => {
                             event.preventDefault();
+                            setDraggedThreadKey(undefined);
+                            setDropIndicator(undefined);
+                            setDividerDropTarget(undefined);
                             const draggedKey = event.dataTransfer.getData("text/plain");
                             if (!draggedKey) return;
-                            const rect = event.currentTarget.getBoundingClientRect();
-                            const position = event.clientY > rect.top + rect.height / 2
-                              ? "after"
-                              : "before";
+                            const position = getDropIndicatorPosition(event);
                             moveDirectoryPin(
                               directory,
                               draggedKey,
@@ -362,14 +413,37 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     {directoryPinnedThreads.length > 0 &&
                     directoryUnpinnedThreads.length > 0 ? (
                       <div
-                        className="recents-pinned-divider directory-row__thread-divider"
+                        className={`recents-pinned-divider directory-row__thread-divider${
+                          dividerDropTarget === directory.key
+                            ? " is-drop-target"
+                            : ""
+                        }`}
                         role="separator"
                         aria-label={`Directory threads for ${directory.label}`}
                         onDragOver={(event) => {
                           event.preventDefault();
+                          if (
+                            !draggedThreadKey ||
+                            !directory.threadKeys.includes(draggedThreadKey)
+                          ) {
+                            event.dataTransfer.dropEffect = "none";
+                            setDividerDropTarget(undefined);
+                            return;
+                          }
+
+                          event.dataTransfer.dropEffect = "move";
+                          setDropIndicator(undefined);
+                          setDividerDropTarget(directory.key);
+                        }}
+                        onDragLeave={(event) => {
+                          if (didDragLeaveCurrentTarget(event)) {
+                            setDividerDropTarget(undefined);
+                          }
                         }}
                         onDrop={(event) => {
                           event.preventDefault();
+                          setDraggedThreadKey(undefined);
+                          setDividerDropTarget(undefined);
                           dropThreadAfterDirectoryPins(
                             directory,
                             event.dataTransfer.getData("text/plain"),
@@ -394,8 +468,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           thinkingThreadKeys={props.thinkingThreadKeys}
                           thread={thread}
                           onDragStartThread={(event) => {
+                            setDraggedThreadKey(threadKey);
                             event.dataTransfer.effectAllowed = "move";
                             event.dataTransfer.setData("text/plain", threadKey);
+                          }}
+                          onDragEndThread={() => {
+                            setDraggedThreadKey(undefined);
+                            setDropIndicator(undefined);
+                            setDividerDropTarget(undefined);
                           }}
                           onOpenContextMenu={props.onOpenThreadContextMenu}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type {
   AppServerBackendKind,
   MessagingThreadBindingSummary,
@@ -9,6 +10,11 @@ import {
   isPinnedThread,
   moveThreadKey,
 } from "@pwragent/shared";
+import {
+  didDragLeaveCurrentTarget,
+  getDropIndicatorPosition,
+  type DropIndicatorState,
+} from "./drag-drop";
 import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
@@ -38,6 +44,13 @@ type RecentsListProps = {
 };
 
 export function RecentsList(props: RecentsListProps) {
+  const [dropIndicator, setDropIndicator] = useState<
+    DropIndicatorState | undefined
+  >(undefined);
+  const [dividerDropTarget, setDividerDropTarget] = useState(false);
+  const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
+    undefined,
+  );
   const pinnedThreads = props.threads
     .filter(isPinnedThread)
     .sort(comparePinnedThreads);
@@ -99,6 +112,11 @@ export function RecentsList(props: RecentsListProps) {
           <ThreadRow
             key={key}
             approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+            dropIndicator={
+              dropIndicator?.targetKey === key
+                ? dropIndicator.position
+                : undefined
+            }
             draggable
             includeLinkedDirectories
             selectedThreadKey={props.selectedThreadKey}
@@ -106,22 +124,48 @@ export function RecentsList(props: RecentsListProps) {
             thread={thread}
             onDragOverThread={(event) => {
               event.preventDefault();
+              const draggedThread = draggedThreadKey
+                ? threadByKey.get(draggedThreadKey)
+                : undefined;
+              if (!draggedThread || draggedThread.source !== thread.source) {
+                event.dataTransfer.dropEffect = "none";
+                setDropIndicator(undefined);
+                return;
+              }
+
+              event.dataTransfer.dropEffect = "move";
+              setDropIndicator({
+                targetKey: key,
+                position: getDropIndicatorPosition(event),
+              });
+              setDividerDropTarget(false);
             }}
             onDragStartThread={(event) => {
+              setDraggedThreadKey(key);
               event.dataTransfer.effectAllowed = "move";
               event.dataTransfer.setData("text/plain", key);
             }}
+            onDragLeaveThread={(event) => {
+              if (didDragLeaveCurrentTarget(event)) {
+                setDropIndicator(undefined);
+              }
+            }}
+            onDragEndThread={() => {
+              setDraggedThreadKey(undefined);
+              setDropIndicator(undefined);
+              setDividerDropTarget(false);
+            }}
             onDropOnThread={(event) => {
               event.preventDefault();
+              setDraggedThreadKey(undefined);
+              setDropIndicator(undefined);
+              setDividerDropTarget(false);
               const draggedKey = event.dataTransfer.getData("text/plain");
               if (!draggedKey) return;
               const draggedThread = threadByKey.get(draggedKey);
               if (!draggedThread || draggedThread.source !== thread.source) return;
               const backendPinnedThreadKeys = pinnedThreadKeysForBackend(thread.source);
-              const rect = event.currentTarget.getBoundingClientRect();
-              const position = event.clientY > rect.top + rect.height / 2
-                ? "after"
-                : "before";
+              const position = getDropIndicatorPosition(event);
               const nextKeys = backendPinnedThreadKeys.includes(draggedKey)
                 ? moveThreadKey(backendPinnedThreadKeys, draggedKey, key, position)
                 : moveThreadKey(
@@ -143,12 +187,39 @@ export function RecentsList(props: RecentsListProps) {
       })}
       {pinnedThreads.length > 0 ? (
         <div
-          className="recents-pinned-divider"
+          className={`recents-pinned-divider${
+            dividerDropTarget ? " is-drop-target" : ""
+          }`}
           role="separator"
           aria-label="Unpinned threads"
-          onDragOver={(event) => event.preventDefault()}
+          onDragOver={(event) => {
+            event.preventDefault();
+            const draggedThread = draggedThreadKey
+              ? threadByKey.get(draggedThreadKey)
+              : undefined;
+            if (
+              !draggedThread ||
+              !draggedThreadKey ||
+              pinnedThreadKeys.includes(draggedThreadKey)
+            ) {
+              event.dataTransfer.dropEffect = "none";
+              setDividerDropTarget(false);
+              return;
+            }
+
+            event.dataTransfer.dropEffect = "move";
+            setDropIndicator(undefined);
+            setDividerDropTarget(true);
+          }}
+          onDragLeave={(event) => {
+            if (didDragLeaveCurrentTarget(event)) {
+              setDividerDropTarget(false);
+            }
+          }}
           onDrop={(event) => {
             event.preventDefault();
+            setDraggedThreadKey(undefined);
+            setDividerDropTarget(false);
             const draggedKey = event.dataTransfer.getData("text/plain");
             const draggedThread = threadByKey.get(draggedKey);
             if (!draggedThread || pinnedThreadKeys.includes(draggedKey)) return;
@@ -173,8 +244,14 @@ export function RecentsList(props: RecentsListProps) {
             thinkingThreadKeys={props.thinkingThreadKeys}
             thread={thread}
             onDragStartThread={(event) => {
+              setDraggedThreadKey(key);
               event.dataTransfer.effectAllowed = "move";
               event.dataTransfer.setData("text/plain", key);
+            }}
+            onDragEndThread={() => {
+              setDraggedThreadKey(undefined);
+              setDropIndicator(undefined);
+              setDividerDropTarget(false);
             }}
             onOpenContextMenu={props.onOpenThreadContextMenu}
             onPrefetchPullRequests={props.onPrefetchPullRequests}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { PrChip } from "../pr-status/PrChip";
+import type { DropIndicatorPosition } from "./drag-drop";
 import { ReactionPicker } from "./ReactionPicker";
 import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
@@ -28,6 +29,7 @@ const HOVER_PREFETCH_DELAY_MS = 750;
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
   compact?: boolean;
+  dropIndicator?: DropIndicatorPosition;
   draggable?: boolean;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
@@ -56,6 +58,8 @@ type ThreadRowProps = {
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onDragStartThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDragOverThread?: (event: DragEvent<HTMLDivElement>) => void;
+  onDragLeaveThread?: (event: DragEvent<HTMLDivElement>) => void;
+  onDragEndThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDropOnThread?: (event: DragEvent<HTMLDivElement>) => void;
   onMovePinnedThread?: (
     thread: NavigationThreadSummary,
@@ -125,7 +129,9 @@ export function ThreadRow(props: ThreadRowProps) {
 
   return (
     <div
-      className={`thread-row-shell${props.draggable ? " is-draggable" : ""}`}
+      className={`thread-row-shell${props.draggable ? " is-draggable" : ""}${
+        props.dropIndicator ? ` is-drop-target-${props.dropIndicator}` : ""
+      }`}
       draggable={props.draggable}
       role="listitem"
       onDragStart={(event) => {
@@ -135,6 +141,8 @@ export function ThreadRow(props: ThreadRowProps) {
         props.onDragStartThread?.(event);
       }}
       onDragOver={props.onDragOverThread}
+      onDragLeave={props.onDragLeaveThread}
+      onDragEnd={props.onDragEndThread}
       onDrop={props.onDropOnThread}
       onContextMenu={(event) => {
         event.preventDefault();

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -289,6 +289,11 @@ function setThreadRowDragImage(event: DragEvent<HTMLDivElement>): void {
   const rect = row.getBoundingClientRect();
   const clone = row.cloneNode(true) as HTMLElement;
   clone.classList.add("thread-row--drag-image");
+  clone.classList.remove("thread-row--compact");
+  clone.querySelector(".thread-row__actions")?.remove();
+  clone.querySelector(".thread-row__chip--add-reaction")?.remove();
+  clone.querySelector(".thread-row__overflow-button")?.remove();
+  clone.setAttribute("aria-hidden", "true");
   clone.style.width = `${rect.width}px`;
   clone.style.height = `${rect.height}px`;
   document.body.appendChild(clone);

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -131,12 +131,16 @@ function createDataTransfer(threadKey: string) {
   return {
     effectAllowed: "move",
     getData: vi.fn((type: string) => (type === "text/plain" ? threadKey : "")),
+    setDragImage: vi.fn(),
     setData: vi.fn(),
   };
 }
 
 afterEach(() => {
   vi.restoreAllMocks();
+  document
+    .querySelectorAll(".thread-row--drag-image")
+    .forEach((element) => element.remove());
   cleanup();
 });
 
@@ -739,6 +743,73 @@ describe("Sidebar", () => {
       "thread-updated",
       "thread-1",
     ]);
+  });
+
+  it("shows recents drop targets for row edges and the pin divider", () => {
+    const pinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, pinnedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const draggedRow = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell");
+    expect(draggedRow).not.toBeNull();
+    const dataTransfer = createDataTransfer("codex:thread-1");
+    fireEvent.dragStart(draggedRow!, { dataTransfer });
+
+    const pinnedRow = screen
+      .getByRole("button", { name: /Updated thread/i })
+      .closest(".thread-row-shell");
+    expect(pinnedRow).not.toBeNull();
+    vi.spyOn(pinnedRow!, "getBoundingClientRect").mockReturnValue({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 300,
+      toJSON: () => ({}),
+      top: 0,
+      width: 300,
+      x: 0,
+      y: 0,
+    });
+
+    fireEvent.dragOver(pinnedRow!, {
+      clientY: 75,
+      dataTransfer,
+    });
+    expect(pinnedRow).toHaveClass("is-drop-target-before");
+
+    fireEvent.dragLeave(pinnedRow!, {
+      relatedTarget: null,
+    });
+    expect(pinnedRow).not.toHaveClass("is-drop-target-before");
+
+    const divider = screen.getByRole("separator", { name: "Unpinned threads" });
+    fireEvent.dragOver(divider, {
+      dataTransfer,
+    });
+    expect(divider).toHaveClass("is-drop-target");
   });
 
   it("ignores attempts to drop a thread on another directory pin divider", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -208,6 +208,43 @@ describe("ThreadRow chip flow", () => {
     expect(addReaction?.textContent ?? "").not.toContain("+");
   });
 
+  it("uses a full card without action controls for the drag preview", () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = renderRow({
+        compact: true,
+        draggable: true,
+      });
+      const shell = container.querySelector(".thread-row-shell") as HTMLElement;
+      const dataTransfer = {
+        setDragImage: vi.fn(),
+      };
+
+      fireEvent.dragStart(shell, {
+        clientX: 12,
+        clientY: 18,
+        dataTransfer,
+      });
+
+      const dragImage = document.body.querySelector(".thread-row--drag-image");
+      expect(dragImage).not.toBeNull();
+      expect(dragImage).not.toHaveClass("thread-row--compact");
+      expect(dragImage?.querySelector(".thread-row__actions")).toBeNull();
+      expect(
+        dragImage?.querySelector(".thread-row__chip--add-reaction"),
+      ).toBeNull();
+      expect(dragImage?.querySelector(".thread-row__overflow-button")).toBeNull();
+      expect(dataTransfer.setDragImage).toHaveBeenCalledWith(
+        dragImage,
+        expect.any(Number),
+        expect.any(Number),
+      );
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("still selects the thread when the row body (outside chips) is clicked", () => {
     const { onSelectThread } = renderRow();
     // The row's accessible name is the thread title; click that to

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -245,6 +245,13 @@ describe("ThreadRow chip flow", () => {
     }
   });
 
+  it("marks the active drop edge on the row shell", () => {
+    const { container } = renderRow({ dropIndicator: "after" });
+    expect(container.querySelector(".thread-row-shell")).toHaveClass(
+      "is-drop-target-after",
+    );
+  });
+
   it("still selects the thread when the row body (outside chips) is clicked", () => {
     const { onSelectThread } = renderRow();
     // The row's accessible name is the thread title; click that to

--- a/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/drag-drop.ts
@@ -1,0 +1,24 @@
+import type { DragEvent } from "react";
+
+export type DropIndicatorPosition = "before" | "after";
+
+export type DropIndicatorState = {
+  position: DropIndicatorPosition;
+  targetKey: string;
+};
+
+export function getDropIndicatorPosition(
+  event: DragEvent<HTMLElement>,
+): DropIndicatorPosition {
+  const rect = event.currentTarget.getBoundingClientRect();
+  return event.clientY > rect.top + rect.height / 2 ? "after" : "before";
+}
+
+export function didDragLeaveCurrentTarget(
+  event: DragEvent<HTMLElement>,
+): boolean {
+  const relatedTarget = event.relatedTarget;
+  return !(
+    relatedTarget instanceof Node && event.currentTarget.contains(relatedTarget)
+  );
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1145,6 +1145,30 @@ textarea,
   cursor: grabbing;
 }
 
+.thread-row-shell.is-drop-target-before::before,
+.thread-row-shell.is-drop-target-after::after {
+  content: "";
+  position: absolute;
+  right: 8px;
+  left: 8px;
+  z-index: 6;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 1px rgba(18, 8, 0, 0.72),
+    0 0 14px var(--accent-shadow);
+  pointer-events: none;
+}
+
+.thread-row-shell.is-drop-target-before::before {
+  top: -3px;
+}
+
+.thread-row-shell.is-drop-target-after::after {
+  bottom: -3px;
+}
+
 .recents-pinned-divider {
   display: flex;
   align-items: center;
@@ -1157,6 +1181,10 @@ textarea,
   text-transform: uppercase;
 }
 
+.recents-pinned-divider.is-drop-target {
+  color: var(--accent-bright);
+}
+
 .recents-pinned-divider::before,
 .recents-pinned-divider::after {
   content: "";
@@ -1164,6 +1192,15 @@ textarea,
   height: 1px;
   flex: 1;
   background: var(--border-subtle);
+}
+
+.recents-pinned-divider.is-drop-target::before,
+.recents-pinned-divider.is-drop-target::after {
+  height: 3px;
+  background: var(--accent);
+  box-shadow:
+    0 0 0 1px rgba(18, 8, 0, 0.72),
+    0 0 14px var(--accent-shadow);
 }
 
 .thread-row {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1194,9 +1194,9 @@ textarea,
 
 .thread-row.thread-row--drag-image {
   position: fixed;
-  top: -10000px;
-  left: -10000px;
-  z-index: -1;
+  top: 0;
+  left: 0;
+  z-index: 10000;
   border-color: var(--border-strong);
   background: var(--bg-panel-elevated);
   box-shadow:


### PR DESCRIPTION
## Summary

I fixed the thread drag preview so it renders as a clean card without the hover-only reaction or overflow controls, and I added visible drop target feedback for thread pin reordering.

## Details

- Normalize compact directory thread rows into the full card layout for the drag preview.
- Keep Electron's custom drag image captureable so it does not fall back to the full hover shell.
- Show an orange insertion line above or below valid row targets while dragging.
- Highlight the pin divider when dropping there would pin the thread at the end of the pinned section.
- Share the before/after cursor calculation between Recents and Directories so the indicator matches the actual drop operation.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
