### PR TITLE
fix(desktop): clean up failed json-rpc sends

### DIFF
--- a/apps/desktop/src/main/__tests__/json-rpc.test.ts
+++ b/apps/desktop/src/main/__tests__/json-rpc.test.ts
@@ -11,6 +11,7 @@ vi.mock("../log", () => ({
 
 class MockTransport implements JsonRpcTransport {
   readonly sentMessages: string[] = [];
+  sendError: Error | undefined;
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
 
@@ -27,6 +28,9 @@ class MockTransport implements JsonRpcTransport {
   }
 
   send(message: string): void {
+    if (this.sendError) {
+      throw this.sendError;
+    }
     this.sentMessages.push(message);
   }
 
@@ -127,5 +131,32 @@ describe("JsonRpcConnection", () => {
     expect(jsonRpcLogError).toHaveBeenCalled();
 
     await connection.close();
+  });
+
+  it("clears pending requests when the transport send fails", async () => {
+    const transport = new MockTransport();
+    const connection = new JsonRpcConnection(transport, 1_000);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason);
+    };
+
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      await connection.connect();
+      transport.sendError = new Error("codex app server stdio not connected");
+
+      await expect(connection.request("thread/list", {})).rejects.toThrow(
+        "codex app server stdio not connected",
+      );
+
+      await connection.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
   });
 });

--- a/apps/desktop/src/main/codex-app-server/json-rpc.ts
+++ b/apps/desktop/src/main/codex-app-server/json-rpc.ts
@@ -141,12 +141,21 @@ export class JsonRpcConnection {
       this.pending.set(id, { resolve, reject, timer });
     });
 
-    await this.sendEnvelope({
-      jsonrpc: "2.0",
-      id,
-      method,
-      params: params ?? {}
-    }, diagnostics);
+    try {
+      await this.sendEnvelope({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params: params ?? {}
+      }, diagnostics);
+    } catch (error) {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+      }
+      throw error;
+    }
 
     return await requestPromise;
   }


### PR DESCRIPTION
## Summary

- I fixed JSON-RPC request cleanup when a request fails before it can be written to the app-server stdio transport.
- I clear the pending request timer/map entry on send failure so a later transport close cannot reject an orphaned promise with `json-rpc transport closed`.
- I added regression coverage for a failed stdio send followed by connection shutdown without an unhandled rejection.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/json-rpc.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
