### PR TITLE
fix(agent-core): collapse workspace scratchpad rows

### DIFF
--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -391,6 +391,58 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("keeps multiple pending workspace drafts selectable instead of collapsing one away", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "workspace:/Users/huntharo/.pwragnt/projects": {
+          directoryKey: "workspace:/Users/huntharo/.pwragnt/projects",
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: "/Users/huntharo/.pwragnt/projects",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Legacy draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+        "workspace:/Users/huntharo/.pwragent/profiles/dev/projects": {
+          directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: "/Users/huntharo/.pwragent/profiles/dev/projects",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Profile draft",
+          workMode: "local",
+          createdAt: 3_000,
+          updatedAt: 4_000,
+        },
+      },
+    });
+
+    expect(directories).toHaveLength(2);
+    expect(directories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "workspace:/Users/huntharo/.pwragnt/projects",
+          launchpad: expect.objectContaining({
+            directoryKey: "workspace:/Users/huntharo/.pwragnt/projects",
+            prompt: "Legacy draft",
+          }),
+        }),
+        expect.objectContaining({
+          key: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
+          launchpad: expect.objectContaining({
+            directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
+            prompt: "Profile draft",
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("keeps same-named Codex worktrees as separate directory rows", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -300,6 +300,97 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("collapses current, legacy, and launchpad-only scratch roots into one Workspaces row", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "019e1e90-ae49-78a0-8414-266602c3a532",
+          inbox: { inInbox: true },
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragent/profiles/dev/projects/2026-05-12-605c84",
+              label: "2026-05-12-605c84",
+              path: "/Users/huntharo/.pwragent/profiles/dev/projects/2026-05-12-605c84",
+              kind: "local",
+            },
+          ],
+          updatedAt: 4_000,
+        }),
+        buildThread({
+          id: "019e1732-3ce4-7dd1-9191-f097f816a5dd",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragent/profiles/dev/projects/2026-05-11-dc5db1",
+              label: "2026-05-11-dc5db1",
+              path: "/Users/huntharo/.pwragent/profiles/dev/projects/2026-05-11-dc5db1",
+              kind: "local",
+            },
+          ],
+          updatedAt: 3_000,
+        }),
+        buildThread({
+          id: "019deae0-5018-7ac3-8b5c-2ac392f8fbd8",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragnt/projects/2026-05-02-bc16ae",
+              label: "2026-05-02-bc16ae",
+              path: "/Users/huntharo/.pwragnt/projects/2026-05-02-bc16ae",
+              kind: "local",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+        buildThread({
+          id: "019de4af-5a9e-7813-88f0-6cc4ac251fda",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragnt/projects/2026-05-01-800a67",
+              label: "2026-05-01-800a67",
+              path: "/Users/huntharo/.pwragnt/projects/2026-05-01-800a67",
+              kind: "local",
+            },
+          ],
+          updatedAt: 1_000,
+        }),
+      ],
+      launchpadsByKey: {
+        "workspace:/Users/huntharo/.pwragent/profiles/default/projects": {
+          directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/default/projects",
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: "/Users/huntharo/.pwragent/profiles/default/projects",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Pending scratchpad draft",
+          workMode: "local",
+          createdAt: 5_000,
+          updatedAt: 6_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "workspace:/Users/huntharo/.pwragent/profiles/default/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/huntharo/.pwragent/profiles/default/projects",
+        threadKeys: [
+          "codex:019e1e90-ae49-78a0-8414-266602c3a532",
+          "codex:019e1732-3ce4-7dd1-9191-f097f816a5dd",
+          "codex:019deae0-5018-7ac3-8b5c-2ac392f8fbd8",
+          "codex:019de4af-5a9e-7813-88f0-6cc4ac251fda",
+        ],
+        needsAttentionCount: 1,
+        latestUpdatedAt: 6_000,
+        launchpad: expect.objectContaining({
+          directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/default/projects",
+          prompt: "Pending scratchpad draft",
+        }),
+      }),
+    ]);
+  });
+
   it("keeps same-named Codex worktrees as separate directory rows", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -183,6 +183,90 @@ function hasPersistableLaunchpadState(
   );
 }
 
+function compareWorkspaceSummaryPreference(
+  left: NavigationDirectorySummary,
+  right: NavigationDirectorySummary,
+): number {
+  const leftLaunchpadUpdatedAt = left.launchpad?.updatedAt ?? 0;
+  const rightLaunchpadUpdatedAt = right.launchpad?.updatedAt ?? 0;
+  const launchpadUpdatedDelta = rightLaunchpadUpdatedAt - leftLaunchpadUpdatedAt;
+  if (launchpadUpdatedDelta !== 0) {
+    return launchpadUpdatedDelta;
+  }
+
+  const updatedDelta = (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0);
+  return updatedDelta !== 0 ? updatedDelta : left.key.localeCompare(right.key);
+}
+
+function chooseWorkspaceSummary(
+  workspaces: NavigationDirectorySummary[],
+): NavigationDirectorySummary {
+  const withPendingLaunchpads = workspaces.filter(
+    (workspace) =>
+      workspace.launchpad && hasPersistableLaunchpadState(workspace.launchpad),
+  );
+  const candidates =
+    withPendingLaunchpads.length > 0 ? withPendingLaunchpads : workspaces;
+  return [...candidates].sort(compareWorkspaceSummaryPreference)[0]!;
+}
+
+function collapseWorkspaceSummaries(params: {
+  summaries: NavigationDirectorySummary[];
+  threads: NavigationThreadSummary[];
+}): NavigationDirectorySummary[] {
+  const workspaces = params.summaries.filter(
+    (summary) => summary.kind === "workspace",
+  );
+  if (workspaces.length <= 1) {
+    return params.summaries;
+  }
+
+  const preferred = chooseWorkspaceSummary(workspaces);
+  const threadOrder = new Map(
+    params.threads.map((thread, index) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      index,
+    ]),
+  );
+  const inboxByThreadKey = new Map(
+    params.threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread.inbox.inInbox,
+    ]),
+  );
+  const threadKeys = [...new Set(workspaces.flatMap((summary) => summary.threadKeys))]
+    .sort(
+      (left, right) =>
+        (threadOrder.get(left) ?? Number.MAX_SAFE_INTEGER) -
+        (threadOrder.get(right) ?? Number.MAX_SAFE_INTEGER),
+    );
+  const latestUpdatedAt = Math.max(
+    ...workspaces.map((summary) => summary.latestUpdatedAt ?? 0),
+  );
+
+  return [
+    {
+      ...preferred,
+      threadKeys,
+      needsAttentionCount: threadKeys.reduce(
+        (count, threadKey) => count + (inboxByThreadKey.get(threadKey) ? 1 : 0),
+        0,
+      ),
+      latestUpdatedAt: latestUpdatedAt || undefined,
+      launchpad: preferred.launchpad
+        ? {
+            ...preferred.launchpad,
+            directoryKey: preferred.key,
+            directoryKind: "workspace",
+            directoryLabel: preferred.label,
+            directoryPath: preferred.path,
+          }
+        : undefined,
+    },
+    ...params.summaries.filter((summary) => summary.kind !== "workspace"),
+  ];
+}
+
 export function buildDirectorySummaries(params: {
   threads: NavigationThreadSummary[];
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
@@ -281,5 +365,8 @@ export function buildDirectorySummaries(params: {
     }
   }
 
-  return [...summaries.values()].sort((left, right) => left.label.localeCompare(right.label));
+  return collapseWorkspaceSummaries({
+    summaries: [...summaries.values()],
+    threads: params.threads,
+  }).sort((left, right) => left.label.localeCompare(right.label));
 }

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -221,6 +221,14 @@ function collapseWorkspaceSummaries(params: {
     return params.summaries;
   }
 
+  const pendingWorkspaces = workspaces.filter(
+    (workspace) =>
+      workspace.launchpad && hasPersistableLaunchpadState(workspace.launchpad),
+  );
+  if (pendingWorkspaces.length > 1) {
+    return params.summaries;
+  }
+
   const preferred = chooseWorkspaceSummary(workspaces);
   const threadOrder = new Map(
     params.threads.map((thread, index) => [


### PR DESCRIPTION
## Summary

- I collapsed duplicate scratch-workspace directory rows into one Workspaces row for the normal navigation case.
- I preserved access to every pending workspace launchpad draft when multiple scratch roots have unsent prompts or touched settings.
- I added regression coverage using the reported thread IDs and a separate multi-draft edge case.

## Verification

- I ran `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts`.
- I ran `pnpm --filter @pwragent/agent-core typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- Root cause: current, profile-scoped, legacy, and launchpad-only scratch workspace roots were all classified as `kind: "workspace"` but emitted as separate navigation summaries with the same `Workspaces` label.
- The collapse intentionally backs off when more than one workspace row has persistable launchpad state, so persisted drafts remain selectable, resettable, and materializable.
