### PR TITLE
feat(desktop): add thread automation scheduling

### DIFF
--- a/apps/desktop/e2e/queued-review-release.spec.ts
+++ b/apps/desktop/e2e/queued-review-release.spec.ts
@@ -328,7 +328,7 @@ test("background queued review releases after active turn branch adoption", asyn
   }
 });
 
-test("duplicate Codex turn starts are rejected while the thread is active", async () => {
+test("duplicate Codex turn starts queue through the desktop API while the thread is active", async () => {
   const fixture = await createDuplicateTurnStartGuardFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -394,8 +394,13 @@ test("duplicate Codex turn starts are rejected while the thread is active", asyn
       }
     });
     expect(second).toMatchObject({
-      ok: false,
-      message: expect.stringContaining("already active"),
+      ok: true,
+      response: {
+        backend: "codex",
+        threadId: "thread-active",
+        queueStatus: "queued",
+        queueEntryId: expect.any(String),
+      },
     });
   } finally {
     await app.close();

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -34,6 +34,18 @@ const registry = {
     threadId: request.threadId,
     turnId: "turn-1",
   })),
+  submitTurn: vi.fn(async (request: StartTurnRequest & { origin: "manual" }) => ({
+    status: "started" as const,
+    entry: {
+      id: "queue-1",
+      backend: request.backend,
+      createdAt: 1,
+      input: request.input,
+      origin: request.origin,
+      threadId: request.threadId,
+    },
+    turnId: "turn-1",
+  })),
   startReview: vi.fn(async (request: StartReviewRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -106,6 +118,7 @@ describe("agent ipc", () => {
     registry.onEvent.mockClear();
     registry.startThread.mockClear();
     registry.startTurn.mockClear();
+    registry.submitTurn.mockClear();
     registry.startReview.mockClear();
     registry.interruptTurn.mockClear();
     registry.steerTurn.mockClear();
@@ -149,6 +162,8 @@ describe("agent ipc", () => {
       }),
     ).toEqual({
       backend: "grok",
+      queueEntryId: "queue-1",
+      queueStatus: "started",
       threadId: "thread-1",
       turnId: "turn-1",
     });

--- a/apps/desktop/src/main/__tests__/automation-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-prompt.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { buildAutomationTurnInput } from "../automations/automation-prompt";
+import type { AutomationRecord } from "../automations/automation-store";
+
+function buildAutomation(): AutomationRecord {
+  return {
+    id: "automation-1",
+    backend: "codex",
+    threadId: "thread-1",
+    name: "Check email",
+    taskPrompt: "Summarize urgent unread mail.",
+    status: "enabled",
+    schedule: {
+      kind: "interval",
+      every: 5,
+      unit: "minutes",
+    },
+    scheduleSummary: "every 5 minutes",
+    backlogPolicy: "coalesce",
+    createdAt: 1_000,
+    updatedAt: 1_000,
+  };
+}
+
+describe("buildAutomationTurnInput", () => {
+  it("includes catch-up metadata before the task prompt", () => {
+    const input = buildAutomationTurnInput({
+      automation: buildAutomation(),
+      run: {
+        id: "run-1",
+        automationId: "automation-1",
+        trigger: "scheduled",
+        status: "pending",
+        scheduledWindows: [
+          { scheduledFor: Date.UTC(2026, 4, 13, 14, 10) },
+          { scheduledFor: Date.UTC(2026, 4, 13, 14, 15) },
+        ],
+      },
+    });
+
+    expect(input).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("Trigger: scheduled catch-up"),
+      },
+    ]);
+    expect(input[0]?.type === "text" ? input[0].text : "").toContain(
+      "Coalesced missed windows: 1",
+    );
+    expect(input[0]?.type === "text" ? input[0].text : "").toContain(
+      "Summarize urgent unread mail.",
+    );
+  });
+
+  it("marks manual run-now prompts distinctly", () => {
+    const [item] = buildAutomationTurnInput({
+      automation: buildAutomation(),
+      run: {
+        id: "run-1",
+        automationId: "automation-1",
+        trigger: "manual",
+        status: "pending",
+        scheduledWindows: [],
+      },
+    });
+
+    expect(item?.type === "text" ? item.text : "").toContain(
+      "Trigger: manual Run Now",
+    );
+    expect(item?.type === "text" ? item.text : "").toContain(
+      "- none; this was manually triggered",
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/automation-schedule.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-schedule.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectDueAutomationWindows,
+  computeNextAutomationRunAt,
+} from "../automations/automation-schedule";
+
+describe("automation schedule calculations", () => {
+  it("computes interval occurrences from an anchor", () => {
+    const schedule = {
+      kind: "interval" as const,
+      every: 5,
+      unit: "minutes" as const,
+      anchorAt: 0,
+    };
+
+    expect(computeNextAutomationRunAt(schedule, 0)).toBe(5 * 60 * 1000);
+    expect(computeNextAutomationRunAt(schedule, 7 * 60 * 1000)).toBe(10 * 60 * 1000);
+    expect(
+      collectDueAutomationWindows({
+        schedule,
+        firstDueAt: 5 * 60 * 1000,
+        through: 15 * 60 * 1000,
+      }),
+    ).toEqual([
+      { scheduledFor: 5 * 60 * 1000 },
+      { scheduledFor: 10 * 60 * 1000 },
+      { scheduledFor: 15 * 60 * 1000 },
+    ]);
+  });
+
+  it("computes weekly and weekday wall-clock occurrences", () => {
+    const fridayMorning = new Date(2026, 4, 15, 8, 0, 0, 0).getTime();
+    const fridayAtFour = new Date(2026, 4, 15, 16, 0, 0, 0).getTime();
+    const mondayAtNine = new Date(2026, 4, 18, 9, 0, 0, 0).getTime();
+
+    expect(
+      computeNextAutomationRunAt(
+        {
+          kind: "weekly",
+          daysOfWeek: ["friday"],
+          timeOfDay: { hour: 16, minute: 0 },
+        },
+        fridayMorning,
+      ),
+    ).toBe(fridayAtFour);
+    expect(
+      computeNextAutomationRunAt(
+        {
+          kind: "weekdays",
+          timeOfDay: { hour: 9, minute: 0 },
+        },
+        fridayAtFour,
+      ),
+    ).toBe(mondayAtNine);
+  });
+});

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -38,6 +38,13 @@ class FakeQueue {
       turnId: `turn-${queuedEntry.id}`,
     };
   }
+
+  updateQueuedInput(entryId: string, input: ThreadTurnQueueEntry["input"]): void {
+    const entry = this.submitted.find((candidate) => candidate.id === entryId);
+    if (entry) {
+      entry.input = input;
+    }
+  }
 }
 
 let tempDir: string;
@@ -92,6 +99,28 @@ function buildScheduler(): AutomationScheduler {
 }
 
 describe("AutomationScheduler", () => {
+  it("reschedules timers when start is called after an automation is added", () => {
+    const timerDelays: number[] = [];
+    const scheduler = new AutomationScheduler({
+      store,
+      queue,
+      now: () => now,
+      setTimer: ((_callback: () => void, delayMs: number) => {
+        timerDelays.push(delayMs);
+        return timerDelays.length;
+      }) as unknown as typeof setTimeout,
+      clearTimer: () => undefined,
+    });
+
+    scheduler.start();
+    expect(timerDelays).toEqual([]);
+
+    createIntervalAutomation();
+    scheduler.start();
+
+    expect(timerDelays).toEqual([5 * 60 * 1000]);
+  });
+
   it("starts due interval automations on idle threads and advances next run", async () => {
     createIntervalAutomation();
     const scheduler = buildScheduler();
@@ -144,6 +173,11 @@ describe("AutomationScheduler", () => {
     await scheduler.evaluateDueAutomations();
 
     expect(queue.submitted).toHaveLength(1);
+    expect(queue.submitted[0]?.input).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining("- 1970-01-01T00:15:00.000Z"),
+      }),
+    ]);
     expect(store.listRunsForAutomation("automation-1")).toEqual([
       expect.objectContaining({
         scheduledWindows: [

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -1,0 +1,206 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ThreadTurnQueueEntry } from "../app-server/thread-turn-queue";
+import { AutomationScheduler } from "../automations/automation-scheduler";
+import { AutomationStore } from "../automations/automation-store";
+import { StateDb } from "../state/state-db";
+
+class FakeQueue {
+  active = false;
+  submitted: ThreadTurnQueueEntry[] = [];
+
+  canStartImmediately(): boolean {
+    return !this.active;
+  }
+
+  async submit(
+    entry: Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
+      Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">>,
+  ) {
+    const queuedEntry: ThreadTurnQueueEntry = {
+      ...entry,
+      id: entry.id ?? `queue-${this.submitted.length + 1}`,
+      createdAt: entry.createdAt ?? 1_000,
+    };
+    this.submitted.push(queuedEntry);
+    if (this.active) {
+      return {
+        status: "queued" as const,
+        entry: queuedEntry,
+        position: this.submitted.length,
+      };
+    }
+    return {
+      status: "started" as const,
+      entry: queuedEntry,
+      turnId: `turn-${queuedEntry.id}`,
+    };
+  }
+}
+
+let tempDir: string;
+let stateDb: StateDb;
+let store: AutomationStore;
+let queue: FakeQueue;
+let now = 0;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-automation-scheduler-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new AutomationStore(stateDb);
+  queue = new FakeQueue();
+  now = 0;
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function createIntervalAutomation(
+  overrides: Parameters<AutomationStore["createAutomation"]>[0] = {
+    backend: "codex",
+    threadId: "thread-1",
+    name: "Check email",
+    taskPrompt: "Check mail",
+    schedule: {
+      kind: "interval",
+      every: 5,
+      unit: "minutes",
+      anchorAt: 0,
+    },
+    nextRunAt: 5 * 60 * 1000,
+  },
+) {
+  return store.createAutomation({
+    id: "automation-1",
+    now: 0,
+    ...overrides,
+  });
+}
+
+function buildScheduler(): AutomationScheduler {
+  return new AutomationScheduler({
+    store,
+    queue,
+    now: () => now,
+    setTimer: (() => 0) as unknown as typeof setTimeout,
+    clearTimer: () => undefined,
+  });
+}
+
+describe("AutomationScheduler", () => {
+  it("starts due interval automations on idle threads and advances next run", async () => {
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 5 * 60 * 1000;
+
+    await scheduler.evaluateDueAutomations();
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        status: "running",
+        backendTurnId: "turn-queue-1",
+        scheduledWindows: [{ scheduledFor: 5 * 60 * 1000 }],
+      }),
+    ]);
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      nextRunAt: 10 * 60 * 1000,
+    });
+  });
+
+  it("coalesces due windows into one queued catch-up run by default", async () => {
+    queue.active = true;
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 15 * 60 * 1000;
+
+    await scheduler.evaluateDueAutomations();
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        status: "queued",
+        scheduledWindows: [
+          { scheduledFor: 5 * 60 * 1000 },
+          { scheduledFor: 10 * 60 * 1000 },
+          { scheduledFor: 15 * 60 * 1000 },
+        ],
+      }),
+    ]);
+  });
+
+  it("merges later due windows into an existing pending coalesced run", async () => {
+    queue.active = true;
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 10 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+
+    now = 15 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        scheduledWindows: [
+          { scheduledFor: 5 * 60 * 1000 },
+          { scheduledFor: 10 * 60 * 1000 },
+          { scheduledFor: 15 * 60 * 1000 },
+        ],
+      }),
+    ]);
+  });
+
+  it("records skipped history for drop_missed while the thread is busy", async () => {
+    queue.active = true;
+    createIntervalAutomation({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      backlogPolicy: "drop_missed",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+        anchorAt: 0,
+      },
+      nextRunAt: 5 * 60 * 1000,
+    });
+    const scheduler = buildScheduler();
+    now = 10 * 60 * 1000;
+
+    await scheduler.evaluateDueAutomations();
+
+    expect(queue.submitted).toEqual([]);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({ status: "skipped", scheduledFor: 10 * 60 * 1000 }),
+      expect.objectContaining({ status: "skipped", scheduledFor: 5 * 60 * 1000 }),
+    ]);
+  });
+
+  it("queues manual run-now without changing the recurring next run", async () => {
+    queue.active = true;
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 2 * 60 * 1000;
+
+    await scheduler.runNow("automation-1");
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        trigger: "manual",
+        status: "queued",
+        scheduledWindows: [],
+      }),
+    ]);
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      nextRunAt: 5 * 60 * 1000,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -203,4 +203,44 @@ describe("AutomationScheduler", () => {
       nextRunAt: 5 * 60 * 1000,
     });
   });
+
+  it("maps terminal backend failure notifications to failed runs", async () => {
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 5 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+    const [run] = store.listRunsForAutomation("automation-1");
+
+    scheduler.handleTurnQueueUpdate({
+      automationRunId: run?.id,
+      status: "terminal",
+      terminalStatus: "turn/failed",
+      now: 6 * 60 * 1000,
+    });
+
+    expect(store.listRunsForAutomation("automation-1")[0]).toMatchObject({
+      status: "failed",
+      errorMessage: "turn/failed",
+    });
+  });
+
+  it("maps terminal backend cancellation notifications to cancelled runs", async () => {
+    createIntervalAutomation();
+    const scheduler = buildScheduler();
+    now = 5 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+    const [run] = store.listRunsForAutomation("automation-1");
+
+    scheduler.handleTurnQueueUpdate({
+      automationRunId: run?.id,
+      status: "terminal",
+      terminalStatus: "turn/cancelled",
+      now: 6 * 60 * 1000,
+    });
+
+    expect(store.listRunsForAutomation("automation-1")[0]).toMatchObject({
+      status: "cancelled",
+      errorMessage: "turn/cancelled",
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -1,0 +1,326 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AutomationStore } from "../automations/automation-store";
+import { StateDb } from "../state/state-db";
+
+let tempDir: string;
+let stateDb: StateDb;
+let store: AutomationStore;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-automations-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new AutomationStore(stateDb, { runHistoryLimit: 3 });
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("AutomationStore", () => {
+  it("creates, updates, pauses, resumes, and soft-deletes automation records", () => {
+    const created = store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check for important mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+      nextRunAt: 10_000,
+      now: 1_000,
+    });
+
+    expect(created).toMatchObject({
+      id: "automation-1",
+      backlogPolicy: "coalesce",
+      scheduleSummary: "every 5 minutes",
+      status: "enabled",
+    });
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      taskPrompt: "Check for important mail",
+    });
+
+    store.updateAutomation("automation-1", {
+      name: "Review inbox",
+      backlogPolicy: "drop_missed",
+      now: 2_000,
+    });
+    expect(store.listAutomationsForThread({ backend: "codex", threadId: "thread-1" }))
+      .toEqual([
+        expect.objectContaining({
+          name: "Review inbox",
+          backlogPolicy: "drop_missed",
+          updatedAt: 2_000,
+        }),
+      ]);
+
+    expect(store.pauseAutomation("automation-1", 3_000)).toMatchObject({
+      status: "paused",
+    });
+    expect(store.resumeAutomation("automation-1", { nextRunAt: 20_000, now: 4_000 }))
+      .toMatchObject({
+        status: "enabled",
+        nextRunAt: 20_000,
+      });
+    expect(store.deleteAutomation("automation-1", 5_000)).toMatchObject({
+      status: "deleted",
+      deletedAt: 5_000,
+    });
+    expect(store.getAutomation("automation-1")).toBeUndefined();
+    expect(store.getAutomation("automation-1", { includeDeleted: true })).toMatchObject({
+      status: "deleted",
+    });
+  });
+
+  it("persists run history, terminal updates, and thread summaries", () => {
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+      nextRunAt: 10_000,
+      now: 1_000,
+    });
+    const run = store.createRun({
+      id: "run-1",
+      automationId: "automation-1",
+      trigger: "scheduled",
+      scheduledFor: 10_000,
+      now: 10_000,
+    });
+
+    expect(run).toMatchObject({
+      id: "run-1",
+      status: "pending",
+      scheduledWindows: [{ scheduledFor: 10_000 }],
+    });
+    store.markRunQueued({
+      runId: "run-1",
+      queueEntryId: "queue-1",
+      queuedAt: 10_100,
+      now: 10_100,
+    });
+    store.markRunStarted({
+      runId: "run-1",
+      backendTurnId: "turn-1",
+      startedAt: 10_200,
+      now: 10_200,
+    });
+    store.markRunTerminal({
+      runId: "run-1",
+      status: "completed",
+      completedAt: 12_000,
+      now: 12_000,
+    });
+
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        id: "run-1",
+        status: "completed",
+        backendTurnId: "turn-1",
+        completedAt: 12_000,
+      }),
+    ]);
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      lastRunAt: 12_000,
+      lastRunStatus: "completed",
+    });
+    expect(store.buildThreadSummaries()["codex:thread-1"]).toMatchObject({
+      totalCount: 1,
+      enabledCount: 1,
+      nextRunAt: 10_000,
+      lastRunAt: 12_000,
+      pendingRunCount: 0,
+    });
+  });
+
+  it("coalesces later scheduled windows into the existing pending scheduled run", () => {
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+      now: 1_000,
+    });
+    store.createRun({
+      id: "run-1",
+      automationId: "automation-1",
+      trigger: "scheduled",
+      scheduledFor: 10_000,
+      now: 10_000,
+    });
+
+    expect(
+      store.coalescePendingScheduledRun({
+        automationId: "automation-1",
+        scheduledWindows: [{ scheduledFor: 15_000 }, { scheduledFor: 10_000 }],
+        now: 15_000,
+      }),
+    ).toMatchObject({
+      id: "run-1",
+      scheduledWindows: [
+        { scheduledFor: 10_000 },
+        { scheduledFor: 15_000 },
+      ],
+    });
+    expect(store.listRunsForAutomation("automation-1")).toHaveLength(1);
+    expect(store.buildThreadSummaries()["codex:thread-1"]).toMatchObject({
+      pendingRunCount: 1,
+      coalescedWindowCount: 1,
+    });
+  });
+
+  it("reconciles stale local runs on startup without creating catch-up rows", () => {
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+      nextRunAt: 5_000,
+      now: 1_000,
+    });
+    store.createRun({
+      id: "run-1",
+      automationId: "automation-1",
+      trigger: "scheduled",
+      scheduledFor: 5_000,
+      status: "queued",
+      queuedAt: 5_100,
+      now: 5_100,
+    });
+
+    store.reconcileStartup({
+      now: 20_000,
+      nextRunAtByAutomationId: {
+        "automation-1": 25_000,
+      },
+    });
+
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        id: "run-1",
+        status: "cancelled",
+        completedAt: 20_000,
+        errorMessage: "PwrAgent restarted before this local automation run completed.",
+      }),
+    ]);
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      nextRunAt: 25_000,
+    });
+  });
+
+  it("caps detailed run history per automation", () => {
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+      now: 1_000,
+    });
+
+    for (let index = 1; index <= 4; index += 1) {
+      store.createRun({
+        id: `run-${index}`,
+        automationId: "automation-1",
+        trigger: "scheduled",
+        status: "skipped",
+        scheduledFor: index * 1_000,
+        now: index * 1_000,
+      });
+    }
+
+    expect(store.listRunsForAutomation("automation-1", 10).map((run) => run.id))
+      .toEqual(["run-4", "run-3", "run-2"]);
+  });
+
+  it("handles malformed persisted payloads as recoverable read omissions", () => {
+    stateDb.raw
+      .prepare(
+        `INSERT INTO automations (
+          automation_id,
+          backend,
+          thread_id,
+          name,
+          status,
+          backlog_policy,
+          created_at,
+          updated_at,
+          payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "automation-bad",
+        "codex",
+        "thread-1",
+        "Broken",
+        "enabled",
+        "coalesce",
+        1_000,
+        1_000,
+        "{not-json",
+      );
+
+    expect(store.getAutomation("automation-bad")).toBeUndefined();
+    expect(store.listAutomations()).toEqual([]);
+  });
+
+  it("persists SQL-looking names and prompts through bound parameters", () => {
+    const created = store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Robert'); DROP TABLE automations;--",
+      taskPrompt: "Check \"mail\" where subject = 'urgent';",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: {
+          hour: 9,
+          minute: 0,
+        },
+      },
+      now: 1_000,
+    });
+
+    expect(created.name).toBe("Robert'); DROP TABLE automations;--");
+    expect(store.getAutomation("automation-1")).toMatchObject({
+      taskPrompt: "Check \"mail\" where subject = 'urgent';",
+      scheduleSummary: "weekdays at 9 AM",
+    });
+    expect(
+      stateDb.raw
+        .prepare("SELECT COUNT(*) AS count FROM automations")
+        .get(),
+    ).toEqual({ count: 1 });
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4866,6 +4866,58 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("releases queued turns for Grok terminal events", async () => {
+    const grokClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const first = await registry.submitTurn({
+      backend: "grok",
+      threadId: "thread-1",
+      origin: "manual",
+      input: [{ type: "text", text: "first" }],
+    });
+    const second = await registry.submitTurn({
+      backend: "grok",
+      threadId: "thread-1",
+      origin: "manual",
+      input: [{ type: "text", text: "second" }],
+    });
+
+    expect(first.status).toBe("started");
+    expect(second.status).toBe("queued");
+    expect(grokClient.lastStartTurnParams?.input).toEqual([
+      { type: "text", text: "first" },
+    ]);
+
+    await grokClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+    });
+
+    await waitForCondition(() =>
+      grokClient.lastStartTurnParams?.input.some(
+        (item) => item.type === "text" && item.text === "second",
+      ) ?? false,
+    );
+    expect(grokClient.lastStartTurnParams?.input).toEqual([
+      { type: "text", text: "second" },
+    ]);
+
+    await registry.close();
+  });
+
   it("emits local turn lifecycle events for registry-started Codex turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "thread/read"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4422,7 +4422,6 @@ command = "pnpm dev"
       turnId: "turn-1",
     });
 
-    expect(codexClient.lastRenameThreadParams).toBeUndefined();
     await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@pwragent/shared";
+import type { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { DesktopAutomationService } from "../automations/desktop-automation-service";
+import { AutomationStore } from "../automations/automation-store";
+import { StateDb } from "../state/state-db";
+
+let tempDir: string;
+let stateDb: StateDb;
+let store: AutomationStore;
+let publishedEvents: AgentEvent[];
+let registry: DesktopBackendRegistry;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-automation-service-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new AutomationStore(stateDb);
+  publishedEvents = [];
+  registry = {
+    canStartThreadTurnImmediately: vi.fn(() => true),
+    submitTurn: vi.fn(async (entry) => ({
+      status: "started" as const,
+      entry: {
+        ...entry,
+        id: entry.id ?? "queue-1",
+        createdAt: entry.createdAt ?? 1_000,
+      },
+      turnId: "turn-1",
+    })),
+    onEvent: vi.fn(() => () => undefined),
+    publishLocalEvent: vi.fn(async (event: AgentEvent) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as DesktopBackendRegistry;
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("DesktopAutomationService", () => {
+  it("creates automations, lists them, and publishes thread automation updates", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+    });
+
+    expect(created.automation).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      backlogPolicy: "coalesce",
+      status: "enabled",
+    });
+    expect(service.list({ backend: "codex", threadId: "thread-1" }).automations)
+      .toEqual([expect.objectContaining({ id: created.automation.id })]);
+    expect(publishedEvents).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/automations/updated",
+        params: { threadId: "thread-1" },
+      },
+    });
+  });
+
+  it("runs automations now through the shared turn queue", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: { hour: 9, minute: 0 },
+      },
+    });
+
+    await expect(
+      service.runNow({ automationId: created.automation.id }),
+    ).resolves.toMatchObject({
+      queueStatus: "started",
+      turnId: "turn-1",
+      run: expect.objectContaining({
+        trigger: "manual",
+        status: "running",
+      }),
+    });
+    expect(registry.submitTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: "automation",
+        automationRunId: expect.any(String),
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -12,6 +12,7 @@ let tempDir: string;
 let stateDb: StateDb;
 let store: AutomationStore;
 let publishedEvents: AgentEvent[];
+let registryListeners: Array<(event: AgentEvent) => void | Promise<void>>;
 let registry: DesktopBackendRegistry;
 
 beforeEach(() => {
@@ -19,8 +20,10 @@ beforeEach(() => {
   stateDb = StateDb.open(path.join(tempDir, "state.db"));
   store = new AutomationStore(stateDb);
   publishedEvents = [];
+  registryListeners = [];
   registry = {
     canStartThreadTurnImmediately: vi.fn(() => true),
+    cancelQueuedTurn: vi.fn(),
     submitTurn: vi.fn(async (entry) => ({
       status: "started" as const,
       entry: {
@@ -30,7 +33,13 @@ beforeEach(() => {
       },
       turnId: "turn-1",
     })),
-    onEvent: vi.fn(() => () => undefined),
+    updateQueuedTurnInput: vi.fn(),
+    onEvent: vi.fn((listener) => {
+      registryListeners.push(listener);
+      return () => {
+        registryListeners = registryListeners.filter((entry) => entry !== listener);
+      };
+    }),
     publishLocalEvent: vi.fn(async (event: AgentEvent) => {
       publishedEvents.push(event);
     }),
@@ -105,5 +114,79 @@ describe("DesktopAutomationService", () => {
         automationRunId: expect.any(String),
       }),
     );
+  });
+
+  it("schedules from now when update enables a paused automation", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      enabled: false,
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+    });
+
+    const updated = await service.update({
+      automationId: created.automation.id,
+      enabled: true,
+    });
+
+    expect(updated.automation.status).toBe("enabled");
+    expect(updated.automation.nextRunAt).toBeGreaterThan(Date.now());
+  });
+
+  it("publishes run updates for queue lifecycle events by run id", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    service.start();
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: { hour: 9, minute: 0 },
+      },
+    });
+    const runNow = await service.runNow({ automationId: created.automation.id });
+    publishedEvents = [];
+
+    await Promise.all(
+      registryListeners.map((listener) =>
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/turnQueue/updated",
+            params: {
+              threadId: "thread-1",
+              queueEntryId: runNow.queueEntryId ?? "queue-1",
+              origin: "automation",
+              status: "terminal",
+              automationRunId: runNow.run.id,
+              terminalStatus: "turn/completed",
+              turnId: "turn-1",
+            },
+          },
+        } as AgentEvent),
+      ),
+    );
+
+    expect(publishedEvents).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "automation/run/updated",
+        params: {
+          automationId: created.automation.id,
+          runId: runNow.run.id,
+          status: "completed",
+          threadId: "thread-1",
+        },
+      },
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -189,4 +189,43 @@ describe("DesktopAutomationService", () => {
       },
     });
   });
+
+  it("cancels every queued automation turn when deleting an automation", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: { hour: 9, minute: 0 },
+      },
+    });
+
+    for (let index = 1; index <= 55; index += 1) {
+      const run = store.createRun({
+        id: `run-${index}`,
+        automationId: created.automation.id,
+        trigger: "manual",
+        now: 1_000 + index,
+      });
+      expect(run).toBeDefined();
+      store.markRunQueued({
+        runId: `run-${index}`,
+        queueEntryId: `queue-${index}`,
+        queuedAt: 2_000 + index,
+        now: 2_000 + index,
+      });
+    }
+
+    await service.delete({ automationId: created.automation.id });
+
+    expect(registry.cancelQueuedTurn).toHaveBeenCalledTimes(55);
+    expect(
+      (registry.cancelQueuedTurn as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([entryId]) => entryId,
+      ),
+    ).toEqual(Array.from({ length: 55 }, (_, index) => `queue-${55 - index}`));
+  });
 });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -9,6 +9,8 @@ const registerAgentIpcHandlersMock = vi.fn();
 const disposeAgentIpcHandlersMock = vi.fn();
 const registerApplicationIpcHandlersMock = vi.fn();
 const disposeApplicationIpcHandlersMock = vi.fn();
+const registerAutomationIpcHandlersMock = vi.fn();
+const disposeAutomationIpcHandlersMock = vi.fn();
 const registerAppMetadataIpcHandlersMock = vi.fn();
 const disposeAppMetadataIpcHandlersMock = vi.fn();
 const registerAppUpdateIpcHandlersMock = vi.fn();
@@ -162,6 +164,11 @@ vi.mock("../ipc/agent-ipc", () => ({
 vi.mock("../ipc/applications", () => ({
   registerApplicationIpcHandlers: registerApplicationIpcHandlersMock,
   disposeApplicationIpcHandlers: disposeApplicationIpcHandlersMock,
+}));
+
+vi.mock("../ipc/automation-ipc", () => ({
+  registerAutomationIpcHandlers: registerAutomationIpcHandlersMock,
+  disposeAutomationIpcHandlers: disposeAutomationIpcHandlersMock,
 }));
 
 vi.mock("../ipc/app-metadata", () => ({
@@ -327,6 +334,8 @@ describe("bootstrapApp", () => {
     initAutoUpdaterMock.mockReset();
     checkForAppUpdatesNowMock.mockReset();
     showAppLogWindowMock.mockReset();
+    registerAutomationIpcHandlersMock.mockReset();
+    disposeAutomationIpcHandlersMock.mockReset();
     showChangelogWindowMock.mockReset();
     showLicenseWindowMock.mockReset();
     showThirdPartyNoticesWindowMock.mockReset();

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1547,6 +1547,137 @@ describe("MessagingController", () => {
     });
   });
 
+  it("posts a durable start notice for automation turns", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/turnQueue/updated",
+        params: {
+          threadId: "thread-1",
+          queueEntryId: "queue-1",
+          origin: "automation",
+          status: "started",
+          turnId: "turn-1",
+          automationRunId: "run-1",
+          automationName: "Batphone",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        role: "system",
+        parts: [
+          expect.objectContaining({
+            text: expect.stringContaining("Automation started: Batphone"),
+          }),
+        ],
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "active",
+    });
+  });
+
+  it("keeps automation messaging quiet until the final assistant response", async () => {
+    const harness = await createHarness({
+      toolUpdateDefaultMode: "show_all",
+      streamingResponsesDefault: true,
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/turnQueue/updated",
+        params: {
+          threadId: "thread-1",
+          queueEntryId: "queue-1",
+          origin: "automation",
+          status: "started",
+          turnId: "turn-1",
+          automationRunId: "run-1",
+          automationName: "Batphone",
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent(
+      buildToolCompletedEvent("tool-1", "pnpm test"),
+    );
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-stream-1",
+          delta: "Intermediate thinking.",
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-commentary-1",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Intermediate commentary.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Final automation response." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "stream_update" ||
+          (intent.kind === "message" && intent.role === "system" &&
+            intent.id.startsWith("tool-update")),
+      ),
+    ).toEqual([]);
+    expect(JSON.stringify(harness.delivered)).not.toContain("Intermediate thinking");
+    expect(JSON.stringify(harness.delivered)).not.toContain("Intermediate commentary");
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          expect.objectContaining({
+            text: "Final automation response.",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("echoes binding routing state into typing activity intents", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(

--- a/apps/desktop/src/main/__tests__/state-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/state-migration.test.ts
@@ -8,6 +8,7 @@ import {
   PWRAGENT_PROFILE_ENV,
 } from "../profile";
 import { migrateIfNeeded } from "../state/migration";
+import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
 
 const tempRoots: string[] = [];
 
@@ -55,6 +56,26 @@ function readProfileName(dbPath: string): string {
 }
 
 describe("state migration", () => {
+  it("initializes automation scheduling tables in the profile database", () => {
+    const root = createTempRoot();
+    const dbPath = path.join(root, "state.db");
+    const stateDb = StateDb.open(dbPath);
+    try {
+      expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+        CURRENT_STATE_DB_USER_VERSION,
+      );
+      expect(
+        stateDb.raw
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('automations', 'automation_runs') ORDER BY name",
+          )
+          .all(),
+      ).toEqual([{ name: "automation_runs" }, { name: "automations" }]);
+    } finally {
+      stateDb.close();
+    }
+  });
+
   it("does not copy legacy default settings into a new named profile", () => {
     const root = createTempRoot();
     const pwragentHome = path.join(root, "pwragent");

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ThreadTurnQueue,
+  type ThreadTurnQueueEntry,
+  type ThreadTurnQueueLifecycleEvent,
+} from "../app-server/thread-turn-queue";
+
+function buildEntry(
+  overrides: Partial<Omit<ThreadTurnQueueEntry, "input">> = {},
+): Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
+  Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">> {
+  return {
+    id: "entry-1",
+    backend: "codex",
+    threadId: "thread-1",
+    origin: "manual",
+    input: [{ type: "text", text: "hello" }],
+    createdAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe("ThreadTurnQueue", () => {
+  it("starts idle thread submissions immediately", async () => {
+    const startedEntries: string[] = [];
+    const events: ThreadTurnQueueLifecycleEvent[] = [];
+    const queue = new ThreadTurnQueue({
+      startTurn: async (entry) => {
+        startedEntries.push(entry.id);
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+      onLifecycle: (event) => {
+        events.push(event);
+      },
+    });
+
+    await expect(queue.submit(buildEntry())).resolves.toMatchObject({
+      status: "started",
+      turnId: "turn-entry-1",
+    });
+    expect(startedEntries).toEqual(["entry-1"]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "started",
+        turnId: "turn-entry-1",
+      }),
+    ]);
+  });
+
+  it("queues active-thread submissions and starts them FIFO on release", async () => {
+    let active = true;
+    const startedEntries: string[] = [];
+    const events: ThreadTurnQueueLifecycleEvent[] = [];
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => active,
+      startTurn: async (entry) => {
+        startedEntries.push(entry.id);
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+      onLifecycle: (event) => {
+        events.push(event);
+      },
+    });
+
+    await expect(queue.submit(buildEntry({ id: "manual-1", origin: "manual" })))
+      .resolves.toMatchObject({
+        status: "queued",
+        position: 1,
+      });
+    await expect(
+      queue.submit(buildEntry({ id: "automation-1", origin: "automation" })),
+    ).resolves.toMatchObject({
+      status: "queued",
+      position: 2,
+    });
+
+    active = false;
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+    await queue.releaseThread({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-manual-1",
+    });
+
+    expect(startedEntries).toEqual(["manual-1", "automation-1"]);
+    expect(events.map((event) => event.type)).toEqual([
+      "queued",
+      "queued",
+      "started",
+      "terminal",
+      "started",
+    ]);
+  });
+
+  it("guards duplicate terminal release signals", async () => {
+    let active = true;
+    const startedEntries: string[] = [];
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => active,
+      startTurn: async (entry) => {
+        startedEntries.push(entry.id);
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+    });
+
+    await queue.submit(buildEntry({ id: "queued-1" }));
+
+    active = false;
+    await Promise.all([
+      queue.releaseThread({ backend: "codex", threadId: "thread-1" }),
+      queue.releaseThread({ backend: "codex", threadId: "thread-1" }),
+    ]);
+
+    expect(startedEntries).toEqual(["queued-1"]);
+  });
+
+  it("starts later queued entries when one queued start fails", async () => {
+    let active = true;
+    const startedEntries: string[] = [];
+    const failed = new Error("backend rejected start");
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => active,
+      startTurn: async (entry) => {
+        if (entry.id === "bad-entry") {
+          throw failed;
+        }
+        startedEntries.push(entry.id);
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+      onLifecycle: vi.fn(),
+    });
+
+    await queue.submit(buildEntry({ id: "bad-entry" }));
+    await queue.submit(buildEntry({ id: "good-entry" }));
+
+    active = false;
+    await queue.releaseThread({ backend: "codex", threadId: "thread-1" });
+
+    expect(startedEntries).toEqual(["good-entry"]);
+  });
+
+  it("cancels pending queue entries by id", async () => {
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => true,
+      startTurn: async (entry) => ({
+        backend: entry.backend,
+        threadId: entry.threadId,
+        turnId: `turn-${entry.id}`,
+      }),
+    });
+
+    await queue.submit(buildEntry({ id: "queued-1" }));
+
+    expect(queue.cancelEntry("queued-1", "test cancel")).toMatchObject({
+      id: "queued-1",
+    });
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1900,6 +1900,7 @@ export class DesktopBackendRegistry {
       queueEntryId: event.entry.id,
       origin: event.entry.origin,
       automationRunId: event.entry.automationRunId,
+      automationName: event.entry.automationName,
     };
 
     await this.emit({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -138,6 +138,13 @@ import {
   type CodexEnvironmentDetachedOutput,
   type CodexEnvironmentSelection,
 } from "./codex-environment-runtime";
+import {
+  ThreadTurnQueue,
+  type ThreadTurnQueueEntry,
+  type ThreadTurnQueueLifecycleEvent,
+  type ThreadTurnQueueOrigin,
+  type ThreadTurnQueueSubmissionResult,
+} from "./thread-turn-queue";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 
 type InitializeResult = {
@@ -1513,6 +1520,7 @@ export class DesktopBackendRegistry {
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
+  private readonly threadTurnQueue: ThreadTurnQueue;
   /**
    * In-memory queue of pending permission-mode changes, keyed by
    * threadId. Populated when a user toggles execution mode while a turn
@@ -1711,6 +1719,12 @@ export class DesktopBackendRegistry {
       codex: this.codexClient,
       grok: this.grokClient,
     });
+    this.threadTurnQueue = new ThreadTurnQueue({
+      startTurn: async (entry) => await this.startTurnNow(entry),
+      isThreadActive: ({ backend, threadId }) =>
+        backend === "codex" ? this.threadHasActiveTurn(threadId) : false,
+      onLifecycle: async (event) => await this.emitTurnQueueLifecycle(event),
+    });
 
     this.isCodexBootstrapDeferredFn =
       options?.isCodexBootstrapDeferred ??
@@ -1876,6 +1890,53 @@ export class DesktopBackendRegistry {
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
     await this.emit(event);
+  }
+
+  private async emitTurnQueueLifecycle(
+    event: ThreadTurnQueueLifecycleEvent,
+  ): Promise<void> {
+    const baseParams = {
+      threadId: event.entry.threadId,
+      queueEntryId: event.entry.id,
+      origin: event.entry.origin,
+      automationRunId: event.entry.automationRunId,
+    };
+
+    await this.emit({
+      backend: event.entry.backend,
+      notification: {
+        method: "thread/turnQueue/updated",
+        params:
+          event.type === "queued"
+            ? {
+                ...baseParams,
+                status: "queued",
+                position: event.position,
+              }
+            : event.type === "started"
+              ? {
+                  ...baseParams,
+                  status: "started",
+                  turnId: event.turnId,
+                }
+              : event.type === "failed"
+                ? {
+                    ...baseParams,
+                    status: "failed",
+                    errorMessage: event.error.message,
+                  }
+                : event.type === "cancelled"
+                  ? {
+                      ...baseParams,
+                      status: "cancelled",
+                    }
+                  : {
+                      ...baseParams,
+                      status: "terminal",
+                      turnId: event.turnId,
+                    },
+      },
+    });
   }
 
   getLatestCodexConfigWarning(): LatestCodexConfigWarningResponse {
@@ -2620,7 +2681,52 @@ export class DesktopBackendRegistry {
     };
   }
 
+  async submitTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    origin?: ThreadTurnQueueOrigin;
+    executionMode?: ThreadExecutionMode;
+    approvalPolicy?: string;
+    sandbox?: string;
+    model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
+    serviceTier?: string;
+    reasoningEffort?: string;
+    fastMode?: boolean;
+    automationRunId?: string;
+  }): Promise<ThreadTurnQueueSubmissionResult> {
+    const { origin = "manual", ...entry } = params;
+    return await this.threadTurnQueue.submit({
+      ...entry,
+      origin,
+    });
+  }
+
+  canStartThreadTurnImmediately(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): boolean {
+    return this.threadTurnQueue.canStartImmediately(params);
+  }
+
   async startTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    executionMode?: ThreadExecutionMode;
+    approvalPolicy?: string;
+    sandbox?: string;
+    model?: string;
+    collaborationMode?: AppServerCollaborationModeRequest;
+    serviceTier?: string;
+    reasoningEffort?: string;
+    fastMode?: boolean;
+  }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
+    return await this.startTurnNow(params);
+  }
+
+  private async startTurnNow(params: {
     backend: AppServerBackendKind;
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -6438,6 +6544,12 @@ export class DesktopBackendRegistry {
           });
         }
       }
+      void this.threadTurnQueue.releaseThread({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId,
+        status: event.notification.method,
+      });
       // Turn-end is the resume boundary — flush any queued mode change
       // now. Fire-and-forget; failures are logged + retried inside
       // flushQueuedExecutionModeIfPresent.
@@ -6467,6 +6579,11 @@ export class DesktopBackendRegistry {
           threadId: event.notification.params.threadId,
         });
       }
+      void this.threadTurnQueue.releaseThread({
+        backend: event.backend,
+        threadId: event.notification.params.threadId,
+        status: readStatusType(event.notification.params.status),
+      });
       // Same resume-boundary flush, triggered from the
       // `thread/status/changed → idle` path (codex emits both, depending
       // on the protocol shape; we cover both for resilience). Idempotent

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1934,6 +1934,7 @@ export class DesktopBackendRegistry {
                       ...baseParams,
                       status: "terminal",
                       turnId: event.turnId,
+                      terminalStatus: event.status,
                     },
       },
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6526,10 +6526,9 @@ export class DesktopBackendRegistry {
     }
 
     if (
-      event.backend === "codex" &&
-      (event.notification.method === "turn/completed" ||
-        event.notification.method === "turn/failed" ||
-        event.notification.method === "turn/cancelled")
+      event.notification.method === "turn/completed" ||
+      event.notification.method === "turn/failed" ||
+      event.notification.method === "turn/cancelled"
     ) {
       const notification = event.notification as {
         params: {
@@ -6541,7 +6540,7 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromTerminalNotification(notification);
-      if (turnId) {
+      if (event.backend === "codex" && turnId) {
         const activeTurnModeKey = buildActiveTurnModeKey(
           notification.params.threadId,
           turnId,
@@ -6566,9 +6565,11 @@ export class DesktopBackendRegistry {
       // Turn-end is the resume boundary — flush any queued mode change
       // now. Fire-and-forget; failures are logged + retried inside
       // flushQueuedExecutionModeIfPresent.
-      void this.flushQueuedExecutionModeIfPresent(
-        notification.params.threadId,
-      );
+      if (event.backend === "codex") {
+        void this.flushQueuedExecutionModeIfPresent(
+          notification.params.threadId,
+        );
+      }
     }
 
     if (

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2704,6 +2704,17 @@ export class DesktopBackendRegistry {
     });
   }
 
+  cancelQueuedTurn(entryId: string, reason?: string): void {
+    this.threadTurnQueue.cancelEntry(entryId, reason);
+  }
+
+  updateQueuedTurnInput(
+    entryId: string,
+    input: AppServerTurnInputItem[],
+  ): void {
+    this.threadTurnQueue.updateQueuedEntryInput(entryId, input);
+  }
+
   canStartThreadTurnImmediately(params: {
     backend: AppServerBackendKind;
     threadId: string;

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -159,6 +159,25 @@ export class ThreadTurnQueue {
     return undefined;
   }
 
+  updateQueuedEntryInput(
+    entryId: string,
+    input: AppServerTurnInputItem[],
+  ): ThreadTurnQueueEntry | undefined {
+    for (const queue of this.queuedEntries.values()) {
+      const index = queue.findIndex((entry) => entry.id === entryId);
+      if (index === -1) continue;
+      const current = queue[index];
+      if (!current) return undefined;
+      const updated = {
+        ...current,
+        input,
+      };
+      queue[index] = updated;
+      return updated;
+    }
+    return undefined;
+  }
+
   async releaseThread(params: {
     backend: AppServerBackendKind;
     threadId: ThreadIdentifier;

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AppServerBackendKind,
+  AppServerCollaborationModeRequest,
+  AppServerTurnInputItem,
+  ThreadExecutionMode,
+  ThreadIdentifier,
+} from "@pwragent/shared";
+
+export type ThreadTurnQueueOrigin = "manual" | "automation" | "messaging";
+
+export type ThreadTurnQueueEntry = {
+  id: string;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  origin: ThreadTurnQueueOrigin;
+  input: AppServerTurnInputItem[];
+  executionMode?: ThreadExecutionMode;
+  approvalPolicy?: string;
+  sandbox?: string;
+  model?: string;
+  collaborationMode?: AppServerCollaborationModeRequest;
+  serviceTier?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+  automationRunId?: string;
+  createdAt: number;
+};
+
+export type ThreadTurnQueueStartResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId: string;
+};
+
+export type ThreadTurnQueueSubmissionResult =
+  | {
+      status: "started";
+      entry: ThreadTurnQueueEntry;
+      turnId: string;
+    }
+  | {
+      status: "queued";
+      entry: ThreadTurnQueueEntry;
+      position: number;
+    };
+
+export type ThreadTurnQueueLifecycleEvent =
+  | {
+      type: "queued";
+      entry: ThreadTurnQueueEntry;
+      position: number;
+    }
+  | {
+      type: "started";
+      entry: ThreadTurnQueueEntry;
+      turnId: string;
+    }
+  | {
+      type: "failed";
+      entry: ThreadTurnQueueEntry;
+      error: Error;
+    }
+  | {
+      type: "cancelled";
+      entry: ThreadTurnQueueEntry;
+      reason?: string;
+    }
+  | {
+      type: "terminal";
+      entry: ThreadTurnQueueEntry;
+      turnId?: string;
+      status?: string;
+    };
+
+export type ThreadTurnQueueOptions = {
+  startTurn: (entry: ThreadTurnQueueEntry) => Promise<ThreadTurnQueueStartResult>;
+  isThreadActive?: (params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  }) => boolean;
+  onLifecycle?: (event: ThreadTurnQueueLifecycleEvent) => void | Promise<void>;
+  now?: () => number;
+};
+
+type RunningEntry = {
+  entry: ThreadTurnQueueEntry;
+  turnId?: string;
+};
+
+export class ThreadTurnQueue {
+  private readonly queuedEntries = new Map<string, ThreadTurnQueueEntry[]>();
+  private readonly startingKeys = new Set<string>();
+  private readonly runningEntries = new Map<string, RunningEntry>();
+  private readonly releasingKeys = new Set<string>();
+
+  constructor(private readonly options: ThreadTurnQueueOptions) {}
+
+  async submit(
+    input: Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
+      Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">>,
+  ): Promise<ThreadTurnQueueSubmissionResult> {
+    const entry: ThreadTurnQueueEntry = {
+      ...input,
+      id: input.id ?? `thread-turn:${randomUUID()}`,
+      createdAt: input.createdAt ?? this.now(),
+    };
+    const key = this.keyFor(entry);
+
+    if (!this.canStartImmediately({ backend: entry.backend, threadId: entry.threadId })) {
+      const queue = this.queueFor(key);
+      queue.push(entry);
+      const position = queue.length;
+      await this.emit({ type: "queued", entry, position });
+      return { status: "queued", entry, position };
+    }
+
+    const started = await this.startEntry(entry);
+    return {
+      status: "started",
+      entry,
+      turnId: started.turnId,
+    };
+  }
+
+  canStartImmediately(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  }): boolean {
+    const key = this.keyFor(params);
+    return (
+      !this.startingKeys.has(key) &&
+      !this.runningEntries.has(key) &&
+      this.queueFor(key).length === 0 &&
+      !(this.options.isThreadActive?.(params) ?? false)
+    );
+  }
+
+  getQueuedEntries(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  }): ThreadTurnQueueEntry[] {
+    return [...this.queueFor(this.keyFor(params))];
+  }
+
+  cancelEntry(entryId: string, reason?: string): ThreadTurnQueueEntry | undefined {
+    for (const [key, queue] of this.queuedEntries.entries()) {
+      const index = queue.findIndex((entry) => entry.id === entryId);
+      if (index === -1) continue;
+      const [entry] = queue.splice(index, 1);
+      if (queue.length === 0) {
+        this.queuedEntries.delete(key);
+      }
+      if (entry) {
+        void this.emit({ type: "cancelled", entry, reason });
+      }
+      return entry;
+    }
+    return undefined;
+  }
+
+  async releaseThread(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    turnId?: string;
+    status?: string;
+  }): Promise<void> {
+    const key = this.keyFor(params);
+    if (this.releasingKeys.has(key)) return;
+    this.releasingKeys.add(key);
+    try {
+      const running = this.runningEntries.get(key);
+      if (
+        running &&
+        (params.turnId === undefined ||
+          running.turnId === undefined ||
+          running.turnId === params.turnId)
+      ) {
+        this.runningEntries.delete(key);
+        await this.emit({
+          type: "terminal",
+          entry: running.entry,
+          turnId: params.turnId,
+          status: params.status,
+        });
+      }
+      if (!(this.options.isThreadActive?.(params) ?? false)) {
+        await this.startNext(key);
+      }
+    } finally {
+      this.releasingKeys.delete(key);
+    }
+  }
+
+  private async startNext(key: string): Promise<void> {
+    if (this.startingKeys.has(key) || this.runningEntries.has(key)) return;
+    const queue = this.queueFor(key);
+    const next = queue.shift();
+    if (!next) return;
+    if (queue.length === 0) {
+      this.queuedEntries.delete(key);
+    }
+    try {
+      await this.startEntry(next);
+    } catch {
+      await this.startNext(key);
+    }
+  }
+
+  private async startEntry(entry: ThreadTurnQueueEntry): Promise<ThreadTurnQueueStartResult> {
+    const key = this.keyFor(entry);
+    this.startingKeys.add(key);
+    try {
+      const result = await this.options.startTurn(entry);
+      this.runningEntries.set(key, {
+        entry,
+        turnId: result.turnId,
+      });
+      await this.emit({ type: "started", entry, turnId: result.turnId });
+      return result;
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      await this.emit({ type: "failed", entry, error: normalized });
+      throw normalized;
+    } finally {
+      this.startingKeys.delete(key);
+    }
+  }
+
+  private queueFor(key: string): ThreadTurnQueueEntry[] {
+    const queue = this.queuedEntries.get(key);
+    if (queue) return queue;
+    const nextQueue: ThreadTurnQueueEntry[] = [];
+    this.queuedEntries.set(key, nextQueue);
+    return nextQueue;
+  }
+
+  private keyFor(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  }): string {
+    return `${params.backend}:${params.threadId}`;
+  }
+
+  private async emit(event: ThreadTurnQueueLifecycleEvent): Promise<void> {
+    await this.options.onLifecycle?.(event);
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -24,6 +24,7 @@ export type ThreadTurnQueueEntry = {
   reasoningEffort?: string;
   fastMode?: boolean;
   automationRunId?: string;
+  automationName?: string;
   createdAt: number;
 };
 

--- a/apps/desktop/src/main/automations/automation-prompt.ts
+++ b/apps/desktop/src/main/automations/automation-prompt.ts
@@ -1,0 +1,42 @@
+import type { AppServerTurnInputItem, AutomationRunSummary } from "@pwragent/shared";
+import type { AutomationRecord } from "./automation-store.js";
+
+export function buildAutomationTurnInput(params: {
+  automation: AutomationRecord;
+  run: AutomationRunSummary;
+}): AppServerTurnInputItem[] {
+  const { automation, run } = params;
+  const scheduledWindows = run.scheduledWindows
+    .map((window) => `- ${new Date(window.scheduledFor).toISOString()}`)
+    .join("\n");
+  const coalescedCount = Math.max(0, run.scheduledWindows.length - 1);
+  const trigger =
+    run.trigger === "manual"
+      ? "manual Run Now"
+      : coalescedCount > 0
+        ? "scheduled catch-up"
+        : "scheduled";
+  const coalescedLine =
+    coalescedCount > 0
+      ? `Coalesced missed windows: ${coalescedCount}`
+      : "Coalesced missed windows: 0";
+
+  return [
+    {
+      type: "text",
+      text: [
+        "Automation run metadata:",
+        `Automation: ${automation.name}`,
+        `Trigger: ${trigger}`,
+        `Schedule: ${automation.scheduleSummary}`,
+        `Backlog policy: ${automation.backlogPolicy}`,
+        coalescedLine,
+        "Scheduled windows covered:",
+        scheduledWindows || "- none; this was manually triggered",
+        "",
+        "Task:",
+        automation.taskPrompt,
+      ].join("\n"),
+    },
+  ];
+}

--- a/apps/desktop/src/main/automations/automation-schedule.ts
+++ b/apps/desktop/src/main/automations/automation-schedule.ts
@@ -1,0 +1,104 @@
+import type {
+  AutomationScheduleDefinition,
+  AutomationWeekday,
+} from "@pwragent/shared";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MAX_DUE_WINDOWS = 1_000;
+
+const WEEKDAY_TO_DATE_DAY: Record<AutomationWeekday, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+export type AutomationDueWindow = {
+  scheduledFor: number;
+};
+
+export function computeNextAutomationRunAt(
+  schedule: AutomationScheduleDefinition,
+  after: number,
+): number {
+  switch (schedule.kind) {
+    case "interval":
+      return computeNextIntervalRunAt(schedule, after);
+    case "weekly":
+      return computeNextWeeklyRunAt(schedule.daysOfWeek, schedule.timeOfDay, after);
+    case "weekdays":
+      return computeNextWeeklyRunAt(
+        ["monday", "tuesday", "wednesday", "thursday", "friday"],
+        schedule.timeOfDay,
+        after,
+      );
+    default:
+      return assertNeverSchedule(schedule);
+  }
+}
+
+export function collectDueAutomationWindows(params: {
+  schedule: AutomationScheduleDefinition;
+  firstDueAt: number;
+  through: number;
+}): AutomationDueWindow[] {
+  if (params.firstDueAt > params.through) return [];
+  const windows: AutomationDueWindow[] = [];
+  let cursor = params.firstDueAt;
+  while (cursor <= params.through && windows.length < MAX_DUE_WINDOWS) {
+    windows.push({ scheduledFor: cursor });
+    cursor = computeNextAutomationRunAt(params.schedule, cursor);
+  }
+  return windows;
+}
+
+function computeNextIntervalRunAt(
+  schedule: Extract<AutomationScheduleDefinition, { kind: "interval" }>,
+  after: number,
+): number {
+  const intervalMs = schedule.every * (schedule.unit === "minutes" ? MINUTE_MS : HOUR_MS);
+  const anchorAt = schedule.anchorAt ?? after;
+  if (after < anchorAt) return anchorAt;
+  const elapsed = after - anchorAt;
+  const completedIntervals = Math.floor(elapsed / intervalMs);
+  return anchorAt + (completedIntervals + 1) * intervalMs;
+}
+
+function computeNextWeeklyRunAt(
+  daysOfWeek: AutomationWeekday[],
+  timeOfDay: { hour: number; minute: number },
+  after: number,
+): number {
+  const allowedDays = new Set(daysOfWeek.map((day) => WEEKDAY_TO_DATE_DAY[day]));
+  const afterDate = new Date(after);
+  const startOfDay = new Date(
+    afterDate.getFullYear(),
+    afterDate.getMonth(),
+    afterDate.getDate(),
+    0,
+    0,
+    0,
+    0,
+  ).getTime();
+
+  for (let dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+    const candidateDate = new Date(startOfDay + dayOffset * DAY_MS);
+    if (!allowedDays.has(candidateDate.getDay())) continue;
+    candidateDate.setHours(timeOfDay.hour, timeOfDay.minute, 0, 0);
+    const candidate = candidateDate.getTime();
+    if (candidate > after) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Unable to compute next automation run time.");
+}
+
+function assertNeverSchedule(schedule: never): never {
+  throw new Error(`Unsupported automation schedule: ${JSON.stringify(schedule)}`);
+}

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -22,6 +22,7 @@ export type AutomationTurnQueue = {
     entry: Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
       Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">>,
   ): Promise<ThreadTurnQueueSubmissionResult>;
+  updateQueuedInput?(entryId: string, input: ThreadTurnQueueEntry["input"]): void;
 };
 
 export type AutomationSchedulerOptions = {
@@ -42,7 +43,10 @@ export class AutomationScheduler {
   }
 
   start(): void {
-    if (this.running) return;
+    if (this.running) {
+      this.scheduleNextTimer();
+      return;
+    }
     this.running = true;
     this.scheduleNextTimer();
   }
@@ -174,11 +178,17 @@ export class AutomationScheduler {
     } else {
       const existing = this.options.store.findPendingScheduledRun(automation.id);
       if (existing) {
-        this.options.store.coalescePendingScheduledRun({
+        const coalesced = this.options.store.coalescePendingScheduledRun({
           automationId: automation.id,
           scheduledWindows: windows,
           now,
         });
+        if (coalesced?.queueEntryId) {
+          this.options.queue.updateQueuedInput?.(
+            coalesced.queueEntryId,
+            buildAutomationTurnInput({ automation, run: coalesced }),
+          );
+        }
       } else {
         await this.enqueueScheduledRun({ automation, windows, now });
       }

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -1,0 +1,297 @@
+import type {
+  AutomationRunStatus,
+  AutomationRunWindow,
+} from "@pwragent/shared";
+import type {
+  ThreadTurnQueueEntry,
+  ThreadTurnQueueSubmissionResult,
+} from "../app-server/thread-turn-queue.js";
+import {
+  computeNextAutomationRunAt,
+  collectDueAutomationWindows,
+} from "./automation-schedule.js";
+import { buildAutomationTurnInput } from "./automation-prompt.js";
+import type { AutomationRecord, AutomationStore } from "./automation-store.js";
+
+export type AutomationTurnQueue = {
+  canStartImmediately(params: {
+    backend: AutomationRecord["backend"];
+    threadId: AutomationRecord["threadId"];
+  }): boolean;
+  submit(
+    entry: Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
+      Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">>,
+  ): Promise<ThreadTurnQueueSubmissionResult>;
+};
+
+export type AutomationSchedulerOptions = {
+  store: AutomationStore;
+  queue: AutomationTurnQueue;
+  now?: () => number;
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+};
+
+export class AutomationScheduler {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+  private readonly sessionStartedAt: number;
+
+  constructor(private readonly options: AutomationSchedulerOptions) {
+    this.sessionStartedAt = this.now();
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.scheduleNextTimer();
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.timer) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async evaluateDueAutomations(): Promise<void> {
+    const now = this.now();
+    const dueAutomations = this.options.store.listEnabledDueAutomations(now);
+    for (const automation of dueAutomations) {
+      await this.evaluateAutomation(automation, now);
+    }
+    this.scheduleNextTimer();
+  }
+
+  async runNow(automationId: string, now = this.now()): Promise<ThreadTurnQueueSubmissionResult | undefined> {
+    const automation = this.options.store.getAutomation(automationId);
+    if (!automation) return undefined;
+    const run = this.options.store.createRun({
+      automationId,
+      trigger: "manual",
+      scheduledWindows: [],
+      now,
+    });
+    if (!run) return undefined;
+    return await this.submitRun({ automation, runId: run.id, windows: [], now });
+  }
+
+  handleTurnQueueUpdate(params: {
+    automationRunId?: string;
+    status: "started" | "failed" | "cancelled" | "terminal";
+    turnId?: string;
+    errorMessage?: string;
+    now?: number;
+  }): void {
+    if (!params.automationRunId) return;
+    const now = params.now ?? this.now();
+    if (params.status === "started" && params.turnId) {
+      this.options.store.markRunStarted({
+        runId: params.automationRunId,
+        backendTurnId: params.turnId,
+        startedAt: now,
+        now,
+      });
+      return;
+    }
+    if (params.status === "failed" || params.status === "cancelled") {
+      this.options.store.markRunTerminal({
+        runId: params.automationRunId,
+        status: params.status === "failed" ? "failed" : "cancelled",
+        errorMessage: params.errorMessage,
+        completedAt: now,
+        now,
+      });
+      return;
+    }
+    if (params.status === "terminal") {
+      this.options.store.markRunTerminal({
+        runId: params.automationRunId,
+        status: "completed",
+        completedAt: now,
+        now,
+      });
+    }
+  }
+
+  private async evaluateAutomation(
+    automation: AutomationRecord,
+    now: number,
+  ): Promise<void> {
+    const firstDueAt = Math.max(automation.nextRunAt ?? now, this.sessionStartedAt);
+    const windows = collectDueAutomationWindows({
+      schedule: automation.schedule,
+      firstDueAt,
+      through: now,
+    });
+    if (windows.length === 0) {
+      this.options.store.updateAutomation(automation.id, {
+        nextRunAt: computeNextAutomationRunAt(automation.schedule, now),
+        now,
+      });
+      return;
+    }
+
+    if (automation.backlogPolicy === "drop_missed") {
+      if (
+        !this.options.queue.canStartImmediately({
+          backend: automation.backend,
+          threadId: automation.threadId,
+        })
+      ) {
+        for (const window of windows) {
+          const skipped = this.options.store.createRun({
+            automationId: automation.id,
+            trigger: "scheduled",
+            status: "skipped",
+            scheduledFor: window.scheduledFor,
+            scheduledWindows: [window],
+            now,
+          });
+          if (skipped) {
+            this.options.store.markRunTerminal({
+              runId: skipped.id,
+              status: "skipped",
+              completedAt: now,
+              errorMessage: "The assigned thread was busy when this schedule fired.",
+              now,
+            });
+          }
+        }
+        this.options.store.updateAutomation(automation.id, {
+          nextRunAt: computeNextAutomationRunAt(automation.schedule, now),
+          now,
+        });
+        return;
+      }
+      await this.enqueueScheduledRun({ automation, windows: [windows[0]!], now });
+    } else {
+      const existing = this.options.store.findPendingScheduledRun(automation.id);
+      if (existing) {
+        this.options.store.coalescePendingScheduledRun({
+          automationId: automation.id,
+          scheduledWindows: windows,
+          now,
+        });
+      } else {
+        await this.enqueueScheduledRun({ automation, windows, now });
+      }
+    }
+
+    this.options.store.updateAutomation(automation.id, {
+      nextRunAt: computeNextAutomationRunAt(automation.schedule, now),
+      now,
+    });
+  }
+
+  private async enqueueScheduledRun(params: {
+    automation: AutomationRecord;
+    windows: AutomationRunWindow[];
+    now: number;
+  }): Promise<ThreadTurnQueueSubmissionResult | undefined> {
+    const run = this.options.store.createRun({
+      automationId: params.automation.id,
+      trigger: "scheduled",
+      scheduledFor: params.windows[0]?.scheduledFor,
+      scheduledWindows: params.windows,
+      now: params.now,
+    });
+    if (!run) return undefined;
+    return await this.submitRun({
+      automation: params.automation,
+      runId: run.id,
+      windows: params.windows,
+      now: params.now,
+    });
+  }
+
+  private async submitRun(params: {
+    automation: AutomationRecord;
+    runId: string;
+    windows: AutomationRunWindow[];
+    now: number;
+  }): Promise<ThreadTurnQueueSubmissionResult | undefined> {
+    const run = this.options.store
+      .listRunsForAutomation(params.automation.id, 1)
+      .find((candidate) => candidate.id === params.runId);
+    if (!run) return undefined;
+
+    try {
+      const result = await this.options.queue.submit({
+        backend: params.automation.backend,
+        threadId: params.automation.threadId,
+        origin: "automation",
+        automationRunId: params.runId,
+        input: buildAutomationTurnInput({
+          automation: params.automation,
+          run,
+        }),
+      });
+      if (result.status === "queued") {
+        this.options.store.markRunQueued({
+          runId: params.runId,
+          queueEntryId: result.entry.id,
+          queuedAt: params.now,
+          now: params.now,
+        });
+      } else {
+        this.options.store.markRunStarted({
+          runId: params.runId,
+          backendTurnId: result.turnId,
+          startedAt: params.now,
+          now: params.now,
+        });
+      }
+      return result;
+    } catch (error) {
+      this.options.store.markRunTerminal({
+        runId: params.runId,
+        status: "failed",
+        completedAt: params.now,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        now: params.now,
+      });
+      return undefined;
+    }
+  }
+
+  private scheduleNextTimer(): void {
+    if (!this.running) return;
+    if (this.timer) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    const nextRunAt = this.options.store
+      .listAutomations()
+      .filter((automation) => automation.status === "enabled")
+      .map((automation) => automation.nextRunAt)
+      .filter((value): value is number => value !== undefined)
+      .sort((left, right) => left - right)[0];
+    if (nextRunAt === undefined) return;
+    const delayMs = Math.max(0, nextRunAt - this.now());
+    this.timer = this.setTimer(() => {
+      void this.evaluateDueAutomations();
+    }, delayMs);
+    this.timer.unref?.();
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  private setTimer(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> {
+    return this.options.setTimer?.(callback, delayMs) ?? setTimeout(callback, delayMs);
+  }
+
+  private clearTimer(timer: ReturnType<typeof setTimeout>): void {
+    if (this.options.clearTimer) {
+      this.options.clearTimer(timer);
+      return;
+    }
+    clearTimeout(timer);
+  }
+}

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -238,6 +238,7 @@ export class AutomationScheduler {
         threadId: params.automation.threadId,
         origin: "automation",
         automationRunId: params.runId,
+        automationName: params.automation.name,
         input: buildAutomationTurnInput({
           automation: params.automation,
           run,

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -79,12 +79,13 @@ export class AutomationScheduler {
 
   handleTurnQueueUpdate(params: {
     automationRunId?: string;
-    status: "started" | "failed" | "cancelled" | "terminal";
+    status: "queued" | "started" | "failed" | "cancelled" | "terminal";
     turnId?: string;
     errorMessage?: string;
     now?: number;
   }): void {
     if (!params.automationRunId) return;
+    if (params.status === "queued") return;
     const now = params.now ?? this.now();
     if (params.status === "started" && params.turnId) {
       this.options.store.markRunStarted({

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -80,6 +80,7 @@ export class AutomationScheduler {
   handleTurnQueueUpdate(params: {
     automationRunId?: string;
     status: "queued" | "started" | "failed" | "cancelled" | "terminal";
+    terminalStatus?: string;
     turnId?: string;
     errorMessage?: string;
     now?: number;
@@ -107,9 +108,12 @@ export class AutomationScheduler {
       return;
     }
     if (params.status === "terminal") {
+      const terminalStatus = classifyTerminalStatus(params.terminalStatus);
       this.options.store.markRunTerminal({
         runId: params.automationRunId,
-        status: "completed",
+        status: terminalStatus,
+        errorMessage:
+          terminalStatus === "completed" ? undefined : params.terminalStatus,
         completedAt: now,
         now,
       });
@@ -295,4 +299,17 @@ export class AutomationScheduler {
     }
     clearTimeout(timer);
   }
+}
+
+function classifyTerminalStatus(
+  status: string | undefined,
+): Extract<AutomationRunStatus, "completed" | "failed" | "cancelled"> {
+  const normalized = status?.toLowerCase() ?? "";
+  if (normalized.includes("fail") || normalized.includes("error")) {
+    return "failed";
+  }
+  if (normalized.includes("cancel") || normalized.includes("interrupt")) {
+    return "cancelled";
+  }
+  return "completed";
 }

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -330,6 +330,17 @@ export class AutomationStore {
     return row ? this.runFromRow(row) : undefined;
   }
 
+  listPendingOrQueuedRunsForAutomation(automationId: string): AutomationRunSummary[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND status IN ('pending', 'queued') ORDER BY updated_at DESC, rowid DESC",
+      )
+      .all(automationId) as AutomationRunRow[];
+    return rows
+      .map((row) => this.runFromRow(row))
+      .filter((run): run is AutomationRunSummary => Boolean(run));
+  }
+
   markRunQueued(params: {
     runId: string;
     queueEntryId: string;

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -383,7 +383,7 @@ export class AutomationStore {
   listRunsForAutomation(automationId: string, limit = 50): AutomationRunSummary[] {
     const rows = this.stateDb.raw
       .prepare(
-        "SELECT * FROM automation_runs WHERE automation_id = ? ORDER BY updated_at DESC LIMIT ?",
+        "SELECT * FROM automation_runs WHERE automation_id = ? ORDER BY updated_at DESC, rowid DESC LIMIT ?",
       )
       .all(automationId, limit) as AutomationRunRow[];
     return rows
@@ -398,7 +398,7 @@ export class AutomationStore {
   }): AutomationRunSummary[] {
     const rows = this.stateDb.raw
       .prepare(
-        "SELECT * FROM automation_runs WHERE backend = ? AND thread_id = ? ORDER BY updated_at DESC LIMIT ?",
+        "SELECT * FROM automation_runs WHERE backend = ? AND thread_id = ? ORDER BY updated_at DESC, rowid DESC LIMIT ?",
       )
       .all(params.backend, params.threadId, params.limit ?? 50) as AutomationRunRow[];
     return rows

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -1,0 +1,803 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AppServerBackendKind,
+  AutomationBacklogPolicy,
+  AutomationListItemSummary,
+  AutomationRunStatus,
+  AutomationRunSummary,
+  AutomationRunTrigger,
+  AutomationRunWindow,
+  AutomationScheduleDefinition,
+  AutomationStatus,
+  AutomationThreadSummary,
+  ThreadIdentifier,
+} from "@pwragent/shared";
+import {
+  DEFAULT_AUTOMATION_BACKLOG_POLICY,
+  buildThreadIdentityKey,
+  formatAutomationScheduleSummary,
+} from "@pwragent/shared";
+import type { StateDb } from "../state/state-db.js";
+
+const DEFAULT_RUN_HISTORY_LIMIT = 200;
+
+export type AutomationRecord = {
+  id: string;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  name: string;
+  taskPrompt: string;
+  status: AutomationStatus;
+  schedule: AutomationScheduleDefinition;
+  scheduleSummary: string;
+  backlogPolicy: AutomationBacklogPolicy;
+  nextRunAt?: number;
+  lastRunAt?: number;
+  lastRunStatus?: AutomationRunStatus;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt?: number;
+};
+
+export type CreateAutomationInput = {
+  id?: string;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  name: string;
+  taskPrompt: string;
+  schedule: AutomationScheduleDefinition;
+  backlogPolicy?: AutomationBacklogPolicy;
+  status?: AutomationStatus;
+  nextRunAt?: number;
+  now?: number;
+};
+
+export type UpdateAutomationInput = {
+  name?: string;
+  taskPrompt?: string;
+  schedule?: AutomationScheduleDefinition;
+  backlogPolicy?: AutomationBacklogPolicy;
+  status?: AutomationStatus;
+  nextRunAt?: number | null;
+  now?: number;
+};
+
+export type CreateAutomationRunInput = {
+  id?: string;
+  automationId: string;
+  trigger: AutomationRunTrigger;
+  status?: AutomationRunStatus;
+  scheduledFor?: number;
+  scheduledWindows?: AutomationRunWindow[];
+  queuedAt?: number;
+  queueEntryId?: string;
+  now?: number;
+};
+
+export type StartupReconciliationInput = {
+  now?: number;
+  nextRunAtByAutomationId?: Record<string, number | undefined>;
+};
+
+type AutomationRow = {
+  automation_id: string;
+  backend: AppServerBackendKind;
+  thread_id: string;
+  name: string;
+  status: AutomationStatus;
+  backlog_policy: AutomationBacklogPolicy;
+  next_run_at: number | null;
+  last_run_at: number | null;
+  created_at: number;
+  updated_at: number;
+  deleted_at: number | null;
+  payload: string;
+};
+
+type AutomationRunRow = {
+  run_id: string;
+  automation_id: string;
+  backend: AppServerBackendKind;
+  thread_id: string;
+  status: AutomationRunStatus;
+  trigger: AutomationRunTrigger;
+  scheduled_for: number | null;
+  queued_at: number | null;
+  started_at: number | null;
+  completed_at: number | null;
+  backend_turn_id: string | null;
+  queue_entry_id: string | null;
+  created_at: number;
+  updated_at: number;
+  payload: string;
+};
+
+type AutomationPayload = {
+  taskPrompt: string;
+  schedule: AutomationScheduleDefinition;
+  scheduleSummary: string;
+  lastRunStatus?: AutomationRunStatus;
+};
+
+type AutomationRunPayload = {
+  scheduledWindows: AutomationRunWindow[];
+  errorMessage?: string;
+};
+
+export class AutomationStore {
+  constructor(
+    private readonly stateDb: StateDb,
+    private readonly options: { runHistoryLimit?: number } = {},
+  ) {}
+
+  createAutomation(input: CreateAutomationInput): AutomationRecord {
+    const now = input.now ?? Date.now();
+    const record: AutomationRecord = {
+      id: input.id ?? `automation:${randomUUID()}`,
+      backend: input.backend,
+      threadId: input.threadId,
+      name: input.name,
+      taskPrompt: input.taskPrompt,
+      status: input.status ?? "enabled",
+      schedule: input.schedule,
+      scheduleSummary: formatAutomationScheduleSummary(input.schedule),
+      backlogPolicy: input.backlogPolicy ?? DEFAULT_AUTOMATION_BACKLOG_POLICY,
+      nextRunAt: input.nextRunAt,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.upsertAutomationRecord(record);
+    return record;
+  }
+
+  updateAutomation(id: string, input: UpdateAutomationInput): AutomationRecord | undefined {
+    const current = this.getAutomation(id, { includeDeleted: true });
+    if (!current) return undefined;
+    const now = input.now ?? Date.now();
+    const schedule = input.schedule ?? current.schedule;
+    const nextRunAt =
+      input.nextRunAt === null ? undefined : input.nextRunAt ?? current.nextRunAt;
+    const record: AutomationRecord = {
+      ...current,
+      name: input.name ?? current.name,
+      taskPrompt: input.taskPrompt ?? current.taskPrompt,
+      status: input.status ?? current.status,
+      schedule,
+      scheduleSummary: formatAutomationScheduleSummary(schedule),
+      backlogPolicy: input.backlogPolicy ?? current.backlogPolicy,
+      nextRunAt,
+      updatedAt: now,
+    };
+
+    this.upsertAutomationRecord(record);
+    return record;
+  }
+
+  pauseAutomation(id: string, now = Date.now()): AutomationRecord | undefined {
+    return this.updateAutomation(id, { status: "paused", now });
+  }
+
+  resumeAutomation(
+    id: string,
+    params: { nextRunAt?: number; now?: number } = {},
+  ): AutomationRecord | undefined {
+    return this.updateAutomation(id, {
+      status: "enabled",
+      nextRunAt: params.nextRunAt,
+      now: params.now,
+    });
+  }
+
+  deleteAutomation(id: string, now = Date.now()): AutomationRecord | undefined {
+    const current = this.getAutomation(id, { includeDeleted: true });
+    if (!current) return undefined;
+    const record: AutomationRecord = {
+      ...current,
+      status: "deleted",
+      deletedAt: now,
+      updatedAt: now,
+    };
+    this.upsertAutomationRecord(record);
+    this.cancelPendingRunsForAutomation({
+      automationId: id,
+      now,
+      errorMessage: "Automation deleted before the run started.",
+    });
+    return record;
+  }
+
+  getAutomation(
+    id: string,
+    options: { includeDeleted?: boolean } = {},
+  ): AutomationRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM automations WHERE automation_id = ?")
+      .get(id) as AutomationRow | undefined;
+    if (!row) return undefined;
+    const record = this.recordFromRow(row);
+    if (!record) return undefined;
+    if (!options.includeDeleted && record.status === "deleted") return undefined;
+    return record;
+  }
+
+  listAutomations(options: { includeDeleted?: boolean } = {}): AutomationRecord[] {
+    const rows = this.stateDb.raw
+      .prepare("SELECT * FROM automations ORDER BY updated_at DESC")
+      .all() as AutomationRow[];
+    return rows
+      .map((row) => this.recordFromRow(row))
+      .filter((record): record is AutomationRecord =>
+        Boolean(record && (options.includeDeleted || record.status !== "deleted")),
+      );
+  }
+
+  listAutomationsForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    includeDeleted?: boolean;
+  }): AutomationRecord[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automations WHERE backend = ? AND thread_id = ? ORDER BY updated_at DESC",
+      )
+      .all(params.backend, params.threadId) as AutomationRow[];
+    return rows
+      .map((row) => this.recordFromRow(row))
+      .filter((record): record is AutomationRecord =>
+        Boolean(record && (params.includeDeleted || record.status !== "deleted")),
+      );
+  }
+
+  listEnabledDueAutomations(now: number): AutomationRecord[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automations WHERE status = 'enabled' AND next_run_at IS NOT NULL AND next_run_at <= ? ORDER BY next_run_at ASC",
+      )
+      .all(now) as AutomationRow[];
+    return rows
+      .map((row) => this.recordFromRow(row))
+      .filter((record): record is AutomationRecord => Boolean(record));
+  }
+
+  createRun(input: CreateAutomationRunInput): AutomationRunSummary | undefined {
+    const automation = this.getAutomation(input.automationId);
+    if (!automation) return undefined;
+    const now = input.now ?? Date.now();
+    const scheduledWindows = input.scheduledWindows ?? (
+      input.scheduledFor === undefined ? [] : [{ scheduledFor: input.scheduledFor }]
+    );
+    const run: AutomationRunSummary = {
+      id: input.id ?? `automation-run:${randomUUID()}`,
+      automationId: automation.id,
+      trigger: input.trigger,
+      status: input.status ?? "pending",
+      scheduledFor: input.scheduledFor ?? scheduledWindows[0]?.scheduledFor,
+      scheduledWindows,
+      queuedAt: input.queuedAt,
+    };
+
+    this.upsertRun(run, {
+      backend: automation.backend,
+      threadId: automation.threadId,
+      queueEntryId: input.queueEntryId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    this.pruneRuns(automation.id);
+    return run;
+  }
+
+  coalescePendingScheduledRun(params: {
+    automationId: string;
+    scheduledWindows: AutomationRunWindow[];
+    now?: number;
+  }): AutomationRunSummary | undefined {
+    const existing = this.findPendingScheduledRun(params.automationId);
+    if (!existing) return undefined;
+    const byScheduledFor = new Map<number, AutomationRunWindow>();
+    for (const window of existing.scheduledWindows) {
+      byScheduledFor.set(window.scheduledFor, window);
+    }
+    for (const window of params.scheduledWindows) {
+      byScheduledFor.set(window.scheduledFor, window);
+    }
+    const nextRun: AutomationRunSummary = {
+      ...existing,
+      scheduledWindows: [...byScheduledFor.values()].sort(
+        (left, right) => left.scheduledFor - right.scheduledFor,
+      ),
+    };
+    const row = this.getRunRow(existing.id);
+    if (!row) return undefined;
+    this.upsertRun(nextRun, {
+      backend: row.backend,
+      threadId: row.thread_id,
+      queueEntryId: row.queue_entry_id ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: params.now ?? Date.now(),
+    });
+    return nextRun;
+  }
+
+  findPendingScheduledRun(automationId: string): AutomationRunSummary | undefined {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND trigger = 'scheduled' AND status IN ('pending', 'queued') ORDER BY updated_at DESC LIMIT 1",
+      )
+      .get(automationId) as AutomationRunRow | undefined;
+    return row ? this.runFromRow(row) : undefined;
+  }
+
+  markRunQueued(params: {
+    runId: string;
+    queueEntryId: string;
+    queuedAt?: number;
+    now?: number;
+  }): AutomationRunSummary | undefined {
+    return this.updateRun(params.runId, {
+      status: "queued",
+      queuedAt: params.queuedAt ?? params.now ?? Date.now(),
+      queueEntryId: params.queueEntryId,
+      now: params.now,
+    });
+  }
+
+  markRunStarted(params: {
+    runId: string;
+    backendTurnId: string;
+    startedAt?: number;
+    now?: number;
+  }): AutomationRunSummary | undefined {
+    return this.updateRun(params.runId, {
+      status: "running",
+      backendTurnId: params.backendTurnId,
+      startedAt: params.startedAt ?? params.now ?? Date.now(),
+      now: params.now,
+    });
+  }
+
+  markRunTerminal(params: {
+    runId: string;
+    status: Extract<AutomationRunStatus, "completed" | "failed" | "cancelled" | "skipped">;
+    completedAt?: number;
+    errorMessage?: string;
+    now?: number;
+  }): AutomationRunSummary | undefined {
+    const completedAt = params.completedAt ?? params.now ?? Date.now();
+    const run = this.updateRun(params.runId, {
+      status: params.status,
+      completedAt,
+      errorMessage: params.errorMessage,
+      now: params.now,
+    });
+    if (!run) return undefined;
+    this.updateAutomationLastRun(run.automationId, {
+      lastRunAt: completedAt,
+      lastRunStatus: params.status,
+      now: params.now ?? completedAt,
+    });
+    return run;
+  }
+
+  listRunsForAutomation(automationId: string, limit = 50): AutomationRunSummary[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? ORDER BY updated_at DESC LIMIT ?",
+      )
+      .all(automationId, limit) as AutomationRunRow[];
+    return rows
+      .map((row) => this.runFromRow(row))
+      .filter((run): run is AutomationRunSummary => Boolean(run));
+  }
+
+  listRunsForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    limit?: number;
+  }): AutomationRunSummary[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE backend = ? AND thread_id = ? ORDER BY updated_at DESC LIMIT ?",
+      )
+      .all(params.backend, params.threadId, params.limit ?? 50) as AutomationRunRow[];
+    return rows
+      .map((row) => this.runFromRow(row))
+      .filter((run): run is AutomationRunSummary => Boolean(run));
+  }
+
+  reconcileStartup(input: StartupReconciliationInput = {}): void {
+    const now = input.now ?? Date.now();
+    const rows = this.stateDb.raw
+      .prepare("SELECT * FROM automation_runs WHERE status IN ('pending', 'queued', 'running')")
+      .all() as AutomationRunRow[];
+
+    const transaction = this.stateDb.raw.transaction(() => {
+      for (const row of rows) {
+        const run = this.runFromRow(row);
+        if (!run) continue;
+        this.upsertRun(
+          {
+            ...run,
+            status: "cancelled",
+            completedAt: now,
+            errorMessage: "PwrAgent restarted before this local automation run completed.",
+          },
+          {
+            backend: row.backend,
+            threadId: row.thread_id,
+            queueEntryId: row.queue_entry_id ?? undefined,
+            createdAt: row.created_at,
+            updatedAt: now,
+          },
+        );
+      }
+
+      for (const [automationId, nextRunAt] of Object.entries(
+        input.nextRunAtByAutomationId ?? {},
+      )) {
+        this.updateAutomation(automationId, {
+          nextRunAt: nextRunAt ?? null,
+          now,
+        });
+      }
+    });
+    transaction();
+  }
+
+  buildThreadSummaries(): Record<string, AutomationThreadSummary> {
+    const summaries: Record<string, AutomationThreadSummary> = {};
+    for (const automation of this.listAutomations()) {
+      const key = buildThreadIdentityKey(automation.backend, automation.threadId);
+      const current = summaries[key] ?? {
+        totalCount: 0,
+        enabledCount: 0,
+        pausedCount: 0,
+        pendingRunCount: 0,
+        coalescedWindowCount: 0,
+        skippedSinceLastCompletedCount: 0,
+        automations: [],
+      };
+      const runCounts = this.countRunsForAutomation(automation.id);
+      const item: AutomationListItemSummary = {
+        id: automation.id,
+        backend: automation.backend,
+        threadId: automation.threadId,
+        name: automation.name,
+        status: automation.status,
+        schedule: automation.schedule,
+        scheduleSummary: automation.scheduleSummary,
+        backlogPolicy: automation.backlogPolicy,
+        nextRunAt: automation.nextRunAt,
+        lastRunAt: automation.lastRunAt,
+        lastRunStatus: automation.lastRunStatus,
+        pendingRunCount: runCounts.pending,
+        coalescedWindowCount: runCounts.coalescedWindows,
+        updatedAt: automation.updatedAt,
+      };
+      current.totalCount += 1;
+      current.enabledCount += automation.status === "enabled" ? 1 : 0;
+      current.pausedCount += automation.status === "paused" ? 1 : 0;
+      current.nextRunAt = minDefined(current.nextRunAt, automation.nextRunAt);
+      current.lastRunAt = maxDefined(current.lastRunAt, automation.lastRunAt);
+      current.pendingRunCount += runCounts.pending;
+      current.coalescedWindowCount += runCounts.coalescedWindows;
+      current.skippedSinceLastCompletedCount += runCounts.skippedSinceLastCompleted;
+      current.automations.push(item);
+      summaries[key] = current;
+    }
+
+    return summaries;
+  }
+
+  private updateRun(
+    runId: string,
+    input: {
+      status?: AutomationRunStatus;
+      queuedAt?: number;
+      startedAt?: number;
+      completedAt?: number;
+      backendTurnId?: string;
+      queueEntryId?: string;
+      errorMessage?: string;
+      now?: number;
+    },
+  ): AutomationRunSummary | undefined {
+    const row = this.getRunRow(runId);
+    if (!row) return undefined;
+    const current = this.runFromRow(row);
+    if (!current) return undefined;
+    const now = input.now ?? Date.now();
+    const nextRun: AutomationRunSummary = {
+      ...current,
+      status: input.status ?? current.status,
+      queuedAt: input.queuedAt ?? current.queuedAt,
+      startedAt: input.startedAt ?? current.startedAt,
+      completedAt: input.completedAt ?? current.completedAt,
+      backendTurnId: input.backendTurnId ?? current.backendTurnId,
+      errorMessage: input.errorMessage ?? current.errorMessage,
+    };
+    this.upsertRun(nextRun, {
+      backend: row.backend,
+      threadId: row.thread_id,
+      queueEntryId: input.queueEntryId ?? row.queue_entry_id ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: now,
+    });
+    return nextRun;
+  }
+
+  private cancelPendingRunsForAutomation(params: {
+    automationId: string;
+    now: number;
+    errorMessage: string;
+  }): void {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND status IN ('pending', 'queued')",
+      )
+      .all(params.automationId) as AutomationRunRow[];
+    for (const row of rows) {
+      const run = this.runFromRow(row);
+      if (!run) continue;
+      this.upsertRun(
+        {
+          ...run,
+          status: "cancelled",
+          completedAt: params.now,
+          errorMessage: params.errorMessage,
+        },
+        {
+          backend: row.backend,
+          threadId: row.thread_id,
+          queueEntryId: row.queue_entry_id ?? undefined,
+          createdAt: row.created_at,
+          updatedAt: params.now,
+        },
+      );
+    }
+  }
+
+  private updateAutomationLastRun(
+    automationId: string,
+    params: {
+      lastRunAt: number;
+      lastRunStatus: AutomationRunStatus;
+      now: number;
+    },
+  ): void {
+    const current = this.getAutomation(automationId, { includeDeleted: true });
+    if (!current) return;
+    this.upsertAutomationRecord({
+      ...current,
+      lastRunAt: params.lastRunAt,
+      lastRunStatus: params.lastRunStatus,
+      updatedAt: params.now,
+    });
+  }
+
+  private upsertAutomationRecord(record: AutomationRecord): void {
+    const payload: AutomationPayload = {
+      taskPrompt: record.taskPrompt,
+      schedule: record.schedule,
+      scheduleSummary: record.scheduleSummary,
+      lastRunStatus: record.lastRunStatus,
+    };
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO automations (
+          automation_id,
+          backend,
+          thread_id,
+          name,
+          status,
+          backlog_policy,
+          next_run_at,
+          last_run_at,
+          created_at,
+          updated_at,
+          deleted_at,
+          payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(automation_id) DO UPDATE SET
+          backend = excluded.backend,
+          thread_id = excluded.thread_id,
+          name = excluded.name,
+          status = excluded.status,
+          backlog_policy = excluded.backlog_policy,
+          next_run_at = excluded.next_run_at,
+          last_run_at = excluded.last_run_at,
+          updated_at = excluded.updated_at,
+          deleted_at = excluded.deleted_at,
+          payload = excluded.payload`,
+      )
+      .run(
+        record.id,
+        record.backend,
+        record.threadId,
+        record.name,
+        record.status,
+        record.backlogPolicy,
+        record.nextRunAt ?? null,
+        record.lastRunAt ?? null,
+        record.createdAt,
+        record.updatedAt,
+        record.deletedAt ?? null,
+        JSON.stringify(payload),
+      );
+  }
+
+  private upsertRun(
+    run: AutomationRunSummary,
+    metadata: {
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      queueEntryId?: string;
+      createdAt: number;
+      updatedAt: number;
+    },
+  ): void {
+    const payload: AutomationRunPayload = {
+      scheduledWindows: run.scheduledWindows,
+      errorMessage: run.errorMessage,
+    };
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO automation_runs (
+          run_id,
+          automation_id,
+          backend,
+          thread_id,
+          status,
+          trigger,
+          scheduled_for,
+          queued_at,
+          started_at,
+          completed_at,
+          backend_turn_id,
+          queue_entry_id,
+          created_at,
+          updated_at,
+          payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+          status = excluded.status,
+          scheduled_for = excluded.scheduled_for,
+          queued_at = excluded.queued_at,
+          started_at = excluded.started_at,
+          completed_at = excluded.completed_at,
+          backend_turn_id = excluded.backend_turn_id,
+          queue_entry_id = excluded.queue_entry_id,
+          updated_at = excluded.updated_at,
+          payload = excluded.payload`,
+      )
+      .run(
+        run.id,
+        run.automationId,
+        metadata.backend,
+        metadata.threadId,
+        run.status,
+        run.trigger,
+        run.scheduledFor ?? null,
+        run.queuedAt ?? null,
+        run.startedAt ?? null,
+        run.completedAt ?? null,
+        run.backendTurnId ?? null,
+        metadata.queueEntryId ?? null,
+        metadata.createdAt,
+        metadata.updatedAt,
+        JSON.stringify(payload),
+      );
+  }
+
+  private recordFromRow(row: AutomationRow): AutomationRecord | undefined {
+    const payload = parseJson<AutomationPayload>(row.payload);
+    if (!payload) return undefined;
+    return {
+      id: row.automation_id,
+      backend: row.backend,
+      threadId: row.thread_id,
+      name: row.name,
+      taskPrompt: payload.taskPrompt,
+      status: row.status,
+      schedule: payload.schedule,
+      scheduleSummary: payload.scheduleSummary,
+      backlogPolicy: row.backlog_policy,
+      nextRunAt: row.next_run_at ?? undefined,
+      lastRunAt: row.last_run_at ?? undefined,
+      lastRunStatus: payload.lastRunStatus,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      deletedAt: row.deleted_at ?? undefined,
+    };
+  }
+
+  private runFromRow(row: AutomationRunRow): AutomationRunSummary | undefined {
+    const payload = parseJson<AutomationRunPayload>(row.payload);
+    if (!payload) return undefined;
+    return {
+      id: row.run_id,
+      automationId: row.automation_id,
+      trigger: row.trigger,
+      status: row.status,
+      scheduledFor: row.scheduled_for ?? undefined,
+      scheduledWindows: payload.scheduledWindows,
+      queuedAt: row.queued_at ?? undefined,
+      startedAt: row.started_at ?? undefined,
+      completedAt: row.completed_at ?? undefined,
+      backendTurnId: row.backend_turn_id ?? undefined,
+      errorMessage: payload.errorMessage,
+    };
+  }
+
+  private getRunRow(runId: string): AutomationRunRow | undefined {
+    return this.stateDb.raw
+      .prepare("SELECT * FROM automation_runs WHERE run_id = ?")
+      .get(runId) as AutomationRunRow | undefined;
+  }
+
+  private countRunsForAutomation(automationId: string): {
+    pending: number;
+    coalescedWindows: number;
+    skippedSinceLastCompleted: number;
+  } {
+    const runs = this.listRunsForAutomation(automationId, this.runHistoryLimit);
+    const pendingRuns = runs.filter((run) =>
+      run.status === "pending" || run.status === "queued",
+    );
+    const latestCompletedAt = runs.find((run) => run.status === "completed")
+      ?.completedAt;
+    return {
+      pending: pendingRuns.length,
+      coalescedWindows: pendingRuns.reduce(
+        (total, run) => total + Math.max(0, run.scheduledWindows.length - 1),
+        0,
+      ),
+      skippedSinceLastCompleted: runs.filter(
+        (run) =>
+          run.status === "skipped" &&
+          (latestCompletedAt === undefined ||
+            (run.completedAt ?? run.scheduledFor ?? 0) > latestCompletedAt),
+      ).length,
+    };
+  }
+
+  private pruneRuns(automationId: string): void {
+    this.stateDb.raw
+      .prepare(
+        `DELETE FROM automation_runs
+         WHERE automation_id = ?
+           AND run_id IN (
+             SELECT run_id FROM automation_runs
+             WHERE automation_id = ?
+             ORDER BY updated_at DESC, rowid DESC
+             LIMIT -1 OFFSET ?
+           )`,
+      )
+      .run(automationId, automationId, this.runHistoryLimit);
+  }
+
+  private get runHistoryLimit(): number {
+    return this.options.runHistoryLimit ?? DEFAULT_RUN_HISTORY_LIMIT;
+  }
+}
+
+function parseJson<T>(value: string): T | undefined {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function minDefined(left: number | undefined, right: number | undefined): number | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return Math.min(left, right);
+}
+
+function maxDefined(left: number | undefined, right: number | undefined): number | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return Math.max(left, right);
+}

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -275,6 +275,7 @@ export class AutomationStore {
       scheduledFor: input.scheduledFor ?? scheduledWindows[0]?.scheduledFor,
       scheduledWindows,
       queuedAt: input.queuedAt,
+      queueEntryId: input.queueEntryId,
     };
 
     this.upsertRun(run, {
@@ -378,6 +379,11 @@ export class AutomationStore {
       now: params.now ?? completedAt,
     });
     return run;
+  }
+
+  getRun(runId: string): AutomationRunSummary | undefined {
+    const row = this.getRunRow(runId);
+    return row ? this.runFromRow(row) : undefined;
   }
 
   listRunsForAutomation(automationId: string, limit = 50): AutomationRunSummary[] {
@@ -723,6 +729,7 @@ export class AutomationStore {
       scheduledFor: row.scheduled_for ?? undefined,
       scheduledWindows: payload.scheduledWindows,
       queuedAt: row.queued_at ?? undefined,
+      queueEntryId: row.queue_entry_id ?? undefined,
       startedAt: row.started_at ?? undefined,
       completedAt: row.completed_at ?? undefined,
       backendTurnId: row.backend_turn_id ?? undefined,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -238,10 +238,12 @@ export class DesktopAutomationService {
       turnId?: string;
       automationRunId?: string;
       errorMessage?: string;
+      terminalStatus?: string;
     };
     this.scheduler.handleTurnQueueUpdate({
       automationRunId: params.automationRunId,
       status: params.status,
+      terminalStatus: params.terminalStatus,
       turnId: params.turnId,
       errorMessage: params.errorMessage,
     });

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -215,8 +215,7 @@ export class DesktopAutomationService {
 
   async delete(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
     const pendingQueueEntryIds = this.options.store
-      .listRunsForAutomation(request.automationId)
-      .filter((run) => run.status === "pending" || run.status === "queued")
+      .listPendingOrQueuedRunsForAutomation(request.automationId)
       .map((run) => run.queueEntryId)
       .filter((entryId): entryId is string => Boolean(entryId));
     const automation = this.options.store.deleteAutomation(request.automationId);

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -1,0 +1,326 @@
+import type {
+  AgentEvent,
+  AutomationDetail,
+  AutomationIdRequest,
+  AutomationMutationResponse,
+  CreateAutomationRequest,
+  ListAutomationRunsRequest,
+  ListAutomationRunsResponse,
+  ListAutomationsRequest,
+  ListAutomationsResponse,
+  RunAutomationNowResponse,
+  UpdateAutomationRequest,
+} from "@pwragent/shared";
+import { validateAutomationScheduleDefinition } from "@pwragent/shared";
+import type { DesktopBackendRegistry } from "../app-server/backend-registry.js";
+import { getDesktopBackendRegistry } from "../app-server/backend-registry.js";
+import { getAppAutomationStore } from "../state/app-state.js";
+import { computeNextAutomationRunAt } from "./automation-schedule.js";
+import { AutomationScheduler } from "./automation-scheduler.js";
+import type { AutomationRecord, AutomationStore } from "./automation-store.js";
+
+let service: DesktopAutomationService | null = null;
+let storeOverride: AutomationStore | null = null;
+
+export function getDesktopAutomationStore(): AutomationStore {
+  return storeOverride ?? getAppAutomationStore();
+}
+
+export function setDesktopAutomationStoreForTests(store: AutomationStore | null): void {
+  storeOverride = store;
+}
+
+export function getDesktopAutomationService(
+  registry = getDesktopBackendRegistry(),
+): DesktopAutomationService {
+  if (!service) {
+    service = new DesktopAutomationService({
+      registry,
+      store: getDesktopAutomationStore(),
+    });
+    service.start();
+  }
+  return service;
+}
+
+export function disposeDesktopAutomationService(): void {
+  service?.dispose();
+  service = null;
+}
+
+export class DesktopAutomationService {
+  private readonly scheduler: AutomationScheduler;
+  private unsubscribeRegistryEvents?: () => void;
+
+  constructor(
+    private readonly options: {
+      registry: DesktopBackendRegistry;
+      store: AutomationStore;
+    },
+  ) {
+    this.scheduler = new AutomationScheduler({
+      store: options.store,
+      queue: {
+        canStartImmediately: (params) =>
+          options.registry.canStartThreadTurnImmediately(params),
+        submit: async (entry) => await options.registry.submitTurn(entry),
+      },
+    });
+    this.reconcileStartupRuns();
+  }
+
+  start(): void {
+    if (!this.unsubscribeRegistryEvents) {
+      this.unsubscribeRegistryEvents = this.options.registry.onEvent((event) =>
+        this.handleRegistryEvent(event),
+      );
+    }
+    this.scheduler.start();
+  }
+
+  dispose(): void {
+    this.scheduler.stop();
+    this.unsubscribeRegistryEvents?.();
+    this.unsubscribeRegistryEvents = undefined;
+  }
+
+  list(request: ListAutomationsRequest = {}): ListAutomationsResponse {
+    const automations =
+      request.backend && request.threadId
+        ? this.options.store.listAutomationsForThread({
+            backend: request.backend,
+            threadId: request.threadId,
+          })
+        : this.options.store.listAutomations().filter((automation) => {
+            if (request.backend && automation.backend !== request.backend) return false;
+            if (request.threadId && automation.threadId !== request.threadId) return false;
+            return true;
+          });
+    return {
+      automations: automations.map(toAutomationDetail),
+    };
+  }
+
+  listRuns(request: ListAutomationRunsRequest): ListAutomationRunsResponse {
+    if (request.automationId) {
+      return {
+        runs: this.options.store.listRunsForAutomation(
+          request.automationId,
+          request.limit,
+        ),
+      };
+    }
+    if (request.backend && request.threadId) {
+      return {
+        runs: this.options.store.listRunsForThread({
+          backend: request.backend,
+          threadId: request.threadId,
+          limit: request.limit,
+        }),
+      };
+    }
+    return { runs: [] };
+  }
+
+  async create(request: CreateAutomationRequest): Promise<AutomationMutationResponse> {
+    this.assertValidSchedule(request.schedule);
+    const now = Date.now();
+    const automation = this.options.store.createAutomation({
+      backend: request.backend,
+      threadId: request.threadId,
+      name: request.name,
+      taskPrompt: request.taskPrompt,
+      schedule: request.schedule,
+      backlogPolicy: request.backlogPolicy,
+      status: request.enabled === false ? "paused" : "enabled",
+      nextRunAt:
+        request.nextRunAt ??
+        (request.enabled === false
+          ? undefined
+          : computeNextAutomationRunAt(request.schedule, now)),
+      now,
+    });
+    await this.notifyThreadAutomationsUpdated(automation);
+    this.scheduler.start();
+    return { automation: toAutomationDetail(automation) };
+  }
+
+  async update(request: UpdateAutomationRequest): Promise<AutomationMutationResponse> {
+    const current = this.options.store.getAutomation(request.automationId);
+    if (!current) {
+      throw new Error("Automation not found.");
+    }
+    if (request.schedule) {
+      this.assertValidSchedule(request.schedule);
+    }
+    const now = Date.now();
+    const schedule = request.schedule ?? current.schedule;
+    const updated = this.options.store.updateAutomation(request.automationId, {
+      name: request.name,
+      taskPrompt: request.taskPrompt,
+      schedule: request.schedule,
+      backlogPolicy: request.backlogPolicy,
+      status:
+        request.enabled === undefined
+          ? undefined
+          : request.enabled
+            ? "enabled"
+            : "paused",
+      nextRunAt:
+        request.nextRunAt !== undefined
+          ? request.nextRunAt
+          : request.schedule && current.status === "enabled"
+            ? computeNextAutomationRunAt(schedule, now)
+            : undefined,
+      now,
+    });
+    if (!updated) throw new Error("Automation not found.");
+    await this.notifyThreadAutomationsUpdated(updated);
+    return { automation: toAutomationDetail(updated) };
+  }
+
+  async pause(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
+    const automation = this.options.store.pauseAutomation(request.automationId);
+    if (!automation) throw new Error("Automation not found.");
+    await this.notifyThreadAutomationsUpdated(automation);
+    return { automation: toAutomationDetail(automation) };
+  }
+
+  async resume(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
+    const current = this.options.store.getAutomation(request.automationId);
+    if (!current) throw new Error("Automation not found.");
+    const automation = this.options.store.resumeAutomation(request.automationId, {
+      nextRunAt: computeNextAutomationRunAt(current.schedule, Date.now()),
+    });
+    if (!automation) throw new Error("Automation not found.");
+    await this.notifyThreadAutomationsUpdated(automation);
+    this.scheduler.start();
+    return { automation: toAutomationDetail(automation) };
+  }
+
+  async delete(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
+    const automation = this.options.store.deleteAutomation(request.automationId);
+    if (!automation) throw new Error("Automation not found.");
+    await this.notifyThreadAutomationsUpdated(automation);
+    return { automation: toAutomationDetail(automation) };
+  }
+
+  async runNow(request: AutomationIdRequest): Promise<RunAutomationNowResponse> {
+    const result = await this.scheduler.runNow(request.automationId);
+    const [run] = this.options.store.listRunsForAutomation(request.automationId, 1);
+    if (!run) {
+      throw new Error("Automation not found.");
+    }
+    const automation = this.options.store.getAutomation(request.automationId);
+    if (automation) {
+      await this.notifyThreadAutomationsUpdated(automation);
+    }
+    return {
+      run,
+      queueStatus: result?.status ?? "failed",
+      queueEntryId: result?.entry.id,
+      turnId: result?.status === "started" ? result.turnId : undefined,
+    };
+  }
+
+  buildThreadSummaries() {
+    return this.options.store.buildThreadSummaries();
+  }
+
+  private async handleRegistryEvent(event: AgentEvent): Promise<void> {
+    if (event.notification.method !== "thread/turnQueue/updated") return;
+    const params = event.notification.params as {
+      threadId: string;
+      queueEntryId: string;
+      origin: "manual" | "automation" | "messaging";
+      status: "queued" | "started" | "failed" | "cancelled" | "terminal";
+      position?: number;
+      turnId?: string;
+      automationRunId?: string;
+      errorMessage?: string;
+    };
+    this.scheduler.handleTurnQueueUpdate({
+      automationRunId: params.automationRunId,
+      status: params.status,
+      turnId: params.turnId,
+      errorMessage: params.errorMessage,
+    });
+    if (params.automationRunId) {
+      const [run] = this.options.store.listRunsForAutomation(params.automationRunId, 1);
+      if (!run) return;
+      const automation = run
+        ? this.options.store.getAutomation(run.automationId, { includeDeleted: true })
+        : undefined;
+      await this.options.registry.publishLocalEvent({
+        backend: event.backend,
+        notification: {
+          method: "automation/run/updated",
+          params: {
+            threadId: params.threadId,
+            automationId: run.automationId,
+            runId: params.automationRunId,
+            status: run.status,
+          },
+        },
+      });
+      if (automation) {
+        await this.notifyThreadAutomationsUpdated(automation);
+      }
+    }
+  }
+
+  private reconcileStartupRuns(): void {
+    const now = Date.now();
+    const nextRunAtByAutomationId = Object.fromEntries(
+      this.options.store
+        .listAutomations()
+        .filter((automation) => automation.status === "enabled")
+        .map((automation) => [
+          automation.id,
+          computeNextAutomationRunAt(automation.schedule, now),
+        ]),
+    );
+    this.options.store.reconcileStartup({ now, nextRunAtByAutomationId });
+  }
+
+  private assertValidSchedule(schedule: CreateAutomationRequest["schedule"]): void {
+    const validation = validateAutomationScheduleDefinition(schedule);
+    if (!validation.ok) {
+      throw new Error(validation.error);
+    }
+  }
+
+  private async notifyThreadAutomationsUpdated(
+    automation: Pick<AutomationRecord, "backend" | "threadId">,
+  ): Promise<void> {
+    await this.options.registry.publishLocalEvent({
+      backend: automation.backend,
+      notification: {
+        method: "thread/automations/updated",
+        params: {
+          threadId: automation.threadId,
+        },
+      },
+    });
+  }
+}
+
+function toAutomationDetail(record: AutomationRecord): AutomationDetail {
+  return {
+    id: record.id,
+    backend: record.backend,
+    threadId: record.threadId,
+    name: record.name,
+    taskPrompt: record.taskPrompt,
+    status: record.status,
+    schedule: record.schedule,
+    scheduleSummary: record.scheduleSummary,
+    backlogPolicy: record.backlogPolicy,
+    nextRunAt: record.nextRunAt,
+    lastRunAt: record.lastRunAt,
+    lastRunStatus: record.lastRunStatus,
+    updatedAt: record.updatedAt,
+    createdAt: record.createdAt,
+    deletedAt: record.deletedAt,
+  };
+}

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -64,6 +64,8 @@ export class DesktopAutomationService {
         canStartImmediately: (params) =>
           options.registry.canStartThreadTurnImmediately(params),
         submit: async (entry) => await options.registry.submitTurn(entry),
+        updateQueuedInput: (entryId, input) =>
+          options.registry.updateQueuedTurnInput(entryId, input),
       },
     });
     this.reconcileStartupRuns();
@@ -155,6 +157,12 @@ export class DesktopAutomationService {
     }
     const now = Date.now();
     const schedule = request.schedule ?? current.schedule;
+    const enablingFromPaused = request.enabled === true && current.status !== "enabled";
+    const disabling = request.enabled === false;
+    const shouldRecomputeNextRun =
+      request.nextRunAt === undefined &&
+      !disabling &&
+      (enablingFromPaused || (request.schedule !== undefined && current.status === "enabled"));
     const updated = this.options.store.updateAutomation(request.automationId, {
       name: request.name,
       taskPrompt: request.taskPrompt,
@@ -169,20 +177,27 @@ export class DesktopAutomationService {
       nextRunAt:
         request.nextRunAt !== undefined
           ? request.nextRunAt
-          : request.schedule && current.status === "enabled"
+          : disabling
+            ? null
+            : shouldRecomputeNextRun
             ? computeNextAutomationRunAt(schedule, now)
             : undefined,
       now,
     });
     if (!updated) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(updated);
+    this.scheduler.start();
     return { automation: toAutomationDetail(updated) };
   }
 
   async pause(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
-    const automation = this.options.store.pauseAutomation(request.automationId);
+    const automation = this.options.store.updateAutomation(request.automationId, {
+      status: "paused",
+      nextRunAt: null,
+    });
     if (!automation) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(automation);
+    this.scheduler.start();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -199,9 +214,21 @@ export class DesktopAutomationService {
   }
 
   async delete(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
+    const pendingQueueEntryIds = this.options.store
+      .listRunsForAutomation(request.automationId)
+      .filter((run) => run.status === "pending" || run.status === "queued")
+      .map((run) => run.queueEntryId)
+      .filter((entryId): entryId is string => Boolean(entryId));
     const automation = this.options.store.deleteAutomation(request.automationId);
     if (!automation) throw new Error("Automation not found.");
+    for (const entryId of pendingQueueEntryIds) {
+      this.options.registry.cancelQueuedTurn(
+        entryId,
+        "Automation deleted before the run started.",
+      );
+    }
     await this.notifyThreadAutomationsUpdated(automation);
+    this.scheduler.start();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -248,7 +275,7 @@ export class DesktopAutomationService {
       errorMessage: params.errorMessage,
     });
     if (params.automationRunId) {
-      const [run] = this.options.store.listRunsForAutomation(params.automationRunId, 1);
+      const run = this.options.store.getRun(params.automationRunId);
       if (!run) return;
       const automation = run
         ? this.options.store.getAutomation(run.automationId, { includeDeleted: true })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,10 @@ import {
   disposeApplicationIpcHandlers,
   registerApplicationIpcHandlers,
 } from "./ipc/applications";
+import {
+  disposeAutomationIpcHandlers,
+  registerAutomationIpcHandlers,
+} from "./ipc/automation-ipc";
 import { disposeAppServerIpcHandlers, registerAppServerIpcHandlers } from "./ipc/app-server";
 import {
   disposeImageNormalizationIpcHandlers,
@@ -193,6 +197,7 @@ function disposeMainProcessResourcesSync(): void {
   startupCpuProfilerForNewWindows = undefined;
   disposeAgentIpcHandlers();
   disposeApplicationIpcHandlers();
+  disposeAutomationIpcHandlers();
   disposeAppMetadataIpcHandlers();
   disposeAppUpdateIpcHandlers();
   disposeComposerDraftIpcHandlers();
@@ -463,6 +468,7 @@ export function bootstrapApp(): void {
     registerAppServerIpcHandlers();
     registerAgentIpcHandlers();
     registerApplicationIpcHandlers();
+    registerAutomationIpcHandlers();
     registerAppMetadataIpcHandlers();
     registerAppUpdateIpcHandlers();
     registerComposerDraftIpcHandlers();

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -233,11 +233,31 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
-        const response = await registry.startTurn(request);
+        const submitted = await registry.submitTurn({
+          ...request,
+          origin: "manual",
+        });
+        const response: StartTurnResponse =
+          submitted.status === "started"
+            ? {
+                backend: submitted.entry.backend,
+                threadId: submitted.entry.threadId,
+                turnId: submitted.turnId,
+                queueStatus: "started",
+                queueEntryId: submitted.entry.id,
+              }
+            : {
+                backend: submitted.entry.backend,
+                threadId: submitted.entry.threadId,
+                turnId: submitted.entry.id,
+                queueStatus: "queued",
+                queueEntryId: submitted.entry.id,
+              };
         logDebug("startTurnResult", {
           backend: response.backend,
           threadId: response.threadId,
           turnId: response.turnId,
+          queueStatus: response.queueStatus ?? "started",
         });
         return response;
       } catch (error) {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -40,6 +40,7 @@ import type {
   NavigationDirectoryGitStatus,
   NavigationDirectoryGitStatusUpdatedNotification,
   NavigationSnapshot,
+  AutomationThreadSummary,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -194,6 +195,19 @@ async function hydrateRetainedThreadOverlayData(
       worktreeSnapshots: overlay.worktreeSnapshots,
     };
   });
+}
+
+function buildAutomationSummariesByThreadKey():
+  | Record<string, AutomationThreadSummary | undefined>
+  | undefined {
+  try {
+    return getDesktopAutomationService().buildThreadSummaries();
+  } catch (error) {
+    appServerLog.warn("automation store unavailable for navigation snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
 }
 
 function directoryStatusesEqual(
@@ -530,8 +544,7 @@ class DesktopAppServerService {
     const bindingsStartedAt = Date.now();
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const bindingsDurationMs = Date.now() - bindingsStartedAt;
-    const automationsByThreadKey = getDesktopAutomationService()
-      .buildThreadSummaries();
+    const automationsByThreadKey = buildAutomationSummariesByThreadKey();
     const queuedExecutionModesByThreadId = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
     const overlayStartedAt = Date.now();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -99,6 +99,7 @@ import {
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { getMainLogger } from "../log";
 import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindings-snapshot";
+import { getDesktopAutomationService } from "../automations/desktop-automation-service";
 import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
@@ -529,11 +530,14 @@ class DesktopAppServerService {
     const bindingsStartedAt = Date.now();
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const bindingsDurationMs = Date.now() - bindingsStartedAt;
+    const automationsByThreadKey = getDesktopAutomationService()
+      .buildThreadSummaries();
     const queuedExecutionModesByThreadId = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
     const overlayStartedAt = Date.now();
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
+      automationsByThreadKey,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadId,

--- a/apps/desktop/src/main/ipc/automation-ipc.ts
+++ b/apps/desktop/src/main/ipc/automation-ipc.ts
@@ -1,0 +1,116 @@
+import { ipcMain } from "electron";
+import type {
+  AutomationIdRequest,
+  AutomationMutationResponse,
+  CreateAutomationRequest,
+  ListAutomationRunsRequest,
+  ListAutomationRunsResponse,
+  ListAutomationsRequest,
+  ListAutomationsResponse,
+  RunAutomationNowResponse,
+  UpdateAutomationRequest,
+} from "@pwragent/shared";
+import {
+  AUTOMATIONS_CREATE_CHANNEL,
+  AUTOMATIONS_DELETE_CHANNEL,
+  AUTOMATIONS_LIST_CHANNEL,
+  AUTOMATIONS_LIST_RUNS_CHANNEL,
+  AUTOMATIONS_PAUSE_CHANNEL,
+  AUTOMATIONS_RESUME_CHANNEL,
+  AUTOMATIONS_RUN_NOW_CHANNEL,
+  AUTOMATIONS_UPDATE_CHANNEL,
+} from "../../shared/ipc";
+import {
+  disposeDesktopAutomationService,
+  getDesktopAutomationService,
+} from "../automations/desktop-automation-service";
+
+export function registerAutomationIpcHandlers(): void {
+  getDesktopAutomationService();
+
+  ipcMain.removeHandler(AUTOMATIONS_LIST_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_LIST_CHANNEL,
+    (_event, request?: ListAutomationsRequest): ListAutomationsResponse =>
+      getDesktopAutomationService().list(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_CREATE_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_CREATE_CHANNEL,
+    async (
+      _event,
+      request: CreateAutomationRequest,
+    ): Promise<AutomationMutationResponse> =>
+      await getDesktopAutomationService().create(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_UPDATE_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_UPDATE_CHANNEL,
+    async (
+      _event,
+      request: UpdateAutomationRequest,
+    ): Promise<AutomationMutationResponse> =>
+      await getDesktopAutomationService().update(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_DELETE_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_DELETE_CHANNEL,
+    async (
+      _event,
+      request: AutomationIdRequest,
+    ): Promise<AutomationMutationResponse> =>
+      await getDesktopAutomationService().delete(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_PAUSE_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_PAUSE_CHANNEL,
+    async (
+      _event,
+      request: AutomationIdRequest,
+    ): Promise<AutomationMutationResponse> =>
+      await getDesktopAutomationService().pause(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_RESUME_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_RESUME_CHANNEL,
+    async (
+      _event,
+      request: AutomationIdRequest,
+    ): Promise<AutomationMutationResponse> =>
+      await getDesktopAutomationService().resume(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_RUN_NOW_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_RUN_NOW_CHANNEL,
+    async (
+      _event,
+      request: AutomationIdRequest,
+    ): Promise<RunAutomationNowResponse> =>
+      await getDesktopAutomationService().runNow(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_LIST_RUNS_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_LIST_RUNS_CHANNEL,
+    (_event, request: ListAutomationRunsRequest): ListAutomationRunsResponse =>
+      getDesktopAutomationService().listRuns(request),
+  );
+}
+
+export function disposeAutomationIpcHandlers(): void {
+  ipcMain.removeHandler(AUTOMATIONS_LIST_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_CREATE_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_UPDATE_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_DELETE_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_PAUSE_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_RESUME_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_RUN_NOW_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_LIST_RUNS_CHANNEL);
+  disposeDesktopAutomationService();
+}

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1492,6 +1492,15 @@ export class MessagingController {
         input: params.input,
         ...turnSettings,
       });
+      if (started.queueStatus === "queued") {
+        this.logger.info?.("messaging turn queued in shared thread FIFO", {
+          bindingId: params.binding.id,
+          threadId: params.binding.threadId,
+          queueEntryId: started.queueEntryId ?? started.turnId,
+          requestedExecutionMode: turnSettings.executionMode ?? "unset",
+        });
+        return true;
+      }
       turnStarted = true;
       this.logger.info?.("messaging turn started", {
         bindingId: params.binding.id,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1499,7 +1499,7 @@ export class MessagingController {
           queueEntryId: started.queueEntryId ?? started.turnId,
           requestedExecutionMode: turnSettings.executionMode ?? "unset",
         });
-        return true;
+        return "queued";
       }
       turnStarted = true;
       this.logger.info?.("messaging turn started", {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -222,6 +222,11 @@ type AssistantStreamBuffer = AssistantStreamDelta & {
   text: string;
 };
 
+type AutomationTurnMessagingContext = {
+  automationName?: string;
+  automationRunId?: string;
+};
+
 type ExecutionModeResolution = {
   mode: ThreadExecutionMode | undefined;
   source: "thread" | "binding-preferences" | "permissions-mode" | "unset";
@@ -473,6 +478,11 @@ export class MessagingController {
   private readonly deliveredAssistantMessageKeys = new Set<string>();
   private readonly assistantStreamBuffers = new Map<string, AssistantStreamBuffer>();
   private readonly assistantStreamDeliveryQueues = new Map<string, Promise<void>>();
+  private readonly automationTurnsByTurnKey = new Map<
+    string,
+    AutomationTurnMessagingContext
+  >();
+  private readonly deliveredAutomationStartKeys = new Set<string>();
   private readonly now: () => number;
   private readonly pendingIntentTtlMs: number;
   private readonly interactionMapper: MessagingInteractionMapper;
@@ -662,6 +672,24 @@ export class MessagingController {
         threadId,
       }),
     );
+    const turnQueueUpdate = turnQueueUpdateForBackendEvent(event);
+    if (turnQueueUpdate) {
+      if (
+        turnQueueUpdate.origin === "automation" &&
+        turnQueueUpdate.status === "started" &&
+        turnQueueUpdate.turnId
+      ) {
+        await this.handleAutomationTurnStarted({
+          automationName: turnQueueUpdate.automationName,
+          automationRunId: turnQueueUpdate.automationRunId,
+          backend: event.backend,
+          bindings,
+          threadId,
+          turnId: turnQueueUpdate.turnId,
+        });
+      }
+      return;
+    }
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
     for (const binding of bindings) {
       let activeTurn = this.getActiveTurn(binding);
@@ -716,20 +744,27 @@ export class MessagingController {
 
       const assistantDelta = assistantDeltaForBackendEvent(event);
       if (assistantDelta) {
-        await this.deliverAssistantStreamUpdate(assistantDelta, binding);
+        if (!this.isAutomationTurnEvent(event, binding, activeTurn?.turnId)) {
+          await this.deliverAssistantStreamUpdate(assistantDelta, binding);
+        }
       }
 
       const assistantText = assistantTextForBackendEvent(event);
       if (assistantText) {
-        const deliveredFinalStream = await this.flushAssistantStreamForEvent(
-          event,
-          binding,
-          assistantText,
-        );
-        if (deliveredFinalStream) {
-          this.markAssistantMessageDelivered(event, binding, assistantText);
-        } else {
-          await this.deliverAssistantMessage(assistantText, event, binding);
+        if (
+          !this.isAutomationTurnEvent(event, binding, activeTurn?.turnId) ||
+          !isNonFinalAssistantTextForBackendEvent(event)
+        ) {
+          const deliveredFinalStream = await this.flushAssistantStreamForEvent(
+            event,
+            binding,
+            assistantText,
+          );
+          if (deliveredFinalStream) {
+            this.markAssistantMessageDelivered(event, binding, assistantText);
+          } else {
+            await this.deliverAssistantMessage(assistantText, event, binding);
+          }
         }
       } else if (isTerminalTurnLifecycle(activeTurn)) {
         await this.waitForAssistantStreamDeliveriesForEvent(event, binding);
@@ -782,6 +817,9 @@ export class MessagingController {
           refreshMs: typingActivityRefreshMsForBackendEvent(event),
         });
       }
+    }
+    if (lifecycle && isTerminalTurnLifecycle(lifecycle)) {
+      this.forgetAutomationTurn(event.backend, threadId, lifecycle.turnId);
     }
   }
 
@@ -7649,6 +7687,138 @@ export class MessagingController {
     return threadKeyForBinding(binding);
   }
 
+  private async handleAutomationTurnStarted(params: {
+    automationName?: string;
+    automationRunId?: string;
+    backend: AppServerBackendKind;
+    bindings: MessagingBindingRecord[];
+    threadId: ThreadIdentifier;
+    turnId: string;
+  }): Promise<void> {
+    this.rememberAutomationTurn({
+      automationName: params.automationName,
+      automationRunId: params.automationRunId,
+      backend: params.backend,
+      threadId: params.threadId,
+      turnId: params.turnId,
+    });
+
+    for (const binding of params.bindings) {
+      const activeTurn: MessagingActiveTurnSummary = {
+        turnId: params.turnId,
+        status: "working",
+        updatedAt: this.now(),
+      };
+      const previousTurn = this.getActiveTurn(binding);
+      if (!isSameActiveTurnState(previousTurn, activeTurn)) {
+        this.setActiveTurn(binding, activeTurn);
+        this.logBindingTurnStateChange(
+          binding,
+          previousTurn,
+          activeTurn,
+          "thread/turnQueue/updated:automation",
+        );
+      }
+      await this.deliverAutomationStartedMessage(binding, {
+        automationName: params.automationName,
+        automationRunId: params.automationRunId,
+        turnId: params.turnId,
+      });
+      await this.signalTurnActivity(binding, activeTurn, {
+        force: true,
+        reason: "thread/turnQueue/updated:automation",
+      });
+    }
+  }
+
+  private rememberAutomationTurn(params: {
+    automationName?: string;
+    automationRunId?: string;
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    turnId: string;
+  }): void {
+    this.automationTurnsByTurnKey.set(
+      automationTurnKey(params),
+      {
+        automationName: params.automationName,
+        automationRunId: params.automationRunId,
+      },
+    );
+  }
+
+  private forgetAutomationTurn(
+    backend: AppServerBackendKind,
+    threadId: ThreadIdentifier,
+    turnId: string,
+  ): void {
+    this.automationTurnsByTurnKey.delete(
+      automationTurnKey({ backend, threadId, turnId }),
+    );
+  }
+
+  private isAutomationTurnEvent(
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+    fallbackTurnId?: string,
+  ): boolean {
+    const turnId = turnIdForBackendEvent(event) ?? fallbackTurnId;
+    if (!turnId) {
+      return false;
+    }
+    return this.automationTurnsByTurnKey.has(
+      automationTurnKey({
+        backend: event.backend,
+        threadId: binding.threadId,
+        turnId,
+      }),
+    );
+  }
+
+  private async deliverAutomationStartedMessage(
+    binding: MessagingBindingRecord,
+    params: {
+      automationName?: string;
+      automationRunId?: string;
+      turnId: string;
+    },
+  ): Promise<void> {
+    const key = [
+      binding.id,
+      params.automationRunId ?? "",
+      params.turnId,
+      "automation-started",
+    ].join("\0");
+    if (this.deliveredAutomationStartKeys.has(key)) {
+      return;
+    }
+    this.deliveredAutomationStartKeys.add(key);
+
+    const name = params.automationName?.trim();
+    const text = [
+      name ? `Automation started: ${name}` : "Automation started.",
+      "I'll post the final response when it's done.",
+    ].join("\n");
+
+    await this.deliver(
+      {
+        id: this.newIntentId("automation-started"),
+        kind: "message",
+        bindingId: binding.id,
+        createdAt: this.now(),
+        role: "system",
+        parts: [
+          {
+            type: "text",
+            text,
+            markdown: "plain",
+          },
+        ],
+      },
+      binding,
+    );
+  }
+
   private async signalTurnActivity(
     binding: MessagingBindingRecord,
     activeTurn: MessagingActiveTurnSummary,
@@ -8217,6 +8387,9 @@ export class MessagingController {
 
     const activity = summarizeToolActivityFromBackendEvent(event);
     if (!activity) {
+      return;
+    }
+    if (this.isAutomationTurnEvent(event, binding, activeTurnId)) {
       return;
     }
 
@@ -9418,6 +9591,59 @@ function turnIdForBackendEvent(event: AgentEvent): string | undefined {
     return params.turnId;
   }
   return typeof params.turn?.id === "string" ? params.turn.id : undefined;
+}
+
+function automationTurnKey(params: {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId: string;
+}): string {
+  return `${params.backend}:${params.threadId}:${params.turnId}`;
+}
+
+function turnQueueUpdateForBackendEvent(event: AgentEvent): {
+  automationName?: string;
+  automationRunId?: string;
+  origin?: string;
+  status?: string;
+  turnId?: string;
+} | undefined {
+  if (event.notification.method !== "thread/turnQueue/updated") {
+    return undefined;
+  }
+  const params = event.notification.params as {
+    automationName?: unknown;
+    automationRunId?: unknown;
+    origin?: unknown;
+    status?: unknown;
+    turnId?: unknown;
+  };
+  return {
+    automationName:
+      typeof params.automationName === "string" ? params.automationName : undefined,
+    automationRunId:
+      typeof params.automationRunId === "string" ? params.automationRunId : undefined,
+    origin: typeof params.origin === "string" ? params.origin : undefined,
+    status: typeof params.status === "string" ? params.status : undefined,
+    turnId: typeof params.turnId === "string" ? params.turnId : undefined,
+  };
+}
+
+function isNonFinalAssistantTextForBackendEvent(event: AgentEvent): boolean {
+  if (event.notification.method !== "item/completed") {
+    return false;
+  }
+  const params = event.notification.params as {
+    item?: {
+      phase?: unknown;
+      type?: unknown;
+    };
+  };
+  if (params.item?.type !== "agentMessage") {
+    return false;
+  }
+  const phase = typeof params.item.phase === "string" ? params.item.phase : undefined;
+  return Boolean(phase && phase !== "final" && phase !== "final_answer");
 }
 
 function isTerminalTurnLifecycle(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -148,7 +148,25 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   }
 
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
-    return await this.registry.startTurn(request);
+    const submitted = await this.registry.submitTurn({
+      ...request,
+      origin: "messaging",
+    });
+    return submitted.status === "started"
+      ? {
+          backend: submitted.entry.backend,
+          threadId: submitted.entry.threadId,
+          turnId: submitted.turnId,
+          queueStatus: "started",
+          queueEntryId: submitted.entry.id,
+        }
+      : {
+          backend: submitted.entry.backend,
+          threadId: submitted.entry.threadId,
+          turnId: submitted.entry.id,
+          queueStatus: "queued",
+          queueEntryId: submitted.entry.id,
+        };
   }
 
   async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -9,6 +9,7 @@ import {
   updateLastUsed,
 } from "../profile";
 import { AppRuntimeInstanceStore } from "./app-runtime-instance-store.js";
+import { AutomationStore } from "../automations/automation-store.js";
 import { migrateIfNeeded } from "./migration.js";
 import { SqliteMessagingStore } from "./messaging-store-sqlite.js";
 import { SqliteOverlayStore } from "./overlay-store-sqlite.js";
@@ -19,6 +20,7 @@ let messagingStore: SqliteMessagingStore | null = null;
 let overlayStore: SqliteOverlayStore | null = null;
 let runtimeInstanceStore: AppRuntimeInstanceStore | null = null;
 let profileRuntimeHeartbeat: ProfileRuntimeHeartbeat | null = null;
+let automationStore: AutomationStore | null = null;
 let activeMode: AppStateMode | null = null;
 // The boot decision is set once at startup and stays put for the
 // process lifetime. Stored here (vs. recomputed lazily) because the
@@ -62,6 +64,7 @@ export function initializeAppState(
   overlayStore: SqliteOverlayStore;
   runtimeInstanceStore: AppRuntimeInstanceStore;
   mode: AppStateMode;
+  automationStore: AutomationStore;
 } {
   if (stateDb) {
     if (activeMode !== mode) {
@@ -79,6 +82,7 @@ export function initializeAppState(
       overlayStore: overlayStore!,
       runtimeInstanceStore: runtimeInstanceStore!,
       mode,
+      automationStore: automationStore!,
     };
   }
 
@@ -109,6 +113,7 @@ export function initializeAppState(
   messagingStore = new SqliteMessagingStore(stateDb);
   overlayStore = new SqliteOverlayStore(stateDb);
   runtimeInstanceStore = new AppRuntimeInstanceStore(stateDb);
+  automationStore = new AutomationStore(stateDb);
   activeMode = mode;
 
   return {
@@ -116,6 +121,7 @@ export function initializeAppState(
     messagingStore: messagingStore!,
     overlayStore: overlayStore!,
     runtimeInstanceStore: runtimeInstanceStore!,
+    automationStore: automationStore!,
     mode,
   };
 }
@@ -148,6 +154,11 @@ export function isAppStateInitialized(): boolean {
   return runtimeInstanceStore !== null;
 }
 
+export function getAppAutomationStore(): AutomationStore {
+  if (!automationStore) throw new Error("App state not initialized. Call initializeAppState() first.");
+  return automationStore;
+}
+
 export function disposeAppState(): void {
   if (profileRuntimeHeartbeat) {
     profileRuntimeHeartbeat.stop();
@@ -159,6 +170,7 @@ export function disposeAppState(): void {
     messagingStore = null;
     overlayStore = null;
     runtimeInstanceStore = null;
+    automationStore = null;
   }
   activeMode = null;
 }
@@ -170,6 +182,7 @@ export function resetAppStateForTests(): void {
   messagingStore = null;
   overlayStore = null;
   runtimeInstanceStore = null;
+  automationStore = null;
   activeMode = null;
   currentBootDecision = null;
 }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerBackendScope,
   AppServerThreadSummary,
+  AutomationThreadSummary,
   DirectoryLaunchpadOverlayState,
   DirectoryOverlayState,
   LinkedDirectorySummary,
@@ -65,6 +66,7 @@ export class SqliteOverlayStore {
       string,
       MessagingThreadBindingSummary[] | undefined
     >;
+    automationsByThreadKey?: Record<string, AutomationThreadSummary | undefined>;
     /**
      * In-memory permission-mode queue map keyed by `threadId`. The queue
      * lives on the registry (not in sqlite) but must be merged onto the
@@ -157,6 +159,7 @@ export class SqliteOverlayStore {
       launchpadDefaults,
       launchpadsByKey,
       directoryOverlayByKey,
+      automationsByThreadKey: params.automationsByThreadKey,
       messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
       overlayByThreadKey,
       previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 8;
+export const CURRENT_STATE_DB_USER_VERSION = 9;
 
 const SCHEMA_V1 = `
 CREATE TABLE meta (
@@ -281,6 +281,56 @@ CREATE INDEX IF NOT EXISTS idx_messaging_topic_cleanup_proposals_supergroup
   ON messaging_topic_cleanup_proposals(channel_kind, supergroup_id, updated_at DESC);
 `;
 
+const AUTOMATION_SCHEMA = `
+CREATE TABLE IF NOT EXISTS automations (
+  automation_id  TEXT PRIMARY KEY,
+  backend        TEXT NOT NULL,
+  thread_id      TEXT NOT NULL,
+  name           TEXT NOT NULL,
+  status         TEXT NOT NULL,
+  backlog_policy TEXT NOT NULL,
+  next_run_at    INTEGER,
+  last_run_at    INTEGER,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  deleted_at     INTEGER,
+  payload        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_automations_thread
+  ON automations(backend, thread_id, status);
+CREATE INDEX IF NOT EXISTS idx_automations_next_run
+  ON automations(status, next_run_at);
+
+CREATE TABLE IF NOT EXISTS automation_runs (
+  run_id          TEXT PRIMARY KEY,
+  automation_id  TEXT NOT NULL,
+  backend         TEXT NOT NULL,
+  thread_id       TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  trigger         TEXT NOT NULL,
+  scheduled_for   INTEGER,
+  queued_at       INTEGER,
+  started_at      INTEGER,
+  completed_at    INTEGER,
+  backend_turn_id TEXT,
+  queue_entry_id  TEXT,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL,
+  payload         TEXT NOT NULL,
+  FOREIGN KEY (automation_id) REFERENCES automations(automation_id)
+    ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_automation_runs_automation_updated
+  ON automation_runs(automation_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_automation_runs_thread_updated
+  ON automation_runs(backend, thread_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_automation_runs_status
+  ON automation_runs(status, updated_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_automation_runs_one_pending_scheduled
+  ON automation_runs(automation_id)
+  WHERE trigger = 'scheduled' AND status IN ('pending', 'queued');
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -374,6 +424,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 8) {
       db.transaction(() => {
         db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
+        db.pragma("user_version = 8");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 9) {
+      db.transaction(() => {
+        db.exec(AUTOMATION_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -518,6 +574,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(DIRECTORY_OVERLAY_SCHEMA);
     db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
     db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
+    db.exec(AUTOMATION_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,8 @@
 import { clipboard, contextBridge, ipcRenderer } from "electron";
 import type {
   AgentEvent,
+  AutomationIdRequest,
+  AutomationMutationResponse,
   ArchiveWorktreeRequest,
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
@@ -13,6 +15,10 @@ import type {
   EnsureDirectoryLaunchpadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  ListAutomationRunsRequest,
+  ListAutomationRunsResponse,
+  ListAutomationsRequest,
+  ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   ListDesktopPwrAgentProfilesResponse,
@@ -38,6 +44,7 @@ import type {
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
   CodexEnvironmentSetupProgressEvent,
+  CreateAutomationRequest,
   GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
@@ -95,6 +102,7 @@ import type {
   RestoreWorktreeResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
+  RunAutomationNowResponse,
   StartReviewRequest,
   StartReviewResponse,
   StartThreadRequest,
@@ -107,6 +115,7 @@ import type {
   TrustCodexProjectResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
+  UpdateAutomationRequest,
   ClearDesktopSettingsSecretRequest,
   CompleteOnboardingCodexBootstrapRequest,
   CompleteOnboardingCodexBootstrapResponse,
@@ -186,6 +195,14 @@ import {
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
   AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
+  AUTOMATIONS_CREATE_CHANNEL,
+  AUTOMATIONS_DELETE_CHANNEL,
+  AUTOMATIONS_LIST_CHANNEL,
+  AUTOMATIONS_LIST_RUNS_CHANNEL,
+  AUTOMATIONS_PAUSE_CHANNEL,
+  AUTOMATIONS_RESUME_CHANNEL,
+  AUTOMATIONS_RUN_NOW_CHANNEL,
+  AUTOMATIONS_UPDATE_CHANNEL,
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
   APP_CHANGELOG_WINDOW_OPEN_CHANNEL,
   APP_LOG_ENTRY_EVENT_CHANNEL,
@@ -366,6 +383,38 @@ const desktopApi = Object.freeze({
   },
   installAppUpdate: async (): Promise<AppUpdateInstallResult> =>
     await ipcRenderer.invoke(APP_UPDATE_INSTALL_CHANNEL),
+  listAutomations: async (
+    request?: ListAutomationsRequest,
+  ): Promise<ListAutomationsResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_LIST_CHANNEL, request),
+  createAutomation: async (
+    request: CreateAutomationRequest,
+  ): Promise<AutomationMutationResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_CREATE_CHANNEL, request),
+  updateAutomation: async (
+    request: UpdateAutomationRequest,
+  ): Promise<AutomationMutationResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_UPDATE_CHANNEL, request),
+  deleteAutomation: async (
+    request: AutomationIdRequest,
+  ): Promise<AutomationMutationResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_DELETE_CHANNEL, request),
+  pauseAutomation: async (
+    request: AutomationIdRequest,
+  ): Promise<AutomationMutationResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_PAUSE_CHANNEL, request),
+  resumeAutomation: async (
+    request: AutomationIdRequest,
+  ): Promise<AutomationMutationResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_RESUME_CHANNEL, request),
+  runAutomationNow: async (
+    request: AutomationIdRequest,
+  ): Promise<RunAutomationNowResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_RUN_NOW_CHANNEL, request),
+  listAutomationRuns: async (
+    request: ListAutomationRunsRequest,
+  ): Promise<ListAutomationRunsResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_LIST_RUNS_CHANNEL, request),
   listPwrAgentProfiles: async (): Promise<ListDesktopPwrAgentProfilesResponse> =>
     await ipcRenderer.invoke(PROFILES_LIST_CHANNEL),
   openPwrAgentProfile: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -33,6 +33,7 @@ import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
+import { AutomationsScreen } from "./features/automations/AutomationsScreen";
 
 const SETTINGS_SECTIONS = new Set<SettingsSection>([
   "general",
@@ -115,7 +116,9 @@ function DesktopAppShell(props: {
   // attributes on the resize handle stay in sync.
   const sidebarMinWidth = 280;
   const sidebarMaxWidth = 560;
-  const [mainView, setMainView] = useState<"thread" | "settings">("thread");
+  const [mainView, setMainView] = useState<"thread" | "settings" | "automations">(
+    "thread",
+  );
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
   // switches mainView. The Messaging Activity surface is its own
@@ -472,9 +475,13 @@ function DesktopAppShell(props: {
         selectedItemKey={navigation.selectedItemKey}
         thinkingThreadKeys={session.thinkingThreadKeys}
         threads={navigation.threads}
+        automationsActive={mainView === "automations"}
         settingsActive={mainView === "settings"}
         onBrowseModeChange={navigation.setBrowseMode}
         onCreateThread={navigation.createThread}
+        onOpenAutomations={() => {
+          setMainView("automations");
+        }}
         onOpenLaunchpad={async (directory, preferredBackend) => {
           setMainView("thread");
           await navigation.openDirectoryLaunchpad(directory, preferredBackend);
@@ -536,6 +543,22 @@ function DesktopAppShell(props: {
             settings={settings}
             onClose={() => setMainView("thread")}
             onOpenMessagingActivity={openMessagingActivityWindow}
+          />
+        </div>
+      ) : null}
+
+      {mainView === "automations" ? (
+        <div className="app-shell__settings-layer">
+          <AutomationsScreen
+            desktopApi={desktopApi}
+            threads={navigation.threads}
+            onClose={() => setMainView("thread")}
+            onOpenMessagingActivity={openMessagingActivityWindow}
+            onRefreshNavigation={navigation.refresh}
+            onSelectThread={(thread) => {
+              setMainView("thread");
+              navigation.selectThread(thread);
+            }}
           />
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -1,0 +1,455 @@
+import { useMemo, useState } from "react";
+import type {
+  AppServerBackendKind,
+  AutomationBacklogPolicy,
+  AutomationDetail,
+  AutomationScheduleDefinition,
+  AutomationWeekday,
+  CreateAutomationRequest,
+  NavigationThreadSummary,
+  ThreadIdentifier,
+  UpdateAutomationRequest,
+} from "@pwragent/shared";
+import {
+  AUTOMATION_WEEKDAYS,
+  formatAutomationScheduleSummary,
+  validateAutomationScheduleDefinition,
+} from "@pwragent/shared";
+
+type AutomationEditorMode =
+  | {
+      automation: AutomationDetail;
+      kind: "edit";
+    }
+  | {
+      assignment?: {
+        backend: AppServerBackendKind;
+        threadId: ThreadIdentifier;
+      };
+      kind: "create";
+    };
+
+export type AutomationEditorSubmit =
+  | { kind: "create"; request: CreateAutomationRequest }
+  | { kind: "update"; request: UpdateAutomationRequest };
+
+type AutomationEditorProps = {
+  mode: AutomationEditorMode;
+  onCancel: () => void;
+  onSubmit: (submission: AutomationEditorSubmit) => Promise<void>;
+  saving?: boolean;
+  threads?: NavigationThreadSummary[];
+};
+
+type ScheduleFormKind = "interval" | "weekdays" | "weekly";
+
+const DAY_LABELS: Record<AutomationWeekday, string> = {
+  monday: "Mon",
+  tuesday: "Tue",
+  wednesday: "Wed",
+  thursday: "Thu",
+  friday: "Fri",
+  saturday: "Sat",
+  sunday: "Sun",
+};
+
+export function AutomationEditor(props: AutomationEditorProps) {
+  const initialAutomation =
+    props.mode.kind === "edit" ? props.mode.automation : undefined;
+  const initialSchedule = initialAutomation?.schedule;
+  const initialAssignment = readInitialAssignment(props);
+  const [name, setName] = useState(initialAutomation?.name ?? "");
+  const [taskPrompt, setTaskPrompt] = useState(initialAutomation?.taskPrompt ?? "");
+  const [enabled, setEnabled] = useState(initialAutomation?.status !== "paused");
+  const [backlogPolicy, setBacklogPolicy] = useState<AutomationBacklogPolicy>(
+    initialAutomation?.backlogPolicy ?? "coalesce",
+  );
+  const [threadKey, setThreadKey] = useState(
+    initialAssignment
+      ? buildThreadKey(initialAssignment.backend, initialAssignment.threadId)
+      : "",
+  );
+  const [scheduleKind, setScheduleKind] = useState<ScheduleFormKind>(
+    initialSchedule?.kind ?? "interval",
+  );
+  const [intervalEvery, setIntervalEvery] = useState(
+    initialSchedule?.kind === "interval" ? String(initialSchedule.every) : "5",
+  );
+  const [intervalUnit, setIntervalUnit] = useState<"minutes" | "hours">(
+    initialSchedule?.kind === "interval" ? initialSchedule.unit : "minutes",
+  );
+  const [timeOfDay, setTimeOfDay] = useState(() => {
+    if (initialSchedule?.kind === "weekly" || initialSchedule?.kind === "weekdays") {
+      return `${String(initialSchedule.timeOfDay.hour).padStart(2, "0")}:${String(
+        initialSchedule.timeOfDay.minute,
+      ).padStart(2, "0")}`;
+    }
+    return "09:00";
+  });
+  const [daysOfWeek, setDaysOfWeek] = useState<AutomationWeekday[]>(
+    initialSchedule?.kind === "weekly"
+      ? initialSchedule.daysOfWeek
+      : ["monday", "tuesday", "wednesday", "thursday", "friday"],
+  );
+  const [validationError, setValidationError] = useState<string>();
+
+  const threadOptions = useMemo(
+    () =>
+      (props.threads ?? []).map((thread) => ({
+        key: buildThreadKey(thread.source, thread.id),
+        label: thread.title,
+      })),
+    [props.threads],
+  );
+  const selectedSchedule = buildSchedule({
+    daysOfWeek,
+    intervalEvery,
+    intervalUnit,
+    scheduleKind,
+    timeOfDay,
+  });
+  const selectedScheduleSummary =
+    selectedSchedule.ok && validateAutomationScheduleDefinition(selectedSchedule.schedule).ok
+      ? formatAutomationScheduleSummary(selectedSchedule.schedule)
+      : "Invalid schedule";
+
+  const submit = async (): Promise<void> => {
+    const trimmedName = name.trim();
+    const trimmedPrompt = taskPrompt.trim();
+    if (!trimmedName) {
+      setValidationError("Name is required.");
+      return;
+    }
+    if (!trimmedPrompt) {
+      setValidationError("Task prompt is required.");
+      return;
+    }
+    if (!selectedSchedule.ok) {
+      setValidationError(selectedSchedule.error);
+      return;
+    }
+    const scheduleValidation = validateAutomationScheduleDefinition(
+      selectedSchedule.schedule,
+    );
+    if (!scheduleValidation.ok) {
+      setValidationError(scheduleValidation.error);
+      return;
+    }
+
+    if (props.mode.kind === "edit") {
+      await props.onSubmit({
+        kind: "update",
+        request: {
+          automationId: props.mode.automation.id,
+          backlogPolicy,
+          enabled,
+          name: trimmedName,
+          schedule: selectedSchedule.schedule,
+          taskPrompt: trimmedPrompt,
+        },
+      });
+      return;
+    }
+
+    const assignment = readAssignmentFromThreadKey(threadKey);
+    if (!assignment) {
+      setValidationError("Choose a thread for this automation.");
+      return;
+    }
+
+    await props.onSubmit({
+      kind: "create",
+      request: {
+        ...assignment,
+        backlogPolicy,
+        enabled,
+        name: trimmedName,
+        schedule: selectedSchedule.schedule,
+        taskPrompt: trimmedPrompt,
+      },
+    });
+  };
+
+  return (
+    <form
+      className="automation-editor"
+      noValidate
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <label className="automation-field">
+        <span>Name</span>
+        <input
+          value={name}
+          onChange={(event) => {
+            setName(event.currentTarget.value);
+            setValidationError(undefined);
+          }}
+        />
+      </label>
+
+      {props.mode.kind === "create" && !props.mode.assignment ? (
+        <label className="automation-field">
+          <span>Thread</span>
+          <select
+            value={threadKey}
+            onChange={(event) => {
+              setThreadKey(event.currentTarget.value);
+              setValidationError(undefined);
+            }}
+          >
+            <option value="">Choose thread</option>
+            {threadOptions.map((thread) => (
+              <option key={thread.key} value={thread.key}>
+                {thread.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      <label className="automation-field">
+        <span>Task prompt</span>
+        <textarea
+          rows={5}
+          value={taskPrompt}
+          onChange={(event) => {
+            setTaskPrompt(event.currentTarget.value);
+            setValidationError(undefined);
+          }}
+        />
+      </label>
+
+      <fieldset className="automation-fieldset">
+        <legend>Schedule</legend>
+        <div className="automation-segmented" role="group" aria-label="Schedule kind">
+          {(["interval", "weekdays", "weekly"] as const).map((kind) => (
+            <button
+              key={kind}
+              aria-pressed={scheduleKind === kind}
+              className={`automation-segmented__button${
+                scheduleKind === kind ? " is-active" : ""
+              }`}
+              type="button"
+              onClick={() => setScheduleKind(kind)}
+            >
+              {kind}
+            </button>
+          ))}
+        </div>
+
+        {scheduleKind === "interval" ? (
+          <div className="automation-inline-fields">
+            <label className="automation-field">
+              <span>Every</span>
+              <input
+                min={1}
+                type="number"
+                value={intervalEvery}
+                onChange={(event) => {
+                  setIntervalEvery(event.currentTarget.value);
+                  setValidationError(undefined);
+                }}
+              />
+            </label>
+            <label className="automation-field">
+              <span>Unit</span>
+              <select
+                value={intervalUnit}
+                onChange={(event) =>
+                  setIntervalUnit(event.currentTarget.value as "minutes" | "hours")
+                }
+              >
+                <option value="minutes">Minutes</option>
+                <option value="hours">Hours</option>
+              </select>
+            </label>
+          </div>
+        ) : (
+          <>
+            <label className="automation-field">
+              <span>Time</span>
+              <input
+                type="time"
+                value={timeOfDay}
+                onChange={(event) => {
+                  setTimeOfDay(event.currentTarget.value);
+                  setValidationError(undefined);
+                }}
+              />
+            </label>
+            {scheduleKind === "weekly" ? (
+              <div className="automation-weekdays" role="group" aria-label="Days">
+                {AUTOMATION_WEEKDAYS.map((day) => (
+                  <button
+                    key={day}
+                    aria-pressed={daysOfWeek.includes(day)}
+                    className={`automation-weekday${
+                      daysOfWeek.includes(day) ? " is-active" : ""
+                    }`}
+                    type="button"
+                    onClick={() => {
+                      setDaysOfWeek((current) =>
+                        current.includes(day)
+                          ? current.filter((entry) => entry !== day)
+                          : [...current, day],
+                      );
+                      setValidationError(undefined);
+                    }}
+                  >
+                    {DAY_LABELS[day]}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </>
+        )}
+        <p className="automation-editor__summary">{selectedScheduleSummary}</p>
+      </fieldset>
+
+      <label className="automation-field">
+        <span>Backlog</span>
+        <select
+          value={backlogPolicy}
+          onChange={(event) =>
+            setBacklogPolicy(event.currentTarget.value as AutomationBacklogPolicy)
+          }
+        >
+          <option value="coalesce">Coalesce missed runs</option>
+          <option value="drop_missed">Drop missed runs</option>
+        </select>
+      </label>
+
+      <label className="automation-checkbox">
+        <input
+          checked={enabled}
+          type="checkbox"
+          onChange={(event) => setEnabled(event.currentTarget.checked)}
+        />
+        <span>Enabled</span>
+      </label>
+
+      {validationError ? (
+        <p className="automation-editor__error" role="alert">
+          {validationError}
+        </p>
+      ) : null}
+
+      <div className="automation-editor__actions">
+        <button className="button button--ghost" type="button" onClick={props.onCancel}>
+          Cancel
+        </button>
+        <button className="button button--primary" disabled={props.saving} type="submit">
+          {props.mode.kind === "edit" ? "Save" : "Create"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function readInitialAssignment(props: AutomationEditorProps):
+  | {
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+    }
+  | undefined {
+  if (props.mode.kind === "edit") {
+    return {
+      backend: props.mode.automation.backend,
+      threadId: props.mode.automation.threadId,
+    };
+  }
+  return props.mode.assignment;
+}
+
+function buildThreadKey(
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+): string {
+  return `${backend}:${threadId}`;
+}
+
+function readAssignmentFromThreadKey(value: string):
+  | {
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+    }
+  | undefined {
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+
+  return {
+    backend: value.slice(0, separatorIndex) as AppServerBackendKind,
+    threadId: value.slice(separatorIndex + 1),
+  };
+}
+
+function buildSchedule(params: {
+  daysOfWeek: AutomationWeekday[];
+  intervalEvery: string;
+  intervalUnit: "minutes" | "hours";
+  scheduleKind: ScheduleFormKind;
+  timeOfDay: string;
+}):
+  | { ok: true; schedule: AutomationScheduleDefinition }
+  | { error: string; ok: false } {
+  if (params.scheduleKind === "interval") {
+    const every = Number(params.intervalEvery);
+    if (!Number.isInteger(every) || every < 1) {
+      return { error: "Interval must be a whole number greater than zero.", ok: false };
+    }
+    return {
+      ok: true,
+      schedule: {
+        every,
+        kind: "interval",
+        unit: params.intervalUnit,
+      },
+    };
+  }
+
+  const timeOfDay = parseTimeOfDay(params.timeOfDay);
+  if (!timeOfDay) {
+    return { error: "Choose a valid time.", ok: false };
+  }
+
+  if (params.scheduleKind === "weekdays") {
+    return {
+      ok: true,
+      schedule: {
+        kind: "weekdays",
+        timeOfDay,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    schedule: {
+      daysOfWeek: params.daysOfWeek,
+      kind: "weekly",
+      timeOfDay,
+    },
+  };
+}
+
+function parseTimeOfDay(value: string): { hour: number; minute: number } | undefined {
+  const [hourValue, minuteValue] = value.split(":");
+  const hour = Number(hourValue);
+  const minute = Number(minuteValue);
+  if (
+    !Number.isInteger(hour) ||
+    hour < 0 ||
+    hour > 23 ||
+    !Number.isInteger(minute) ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return undefined;
+  }
+  return { hour, minute };
+}

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from "react";
+import type {
+  AutomationDetail,
+  MessagingChannelKind,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+import {
+  formatAutomationRelative,
+  formatAutomationStatus,
+  formatAutomationTimestamp,
+  formatBacklogPolicy,
+  formatRunStatus,
+} from "./automation-format";
+import {
+  AutomationEditor,
+  type AutomationEditorSubmit,
+} from "./AutomationEditor";
+import { useAutomationRuns, useAutomations } from "./useAutomations";
+
+type AutomationsScreenProps = {
+  desktopApi?: DesktopApi;
+  onClose: () => void;
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  onRefreshNavigation?: () => Promise<void>;
+  onSelectThread?: (thread: NavigationThreadSummary) => void;
+  threads: NavigationThreadSummary[];
+};
+
+export function AutomationsScreen(props: AutomationsScreenProps) {
+  const automations = useAutomations(props.desktopApi);
+  const [editorMode, setEditorMode] = useState<
+    | { automation: AutomationDetail; kind: "edit" }
+    | { kind: "create" }
+    | undefined
+  >();
+  const [saving, setSaving] = useState(false);
+  const [expandedAutomationId, setExpandedAutomationId] = useState<string>();
+  const threadsByKey = useMemo(
+    () =>
+      new Map(
+        props.threads.map((thread) => [
+          `${thread.source}:${thread.id}`,
+          thread,
+        ]),
+      ),
+    [props.threads],
+  );
+
+  const submitEditor = async (submission: AutomationEditorSubmit): Promise<void> => {
+    setSaving(true);
+    try {
+      if (submission.kind === "create") {
+        await automations.createAutomation(submission.request);
+      } else {
+        await automations.updateAutomation(submission.request);
+      }
+      setEditorMode(undefined);
+      await props.onRefreshNavigation?.();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="automations-screen" aria-label="Automations">
+      <nav className="settings-nav" aria-label="Automation navigation">
+        <header className="settings-nav__masthead">
+          <p className="settings-nav__brand">
+            Pwr<span className="settings-nav__brand-accent">Agent</span>
+          </p>
+        </header>
+        <button className="settings-nav__exit" type="button" onClick={props.onClose}>
+          <span aria-hidden="true">&lt;</span> Exit Automations
+        </button>
+        <p className="settings-nav__group-label">Schedules</p>
+        <button
+          aria-current="page"
+          className="settings-nav__button is-active"
+          type="button"
+        >
+          All Automations
+        </button>
+      </nav>
+
+      <div className="automations-main">
+        <header className="settings-titlebar">
+          <div className="settings-titlebar__breadcrumb">
+            <span className="settings-titlebar__eyebrow">Automations</span>
+            <span aria-hidden="true" className="settings-titlebar__separator">
+              &gt;
+            </span>
+            <span className="settings-titlebar__current">All Automations</span>
+          </div>
+          <div className="settings-titlebar__spacer" />
+          <MessagingStatusBar
+            desktopApi={props.desktopApi}
+            onOpenActivity={props.onOpenMessagingActivity}
+          />
+        </header>
+
+        <div className="automations-content">
+          <div className="automations-toolbar">
+            <div>
+              <p className="eyebrow">Serial thread queues</p>
+              <h2>Automations</h2>
+            </div>
+            <button
+              className="button button--primary"
+              type="button"
+              onClick={() => setEditorMode({ kind: "create" })}
+            >
+              New Automation
+            </button>
+          </div>
+
+          {editorMode ? (
+            <div className="automations-editor-panel">
+              <AutomationEditor
+                mode={
+                  editorMode.kind === "create"
+                    ? { kind: "create" }
+                    : { automation: editorMode.automation, kind: "edit" }
+                }
+                saving={saving}
+                threads={props.threads}
+                onCancel={() => setEditorMode(undefined)}
+                onSubmit={submitEditor}
+              />
+            </div>
+          ) : null}
+
+          {automations.error ? (
+            <p className="automations-error" role="alert">
+              {automations.error}
+            </p>
+          ) : null}
+
+          {automations.loading ? (
+            <p className="settings-empty">Loading automations...</p>
+          ) : automations.automations.length === 0 ? (
+            <p className="settings-empty">No automations configured.</p>
+          ) : (
+            <div className="automations-table" role="table" aria-label="Automations">
+              <div className="automations-table__header" role="row">
+                <span role="columnheader">Automation</span>
+                <span role="columnheader">Thread</span>
+                <span role="columnheader">Schedule</span>
+                <span role="columnheader">Status</span>
+                <span role="columnheader">Actions</span>
+              </div>
+              {automations.automations.map((automation) => {
+                const thread = threadsByKey.get(
+                  `${automation.backend}:${automation.threadId}`,
+                );
+                return (
+                  <AutomationTableRow
+                    key={automation.id}
+                    automation={automation}
+                    desktopApi={props.desktopApi}
+                    expanded={expandedAutomationId === automation.id}
+                    thread={thread}
+                    onDelete={async () => {
+                      await automations.deleteAutomation({
+                        automationId: automation.id,
+                      });
+                      await props.onRefreshNavigation?.();
+                    }}
+                    onEdit={() => setEditorMode({ automation, kind: "edit" })}
+                    onExpand={() =>
+                      setExpandedAutomationId((current) =>
+                        current === automation.id ? undefined : automation.id,
+                      )
+                    }
+                    onPauseResume={async () => {
+                      if (automation.status === "paused") {
+                        await automations.resumeAutomation({
+                          automationId: automation.id,
+                        });
+                      } else {
+                        await automations.pauseAutomation({
+                          automationId: automation.id,
+                        });
+                      }
+                      await props.onRefreshNavigation?.();
+                    }}
+                    onRunNow={async () => {
+                      await automations.runAutomationNow({
+                        automationId: automation.id,
+                      });
+                      setExpandedAutomationId(automation.id);
+                      await props.onRefreshNavigation?.();
+                    }}
+                    onSelectThread={
+                      thread && props.onSelectThread
+                        ? () => props.onSelectThread?.(thread)
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AutomationTableRow(props: {
+  automation: AutomationDetail;
+  desktopApi?: DesktopApi;
+  expanded: boolean;
+  onDelete: () => Promise<void>;
+  onEdit: () => void;
+  onExpand: () => void;
+  onPauseResume: () => Promise<void>;
+  onRunNow: () => Promise<void>;
+  onSelectThread?: () => void;
+  thread?: NavigationThreadSummary;
+}) {
+  const [busy, setBusy] = useState<string>();
+  const runAction = async (
+    action: string,
+    callback: () => Promise<void>,
+  ): Promise<void> => {
+    setBusy(action);
+    try {
+      await callback();
+    } finally {
+      setBusy(undefined);
+    }
+  };
+
+  return (
+    <>
+      <article className="automations-table__row" role="row">
+        <div role="cell">
+          <h3>{props.automation.name}</h3>
+          <p>{formatBacklogPolicy(props.automation.backlogPolicy)}</p>
+        </div>
+        <div role="cell">
+          {props.onSelectThread ? (
+            <button
+              className="automations-table__thread-link"
+              type="button"
+              onClick={props.onSelectThread}
+            >
+              {props.thread?.title ?? props.automation.threadId}
+            </button>
+          ) : (
+            <span>{props.thread?.title ?? props.automation.threadId}</span>
+          )}
+          <p>{props.automation.backend}</p>
+        </div>
+        <div role="cell">
+          <span>{props.automation.scheduleSummary}</span>
+          <p>Next {formatAutomationRelative(props.automation.nextRunAt)}</p>
+        </div>
+        <div role="cell">
+          <span className={`automation-status automation-status--${props.automation.status}`}>
+            {formatAutomationStatus(props.automation.status)}
+          </span>
+          <p>
+            Last {props.automation.lastRunStatus ?? "none"}{" "}
+            {formatAutomationRelative(props.automation.lastRunAt)}
+          </p>
+        </div>
+        <div className="automations-table__actions" role="cell">
+          <button
+            className="context-list__action"
+            disabled={Boolean(busy)}
+            type="button"
+            onClick={() => void runAction("run", props.onRunNow)}
+          >
+            Run
+          </button>
+          <button className="context-list__action" type="button" onClick={props.onEdit}>
+            Edit
+          </button>
+          <button
+            className="context-list__action"
+            disabled={Boolean(busy)}
+            type="button"
+            onClick={() => void runAction("pause", props.onPauseResume)}
+          >
+            {props.automation.status === "paused" ? "Resume" : "Pause"}
+          </button>
+          <button className="context-list__action" type="button" onClick={props.onExpand}>
+            {props.expanded ? "Hide" : "History"}
+          </button>
+          <button
+            className="context-list__action context-list__action--danger"
+            disabled={Boolean(busy)}
+            type="button"
+            onClick={() => void runAction("delete", props.onDelete)}
+          >
+            Delete
+          </button>
+        </div>
+      </article>
+      {props.expanded ? (
+        <AutomationTableHistory
+          automationId={props.automation.id}
+          desktopApi={props.desktopApi}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function AutomationTableHistory(props: {
+  automationId: string;
+  desktopApi?: DesktopApi;
+}) {
+  const runs = useAutomationRuns(props.desktopApi, props.automationId);
+
+  return (
+    <div className="automations-table__history">
+      {runs.loading ? (
+        <p>Loading run history...</p>
+      ) : runs.error ? (
+        <p>{runs.error}</p>
+      ) : runs.runs.length === 0 ? (
+        <p>No runs yet.</p>
+      ) : (
+        <ol className="automation-run-history">
+          {runs.runs.map((run) => (
+            <li key={run.id} className="automation-run-history__item">
+              <span className={`automation-run-status automation-run-status--${run.status}`}>
+                {formatRunStatus(run.status)}
+              </span>
+              <span>
+                {run.trigger}
+                {run.scheduledFor
+                  ? ` for ${formatAutomationTimestamp(run.scheduledFor)}`
+                  : ""}
+              </span>
+              <span className="automation-run-history__time">
+                {formatAutomationTimestamp(run.completedAt ?? run.startedAt ?? run.queuedAt)}
+              </span>
+              {run.scheduledWindows.length > 1 ? (
+                <span className="automation-run-history__time">
+                  {run.scheduledWindows.length} windows
+                </span>
+              ) : null}
+              {run.errorMessage ? (
+                <span className="automation-run-history__error">{run.errorMessage}</span>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
@@ -1,0 +1,301 @@
+import { useMemo, useState } from "react";
+import type {
+  AutomationDetail,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  formatAutomationRelative,
+  formatAutomationStatus,
+  formatAutomationTimestamp,
+  formatBacklogPolicy,
+  formatRunStatus,
+} from "./automation-format";
+import {
+  AutomationEditor,
+  type AutomationEditorSubmit,
+} from "./AutomationEditor";
+import {
+  sameAutomationThread,
+  useAutomationRuns,
+  useAutomations,
+} from "./useAutomations";
+
+type ThreadAutomationsPanelProps = {
+  desktopApi?: DesktopApi;
+  thread: NavigationThreadSummary;
+  onRefreshNavigation?: () => Promise<void>;
+};
+
+export function ThreadAutomationsPanel(props: ThreadAutomationsPanelProps) {
+  const automations = useAutomations(props.desktopApi, {
+    backend: props.thread.source,
+    threadId: props.thread.id,
+  });
+  const [editorMode, setEditorMode] = useState<
+    | { kind: "create" }
+    | { automation: AutomationDetail; kind: "edit" }
+    | undefined
+  >();
+  const [saving, setSaving] = useState(false);
+  const [expandedAutomationId, setExpandedAutomationId] = useState<string>();
+  const expandedAutomation = useMemo(
+    () =>
+      automations.automations.find(
+        (automation) => automation.id === expandedAutomationId,
+      ),
+    [automations.automations, expandedAutomationId],
+  );
+
+  const submitEditor = async (submission: AutomationEditorSubmit): Promise<void> => {
+    setSaving(true);
+    try {
+      if (submission.kind === "create") {
+        await automations.createAutomation(submission.request);
+      } else {
+        await automations.updateAutomation(submission.request);
+      }
+      setEditorMode(undefined);
+      await props.onRefreshNavigation?.();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="context-panel__section thread-automations">
+      <div className="automation-section-header">
+        <div>
+          <h3>Automations</h3>
+          <p className="automation-section-header__meta">
+            {formatThreadAutomationSummary(props.thread)}
+          </p>
+        </div>
+        <button
+          className="context-list__action"
+          type="button"
+          onClick={() => setEditorMode({ kind: "create" })}
+        >
+          Add
+        </button>
+      </div>
+
+      {editorMode ? (
+        <AutomationEditor
+          mode={
+            editorMode.kind === "create"
+              ? {
+                  assignment: {
+                    backend: props.thread.source,
+                    threadId: props.thread.id,
+                  },
+                  kind: "create",
+                }
+              : { automation: editorMode.automation, kind: "edit" }
+          }
+          saving={saving}
+          onCancel={() => setEditorMode(undefined)}
+          onSubmit={submitEditor}
+        />
+      ) : null}
+
+      {automations.error ? (
+        <p className="context-empty context-empty--error">{automations.error}</p>
+      ) : null}
+
+      {automations.loading ? (
+        <p className="context-empty">Loading automations...</p>
+      ) : automations.automations.length === 0 && !editorMode ? (
+        <p className="context-empty">No automations on this thread.</p>
+      ) : (
+        <ul className="automation-list">
+          {automations.automations.map((automation) => (
+            <li key={automation.id} className="automation-list__item">
+              <AutomationSummary
+                automation={automation}
+                expanded={automation.id === expandedAutomationId}
+                onDelete={async () => {
+                  await automations.deleteAutomation({ automationId: automation.id });
+                  await props.onRefreshNavigation?.();
+                }}
+                onEdit={() => setEditorMode({ automation, kind: "edit" })}
+                onExpand={() =>
+                  setExpandedAutomationId((current) =>
+                    current === automation.id ? undefined : automation.id,
+                  )
+                }
+                onPauseResume={async () => {
+                  if (automation.status === "paused") {
+                    await automations.resumeAutomation({ automationId: automation.id });
+                  } else {
+                    await automations.pauseAutomation({ automationId: automation.id });
+                  }
+                  await props.onRefreshNavigation?.();
+                }}
+                onRunNow={async () => {
+                  await automations.runAutomationNow({ automationId: automation.id });
+                  setExpandedAutomationId(automation.id);
+                  await props.onRefreshNavigation?.();
+                }}
+              />
+              {expandedAutomation?.id === automation.id ? (
+                <AutomationRunHistory
+                  automationId={automation.id}
+                  desktopApi={props.desktopApi}
+                />
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function AutomationSummary(props: {
+  automation: AutomationDetail;
+  expanded: boolean;
+  onDelete: () => Promise<void>;
+  onEdit: () => void;
+  onExpand: () => void;
+  onPauseResume: () => Promise<void>;
+  onRunNow: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState<string>();
+  const runAction = async (
+    action: string,
+    callback: () => Promise<void>,
+  ): Promise<void> => {
+    setBusy(action);
+    try {
+      await callback();
+    } finally {
+      setBusy(undefined);
+    }
+  };
+
+  return (
+    <article className="automation-row">
+      <div className="automation-row__main">
+        <div className="automation-row__title-line">
+          <h4>{props.automation.name}</h4>
+          <span className={`automation-status automation-status--${props.automation.status}`}>
+            {formatAutomationStatus(props.automation.status)}
+          </span>
+        </div>
+        <p className="automation-row__schedule">{props.automation.scheduleSummary}</p>
+        <p className="automation-row__meta">
+          next {formatAutomationRelative(props.automation.nextRunAt)} -{" "}
+          {formatBacklogPolicy(props.automation.backlogPolicy)}
+        </p>
+        {props.automation.pendingRunCount || props.automation.coalescedWindowCount ? (
+          <p className="automation-row__meta">
+            {props.automation.pendingRunCount ?? 0} queued -{" "}
+            {props.automation.coalescedWindowCount ?? 0} coalesced
+          </p>
+        ) : null}
+      </div>
+      <div className="automation-row__actions">
+        <button
+          className="context-list__action"
+          disabled={Boolean(busy)}
+          type="button"
+          onClick={() => void runAction("run", props.onRunNow)}
+        >
+          Run
+        </button>
+        <button className="context-list__action" type="button" onClick={props.onEdit}>
+          Edit
+        </button>
+        <button
+          className="context-list__action"
+          disabled={Boolean(busy)}
+          type="button"
+          onClick={() => void runAction("pause", props.onPauseResume)}
+        >
+          {props.automation.status === "paused" ? "Resume" : "Pause"}
+        </button>
+        <button className="context-list__action" type="button" onClick={props.onExpand}>
+          {props.expanded ? "Hide" : "History"}
+        </button>
+        <button
+          className="context-list__action context-list__action--danger"
+          disabled={Boolean(busy)}
+          type="button"
+          onClick={() => void runAction("delete", props.onDelete)}
+        >
+          Delete
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export function AutomationRunHistory(props: {
+  automationId: string;
+  desktopApi?: DesktopApi;
+}) {
+  const runs = useAutomationRuns(props.desktopApi, props.automationId);
+
+  if (runs.loading) {
+    return <p className="automation-run-history__empty">Loading run history...</p>;
+  }
+
+  if (runs.error) {
+    return <p className="automation-run-history__empty">{runs.error}</p>;
+  }
+
+  if (runs.runs.length === 0) {
+    return <p className="automation-run-history__empty">No runs yet.</p>;
+  }
+
+  return (
+    <ol className="automation-run-history">
+      {runs.runs.map((run) => (
+        <li key={run.id} className="automation-run-history__item">
+          <span className={`automation-run-status automation-run-status--${run.status}`}>
+            {formatRunStatus(run.status)}
+          </span>
+          <span>
+            {run.trigger}
+            {run.scheduledFor ? ` for ${formatAutomationTimestamp(run.scheduledFor)}` : ""}
+          </span>
+          <span className="automation-run-history__time">
+            {formatAutomationTimestamp(run.completedAt ?? run.startedAt ?? run.queuedAt)}
+          </span>
+          {run.scheduledWindows.length > 1 ? (
+            <span className="automation-run-history__time">
+              {run.scheduledWindows.length} windows
+            </span>
+          ) : null}
+          {run.errorMessage ? (
+            <span className="automation-run-history__error">{run.errorMessage}</span>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function formatThreadAutomationSummary(thread: NavigationThreadSummary): string {
+  const summary = thread.automationSummary;
+  if (!summary || summary.totalCount === 0) {
+    return "One serial queue per thread.";
+  }
+  const queued = summary.pendingRunCount
+    ? ` - ${summary.pendingRunCount} queued`
+    : "";
+  const coalesced = summary.coalescedWindowCount
+    ? ` - ${summary.coalescedWindowCount} coalesced`
+    : "";
+  return `${summary.enabledCount} enabled, ${summary.pausedCount} paused${queued}${coalesced}`;
+}
+
+export function automationsForThread(
+  automations: AutomationDetail[],
+  thread: NavigationThreadSummary,
+): AutomationDetail[] {
+  return automations.filter((automation) =>
+    sameAutomationThread(automation, thread.source, thread.id),
+  );
+}

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -1,0 +1,86 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutomationEditor } from "../AutomationEditor";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AutomationEditor", () => {
+  it("submits a coalescing interval automation for the assigned thread", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(
+      <AutomationEditor
+        mode={{
+          assignment: { backend: "codex", threadId: "thread-1" },
+          kind: "create",
+        }}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Check email" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Check email and summarize anything urgent." },
+    });
+    fireEvent.change(screen.getByLabelText("Every"), {
+      target: { value: "5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      kind: "create",
+      request: {
+        backend: "codex",
+        backlogPolicy: "coalesce",
+        enabled: true,
+        name: "Check email",
+        schedule: {
+          every: 5,
+          kind: "interval",
+          unit: "minutes",
+        },
+        taskPrompt: "Check email and summarize anything urgent.",
+        threadId: "thread-1",
+      },
+    });
+  });
+
+  it("shows inline validation instead of submitting an invalid interval", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(
+      <AutomationEditor
+        mode={{
+          assignment: { backend: "codex", threadId: "thread-1" },
+          kind: "create",
+        }}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Bad interval" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Try to run too often." },
+    });
+    fireEvent.change(screen.getByLabelText("Every"), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Interval must be a whole number greater than zero.",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AutomationDetail, NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { AutomationsScreen } from "../AutomationsScreen";
+
+const thread: NavigationThreadSummary = {
+  executionMode: "default",
+  id: "thread-1",
+  inbox: { inInbox: false },
+  linkedDirectories: [],
+  source: "codex",
+  title: "Email triage",
+  titleSource: "explicit",
+  updatedAt: 1,
+};
+
+const automation: AutomationDetail = {
+  backend: "codex",
+  backlogPolicy: "coalesce",
+  createdAt: 1,
+  id: "automation-1",
+  name: "Check email",
+  schedule: {
+    every: 5,
+    kind: "interval",
+    unit: "minutes",
+  },
+  scheduleSummary: "every 5 minutes",
+  status: "enabled",
+  taskPrompt: "Check email.",
+  threadId: "thread-1",
+  updatedAt: 1,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AutomationsScreen", () => {
+  it("lists automations without adding a thread lens and navigates to the assigned thread", async () => {
+    const onSelectThread = vi.fn();
+    const desktopApi: DesktopApi = {
+      listAutomations: vi.fn(async () => ({ automations: [automation] })),
+      listAutomationRuns: vi.fn(async () => ({ runs: [] })),
+      onAgentEvent: () => () => undefined,
+    };
+
+    render(
+      <AutomationsScreen
+        desktopApi={desktopApi}
+        threads={[thread]}
+        onClose={() => undefined}
+        onSelectThread={onSelectThread}
+      />,
+    );
+
+    expect(await screen.findByText("Check email")).toBeInTheDocument();
+    expect(screen.getByText("every 5 minutes")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Thread lenses" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Email triage" }));
+
+    expect(onSelectThread).toHaveBeenCalledWith(thread);
+  });
+
+  it("creates an automation with an assigned thread from the global editor", async () => {
+    const createAutomation = vi.fn(async () => ({ automation }));
+    const desktopApi: DesktopApi = {
+      createAutomation,
+      listAutomations: vi
+        .fn()
+        .mockResolvedValueOnce({ automations: [] })
+        .mockResolvedValue({ automations: [automation] }),
+      onAgentEvent: () => () => undefined,
+    };
+
+    render(
+      <AutomationsScreen
+        desktopApi={desktopApi}
+        threads={[thread]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "New Automation" }));
+    const editor = screen.getByLabelText("Name").closest("form") as HTMLElement;
+    expect(editor).not.toBeNull();
+    fireEvent.change(within(editor).getByLabelText("Name"), {
+      target: { value: "Check email" },
+    });
+    fireEvent.change(within(editor).getByLabelText("Thread"), {
+      target: { value: "codex:thread-1" },
+    });
+    fireEvent.change(within(editor).getByLabelText("Task prompt"), {
+      target: { value: "Check email." },
+    });
+    fireEvent.click(within(editor).getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(createAutomation).toHaveBeenCalledTimes(1));
+    expect(createAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        backlogPolicy: "coalesce",
+        threadId: "thread-1",
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/automations/automation-format.ts
+++ b/apps/desktop/src/renderer/src/features/automations/automation-format.ts
@@ -1,0 +1,62 @@
+import type {
+  AutomationBacklogPolicy,
+  AutomationRunStatus,
+  AutomationScheduleDefinition,
+  AutomationStatus,
+} from "@pwragent/shared";
+
+export function formatAutomationTimestamp(timestamp: number | undefined): string {
+  if (!timestamp) {
+    return "Not scheduled";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+export function formatAutomationRelative(timestamp: number | undefined): string {
+  if (!timestamp) {
+    return "never";
+  }
+
+  const deltaSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const absoluteSeconds = Math.abs(deltaSeconds);
+  const suffix = deltaSeconds >= 0 ? "from now" : "ago";
+  if (absoluteSeconds < 60) {
+    return deltaSeconds >= 0 ? "now" : "just now";
+  }
+  const minutes = Math.round(absoluteSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${suffix}`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ${suffix}`;
+  }
+  const days = Math.round(hours / 24);
+  return `${days}d ${suffix}`;
+}
+
+export function formatBacklogPolicy(policy: AutomationBacklogPolicy): string {
+  return policy === "coalesce" ? "Coalesce missed runs" : "Drop missed runs";
+}
+
+export function formatAutomationStatus(status: AutomationStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export function formatRunStatus(status: AutomationRunStatus): string {
+  return status.replace("_", " ");
+}
+
+export function formatScheduleKind(schedule: AutomationScheduleDefinition): string {
+  if (schedule.kind === "interval") {
+    return "Interval";
+  }
+  if (schedule.kind === "weekdays") {
+    return "Weekdays";
+  }
+  return "Weekly";
+}

--- a/apps/desktop/src/renderer/src/features/automations/useAutomations.ts
+++ b/apps/desktop/src/renderer/src/features/automations/useAutomations.ts
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  AppServerBackendKind,
+  AutomationDetail,
+  AutomationIdRequest,
+  AutomationRunSummary,
+  CreateAutomationRequest,
+  ListAutomationsRequest,
+  ThreadIdentifier,
+  UpdateAutomationRequest,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+type AutomationState = {
+  automations: AutomationDetail[];
+  error?: string;
+  loading: boolean;
+  refreshing: boolean;
+};
+
+export type UseAutomationsResult = AutomationState & {
+  createAutomation: (request: CreateAutomationRequest) => Promise<AutomationDetail>;
+  deleteAutomation: (request: AutomationIdRequest) => Promise<AutomationDetail>;
+  pauseAutomation: (request: AutomationIdRequest) => Promise<AutomationDetail>;
+  refresh: () => Promise<void>;
+  resumeAutomation: (request: AutomationIdRequest) => Promise<AutomationDetail>;
+  runAutomationNow: (request: AutomationIdRequest) => Promise<void>;
+  updateAutomation: (request: UpdateAutomationRequest) => Promise<AutomationDetail>;
+};
+
+export function useAutomations(
+  desktopApi: DesktopApi | undefined,
+  request?: ListAutomationsRequest,
+): UseAutomationsResult {
+  const [state, setState] = useState<AutomationState>({
+    automations: [],
+    loading: Boolean(desktopApi?.listAutomations),
+    refreshing: false,
+  });
+  const requestKey = useMemo(() => JSON.stringify(request ?? {}), [request]);
+
+  const refresh = useCallback(async () => {
+    if (!desktopApi?.listAutomations) {
+      setState({
+        automations: [],
+        error: "Automation IPC is unavailable.",
+        loading: false,
+        refreshing: false,
+      });
+      return;
+    }
+
+    setState((current) => ({
+      ...current,
+      error: undefined,
+      loading: current.automations.length === 0,
+      refreshing: current.automations.length > 0,
+    }));
+
+    try {
+      const response = await desktopApi.listAutomations(request);
+      setState({
+        automations: response.automations,
+        loading: false,
+        refreshing: false,
+      });
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        error: formatAutomationError(error),
+        loading: false,
+        refreshing: false,
+      }));
+    }
+  }, [desktopApi, requestKey]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
+
+    return desktopApi.onAgentEvent((event) => {
+      if (
+        event.notification.method === "thread/automations/updated" ||
+        event.notification.method === "automation/run/updated"
+      ) {
+        void refresh();
+      }
+    });
+  }, [desktopApi, refresh]);
+
+  const mutate = useCallback(
+    async <TRequest,>(
+      action: ((request: TRequest) => Promise<{ automation: AutomationDetail }>) | undefined,
+      request: TRequest,
+      fallback: string,
+    ): Promise<AutomationDetail> => {
+      if (!action) {
+        throw new Error("Automation IPC is unavailable.");
+      }
+
+      try {
+        const response = await action(request);
+        await refresh();
+        return response.automation;
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          error: formatAutomationError(error, fallback),
+        }));
+        throw error;
+      }
+    },
+    [refresh],
+  );
+
+  const createAutomation = useCallback(
+    (createRequest: CreateAutomationRequest) =>
+      mutate(desktopApi?.createAutomation, createRequest, "Automation could not be created."),
+    [desktopApi, mutate],
+  );
+  const updateAutomation = useCallback(
+    (updateRequest: UpdateAutomationRequest) =>
+      mutate(desktopApi?.updateAutomation, updateRequest, "Automation could not be updated."),
+    [desktopApi, mutate],
+  );
+  const deleteAutomation = useCallback(
+    (deleteRequest: AutomationIdRequest) =>
+      mutate(desktopApi?.deleteAutomation, deleteRequest, "Automation could not be deleted."),
+    [desktopApi, mutate],
+  );
+  const pauseAutomation = useCallback(
+    (pauseRequest: AutomationIdRequest) =>
+      mutate(desktopApi?.pauseAutomation, pauseRequest, "Automation could not be paused."),
+    [desktopApi, mutate],
+  );
+  const resumeAutomation = useCallback(
+    (resumeRequest: AutomationIdRequest) =>
+      mutate(desktopApi?.resumeAutomation, resumeRequest, "Automation could not be resumed."),
+    [desktopApi, mutate],
+  );
+  const runAutomationNow = useCallback(
+    async (runRequest: AutomationIdRequest) => {
+      if (!desktopApi?.runAutomationNow) {
+        throw new Error("Automation IPC is unavailable.");
+      }
+      try {
+        await desktopApi.runAutomationNow(runRequest);
+        await refresh();
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          error: formatAutomationError(error, "Automation could not be queued."),
+        }));
+        throw error;
+      }
+    },
+    [desktopApi, refresh],
+  );
+
+  return {
+    ...state,
+    createAutomation,
+    deleteAutomation,
+    pauseAutomation,
+    refresh,
+    resumeAutomation,
+    runAutomationNow,
+    updateAutomation,
+  };
+}
+
+export function useAutomationRuns(
+  desktopApi: DesktopApi | undefined,
+  automationId: string | undefined,
+): {
+  error?: string;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  runs: AutomationRunSummary[];
+} {
+  const [runs, setRuns] = useState<AutomationRunSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const refresh = useCallback(async () => {
+    if (!automationId || !desktopApi?.listAutomationRuns) {
+      setRuns([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await desktopApi.listAutomationRuns({
+        automationId,
+        limit: 20,
+      });
+      setRuns(response.runs);
+    } catch (candidate) {
+      setError(formatAutomationError(candidate, "Automation runs could not be loaded."));
+    } finally {
+      setLoading(false);
+    }
+  }, [automationId, desktopApi]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!automationId || !desktopApi?.onAgentEvent) {
+      return;
+    }
+
+    return desktopApi.onAgentEvent((event) => {
+      if (event.notification.method !== "automation/run/updated") {
+        return;
+      }
+
+      const params = event.notification.params as Record<string, unknown> | undefined;
+      if (params?.automationId === automationId) {
+        void refresh();
+      }
+    });
+  }, [automationId, desktopApi, refresh]);
+
+  return { error, loading, refresh, runs };
+}
+
+export function sameAutomationThread(
+  automation: AutomationDetail,
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+): boolean {
+  return automation.backend === backend && automation.threadId === threadId;
+}
+
+function formatAutomationError(error: unknown, fallback = "Automation request failed."): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2474,8 +2474,10 @@ export function Composer(props: ComposerProps) {
           ? Boolean(currentSettings?.fastMode)
           : undefined,
       });
-      updateActiveTurnId(response.turnId);
-      props.onActiveTurnIdChange?.(response.turnId);
+      if (response.queueStatus !== "queued") {
+        updateActiveTurnId(response.turnId);
+        props.onActiveTurnIdChange?.(response.turnId);
+      }
       if (queued) {
         if (!options?.queueClaimed) {
           removeQueuedTurn(queued);

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -62,6 +62,7 @@ type SidebarProps = {
   renameThreadError?: string;
   runtimeIdentity?: RuntimeIdentity;
   activeProfile?: string;
+  automationsActive?: boolean;
   profiles?: DesktopPwrAgentProfileSummary[];
   settingsActive?: boolean;
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -70,6 +71,7 @@ type SidebarProps = {
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: () => Promise<void>;
+  onOpenAutomations?: () => void;
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
@@ -619,6 +621,15 @@ export function Sidebar(props: SidebarProps) {
         <p className="sidebar__brand">Pwr<span className="sidebar__brand-accent">Agent</span></p>
 
         <div className="sidebar__masthead-actions">
+          <button
+            aria-label="Open automations"
+            aria-pressed={props.automationsActive}
+            className={`sidebar__icon-button${props.automationsActive ? " is-active" : ""}`}
+            type="button"
+            onClick={props.onOpenAutomations}
+          >
+            <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/></svg>
+          </button>
           <button
             aria-label="Open settings"
             aria-pressed={props.settingsActive}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -27,6 +27,7 @@ import {
   formatRateLimitLine,
   selectVisibleRateLimits,
 } from "../../lib/backend-status-format";
+import { ThreadAutomationsPanel } from "../automations/ThreadAutomationsPanel";
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
@@ -35,8 +36,9 @@ const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 type ThreadContextPanelProps = {
   backendError?: string;
   backends: BackendSummary[];
-  desktopApi?: Pick<DesktopApi, "getWindowPointerSnapshot">;
+  desktopApi?: DesktopApi;
   onPinnedChange?: (pinned: boolean) => void;
+  onRefreshNavigation?: () => Promise<void>;
   onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
   pinned: boolean;
@@ -588,6 +590,12 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
               </p>
             ) : null}
           </section>
+
+          <ThreadAutomationsPanel
+            desktopApi={props.desktopApi}
+            thread={props.thread}
+            onRefreshNavigation={props.onRefreshNavigation}
+          />
 
           {props.thread.worktreeSnapshots?.some(
             (snapshot) => snapshot.state === "archived"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -7,6 +7,7 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { formatAutomationRelative } from "../automations/automation-format";
 
 type ThreadHeaderProps = {
   desktopApi?: DesktopApi;
@@ -75,6 +76,14 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           <span className="chip chip--mode">
             {formatExecutionModeLabel(props.thread.executionMode)}
           </span>
+          {props.thread.automationSummary?.totalCount ? (
+            <span
+              className="thread-row__chip thread-row__chip--automation"
+              title={formatThreadAutomationTitle(props.thread)}
+            >
+              {formatThreadAutomationChip(props.thread)}
+            </span>
+          ) : null}
         </div>
         {missingPath ? (
           <p className="thread-header__warning" role="alert">
@@ -95,4 +104,33 @@ export function ThreadHeader(props: ThreadHeaderProps) {
       />
     </header>
   );
+}
+
+function formatThreadAutomationChip(thread: NavigationThreadSummary): string {
+  const summary = thread.automationSummary;
+  if (!summary) {
+    return "";
+  }
+  if (summary.pendingRunCount > 0) {
+    return `${summary.pendingRunCount} queued automation${
+      summary.pendingRunCount === 1 ? "" : "s"
+    }`;
+  }
+  if (summary.nextRunAt) {
+    return `${summary.enabledCount} automation${
+      summary.enabledCount === 1 ? "" : "s"
+    } - next ${formatAutomationRelative(summary.nextRunAt)}`;
+  }
+  return `${summary.totalCount} automation${summary.totalCount === 1 ? "" : "s"}`;
+}
+
+function formatThreadAutomationTitle(thread: NavigationThreadSummary): string {
+  const summary = thread.automationSummary;
+  if (!summary) {
+    return "";
+  }
+  const coalesced = summary.coalescedWindowCount
+    ? `, ${summary.coalescedWindowCount} coalesced`
+    : "";
+  return `${summary.enabledCount} enabled, ${summary.pausedCount} paused${coalesced}`;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2204,6 +2204,7 @@ export function ThreadView(props: ThreadViewProps) {
           backends={props.backends}
           desktopApi={props.desktopApi}
           onPinnedChange={setContextRailPinned}
+          onRefreshNavigation={props.onRefreshNavigation}
           onResizingChange={setContextRailResizing}
           onWidthChange={setContextRailWidth}
           // Auto-pinned when wide (issue #240) — the panel renders

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -749,6 +749,122 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage).toBeUndefined();
   });
 
+  it("renders completed assistant message items without waiting for a transcript reread", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: "codex" | "grok";
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-message-1`,
+              role: "user" as const,
+              text: "Automation run metadata...",
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-message-1`,
+              role: "user" as const,
+              text: "Automation run metadata...",
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "turn-1",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "assistant-message-1",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "The automation result is ready.",
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+      )
+    ).toEqual([
+      "user:Automation run metadata...",
+      "assistant:The automation result is ready.",
+    ]);
+    expect(
+      result.current.entries.find(
+        (entry) => entry.type === "message" && entry.role === "assistant"
+      )
+    ).toMatchObject({
+      id: "assistant-message-1",
+      phase: "final",
+      turn: { id: "turn-1", status: "in_progress" },
+    });
+    expect(readThread).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps live read activity in receipt order between assistant messages", async () => {
     let now = 10_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -8,6 +8,8 @@ import type {
 } from "../../../shared/image-normalization";
 import type {
   AgentEvent,
+  AutomationIdRequest,
+  AutomationMutationResponse,
   ArchiveWorktreeRequest,
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
@@ -16,6 +18,7 @@ import type {
   AppServerListSkillsResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CreateAutomationRequest,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
   FocusedDiffAnalysisRequest,
@@ -30,6 +33,10 @@ import type {
   InterruptTurnRequest,
   InterruptTurnResponse,
   LatestCodexConfigWarningResponse,
+  ListAutomationRunsRequest,
+  ListAutomationRunsResponse,
+  ListAutomationsRequest,
+  ListAutomationsResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   ListDesktopPwrAgentProfilesResponse,
@@ -87,6 +94,7 @@ import type {
   RestoreWorktreeResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
+  RunAutomationNowResponse,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
   QueueThreadExecutionModeRequest,
@@ -109,6 +117,7 @@ import type {
   TrustCodexProjectResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
+  UpdateAutomationRequest,
   ClearDesktopSettingsSecretRequest,
   CompleteOnboardingCodexBootstrapRequest,
   CompleteOnboardingCodexBootstrapResponse,
@@ -197,6 +206,30 @@ export type DesktopApi = {
   readAppUpdateReleaseVersions?: () => Promise<AppUpdateReleaseVersions>;
   onAppUpdateStatus?: (callback: (status: AppUpdateStatus) => void) => () => void;
   installAppUpdate?: () => Promise<AppUpdateInstallResult>;
+  listAutomations?: (
+    request?: ListAutomationsRequest,
+  ) => Promise<ListAutomationsResponse>;
+  createAutomation?: (
+    request: CreateAutomationRequest,
+  ) => Promise<AutomationMutationResponse>;
+  updateAutomation?: (
+    request: UpdateAutomationRequest,
+  ) => Promise<AutomationMutationResponse>;
+  deleteAutomation?: (
+    request: AutomationIdRequest,
+  ) => Promise<AutomationMutationResponse>;
+  pauseAutomation?: (
+    request: AutomationIdRequest,
+  ) => Promise<AutomationMutationResponse>;
+  resumeAutomation?: (
+    request: AutomationIdRequest,
+  ) => Promise<AutomationMutationResponse>;
+  runAutomationNow?: (
+    request: AutomationIdRequest,
+  ) => Promise<RunAutomationNowResponse>;
+  listAutomationRuns?: (
+    request: ListAutomationRunsRequest,
+  ) => Promise<ListAutomationRunsResponse>;
   listPwrAgentProfiles?: () => Promise<ListDesktopPwrAgentProfilesResponse>;
   openPwrAgentProfile?: (
     request: OpenDesktopPwrAgentProfileRequest,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -212,6 +212,13 @@ function messagingBindingsEqual(
   });
 }
 
+function automationSummariesEqual(
+  left: NavigationThreadSummary["automationSummary"],
+  right: NavigationThreadSummary["automationSummary"]
+): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
 function prSummariesEqual(
   left: NavigationThreadSummary["prs"],
   right: NavigationThreadSummary["prs"]
@@ -337,6 +344,7 @@ function threadSummariesEqual(
     // previous thread reference whenever nothing else changed and chips on
     // the row stay stale until something else triggers a re-render.
     messagingBindingsEqual(left.messagingBindings, right.messagingBindings) &&
+    automationSummariesEqual(left.automationSummary, right.automationSummary) &&
     prSummariesEqual(left.prs, right.prs) &&
     reactionsEqual(left.reactions, right.reactions) &&
     permissionTransitionLogsEqual(
@@ -1990,6 +1998,15 @@ export function useThreadNavigation(
             ? { ...current, model, reasoningEffort, serviceTier, fastMode }
             : current
         );
+        return;
+      }
+
+      if (
+        method === "thread/automations/updated" ||
+        method === "automation/run/updated" ||
+        method === "thread/turnQueue/updated"
+      ) {
+        scheduleRefresh();
         return;
       }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1088,6 +1088,18 @@ function withCompletedResponseTurnMetadata(
   };
 }
 
+function normalizeLiveAssistantMessagePhase(
+  value: unknown
+): AppServerThreadMessageEntry["phase"] | undefined {
+  if (value === "commentary") {
+    return "commentary";
+  }
+  if (value === "final" || value === "final_answer") {
+    return "final";
+  }
+  return undefined;
+}
+
 function flushPendingAssistantToOptimistic(
   current: ThreadSessionEntry
 ): ThreadSessionEntry {
@@ -1574,6 +1586,57 @@ function userMessageEntryFromCompletedItem(params: {
   };
 }
 
+function assistantMessageEntryFromCompletedItem(params: {
+  itemParams: AppServerNotification["params"];
+  turn: AppServerThreadTurnMetadata | undefined;
+}): AppServerThreadMessageEntry | undefined {
+  const itemParams = params.itemParams as Record<string, unknown>;
+  const item = itemParams.item;
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+
+  const record = item as Record<string, unknown>;
+  const itemType =
+    typeof record.type === "string"
+      ? record.type.replace(/[-_\s]/g, "").toLowerCase()
+      : undefined;
+  if (
+    itemType !== "agentmessage" &&
+    itemType !== "assistantmessage" &&
+    itemType !== "assistant"
+  ) {
+    return undefined;
+  }
+
+  const text = typeof record.text === "string" ? record.text.trim() : "";
+  if (!text) {
+    return undefined;
+  }
+
+  const id =
+    typeof record.id === "string" && record.id.trim()
+      ? record.id
+      : typeof record.itemId === "string" && record.itemId.trim()
+        ? record.itemId
+        : typeof record.item_id === "string" && record.item_id.trim()
+          ? record.item_id
+          : typeof itemParams.turnId === "string"
+            ? `${itemParams.turnId}:assistant`
+            : `assistant-${Date.now()}`;
+  const phase = normalizeLiveAssistantMessagePhase(record.phase);
+
+  return {
+    type: "message",
+    id,
+    role: "assistant",
+    text,
+    createdAt: Date.now(),
+    ...(params.turn ? { turn: params.turn } : {}),
+    ...(phase ? { phase } : {}),
+  };
+}
+
 function hasReviewEntryForTurn(
   response: AppServerReadThreadResponse | undefined,
   turnId: string | undefined
@@ -2031,6 +2094,14 @@ export function useThreadSessionState(params: {
       return;
     }
 
+    if (
+      session.needsHydrationAfterCompletion &&
+      session.completionHydrationRetries < 2
+    ) {
+      void loadLatest(thread);
+      return;
+    }
+
     if (thread.updatedAt == null || session.hydratedUpdatedAt === thread.updatedAt) {
       return;
     }
@@ -2397,6 +2468,49 @@ export function useThreadSessionState(params: {
                   entry.type !== "message" ||
                   !messageMatchesOptimisticEntry(userMessageEntry, entry)
               ),
+              response: nextResponse,
+            };
+          }
+
+          const assistantTurn = buildTurnMetadata({
+            fallbackId:
+              typeof event.notification.params.turnId === "string"
+                ? event.notification.params.turnId
+                : current.activeTurnId,
+            fallbackStartedAt: current.activeTurnStartedAt,
+            fallbackStatus: "in_progress",
+          });
+          const assistantMessageEntry = assistantMessageEntryFromCompletedItem({
+            itemParams: event.notification.params,
+            turn: assistantTurn,
+          });
+          if (assistantMessageEntry) {
+            const nextResponse = appendMessageEntries(
+              current.response,
+              {
+                backend: event.backend,
+                threadId: notificationThreadId,
+              },
+              [
+                ...current.optimisticEntries.filter(
+                  (entry): entry is AppServerThreadMessageEntry => entry.type === "message"
+                ),
+                assistantMessageEntry,
+              ]
+            );
+
+            return {
+              ...current,
+              expectOwnUpdate: true,
+              interacted: true,
+              lastTouchedAt: nextLastTouchedAt,
+              optimisticEntries: current.optimisticEntries.filter(
+                (entry) => entry.type !== "message"
+              ),
+              pendingAssistantMessage:
+                current.pendingAssistantMessage?.id === assistantMessageEntry.id
+                  ? undefined
+                  : current.pendingAssistantMessage,
               response: nextResponse,
             };
           }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3170,6 +3170,142 @@ textarea,
   overflow: hidden;
 }
 
+.automations-screen {
+  display: grid;
+  grid-template-columns: 188px minmax(0, 1fr);
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.automations-main {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.automations-content {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px;
+  overflow: auto;
+}
+
+.automations-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.automations-toolbar h2 {
+  margin: 2px 0 0;
+  font-size: 22px;
+  font-weight: 650;
+}
+
+.automations-editor-panel {
+  max-width: 780px;
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.automations-error {
+  margin: 0;
+  color: var(--danger-text);
+  font-size: 13px;
+}
+
+.automations-table {
+  display: flex;
+  min-width: 760px;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  overflow: hidden;
+}
+
+.automations-table__header,
+.automations-table__row {
+  display: grid;
+  grid-template-columns:
+    minmax(180px, 1.5fr)
+    minmax(160px, 1.2fr)
+    minmax(160px, 1fr)
+    minmax(130px, 0.8fr)
+    minmax(260px, 1.4fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.automations-table__header {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.automations-table__row {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.automations-table__row h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.automations-table__row p,
+.automations-table__history p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.automations-table__thread-link {
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.automations-table__thread-link:hover,
+.automations-table__thread-link:focus-visible {
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.automations-table__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.automations-table__history {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
 /* ----------------------------------------------------------------
    SETTINGS OVERLAY — chrome
    Lives ONLY inside `.app-shell__settings-layer`. The layout mirrors
@@ -7924,6 +8060,271 @@ textarea,
 .context-list__action:hover,
 .context-list__action:focus-visible {
   border-color: var(--border-strong);
+  outline: none;
+}
+
+.context-list__action--danger {
+  border-color: var(--danger-border);
+  color: var(--danger-text);
+}
+
+.thread-automations {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.automation-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.automation-section-header__meta,
+.automation-row__meta,
+.automation-row__schedule,
+.automation-editor__summary,
+.automation-run-history__empty {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.automation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.automation-list__item {
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.automation-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.automation-row__main {
+  min-width: 0;
+}
+
+.automation-row__title-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.automation-row__title-line h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.automation-row__actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.automation-status,
+.automation-run-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: capitalize;
+}
+
+.automation-status--enabled,
+.automation-run-status--completed {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.automation-status--paused,
+.automation-run-status--queued,
+.automation-run-status--pending,
+.automation-run-status--running {
+  color: var(--text-primary);
+}
+
+.automation-run-status--failed,
+.automation-run-status--cancelled {
+  border-color: var(--danger-border);
+  color: var(--danger-text);
+}
+
+.automation-run-status--skipped {
+  color: var(--text-muted);
+}
+
+.automation-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.automation-field,
+.automation-checkbox {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.automation-checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.automation-field input,
+.automation-field select,
+.automation-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.automation-field input,
+.automation-field select {
+  min-height: 32px;
+  padding: 0 9px;
+}
+
+.automation-field textarea {
+  padding: 9px;
+  resize: vertical;
+}
+
+.automation-field input:focus,
+.automation-field select:focus,
+.automation-field textarea:focus {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.automation-fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.automation-fieldset legend {
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.automation-segmented {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.automation-segmented__button,
+.automation-weekday {
+  min-width: 0;
+  min-height: 30px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.automation-segmented__button.is-active,
+.automation-weekday.is-active {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+}
+
+.automation-inline-fields {
+  display: grid;
+  grid-template-columns: minmax(72px, 0.8fr) minmax(120px, 1.2fr);
+  gap: 10px;
+}
+
+.automation-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.automation-editor__error {
+  margin: 0;
+  color: var(--danger-text);
+  font-size: 12px;
+}
+
+.automation-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.automation-run-history {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.automation-run-history__item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px 8px;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.automation-run-history__time {
+  color: var(--text-muted);
+}
+
+.automation-run-history__error {
+  grid-column: 1 / -1;
+  color: var(--danger-text);
 }
 
 .context-list__label,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -80,6 +80,14 @@ export const MESSAGING_APPROVE_PAIRING_CHANNEL = "messaging:approve-pairing";
 export const MESSAGING_REJECT_PAIRING_CHANNEL = "messaging:reject-pairing";
 export const MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL =
   "messaging:pairing-changed";
+export const AUTOMATIONS_LIST_CHANNEL = "automations:list";
+export const AUTOMATIONS_CREATE_CHANNEL = "automations:create";
+export const AUTOMATIONS_UPDATE_CHANNEL = "automations:update";
+export const AUTOMATIONS_DELETE_CHANNEL = "automations:delete";
+export const AUTOMATIONS_PAUSE_CHANNEL = "automations:pause";
+export const AUTOMATIONS_RESUME_CHANNEL = "automations:resume";
+export const AUTOMATIONS_RUN_NOW_CHANNEL = "automations:run-now";
+export const AUTOMATIONS_LIST_RUNS_CHANNEL = "automations:list-runs";
 /**
  * Fire-and-forget IPC: opens the dedicated Messaging Activity window
  * (or focuses it if already open). The activity surface is a separate

--- a/docs/automation-scheduling.md
+++ b/docs/automation-scheduling.md
@@ -1,0 +1,76 @@
+# Automation Scheduling
+
+PwrAgent automations are local recurring tasks assigned to an existing thread.
+They are intentionally not background daemons: schedules fire only while the
+desktop app is running, and every automation turn enters the same per-thread
+FIFO queue as manual messages and messaging follow-ups.
+
+## Thread Assignment
+
+Each automation belongs to one backend thread. The thread remains an ordinary
+thread, so a user can open it, read the transcript, and ask what happened.
+Manual interaction is allowed, but it changes the same conversation context and
+uses the same queue as scheduled work. If a manual message is sent while an
+automation run is queued or running, it waits its turn instead of overlapping.
+
+The thread context rail is the primary management surface. It shows the
+thread's automations, enabled or paused state, next run, pending/coalesced
+counts, run-now, pause/resume, edit/delete, and recent run history. The global
+Automations view is a secondary overview reached from the sidebar; it does not
+replace the Recents and Directories thread lenses.
+
+## Schedule Model
+
+V1 stores structured schedules rather than raw cron strings:
+
+- Interval: every N minutes or every N hours.
+- Weekdays: Monday through Friday at a time of day.
+- Weekly: one or more selected weekdays at a time of day.
+
+The scheduler runs in the desktop main process. Renderer components only create,
+edit, and inspect schedule records through IPC.
+
+## Local-Only Timing
+
+When PwrAgent is closed, scheduled ticks do not fire and are not replayed on the
+next launch. Startup computes the next future occurrence for enabled
+automations. This avoids surprising launch-time work after the app has been
+closed overnight or over a weekend.
+
+If the app stays open but the event loop wakes late, the scheduler evaluates the
+missed windows up to the current time and applies the automation's backlog
+policy.
+
+## Backlog Policies
+
+`coalesce` is the default. If one automation already has a pending or queued
+scheduled run, later due windows merge into that run. The run history and prompt
+metadata record the scheduled windows covered by the catch-up run. Example: an
+automation scheduled every 5 minutes that takes 8 minutes can collapse the 10
+and 15 minute windows into one catch-up run instead of creating overlapping
+turns.
+
+`drop_missed` records skipped scheduled windows when the assigned thread cannot
+start the run immediately. It does not enqueue stale work.
+
+`Run now` creates a manual automation run and still enters the same thread FIFO.
+It does not bypass an active turn and does not change the recurring schedule's
+next automatic run.
+
+## Run History
+
+Automation runs are persisted in the profile SQLite state database and capped
+per automation. History records whether a run was scheduled or manual, its
+status, queue/start/completion timestamps, backend turn id when available,
+errors, and the scheduled windows covered by coalesced runs.
+
+On app restart, stale local pending, queued, or running automation records are
+closed as cancelled because queued desktop-local work is not durable across
+process lifetimes.
+
+## Future Personality Profiles
+
+Personality profile selection is intentionally deferred. If future versions add
+profile-backed instruction files such as `SOUL.md`, keep the total profile text
+short. As a practical guidance point, keep custom instruction files to roughly
+300 total lines or less so they remain useful in model context.

--- a/docs/brainstorms/2026-05-13-automation-scheduling-requirements.md
+++ b/docs/brainstorms/2026-05-13-automation-scheduling-requirements.md
@@ -1,0 +1,198 @@
+---
+date: 2026-05-13
+topic: automation-scheduling
+---
+
+# Automation Scheduling
+
+## Problem Frame
+
+PwrAgent should support intentional recurring automations without pretending
+that an agent can run overlapping work on the same thread. A scheduled
+automation belongs to a thread, fires while the desktop app is running, and
+enters the same serial queue as manual user messages for that thread. If the
+agent is already working, the automation's configured backlog policy decides
+whether missed schedule windows are coalesced into one catch-up run or dropped.
+
+The design should make contention visible instead of surprising. A user should
+understand that interacting manually with an automation thread is possible, but
+that doing so changes the same context and queue that scheduled work depends on.
+
+```mermaid
+flowchart TB
+  A["Schedule reaches next run time"] --> B{"PwrAgent running?"}
+  B -->|No| C["Do not backfill missed closed-app ticks"]
+  B -->|Yes| D["Enqueue automation event on assigned thread"]
+  D --> E{"Thread agent idle?"}
+  E -->|Yes| F["Run automation turn"]
+  E -->|No| G{"Backlog policy"}
+  G -->|coalesce| H["Merge missed windows into one pending catch-up run"]
+  G -->|drop_missed| I["Drop missed window while busy"]
+  H --> J["Agent becomes idle"]
+  J --> K["Run one catch-up turn with missed-window metadata"]
+```
+
+## Requirements
+
+**Scheduling Model**
+- R1. Users must be able to create recurring automations assigned to an existing
+  thread.
+- R2. V1 schedule inputs must support friendly interval and calendar-style
+  schedules such as "every 5 minutes", "hourly", "weekdays at 9 AM", and
+  "Fridays at 4 PM"; raw cron is out of scope for the first version.
+- R3. Scheduled automation ticks must run only while the desktop app is running.
+  If PwrAgent is closed, missed ticks are not replayed on the next launch.
+- R4. Each automation must expose next run, last run, enabled/paused state, and
+  the assigned thread.
+
+**Serial Queue Contract**
+- R5. A thread must execute at most one agent turn at a time across manual
+  messages and scheduled automation runs.
+- R6. Manual messages and scheduled automation runs must share a single FIFO
+  queue ordered by enqueue time.
+- R7. The UI and copy must state that automation threads are normal threads, but
+  manual interaction changes the same context and queue used by the automation.
+- R8. Users must be able to inspect an automation thread to ask what happened,
+  while receiving clear affordances that the thread is primarily scheduled work.
+
+**Backlog Policies**
+- R9. Each automation must choose one of two backlog policies:
+
+  | Policy | Behavior | Best For |
+  |---|---|---|
+  | `coalesce` | Missed windows while the thread is busy collapse into one pending catch-up run. | Work that should catch up on elapsed time without running every stale tick. |
+  | `drop_missed` | Ticks that fire while the thread is busy are skipped. | Freshness-oriented checks where stale runs are not useful. |
+
+- R10. `coalesce` must be the default backlog policy.
+- R11. When `coalesce` creates a catch-up run, the agent prompt must include
+  explicit missed-window metadata, such as which scheduled times were collapsed
+  and why the run is executing once now.
+- R12. While a coalesced catch-up run is pending, later missed ticks for the
+  same automation must merge into that pending run rather than creating
+  additional queued automation runs.
+- R13. When `drop_missed` skips a tick, the UI must preserve enough history for
+  the user to see that the schedule fired and was skipped because the assigned
+  thread was busy.
+- R14. The first version must not offer a "run every missed tick" backlog mode.
+
+**Management Surfaces**
+- R15. The primary management surface must be thread-first: an assigned thread
+  shows its automations, next run, pending/coalesced state, last run, pause or
+  resume, run now, and delete.
+- R16. "Run now" must enqueue an explicit automation run on the same thread FIFO
+  queue; it must not bypass an in-flight manual message or scheduled run.
+- R17. A secondary global Automations view must list automations across threads
+  for discovery and status scanning, while preserving the thread assignment as a
+  first-class column or grouping.
+- R18. The global view may remain secondary in V1, but it must not imply that
+  automations are detached from thread queues.
+
+**Run History and Auditability**
+- R19. Automation history must distinguish completed runs, failed runs, skipped
+  ticks, pending coalesced catch-up runs, and manually-triggered runs.
+- R20. Run history must be visible from the thread context where the automation
+  executes.
+- R21. A user inspecting a catch-up run must be able to see which schedule
+  windows were covered by that run.
+
+**Deferred Personality Profiles**
+- R22. V1 does not need to implement automation personality profiles.
+- R23. The requirements and later UI copy should leave room for future
+  thread-level personality profiles, including short context files such as
+  `SOUL.md`, but must warn that long instruction bundles degrade usefulness.
+- R24. Future personality guidance should recommend keeping the total custom
+  instruction footprint around 300 lines or less across personality/context
+  files.
+
+## Success Criteria
+
+- A user can schedule "check email every 5 minutes" on a thread and understand
+  exactly what happens when one run takes 8 minutes.
+- No schedule can cause overlapping turns on the same thread.
+- The default `coalesce` behavior produces one visible catch-up run for missed
+  windows rather than accumulating stale work indefinitely.
+- `drop_missed` gives users a clear freshness-oriented alternative without
+  adding a large policy matrix.
+- Manual messages, scheduled runs, run history, and coalesced/skipped state are
+  visible enough that users can debug "what happened?" without reading logs.
+
+## Scope Boundaries
+
+- In scope: local desktop scheduling while PwrAgent is running, recurring
+  interval/calendar schedules, per-automation backlog policy, serial thread queue
+  semantics, thread-first management, secondary global visibility, and run
+  history.
+- Out of scope for V1: raw cron entry, cloud or daemon scheduling while the app
+  is closed, replaying missed closed-app ticks, detached background automation
+  runs, "run every missed tick" backlog mode, automation-specific priorities,
+  and personality profile management.
+- Out of scope: changing existing manual turn semantics except where manual
+  messages share the same per-thread serial queue with automation runs.
+
+## Key Decisions
+
+- Automations are assigned to threads: this reinforces that scheduled work runs
+  through a concrete agent context, not an invisible background worker.
+- One serial queue per thread: this makes contention understandable and avoids
+  overlapping agent runs.
+- FIFO across manual and scheduled input: this keeps the first version honest and
+  predictable.
+- `coalesce` default with `drop_missed` option: this gives users a useful policy
+  choice without exposing a high-risk "run all stale ticks" backlog.
+- Local-only V1: scheduled ticks require the desktop app to be running; no
+  launch-time backfill and no background service are required.
+- Personality profiles are deferred: they are important future context controls,
+  but they should not expand the scheduling MVP.
+
+## Dependencies / Assumptions
+
+- Existing PwrAgent turn-admission and permission-mode queue work provides
+  product precedent for visible queuing instead of pretending mid-turn changes or
+  follow-ups apply immediately.
+- Codex exposes personality fields in its protocol, but this repo does not yet
+  have a `SOUL.md` product convention; personality profile behavior should be
+  defined later instead of assumed in scheduling V1.
+
+## Alternatives Considered
+
+| Alternative | Decision | Rationale |
+|---|---|---|
+| Coalesce-only policy | Rejected | Simpler, but users also need an explicit freshness-over-catch-up mode. |
+| Full OpenClaw-style policy matrix | Deferred | More expressive, but too much v1 UI/support surface for the core scheduling story. |
+| Detached background runs | Rejected for V1 | Useful later, but weaker for explaining serial agent queues and thread context. |
+| Cron-first schedules | Rejected for V1 | Precise, but less aligned with the intended user-facing mental model. |
+| Backfill missed closed-app ticks | Rejected for V1 | Creates surprising launch-time work and implies scheduler durability that local desktop scheduling does not provide. |
+
+## Source Context
+
+- OpenAI Codex Automations frames scheduled tasks as recurring Codex work that
+  can run from a conversation context: https://openai.com/academy/codex-automations/
+- OpenClaw command queue docs describe explicit queue modes including collect,
+  debounce, caps, and overflow behavior: https://docs.openclaw.ai/concepts/queue
+- OpenClaw task docs distinguish background task tracking from ordinary command
+  queueing: https://docs.openclaw.ai/automation/tasks
+- PwrAgent has adjacent queue precedents in
+  `docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md`,
+  `docs/plans/2026-05-07-001-feat-codex-single-instance-queued-permissions-plan.md`,
+  and `docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md`.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R2][Technical] How friendly interval/calendar schedule input should
+  be parsed and validated.
+- [Affects R5-R6][Technical] Whether the existing thread admission queue can be
+  extended for scheduled runs or needs a scheduler-owned admission layer.
+- [Affects R11-R13][Technical] Exact run-history persistence and display model
+  for skipped and coalesced schedule windows.
+- [Affects R15-R18][Design] Exact thread-first and global Automations view layout
+  in the desktop UI.
+
+## Next Steps
+
+→ `/prompts:ce-plan` for structured implementation planning.

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -209,6 +209,18 @@ test -f "$APP/Contents/Resources/THIRD_PARTY_LICENSES"
 test -f "$APP/Contents/Resources/CHANGELOG.md"
 ```
 
+For releases that include automation scheduling changes, smoke-test one migrated
+profile before publishing broadly:
+
+```bash
+PWRAGENT_PROFILE=release-smoke open "$APP"
+```
+
+Create an interval automation on an existing thread, use **Run now**, confirm it
+appears in the thread context and global Automations view, then quit and relaunch
+to verify closed-app ticks are not backfilled. Automation state lives in the
+profile SQLite database under `~/.pwragent/profiles/<name>/state/state.db`.
+
 ---
 
 ## Auto-update on Phase 1

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -338,7 +338,7 @@ summary fields.
   automation summaries, and no implementation unit needs to invent type names or
   status vocabulary.
 
-- [ ] **Unit 2: Add Profile-Local Automation Persistence**
+- [x] **Unit 2: Add Profile-Local Automation Persistence**
 
 **Goal:** Store automation definitions, pending/coalesced run state, and run
 history in `state.db` with restart reconciliation rules.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -749,7 +749,7 @@ submission onto the shared turn FIFO while preserving their existing UX.
 - Manual desktop, scheduled automation, and messaging follow-up next-turn paths
   no longer maintain competing FIFO queues for the same thread.
 
-- [ ] **Unit 8: Add Integration Coverage, Docs, and Release Checks**
+- [x] **Unit 8: Add Integration Coverage, Docs, and Release Checks**
 
 **Goal:** Prove the feature across persistence, scheduling, queue admission, and
 UI surfaces; document the local-only scheduling contract.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -399,7 +399,7 @@ history in `state.db` with restart reconciliation rules.
   across database reopen, and closed-app ticks are not replayed during startup
   reconciliation.
 
-- [ ] **Unit 3: Introduce Registry-Level Per-Thread Turn FIFO**
+- [x] **Unit 3: Introduce Registry-Level Per-Thread Turn FIFO**
 
 **Goal:** Provide one main-process admission queue for desktop manual turns,
 scheduled automation turns, and messaging queued follow-up submissions.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -611,7 +611,7 @@ operations to the renderer while keeping snapshots and secondary windows fresh.
 - Renderer-facing API can manage automations without importing desktop main
   modules, and navigation summaries refresh after automation mutations.
 
-- [ ] **Unit 6: Build Thread-First and Secondary Global Automation UI**
+- [x] **Unit 6: Build Thread-First and Secondary Global Automation UI**
 
 **Goal:** Add UI for creating, inspecting, pausing/resuming, running, deleting,
 and scanning automations without making Automations a primary thread lens.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -690,7 +690,7 @@ and scanning automations without making Automations a primary thread lens.
   existing shell hierarchy, and give users enough history to ask "what
   happened?" from the thread context.
 
-- [ ] **Unit 7: Converge Existing Composer and Messaging Queue Paths**
+- [x] **Unit 7: Converge Existing Composer and Messaging Queue Paths**
 
 **Goal:** Move manual desktop turn queue release and messaging queued follow-up
 submission onto the shared turn FIFO while preserving their existing UX.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -546,7 +546,7 @@ enqueue automation runs, and update run history from queue/backend events.
 - Scheduler tests prove due-window calculation, backlog policy outcomes,
   prompt metadata, and queue handoff without needing a live Electron window.
 
-- [ ] **Unit 5: Wire Automation IPC, Navigation Summaries, and Events**
+- [x] **Unit 5: Wire Automation IPC, Navigation Summaries, and Events**
 
 **Goal:** Expose automation CRUD, run-now, pause/resume, history, and global list
 operations to the renderer while keeping snapshots and secondary windows fresh.

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -1,0 +1,879 @@
+---
+title: feat: Add thread-assigned automation scheduling
+type: feat
+status: active
+date: 2026-05-13
+origin: docs/brainstorms/2026-05-13-automation-scheduling-requirements.md
+deepened: 2026-05-13
+---
+
+# feat: Add thread-assigned automation scheduling
+
+## Overview
+
+Add local desktop scheduling for recurring automations assigned to existing
+threads. Each automation has a friendly schedule, task prompt, backlog policy,
+run history, and thread assignment. Scheduled runs, manual desktop messages, and
+messaging follow-up submissions must converge on one per-thread turn admission
+queue so the product can honestly say that one agent handles one queue serially.
+
+The first version is local-only: schedules fire while PwrAgent is running, do
+not backfill closed-app ticks on launch, and do not create detached background
+workers. `coalesce` is the default backlog policy; `drop_missed` is the
+freshness-oriented alternative.
+
+## Problem Frame
+
+The origin requirements define the product contract: automations are assigned to
+threads, scheduled ticks enter the same serial queue as manual thread work, and
+users must be able to inspect what happened without reading logs (see origin:
+`docs/brainstorms/2026-05-13-automation-scheduling-requirements.md`). The hard
+part is not firing a timer. The hard part is making contention, skipped ticks,
+coalesced catch-up windows, and manual interference visible while preserving the
+existing thread-first desktop model.
+
+## Requirements Trace
+
+- R1. Create recurring automations assigned to existing threads.
+- R2. Support friendly interval/calendar schedule inputs without exposing raw
+  cron in V1.
+- R3. Run schedules only while the desktop app is running; skip closed-app
+  backfill on launch.
+- R4. Expose next run, last run, enabled/paused state, and assigned thread.
+- R5. Execute at most one agent turn at a time per thread.
+- R6. Order manual messages and scheduled automation runs through one FIFO queue.
+- R7. Make clear that automation threads are normal threads, and manual
+  interaction changes the same context and queue used by the automation.
+- R8. Let users inspect automation threads to ask what happened.
+- R9-R14. Support `coalesce` and `drop_missed`, default to `coalesce`, merge
+  later missed ticks into the pending catch-up run, include catch-up metadata in
+  the agent prompt, and exclude run-all-stale-ticks mode.
+- R15-R18. Provide thread-first automation management plus a secondary global
+  Automations view that preserves thread assignment.
+- R19-R21. Persist and display run history for completed, failed, skipped,
+  pending coalesced, and manually-triggered runs.
+- R22-R24. Defer personality profile management while leaving room for short
+  future context files such as `SOUL.md`.
+
+## Scope Boundaries
+
+- In scope: local desktop scheduler, constrained friendly schedule model,
+  profile-local persistence, per-thread turn queue admission, automation run
+  lifecycle, thread-first UI, secondary global view, run history, and tests.
+- Out of scope: raw cron entry, cloud scheduling, daemon scheduling while the
+  app is closed, replaying closed-app ticks on startup, detached background
+  automation runs, automation-specific priorities, run-every-missed-tick mode,
+  and personality profile management.
+- Out of scope: changing Codex/Grok app-server protocol semantics beyond
+  passing ordinary turn input through the existing `turn/start` surface.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/state/state-db.ts` owns profile-local sqlite schema and
+  migrations. Automations should live in the same profile database as thread
+  overlays, messaging bindings, and launchpads.
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts` stores thread overlay
+  payloads and demonstrates capped audit logs for permission transitions. Use
+  this as the pattern for summary data exposed on navigation snapshots, but
+  store automation records in dedicated tables instead of expanding the thread
+  overlay blob indefinitely.
+- `packages/agent-core/src/domain/navigation-state.ts` materializes desktop-only
+  per-thread extras such as messaging bindings into `NavigationThreadSummary`
+  without violating renderer dependency boundaries. Automation summaries should
+  follow the same optional-by-thread map pattern.
+- `apps/desktop/src/main/app-server/backend-registry.ts` already owns app-server
+  clients, active-turn tracking, permission queue flushing, and backend event
+  fanout.
+- `apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts` and
+  `apps/desktop/src/renderer/src/features/composer/Composer.tsx` implement the
+  current desktop composer queue. This must be reconciled with the new
+  main-process FIFO queue so scheduled and manual work do not race.
+- `apps/desktop/src/main/messaging/core/messaging-turn-admission.ts` and
+  `apps/desktop/src/main/messaging/core/messaging-controller.ts` provide a
+  useful model for debouncing, queued follow-up entries, and Steer/Cancel
+  affordances, but the automation scheduler needs a shared registry-level queue
+  rather than another caller-specific queue.
+- `apps/desktop/src/main/ipc/app-server.ts`, `apps/desktop/src/main/ipc/agent-ipc.ts`,
+  `apps/desktop/src/preload/index.ts`, and
+  `apps/desktop/src/renderer/src/lib/desktop-api.ts` show the IPC/preload/shared
+  API wiring pattern.
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`,
+  `ThreadHeader.tsx`, and `ThreadView.tsx` are the right thread-first surfaces
+  for automation status and history. The global view should be a secondary main
+  view from `App.tsx`, not a third Recents/Directories lens.
+- `docs/UI-THEME.md` and `docs/design/desktop-style-guide.md` require the
+  sidebar to remain a thread operating surface, with only Recents and
+  Directories in the thread lens switch.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` says the UX
+  should queue or delay visibly when upstream semantics impose waiting. This is
+  directly applicable to schedule ticks that fire while a thread is active.
+- `docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md` established
+  that overlapping turns are unsafe and that queued work should be visible,
+  cancellable when user-originated, and flushed from terminal turn events.
+- `docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md`
+  established drop/coalesce as an explicit admission outcome vocabulary for
+  stale work rather than silently building unbounded queues.
+
+### External References
+
+- OpenAI Codex Automations frames scheduled work as recurring Codex tasks that
+  can run from a conversation context:
+  https://openai.com/academy/codex-automations/
+- OpenClaw queue docs describe explicit queue modes, including collect/coalesce
+  style behavior, caps, and overflow outcomes:
+  https://docs.openclaw.ai/concepts/queue
+- OpenClaw task docs distinguish tracked background tasks from ordinary command
+  queueing: https://docs.openclaw.ai/automation/tasks
+- `rrule` was checked as a possible recurrence helper. It can compute
+  occurrences and parse/serialize RFC-style recurrence strings, but the package
+  is BSD-3-Clause, not MIT, and would introduce RFC/timezone complexity beyond
+  V1's constrained schedule shapes. Prefer a small explicit schedule model first.
+
+## Key Technical Decisions
+
+- **Use dedicated automation tables, not thread overlay blobs.** Automations and
+  run history are first-class profile data with their own lifecycle, queries,
+  and retention needs. Thread summaries should receive compact derived summaries
+  from the automation store.
+- **Use a constrained schedule model instead of free-form parsing.** The UI can
+  present friendly interval/calendar controls and render summaries such as
+  `every 5 minutes` or `Fridays at 4 PM`. Internally store typed schedule
+  definitions so validation and next-run calculation stay deterministic.
+- **Keep schedule evaluation in the desktop main process.** Renderer timers
+  would stop when windows are hidden or replaced, and renderer ownership would
+  force the UI to know about backend admission. The scheduler belongs next to
+  state, app-server clients, and runtime lifecycle.
+- **Introduce one registry-level thread turn queue.** The scheduler, desktop
+  composer, and messaging follow-up flushes should all submit to one
+  per-backend/thread FIFO queue. Low-level app-server `startTurn` remains the
+  execution primitive; the new admission API decides whether work starts now or
+  waits.
+- **Persist run/audit history, not queued turn payloads across restart.** A
+  restart cancels pending/in-flight local automation work with a visible history
+  entry and computes the next future schedule. This preserves the local-only
+  closed-app policy while keeping history honest.
+- **Treat OS sleep as app-running delay, not closed-app backfill.** If the
+  process remains alive and timers wake late, compute due schedule windows up to
+  `now` and apply the automation's backlog policy. If the process restarts,
+  advance to the next future tick without replaying closed-app windows.
+- **Do not add an Automations thread lens.** The global view is secondary and
+  should be reachable as a global app surface. Recents/Directories remains the
+  thread lens switch.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should V1 use a third-party recurrence parser?** No. A constrained typed
+  schedule model is enough for interval and weekly/calendar schedules, keeps the
+  UI honest, and avoids cron/RFC recurrence semantics that are explicitly out of
+  scope.
+- **Should queued automation payloads survive app restart?** No. Persist the
+  audit trail and mark interrupted/pending local runs as cancelled on startup;
+  do not replay closed-app ticks.
+- **Should "Run now" bypass the queue?** No. It enqueues through the same FIFO
+  turn queue and is recorded as a manually-triggered automation run.
+- **Should the global Automations view be a sidebar lens?** No. Preserve the
+  two-lens Recents/Directories contract and expose Automations as a secondary
+  global surface.
+
+### Deferred to Implementation
+
+- Exact CSS/layout details for the thread automation panel and global
+  Automations view after the components are rendered against real data.
+- Exact retention cap for detailed run history. Start with a conservative cap
+  in the store and tune only if UI/tests show the history is too shallow.
+- Exact wake-from-sleep timing edge cases. Unit tests should cover late timer
+  evaluation; implementation can refine timestamp names while preserving the
+  product rule above.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant Scheduler as AutomationScheduler
+  participant Store as AutomationStore
+  participant Queue as ThreadTurnQueue
+  participant Registry as BackendRegistry
+  participant Backend as Codex/Grok app-server
+  participant UI as Renderer
+
+  Scheduler->>Store: load enabled automations + nextRunAt
+  Scheduler->>Scheduler: timer wakes at earliest nextRunAt
+  Scheduler->>Store: compute due windows up to now
+  alt drop_missed and thread busy
+    Scheduler->>Store: record skipped tick
+    Store-->>UI: automation history/status changed
+  else coalesce and existing pending catch-up
+    Scheduler->>Store: append due windows to pending run
+    Store-->>UI: coalesced window count changed
+  else enqueue run
+    Scheduler->>Store: create pending run
+    Scheduler->>Queue: submit automation turn
+    Queue->>Registry: start when thread FIFO reaches entry
+    Registry->>Backend: turn/start
+    Registry-->>Queue: turn started
+    Queue->>Store: mark run started with turn id
+  end
+  Backend-->>Registry: turn completed/failed/cancelled
+  Registry-->>Queue: terminal event
+  Queue->>Store: mark automation run terminal when matched
+  Queue->>Queue: start next queued thread entry
+```
+
+Schedule shapes for V1:
+
+| Shape | Example summaries | Notes |
+|---|---|---|
+| Interval | `every 5 minutes`, `hourly`, `every 2 hours` | Minimum interval should be clamped to avoid accidental tight loops. |
+| Weekly calendar | `Fridays at 4 PM`, `Mondays and Wednesdays at 9 AM` | Store selected weekdays and local wall-clock time. |
+| Weekdays calendar | `weekdays at 9 AM` | Convenience wrapper around Monday-Friday weekly calendar. |
+
+Thread-turn admission states:
+
+| State | Meaning | Next transition |
+|---|---|---|
+| idle | No active turn and no queued entry for thread | Start first submitted entry immediately. |
+| starting | Low-level `turn/start` is in flight | Later entries queue FIFO. |
+| working | Backend emitted active turn state | Later entries queue FIFO. |
+| queued | One or more entries waiting for this thread | Start next entry after terminal/idle signal. |
+| terminal-releasing | Terminal event is retiring current entry and waking next | Idempotent guard prevents double-start on duplicate terminal signals. |
+
+## Delivery Gates
+
+- **Gate 1: Internal foundations only.** Units 1-5 can land behind internal
+  APIs and tests, but no user-facing automation UI should ship until the shared
+  turn FIFO is the normal submission path for manual desktop sends, scheduler
+  runs, and messaging queued follow-ups.
+- **Gate 2: FIFO truth before scheduler UI.** Unit 7 is a release blocker for
+  Unit 6 if the UI is enabled by default. This prevents a visible scheduling
+  surface from promising one serial thread queue while old composer or messaging
+  paths can still bypass it.
+- **Gate 3: Local-only semantics verified.** Before enabling the feature, tests
+  must cover app restart no-backfill, late timer coalescing while the process
+  remains alive, `drop_missed` skip history, and run-now FIFO ordering.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["Unit 1: Shared contracts and schedule model"] --> U2["Unit 2: Automation persistence"]
+  U1 --> U3["Unit 3: Registry turn FIFO"]
+  U2 --> U4["Unit 4: Scheduler and run lifecycle"]
+  U3 --> U4
+  U1 --> U5["Unit 5: IPC, navigation, and event fanout"]
+  U2 --> U5
+  U4 --> U5
+  U5 --> U6["Unit 6: Thread-first and global UI"]
+  U3 --> U7["Unit 7: Composer/messaging queue convergence"]
+  U5 --> U7
+  U6 --> U8["Unit 8: E2E, docs, and release checks"]
+  U7 --> U8
+```
+
+- [ ] **Unit 1: Define Shared Automation Contracts and Schedule Model**
+
+**Goal:** Add provider-neutral automation types, schedule definitions, backlog
+policy vocabulary, run statuses, IPC request/response contracts, and thread
+summary fields.
+
+**Requirements:** R1-R4, R9-R14, R17-R21, R22-R24
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/shared/src/contracts/automations.ts`
+- Modify: `packages/shared/src/contracts/navigation.ts`
+- Modify: `packages/shared/src/contracts/normalized-app-server.ts`
+- Modify: `packages/shared/src/index.ts`
+- Modify: `packages/agent-core/src/domain/navigation-state.ts`
+- Test: `packages/shared/src/contracts/__tests__/automations.test.ts`
+- Test: `packages/agent-core/src/__tests__/navigation-state.test.ts`
+
+**Approach:**
+- Define `AutomationBacklogPolicy` as `coalesce | drop_missed`.
+- Define V1 schedule definitions as explicit structured shapes: interval,
+  weekly calendar, and weekdays calendar. Include timezone/local-time metadata
+  only as needed to state that schedules evaluate in the user's local desktop
+  timezone.
+- Define automation summaries for thread/global lists separately from detailed
+  records and run-history rows.
+- Add optional `automations` or `automationSummary` data to
+  `NavigationThreadSummary`, populated from a desktop-supplied
+  `automationsByThreadKey` map in `buildNavigationSnapshot`.
+- Add app-server notification methods such as `thread/automations/updated` and
+  `automation/run/updated` only for renderer/messaging fanout; keep detailed
+  CRUD on dedicated automation IPC.
+- Preserve personality profile fields as deferred metadata or future-facing
+  notes only. Do not define `SOUL.md` loading behavior in V1.
+
+**Patterns to follow:**
+- Optional desktop-only maps in `packages/agent-core/src/domain/navigation-state.ts`
+  for messaging bindings.
+- Permission queue notification shape in
+  `packages/shared/src/contracts/normalized-app-server.ts`.
+- Shared package leaf rules in `packages/shared/AGENTS.md`.
+
+**Test scenarios:**
+- Happy path: interval schedule summaries and definitions round-trip through
+  shared contract helpers.
+- Happy path: weekly and weekdays schedules validate selected day/time fields
+  and reject empty day sets.
+- Edge case: unsupported raw cron-like input is not representable as a V1
+  schedule definition.
+- Edge case: navigation snapshot hash changes when a thread's automation summary
+  changes, so renderer refreshes are not skipped.
+- Regression: shared exports remain leaf-package safe and do not import desktop
+  or agent-core modules.
+
+**Verification:**
+- Shared contracts compile, navigation snapshot materialization can carry compact
+  automation summaries, and no implementation unit needs to invent type names or
+  status vocabulary.
+
+- [ ] **Unit 2: Add Profile-Local Automation Persistence**
+
+**Goal:** Store automation definitions, pending/coalesced run state, and run
+history in `state.db` with restart reconciliation rules.
+
+**Requirements:** R1, R3-R4, R11-R13, R17-R21
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/state/state-db.ts`
+- Create: `apps/desktop/src/main/automations/automation-store.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-store.test.ts`
+- Test: `apps/desktop/src/main/__tests__/state-migration.test.ts`
+
+**Approach:**
+- Add a new schema migration for automation tables. Use dedicated tables for
+  automation records and run history; avoid embedding this data in the thread
+  overlay payload.
+- Store enough on each automation to evaluate schedules locally: id, backend,
+  thread id, name, task prompt, schedule definition, backlog policy, enabled
+  state, next run time, last run summary, created/updated timestamps.
+- Store run history rows for pending, started, completed, failed, cancelled,
+  skipped, and coalesced states. Include scheduled window timestamps so
+  catch-up runs can explain what they cover.
+- On startup, reconcile rows left pending/started by a previous process into a
+  terminal local-cancelled/interrupted status, then compute the next future run
+  without replaying closed-app ticks.
+- Cap detailed history per automation while preserving the latest state needed
+  for thread/global summaries.
+- Use prepared statements only; do not interpolate user prompt, automation name,
+  or thread ids into SQL strings.
+
+**Patterns to follow:**
+- Migration structure in `apps/desktop/src/main/state/state-db.ts`.
+- SQLite store style in `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+  and messaging store tests.
+- SQL safety guidance in `apps/desktop/AGENTS.md`.
+
+**Test scenarios:**
+- Happy path: create/update/pause/resume/delete automation records and read them
+  by id, by thread, and globally.
+- Happy path: append run history, update a pending run to started/terminal, and
+  read latest summary fields.
+- Happy path: coalescing a second due window updates the existing pending run
+  rather than creating a second pending run for the same automation.
+- Edge case: startup reconciliation converts stale pending/started local runs to
+  cancelled/interrupted and advances next run to the future without creating a
+  catch-up run.
+- Edge case: history cap evicts oldest detailed rows without losing the latest
+  automation summary.
+- Error path: malformed persisted payload is handled with a recoverable store
+  error rather than crashing scheduler startup.
+- Security regression: names/prompts containing quotes or SQL-looking text are
+  persisted through bound parameters and read back unchanged.
+
+**Verification:**
+- State migration is idempotent, automation CRUD and run history are durable
+  across database reopen, and closed-app ticks are not replayed during startup
+  reconciliation.
+
+- [ ] **Unit 3: Introduce Registry-Level Per-Thread Turn FIFO**
+
+**Goal:** Provide one main-process admission queue for desktop manual turns,
+scheduled automation turns, and messaging queued follow-up submissions.
+
+**Requirements:** R5-R6, R16
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/thread-turn-queue.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Modify: `packages/shared/src/contracts/normalized-app-server.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-turn-queue.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Add a high-level turn submission path that returns either started or queued
+  metadata. The low-level app-server `turn/start` call remains internal to the
+  queue runner.
+- Expose an internal queue inspection method for scheduler decisions, for
+  example "can this backend/thread start a turn immediately with no active,
+  starting, or earlier queued work?" The `drop_missed` policy should use this
+  check before deciding whether to skip a due window.
+- Key FIFO state by backend/thread identity. Track `starting`, active turn id,
+  queued entries, and terminal-release guards so duplicate terminal notifications
+  do not start two queued entries.
+- Queue entries should include origin (`manual`, `automation`, `messaging`),
+  input, resolved turn settings, created timestamp, and optional automation run
+  id. Keep input payloads memory-only while the app is running.
+- Preserve existing Codex permission-mode queue flushing before starting the
+  next queued turn. The permission queue must apply before an automation or
+  manual turn starts, just like today's `startTurn` path.
+- Emit queue lifecycle notifications for UI refresh and automation run tracking:
+  queued, started, cancelled/interrupted, and terminal when applicable.
+- Keep backend/agent-core overlap rejection as a safety net. The queue should
+  prevent overlap before calling the backend; app-server rejection still protects
+  unexpected callers.
+
+**Patterns to follow:**
+- Permission queue idempotent claim/flush in
+  `apps/desktop/src/main/app-server/backend-registry.ts`.
+- Messaging turn admission state machine in
+  `apps/desktop/src/main/messaging/core/messaging-turn-admission.ts`.
+- Agent-core overlap rejection in `packages/agent-core/src/app-server/codex-app-server.ts`.
+
+**Test scenarios:**
+- Happy path: an idle thread submission starts immediately and returns a started
+  turn id.
+- Happy path: while a turn is active, manual then automation submissions queue
+  FIFO and start in enqueue order after terminal events.
+- Happy path: while a turn is active, automation then manual submissions queue
+  FIFO and start in enqueue order after terminal events.
+- Happy path: a pending permission-mode queue flushes before the next queued
+  automation turn starts.
+- Edge case: duplicate `turn/completed` and `thread/status/changed` idle signals
+  release at most one queued entry.
+- Edge case: backend `turn/start` rejects due to active turn despite queue state;
+  the entry remains queued or terminal-failed without dropping later entries.
+- Error path: invalid thread/backend submission fails the specific queue entry
+  and does not poison the thread queue.
+- Integration: messaging queued follow-up flushes call the shared turn queue
+  instead of racing scheduled/manual queued entries.
+
+**Verification:**
+- Tests demonstrate that all main-process ordinary turn origins serialize through
+  the same per-thread FIFO and that low-level overlap errors become exceptional
+  safety-net paths, not normal control flow.
+
+- [ ] **Unit 4: Implement Scheduler Evaluation and Automation Run Lifecycle**
+
+**Goal:** Evaluate due schedules while the app is running, apply backlog policy,
+enqueue automation runs, and update run history from queue/backend events.
+
+**Requirements:** R1-R4, R9-R14, R16-R21
+
+**Dependencies:** Units 2 and 3
+
+**Files:**
+- Create: `apps/desktop/src/main/automations/automation-schedule.ts`
+- Create: `apps/desktop/src/main/automations/automation-prompt.ts`
+- Create: `apps/desktop/src/main/automations/automation-scheduler.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-schedule.test.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-prompt.test.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-scheduler.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Use one scheduler service in the main process with a single timer set to the
+  earliest enabled `nextRunAt`, recalculated after every automation mutation or
+  run-history update.
+- On app startup, ask the store to reconcile stale local runs and advance all
+  enabled automations to their next future occurrence without replaying ticks
+  missed while the app was closed.
+- Track a scheduler session start timestamp in memory. Due-window evaluation
+  should distinguish windows missed before this process was running from windows
+  delayed while this process stayed alive, so restart no-backfill and
+  wake-from-sleep catch-up do not collapse into the same behavior.
+- On late timer wake while the process stayed alive, compute all due schedule
+  windows up to `now` and apply the automation's backlog policy.
+- For `coalesce`, create one pending run when no pending run exists; if one is
+  already pending for that automation, append the new scheduled windows to it.
+- For `drop_missed`, if the assigned thread cannot start immediately because it
+  is active, starting, or has earlier queued entries, record skipped windows
+  instead of queuing stale work.
+- Build automation turn input with clear metadata before the user task prompt:
+  automation name, trigger type, scheduled windows covered, coalesced count, and
+  why the run is executing now.
+- Track queue submission id and backend turn id on the run row. Mark terminal
+  status from queue/backend events.
+- A manual "Run now" creates a manually-triggered run row and submits it through
+  the same queue; it does not alter the recurring schedule's next automatic run
+  except for last-run summary fields.
+
+**Patterns to follow:**
+- Timer ownership/disposal in `MessagingTurnAdmission`.
+- Backend terminal lifecycle handling in `BackendRegistry.emit`.
+- Permission transition audit language for honest queued/applied/cancelled
+  lifecycle.
+
+**Test scenarios:**
+- Happy path: `every 5 minutes` due on an idle thread creates a pending run,
+  starts it immediately, and computes the next run.
+- Happy path: if a 5-minute automation is busy through two windows, `coalesce`
+  produces one pending catch-up run whose prompt metadata covers both windows.
+- Happy path: while a coalesced catch-up is pending, a later due window merges
+  into the same run rather than adding a second queued run.
+- Happy path: `drop_missed` records a skipped run when the thread is occupied
+  and advances to the next future occurrence.
+- Happy path: "Run now" enqueues a manually-triggered run behind any earlier
+  queued entries and records it distinctly from scheduled runs.
+- Edge case: app startup with `nextRunAt` in the past advances to the next
+  future occurrence without creating skipped/catch-up rows for closed-app time.
+- Edge case: process sleep/timer delay while running evaluates due windows up to
+  `now` and applies backlog policy.
+- Error path: backend start failure marks that automation run failed and leaves
+  later queued entries intact.
+- Regression: `coalesce` remains the default when a new automation is created
+  without an explicit backlog policy.
+
+**Verification:**
+- Scheduler tests prove due-window calculation, backlog policy outcomes,
+  prompt metadata, and queue handoff without needing a live Electron window.
+
+- [ ] **Unit 5: Wire Automation IPC, Navigation Summaries, and Events**
+
+**Goal:** Expose automation CRUD, run-now, pause/resume, history, and global list
+operations to the renderer while keeping snapshots and secondary windows fresh.
+
+**Requirements:** R1-R4, R15-R21
+
+**Dependencies:** Units 1, 2, and 4
+
+**Files:**
+- Create: `apps/desktop/src/main/ipc/automation-ipc.ts`
+- Modify: `apps/desktop/src/main/ipc/index.ts`
+- Modify: `apps/desktop/src/main/ipc/app-server.ts`
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
+
+**Approach:**
+- Add IPC methods for create/update/delete/list/list-by-thread/list-runs/run-now
+  and pause/resume. Keep requests/responses typed through `@pwragent/shared`.
+- Add a main-process automation service accessor near existing app-server/state
+  services so startup/shutdown can start and dispose scheduler timers
+  deterministically.
+- Feed compact automation summaries into navigation snapshot reconciliation,
+  mirroring the `messagingBindingsByThreadKey` pattern.
+- Emit a lightweight automation-changed event after store mutations and run
+  lifecycle changes. Renderer listeners should refetch or patch summaries rather
+  than inventing partial state.
+- Add `useThreadNavigation` handling for automation-related backend events so
+  the selected thread and global list stay fresh after scheduled runs, skip
+  events, and coalesced pending window updates.
+- Make delete/pause behavior explicit: pausing stops future scheduling but does
+  not cancel an already-started turn; deleting cancels pending unstarted
+  automation queue entries when possible and preserves completed history only if
+  the store model chooses soft deletion.
+
+**Patterns to follow:**
+- IPC channel constants in `apps/desktop/src/shared/ipc.ts`.
+- Preload method wiring in `apps/desktop/src/preload/index.ts`.
+- Navigation refresh and patch handling in
+  `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`.
+- Messaging bindings changed event for refetch-oriented renderer updates.
+
+**Test scenarios:**
+- Happy path: create automation through IPC, list it globally, and see it in the
+  assigned thread's navigation summary.
+- Happy path: pause/resume updates scheduler state and notifies the renderer.
+- Happy path: run-now creates a manually-triggered run and returns queued/started
+  status metadata.
+- Happy path: list-runs returns newest-first run history for a thread automation.
+- Edge case: deleting an automation with a pending unstarted queue entry marks
+  the pending run cancelled and emits a refresh event.
+- Error path: creating with an unknown thread id returns a recoverable validation
+  error and does not persist a dangling automation.
+- Integration: automation summary changes affect navigation snapshot hash so a
+  normal refresh updates the UI.
+
+**Verification:**
+- Renderer-facing API can manage automations without importing desktop main
+  modules, and navigation summaries refresh after automation mutations.
+
+- [ ] **Unit 6: Build Thread-First and Secondary Global Automation UI**
+
+**Goal:** Add UI for creating, inspecting, pausing/resuming, running, deleting,
+and scanning automations without making Automations a primary thread lens.
+
+**Requirements:** R4, R7-R8, R15-R21, R22-R24
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/automations/useAutomations.ts`
+- Create: `apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx`
+- Create: `apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx`
+- Create: `apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Test: `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+
+**Approach:**
+- Put the thread-first management surface in the thread detail context rail or
+  an adjacent inspector-style panel. It should show active automations for the
+  selected thread, next run, last run, current pending/coalesced state, pause or
+  resume, run now, delete, and recent history.
+- Add a compact header/status signal only when a thread has automations or a
+  pending/skipped state worth surfacing. Avoid cluttering every thread header.
+- Add a global Automations screen as a secondary app surface reachable from a
+  global sidebar action. Do not add a third tab to the Recents/Directories lens
+  switch.
+- Provide creation/editing controls as structured inputs: task prompt, schedule
+  shape, interval value/unit or weekday/time selection, backlog policy, enabled
+  state, and assigned thread. Do not ship a raw cron text box.
+- Copy should be direct and operational: explain that automation threads are
+  ordinary threads and manual messages enter the same queue. Avoid scaffold
+  narration or implementation language.
+- Include deferred personality profile guidance only as future-facing copy where
+  appropriate; do not expose profile selection controls in V1.
+- Keep controls stable and compact, use existing buttons/tokens, and avoid card
+  nesting. Long automation names/prompts should truncate or wrap without
+  shifting fixed controls.
+
+**Patterns to follow:**
+- Context rail layout in `ThreadContextPanel.tsx`.
+- Settings-style grouped controls in `apps/desktop/src/renderer/src/features/settings`.
+- Sidebar global action treatment in `Sidebar.tsx`.
+- Visual constraints in `docs/UI-THEME.md` and
+  `docs/design/desktop-style-guide.md`.
+
+**Test scenarios:**
+- Happy path: selected thread with no automations shows an intentional empty
+  state and a create action.
+- Happy path: selected thread with an enabled automation shows next run, last
+  run, policy, and run-now/pause/delete actions.
+- Happy path: global Automations screen lists automations grouped or filterable
+  by assigned thread and can navigate back to the thread.
+- Happy path: creating "every 5 minutes" defaults policy to `coalesce` and
+  persists via `desktopApi`.
+- Happy path: editing to `drop_missed` updates the displayed policy and summary.
+- Edge case: a pending coalesced run shows the number or list of covered windows
+  without creating multiple visible queued runs.
+- Edge case: very long names/prompts do not overflow action buttons or occlude
+  neighboring UI.
+- Error path: validation failures for invalid interval/time/day combinations
+  are shown inline and do not call create/update IPC.
+- Accessibility: schedule controls, pause/resume, run now, and delete are
+  keyboard reachable with clear accessible labels.
+- Regression: sidebar lens switch still contains only Recents and Directories.
+
+**Verification:**
+- Thread-first and global views make automation state visible, preserve the
+  existing shell hierarchy, and give users enough history to ask "what
+  happened?" from the thread context.
+
+- [ ] **Unit 7: Converge Existing Composer and Messaging Queue Paths**
+
+**Goal:** Move manual desktop turn queue release and messaging queued follow-up
+submission onto the shared turn FIFO while preserving their existing UX.
+
+**Requirements:** R5-R8, R16
+
+**Dependencies:** Units 3 and 5
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts`
+
+**Approach:**
+- Keep the composer visible queued-draft affordance for selected-thread UX, but
+  make the actual release path submit through the shared main-process queue so
+  scheduled runs and manual queued drafts cannot leapfrog each other.
+- When the shared queue returns queued metadata for a desktop manual submission,
+  update composer queue state from that response rather than assuming a turn id
+  exists immediately.
+- Preserve Steer behavior for active turns. Steering remains a deliberate
+  injection into the current turn; ordinary "send as next turn" uses FIFO.
+- Messaging should keep its debounce and Steer/Cancel notice behavior, but when
+  a queued follow-up is submitted as the next turn, it should call the shared
+  queue rather than the low-level backend start path.
+- Ensure queue entries from different origins have enough display metadata for
+  debugging without leaking full prompt text into unrelated surfaces.
+
+**Patterns to follow:**
+- Existing composer queued draft UI in `Composer.tsx`.
+- `MessagingTurnAdmission` queue entry lifecycle.
+- Shared turn queue notifications from Unit 3.
+
+**Test scenarios:**
+- Happy path: while a turn is active, a manual desktop draft and then a due
+  automation run start in FIFO order after the active turn completes.
+- Happy path: while a turn is active, a due automation run and then a manual
+  desktop draft start in FIFO order after the active turn completes.
+- Happy path: messaging queued follow-up preserves Steer/Cancel actions, and
+  choosing "send after turn" participates in FIFO with automation entries.
+- Edge case: steering a queued manual or messaging draft removes it from the
+  normal FIFO release path.
+- Edge case: selected-thread composer state remains accurate when a queued
+  automation starts first because it was enqueued earlier.
+- Error path: if the shared queue rejects a queued manual entry, composer keeps
+  the draft visible with a recoverable error rather than dropping it.
+- Regression: branch drift preflight still blocks manual turn submission when it
+  should, before the manual entry reaches the shared queue.
+
+**Verification:**
+- Manual desktop, scheduled automation, and messaging follow-up next-turn paths
+  no longer maintain competing FIFO queues for the same thread.
+
+- [ ] **Unit 8: Add Integration Coverage, Docs, and Release Checks**
+
+**Goal:** Prove the feature across persistence, scheduling, queue admission, and
+UI surfaces; document the local-only scheduling contract.
+
+**Requirements:** All requirements, especially success criteria
+
+**Dependencies:** Units 1-7
+
+**Files:**
+- Create or modify: `apps/desktop/e2e/automation-scheduling.spec.ts`
+- Modify: `docs/desktop-release-runbook.md` if automation state or release
+  notes need operator awareness
+- Create: `docs/automation-scheduling.md`
+- Modify: `README.md` only if the user-facing feature list mentions
+  automations
+- Test: `apps/desktop/e2e/automation-scheduling.spec.ts`
+- Test: targeted unit tests from Units 1-7
+
+**Approach:**
+- Add replay/state-seeded E2E coverage for creating an automation, seeing it on
+  the thread surface, opening the global view, pausing/resuming, and run-now
+  queueing behind an active turn.
+- Add deterministic main-process integration tests for schedule due windows,
+  startup no-backfill, coalescing, drop-missed, and FIFO ordering.
+- Document local-only behavior, closed-app no-backfill, OS sleep/late timer
+  treatment, backlog policies, and the warning that manual interaction changes
+  the automation thread's context.
+- Include personality profile guidance as future-facing documentation only:
+  profiles are deferred, and any future custom instruction files should stay
+  short, around 300 total lines.
+- Update license/dependency artifacts only if implementation adds a package. If
+  the constrained parser approach holds, no third-party scheduling dependency is
+  needed.
+
+**Patterns to follow:**
+- Existing replay-backed E2E conventions under `apps/desktop/e2e`.
+- Documentation style in `docs/messaging-platform-integration.md` and release
+  runbooks.
+- Project guidance for `pnpm test:desktop-e2e` from the repo root.
+
+**Test scenarios:**
+- Happy path: create an enabled interval automation from a thread, observe it in
+  thread and global views, and verify next run/last run summaries update.
+- Happy path: run-now while the thread is active queues behind the active turn
+  and records a manually-triggered run.
+- Happy path: coalesced missed windows appear as one pending catch-up run with
+  explicit covered-window metadata.
+- Happy path: drop-missed records skipped history while busy and does not enqueue
+  stale work.
+- Edge case: app startup with past `nextRunAt` shows no launch-time backfill.
+- Edge case: deleting or pausing an automation updates both thread and global
+  views without leaving stale actions.
+- Error path: failed backend start surfaces failed run history and does not
+  block later queued thread work.
+- Regression: existing permission-mode queue, branch-drift checks, composer
+  queued turns, and messaging queued turns still work with the new shared queue.
+
+**Verification:**
+- Unit and E2E coverage demonstrate the user-facing example from the origin:
+  "check email every 5 minutes" taking 8 minutes produces an understandable
+  coalesced catch-up rather than overlapping or unbounded stale runs.
+
+## System-Wide Impact
+
+- **Interaction graph:** Automation CRUD flows through renderer components,
+  preload IPC, main-process automation service/store, scheduler timers, the
+  shared turn queue, `BackendRegistry`, backend app-server events, navigation
+  snapshots, and renderer refresh hooks.
+- **Error propagation:** Validation errors should stay on create/edit controls;
+  scheduler/store errors should mark affected automation runs failed or paused
+  with visible history; backend start failures should terminal-fail only the
+  relevant queue entry.
+- **State lifecycle risks:** Timer wake, app restart, stale pending queue entries,
+  duplicate terminal notifications, and history retention need explicit tests.
+  Restart must not replay closed-app ticks.
+- **API surface parity:** Shared contracts, IPC channels, preload, desktop API,
+  navigation summaries, and renderer hooks must be updated together. The
+  renderer must continue importing only `@pwragent/shared`.
+- **Integration coverage:** Unit tests alone are not enough; at least one E2E or
+  integration flow should cover create → schedule/run-now → queue → history →
+  UI refresh.
+- **Unchanged invariants:** Recents/Directories remain the only thread lens
+  switch options; first-party licensing remains MIT; dependency boundaries must
+  not be loosened; raw cron and daemon/cloud scheduling remain out of scope.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Competing queues make FIFO claims false | Introduce the registry-level turn FIFO before shipping scheduler UI, then migrate composer and messaging next-turn release paths onto it. |
+| Scheduler replays closed-app ticks on launch | Store startup reconciliation explicitly advances to the next future occurrence and marks stale local runs cancelled/interrupted. |
+| Schedule parsing becomes vague natural language | Use structured controls and typed schedule definitions, with generated friendly summaries. |
+| Coalesced runs lose auditability | Persist scheduled windows covered by each run and inject that metadata into the automation turn prompt. |
+| `drop_missed` hides skipped work | Record skipped history rows and show them in thread/global history. |
+| UI violates thread-first navigation | Put management on the thread surface and expose global Automations as a secondary app view, not a third thread lens. |
+| Persistent prompt/history data grows without bound | Cap detailed run history per automation and keep summaries compact. |
+| New sqlite code introduces SQL injection risk | Use prepared statements for all user-controlled values and run SQL-template lint after implementation. |
+| Added dependency violates licensing preference | Prefer no scheduling dependency for V1. If a dependency becomes necessary, verify permissive licensing and update third-party license artifacts. |
+
+## Documentation / Operational Notes
+
+- Add user/operator documentation for local-only scheduling semantics, backlog
+  policies, and the no-backfill-on-launch rule.
+- Document that automation threads are ordinary threads; manual messages enter
+  the same context and queue.
+- Document that personality profiles are deferred and that future context files
+  should stay short, around 300 total lines, to avoid instruction dilution.
+- No release pipeline change is expected unless implementation adds a new
+  dependency; if it does, run the repository license checks and update generated
+  third-party license disclosures.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-13-automation-scheduling-requirements.md`
+- Relevant code: `apps/desktop/src/main/state/state-db.ts`
+- Relevant code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Relevant code: `apps/desktop/src/main/messaging/core/messaging-turn-admission.ts`
+- Relevant code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Relevant code: `apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts`
+- Relevant code: `packages/agent-core/src/domain/navigation-state.ts`
+- Institutional learning: `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`
+- Prior plan: `docs/plans/2026-05-03-001-fix-messaging-turn-admission-plan.md`
+- Prior plan: `docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md`
+- OpenAI Codex Automations: https://openai.com/academy/codex-automations/
+- OpenClaw queue docs: https://docs.openclaw.ai/concepts/queue
+- OpenClaw task docs: https://docs.openclaw.ai/automation/tasks
+- `rrule` documentation checked through Context7: `/jkbrzt/rrule`

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -278,7 +278,7 @@ flowchart TB
   U7 --> U8
 ```
 
-- [ ] **Unit 1: Define Shared Automation Contracts and Schedule Model**
+- [x] **Unit 1: Define Shared Automation Contracts and Schedule Model**
 
 **Goal:** Add provider-neutral automation types, schedule definitions, backlog
 policy vocabulary, run statuses, IPC request/response contracts, and thread

--- a/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
+++ b/docs/plans/2026-05-13-001-feat-thread-automation-scheduling-plan.md
@@ -470,7 +470,7 @@ scheduled automation turns, and messaging queued follow-up submissions.
   the same per-thread FIFO and that low-level overlap errors become exceptional
   safety-net paths, not normal control flow.
 
-- [ ] **Unit 4: Implement Scheduler Evaluation and Automation Run Lifecycle**
+- [x] **Unit 4: Implement Scheduler Evaluation and Automation Run Lifecycle**
 
 **Goal:** Evaluate due schedules while the app is running, apply backlog policy,
 enqueue automation runs, and update run history from queue/backend events.

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadSummary,
+  AutomationThreadSummary,
+} from "@pwragent/shared";
+
+import {
+  buildNavigationSnapshotHash,
+  materializeNavigationThreads,
+} from "../domain/navigation-state";
+
+function buildThread(
+  overrides: Partial<AppServerThreadSummary> = {},
+): AppServerThreadSummary {
+  return {
+    id: "thread-1",
+    title: "Automation Thread",
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    updatedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function buildAutomationSummary(
+  overrides: Partial<AutomationThreadSummary> = {},
+): AutomationThreadSummary {
+  return {
+    totalCount: 1,
+    enabledCount: 1,
+    pausedCount: 0,
+    nextRunAt: 10_000,
+    lastRunAt: 5_000,
+    pendingRunCount: 0,
+    coalescedWindowCount: 0,
+    skippedSinceLastCompletedCount: 0,
+    automations: [
+      {
+        id: "automation-1",
+        backend: "codex",
+        threadId: "thread-1",
+        name: "Check email",
+        status: "enabled",
+        schedule: {
+          kind: "interval",
+          every: 5,
+          unit: "minutes",
+        },
+        scheduleSummary: "every 5 minutes",
+        backlogPolicy: "coalesce",
+        nextRunAt: 10_000,
+        lastRunAt: 5_000,
+        lastRunStatus: "completed",
+        updatedAt: 4_000,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("navigation automation summaries", () => {
+  it("materializes compact automation summaries onto thread navigation rows", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      automationsByThreadKey: {
+        "codex:thread-1": buildAutomationSummary(),
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+
+    expect(thread?.automationSummary).toEqual(
+      expect.objectContaining({
+        enabledCount: 1,
+        nextRunAt: 10_000,
+        automations: [
+          expect.objectContaining({
+            id: "automation-1",
+            scheduleSummary: "every 5 minutes",
+            backlogPolicy: "coalesce",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("includes automation summaries in the navigation snapshot hash", () => {
+    const [threadWithoutAutomation] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+    const [threadWithAutomation] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      automationsByThreadKey: {
+        "codex:thread-1": buildAutomationSummary(),
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+
+    expect(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithoutAutomation!],
+      }),
+    ).not.toBe(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithAutomation!],
+      }),
+    );
+  });
+});

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -2,6 +2,7 @@ import type {
   DirectoryLaunchpadOverlayState,
   DirectoryOverlayState,
   CodexEnvironmentOption,
+  AutomationThreadSummary,
   NavigationDirectoryGitStatus,
   AppServerBackendScope,
   AppServerThreadSummary,
@@ -132,6 +133,7 @@ export function materializeNavigationThreads(params: {
    * (tests, server-side use) don't need to wire it.
    */
   messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
+  automationsByThreadKey?: Record<string, AutomationThreadSummary | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummaryWithEnvironmentOptions[];
 }): NavigationThreadSummary[] {
@@ -147,6 +149,7 @@ export function materializeNavigationThreads(params: {
     const gitBranch = resolveNavigationGitBranch({ overlay, thread });
     const observedGitBranch = resolveNavigationObservedBranch({ overlay, thread });
     const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
+    const automationSummary = params.automationsByThreadKey?.[threadKey];
 
     return {
       ...thread,
@@ -173,6 +176,7 @@ export function materializeNavigationThreads(params: {
       messagingBindings: messagingBindings && messagingBindings.length > 0
         ? messagingBindings
         : undefined,
+      automationSummary,
       inbox: deriveInboxState({
         firstSnapshot: params.firstSnapshot,
         isNewThread: !previousKnownThreadKeys.has(threadKey),
@@ -200,6 +204,7 @@ export function buildNavigationSnapshot(params: {
    */
   directoryOverlayByKey?: Record<string, DirectoryOverlayState | undefined>;
   messagingBindingsByThreadKey?: Record<string, MessagingThreadBindingSummary[] | undefined>;
+  automationsByThreadKey?: Record<string, AutomationThreadSummary | undefined>;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummaryWithEnvironmentOptions[];
@@ -211,6 +216,7 @@ export function buildNavigationSnapshot(params: {
     now: params.now,
     overlayByThreadKey: params.overlayByThreadKey,
     messagingBindingsByThreadKey: params.messagingBindingsByThreadKey,
+    automationsByThreadKey: params.automationsByThreadKey,
     previousKnownThreadKeys: params.previousKnownThreadKeys,
     threads: params.threads,
   });
@@ -404,6 +410,32 @@ export function buildNavigationSnapshotHash(params: {
         parentTitle: binding.parentTitle ?? null,
         ancestorTitle: binding.ancestorTitle ?? null,
       })),
+      automationSummary: thread.automationSummary
+        ? {
+            totalCount: thread.automationSummary.totalCount,
+            enabledCount: thread.automationSummary.enabledCount,
+            pausedCount: thread.automationSummary.pausedCount,
+            nextRunAt: thread.automationSummary.nextRunAt ?? null,
+            lastRunAt: thread.automationSummary.lastRunAt ?? null,
+            pendingRunCount: thread.automationSummary.pendingRunCount,
+            coalescedWindowCount: thread.automationSummary.coalescedWindowCount,
+            skippedSinceLastCompletedCount:
+              thread.automationSummary.skippedSinceLastCompletedCount,
+            automations: thread.automationSummary.automations.map((automation) => ({
+              id: automation.id,
+              name: automation.name,
+              status: automation.status,
+              scheduleSummary: automation.scheduleSummary,
+              backlogPolicy: automation.backlogPolicy,
+              nextRunAt: automation.nextRunAt ?? null,
+              lastRunAt: automation.lastRunAt ?? null,
+              lastRunStatus: automation.lastRunStatus ?? null,
+              pendingRunCount: automation.pendingRunCount ?? null,
+              coalescedWindowCount: automation.coalescedWindowCount ?? null,
+              updatedAt: automation.updatedAt,
+            })),
+          }
+        : null,
     })),
     directories: (params.directories ?? []).map((directory) => ({
       key: directory.key,

--- a/packages/shared/src/contracts/__tests__/automations.test.ts
+++ b/packages/shared/src/contracts/__tests__/automations.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AUTOMATION_BACKLOG_POLICY,
+  formatAutomationScheduleSummary,
+  validateAutomationScheduleDefinition,
+  type AutomationScheduleDefinition,
+} from "../automations";
+
+describe("automation contracts", () => {
+  it("defaults backlog handling to coalescing missed windows", () => {
+    expect(DEFAULT_AUTOMATION_BACKLOG_POLICY).toBe("coalesce");
+  });
+
+  it("formats and validates interval schedule definitions", () => {
+    const schedule: AutomationScheduleDefinition = {
+      kind: "interval",
+      every: 5,
+      unit: "minutes",
+    };
+
+    expect(validateAutomationScheduleDefinition(schedule)).toEqual({ ok: true });
+    expect(formatAutomationScheduleSummary(schedule)).toBe("every 5 minutes");
+    expect(
+      formatAutomationScheduleSummary({
+        kind: "interval",
+        every: 1,
+        unit: "hours",
+      }),
+    ).toBe("hourly");
+  });
+
+  it("formats and validates weekly calendar schedule definitions", () => {
+    const schedule: AutomationScheduleDefinition = {
+      kind: "weekly",
+      daysOfWeek: ["friday"],
+      timeOfDay: {
+        hour: 16,
+        minute: 0,
+      },
+    };
+
+    expect(validateAutomationScheduleDefinition(schedule)).toEqual({ ok: true });
+    expect(formatAutomationScheduleSummary(schedule)).toBe("Fridays at 4 PM");
+    expect(
+      formatAutomationScheduleSummary({
+        kind: "weekly",
+        daysOfWeek: ["monday", "wednesday"],
+        timeOfDay: {
+          hour: 9,
+          minute: 30,
+        },
+      }),
+    ).toBe("Mondays and Wednesdays at 9:30 AM");
+  });
+
+  it("formats and validates weekday schedule definitions", () => {
+    const schedule: AutomationScheduleDefinition = {
+      kind: "weekdays",
+      timeOfDay: {
+        hour: 9,
+        minute: 0,
+      },
+    };
+
+    expect(validateAutomationScheduleDefinition(schedule)).toEqual({ ok: true });
+    expect(formatAutomationScheduleSummary(schedule)).toBe("weekdays at 9 AM");
+  });
+
+  it("rejects invalid schedule boundaries", () => {
+    expect(
+      validateAutomationScheduleDefinition({
+        kind: "interval",
+        every: 0,
+        unit: "minutes",
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Interval schedules must run every whole number greater than zero.",
+    });
+    expect(
+      validateAutomationScheduleDefinition({
+        kind: "weekly",
+        daysOfWeek: [],
+        timeOfDay: {
+          hour: 9,
+          minute: 0,
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Weekly schedules must include at least one day.",
+    });
+    expect(
+      validateAutomationScheduleDefinition({
+        kind: "weekdays",
+        timeOfDay: {
+          hour: 24,
+          minute: 0,
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: "Schedule hour must be a whole number from 0 through 23.",
+    });
+  });
+
+  it("does not represent raw cron as a v1 schedule definition", () => {
+    const _cronSchedule: AutomationScheduleDefinition = {
+      // @ts-expect-error raw cron is intentionally outside the v1 schedule model.
+      kind: "cron",
+      expression: "*/5 * * * *",
+    };
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -57,6 +57,8 @@ export type StartTurnResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   turnId: string;
+  queueStatus?: "started" | "queued";
+  queueEntryId?: string;
 };
 
 export type StartReviewRequest = {

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -1,0 +1,260 @@
+import type {
+  AppServerBackendKind,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+
+export const AUTOMATION_BACKLOG_POLICIES = [
+  "coalesce",
+  "drop_missed",
+] as const;
+
+export type AutomationBacklogPolicy =
+  (typeof AUTOMATION_BACKLOG_POLICIES)[number];
+
+export const DEFAULT_AUTOMATION_BACKLOG_POLICY: AutomationBacklogPolicy =
+  "coalesce";
+
+export const AUTOMATION_STATUSES = ["enabled", "paused", "deleted"] as const;
+
+export type AutomationStatus = (typeof AUTOMATION_STATUSES)[number];
+
+export const AUTOMATION_RUN_STATUSES = [
+  "pending",
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+] as const;
+
+export type AutomationRunStatus = (typeof AUTOMATION_RUN_STATUSES)[number];
+
+export const AUTOMATION_RUN_TRIGGERS = ["scheduled", "manual"] as const;
+
+export type AutomationRunTrigger = (typeof AUTOMATION_RUN_TRIGGERS)[number];
+
+export const AUTOMATION_INTERVAL_UNITS = ["minutes", "hours"] as const;
+
+export type AutomationIntervalUnit = (typeof AUTOMATION_INTERVAL_UNITS)[number];
+
+export const AUTOMATION_WEEKDAYS = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const;
+
+export type AutomationWeekday = (typeof AUTOMATION_WEEKDAYS)[number];
+
+export type AutomationTimeOfDay = {
+  hour: number;
+  minute: number;
+};
+
+export type AutomationIntervalScheduleDefinition = {
+  kind: "interval";
+  every: number;
+  unit: AutomationIntervalUnit;
+  /** Epoch ms used as the recurrence anchor. When omitted, creation time is used. */
+  anchorAt?: number;
+};
+
+export type AutomationWeeklyScheduleDefinition = {
+  kind: "weekly";
+  daysOfWeek: AutomationWeekday[];
+  timeOfDay: AutomationTimeOfDay;
+};
+
+export type AutomationWeekdaysScheduleDefinition = {
+  kind: "weekdays";
+  timeOfDay: AutomationTimeOfDay;
+};
+
+export type AutomationScheduleDefinition =
+  | AutomationIntervalScheduleDefinition
+  | AutomationWeeklyScheduleDefinition
+  | AutomationWeekdaysScheduleDefinition;
+
+export type AutomationScheduleValidationResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type AutomationThreadAssignment = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type AutomationListItemSummary = AutomationThreadAssignment & {
+  id: string;
+  name: string;
+  status: AutomationStatus;
+  schedule: AutomationScheduleDefinition;
+  scheduleSummary: string;
+  backlogPolicy: AutomationBacklogPolicy;
+  nextRunAt?: number;
+  lastRunAt?: number;
+  lastRunStatus?: AutomationRunStatus;
+  pendingRunCount?: number;
+  coalescedWindowCount?: number;
+  updatedAt: number;
+};
+
+export type AutomationThreadSummary = {
+  totalCount: number;
+  enabledCount: number;
+  pausedCount: number;
+  nextRunAt?: number;
+  lastRunAt?: number;
+  pendingRunCount: number;
+  coalescedWindowCount: number;
+  skippedSinceLastCompletedCount: number;
+  automations: AutomationListItemSummary[];
+};
+
+export type AutomationRunWindow = {
+  scheduledFor: number;
+};
+
+export type AutomationRunSummary = {
+  id: string;
+  automationId: string;
+  trigger: AutomationRunTrigger;
+  status: AutomationRunStatus;
+  scheduledFor?: number;
+  scheduledWindows: AutomationRunWindow[];
+  queuedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
+  backendTurnId?: string;
+  errorMessage?: string;
+};
+
+export function validateAutomationScheduleDefinition(
+  schedule: AutomationScheduleDefinition,
+): AutomationScheduleValidationResult {
+  switch (schedule.kind) {
+    case "interval":
+      if (!Number.isInteger(schedule.every) || schedule.every < 1) {
+        return {
+          ok: false,
+          error: "Interval schedules must run every whole number greater than zero.",
+        };
+      }
+      if (!AUTOMATION_INTERVAL_UNITS.includes(schedule.unit)) {
+        return {
+          ok: false,
+          error: "Interval schedules must use minutes or hours.",
+        };
+      }
+      return { ok: true };
+    case "weekly": {
+      const uniqueDays = new Set(schedule.daysOfWeek);
+      if (uniqueDays.size === 0) {
+        return {
+          ok: false,
+          error: "Weekly schedules must include at least one day.",
+        };
+      }
+      if (uniqueDays.size !== schedule.daysOfWeek.length) {
+        return {
+          ok: false,
+          error: "Weekly schedules cannot include duplicate days.",
+        };
+      }
+      for (const day of uniqueDays) {
+        if (!AUTOMATION_WEEKDAYS.includes(day)) {
+          return {
+            ok: false,
+            error: "Weekly schedules contain an unsupported day.",
+          };
+        }
+      }
+      return validateTimeOfDay(schedule.timeOfDay);
+    }
+    case "weekdays":
+      return validateTimeOfDay(schedule.timeOfDay);
+    default:
+      return assertNeverSchedule(schedule);
+  }
+}
+
+export function formatAutomationScheduleSummary(
+  schedule: AutomationScheduleDefinition,
+): string {
+  switch (schedule.kind) {
+    case "interval":
+      if (schedule.every === 1 && schedule.unit === "hours") {
+        return "hourly";
+      }
+      if (schedule.every === 1 && schedule.unit === "minutes") {
+        return "every minute";
+      }
+      return `every ${schedule.every} ${schedule.unit}`;
+    case "weekly":
+      return `${formatWeekdayList(schedule.daysOfWeek)} at ${formatTimeOfDay(schedule.timeOfDay)}`;
+    case "weekdays":
+      return `weekdays at ${formatTimeOfDay(schedule.timeOfDay)}`;
+    default:
+      return assertNeverSchedule(schedule);
+  }
+}
+
+function validateTimeOfDay(
+  timeOfDay: AutomationTimeOfDay,
+): AutomationScheduleValidationResult {
+  if (!Number.isInteger(timeOfDay.hour) || timeOfDay.hour < 0 || timeOfDay.hour > 23) {
+    return {
+      ok: false,
+      error: "Schedule hour must be a whole number from 0 through 23.",
+    };
+  }
+  if (
+    !Number.isInteger(timeOfDay.minute) ||
+    timeOfDay.minute < 0 ||
+    timeOfDay.minute > 59
+  ) {
+    return {
+      ok: false,
+      error: "Schedule minute must be a whole number from 0 through 59.",
+    };
+  }
+  return { ok: true };
+}
+
+function formatWeekdayList(daysOfWeek: AutomationWeekday[]): string {
+  const labels = daysOfWeek.map((day) => pluralizeWeekday(day));
+  if (labels.length <= 1) {
+    return labels[0] ?? "";
+  }
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
+
+function pluralizeWeekday(day: AutomationWeekday): string {
+  const label = `${day[0]?.toUpperCase() ?? ""}${day.slice(1)}`;
+  return `${label}s`;
+}
+
+function formatTimeOfDay(timeOfDay: AutomationTimeOfDay): string {
+  const period = timeOfDay.hour >= 12 ? "PM" : "AM";
+  const hour12 = timeOfDay.hour % 12 || 12;
+  if (timeOfDay.minute === 0) {
+    return `${hour12} ${period}`;
+  }
+  return `${hour12}:${String(timeOfDay.minute).padStart(2, "0")} ${period}`;
+}
+
+function assertNeverSchedule(schedule: never): never {
+  throw new Error(`Unsupported automation schedule: ${JSON.stringify(schedule)}`);
+}

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -138,6 +138,7 @@ export type AutomationRunSummary = {
   scheduledFor?: number;
   scheduledWindows: AutomationRunWindow[];
   queuedAt?: number;
+  queueEntryId?: string;
   startedAt?: number;
   completedAt?: number;
   backendTurnId?: string;

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -108,6 +108,12 @@ export type AutomationListItemSummary = AutomationThreadAssignment & {
   updatedAt: number;
 };
 
+export type AutomationDetail = AutomationListItemSummary & {
+  taskPrompt: string;
+  createdAt: number;
+  deletedAt?: number;
+};
+
 export type AutomationThreadSummary = {
   totalCount: number;
   enabledCount: number;
@@ -136,6 +142,60 @@ export type AutomationRunSummary = {
   completedAt?: number;
   backendTurnId?: string;
   errorMessage?: string;
+};
+
+export type CreateAutomationRequest = AutomationThreadAssignment & {
+  name: string;
+  taskPrompt: string;
+  schedule: AutomationScheduleDefinition;
+  backlogPolicy?: AutomationBacklogPolicy;
+  enabled?: boolean;
+  nextRunAt?: number;
+};
+
+export type UpdateAutomationRequest = {
+  automationId: string;
+  name?: string;
+  taskPrompt?: string;
+  schedule?: AutomationScheduleDefinition;
+  backlogPolicy?: AutomationBacklogPolicy;
+  enabled?: boolean;
+  nextRunAt?: number | null;
+};
+
+export type AutomationIdRequest = {
+  automationId: string;
+};
+
+export type ListAutomationsRequest = {
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+};
+
+export type ListAutomationsResponse = {
+  automations: AutomationDetail[];
+};
+
+export type AutomationMutationResponse = {
+  automation: AutomationDetail;
+};
+
+export type ListAutomationRunsRequest = {
+  automationId?: string;
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  limit?: number;
+};
+
+export type ListAutomationRunsResponse = {
+  runs: AutomationRunSummary[];
+};
+
+export type RunAutomationNowResponse = {
+  run: AutomationRunSummary;
+  queueStatus: "started" | "queued" | "failed";
+  queueEntryId?: string;
+  turnId?: string;
 };
 
 export function validateAutomationScheduleDefinition(

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -16,6 +16,7 @@ import type {
   MessagingConversationKind,
 } from "./messaging";
 import type { DesktopGhDiscoverySnapshot } from "./settings";
+import type { AutomationThreadSummary } from "./automations";
 
 export type InboxReason = "new-thread" | "updated-since-seen";
 
@@ -70,6 +71,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * the user unbind from the desktop side via the chip menu.
    */
   messagingBindings?: MessagingThreadBindingSummary[];
+  /**
+   * Compact automation state for the thread. Detailed records and run
+   * history are fetched through automation IPC; this summary only keeps
+   * navigation refreshes and thread chrome honest.
+   */
+  automationSummary?: AutomationThreadSummary;
 };
 
 /**

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1004,6 +1004,7 @@ export type AppServerNotification =
         turnId?: string;
         automationRunId?: string;
         errorMessage?: string;
+        terminalStatus?: string;
       };
     }
   | {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1003,6 +1003,7 @@ export type AppServerNotification =
         position?: number;
         turnId?: string;
         automationRunId?: string;
+        automationName?: string;
         errorMessage?: string;
         terminalStatus?: string;
       };

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -994,6 +994,19 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/turnQueue/updated";
+      params: {
+        threadId: string;
+        queueEntryId: string;
+        origin: "manual" | "automation" | "messaging";
+        status: "queued" | "started" | "failed" | "cancelled" | "terminal";
+        position?: number;
+        turnId?: string;
+        automationRunId?: string;
+        errorMessage?: string;
+      };
+    }
+  | {
       method: "thread/pin/added";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -972,6 +972,28 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/automations/updated";
+      params: {
+        threadId: string;
+      };
+    }
+  | {
+      method: "automation/run/updated";
+      params: {
+        threadId: string;
+        automationId: string;
+        runId: string;
+        status:
+          | "pending"
+          | "queued"
+          | "running"
+          | "completed"
+          | "failed"
+          | "cancelled"
+          | "skipped";
+      };
+    }
+  | {
       method: "thread/pin/added";
       params: {
         threadId: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./backend-selection";
 export * from "./codex-environment-action-runs";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
+export * from "./contracts/automations";
 export * from "./contracts/branch-drift";
 export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";


### PR DESCRIPTION
## Summary

- Added thread-assigned local automation scheduling with typed interval/weekday/weekly schedules, coalescing/drop-missed backlog policies, persisted run history, and startup reconciliation.
- Added a per-thread FIFO turn queue shared by manual composer sends, messaging next-turn sends, and scheduled automation runs.
- Added desktop IPC/preload/renderer support, thread-context automation management, a secondary global Automations view, and documentation for local-only scheduling semantics.

## Verification

- `pnpm lint`
- `pnpm test`
- `pnpm --filter @pwragent/desktop build`

## Notes

- Automations are local-only in V1: closed-app schedule windows are not backfilled on relaunch.
- I did not capture browser screenshots because this is an Electron renderer surface without a standalone localhost route; I verified the renderer through focused tests and the desktop production build.

## Post-Deploy Monitoring & Validation

- Validation window: first dogfood session after installing this build.
- Owner: PwrAgent maintainer running the dogfood profile.
- Healthy signals: creating an interval automation updates the thread context and global Automations view; `Run now` queues behind any active thread turn; run history records queued/running/completed states; relaunching after missed closed-app windows does not create backfilled runs.
- Failure signals: repeated `automation store unavailable for navigation snapshot`, failed automation runs with scheduler/store errors, stuck `pending` or `queued` automation runs after the thread becomes idle, or manual/messaging turns leapfrogging earlier automation queue entries.
- Log search terms: `automation`, `thread/turnQueue/updated`, `startTurn failed`, `automation store unavailable for navigation snapshot`.
- Mitigation trigger: if scheduler queueing blocks ordinary manual thread work or creates unbounded pending runs, pause/delete affected automations from the global view and revert this branch before release.
