### PR TITLE
fix(messaging): unify detach confirmations

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1910,11 +1910,27 @@ describe("MessagingController", () => {
     const harness = await createHarness();
     try {
       await harness.controller.handleInboundEvent(buildCommandEvent("/monitor"));
+      const monitorIntent = harness.delivered.at(-1);
+      const monitorSurface = monitorIntent?.targetSurface
+        ?? (monitorIntent
+          ? { channel: "telegram" as const, id: `surface:${monitorIntent.id}` }
+          : undefined);
       harness.delivered.splice(0);
 
       await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
 
-      expect(harness.delivered).toHaveLength(1);
+      expect(harness.delivered).toHaveLength(2);
+      expect(harness.delivered.at(-2)).toMatchObject({
+        kind: "confirmation",
+        title: "Monitor detached",
+        actions: [],
+        delivery: {
+          mode: "update",
+          replaceMarkup: true,
+          fallback: "fail",
+        },
+        targetSurface: monitorSurface,
+      });
       expect(harness.delivered.at(-1)).toMatchObject({
         kind: "confirmation",
         title: "Monitor detached",
@@ -1942,11 +1958,27 @@ describe("MessagingController", () => {
     try {
       await bindThread(harness);
       await harness.controller.handleInboundEvent(buildCommandEvent("/monitor"));
+      const monitorIntent = harness.delivered.at(-1);
+      const monitorSurface = monitorIntent?.targetSurface
+        ?? (monitorIntent
+          ? { channel: "telegram" as const, id: `surface:${monitorIntent.id}` }
+          : undefined);
       harness.delivered.splice(0);
 
       await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
 
-      expect(harness.delivered).toHaveLength(3);
+      expect(harness.delivered).toHaveLength(4);
+      expect(harness.delivered.at(-4)).toMatchObject({
+        kind: "confirmation",
+        title: "Monitor detached",
+        actions: [],
+        delivery: {
+          mode: "update",
+          replaceMarkup: true,
+          fallback: "fail",
+        },
+        targetSurface: monitorSurface,
+      });
       expect(harness.delivered.at(-1)).toMatchObject({
         kind: "confirmation",
         title: "Thread and Monitor detached",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1866,9 +1866,11 @@ describe("MessagingController", () => {
     const binding = await harness.store.findActiveBindingForChannel(
       buildCommandEvent("/detach").channel,
     );
+    harness.delivered.splice(0);
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
 
+    expect(harness.delivered).toHaveLength(3);
     expect(harness.delivered.at(-3)).toMatchObject({
       kind: "status",
       actions: [],
@@ -1886,9 +1888,94 @@ describe("MessagingController", () => {
       },
       targetSurface: binding?.pinnedStatusSurface,
     });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Thread detached",
+      body: "Messages in this conversation will no longer route to PwrAgent.",
+    });
+    expect(harness.delivered).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({
+          title: "Monitor stopped",
+        }),
+      ]),
+    );
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/detach").channel),
     ).resolves.toBeUndefined();
+  });
+
+  it("uses /detach to stop Monitor when no thread is bound", async () => {
+    vi.useFakeTimers();
+    const harness = await createHarness();
+    try {
+      await harness.controller.handleInboundEvent(buildCommandEvent("/monitor"));
+      harness.delivered.splice(0);
+
+      await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
+
+      expect(harness.delivered).toHaveLength(1);
+      expect(harness.delivered.at(-1)).toMatchObject({
+        kind: "confirmation",
+        title: "Monitor detached",
+        body: "Recent thread updates will no longer post to this conversation.",
+      });
+      await expect(
+        harness.store.findActiveMonitorSubscriptionForChannel(
+          buildCommandEvent("/detach").channel,
+        ),
+      ).resolves.toMatchObject({
+        monitor: {
+          enabled: false,
+        },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      harness.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses one /detach confirmation when both thread and Monitor are attached", async () => {
+    vi.useFakeTimers();
+    const harness = await createHarness();
+    try {
+      await bindThread(harness);
+      await harness.controller.handleInboundEvent(buildCommandEvent("/monitor"));
+      harness.delivered.splice(0);
+
+      await harness.controller.handleInboundEvent(buildCommandEvent("/detach"));
+
+      expect(harness.delivered).toHaveLength(3);
+      expect(harness.delivered.at(-1)).toMatchObject({
+        kind: "confirmation",
+        title: "Thread and Monitor detached",
+        body: "Messages in this conversation will no longer route to PwrAgent, and recent thread updates will no longer post here.",
+      });
+      expect(harness.delivered).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            title: "Monitor stopped",
+          }),
+        ]),
+      );
+      await expect(
+        harness.store.findActiveBindingForChannel(buildCommandEvent("/detach").channel),
+      ).resolves.toBeUndefined();
+      await expect(
+        harness.store.findActiveMonitorSubscriptionForChannel(
+          buildCommandEvent("/detach").channel,
+        ),
+      ).resolves.toMatchObject({
+        monitor: {
+          enabled: false,
+        },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      harness.controller.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it("shows the help menu for unbound text before routing text", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3698,10 +3698,12 @@ export class MessagingController {
   private async stopMonitoringForBinding(
     binding: MessagingBindingRecord,
     event?: MessagingInboundEvent,
+    options: { deliverStatus?: boolean } = {},
   ): Promise<MessagingBindingRecord> {
     this.clearMonitorTimer(binding.id);
     const now = this.now();
-    if (binding.monitorSurface) {
+    const deliverStatus = options.deliverStatus ?? true;
+    if (deliverStatus && binding.monitorSurface) {
       try {
         await this.deliver(
           buildConfirmationIntent({
@@ -3728,7 +3730,7 @@ export class MessagingController {
           threadId: binding.threadId,
         });
       }
-    } else if (event) {
+    } else if (deliverStatus && event) {
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("monitor-stopped"),
@@ -3751,6 +3753,25 @@ export class MessagingController {
         enabled: false,
         intervalMs: binding.monitor?.intervalMs ?? MESSAGING_MONITOR_INTERVAL_MS,
         lastRenderedAt: binding.monitor?.lastRenderedAt,
+        updatedAt: now,
+      },
+      monitorSurface: undefined,
+      updatedAt: now,
+    });
+  }
+
+  private async disableChannelMonitorSubscription(
+    subscription: MessagingMonitorSubscriptionRecord,
+  ): Promise<MessagingMonitorSubscriptionRecord> {
+    this.clearMonitorSubscriptionTimer(subscription.id);
+    const now = this.now();
+    return await this.options.store.upsertMonitorSubscription({
+      ...subscription,
+      monitor: {
+        ...subscription.monitor,
+        enabled: false,
+        intervalMs: subscription.monitor.intervalMs,
+        lastRenderedAt: subscription.monitor.lastRenderedAt,
         updatedAt: now,
       },
       monitorSurface: undefined,
@@ -5006,21 +5027,56 @@ export class MessagingController {
 
   private async detachBinding(event: MessagingInboundEvent): Promise<void> {
     const binding = await this.options.store.findActiveBindingForChannel(event.channel);
-    if (!binding) {
+    const channelMonitor =
+      await this.options.store.findActiveMonitorSubscriptionForChannel(event.channel);
+    const hasThread = Boolean(binding);
+    const hasChannelMonitor = channelMonitor?.monitor.enabled === true;
+    const hasBindingMonitor = binding?.monitor?.enabled === true;
+    const hasMonitor = hasChannelMonitor || hasBindingMonitor;
+    if (!hasThread && !hasMonitor) {
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("detach-unbound"),
           capabilityProfile: this.capabilityProfile,
           createdAt: this.now(),
-          title: "No thread bound",
-          body: "This conversation is not bound to a PwrAgent thread.",
+          title: "Nothing attached",
+          body: "Neither a thread nor Monitor is attached to this conversation.",
         }),
         undefined,
         event,
       );
       return;
     }
-    await this.runDetachPipeline(binding, event);
+
+    if (channelMonitor && hasChannelMonitor) {
+      await this.disableChannelMonitorSubscription(channelMonitor);
+    }
+    if (binding) {
+      await this.runDetachPipeline(binding, event, {
+        deliverConfirmation: false,
+        deliverMonitorStatus: false,
+      });
+    }
+
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("detached"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: hasThread && hasMonitor
+          ? "Thread and Monitor detached"
+          : hasThread
+            ? "Thread detached"
+            : "Monitor detached",
+        body: hasThread && hasMonitor
+          ? "Messages in this conversation will no longer route to PwrAgent, and recent thread updates will no longer post here."
+          : hasThread
+            ? "Messages in this conversation will no longer route to PwrAgent."
+            : "Recent thread updates will no longer post to this conversation.",
+      }),
+      binding,
+      event,
+    );
   }
 
   /**
@@ -5038,6 +5094,10 @@ export class MessagingController {
   private async runDetachPipeline(
     binding: MessagingBindingRecord,
     event?: MessagingInboundEvent,
+    options: {
+      deliverConfirmation?: boolean;
+      deliverMonitorStatus?: boolean;
+    } = {},
   ): Promise<void> {
     const activeTurn = this.getActiveTurn(binding);
     if (activeTurn) {
@@ -5052,7 +5112,9 @@ export class MessagingController {
       );
     }
     await this.flushToolUpdatesForBinding(binding, { clear: true });
-    await this.stopMonitoringForBinding(binding, event);
+    await this.stopMonitoringForBinding(binding, event, {
+      deliverStatus: options.deliverMonitorStatus,
+    });
     await this.retireBindingStatus(
       binding,
       event,
@@ -5065,17 +5127,19 @@ export class MessagingController {
     });
     await this.recordBindingTransition("unbound", binding);
     this.notifyBindingChanged("detach");
-    await this.deliver(
-      buildConfirmationIntent({
-        id: this.newIntentId("detached"),
-        capabilityProfile: this.capabilityProfile,
-        createdAt: this.now(),
-        title: "Thread detached",
-        body: "Messages in this conversation will no longer route to PwrAgent.",
-      }),
-      binding,
-      event,
-    );
+    if (options.deliverConfirmation !== false) {
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("detached"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          title: "Thread detached",
+          body: "Messages in this conversation will no longer route to PwrAgent.",
+        }),
+        binding,
+        event,
+      );
+    }
   }
 
   /**

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3762,9 +3762,37 @@ export class MessagingController {
 
   private async disableChannelMonitorSubscription(
     subscription: MessagingMonitorSubscriptionRecord,
+    event?: MessagingInboundEvent,
   ): Promise<MessagingMonitorSubscriptionRecord> {
     this.clearMonitorSubscriptionTimer(subscription.id);
     const now = this.now();
+    if (subscription.monitorSurface) {
+      try {
+        await this.deliver(
+          buildConfirmationIntent({
+            id: this.newIntentId("monitor-detached"),
+            capabilityProfile: this.capabilityProfile,
+            createdAt: now,
+            title: "Monitor detached",
+            body: "Recent thread updates will no longer post to this conversation.",
+            actions: [],
+            delivery: {
+              mode: "update",
+              replaceMarkup: true,
+              fallback: "fail",
+            },
+            targetSurface: subscription.monitorSurface,
+          }),
+          undefined,
+          event,
+        );
+      } catch (error) {
+        this.logger.debug?.("messaging channel monitor detach update failed", {
+          error: error instanceof Error ? error.message : String(error),
+          subscriptionId: subscription.id,
+        });
+      }
+    }
     return await this.options.store.upsertMonitorSubscription({
       ...subscription,
       monitor: {
@@ -5049,7 +5077,7 @@ export class MessagingController {
     }
 
     if (channelMonitor && hasChannelMonitor) {
-      await this.disableChannelMonitorSubscription(channelMonitor);
+      await this.disableChannelMonitorSubscription(channelMonitor, event);
     }
     if (binding) {
       await this.runDetachPipeline(binding, event, {


### PR DESCRIPTION
## Summary

- I made `/detach` resolve the thread binding and Monitor state together so it sends one coherent confirmation.
- I stop channel Monitor subscriptions from `/detach` when no thread is bound, and detach both when both are active.
- I suppress the legacy binding Monitor helper's standalone "Monitor stopped" reply during detach so users no longer see contradictory paired messages.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` and all 134 tests passed.
- I ran `pnpm --filter @pwragent/desktop typecheck`.

## Notes

- The branch commit is signed.
