### PR TITLE
fix(messaging): handle Lark post messages

### DIFF
--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -368,6 +368,75 @@ describe("FeishuAdapter", () => {
     ]);
   });
 
+  it("normalizes rich-text post images into downloadable media events", async () => {
+    const adapter = new FeishuAdapter({
+      config: {
+        ...baseConfig,
+        authorizedChatIds: [{ id: "oc_chat", displayName: "Development" }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await adapter.handleWebhookPayload({
+      header: {
+        event_id: "evt_post_image",
+        event_type: "im.message.receive_v1",
+        tenant_key: "tenant_1",
+        token: "verify-token",
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          tenant_key: "tenant_1",
+        },
+        message: {
+          chat_id: "oc_chat",
+          chat_type: "group",
+          content: JSON.stringify({
+            content: [
+              [
+                { tag: "at", user_id: "ou_bot", user_name: "PwrAgent" },
+                { tag: "img", image_key: "img_v3_inline" },
+              ],
+              [{ tag: "text", text: "What's in this image?" }],
+            ],
+          }),
+          message_id: "om_post_image",
+          message_type: "post",
+        },
+      },
+    });
+    await adapter.stop();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            disposition: "available",
+            id: "feishu:image:img_v3_inline",
+            kind: "image",
+            state: {
+              opaque: {
+                fileKey: "img_v3_inline",
+                messageId: "om_post_image",
+                provider: "feishu",
+                resourceType: "image",
+              },
+            },
+          }),
+        ],
+        kind: "media",
+        text: "What's in this image?",
+      }),
+    ]);
+  });
+
   it("normalizes authorized image messages into downloadable media events", async () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -305,6 +305,69 @@ describe("FeishuAdapter", () => {
     ]);
   });
 
+  it("normalizes authorized rich-text post events", async () => {
+    const adapter = new FeishuAdapter({
+      config: {
+        ...baseConfig,
+        authorizedChatIds: [{ id: "oc_chat", displayName: "Development" }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await adapter.handleWebhookPayload({
+      header: {
+        event_id: "evt_post",
+        event_type: "im.message.receive_v1",
+        tenant_key: "tenant_1",
+        token: "verify-token",
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          tenant_key: "tenant_1",
+        },
+        message: {
+          chat_id: "oc_chat",
+          chat_type: "group",
+          content: JSON.stringify({
+            content: [
+              [
+                { tag: "at", user_id: "ou_bot", user_name: "PwrAgent" },
+                { tag: "text", text: " Run " },
+                { tag: "text", text: "npm view openclaw" },
+                { tag: "text", text: " again" },
+              ],
+            ],
+          }),
+          mentions: [
+            {
+              id: { open_id: "ou_bot" },
+              key: "@_user_1",
+              name: "PwrAgent",
+            },
+          ],
+          message_id: "om_post",
+          message_type: "post",
+        },
+      },
+    });
+    await adapter.stop();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        actor: { platformUserId: "ou_user" },
+        kind: "text",
+        text: "Run npm view openclaw again",
+      }),
+    ]);
+  });
+
   it("normalizes authorized image messages into downloadable media events", async () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -341,6 +341,8 @@ describe("FeishuAdapter", () => {
                 { tag: "at", user_id: "ou_bot", user_name: "PwrAgent" },
                 { tag: "text", text: " Run " },
                 { tag: "text", text: "npm view openclaw" },
+                { tag: "text", text: " with " },
+                { tag: "at", user_id: "ou_alice", user_name: "Alice" },
                 { tag: "text", text: " again" },
               ],
             ],
@@ -350,6 +352,11 @@ describe("FeishuAdapter", () => {
               id: { open_id: "ou_bot" },
               key: "@_user_1",
               name: "PwrAgent",
+            },
+            {
+              id: { open_id: "ou_alice" },
+              key: "@_user_2",
+              name: "Alice",
             },
           ],
           message_id: "om_post",
@@ -363,7 +370,7 @@ describe("FeishuAdapter", () => {
       expect.objectContaining({
         actor: { platformUserId: "ou_user" },
         kind: "text",
-        text: "Run npm view openclaw again",
+        text: "Run npm view openclaw with @Alice again",
       }),
     ]);
   });
@@ -435,6 +442,93 @@ describe("FeishuAdapter", () => {
         text: "What's in this image?",
       }),
     ]);
+  });
+
+  it("marks rich-text post media attachments as unsupported without using cover images", async () => {
+    const adapter = new FeishuAdapter({
+      config: {
+        ...baseConfig,
+        authorizedChatIds: [{ id: "oc_chat", displayName: "Development" }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await adapter.handleWebhookPayload({
+      header: {
+        event_id: "evt_post_media",
+        event_type: "im.message.receive_v1",
+        tenant_key: "tenant_1",
+        token: "verify-token",
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          tenant_key: "tenant_1",
+        },
+        message: {
+          chat_id: "oc_chat",
+          chat_type: "group",
+          content: JSON.stringify({
+            content: [
+              [
+                { tag: "at", user_id: "ou_bot", user_name: "PwrAgent" },
+                {
+                  tag: "media",
+                  file_key: "file_v3_inline_video",
+                  file_name: "clip.mp4",
+                  image_key: "img_v3_cover",
+                },
+              ],
+              [{ tag: "text", text: "Can you use this clip?" }],
+            ],
+          }),
+          message_id: "om_post_media",
+          message_type: "post",
+        },
+      },
+    });
+    await adapter.stop();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            disposition: "unsupported",
+            id: "feishu:media:file_v3_inline_video",
+            kind: "video",
+            name: "clip.mp4",
+            reason: "media attachments are not supported",
+            state: {
+              opaque: {
+                fileKey: "file_v3_inline_video",
+                messageId: "om_post_media",
+                provider: "feishu",
+                resourceType: "file",
+              },
+            },
+          }),
+        ],
+        disposition: "unsupported",
+        kind: "media",
+        text: "Can you use this clip?",
+      }),
+    ]);
+    const mediaEvent = events[0];
+    expect(mediaEvent?.kind).toBe("media");
+    if (mediaEvent?.kind !== "media") throw new Error("expected media event");
+    expect(mediaEvent.attachments).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "feishu:image:img_v3_cover",
+        }),
+      ]),
+    );
   });
 
   it("normalizes authorized image messages into downloadable media events", async () => {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -1666,8 +1666,27 @@ function parseFeishuMessageContent(content: string | undefined): Record<string, 
 
 function extractFeishuText(content: Record<string, unknown>): string {
   if (typeof content.text === "string") return content.text;
+  const postText = extractFeishuPostText(content.content);
+  if (postText.trim()) return postText;
   if (typeof content.title === "string") return content.title;
   return "";
+}
+
+function extractFeishuPostText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const separator = value.every(Array.isArray) ? "\n" : "";
+    return value
+      .map((item) => extractFeishuPostText(item))
+      .filter(Boolean)
+      .join(separator);
+  }
+  if (!value || typeof value !== "object") return "";
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === "string") return record.text;
+  if (typeof record.content === "string") return record.content;
+  if (record.tag === "at") return "";
+  return record.content === undefined ? "" : extractFeishuPostText(record.content);
 }
 
 function feishuAttachmentsFromMessage(params: {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -185,7 +185,7 @@ type FeishuReceiveMessageEvent = {
     chat_type?: "group" | "p2p";
     content?: string;
     create_time?: string;
-    mentions?: Array<{ id?: { open_id?: string }; key?: string; name?: string; tenant_key?: string }>;
+    mentions?: FeishuMessageMention[];
     message_id?: string;
     message_type?: string;
   };
@@ -198,6 +198,13 @@ type FeishuReceiveMessageEvent = {
     sender_type?: string;
     tenant_key?: string;
   };
+};
+
+type FeishuMessageMention = {
+  id?: { open_id?: string };
+  key?: string;
+  name?: string;
+  tenant_key?: string;
 };
 
 type FeishuCardActionEvent = {
@@ -305,6 +312,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private authorizedActorIdsValue: string[];
   private botAccount: string | undefined;
   private botAccountDetail: string | undefined;
+  private botOpenId: string | undefined;
   private listener: FeishuInboundListener | undefined;
   private started = false;
   private webhookListening = false;
@@ -408,6 +416,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     const botInfo = await this.api.getBotInfo();
     this.botAccount = botInfo.appName ?? botInfo.openId;
     this.botAccountDetail = botInfo.tenantKey ?? hostFromUrl(this.config.tenantUrl);
+    this.botOpenId = botInfo.openId;
     if (this.config.inboundMode === "webhook") {
       await this.listenForCallbacks();
     } else {
@@ -724,8 +733,17 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     };
 
     const content = parseFeishuMessageContent(message.content);
-    const text = extractFeishuText(content);
-    const messageText = stripBotMentions(text, message.mentions);
+    const text = extractFeishuText({
+      botOpenId: this.botOpenId,
+      content,
+      mentions: message.mentions,
+    });
+    const messageText = stripBotMentions({
+      botName: this.botAccount,
+      botOpenId: this.botOpenId,
+      mentions: message.mentions,
+      text,
+    });
     const attachments = feishuAttachmentsFromMessage({
       content,
       message,
@@ -1664,20 +1682,28 @@ function parseFeishuMessageContent(content: string | undefined): Record<string, 
   }
 }
 
-function extractFeishuText(content: Record<string, unknown>): string {
+function extractFeishuText(params: {
+  botOpenId?: string;
+  content: Record<string, unknown>;
+  mentions?: FeishuMessageMention[];
+}): string {
+  const { content } = params;
   if (typeof content.text === "string") return content.text;
-  const postText = extractFeishuPostText(content.content);
+  const postText = extractFeishuPostText(content.content, params);
   if (postText.trim()) return postText;
   if (typeof content.title === "string") return content.title;
   return "";
 }
 
-function extractFeishuPostText(value: unknown): string {
+function extractFeishuPostText(
+  value: unknown,
+  context: { botOpenId?: string; mentions?: FeishuMessageMention[] },
+): string {
   if (typeof value === "string") return value;
   if (Array.isArray(value)) {
     const separator = value.every(Array.isArray) ? "\n" : "";
     return value
-      .map((item) => extractFeishuPostText(item))
+      .map((item) => extractFeishuPostText(item, context))
       .filter(Boolean)
       .join(separator);
   }
@@ -1685,8 +1711,8 @@ function extractFeishuPostText(value: unknown): string {
   const record = value as Record<string, unknown>;
   if (typeof record.text === "string") return record.text;
   if (typeof record.content === "string") return record.content;
-  if (record.tag === "at") return "";
-  return record.content === undefined ? "" : extractFeishuPostText(record.content);
+  if (record.tag === "at") return feishuPostMentionText(record, context);
+  return record.content === undefined ? "" : extractFeishuPostText(record.content, context);
 }
 
 function feishuAttachmentsFromMessage(params: {
@@ -1716,7 +1742,7 @@ function feishuAttachmentsFromMessage(params: {
     ];
   }
   if (messageType === "post") {
-    return feishuPostImageAttachments({
+    return feishuPostAttachments({
       messageId: params.messageId,
       value: params.content.content,
     });
@@ -1764,45 +1790,67 @@ function feishuAttachmentsFromMessage(params: {
   return [];
 }
 
-function feishuPostImageAttachments(params: {
+function feishuPostAttachments(params: {
   messageId: string;
   value: unknown;
 }): MessagingAttachmentDescriptor[] {
-  const imageKeys: string[] = [];
-  collectFeishuPostImageKeys(params.value, imageKeys);
-  return imageKeys.map((imageKey) => ({
-    id: `feishu:image:${imageKey}`,
-    kind: "image",
-    name: "lark-image",
-    disposition: "available",
-    state: {
-      opaque: {
-        fileKey: imageKey,
-        messageId: params.messageId,
-        provider: "feishu",
-        resourceType: "image",
-      },
-    },
-  }));
+  const attachments: MessagingAttachmentDescriptor[] = [];
+  collectFeishuPostAttachments(params.value, params.messageId, attachments);
+  return attachments;
 }
 
-function collectFeishuPostImageKeys(value: unknown, imageKeys: string[]): void {
+function collectFeishuPostAttachments(
+  value: unknown,
+  messageId: string,
+  attachments: MessagingAttachmentDescriptor[],
+): void {
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectFeishuPostImageKeys(item, imageKeys);
+      collectFeishuPostAttachments(item, messageId, attachments);
     }
     return;
   }
   if (!value || typeof value !== "object") return;
   const record = value as Record<string, unknown>;
-  const imageKey =
-    stringField(record.image_key) ??
-    (record.tag === "img" ? stringField(record.file_key) : undefined);
-  if (imageKey) {
-    imageKeys.push(imageKey);
+  const tag = stringField(record.tag);
+  if (tag === "img") {
+    const imageKey = stringField(record.image_key) ?? stringField(record.file_key);
+    if (imageKey) {
+      attachments.push({
+        id: `feishu:image:${imageKey}`,
+        kind: "image",
+        name: "lark-image",
+        disposition: "available",
+        state: {
+          opaque: {
+            fileKey: imageKey,
+            messageId,
+            provider: "feishu",
+            resourceType: "image",
+          },
+        },
+      });
+    }
+  } else if (tag === "media" || tag === "video" || tag === "audio" || tag === "file") {
+    const fileKey = stringField(record.file_key);
+    attachments.push({
+      id: `feishu:${tag}:${fileKey ?? messageId}`,
+      kind: tag === "audio" ? "audio" : tag === "file" ? "file" : "video",
+      name: stringField(record.file_name) ?? `lark-${tag}`,
+      disposition: "unsupported",
+      reason: `${tag} attachments are not supported`,
+      state: {
+        opaque: {
+          ...(fileKey ? { fileKey } : {}),
+          messageId,
+          provider: "feishu",
+          resourceType: "file",
+        },
+      },
+    });
   }
-  collectFeishuPostImageKeys(record.content, imageKeys);
-  collectFeishuPostImageKeys(record.elements, imageKeys);
+  collectFeishuPostAttachments(record.content, messageId, attachments);
+  collectFeishuPostAttachments(record.elements, messageId, attachments);
 }
 
 function readAttachmentResourceType(
@@ -1854,15 +1902,46 @@ function isMarkdownTableSeparator(line: string): boolean {
   return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
 }
 
-function stripBotMentions(
-  text: string,
-  mentions: FeishuReceiveMessageEvent["message"] extends infer M
-    ? M extends { mentions?: infer T } ? T | undefined : never
-    : never,
+function feishuPostMentionText(
+  record: Record<string, unknown>,
+  context: { botOpenId?: string; mentions?: FeishuMessageMention[] },
 ): string {
-  let stripped = text;
-  for (const mention of mentions ?? []) {
+  const userId = stringField(record.user_id);
+  const matchingMention = context.mentions?.find((mention) => mention.id?.open_id === userId);
+  if (userId && context.botOpenId && userId === context.botOpenId) {
+    return matchingMention?.key ?? "";
+  }
+  return mentionDisplayName(record, matchingMention);
+}
+
+function mentionDisplayName(
+  record: Record<string, unknown>,
+  mention: FeishuMessageMention | undefined,
+): string {
+  const name =
+    stringField(record.user_name)
+    ?? mention?.name
+    ?? stringField(record.name)
+    ?? stringField(record.key)
+    ?? stringField(record.user_id);
+  if (!name) return "";
+  return name.startsWith("@") ? name : `@${name}`;
+}
+
+function stripBotMentions(params: {
+  botName?: string;
+  botOpenId?: string;
+  mentions?: FeishuMessageMention[];
+  text: string;
+}): string {
+  let stripped = params.text;
+  for (const mention of params.mentions ?? []) {
+    const isBotMention = params.botOpenId
+      ? mention.id?.open_id === params.botOpenId
+      : Boolean(params.botName && mention.name === params.botName);
+    if (!isBotMention) continue;
     if (mention.key) stripped = stripped.replaceAll(mention.key, "");
+    if (mention.name) stripped = stripped.replaceAll(`@${mention.name}`, "");
   }
   return stripped.trim();
 }

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -1715,6 +1715,12 @@ function feishuAttachmentsFromMessage(params: {
       },
     ];
   }
+  if (messageType === "post") {
+    return feishuPostImageAttachments({
+      messageId: params.messageId,
+      value: params.content.content,
+    });
+  }
   if (messageType === "file") {
     const fileKey = stringField(params.content.file_key);
     if (!fileKey) return [];
@@ -1756,6 +1762,47 @@ function feishuAttachmentsFromMessage(params: {
     ];
   }
   return [];
+}
+
+function feishuPostImageAttachments(params: {
+  messageId: string;
+  value: unknown;
+}): MessagingAttachmentDescriptor[] {
+  const imageKeys: string[] = [];
+  collectFeishuPostImageKeys(params.value, imageKeys);
+  return imageKeys.map((imageKey) => ({
+    id: `feishu:image:${imageKey}`,
+    kind: "image",
+    name: "lark-image",
+    disposition: "available",
+    state: {
+      opaque: {
+        fileKey: imageKey,
+        messageId: params.messageId,
+        provider: "feishu",
+        resourceType: "image",
+      },
+    },
+  }));
+}
+
+function collectFeishuPostImageKeys(value: unknown, imageKeys: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFeishuPostImageKeys(item, imageKeys);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  const record = value as Record<string, unknown>;
+  const imageKey =
+    stringField(record.image_key) ??
+    (record.tag === "img" ? stringField(record.file_key) : undefined);
+  if (imageKey) {
+    imageKeys.push(imageKey);
+  }
+  collectFeishuPostImageKeys(record.content, imageKeys);
+  collectFeishuPostImageKeys(record.elements, imageKeys);
 }
 
 function readAttachmentResourceType(


### PR DESCRIPTION
## Summary

I fixed the basic Lark/Feishu message handling path that was misclassifying ordinary rich-text posts and pasted post images as unsupported attachments.

Related to #353.

## What changed

- Flatten Feishu/Lark `message_type=post` rich-text content into normal inbound text so captions and prompts like "What's in this image?" are preserved.
- Convert inline post images with `image_key` into downloadable image attachments instead of dropping them.
- Cover both post text and post image cases in the Feishu adapter tests.

## Validation

- `pnpm test packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts`
- `pnpm --filter @pwragent/messaging-provider-feishu typecheck`
- `pnpm lint:boundaries`
