### PR TITLE
fix(desktop): release messaging lease on shutdown signals

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appEventHandlers = new Map<string, (...args: unknown[]) => void>();
+const processEventHandlers = new Map<string, (...args: unknown[]) => void>();
 const createMainWindowMock = vi.fn();
 const registerAppServerIpcHandlersMock = vi.fn();
 const disposeAppServerIpcHandlersMock = vi.fn();
@@ -45,6 +46,7 @@ const setAboutPanelOptionsMock = vi.fn();
 const getAppPathMock = vi.fn(() => "/test/app");
 const getVersionMock = vi.fn(() => "1.0.0-alpha.0");
 const whenReadyMock = vi.fn(() => Promise.resolve());
+const quitMock = vi.fn();
 const getAllWindowsMock = vi.fn(() => []);
 const dockSetIconMock = vi.fn();
 const nativeImageMock = {
@@ -73,7 +75,7 @@ vi.mock("electron", () => ({
     on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       appEventHandlers.set(event, handler);
     }),
-    quit: vi.fn(),
+    quit: quitMock,
   },
   BrowserWindow: {
     getAllWindows: getAllWindowsMock,
@@ -207,6 +209,13 @@ async function flushMicrotasks(): Promise<void> {
 describe("bootstrapApp", () => {
   beforeEach(() => {
     appEventHandlers.clear();
+    processEventHandlers.clear();
+    vi.spyOn(process, "once").mockImplementation(
+      (event: string | symbol, handler: (...args: unknown[]) => void) => {
+        processEventHandlers.set(String(event), handler);
+        return process;
+      },
+    );
     createMainWindowMock.mockReset();
     registerAppServerIpcHandlersMock.mockReset();
     disposeAppServerIpcHandlersMock.mockReset();
@@ -251,6 +260,7 @@ describe("bootstrapApp", () => {
     nativeImageCreateFromPathMock.mockClear();
     whenReadyMock.mockReset();
     whenReadyMock.mockReturnValue(Promise.resolve());
+    quitMock.mockReset();
     getAllWindowsMock.mockReset();
     getAllWindowsMock.mockReturnValue([]);
     startupProfilerInstance.start.mockReset();
@@ -262,6 +272,7 @@ describe("bootstrapApp", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
 
@@ -382,6 +393,28 @@ describe("bootstrapApp", () => {
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the messaging lease synchronously on SIGTERM", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const sigtermHandler = processEventHandlers.get("SIGTERM");
+    expect(sigtermHandler).toBeTypeOf("function");
+    if (!sigtermHandler) {
+      return;
+    }
+
+    sigtermHandler("SIGTERM");
+
+    expect(messagingLeaseShutdownSyncMock).toHaveBeenCalledTimes(1);
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(quitMock).toHaveBeenCalledTimes(1);
+
+    appEventHandlers.get("before-quit")?.();
+    expect(messagingLeaseShutdownSyncMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips messaging runtime startup when messaging is disabled for the app instance", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -31,9 +31,14 @@ const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const mainLogWarnMock = vi.fn();
 const mainLogErrorMock = vi.fn();
+const initializeAppStateMock = vi.fn();
+const disposeAppStateMock = vi.fn();
+const isAppStateInitializedMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseShutdownSyncMock = vi.fn();
+const getRuntimeMessagingLeaseCoordinatorMock = vi.fn();
+const getExistingRuntimeMessagingLeaseCoordinatorMock = vi.fn();
 const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
@@ -179,11 +184,21 @@ vi.mock("../messaging/messaging-runtime", () => ({
 }));
 
 vi.mock("../runtime-messaging-lease", () => ({
-  getRuntimeMessagingLeaseCoordinator: vi.fn(() => ({
-    start: messagingLeaseStartMock,
-    shutdownSync: messagingLeaseShutdownSyncMock,
-  })),
+  getRuntimeMessagingLeaseCoordinator: getRuntimeMessagingLeaseCoordinatorMock,
+  getExistingRuntimeMessagingLeaseCoordinator:
+    getExistingRuntimeMessagingLeaseCoordinatorMock,
 }));
+
+vi.mock("../state/app-state", () => ({
+  initializeAppState: initializeAppStateMock,
+  disposeAppState: disposeAppStateMock,
+  isAppStateInitialized: isAppStateInitializedMock,
+}));
+
+const runtimeMessagingLeaseCoordinatorMock = {
+  start: messagingLeaseStartMock,
+  shutdownSync: messagingLeaseShutdownSyncMock,
+};
 
 vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
@@ -240,11 +255,23 @@ describe("bootstrapApp", () => {
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
     mainLogErrorMock.mockReset();
+    initializeAppStateMock.mockReset();
+    disposeAppStateMock.mockReset();
+    isAppStateInitializedMock.mockReset();
+    isAppStateInitializedMock.mockReturnValue(true);
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
     messagingLeaseStartMock.mockReset();
     messagingLeaseStartMock.mockResolvedValue();
     messagingLeaseShutdownSyncMock.mockReset();
+    getRuntimeMessagingLeaseCoordinatorMock.mockReset();
+    getRuntimeMessagingLeaseCoordinatorMock.mockReturnValue(
+      runtimeMessagingLeaseCoordinatorMock,
+    );
+    getExistingRuntimeMessagingLeaseCoordinatorMock.mockReset();
+    getExistingRuntimeMessagingLeaseCoordinatorMock.mockReturnValue(
+      runtimeMessagingLeaseCoordinatorMock,
+    );
     requestBindingRevokeAllForThreadMock.mockReset();
     setMessagingArchiveCleanerMock.mockReset();
     disposeDesktopMessagingRuntimeMock.mockReset();
@@ -393,6 +420,27 @@ describe("bootstrapApp", () => {
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create the messaging lease coordinator on early SIGTERM", async () => {
+    whenReadyMock.mockReturnValue(new Promise(() => {}));
+    isAppStateInitializedMock.mockReturnValue(false);
+    getExistingRuntimeMessagingLeaseCoordinatorMock.mockReturnValue(null);
+
+    await import("../index");
+
+    const sigtermHandler = processEventHandlers.get("SIGTERM");
+    expect(sigtermHandler).toBeTypeOf("function");
+    if (!sigtermHandler) {
+      return;
+    }
+
+    expect(() => sigtermHandler("SIGTERM")).not.toThrow();
+
+    expect(getRuntimeMessagingLeaseCoordinatorMock).not.toHaveBeenCalled();
+    expect(messagingLeaseShutdownSyncMock).not.toHaveBeenCalled();
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(quitMock).toHaveBeenCalledTimes(1);
   });
 
   it("releases the messaging lease synchronously on SIGTERM", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -62,6 +62,43 @@ const APP_WEBSITE = "https://pwrdrvr.com";
 const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
+let mainProcessResourcesDisposed = false;
+
+function disposeMainProcessResourcesSync(): void {
+  if (mainProcessResourcesDisposed) {
+    return;
+  }
+  mainProcessResourcesDisposed = true;
+  disposeAgentIpcHandlers();
+  disposeApplicationIpcHandlers();
+  disposeAppMetadataIpcHandlers();
+  disposeAppUpdateIpcHandlers();
+  disposeImageNormalizationIpcHandlers();
+  disposePreloadLogIpcHandlers();
+  disposeProfilesIpcHandlers();
+  disposeSettingsIpcHandlers();
+  if (isDevelopment) {
+    disposeRuntimeIdentityIpcHandlers();
+  }
+  void disposeMessagingStatusIpcHandlers();
+  getRuntimeMessagingLeaseCoordinator().shutdownSync();
+  void disposeDesktopMessagingRuntime();
+  void disposeAppServerIpcHandlers();
+  disposeAppState();
+}
+
+function installProcessShutdownHandlers(): void {
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    mainLog.info("main process shutdown signal received", { signal });
+    disposeMainProcessResourcesSync();
+    app.quit();
+  };
+  process.once("SIGTERM", handleSignal);
+  process.once("SIGINT", handleSignal);
+  process.once("exit", () => {
+    disposeMainProcessResourcesSync();
+  });
+}
 
 function installDevelopmentDockIcon(): void {
   if (!isMac || !isDevelopment) {
@@ -128,6 +165,7 @@ export function bootstrapApp(): void {
     copyright: APP_COPYRIGHT,
   });
   initializeMainLogger();
+  installProcessShutdownHandlers();
 
   app.whenReady().then(async () => {
     const startupCpuProfiler = new StartupCpuProfiler();
@@ -221,22 +259,7 @@ export function bootstrapApp(): void {
   });
 
   app.on("before-quit", () => {
-    disposeAgentIpcHandlers();
-    disposeApplicationIpcHandlers();
-    disposeAppMetadataIpcHandlers();
-    disposeAppUpdateIpcHandlers();
-    disposeImageNormalizationIpcHandlers();
-    disposePreloadLogIpcHandlers();
-    disposeProfilesIpcHandlers();
-    disposeSettingsIpcHandlers();
-    if (isDevelopment) {
-      disposeRuntimeIdentityIpcHandlers();
-    }
-    void disposeMessagingStatusIpcHandlers();
-    getRuntimeMessagingLeaseCoordinator().shutdownSync();
-    void disposeDesktopMessagingRuntime();
-    void disposeAppServerIpcHandlers();
-    disposeAppState();
+    disposeMainProcessResourcesSync();
   });
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -51,9 +51,16 @@ import {
 } from "./messaging/messaging-runtime";
 import { loadDesktopMessagingConfigFromSettings } from "./messaging/messaging-config";
 import { resolveRuntimeMessagingOverride } from "./runtime-flags";
-import { getRuntimeMessagingLeaseCoordinator } from "./runtime-messaging-lease";
+import {
+  getExistingRuntimeMessagingLeaseCoordinator,
+  getRuntimeMessagingLeaseCoordinator,
+} from "./runtime-messaging-lease";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
-import { disposeAppState, initializeAppState } from "./state/app-state";
+import {
+  disposeAppState,
+  initializeAppState,
+  isAppStateInitialized,
+} from "./state/app-state";
 import { createMainWindow } from "./window";
 
 const APP_NAME = "PwrAgent";
@@ -81,7 +88,10 @@ function disposeMainProcessResourcesSync(): void {
     disposeRuntimeIdentityIpcHandlers();
   }
   void disposeMessagingStatusIpcHandlers();
-  getRuntimeMessagingLeaseCoordinator().shutdownSync();
+  const runtimeMessagingLeaseCoordinator =
+    getExistingRuntimeMessagingLeaseCoordinator() ??
+    (isAppStateInitialized() ? getRuntimeMessagingLeaseCoordinator() : null);
+  runtimeMessagingLeaseCoordinator?.shutdownSync();
   void disposeDesktopMessagingRuntime();
   void disposeAppServerIpcHandlers();
   disposeAppState();

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -412,6 +412,12 @@ export function getRuntimeMessagingLeaseCoordinator(): RuntimeMessagingLeaseCoor
   return coordinator;
 }
 
+export function getExistingRuntimeMessagingLeaseCoordinator():
+  | RuntimeMessagingLeaseCoordinator
+  | null {
+  return coordinator;
+}
+
 export function setRuntimeMessagingLeaseCoordinatorForTests(
   next: RuntimeMessagingLeaseCoordinator | null,
 ): void {

--- a/apps/desktop/src/main/state/app-state.ts
+++ b/apps/desktop/src/main/state/app-state.ts
@@ -65,6 +65,10 @@ export function getAppRuntimeInstanceStore(): AppRuntimeInstanceStore {
   return runtimeInstanceStore;
 }
 
+export function isAppStateInitialized(): boolean {
+  return runtimeInstanceStore !== null;
+}
+
 export function disposeAppState(): void {
   if (stateDb) {
     stateDb.close();


### PR DESCRIPTION
## Summary

- I release the messaging startup lease from shutdown signal handlers so dev startup state does not stay leased after SIGINT or SIGTERM.
- I keep the lease release synchronous and idempotent around existing app shutdown flow.
- I added focused desktop main-process coverage for SIGTERM lease release.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/index.test.ts` and it passed with 8 tests.

## Notes

- This is a cherry-pick of `ab61ac6b2 fix(desktop): release messaging lease on shutdown signals`.
