### PR TITLE
feat(desktop): restore thread lens modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,11 +95,16 @@ accidental.
 ## Current Product Direction
 
 - Threads are first-class and may exist without a directory.
-- Recents and Directories share the thread lens switch.
-- Recents is the default browsing lens and owns user-curated Pins as a
-  scrollable section at the top of the Recents list.
-- Inbox is not a primary lens. Unread state remains available as the orange
-  cookie marker on thread rows wherever they appear.
+- Inbox, Recents, and Directories share the thread lens switch.
+- Inbox is the default browsing lens. Its thread population and ordering match
+  the former Recents behavior: all threads, user-curated Pins at the top, and
+  unpinned threads in recent-activity order.
+- Recents keeps the same pinned section, but unpinned threads sort by thread
+  creation time so active threads do not jump around.
+- Directories keep pinned threads first within each directory, then sort
+  unpinned threads by thread creation time.
+- Unread state remains available as the orange cookie marker on thread rows
+  wherever they appear.
 - A thread may be associated with multiple linked Git directories.
 
 ## Dependency Boundary Enforcement

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -26,9 +26,10 @@ The desktop style guide defines:
 
 ## Non-Negotiables
 
-- Recents and Directories live in one thread lens switch; Recents is the
+- Inbox, Recents, and Directories live in one thread lens switch; Inbox is the
   default browsing lens.
-- User-curated Pins live as a scrollable section at the top of Recents.
+- User-curated Pins live as a scrollable section at the top of Inbox and
+  Recents.
 - Unread state uses the orange cookie marker, not punctuation badges.
 - The sidebar is an information surface, not a stack of generic cards.
 - Do not use browser-default controls in shipped UI.

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -132,6 +132,8 @@ function DesktopAppShell(props: {
         creatingThread={navigation.creatingThread}
         directories={navigation.directories}
         error={navigation.error}
+        inboxThreads={navigation.inboxThreads}
+        recentThreads={navigation.recentThreads}
         archiveThreadError={navigation.archiveThreadError}
         renameThreadError={navigation.renameThreadError}
         runtimeIdentity={runtimeIdentity}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -505,7 +505,7 @@ describe("App", () => {
     expect(screen.queryByRole("heading", { level: 1, name: "Threads" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "inbox" })).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "recents" })
+      screen.getByRole("button", { name: "Created" })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New thread" })).toBeInTheDocument();
     expect(

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -95,6 +95,12 @@ type SidebarProps = {
   onResizeByKeyboard?: (delta: number) => void;
 };
 
+const browseModeLabels = {
+  inbox: "Updated",
+  recents: "Created",
+  directories: "Directories",
+} satisfies Record<BrowseMode, string>;
+
 export function Sidebar(props: SidebarProps) {
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -442,7 +448,7 @@ export function Sidebar(props: SidebarProps) {
               type="button"
               onClick={() => props.onBrowseModeChange(mode)}
             >
-              {mode}
+              {browseModeLabels[mode]}
             </button>
           ))}
         </div>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -35,6 +35,7 @@ type SidebarProps = {
   directories: NavigationDirectorySummary[];
   error?: string;
   inboxThreads?: NavigationThreadSummary[];
+  recentThreads?: NavigationThreadSummary[];
   loading: boolean;
   creatingThread?: {
     backend: AppServerBackendKind;
@@ -128,6 +129,10 @@ export function Sidebar(props: SidebarProps) {
   const runtimeGitRefValue = props.runtimeIdentity
     ? runtimeGitRefCopyValue(props.runtimeIdentity)
     : undefined;
+  const visibleThreads =
+    props.browseMode === "recents"
+      ? props.recentThreads ?? props.threads
+      : props.inboxThreads ?? props.threads;
 
   useEffect(() => {
     if (!copiedRuntimeValue) {
@@ -427,7 +432,7 @@ export function Sidebar(props: SidebarProps) {
 
       <section className="sidebar__section sidebar__section--fill" aria-label="Thread browser">
         <div className="lens-switch" role="tablist" aria-label="Thread lenses">
-          {(["recents", "directories"] as const).map((mode) => (
+          {(["inbox", "recents", "directories"] as const).map((mode) => (
             <button
               key={mode}
               aria-pressed={props.browseMode === mode}
@@ -463,14 +468,14 @@ export function Sidebar(props: SidebarProps) {
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
-            props.threads.length === 0 ? (
+            visibleThreads.length === 0 ? (
               <p className="sidebar-empty">No threads yet.</p>
             ) : (
               <RecentsList
                 approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}
-                threads={props.threads}
+                threads={visibleThreads}
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
                 onReorderThreadPins={props.onReorderThreadPins}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -145,7 +145,7 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
-  it("renders Recents as the first thread lens and keeps directory rows available", () => {
+  it("renders Inbox as the first thread lens and keeps directory rows available", () => {
     const onOpenSettings = vi.fn();
     render(
       <Sidebar
@@ -175,6 +175,7 @@ describe("Sidebar", () => {
       screen.getByRole("tablist", { name: "Thread lenses" })
     ).getAllByRole("button");
     expect(lensButtons.map((button) => button.textContent)).toEqual([
+      "inbox",
       "recents",
       "directories",
     ]);
@@ -520,11 +521,13 @@ describe("Sidebar", () => {
     expect(unreadIndicator).not.toHaveTextContent("!");
   });
 
-  it("does not render the retired inbox lens", () => {
+  it("renders Inbox as the updated-activity thread lens", () => {
+    const onBrowseModeChange = vi.fn();
+
     render(
       <Sidebar
         backends={backends}
-        browseMode="recents"
+        browseMode="inbox"
         createThreadError={undefined}
         directories={directories}
         inboxThreads={[updatedSinceSeenThread]}
@@ -533,6 +536,59 @@ describe("Sidebar", () => {
         creatingThread={undefined}
         selectedItemKey={undefined}
         threads={[sharedThread, updatedSinceSeenThread]}
+        onBrowseModeChange={onBrowseModeChange}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "inbox" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "recents" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: /Updated thread/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "recents" }));
+
+    expect(onBrowseModeChange).toHaveBeenCalledWith("recents");
+  });
+
+  it("renders Recents from the creation-time thread order", () => {
+    const updatedLater = {
+      ...sharedThread,
+      id: "updated-later",
+      title: "Updated later",
+      createdAt: 1_000,
+      updatedAt: 9_000,
+      inbox: { inInbox: false },
+    };
+    const createdLater = {
+      ...sharedThread,
+      id: "created-later",
+      title: "Created later",
+      createdAt: 2_000,
+      updatedAt: 2_000,
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[updatedLater, createdLater]}
+        recentThreads={[createdLater, updatedLater]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[updatedLater, createdLater]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
@@ -540,11 +596,14 @@ describe("Sidebar", () => {
       />
     );
 
-    expect(screen.queryByRole("button", { name: "inbox" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "recents" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    const rows = within(browseSection as HTMLElement).getAllByRole("button", {
+      name: /Updated later|Created later/i,
+    });
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Created later"),
+      expect.stringContaining("Updated later"),
+    ]);
   });
 
   it("opens thread actions from the row overflow button", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -175,11 +175,11 @@ describe("Sidebar", () => {
       screen.getByRole("tablist", { name: "Thread lenses" })
     ).getAllByRole("button");
     expect(lensButtons.map((button) => button.textContent)).toEqual([
-      "inbox",
-      "recents",
-      "directories",
+      "Updated",
+      "Created",
+      "Directories",
     ]);
-    expect(screen.getByRole("button", { name: "directories" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Directories" })).toHaveAttribute(
       "aria-pressed",
       "true"
     );
@@ -543,17 +543,17 @@ describe("Sidebar", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: "inbox" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Updated" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.getByRole("button", { name: "recents" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Created" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
     expect(screen.getByRole("button", { name: /Updated thread/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "recents" }));
+    fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
     expect(onBrowseModeChange).toHaveBeenCalledWith("recents");
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -100,12 +100,13 @@ describe("useThreadNavigation", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.inboxThreads).toHaveLength(0);
+      expect(result.current.inboxThreads).toHaveLength(1);
+      expect(result.current.inboxThreads[0]?.inbox.inInbox).toBe(false);
       expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
     });
   });
 
-  it("keeps a selected unread thread in Inbox until another item is selected", async () => {
+  it("keeps a selected unread marker until another item is selected", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-unread",
@@ -163,6 +164,7 @@ describe("useThreadNavigation", () => {
     await waitFor(() => {
       expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
         "thread-unread",
+        "thread-read",
       ]);
     });
 
@@ -179,14 +181,70 @@ describe("useThreadNavigation", () => {
     });
     expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
       "thread-unread",
+      "thread-read",
     ]);
+    expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
 
     act(() => {
       result.current.selectThread(result.current.threads[1]!);
     });
 
     await waitFor(() => {
-      expect(result.current.inboxThreads).toHaveLength(0);
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    });
+  });
+
+  it("orders recent threads by creation time without changing inbox order", async () => {
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "updated-newer",
+          title: "Updated newer",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          createdAt: 1_000,
+          updatedAt: 9_000,
+        },
+        {
+          id: "created-newer",
+          title: "Created newer",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          createdAt: 2_000,
+          updatedAt: 2_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
+        "updated-newer",
+        "created-newer",
+      ]);
+      expect(result.current.recentThreads.map((thread) => thread.id)).toEqual([
+        "created-newer",
+        "updated-newer",
+      ]);
     });
   });
 
@@ -447,7 +505,9 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads.map((thread) => thread.id)).toEqual([
       "thread-remaining",
     ]);
-    expect(result.current.inboxThreads).toHaveLength(0);
+    expect(result.current.inboxThreads.map((thread) => thread.id)).toEqual([
+      "thread-remaining",
+    ]);
     expect(result.current.directories[0]?.threadKeys).toEqual([]);
     expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -20,11 +20,12 @@ import {
   buildPinnedRanks,
   buildThreadIdentityKey,
   comparePinnedThreads,
+  compareThreadsByCreatedAtDesc,
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 
-export type BrowseMode = "recents" | "directories";
+export type BrowseMode = "inbox" | "recents" | "directories";
 
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
@@ -1028,6 +1029,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   directories: NavigationDirectorySummary[];
   error?: string;
   inboxThreads: NavigationThreadSummary[];
+  recentThreads: NavigationThreadSummary[];
   launchpadError?: string;
   archiveThreadError?: string;
   worktreeArchiveError?: string;
@@ -1125,7 +1127,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const cancelThreadExecutionModeQueueRequest =
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
-  const [browseMode, setBrowseMode] = useState<BrowseMode>("recents");
+  const [browseMode, setBrowseMode] = useState<BrowseMode>("inbox");
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
   const [retainedUnreadThread, setRetainedUnreadThread] =
@@ -1735,28 +1737,11 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     [optimisticThread, state.response?.directories, state.response?.threads]
   );
 
-  const inboxThreads = useMemo(() => {
-    const unreadThreads = threads.filter(
-      (thread) => thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen"
-    );
-    if (!retainedUnreadThread) {
-      return unreadThreads;
-    }
-
-    const retainedThreadKey = buildThreadIdentityKey(
-      retainedUnreadThread.source,
-      retainedUnreadThread.id
-    );
-    if (
-      unreadThreads.some(
-        (thread) => buildThreadIdentityKey(thread.source, thread.id) === retainedThreadKey
-      )
-    ) {
-      return unreadThreads;
-    }
-
-    return [retainedUnreadThread, ...unreadThreads];
-  }, [retainedUnreadThread, threads]);
+  const inboxThreads = threads;
+  const recentThreads = useMemo(
+    () => [...threads].sort(compareThreadsByCreatedAtDesc),
+    [threads],
+  );
 
   const selectedThreadKey = useMemo(() => {
     if (selectedItemKey && !getDirectoryKeyFromLaunchpadSelection(selectedItemKey)) {
@@ -2703,6 +2688,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     directories,
     error: state.error,
     inboxThreads,
+    recentThreads,
     launchpadError,
     archiveThreadError,
     worktreeArchiveError,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1216,7 +1216,8 @@ textarea,
 .lens-switch {
   display: inline-grid;
   width: 100%;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
   padding: 3px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -1237,11 +1238,11 @@ textarea,
 .lens-switch__button {
   min-width: 0;
   height: 32px;
-  padding: 0 8px;
+  padding: 0 6px;
   background: transparent;
   color: var(--text-secondary);
-  text-transform: capitalize;
   transition: none;
+  white-space: nowrap;
 }
 
 .lens-switch__button.is-active {

--- a/docs/design/desktop-style-guide.md
+++ b/docs/design/desktop-style-guide.md
@@ -175,16 +175,17 @@ The main shell should not look like stacked floating cards on a dark background.
 The sidebar is a structured queue. It should contain:
 
 1. top-level global actions
-2. Recents / Directories thread lens switch
+2. Inbox / Recents / Directories thread lens switch
 3. thread or project lists
 4. utility footer items
 
 Rules:
 
-- Recents is the default thread lens and should include user-curated Pins at
-  the top of its scrollable list
-- unread work is a row-local state shown with the orange cookie marker, not a
-  separate primary lens
+- Inbox is the default thread lens and should include user-curated Pins at the
+  top of its scrollable list
+- Recents keeps the pinned section but sorts unpinned rows by thread creation
+  time
+- unread work is a row-local state shown with the orange cookie marker
 - section headers should be quiet, compact, and utility-first
 - rows should carry metadata inline
 - active row state should be obvious without being loud

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -27,6 +27,7 @@ describe("buildDirectorySummaries", () => {
       threads: [
         buildThread({
           id: "thread-1",
+          createdAt: 2_000,
           inbox: { inInbox: true },
           linkedDirectories: [
             {
@@ -39,6 +40,7 @@ describe("buildDirectorySummaries", () => {
         }),
         buildThread({
           id: "thread-2",
+          createdAt: 1_000,
           inbox: { inInbox: false },
           linkedDirectories: [
             {
@@ -137,6 +139,7 @@ describe("buildDirectorySummaries", () => {
     const directories = buildDirectorySummaries({
       threads: [
         buildThread({
+          createdAt: 2_000,
           linkedDirectories: [
             {
               id: "dir-1",
@@ -276,6 +279,7 @@ describe("buildDirectorySummaries", () => {
     const directories = buildDirectorySummaries({
       threads: [
         buildThread({
+          createdAt: 2_000,
           linkedDirectories: [
             {
               id: "/Users/huntharo/.pwragent/projects",
@@ -287,6 +291,7 @@ describe("buildDirectorySummaries", () => {
         }),
         buildThread({
           id: "thread-2",
+          createdAt: 1_000,
           linkedDirectories: [
             {
               id: "/Users/huntharo/.pwragent/projects/2026-05-02-a1b2c3",
@@ -486,6 +491,7 @@ describe("buildDirectorySummaries", () => {
       threads: [
         buildThread({
           id: "thread-1",
+          createdAt: 2_000,
           linkedDirectories: [
             {
               id: "dir-1",
@@ -497,6 +503,7 @@ describe("buildDirectorySummaries", () => {
         }),
         buildThread({
           id: "thread-2",
+          createdAt: 1_000,
           linkedDirectories: [
             {
               id: "dir-2",
@@ -534,6 +541,7 @@ describe("buildDirectorySummaries", () => {
       threads: [
         buildThread({
           id: "thread-1",
+          createdAt: 2_000,
           linkedDirectories: [
             {
               id: "dir-1",
@@ -546,6 +554,7 @@ describe("buildDirectorySummaries", () => {
         }),
         buildThread({
           id: "thread-2",
+          createdAt: 1_000,
           linkedDirectories: [
             {
               id: "dir-2",
@@ -576,6 +585,7 @@ describe("buildDirectorySummaries", () => {
       threads: [
         buildThread({
           id: "thread-home",
+          createdAt: 2_000,
           linkedDirectories: [
             {
               id: "/Users/huntharo/claude-worktrees/PwrAgnt/modest/apps/desktop",
@@ -587,6 +597,7 @@ describe("buildDirectorySummaries", () => {
         }),
         buildThread({
           id: "thread-worktree",
+          createdAt: 1_000,
           linkedDirectories: [
             {
               id: "/Users/huntharo/.pwragent/worktrees/mord46hf/PwrAgnt",

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -64,6 +64,44 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("orders directory threads by creation time instead of last update time", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "updated-later",
+          createdAt: 1_000,
+          updatedAt: 9_000,
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "created-later",
+          createdAt: 2_000,
+          updatedAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories[0]?.threadKeys).toEqual([
+      "codex:created-later",
+      "codex:updated-later",
+    ]);
+  });
+
   it("includes launchpad-only directories even when no current thread is linked", () => {
     const directories = buildDirectorySummaries({
       threads: [],

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -5,7 +5,10 @@ import type {
   NavigationDirectorySummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  compareThreadsByCreatedAtDesc,
+} from "@pwragent/shared";
 
 type DirectoryDescriptor = Pick<
   NavigationDirectorySummary,
@@ -230,12 +233,7 @@ function collapseWorkspaceSummaries(params: {
   }
 
   const preferred = chooseWorkspaceSummary(workspaces);
-  const threadOrder = new Map(
-    params.threads.map((thread, index) => [
-      buildThreadIdentityKey(thread.source, thread.id),
-      index,
-    ]),
-  );
+  const threadOrder = buildThreadCreationOrder(params.threads);
   const inboxByThreadKey = new Map(
     params.threads.map((thread) => [
       buildThreadIdentityKey(thread.source, thread.id),
@@ -273,6 +271,35 @@ function collapseWorkspaceSummaries(params: {
     },
     ...params.summaries.filter((summary) => summary.kind !== "workspace"),
   ];
+}
+
+function buildThreadCreationOrder(
+  threads: NavigationThreadSummary[],
+): Map<string, number> {
+  return new Map(
+    [...threads]
+      .sort(compareThreadsByCreatedAtDesc)
+      .map((thread, index) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        index,
+      ]),
+  );
+}
+
+function sortDirectoryThreadKeysByCreation(
+  summaries: NavigationDirectorySummary[],
+  threads: NavigationThreadSummary[],
+): NavigationDirectorySummary[] {
+  const threadOrder = buildThreadCreationOrder(threads);
+
+  return summaries.map((summary) => ({
+    ...summary,
+    threadKeys: [...summary.threadKeys].sort(
+      (left, right) =>
+        (threadOrder.get(left) ?? Number.MAX_SAFE_INTEGER) -
+        (threadOrder.get(right) ?? Number.MAX_SAFE_INTEGER),
+    ),
+  }));
 }
 
 export function buildDirectorySummaries(params: {
@@ -373,8 +400,11 @@ export function buildDirectorySummaries(params: {
     }
   }
 
-  return collapseWorkspaceSummaries({
-    summaries: [...summaries.values()],
-    threads: params.threads,
-  }).sort((left, right) => left.label.localeCompare(right.label));
+  return sortDirectoryThreadKeysByCreation(
+    collapseWorkspaceSummaries({
+      summaries: [...summaries.values()],
+      threads: params.threads,
+    }),
+    params.threads,
+  ).sort((left, right) => left.label.localeCompare(right.label));
 }

--- a/packages/shared/src/__tests__/thread-pins.test.ts
+++ b/packages/shared/src/__tests__/thread-pins.test.ts
@@ -3,6 +3,7 @@ import {
   buildAppendPinRank,
   buildPinnedRanks,
   comparePinnedThreads,
+  compareThreadsByCreatedAtDesc,
   moveThreadKey,
 } from "../thread-pins";
 
@@ -28,6 +29,22 @@ describe("thread pins", () => {
     ].sort(comparePinnedThreads);
 
     expect(sorted.map((thread) => thread.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("sorts created threads deterministically when creation timestamps are missing", () => {
+    const sorted = [
+      { id: "legacy-z", updatedAt: 9_000 },
+      { id: "created-newer", createdAt: 2_000, updatedAt: 2_000 },
+      { id: "legacy-a", updatedAt: 10_000 },
+      { id: "created-older", createdAt: 1_000, updatedAt: 8_000 },
+    ].sort(compareThreadsByCreatedAtDesc);
+
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      "created-newer",
+      "created-older",
+      "legacy-z",
+      "legacy-a",
+    ]);
   });
 
   it("moves a dragged key before or after the target key", () => {

--- a/packages/shared/src/thread-pins.ts
+++ b/packages/shared/src/thread-pins.ts
@@ -6,6 +6,12 @@ type PinSortableThread = {
   updatedAt?: number;
 };
 
+type CreationSortableThread = {
+  id: string;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
 export function isPinnedThread(thread: PinSortableThread): boolean {
   return Boolean(thread.pinnedRank?.trim());
 }
@@ -28,6 +34,17 @@ export function comparePinRanks(left?: string, right?: string): number {
   const rightNumber = parsePinRank(right);
   if (leftNumber !== rightNumber) return leftNumber - rightNumber;
   return (left ?? "").localeCompare(right ?? "");
+}
+
+export function compareThreadsByCreatedAtDesc<T extends CreationSortableThread>(
+  left: T,
+  right: T,
+): number {
+  if (left.createdAt === undefined || right.createdAt === undefined) {
+    return 0;
+  }
+
+  return right.createdAt - left.createdAt;
 }
 
 export function buildAppendPinRank(existingRanks: Array<string | undefined>): string {

--- a/packages/shared/src/thread-pins.ts
+++ b/packages/shared/src/thread-pins.ts
@@ -40,11 +40,10 @@ export function compareThreadsByCreatedAtDesc<T extends CreationSortableThread>(
   left: T,
   right: T,
 ): number {
-  if (left.createdAt === undefined || right.createdAt === undefined) {
-    return 0;
-  }
+  const createdComparison = (right.createdAt ?? 0) - (left.createdAt ?? 0);
+  if (createdComparison !== 0) return createdComparison;
 
-  return right.createdAt - left.createdAt;
+  return right.id.localeCompare(left.id);
 }
 
 export function buildAppendPinRank(existingRanks: Array<string | undefined>): string {


### PR DESCRIPTION
## Summary

- I restored Inbox as the default thread lens with the former activity-sorted Recents behavior.
- I changed Recents into the creation-time lens and made directory thread ordering use creation time below pins so active threads do not jump around.
- I renamed the visible lens labels to Updated / Created / Directories and tightened the segmented control so all three fit on one row.
- I updated the repo guidance and desktop style guide so future work follows the new lens semantics.

## Verification

- I ran `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I ran `pnpm --filter @pwragent/shared typecheck`.
- I ran `pnpm --filter @pwragent/agent-core typecheck`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.
- I started the dev-profile app from this checkout with `pwragent-dev-profile`.

## Notes

- The branch contains signed commits rebased onto current `origin/main`.
