### PR TITLE
fix(messaging): dedupe Feishu inbound retries

### DIFF
--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -1007,6 +1007,67 @@ describe("FeishuAdapter", () => {
     ]);
   });
 
+  it("ignores duplicate message webhook deliveries", async () => {
+    const logger = {
+      info: vi.fn(),
+    };
+    const adapter = new FeishuAdapter({
+      config: {
+        ...baseConfig,
+        authorizedChatIds: [{ id: "oc_chat", displayName: "Ops" }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      logger,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    const payload: Parameters<FeishuAdapter["handleWebhookPayload"]>[0] = {
+      header: {
+        event_id: "evt_retry",
+        event_type: "im.message.receive_v1",
+        tenant_key: "tenant_1",
+        token: "verify-token",
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          tenant_key: "tenant_1",
+        },
+        message: {
+          chat_id: "oc_chat",
+          chat_type: "group",
+          content: JSON.stringify({ text: "@_user_1 /detach" }),
+          mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "PwrAgent" }],
+          message_id: "om_retry",
+          message_type: "text",
+        },
+      },
+    };
+
+    await adapter.handleWebhookPayload(payload);
+    await adapter.handleWebhookPayload(payload);
+    await adapter.stop();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "command",
+        command: "detach",
+        rawText: "/detach",
+      }),
+    ]);
+    expect(logger.info).toHaveBeenCalledWith(
+      "feishu duplicate inbound message ignored",
+      expect.objectContaining({
+        dedupKey: "event:evt_retry",
+        messageId: "om_retry",
+      }),
+    );
+  });
+
   it("lets pairing-token messages reach the runtime before authorization", async () => {
     const adapter = new FeishuAdapter({
       config: {

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -1068,6 +1068,61 @@ describe("FeishuAdapter", () => {
     );
   });
 
+  it("does not redispatch a retry after downstream handling fails", async () => {
+    const logger = {
+      info: vi.fn(),
+    };
+    const adapter = new FeishuAdapter({
+      config: {
+        ...baseConfig,
+        authorizedChatIds: [{ id: "oc_chat", displayName: "Ops" }],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      logger,
+      now: () => 1_700_000_000_000,
+    });
+    const listener = vi.fn(async () => {
+      throw new Error("runtime unavailable");
+    });
+    await adapter.start(listener);
+    const payload: Parameters<FeishuAdapter["handleWebhookPayload"]>[0] = {
+      header: {
+        event_id: "evt_retry_after_failure",
+        event_type: "im.message.receive_v1",
+        tenant_key: "tenant_1",
+        token: "verify-token",
+      },
+      event: {
+        sender: {
+          sender_id: { open_id: "ou_user" },
+          tenant_key: "tenant_1",
+        },
+        message: {
+          chat_id: "oc_chat",
+          chat_type: "group",
+          content: JSON.stringify({ text: "@_user_1 /detach" }),
+          mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "PwrAgent" }],
+          message_id: "om_retry_after_failure",
+          message_type: "text",
+        },
+      },
+    };
+
+    await expect(adapter.handleWebhookPayload(payload)).rejects.toThrow("runtime unavailable");
+    await expect(adapter.handleWebhookPayload(payload)).resolves.toEqual({ status: 200 });
+    await adapter.stop();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "feishu duplicate inbound message ignored",
+      expect.objectContaining({
+        dedupKey: "event:evt_retry_after_failure",
+        messageId: "om_retry_after_failure",
+      }),
+    );
+  });
+
   it("lets pairing-token messages reach the runtime before authorization", async () => {
     const adapter = new FeishuAdapter({
       config: {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -60,6 +60,8 @@ const DEFAULT_CALLBACK_PORT = 47823;
 const DEFAULT_CALLBACK_HOST = "127.0.0.1";
 const FEISHU_SIGNED_VALUE_VERSION = 1;
 const FEISHU_WEBHOOK_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
+const FEISHU_INBOUND_DEDUP_TTL_MS = 10 * 60 * 1000;
+const FEISHU_INBOUND_DEDUP_MAX = 1_000;
 
 export type FeishuProviderLogger = {
   debug?: (message: string, data?: Record<string, unknown>) => void;
@@ -320,6 +322,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
   private readonly diagnosticListeners = new Set<MessagingAdapterDiagnosticListener>();
   private readonly inboundRejectedListeners = new Set<MessagingInboundRejectedListener>();
   private readonly rateLimitListeners = new Set<(info: MessagingRateLimitInfo) => void>();
+  private readonly recentlyHandledInboundKeys = new Map<string, number>();
 
   constructor(options: FeishuAdapterOptions) {
     this.config = options.config;
@@ -707,6 +710,10 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     const tenantKey = payload.header?.tenant_key ?? event?.sender?.tenant_key;
     const ids = this.validateInboundIds({ chatId, messageId, openId: senderId, tenantKey });
     if (!ids || !message) return;
+    const dedupKey = buildFeishuInboundDedupKey(payload, ids.messageId);
+    if (this.markInboundDuplicate(dedupKey, ids.messageId, ids.chatId)) {
+      return;
+    }
 
     const conversationKind: MessagingConversationKind =
       message.chat_type === "p2p" ? "dm" : "channel";
@@ -810,6 +817,36 @@ export class FeishuAdapter implements FeishuProviderAdapter {
             text: messageText,
           };
     await this.listener?.(inbound);
+  }
+
+  private markInboundDuplicate(
+    dedupKey: string,
+    messageId: string,
+    chatId: string,
+  ): boolean {
+    const now = this.now();
+    for (const [key, expiresAt] of this.recentlyHandledInboundKeys) {
+      if (expiresAt > now) continue;
+      this.recentlyHandledInboundKeys.delete(key);
+    }
+    if (this.recentlyHandledInboundKeys.has(dedupKey)) {
+      this.logger.info?.("feishu duplicate inbound message ignored", {
+        chatId,
+        dedupKey,
+        messageId,
+      });
+      return true;
+    }
+    this.recentlyHandledInboundKeys.set(
+      dedupKey,
+      now + FEISHU_INBOUND_DEDUP_TTL_MS,
+    );
+    while (this.recentlyHandledInboundKeys.size > FEISHU_INBOUND_DEDUP_MAX) {
+      const oldest = this.recentlyHandledInboundKeys.keys().next().value;
+      if (oldest === undefined) break;
+      this.recentlyHandledInboundKeys.delete(oldest);
+    }
+    return false;
   }
 
   private async handleBotP2pChatEnteredEvent(payload: FeishuEventEnvelope): Promise<void> {
@@ -1670,6 +1707,15 @@ export function parseFeishuCommandText(
     return { command: "cas_click", args: [tokens[1], ...tokens.slice(2)] };
   }
   return { command: first, args: tokens.slice(1) };
+}
+
+function buildFeishuInboundDedupKey(
+  payload: FeishuEventEnvelope,
+  messageId: string,
+): string {
+  return payload.header?.event_id
+    ? `event:${payload.header.event_id}`
+    : `message:${messageId}`;
 }
 
 function parseFeishuMessageContent(content: string | undefined): Record<string, unknown> {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -711,6 +711,9 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     const ids = this.validateInboundIds({ chatId, messageId, openId: senderId, tenantKey });
     if (!ids || !message) return;
     const dedupKey = buildFeishuInboundDedupKey(payload, ids.messageId);
+    // Feishu/Lark retries webhook deliveries after slow or failed ACKs. Once
+    // the adapter has received a well-formed message, transport retries must
+    // not resubmit the same user command to the runtime.
     if (this.markInboundDuplicate(dedupKey, ids.messageId, ids.chatId)) {
       return;
     }


### PR DESCRIPTION
## Summary

- I fixed Feishu/Lark inbound webhook retries so repeated deliveries of the same `event_id` or `message_id` are ignored for a short window instead of dispatching the same user command twice.
- I made the dedupe intentionally receipt-level: once the adapter receives a well-formed message, transport retries do not resubmit it to the runtime even if downstream handling fails.
- I added regression coverage for duplicate `/detach` deliveries and the downstream-failure retry case.

## Verification

- `pnpm test packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts`
- `pnpm lint:boundaries`

## Notes

- This targets the duplicate "Nothing attached" response caused by Feishu/Lark retrying a slow `/detach` webhook delivery.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
