### PR TITLE
fix(desktop): align launchpad header chips

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -32,6 +32,7 @@ import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import { useMediaQuery } from "../../lib/useMediaQuery";
 import { Composer } from "../composer/Composer";
 import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
@@ -1433,7 +1434,7 @@ export function ThreadView(props: ThreadViewProps) {
     return (
       <section className="thread-view thread-view--launchpad">
         <header className="thread-header thread-header--launchpad">
-          <div>
+          <div className="thread-header__main thread-header__main--launchpad">
             <div className="thread-header__eyebrow-row">
               <p className="eyebrow">New thread</p>
               <span className="thread-row__chip thread-row__chip--backend">
@@ -1446,21 +1447,27 @@ export function ThreadView(props: ThreadViewProps) {
             <h2 className="thread-header__title">{launchpadTitle}</h2>
           </div>
 
-          <div className="thread-header__stats">
-            <div>
-              <span className="thread-header__stat-label">Workspace</span>
-              <strong>{workspaceLabel}</strong>
+          <div className="thread-header__launchpad-aside">
+            <div className="thread-header__stats">
+              <div>
+                <span className="thread-header__stat-label">Workspace</span>
+                <strong>{workspaceLabel}</strong>
+              </div>
+              <div>
+                <span className="thread-header__stat-label">Branch</span>
+                <strong>
+                  {selectedLaunchpad.workMode === "worktree"
+                    ? selectedLaunchpad.branchName ??
+                      props.selectedDirectory.gitStatus?.currentBranch ??
+                      "Pick one"
+                    : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached"}
+                </strong>
+              </div>
             </div>
-            <div>
-              <span className="thread-header__stat-label">Branch</span>
-              <strong>
-                {selectedLaunchpad.workMode === "worktree"
-                  ? selectedLaunchpad.branchName ??
-                    props.selectedDirectory.gitStatus?.currentBranch ??
-                    "Pick one"
-                  : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached"}
-              </strong>
-            </div>
+            <MessagingStatusBar
+              desktopApi={props.desktopApi}
+              onOpenActivity={props.onOpenMessagingActivity}
+            />
           </div>
         </header>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2,7 +2,13 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppServerNotification, AppServerPendingRequestNotification } from "@pwragent/shared";
+import type {
+  AppServerNotification,
+  AppServerPendingRequestNotification,
+  MessagingPlatformStatus,
+  NavigationDirectorySummary,
+  NavigationLaunchpadDraft,
+} from "@pwragent/shared";
 import type { PendingMcpInteractionState } from "../mcp-elicitation";
 import type { PendingQuestionnaireState } from "../questionnaire";
 import { ThreadView } from "../ThreadView";
@@ -219,6 +225,114 @@ describe("ThreadView", () => {
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("renders launchpad header chips and messaging status icons", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+        account: "@pwragent_bot",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const selectedDirectory = {
+      key: "directory:/Users/huntharo/github/PwrAgnt",
+      kind: "directory",
+      label: "PwrAgnt",
+      path: "/Users/huntharo/github/PwrAgnt",
+      threadKeys: ["thread-1", "thread-2"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "main",
+        upstreamBranch: "origin/main",
+        syncState: "in-sync",
+      },
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      branchName: "main",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "full-access",
+      prompt: "",
+      updatedAt: 1000,
+      workMode: "worktree",
+    } satisfies NavigationLaunchpadDraft;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{
+          getMessagingPlatformStatuses: vi.fn(async () => statuses),
+          onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-launchpad",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={2}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    const header = document.querySelector(".thread-header--launchpad");
+    expect(header).not.toBeNull();
+    expect(within(header as HTMLElement).getByText("New thread")).toBeInTheDocument();
+    expect(within(header as HTMLElement).getByText("OpenAI")).toBeInTheDocument();
+    expect(within(header as HTMLElement).getByText("Full Access")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
   it("shows missing recorded working directory details and copies the thread id", async () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -202,6 +202,23 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps launchpad header chips content-sized and aligned with the eyebrow", () => {
+    const launchpadHeaderRule = extractRuleBody(css, ".thread-header--launchpad");
+    const launchpadAsideRule = extractRuleBody(css, ".thread-header__launchpad-aside");
+    const eyebrowRule = extractRuleBody(css, ".thread-header__eyebrow-row > .eyebrow");
+
+    expect(launchpadHeaderRule).toContain("align-items: flex-start;");
+    expect(launchpadAsideRule).toContain("align-items: flex-start;");
+    expect(eyebrowRule).toContain("height: 24px;");
+    expect(eyebrowRule).toContain("margin: 0 2px 0 0;");
+    expect(css).toMatch(
+      /\.thread-header--launchpad \.thread-header__eyebrow-row > \.thread-row__chip\s*\{[\s\S]*?max-width:\s*100%;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.thread-header--launchpad \.messaging-status-bar\s*\{[\s\S]*?padding-top:\s*0;[\s\S]*?padding-bottom:\s*0;[\s\S]*?\}/
+    );
+  });
+
   it("reserves opened context rail width for the thread header status area", () => {
     expect(css).toMatch(
       /\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), calc\(100% - 32px\)\) \+ 12px\);[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3923,7 +3923,24 @@ textarea,
 }
 
 .thread-header--launchpad {
-  align-items: center;
+  align-items: flex-start;
+}
+
+.thread-header__main--launchpad {
+  flex: 1 1 auto;
+}
+
+.thread-header__launchpad-aside {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  gap: 16px;
+  min-width: max-content;
+}
+
+.thread-header--launchpad .messaging-status-bar {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .thread-header--launchpad .thread-header__title {
@@ -3936,6 +3953,14 @@ textarea,
   gap: 8px;
   max-width: 100%;
   min-width: 0;
+}
+
+.thread-header__eyebrow-row > .eyebrow {
+  display: inline-flex;
+  height: 24px;
+  align-items: center;
+  margin: 0 2px 0 0;
+  line-height: 1;
 }
 
 .thread-header__compact-title {
@@ -3956,6 +3981,14 @@ textarea,
 .thread-header__eyebrow-row > .thread-row__chip {
   flex: 0 0 auto;
   max-width: min(26ch, 28%);
+}
+
+.thread-header--launchpad .thread-header__eyebrow-row {
+  flex-wrap: wrap;
+}
+
+.thread-header--launchpad .thread-header__eyebrow-row > .thread-row__chip {
+  max-width: 100%;
 }
 
 .thread-header__warning {


### PR DESCRIPTION
## Summary

- I aligned the New Thread launchpad header with the v2 design direction by keeping the eyebrow and chips on a single 24px row.
- I removed the launchpad-specific chip width cap so `Full Access` renders at its content width instead of clipping.
- I added the shared messaging status bar to the launchpad header so configured messaging platforms appear on this screen too.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm --filter @pwragent/desktop build`.
- I verified the screen in a replay-backed Electron window: `NEW THREAD`, `OpenAI`, and `Full Access` share the same centerline, the `Full Access` chip is not clipped, and the Telegram status icon renders in the launchpad header.

## Notes

- I added renderer and theme-contract coverage to prevent the launchpad header from drifting back to capped chips or missing messaging icons.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
