### PR TITLE
fix(desktop): restore queued permission transcript state

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { shortenDerivedThreadTitle } from "@pwragent/shared";
+import type { NavigationSnapshot } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadNavigation } from "../useThreadNavigation";
@@ -1612,7 +1613,7 @@ describe("useThreadNavigation", () => {
 
   it("patches the snapshot for thread/executionMode/queued and queueCleared", async () => {
     const listeners = new Set<(event: any) => void>();
-    const getNavigationSnapshot = vi.fn(async () => ({
+    let navigationSnapshot: NavigationSnapshot = {
       backend: "all" as const,
       fetchedAt: Date.now(),
       unchanged: false,
@@ -1634,7 +1635,8 @@ describe("useThreadNavigation", () => {
         backend: "codex" as const,
         executionMode: "default" as const,
       },
-    }));
+    };
+    const getNavigationSnapshot = vi.fn(async () => navigationSnapshot);
 
     const desktopApi: DesktopApi = {
       getNavigationSnapshot,
@@ -1651,6 +1653,27 @@ describe("useThreadNavigation", () => {
     await waitFor(() => {
       expect(result.current.selectedThread?.executionMode).toBe("default");
     });
+
+    navigationSnapshot = {
+      ...navigationSnapshot,
+      threads: [
+        {
+          ...navigationSnapshot.threads[0]!,
+          queuedExecutionMode: "full-access" as const,
+          queuedExecutionModeAt: 5_000,
+          permissionTransitionLog: [
+            {
+              id: "permission-transition-1",
+              fromExecutionMode: "default" as const,
+              toExecutionMode: "full-access" as const,
+              status: "queued" as const,
+              occurredAt: 5_000,
+              queueId: "queue-1",
+            },
+          ],
+        },
+      ],
+    };
 
     await act(async () => {
       for (const listener of listeners) {
@@ -1676,6 +1699,30 @@ describe("useThreadNavigation", () => {
       // Applied mode is unchanged while queued.
       expect(result.current.selectedThread?.executionMode).toBe("default");
     });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.permissionTransitionLog).toEqual([
+        {
+          id: "permission-transition-1",
+          fromExecutionMode: "default",
+          toExecutionMode: "full-access",
+          status: "queued",
+          occurredAt: 5_000,
+          queueId: "queue-1",
+        },
+      ]);
+    });
+
+    navigationSnapshot = {
+      ...navigationSnapshot,
+      threads: [
+        {
+          ...navigationSnapshot.threads[0]!,
+          queuedExecutionMode: undefined,
+          queuedExecutionModeAt: undefined,
+        },
+      ],
+    };
 
     await act(async () => {
       for (const listener of listeners) {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -208,6 +208,56 @@ function reactionsEqual(
   );
 }
 
+function permissionTransitionLogsEqual(
+  left: NavigationThreadSummary["permissionTransitionLog"],
+  right: NavigationThreadSummary["permissionTransitionLog"]
+): boolean {
+  const leftLog = left ?? [];
+  const rightLog = right ?? [];
+  if (leftLog.length !== rightLog.length) {
+    return false;
+  }
+
+  return leftLog.every((entry, index) => {
+    const candidate = rightLog[index];
+    return (
+      candidate?.id === entry.id &&
+      candidate.fromExecutionMode === entry.fromExecutionMode &&
+      candidate.toExecutionMode === entry.toExecutionMode &&
+      candidate.status === entry.status &&
+      candidate.occurredAt === entry.occurredAt &&
+      candidate.queueId === entry.queueId &&
+      candidate.note === entry.note
+    );
+  });
+}
+
+function messagingBindingTransitionLogsEqual(
+  left: NavigationThreadSummary["messagingBindingTransitionLog"],
+  right: NavigationThreadSummary["messagingBindingTransitionLog"]
+): boolean {
+  const leftLog = left ?? [];
+  const rightLog = right ?? [];
+  if (leftLog.length !== rightLog.length) {
+    return false;
+  }
+
+  return leftLog.every((entry, index) => {
+    const candidate = rightLog[index];
+    return (
+      candidate?.id === entry.id &&
+      candidate.action === entry.action &&
+      candidate.bindingId === entry.bindingId &&
+      candidate.platform === entry.platform &&
+      candidate.conversationKind === entry.conversationKind &&
+      candidate.conversationTitle === entry.conversationTitle &&
+      candidate.parentTitle === entry.parentTitle &&
+      candidate.ancestorTitle === entry.ancestorTitle &&
+      candidate.occurredAt === entry.occurredAt
+    );
+  });
+}
+
 function threadSummariesEqual(
   left: NavigationThreadSummary,
   right: NavigationThreadSummary
@@ -224,6 +274,8 @@ function threadSummariesEqual(
     left.gitBranch === right.gitBranch &&
     left.observedGitBranch === right.observedGitBranch &&
     left.executionMode === right.executionMode &&
+    left.queuedExecutionMode === right.queuedExecutionMode &&
+    left.queuedExecutionModeAt === right.queuedExecutionModeAt &&
     left.model === right.model &&
     left.reasoningEffort === right.reasoningEffort &&
     left.serviceTier === right.serviceTier &&
@@ -245,7 +297,15 @@ function threadSummariesEqual(
     // the row stay stale until something else triggers a re-render.
     messagingBindingsEqual(left.messagingBindings, right.messagingBindings) &&
     prSummariesEqual(left.prs, right.prs) &&
-    reactionsEqual(left.reactions, right.reactions)
+    reactionsEqual(left.reactions, right.reactions) &&
+    permissionTransitionLogsEqual(
+      left.permissionTransitionLog,
+      right.permissionTransitionLog
+    ) &&
+    messagingBindingTransitionLogsEqual(
+      left.messagingBindingTransitionLog,
+      right.messagingBindingTransitionLog
+    )
   );
 }
 


### PR DESCRIPTION
## Summary

I fixed the desktop renderer navigation reconciler so queued permission audit state is restored when returning to a thread.

The issue was that `useThreadNavigation` reused the previous thread object when only transcript audit fields changed. A queued permission transition could be persisted and present in the fresh navigation snapshot, but the selected thread still pointed at an older object until a later turn-completion update changed another field.

## Changes

- Compare queued permission fields during thread summary reconciliation.
- Compare `permissionTransitionLog` and `messagingBindingTransitionLog` so synthetic transcript entries refresh immediately.
- Added regression coverage for a queued permission event followed by a refreshed snapshot containing the queued audit log.

## Verification

I verified this locally:

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm typecheck`
- `git diff --check`
