### PR TITLE
fix(deps): allow electron install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
+          node-version: 24.x
           lookup-only: "true"
 
   lint:
@@ -40,6 +41,8 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
+        with:
+          node-version: 24.x
 
       - name: License metadata
         timeout-minutes: 10
@@ -80,6 +83,8 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
+        with:
+          node-version: 24.x
 
       - name: Build
         timeout-minutes: 10
@@ -97,6 +102,8 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
+        with:
+          node-version: 24.x
 
       - name: Install ripgrep
         uses: ./.github/actions/install-ripgrep
@@ -119,6 +126,8 @@ jobs:
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
+        with:
+          node-version: 24.x
 
       - name: Run desktop replay-backed Electron tests
         timeout-minutes: 10
@@ -205,6 +214,8 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
+        with:
+          node-version: 24.x
 
       - name: Install ripgrep
         if: steps.changes.outputs.relevant == 'true'

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        with:
+          node-version: 24.x
 
       - name: Compute preview version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        with:
+          node-version: 24.x
 
       - name: Check release metadata
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=false

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,45 @@
+'use strict'
+
+const dependencyFields = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+]
+
+const gitSpecPattern = /^(?:git(?:\+|:)|git@|ssh:\/\/git@|github:|gitlab:|bitbucket:|https?:\/\/(?:www\.)?(?:github|gitlab|bitbucket)\.com\/|[^/@\s]+\/[^/\s]+(?:#.*)?$)/
+
+function isGitSpec(spec) {
+  return typeof spec === 'string' && gitSpecPattern.test(spec)
+}
+
+function readPackage(pkg) {
+  for (const field of dependencyFields) {
+    const dependencies = pkg[field]
+    if (!dependencies) continue
+
+    for (const [name, spec] of Object.entries(dependencies)) {
+      if (isGitSpec(spec)) {
+        throw new Error(`Blocked git dependency ${name}@${spec}`)
+      }
+    }
+  }
+
+  return pkg
+}
+
+function blockGitFetcher() {
+  return async () => {
+    throw new Error('Blocked pnpm git dependency fetch')
+  }
+}
+
+module.exports = {
+  hooks: {
+    readPackage,
+    fetchers: {
+      git: blockGitFetcher,
+      gitHostedTarball: blockGitFetcher,
+    },
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+pnpmfileChecksum: sha256-qhUjtdsDx+KID8QibUkWT/nJBDVb/TMK08fsoGdLy78=
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,14 +3,7 @@ packages:
   - packages/*
   - packages/messaging/*
   - packages/messaging/providers/*
-allowBuilds:
-  b: true
-  better-sqlite3: true
-  d: true
-  e: true
-  electron: true
-  esbuild: true
-  i: true
-  l: true
-  s: true
-  u: true
+onlyBuiltDependencies:
+  - better-sqlite3
+  - electron
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,11 @@ packages:
   - packages/*
   - packages/messaging/*
   - packages/messaging/providers/*
+globalPnpmfile: ''
+ignoreScripts: false
+ignoredBuiltDependencies:
+  - electron-winstaller
+  - protobufjs
 onlyBuiltDependencies:
   - better-sqlite3
   - electron


### PR DESCRIPTION
## Summary

- I cherry-picked `8752dfec` to allow install scripts in pnpm again.
- I replaced the malformed `allowBuilds` map with `onlyBuiltDependencies` for `better-sqlite3`, `electron`, and `esbuild`.
- I pinned every `pwrdrvr/configure-nodejs@v1` workflow use to `node-version: 24.x` so CI, preview, and release jobs use the GitHub Actions Node 24 line instead of the action's Node 22 default.
- I made the workspace pnpm config self-contained so local `~/.npmrc` settings for ignored scripts and strict build handling do not leave Electron half-installed.
- I moved the git-dependency blocking pnpmfile policy into a repo-owned `.pnpmfile.cjs` and captured its stable `pnpmfileChecksum` in the lockfile.

## Verification

- I removed every `node_modules` directory and ran plain `pnpm i`; it completed without manual repair.
- I verified the desktop workspace resolves Electron from this worktree and that `electron/path.txt` points at the local Electron app.
- I started `pnpm --filter @pwragent/desktop dev -- --disable-messaging` with `NODE_PATH` and `ELECTRON_EXEC_PATH` unset; it built, started Vite, and launched Electron without the `Electron uninstall` error.
- I reproduced the GitHub Actions install environment with Linux + Node 24.14.1 and verified `pnpm install --frozen-lockfile` succeeds there with the captured pnpmfile checksum, including the Electron install script.
- I parsed the changed workflow YAML files with Ruby's YAML parser.

## Notes

- The branch now includes the cherry-picked dependency-script policy change, the workflow Node 24 override needed for `configure-nodejs`, and local pnpm hardening for clean installs.
- The repo-owned pnpmfile avoids relying on a developer-specific global pnpmfile while still keeping the lockfile checksum explicit and stable.
