### PR TITLE
ci: cap workflow steps and pin ripgrep install

### DIFF
--- a/.github/actions/install-ripgrep/action.yml
+++ b/.github/actions/install-ripgrep/action.yml
@@ -1,0 +1,36 @@
+name: Install ripgrep
+description: Install a pinned ripgrep binary from the official release archive.
+
+runs:
+  using: composite
+  steps:
+    - name: Download ripgrep
+      shell: bash
+      env:
+        RIPGREP_VERSION: "15.1.0"
+        RIPGREP_SHA256: "1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599"
+      run: |
+        set -euo pipefail
+
+        platform="x86_64-unknown-linux-musl"
+        archive="$RUNNER_TEMP/ripgrep.tar.gz"
+        install_root="$RUNNER_TEMP/ripgrep"
+        url="https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-${platform}.tar.gz"
+
+        rm -rf "$install_root"
+        mkdir -p "$install_root"
+
+        curl --fail --show-error --location \
+          --connect-timeout 15 \
+          --max-time 120 \
+          --retry 3 \
+          --retry-delay 2 \
+          --retry-connrefused \
+          --output "$archive" \
+          "$url"
+
+        printf "%s  %s\n" "$RIPGREP_SHA256" "$archive" | sha256sum --check -
+        tar -xzf "$archive" --strip-components=1 --directory "$install_root"
+
+        echo "$install_root" >> "$GITHUB_PATH"
+        "$install_root/rg" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
         with:
           lookup-only: "true"
 
@@ -33,11 +35,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
 
       - name: License metadata
+        timeout-minutes: 10
         run: |
           if ! pnpm licenses:check; then
             echo "License check failed; forcing pnpm to relink dependencies before retrying."
@@ -46,9 +51,11 @@ jobs:
           fi
 
       - name: Type check
+        timeout-minutes: 10
         run: pnpm typecheck
 
       - name: Dependency boundaries
+        timeout-minutes: 10
         run: |
           pnpm exec depcruise --config .dependency-cruiser.cjs \
             --output-type json --output-to cruise-result.json \
@@ -57,6 +64,7 @@ jobs:
 
       - name: Boundary violation summary
         if: failure()
+        timeout-minutes: 10
         run: |
           pnpm exec depcruise-fmt -T markdown cruise-result.json >> "$GITHUB_STEP_SUMMARY"
 
@@ -67,11 +75,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
 
       - name: Build
+        timeout-minutes: 10
         run: pnpm run build
 
   test:
@@ -81,14 +92,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        uses: ./.github/actions/install-ripgrep
+        timeout-minutes: 5
 
       - name: Test
+        timeout-minutes: 10
         run: pnpm run test
 
   desktop-e2e:
@@ -99,16 +114,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
 
       - name: Install Node.js and dependencies
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
 
       - name: Run desktop replay-backed Electron tests
+        timeout-minutes: 10
         run: xvfb-run --auto-servernum pnpm run test:desktop-e2e
 
       - name: Upload desktop Playwright artifacts
         uses: actions/upload-artifact@v5
         if: ${{ !cancelled() }}
+        timeout-minutes: 10
         with:
           name: desktop-e2e-artifacts
           path: |
@@ -124,12 +143,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        timeout-minutes: 10
         with:
           fetch-depth: 0
 
       - name: Detect live agent-core inputs
         id: changes
         shell: bash
+        timeout-minutes: 10
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -183,13 +204,16 @@ jobs:
       - name: Install Node.js and dependencies
         if: steps.changes.outputs.relevant == 'true'
         uses: pwrdrvr/configure-nodejs@v1
+        timeout-minutes: 10
 
       - name: Install ripgrep
         if: steps.changes.outputs.relevant == 'true'
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        uses: ./.github/actions/install-ripgrep
+        timeout-minutes: 5
 
       - name: Live agent-core smoke and tool coverage
         if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 10
         env:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           XAI_BASE_URL: https://api.x.ai/v1


### PR DESCRIPTION
## Summary

- I capped CI workflow steps so no individual step can run past 10 minutes, with ripgrep installation capped at 5 minutes.
- I replaced the apt-based ripgrep install with a local composite action that downloads the pinned official ripgrep 15.1.0 Linux musl archive, verifies its SHA256, and adds `rg` to `PATH`.
- I updated both CI ripgrep install sites to use the shared action instead of `sudo apt-get update && sudo apt-get install -y ripgrep`.

## Verification

- I verified the workflow and composite-action YAML parses locally.
- I verified the embedded composite-action shell script with `bash -n`.
- I downloaded the official ripgrep archive, verified the pinned SHA256 locally, and confirmed the archive contains the Linux `rg` binary.

## Notes

- The local Linux `rg` binary smoke execution cannot run on this macOS host; `file` confirms it is the expected x86-64 ELF binary for the Ubuntu runner.
