### PR TITLE
fix(desktop): brighten thread menu hover state

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -233,6 +233,12 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps thread context menu hover states visible", () => {
+    expect(css).toMatch(
+      /\.thread-context-menu button:hover,\s*\.thread-context-menu button:focus-visible\s*\{[\s\S]*?background:\s*var\(--accent-soft\);[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/
+    );
+  });
+
   it("keeps composer autocomplete visually separated from transcript surfaces", () => {
     const autocompleteRule = extractRuleBody(css, ".composer__autocomplete");
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2310,7 +2310,9 @@ textarea,
 
 .thread-context-menu button:hover,
 .thread-context-menu button:focus-visible {
-  background: var(--bg-panel-hover);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
 }
 
 .thread-context-menu__separator {


### PR DESCRIPTION
## Summary

- Make thread list context menu hover and keyboard-focus states visibly highlight the active menu item.
- Use the existing accent hover treatment already used by other desktop popovers.
- Add a theme contract test so the hover state does not regress back to an indistinct panel color.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`; it passed with 1 file and 19 tests.

## Notes

- This PR intentionally excludes the pnpm/Electron install-script config change; that is being handled on a different branch.
