### PR TITLE
fix(deps): add pnpm release cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
   - packages/messaging/*
   - packages/messaging/providers/*
+minimumReleaseAge: 10080
 globalPnpmfile: ''
 ignoreScripts: false
 ignoredBuiltDependencies:


### PR DESCRIPTION
## Summary
- add a repo-level pnpm 7-day release cooldown via `minimumReleaseAge: 10080`
- ensures machines without stricter global pnpm config still wait before accepting newly published packages

## Verification
- `/Users/huntharo/.nvm/versions/node/v24.14.1/bin/pnpm config get minimumReleaseAge --location project` -> `10080`
