### PR TITLE
fix(desktop): persist registered project directories

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1429,6 +1429,38 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("marks picked project directories as registered launchpads", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const opened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      registeredAt: 12_345,
+    });
+
+    expect(opened.launchpad.registeredAt).toBe(12_345);
+    await expect(
+      overlayStore.getDirectoryLaunchpad({ directoryKey: "directory:/repo-a" }),
+    ).resolves.toMatchObject({
+      directoryKey: "directory:/repo-a",
+      registeredAt: 12_345,
+      prompt: "",
+    });
+
+    await registry.close();
+  });
+
   it("keeps launchpad directory metadata when the first draft update arrives", async () => {
     const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
@@ -68,6 +68,8 @@ function buildEnsureSpy() {
       directoryLabel: string;
       directoryPath: string;
       currentBranch?: string;
+      preferredBackend?: "codex" | "grok";
+      registeredAt?: number;
     }) => Promise<EnsureDirectoryLaunchpadResponse>
   >(async (request) => {
     return {
@@ -77,6 +79,7 @@ function buildEnsureSpy() {
         directoryLabel: request.directoryLabel,
         directoryPath: request.directoryPath,
         branchName: request.currentBranch,
+        registeredAt: request.registeredAt,
       },
       defaults: sampleDefaults,
     };
@@ -127,7 +130,9 @@ describe("registerDirectoryFromDisk", () => {
       directoryPath: "/Users/huntharo/code/PwrAgent",
       currentBranch: "main",
       preferredBackend: undefined,
+      registeredAt: expect.any(Number),
     });
+    expect(result.launchpad.registeredAt).toEqual(expect.any(Number));
   });
 
   it("normalizes symlinked roots via `git rev-parse --show-toplevel`", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2946,6 +2946,7 @@ export class DesktopBackendRegistry {
       request.preferredBackend,
     );
     if (existing) {
+      const registeredAt = existing.registeredAt ?? request.registeredAt;
       const backend = await this.resolveLaunchpadBackend(existing.backend);
       const modelSettings = await this.resolveLaunchpadModelSettings(
         backend,
@@ -2980,6 +2981,7 @@ export class DesktopBackendRegistry {
           fastMode: defaults.fastMode,
           workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
+          registeredAt,
           updatedAt: Date.now(),
         };
         return {
@@ -2995,7 +2997,8 @@ export class DesktopBackendRegistry {
         normalizedExisting.model !== existing.model ||
         normalizedExisting.reasoningEffort !== existing.reasoningEffort ||
         normalizedExisting.serviceTier !== existing.serviceTier ||
-        normalizedExisting.fastMode !== existing.fastMode
+        normalizedExisting.fastMode !== existing.fastMode ||
+        registeredAt !== existing.registeredAt
       ) {
         return {
           launchpad: await this.overlayStore.upsertDirectoryLaunchpad({
@@ -3003,6 +3006,7 @@ export class DesktopBackendRegistry {
             directoryKind: request.directoryKind,
             directoryLabel: request.directoryLabel,
             directoryPath: request.directoryPath,
+            registeredAt,
             updatedAt: Date.now(),
           }),
           defaults,
@@ -3027,6 +3031,7 @@ export class DesktopBackendRegistry {
       serviceTier: defaults.serviceTier,
       fastMode: defaults.fastMode,
       prompt: "",
+      registeredAt: request.registeredAt,
       workMode: defaultLaunchpadWorkMode(request, defaults),
       branchName: request.currentBranch,
       createdAt: Date.now(),

--- a/apps/desktop/src/main/app-server/directory-registration-service.ts
+++ b/apps/desktop/src/main/app-server/directory-registration-service.ts
@@ -40,6 +40,7 @@ export type DirectoryRegistrationDeps = {
     directoryPath: string;
     currentBranch?: string;
     preferredBackend?: AppServerBackendKind;
+    registeredAt?: number;
   }) => Promise<EnsureDirectoryLaunchpadResponse>;
   /** Test seam — defaults to a real `git` execFile invocation. */
   runGit?: (cwd: string, args: string[]) => Promise<string>;
@@ -169,6 +170,7 @@ export async function registerDirectoryFromDisk(
     directoryPath: repoRoot,
     currentBranch,
     preferredBackend: request.preferredBackend,
+    registeredAt: Date.now(),
   });
 
   return {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2033,6 +2033,87 @@ describe("useThreadNavigation", () => {
       };
     }
 
+    it("keeps newly registered directories sorted by label", async () => {
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/Users/me/repos/kube-manifests",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: true as const,
+        directoryPath: "/Users/me/repos/kube-manifests",
+        directoryKey: "directory:/Users/me/repos/kube-manifests",
+        directoryLabel: "kube-manifests",
+        currentBranch: "main",
+        launchpad: {
+          directoryKey: "directory:/Users/me/repos/kube-manifests",
+          directoryKind: "directory" as const,
+          directoryLabel: "kube-manifests",
+          directoryPath: "/Users/me/repos/kube-manifests",
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          workMode: "local" as const,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        defaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      }));
+      const getNavigationSnapshot = vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [],
+        directories: [
+          {
+            key: "directory:/Users/me/repos/web-app",
+            kind: "directory" as const,
+            label: "web-app",
+            path: "/Users/me/repos/web-app",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+          {
+            key: "directory:/Users/me/repos/infra",
+            kind: "directory" as const,
+            label: "infra",
+            path: "/Users/me/repos/infra",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      }));
+
+      const desktopApi = buildBaseDesktopApi({
+        getNavigationSnapshot,
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.pickAndRegisterDirectory();
+      });
+
+      expect(result.current.directories.map((directory) => directory.label)).toEqual([
+        "infra",
+        "kube-manifests",
+        "web-app",
+      ]);
+      expect(result.current.selectedItemKey).toBe(
+        "launchpad:directory:/Users/me/repos/kube-manifests",
+      );
+    });
+
     it("seeds the launchpad and focuses it on a successful pick", async () => {
       const pickDirectoryFromDisk = vi.fn(async () => ({
         canceled: false as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -50,6 +50,20 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
   return selectionKey.slice("launchpad:".length);
 }
 
+function compareNavigationDirectoriesByLabel(
+  left: NavigationDirectorySummary,
+  right: NavigationDirectorySummary
+): number {
+  const labelDelta = left.label.localeCompare(right.label);
+  return labelDelta !== 0 ? labelDelta : left.key.localeCompare(right.key);
+}
+
+function sortNavigationDirectories(
+  directories: NavigationSnapshot["directories"]
+): NavigationSnapshot["directories"] {
+  return [...directories].sort(compareNavigationDirectoriesByLabel);
+}
+
 function formatArchiveCleanupFailure(
   cleanup: ArchiveThreadCleanupResult[]
 ): string | undefined {
@@ -814,20 +828,22 @@ function applyLaunchpadUpdate(
 
   return {
     ...snapshot,
-    directories: foundDirectory
-      ? directories
-      : [
-          {
-            key: launchpad.directoryKey,
-            kind: launchpad.directoryKind,
-            label: launchpad.directoryLabel,
-            path: launchpad.directoryPath,
-            threadKeys: [],
-            needsAttentionCount: 0,
-            launchpad,
-          },
-          ...directories,
-        ],
+    directories: sortNavigationDirectories(
+      foundDirectory
+        ? directories
+        : [
+            ...directories,
+            {
+              key: launchpad.directoryKey,
+              kind: launchpad.directoryKind,
+              label: launchpad.directoryLabel,
+              path: launchpad.directoryPath,
+              threadKeys: [],
+              needsAttentionCount: 0,
+              launchpad,
+            },
+          ],
+    ),
     launchpadDefaults: defaults,
   };
 }
@@ -907,7 +923,7 @@ function projectOptimisticThreadIntoDirectories(
     changed = true;
   }
 
-  return changed ? nextDirectories : directories;
+  return changed ? sortNavigationDirectories(nextDirectories) : directories;
 }
 
 function hasSelectionKey(

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -244,6 +244,39 @@ describe("buildDirectorySummaries", () => {
     expect(directories).toEqual([]);
   });
 
+  it("keeps explicitly registered directories even when their launchpad is empty", () => {
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "directory:/Users/huntharo/pwrdrvr/PwrAgent": {
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          registeredAt: 1_500,
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        launchpad: expect.objectContaining({
+          prompt: "",
+          registeredAt: 1_500,
+        }),
+      }),
+    ]);
+  });
+
   it("keeps launchpads with user-touched settings even when the prompt is empty", () => {
     const directories = buildDirectorySummaries({
       threads: [],

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -182,6 +182,7 @@ function hasPersistableLaunchpadState(
   return (
     launchpad.prompt.trim().length > 0 ||
     (launchpad.imageAttachments?.length ?? 0) > 0 ||
+    launchpad.registeredAt !== undefined ||
     launchpad.settingsTouchedAt !== undefined
   );
 }

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -338,6 +338,7 @@ export function buildNavigationSnapshotHash(params: {
             })),
             workMode: directory.launchpad.workMode,
             branchName: directory.launchpad.branchName ?? null,
+            registeredAt: directory.launchpad.registeredAt ?? null,
             settingsTouchedAt: directory.launchpad.settingsTouchedAt ?? null,
             updatedAt: directory.launchpad.updatedAt,
           }

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -360,6 +360,10 @@ export function migrateOverlayStoreData(raw: unknown): OverlayStoreData {
               typeof launchpadRecord.settingsTouchedAt === "number"
                 ? launchpadRecord.settingsTouchedAt
                 : undefined,
+            registeredAt:
+              typeof launchpadRecord.registeredAt === "number"
+                ? launchpadRecord.registeredAt
+                : undefined,
             createdAt:
               typeof launchpadRecord.createdAt === "number"
                 ? launchpadRecord.createdAt

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -224,6 +224,7 @@ export type EnsureDirectoryLaunchpadRequest = {
   directoryPath?: string;
   currentBranch?: string;
   preferredBackend?: AppServerBackendKind;
+  registeredAt?: number;
 };
 
 export type EnsureDirectoryLaunchpadResponse = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -158,6 +158,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   editorDocument?: Record<string, unknown>;
   imageAttachments?: NavigationLaunchpadImageAttachment[];
   prompt: string;
+  registeredAt?: number;
   settingsTouchedAt?: number;
   workMode: LaunchpadWorkMode;
   branchName?: string;


### PR DESCRIPTION
## Summary
- Persist project directories added from the new-thread picker by marking their launchpad rows as explicitly registered.
- Keep registered empty launchpads in directory navigation on startup while still filtering transient opened-only launchpads.
- Sort locally inserted directory rows by label so new additions match the backend snapshot order immediately.

## Verification
- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/main/__tests__/directory-registration-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`