### PR TITLE
fix(desktop): avoid stale PR chips on detached worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -83,6 +83,42 @@ describe("detectPullRequestsForThread", () => {
     expect(fetchedBranches).toEqual(["main"]);
     expect(prs).toEqual([]);
   });
+
+  it("preserves feature branch lookup when fallback default candidates are not at HEAD", async () => {
+    const repo = await createDetachedRepoWithDevelopAndFeatureAtHead(
+      "fix/detached-feature-pr",
+    );
+    const fetchedBranches: string[] = [];
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
+        fetchedBranches.push(branch);
+        if (branch !== "fix/detached-feature-pr") {
+          return [];
+        }
+        return [
+          {
+            number: 393,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/393",
+          },
+        ];
+      }),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "HEAD",
+      directoryPaths: [repo],
+    });
+
+    expect(fetchedBranches).toEqual(
+      expect.arrayContaining(["develop", "fix/detached-feature-pr"]),
+    );
+    expect(fetchedBranches).not.toEqual(["develop"]);
+    expect(prs).toHaveLength(1);
+  });
 });
 
 async function createDetachedRepoWithFeatureBranchAtHead(
@@ -112,6 +148,23 @@ async function createDetachedRepoWithDefaultAndStaleBranchAtHead(
   await git(repo, "commit", "--allow-empty", "-m", "initial");
   const sha = (await git(repo, "rev-parse", "HEAD")).trim();
   await git(repo, "branch", branch, sha);
+  await git(repo, "checkout", "--detach", sha);
+  return repo;
+}
+
+async function createDetachedRepoWithDevelopAndFeatureAtHead(
+  branch: string,
+): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
+  tempDirs.push(repo);
+  await git(repo, "init", "-b", "main");
+  await git(repo, "config", "user.email", "test@example.com");
+  await git(repo, "config", "user.name", "PwrAgent Test");
+  await git(repo, "commit", "--allow-empty", "-m", "initial");
+  const sha = (await git(repo, "rev-parse", "HEAD")).trim();
+  await git(repo, "branch", "develop", sha);
+  await git(repo, "branch", branch, sha);
+  await git(repo, "commit", "--allow-empty", "-m", "move main forward");
   await git(repo, "checkout", "--detach", sha);
   return repo;
 }

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -17,7 +17,9 @@ afterEach(async () => {
 
 describe("detectPullRequestsForThread", () => {
   it("uses local branches pointing at HEAD when the thread is detached", async () => {
-    const repo = await createDetachedRepoWithBranchAtHead("fix/messaging-nonblocking-startup");
+    const repo = await createDetachedRepoWithFeatureBranchAtHead(
+      "fix/messaging-nonblocking-startup",
+    );
     const fetchedBranches: string[] = [];
     const fetcher = {
       fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
@@ -48,12 +50,63 @@ describe("detectPullRequestsForThread", () => {
     );
     expect(prs).toHaveLength(1);
   });
+
+  it("does not inherit stale PR branches when a detached thread is at the default branch tip", async () => {
+    const repo = await createDetachedRepoWithDefaultAndStaleBranchAtHead(
+      "fix/sidebar-tooltips",
+    );
+    const fetchedBranches: string[] = [];
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
+        fetchedBranches.push(branch);
+        if (branch !== "fix/sidebar-tooltips") {
+          return [];
+        }
+        return [
+          {
+            number: 317,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "merged",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/317",
+          },
+        ];
+      }),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "HEAD",
+      directoryPaths: [repo],
+    });
+
+    expect(fetchedBranches).toEqual(["main"]);
+    expect(prs).toEqual([]);
+  });
 });
 
-async function createDetachedRepoWithBranchAtHead(branch: string): Promise<string> {
+async function createDetachedRepoWithFeatureBranchAtHead(
+  branch: string,
+): Promise<string> {
   const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
   tempDirs.push(repo);
-  await git(repo, "init");
+  await git(repo, "init", "-b", "main");
+  await git(repo, "config", "user.email", "test@example.com");
+  await git(repo, "config", "user.name", "PwrAgent Test");
+  await git(repo, "commit", "--allow-empty", "-m", "initial");
+  const sha = (await git(repo, "rev-parse", "HEAD")).trim();
+  await git(repo, "branch", branch, sha);
+  await git(repo, "commit", "--allow-empty", "-m", "move main forward");
+  await git(repo, "checkout", "--detach", sha);
+  return repo;
+}
+
+async function createDetachedRepoWithDefaultAndStaleBranchAtHead(
+  branch: string,
+): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
+  tempDirs.push(repo);
+  await git(repo, "init", "-b", "main");
   await git(repo, "config", "user.email", "test@example.com");
   await git(repo, "config", "user.name", "PwrAgent Test");
   await git(repo, "commit", "--allow-empty", "-m", "initial");

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -69,6 +69,10 @@ async function resolvePrLookupBranches(params: {
   }
 
   const branchesAtHead = await readLocalBranchesPointingAtHead(params.cwd);
+  const defaultBranch = await readDefaultBranch(params.cwd);
+  if (defaultBranch && branchesAtHead.includes(defaultBranch)) {
+    return [defaultBranch];
+  }
   return branchesAtHead.length > 0 ? branchesAtHead : ["HEAD"];
 }
 
@@ -97,6 +101,44 @@ async function readLocalBranchesPointingAtHead(cwd: string): Promise<string[]> {
     );
   } catch {
     return [];
+  }
+}
+
+async function readDefaultBranch(cwd: string): Promise<string | undefined> {
+  const remoteHead = await readGitLine(cwd, [
+    "symbolic-ref",
+    "refs/remotes/origin/HEAD",
+    "--short",
+  ]);
+  const normalizedRemoteHead = remoteHead?.replace(/^origin\//, "").trim();
+  if (normalizedRemoteHead) {
+    return normalizedRemoteHead;
+  }
+
+  const branches = await readGitLine(cwd, [
+    "for-each-ref",
+    "--format=%(refname:short)",
+    "refs/heads/main",
+    "refs/heads/master",
+    "refs/heads/develop",
+    "refs/heads/trunk",
+  ]);
+  return branches?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+}
+
+async function readGitLine(
+  cwd: string,
+  args: string[],
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      maxBuffer: 64 * 1024,
+      timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
+    });
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -8,6 +8,12 @@ import type { GithubPrFetcher } from "./github-pr-fetcher";
 
 const execFileAsync = promisify(execFile);
 const GIT_BRANCH_LOOKUP_TIMEOUT_MS = 2_000;
+const FALLBACK_DEFAULT_BRANCHES = [
+  "main",
+  "master",
+  "develop",
+  "trunk",
+] as const;
 
 /**
  * Detect PRs for a single thread by walking the resolved directory paths
@@ -115,15 +121,17 @@ async function readDefaultBranch(cwd: string): Promise<string | undefined> {
     return normalizedRemoteHead;
   }
 
-  const branches = await readGitLine(cwd, [
-    "for-each-ref",
-    "--format=%(refname:short)",
-    "refs/heads/main",
-    "refs/heads/master",
-    "refs/heads/develop",
-    "refs/heads/trunk",
-  ]);
-  return branches?.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+  for (const branch of FALLBACK_DEFAULT_BRANCHES) {
+    const localBranch = await readGitLine(cwd, [
+      "for-each-ref",
+      "--format=%(refname:short)",
+      `refs/heads/${branch}`,
+    ]);
+    if (localBranch === branch) {
+      return branch;
+    }
+  }
+  return undefined;
 }
 
 async function readGitLine(


### PR DESCRIPTION
## Summary

I fixed detached-HEAD PR detection so a new thread at the default branch tip does not inherit a stale PR chip from another local branch that happens to point at the same commit.

The fix now resolves the repository default branch when the observed branch is `HEAD`. If detached `HEAD` is also the default branch tip, PR lookup only queries the default branch instead of every local branch at that commit. Detached feature-branch worktrees still fall back to local branches pointing at `HEAD`.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts`
- `git diff --check`

`pnpm --filter @pwragent/desktop typecheck` could not run in this worktree because local `node_modules` are missing; pnpm reported missing `node` and `vitest/globals` types.
