### PR TITLE
fix(desktop): show full codex account email

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -680,7 +680,7 @@ function formatBackendAccountText(
   account: NonNullable<BackendSummary["account"]>
 ): string {
   if (account.type === "chatgpt" && account.email?.trim()) {
-    return formatMaskedEmail(account.email);
+    return account.email.trim();
   }
   if (account.type === "apiKey") {
     return "API key";
@@ -692,16 +692,6 @@ function formatBackendAccountText(
     return "Not signed in";
   }
   return "Unknown";
-}
-
-function formatMaskedEmail(email: string): string {
-  const trimmed = email.trim();
-  const atIndex = trimmed.indexOf("@");
-  if (atIndex <= 1) {
-    return trimmed;
-  }
-  const local = trimmed.slice(0, atIndex);
-  return `${local.slice(0, 2)}...${trimmed.slice(atIndex)}`;
 }
 
 function splitRateLimitName(name: string): {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -218,7 +218,7 @@ describe("ThreadView", () => {
     expect(screen.getByRole("heading", { level: 3, name: "Execution context" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Pin context rail" })).toBeInTheDocument();
     expect(screen.getByText("Codex app server")).toBeInTheDocument();
-    expect(screen.getByText("us...@example.com")).toBeInTheDocument();
+    expect(screen.getByText("user@example.com")).toBeInTheDocument();
     expect(screen.getByText("pro")).toBeInTheDocument();
     expect(screen.getByText(/5h limit: 85% left/)).toBeInTheDocument();
     expect(screen.getByText(/Weekly limit: 91% left/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Show the full trimmed ChatGPT account email in the desktop App servers rail instead of masking it.
- Remove the renderer-only email masking helper and update the thread view expectation.
- Leave messaging status account formatting untouched.

## Verification
- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
- pnpm --filter @pwragent/desktop typecheck