### PR TITLE
fix(desktop): refine workspace handoff options

### DIFF
--- a/apps/desktop/e2e/fixtures/workspace-handoff-fixture.ts
+++ b/apps/desktop/e2e/fixtures/workspace-handoff-fixture.ts
@@ -3,6 +3,147 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+function createReplayFixture(params: {
+  fixturePath: string;
+  gitBranch?: string;
+  linkedDirectory: Record<string, unknown>;
+  observedGitBranch?: string;
+  scenario: string;
+  summary: string;
+  threadId: string;
+  title: string;
+}): Promise<void> {
+  return writeFile(
+    params.fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: params.scenario,
+          threadId: params.threadId,
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: params.threadId,
+                title: params.title,
+                titleSource: "explicit",
+                summary: params.summary,
+                source: "codex",
+                executionMode: "default",
+                gitBranch: params.gitBranch ?? "main",
+                observedGitBranch: params.observedGitBranch ?? params.gitBranch ?? "main",
+                linkedDirectories: [params.linkedDirectory],
+                updatedAt: 1_760_000_000_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The workspace handoff replay is loaded.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The workspace handoff replay is loaded.",
+                },
+              ],
+              lastAssistantMessage: "The workspace handoff replay is loaded.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+export async function createLocalHandoffFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+  threadId: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-local-handoff-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const threadId = "thread-local-handoff";
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed handoff fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+  execFileSync("git", ["branch", "release"], { cwd: repoDir, stdio: "ignore" });
+
+  const fixturePath = path.join(rootDir, "local-handoff.fixture.json");
+  await createReplayFixture({
+    fixturePath,
+    linkedDirectory: {
+      id: "fixture-local",
+      label: "FixtureRepo",
+      path: repoDir,
+      kind: "local",
+    },
+    scenario: "local-handoff-dialog",
+    summary: "Move this local checkout into a worktree",
+    threadId,
+    title: "Local handoff thread",
+  });
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    fixturePath,
+    repoDir,
+    threadId,
+  };
+}
+
 export async function createWorktreeHandoffFixture(): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
@@ -39,89 +180,22 @@ export async function createWorktreeHandoffFixture(): Promise<{
   });
 
   const fixturePath = path.join(rootDir, "worktree-handoff.fixture.json");
-  await writeFile(
+  await createReplayFixture({
     fixturePath,
-    JSON.stringify(
-      {
-        metadata: {
-          backend: "codex",
-          scenario: "worktree-handoff-dialog",
-          threadId,
-        },
-        steps: [
-          {
-            id: "initialize-1",
-            kind: "response",
-            method: "initialize",
-            result: {
-              serverInfo: {
-                name: "Replay Codex",
-                version: "1.0.0",
-              },
-              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
-            },
-          },
-          {
-            id: "thread-list-1",
-            kind: "response",
-            method: "thread/list",
-            result: [
-              {
-                id: threadId,
-                title: "Worktree handoff thread",
-                titleSource: "explicit",
-                summary: "Move this worktree back to Local",
-                source: "codex",
-                executionMode: "default",
-                gitBranch: "feature/handoff",
-                observedGitBranch: "feature/handoff",
-                linkedDirectories: [
-                  {
-                    id: "fixture-worktree",
-                    label: "FixtureRepo",
-                    path: repoDir,
-                    worktreePath,
-                    kind: "worktree",
-                  },
-                ],
-                updatedAt: 1_760_000_000_000,
-              },
-            ],
-          },
-          {
-            id: "thread-read-1",
-            kind: "response",
-            method: "thread/read",
-            result: {
-              entries: [
-                {
-                  type: "message",
-                  id: "message-1",
-                  role: "assistant",
-                  text: "The worktree handoff replay is loaded.",
-                },
-              ],
-              messages: [
-                {
-                  id: "message-1",
-                  role: "assistant",
-                  text: "The worktree handoff replay is loaded.",
-                },
-              ],
-              lastAssistantMessage: "The worktree handoff replay is loaded.",
-              pagination: {
-                supportsPagination: false,
-                hasPreviousPage: false,
-              },
-            },
-          },
-        ],
-      },
-      null,
-      2,
-    ),
-    "utf8",
-  );
+    gitBranch: "feature/handoff",
+    linkedDirectory: {
+      id: "fixture-worktree",
+      label: "FixtureRepo",
+      path: repoDir,
+      worktreePath,
+      kind: "worktree",
+    },
+    observedGitBranch: "feature/handoff",
+    scenario: "worktree-handoff-dialog",
+    summary: "Move this worktree back to Local",
+    threadId,
+    title: "Worktree handoff thread",
+  });
 
   return {
     cleanup: async () => {

--- a/apps/desktop/e2e/fixtures/workspace-handoff-fixture.ts
+++ b/apps/desktop/e2e/fixtures/workspace-handoff-fixture.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export async function createWorktreeHandoffFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+  threadId: string;
+  worktreePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-worktree-handoff-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const worktreePath = path.join(rootDir, ".worktrees", "pwragent-feature-handoff");
+  const threadId = "thread-worktree-handoff";
+  await mkdir(repoDir, { recursive: true });
+  await mkdir(path.dirname(worktreePath), { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed handoff fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+  execFileSync("git", ["worktree", "add", "-b", "feature/handoff", worktreePath, "main"], {
+    cwd: repoDir,
+    stdio: "ignore",
+  });
+
+  const fixturePath = path.join(rootDir, "worktree-handoff.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "worktree-handoff-dialog",
+          threadId,
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: threadId,
+                title: "Worktree handoff thread",
+                titleSource: "explicit",
+                summary: "Move this worktree back to Local",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "feature/handoff",
+                observedGitBranch: "feature/handoff",
+                linkedDirectories: [
+                  {
+                    id: "fixture-worktree",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    worktreePath,
+                    kind: "worktree",
+                  },
+                ],
+                updatedAt: 1_760_000_000_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The worktree handoff replay is loaded.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "assistant",
+                  text: "The worktree handoff replay is loaded.",
+                },
+              ],
+              lastAssistantMessage: "The worktree handoff replay is loaded.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    fixturePath,
+    repoDir,
+    threadId,
+    worktreePath,
+  };
+}

--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { createWorktreeHandoffFixture } from "./fixtures/workspace-handoff-fixture";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+test.skip(
+  process.env.PWRAGENT_E2E_INSPECT !== "1",
+  "Set PWRAGENT_E2E_INSPECT=1 through the package script to run this manual inspector.",
+);
+
+test("opens the worktree-to-local handoff dialog until Electron is closed manually", async () => {
+  test.setTimeout(0);
+
+  const fixture = await createWorktreeHandoffFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: {
+      height: 900,
+      width: 1440,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: "Worktree handoff thread" })
+      .click();
+
+    const workspaceMode = app.window.getByLabel("Workspace mode");
+    await workspaceMode.click();
+    await app.window.getByRole("menuitem", { name: "Handoff to Local" }).click();
+
+    const dialog = app.window.getByRole("dialog", { name: "Handoff to Local" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("feature/handoff");
+    await expect(dialog).toContainText("Ignored files are not moved by handoff.");
+
+    console.log(
+      [
+        "",
+        "Worktree-to-Local handoff inspection is ready.",
+        "Take screenshots from the Electron window now.",
+        "Close the Electron window or quit the app to finish this command.",
+        "",
+      ].join("\n"),
+    );
+
+    await Promise.race([
+      app.window.waitForEvent("close", { timeout: 0 }).then(() => undefined),
+      app.electronApp.waitForEvent("close", { timeout: 0 }).then(() => undefined),
+    ]);
+  } finally {
+    await app.close().catch(() => undefined);
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createWorktreeHandoffFixture } from "./fixtures/workspace-handoff-fixture";
+import { createLocalHandoffFixture } from "./fixtures/workspace-handoff-fixture";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 test.skip(
@@ -7,10 +7,10 @@ test.skip(
   "Set PWRAGENT_E2E_INSPECT=1 through the package script to run this manual inspector.",
 );
 
-test("opens the worktree-to-local handoff dialog until Electron is closed manually", async () => {
+test("opens the local-to-worktree handoff dialog until Electron is closed manually", async () => {
   test.setTimeout(0);
 
-  const fixture = await createWorktreeHandoffFixture();
+  const fixture = await createLocalHandoffFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
     windowSize: {
@@ -20,23 +20,22 @@ test("opens the worktree-to-local handoff dialog until Electron is closed manual
   });
 
   try {
-    await app.window
-      .getByRole("button", { name: "Worktree handoff thread" })
-      .click();
+    await app.window.getByRole("button", { name: "Local handoff thread" }).click();
 
     const workspaceMode = app.window.getByLabel("Workspace mode");
     await workspaceMode.click();
-    await app.window.getByRole("menuitem", { name: "Handoff to Local" }).click();
+    await app.window.getByRole("menuitem", { name: "Handoff to New Worktree" }).click();
 
-    const dialog = app.window.getByRole("dialog", { name: "Handoff to Local" });
+    const dialog = app.window.getByRole("dialog", { name: "Handoff to New Worktree" });
     await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText("feature/handoff");
+    await expect(dialog).toContainText("Handoff to Detached HEAD");
+    await expect(dialog).toContainText("main");
     await expect(dialog).toContainText("Ignored files are not moved by handoff.");
 
     console.log(
       [
         "",
-        "Worktree-to-Local handoff inspection is ready.",
+        "Local-to-Worktree handoff inspection is ready.",
         "Take screenshots from the Electron window now.",
         "Close the Electron window or quit the app to finish this command.",
         "",

--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -30,6 +30,10 @@ test("opens the local-to-worktree handoff dialog until Electron is closed manual
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
+    await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
+    await expect(dialog.getByLabel("New branch name")).toHaveValue(
+      "pwragent/main-handoff",
+    );
     await expect(dialog).toContainText("Ignored files are not moved by handoff.");
 
     console.log(

--- a/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.inspect.spec.ts
@@ -30,10 +30,8 @@ test("opens the local-to-worktree handoff dialog until Electron is closed manual
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
-    await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
-    await expect(dialog.getByLabel("New branch name")).toHaveValue(
-      "pwragent/main-handoff",
-    );
+    await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
+    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
     await expect(dialog).toContainText("Ignored files are not moved by handoff.");
 
     console.log(

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { createWorktreeHandoffFixture } from "./fixtures/workspace-handoff-fixture";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+test("centers the worktree-to-local handoff dialog in the window", async () => {
+  const fixture = await createWorktreeHandoffFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: {
+      height: 900,
+      width: 1440,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: "Worktree handoff thread" })
+      .click();
+
+    await app.window.getByLabel("Workspace mode").click();
+    await app.window.getByRole("menuitem", { name: "Handoff to Local" }).click();
+
+    const dialog = app.window.getByRole("dialog", { name: "Handoff to Local" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("feature/handoff");
+
+    const geometry = await dialog.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        dialogCenterX: rect.left + rect.width / 2,
+        viewportCenterX: window.innerWidth / 2,
+        parentTagName: element.parentElement?.parentElement?.tagName,
+      };
+    });
+
+    expect(geometry.parentTagName).toBe("BODY");
+    expect(Math.abs(geometry.dialogCenterX - geometry.viewportCenterX)).toBeLessThanOrEqual(
+      1,
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -1,6 +1,53 @@
-import { expect, test } from "@playwright/test";
-import { createWorktreeHandoffFixture } from "./fixtures/workspace-handoff-fixture";
+import { expect, test, type Locator } from "@playwright/test";
+import {
+  createLocalHandoffFixture,
+  createWorktreeHandoffFixture,
+} from "./fixtures/workspace-handoff-fixture";
 import { launchElectronApp } from "./fixtures/electron-app";
+
+async function expectDialogCentered(dialog: Locator) {
+  const geometry = await dialog.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      dialogCenterX: rect.left + rect.width / 2,
+      viewportCenterX: window.innerWidth / 2,
+      parentTagName: element.parentElement?.parentElement?.tagName,
+    };
+  });
+
+  expect(geometry.parentTagName).toBe("BODY");
+  expect(Math.abs(geometry.dialogCenterX - geometry.viewportCenterX)).toBeLessThanOrEqual(
+    1,
+  );
+}
+
+test("centers the local-to-worktree handoff dialog in the window", async () => {
+  const fixture = await createLocalHandoffFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: {
+      height: 900,
+      width: 1440,
+    },
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "Local handoff thread" }).click();
+
+    await app.window.getByLabel("Workspace mode").click();
+    await app.window.getByRole("menuitem", { name: "Handoff to New Worktree" }).click();
+
+    const dialog = app.window.getByRole("dialog", { name: "Handoff to New Worktree" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Handoff to Detached HEAD");
+    await expect(dialog).toContainText("main");
+
+    await expectDialogCentered(dialog);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
 
 test("centers the worktree-to-local handoff dialog in the window", async () => {
   const fixture = await createWorktreeHandoffFixture();
@@ -24,19 +71,7 @@ test("centers the worktree-to-local handoff dialog in the window", async () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText("feature/handoff");
 
-    const geometry = await dialog.evaluate((element) => {
-      const rect = element.getBoundingClientRect();
-      return {
-        dialogCenterX: rect.left + rect.width / 2,
-        viewportCenterX: window.innerWidth / 2,
-        parentTagName: element.parentElement?.parentElement?.tagName,
-      };
-    });
-
-    expect(geometry.parentTagName).toBe("BODY");
-    expect(Math.abs(geometry.dialogCenterX - geometry.viewportCenterX)).toBeLessThanOrEqual(
-      1,
-    );
+    await expectDialogCentered(dialog);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -42,6 +42,9 @@ test("centers the local-to-worktree handoff dialog in the window", async () => {
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
 
+    await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
+    await expect(dialog.getByLabel("Leave current checkout on")).toHaveValue("HEAD");
+
     await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
     await expect(dialog.getByLabel("New branch name")).toHaveValue(
       "pwragent/main-handoff",

--- a/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-dialog.spec.ts
@@ -42,6 +42,11 @@ test("centers the local-to-worktree handoff dialog in the window", async () => {
     await expect(dialog).toContainText("Handoff to Detached HEAD");
     await expect(dialog).toContainText("main");
 
+    await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
+    await expect(dialog.getByLabel("New branch name")).toHaveValue(
+      "pwragent/main-handoff",
+    );
+
     await expectDialogCentered(dialog);
   } finally {
     await app.close();

--- a/apps/desktop/e2e/workspace-handoff-flows.spec.ts
+++ b/apps/desktop/e2e/workspace-handoff-flows.spec.ts
@@ -1,0 +1,365 @@
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+type WorktreeEntry = {
+  branch?: string;
+  path: string;
+};
+
+type HandoffFixture = {
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+  threadId: string;
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function parseWorktreeList(output: string): WorktreeEntry[] {
+  const entries: WorktreeEntry[] = [];
+  let current: WorktreeEntry | undefined;
+
+  for (const line of output.split("\n")) {
+    if (!line.trim()) {
+      if (current) {
+        entries.push(current);
+      }
+      current = undefined;
+      continue;
+    }
+
+    if (line.startsWith("worktree ")) {
+      if (current) {
+        entries.push(current);
+      }
+      current = { path: line.slice("worktree ".length).trim() };
+      continue;
+    }
+
+    if (current && line.startsWith("branch ")) {
+      current.branch = line
+        .slice("branch ".length)
+        .trim()
+        .replace(/^refs\/heads\//, "");
+    }
+  }
+
+  if (current) {
+    entries.push(current);
+  }
+
+  return entries;
+}
+
+function getWorktrees(repoDir: string): WorktreeEntry[] {
+  return parseWorktreeList(git(repoDir, ["worktree", "list", "--porcelain"]));
+}
+
+function getSecondaryWorktree(repoDir: string): WorktreeEntry {
+  const repoRealPath = realpathSync.native(repoDir);
+  const secondary = getWorktrees(repoDir).find(
+    (entry) => realpathSync.native(entry.path) !== repoRealPath,
+  );
+  if (!secondary) {
+    throw new Error("Expected a secondary worktree to exist.");
+  }
+  return secondary;
+}
+
+async function createHandoffFixture(testId: string): Promise<HandoffFixture> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), `pwragent-handoff-flow-${testId}-`));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  const threadId = `thread-handoff-${testId}`;
+  await mkdir(repoDir, { recursive: true });
+
+  git(repoDir, ["init", "-b", "main"]);
+  git(repoDir, ["config", "user.name", "PwrAgent Tests"]);
+  git(repoDir, ["config", "user.email", "pwragent-tests@example.invalid"]);
+  await writeFile(path.join(repoDir, ".gitignore"), ".worktrees/\n", "utf8");
+  await writeFile(path.join(repoDir, "README.md"), "clean main\n", "utf8");
+  git(repoDir, ["add", "."]);
+  git(repoDir, ["commit", "-m", "initial"]);
+  git(repoDir, ["branch", "release"]);
+  git(repoDir, ["switch", "-c", "feature/handoff"]);
+  await writeFile(path.join(repoDir, "feature.txt"), "feature branch\n", "utf8");
+  git(repoDir, ["add", "feature.txt"]);
+  git(repoDir, ["commit", "-m", "feature"]);
+  await writeFile(path.join(repoDir, "README.md"), `dirty ${testId}\n`, "utf8");
+  await writeFile(path.join(repoDir, "dirty.txt"), `untracked ${testId}\n`, "utf8");
+
+  const fixturePath = path.join(rootDir, "workspace-handoff-flow.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: `workspace-handoff-flow-${testId}`,
+          threadId,
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: threadId,
+                title: `Round trip ${testId}`,
+                titleSource: "explicit",
+                summary: "Exercise workspace handoff against a real git repo",
+                source: "codex",
+                executionMode: "default",
+                gitBranch: "feature/handoff",
+                observedGitBranch: "feature/handoff",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1_760_000_000_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-1",
+                  role: "user",
+                  text: "Move my in-flight repo changes.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-1",
+                  role: "user",
+                  text: "Move my in-flight repo changes.",
+                },
+              ],
+              lastUserMessage: "Move my in-flight repo changes.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    fixturePath,
+    repoDir,
+    threadId,
+  };
+}
+
+async function openLocalHandoffDialog(page: Page, title: string) {
+  await page.getByRole("button", { name: title }).click();
+  await page.getByLabel("Workspace mode").click();
+  await page.getByRole("menuitem", { name: "Handoff to New Worktree" }).click();
+  const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function handoffBackToLocal(page: Page) {
+  await page.getByLabel("Workspace mode").click();
+  await page.getByRole("menuitem", { name: "Handoff to Local" }).click();
+  const dialog = page.getByRole("dialog", { name: "Handoff to Local" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Handoff" }).click();
+  await expect(dialog).toBeHidden();
+}
+
+async function expectDirtyWipAt(workspacePath: string, testId: string): Promise<void> {
+  await expect(readFile(path.join(workspacePath, "README.md"), "utf8")).resolves.toBe(
+    `dirty ${testId}\n`,
+  );
+  await expect(readFile(path.join(workspacePath, "dirty.txt"), "utf8")).resolves.toBe(
+    `untracked ${testId}\n`,
+  );
+}
+
+test.describe("workspace handoff git flows", () => {
+  const cases = [
+    {
+      testId: "detached",
+      configure: async () => undefined,
+      expectedLocalBranchAfterLocalHandoff: "feature/handoff",
+      expectedLocalBranchAfterReturn: "",
+      expectedWorktreeBranch: "",
+    },
+    {
+      testId: "new-branch",
+      configure: async (page: Page) => {
+        const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+        await dialog.getByRole("radio", { name: /Handoff to New Branch/ }).click();
+        await dialog.getByLabel("New branch name").fill("pwragent/e2e-handoff");
+      },
+      expectedLocalBranchAfterLocalHandoff: "feature/handoff",
+      expectedLocalBranchAfterReturn: "pwragent/e2e-handoff",
+      expectedWorktreeBranch: "pwragent/e2e-handoff",
+    },
+    {
+      testId: "move-leave-main",
+      configure: async (page: Page) => {
+        const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+        await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
+        await dialog.getByLabel("Leave current checkout on").selectOption("main");
+      },
+      expectedLocalBranchAfterLocalHandoff: "main",
+      expectedLocalBranchAfterReturn: "feature/handoff",
+      expectedWorktreeBranch: "feature/handoff",
+    },
+    {
+      testId: "move-leave-detached",
+      configure: async (page: Page) => {
+        const dialog = page.getByRole("dialog", { name: "Handoff to New Worktree" });
+        await dialog.getByRole("radio", { name: /Handoff Current Branch/ }).click();
+        await dialog.getByLabel("Leave current checkout on").selectOption("HEAD");
+      },
+      expectedLocalBranchAfterLocalHandoff: "",
+      expectedLocalBranchAfterReturn: "feature/handoff",
+      expectedWorktreeBranch: "feature/handoff",
+    },
+  ];
+
+  for (const handoffCase of cases) {
+    test(`round trips dirty WIP through ${handoffCase.testId}`, async () => {
+      const fixture = await createHandoffFixture(handoffCase.testId);
+      const app = await launchElectronApp({
+        fixturePath: fixture.fixturePath,
+      });
+
+      try {
+        const dialog = await openLocalHandoffDialog(
+          app.window,
+          `Round trip ${handoffCase.testId}`,
+        );
+        await handoffCase.configure(app.window);
+        await dialog.getByRole("button", { name: "Handoff" }).click();
+        await expect(dialog).toBeHidden();
+
+        await expect
+          .poll(() => getWorktrees(fixture.repoDir).length)
+          .toBe(2);
+        const worktree = getSecondaryWorktree(fixture.repoDir);
+        expect(git(fixture.repoDir, ["branch", "--show-current"])).toBe(
+          handoffCase.expectedLocalBranchAfterLocalHandoff,
+        );
+        expect(git(worktree.path, ["branch", "--show-current"])).toBe(
+          handoffCase.expectedWorktreeBranch,
+        );
+        expect(git(fixture.repoDir, ["status", "--porcelain", "--untracked-files=normal"])).toBe(
+          "",
+        );
+        await expectDirtyWipAt(worktree.path, handoffCase.testId);
+
+        await handoffBackToLocal(app.window);
+
+        await expect
+          .poll(async () => await pathExists(worktree.path))
+          .toBe(false);
+        expect(git(fixture.repoDir, ["branch", "--show-current"])).toBe(
+          handoffCase.expectedLocalBranchAfterReturn,
+        );
+        await expectDirtyWipAt(fixture.repoDir, handoffCase.testId);
+      } finally {
+        await app.close();
+        await fixture.cleanup();
+      }
+    });
+  }
+
+  test("blocks handoff back to Local when Local has WIP", async () => {
+    const fixture = await createHandoffFixture("dirty-local");
+    const app = await launchElectronApp({
+      fixturePath: fixture.fixturePath,
+    });
+
+    try {
+      const dialog = await openLocalHandoffDialog(app.window, "Round trip dirty-local");
+      await dialog.getByRole("button", { name: "Handoff" }).click();
+      await expect(dialog).toBeHidden();
+
+      await expect
+        .poll(() => getWorktrees(fixture.repoDir).length)
+        .toBe(2);
+      const worktree = getSecondaryWorktree(fixture.repoDir);
+      await writeFile(path.join(fixture.repoDir, "local-wip.txt"), "local only\n", "utf8");
+      await writeFile(path.join(worktree.path, "worktree-wip.txt"), "worktree only\n", "utf8");
+
+      await app.window.getByLabel("Workspace mode").click();
+      await app.window.getByRole("menuitem", { name: "Handoff to Local" }).click();
+      const returnDialog = app.window.getByRole("dialog", { name: "Handoff to Local" });
+      await expect(returnDialog).toBeVisible();
+      await returnDialog.getByRole("button", { name: "Handoff" }).click();
+
+      await expect(returnDialog).toContainText(
+        "Local has dirty tracked or untracked changes",
+      );
+      expect(await pathExists(worktree.path)).toBe(true);
+      await expect(readFile(path.join(fixture.repoDir, "local-wip.txt"), "utf8")).resolves.toBe(
+        "local only\n",
+      );
+      await expect(readFile(path.join(worktree.path, "worktree-wip.txt"), "utf8")).resolves.toBe(
+        "worktree only\n",
+      );
+      expect(git(fixture.repoDir, ["stash", "list"])).toBe("");
+    } finally {
+      await app.close();
+      await fixture.cleanup();
+    }
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
     "preview": "electron-vite preview",
     "test:e2e": "playwright test -c playwright.config.ts",
     "inspect:e2e:branch-drift": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/thread-branch-drift.inspect.spec.ts --headed --timeout=0",
+    "inspect:e2e:workspace-handoff": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/workspace-handoff-dialog.inspect.spec.ts --headed --timeout=0",
     "inspect:e2e:markdown-table": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/markdown-findings-table.inspect.spec.ts --headed --timeout=0",
     "screenshot:readme": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_SCREENSHOT_CAPTURE=1 playwright test -c playwright.config.ts e2e/readme-screenshots.inspect.spec.ts --headed",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -344,7 +344,7 @@ describe("GitWorkspaceHandoffService", () => {
     );
   });
 
-  it("protects dirty local changes separately when moving a worktree branch to local", async () => {
+  it("rejects moving a worktree branch to local when local has dirty changes", async () => {
     const repoPath = await createRepo();
     await git(repoPath, ["switch", "main"]);
     await writeFile(path.join(repoPath, "local-only.txt"), "local dirty\n", "utf8");
@@ -352,22 +352,25 @@ describe("GitWorkspaceHandoffService", () => {
     await git(repoPath, ["worktree", "add", worktreePath, "feature/handoff"]);
 
     const service = new GitWorkspaceHandoffService();
-    const result = await service.handoff({
-      backend: "codex",
-      threadId: "thread-1",
-      direction: "worktree-to-local",
-      repositoryPath: repoPath,
-      sourcePath: worktreePath,
-      sourceBranch: "feature/handoff",
-      now: 3000,
-    });
+    await expect(
+      service.handoff({
+        backend: "codex",
+        threadId: "thread-1",
+        direction: "worktree-to-local",
+        repositoryPath: repoPath,
+        sourcePath: worktreePath,
+        sourceBranch: "feature/handoff",
+        now: 3000,
+      }),
+    ).rejects.toThrow(/Local has dirty tracked or untracked changes/);
 
-    expect(result.destinationStash).toMatchObject({
-      applied: false,
-      dropped: false,
-    });
-    expect(await pathExists(path.join(repoPath, "local-only.txt"))).toBe(false);
-    expect(await git(repoPath, ["stash", "list"])).toContain("destination");
+    expect(await pathExists(worktreePath)).toBe(true);
+    expect(await pathExists(path.join(repoPath, "local-only.txt"))).toBe(true);
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("main");
+    expect(await git(worktreePath, ["branch", "--show-current"])).toBe(
+      "feature/handoff",
+    );
+    expect(await git(repoPath, ["stash", "list"])).toBe("");
   });
 
   it("fails before stashing when the target branch is checked out in another worktree", async () => {

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -217,6 +217,34 @@ describe("GitWorkspaceHandoffService", () => {
     expect(await git(repoPath, ["status", "--porcelain", "--untracked-files=normal"])).toBe("");
   });
 
+  it("preserves a valid requested new branch name without sanitizing it", async () => {
+    const repoPath = await createRepo();
+    const requestedBranchName = "feature/foo+bar";
+    await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "new-branch",
+      newBranchName: ` ${requestedBranchName} `,
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      now: 1775,
+    });
+
+    expect(result.branch).toBe(requestedBranchName);
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe(
+      requestedBranchName,
+    );
+    expect(await git(repoPath, ["show-ref", "--verify", `refs/heads/${requestedBranchName}`]))
+      .toMatch(/refs\/heads\/feature\/foo\+bar$/);
+  });
+
   it("rejects new branch handoff when the requested branch already exists", async () => {
     const repoPath = await createRepo();
 

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -97,6 +97,40 @@ describe("GitWorkspaceHandoffService", () => {
     );
   });
 
+  it("moves a dirty local branch to a new worktree and leaves local detached", async () => {
+    const repoPath = await createRepo();
+    const headSha = await git(repoPath, ["rev-parse", "HEAD"]);
+    await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      leaveLocalBranch: "HEAD",
+      now: 1250,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.branch).toBe("feature/handoff");
+    expect(result.warnings).toContain(
+      "Local was left on a detached HEAD at the moved branch commit.",
+    );
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("");
+    expect(await git(repoPath, ["rev-parse", "HEAD"])).toBe(headSha);
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe(
+      "feature/handoff",
+    );
+    await expect(readFile(path.join(result.targetPath, "README.md"), "utf8")).resolves.toBe(
+      "dirty local\n",
+    );
+  });
+
   it("moves dirty local changes to a detached worktree and leaves local on the current branch", async () => {
     const repoPath = await createRepo();
     await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");

--- a/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts
@@ -143,6 +143,69 @@ describe("GitWorkspaceHandoffService", () => {
     expect(await git(repoPath, ["status", "--porcelain", "--untracked-files=normal"])).toBe("");
   });
 
+  it("moves dirty local changes to a new branch worktree and leaves local on the current branch", async () => {
+    const repoPath = await createRepo();
+    const baseSha = await git(repoPath, ["rev-parse", "HEAD"]);
+    await writeFile(path.join(repoPath, "README.md"), "dirty local\n", "utf8");
+    await writeFile(path.join(repoPath, "notes.txt"), "untracked\n", "utf8");
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const result = await service.handoff({
+      backend: "codex",
+      threadId: "thread-1",
+      direction: "local-to-worktree",
+      strategy: "new-branch",
+      newBranchName: "pwragent/feature-handoff",
+      repositoryPath: repoPath,
+      sourcePath: repoPath,
+      sourceBranch: "feature/handoff",
+      now: 1750,
+    });
+
+    expect(result.workMode).toBe("worktree");
+    expect(result.strategy).toBe("new-branch");
+    expect(result.branch).toBe("pwragent/feature-handoff");
+    expect(result.baseSha).toBe(baseSha);
+    expect(result.sourceStash).toMatchObject({ applied: true, dropped: true });
+    expect(await git(repoPath, ["branch", "--show-current"])).toBe("feature/handoff");
+    expect(await git(result.targetPath, ["branch", "--show-current"])).toBe(
+      "pwragent/feature-handoff",
+    );
+    expect(await git(result.targetPath, ["rev-parse", "HEAD"])).toBe(baseSha);
+    await expect(readFile(path.join(result.targetPath, "README.md"), "utf8")).resolves.toBe(
+      "dirty local\n",
+    );
+    await expect(readFile(path.join(result.targetPath, "notes.txt"), "utf8")).resolves.toBe(
+      "untracked\n",
+    );
+    expect(await git(repoPath, ["status", "--porcelain", "--untracked-files=normal"])).toBe("");
+  });
+
+  it("rejects new branch handoff when the requested branch already exists", async () => {
+    const repoPath = await createRepo();
+
+    const service = new GitWorkspaceHandoffService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    await expect(
+      service.handoff({
+        backend: "codex",
+        threadId: "thread-1",
+        direction: "local-to-worktree",
+        strategy: "new-branch",
+        newBranchName: "main",
+        repositoryPath: repoPath,
+        sourcePath: repoPath,
+        sourceBranch: "feature/handoff",
+        now: 1800,
+      }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(await git(repoPath, ["stash", "list"])).toBe("");
+  });
+
   it("moves a dirty worktree branch back to local and archives the old worktree", async () => {
     const repoPath = await createRepo();
     await git(repoPath, ["switch", "main"]);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6613,22 +6613,22 @@ describe("MessagingController", () => {
       choices: expect.arrayContaining([
         expect.objectContaining({
           id: "handoff:select-leave-branch",
-          label: "1. main",
+          label: "1. Detached HEAD",
         }),
       ]),
     });
 
-    const leaveMain = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
+    const leaveDetached = findChoice(harness.delivered.at(-1), "handoff:select-leave-branch");
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
-        actionId: leaveMain.id,
-        value: leaveMain.value,
+        actionId: leaveDetached.id,
+        value: leaveDetached.value,
       }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      body: expect.stringContaining("Leave Local on: main"),
+      body: expect.stringContaining("Leave Local on: Detached HEAD"),
     });
 
     const confirm = findAction(harness.delivered.at(-1), "handoff:confirm");
@@ -6646,7 +6646,7 @@ describe("MessagingController", () => {
     expect(harness.handoffThreadWorkspace).toHaveBeenCalledWith({
       backend: "codex",
       direction: "local-to-worktree",
-      leaveLocalBranch: "main",
+      leaveLocalBranch: "HEAD",
       repositoryPath: "/repo/pwragent",
       sourceBranch: "feature/handoff",
       sourcePath: "/repo/pwragent",
@@ -6717,7 +6717,7 @@ describe("MessagingController", () => {
     expect(secondPage.prompt).toContain("Page 2/3.");
     expect(secondPage.choices[0]).toMatchObject({
       id: "handoff:select-leave-branch",
-      label: "9. branch-9",
+      label: "9. branch-8",
     });
     expect(secondPage.choices).toContainEqual(
       expect.objectContaining({
@@ -6772,7 +6772,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("offers detached-head handoff for a local checkout with no alternate branches", async () => {
+  it("offers move-branch handoff for a local checkout with no alternate branches", async () => {
     const harness = await createHarness();
     const navigation = buildLocalHandoffNavigationSnapshot();
     navigation.directories[0] = {
@@ -6795,13 +6795,16 @@ describe("MessagingController", () => {
     if (!overview || !("choices" in overview)) {
       throw new Error("Expected handoff overview");
     }
-    expect(overview.choices).not.toContainEqual(
-      expect.objectContaining({ id: "handoff:move-branch" }),
+    expect(overview.choices).toContainEqual(
+      expect.objectContaining({
+        id: "handoff:move-branch",
+        fallbackText: "1",
+      }),
     );
     expect(overview.choices).toContainEqual(
       expect.objectContaining({
         id: "handoff:create-detached",
-        fallbackText: "1",
+        fallbackText: "2",
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -476,9 +476,9 @@ describe("buildBindingStatusIntent", () => {
     });
     expect(branchPicker.choices[0]).toMatchObject({
       id: "handoff:select-leave-branch",
-      label: "1. main",
+      label: "1. Detached HEAD",
       value: expect.objectContaining({
-        leaveLocalBranch: "main",
+        leaveLocalBranch: "HEAD",
       }),
     });
 
@@ -632,7 +632,7 @@ function buildHandoffContext(): MessagingWorkspaceHandoffContext {
   return {
     backend: "codex",
     branch: "feature/handoff",
-    leaveLocalBranches: ["main", "develop"],
+    leaveLocalBranches: ["HEAD", "main", "develop"],
     projectLabel: "PwrAgent",
     repositoryPath: "/repo/pwragent",
     threadId: "thread-1",

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -404,7 +404,7 @@ export class GitWorkspaceHandoffService {
     context: HandoffContext,
   ): Promise<HandoffThreadWorkspaceResponse> {
     const baseSha = context.headSha;
-    const newBranchName = sanitizeBranchName(params.newBranchName ?? "");
+    const newBranchName = (params.newBranchName ?? "").trim();
     if (!newBranchName) {
       throw new Error("Choose a new branch name for handoff.");
     }

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -38,6 +38,7 @@ type HandoffParams = {
   sourcePath?: string;
   sourceBranch?: string;
   leaveLocalBranch?: string;
+  newBranchName?: string;
   now?: number;
 };
 
@@ -195,6 +196,23 @@ async function dropStashByCommit(cwd: string, commit: string): Promise<void> {
   await runGit(cwd, ["stash", "drop", match]);
 }
 
+async function validateBranchName(cwd: string, branch: string): Promise<void> {
+  try {
+    await runGit(cwd, ["check-ref-format", "--branch", branch]);
+  } catch {
+    throw new Error(`Invalid branch name: ${branch}`);
+  }
+}
+
+async function branchExists(cwd: string, branch: string): Promise<boolean> {
+  try {
+    await runGit(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function applyVerifyAndDropStash(
   cwd: string,
   stash: ThreadWorkspaceHandoffStashSummary | undefined,
@@ -292,6 +310,9 @@ export class GitWorkspaceHandoffService {
     if (strategy === "detached-changes") {
       return await this.handoffLocalChangesToDetachedWorktree(params, context);
     }
+    if (strategy === "new-branch") {
+      return await this.handoffLocalChangesToNewBranchWorktree(params, context);
+    }
 
     if (context.branch === "HEAD") {
       throw new Error("Local-to-worktree handoff requires a named source branch.");
@@ -344,6 +365,78 @@ export class GitWorkspaceHandoffService {
       strategy: "move-branch",
       workMode: "worktree",
       branch: context.branch,
+      repositoryPath: context.repositoryPath,
+      targetPath,
+      linkedDirectory,
+      sourceStash: appliedSourceStash,
+      warnings,
+      completedAt: context.now,
+    };
+  }
+
+  private async handoffLocalChangesToNewBranchWorktree(
+    params: HandoffParams,
+    context: HandoffContext,
+  ): Promise<HandoffThreadWorkspaceResponse> {
+    const baseSha = context.headSha;
+    const newBranchName = sanitizeBranchName(params.newBranchName ?? "");
+    if (!newBranchName) {
+      throw new Error("Choose a new branch name for handoff.");
+    }
+    if (newBranchName === context.branch) {
+      throw new Error("New branch name must differ from the current branch.");
+    }
+    await validateBranchName(context.repositoryPath, newBranchName);
+    if (await branchExists(context.repositoryPath, newBranchName)) {
+      throw new Error(`Branch ${newBranchName} already exists.`);
+    }
+
+    const storage = await this.resolveStorage();
+    const targetPath = await computeWorktreePath({
+      backend: context.backend,
+      repoRoot: context.repositoryPath,
+      storage,
+      homeDir: this.homeDir,
+      timestamp: context.now,
+    });
+
+    const warnings = [
+      "Ignored files are not preserved by workspace handoff.",
+      `The new worktree starts from ${context.branch} at the current commit.`,
+    ];
+    const sourceStash = await createNamedStashIfDirty({
+      path: context.sourcePath,
+      message: this.buildStashMessage(context, "source"),
+    });
+    if (!sourceStash) {
+      warnings.push("No dirty non-ignored changes were available to move.");
+    }
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await runGit(context.repositoryPath, [
+      "worktree",
+      "add",
+      "-b",
+      newBranchName,
+      targetPath,
+      baseSha,
+    ]);
+    const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
+
+    const linkedDirectory = this.buildLinkedDirectory({
+      context,
+      kind: "worktree",
+      targetPath,
+    });
+
+    return {
+      backend: context.backend,
+      threadId: context.threadId,
+      direction: "local-to-worktree",
+      strategy: "new-branch",
+      workMode: "worktree",
+      branch: newBranchName,
+      baseSha,
       repositoryPath: context.repositoryPath,
       targetPath,
       linkedDirectory,

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -159,10 +159,7 @@ function ensureBranchNotCheckedOutElsewhere(params: {
 async function createNamedStashIfDirty(
   options: StashOptions,
 ): Promise<ThreadWorkspaceHandoffStashSummary | undefined> {
-  const status = trim(
-    (await runGit(options.path, ["status", "--porcelain", "--untracked-files=normal"]))
-      .stdout,
-  );
+  const status = await getDirtyStatus(options.path);
   if (!status) {
     return undefined;
   }
@@ -179,6 +176,21 @@ async function createNamedStashIfDirty(
     applied: false,
     dropped: false,
   };
+}
+
+async function getDirtyStatus(workspacePath: string): Promise<string> {
+  return trim(
+    (await runGit(workspacePath, ["status", "--porcelain", "--untracked-files=normal"]))
+      .stdout,
+  );
+}
+
+async function assertLocalCleanForDestinationHandoff(repositoryPath: string): Promise<void> {
+  if (await getDirtyStatus(repositoryPath)) {
+    throw new Error(
+      "Local has dirty tracked or untracked changes. Commit, stash, or discard them before handing a worktree back to Local.",
+    );
+  }
 }
 
 async function dropStashByCommit(cwd: string, commit: string): Promise<void> {
@@ -530,19 +542,11 @@ export class GitWorkspaceHandoffService {
     });
 
     const warnings = ["Ignored files are not preserved by workspace handoff."];
+    await assertLocalCleanForDestinationHandoff(context.repositoryPath);
     const sourceStash = await createNamedStashIfDirty({
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
-    const destinationStash = await createNamedStashIfDirty({
-      path: context.repositoryPath,
-      message: this.buildStashMessage(context, "destination"),
-    });
-    if (destinationStash) {
-      warnings.push(
-        "Local had dirty changes; they were saved in a separate stash and not applied to the moved branch.",
-      );
-    }
 
     await runGit(context.sourcePath, ["switch", "--detach"]);
     await runGit(context.repositoryPath, ["switch", context.branch]);
@@ -576,7 +580,6 @@ export class GitWorkspaceHandoffService {
       linkedDirectory,
       archivedSourceWorktree,
       sourceStash: appliedSourceStash,
-      destinationStash,
       warnings,
       completedAt: context.now,
     };
@@ -589,19 +592,11 @@ export class GitWorkspaceHandoffService {
       "Ignored files are not preserved by workspace handoff.",
       "Local will be left on a detached HEAD at the moved worktree commit.",
     ];
+    await assertLocalCleanForDestinationHandoff(context.repositoryPath);
     const sourceStash = await createNamedStashIfDirty({
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
-    const destinationStash = await createNamedStashIfDirty({
-      path: context.repositoryPath,
-      message: this.buildStashMessage(context, "destination"),
-    });
-    if (destinationStash) {
-      warnings.push(
-        "Local had dirty changes; they were saved in a separate stash and not applied to the moved detached HEAD.",
-      );
-    }
 
     await runGit(context.repositoryPath, ["switch", "--detach", context.headSha]);
     const appliedSourceStash = await applyVerifyAndDropStash(
@@ -634,7 +629,6 @@ export class GitWorkspaceHandoffService {
       linkedDirectory,
       archivedSourceWorktree,
       sourceStash: appliedSourceStash,
-      destinationStash,
       warnings,
       completedAt: context.now,
     };

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -18,6 +18,7 @@ import { computeWorktreePath } from "./git-directory-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 
 const execFileAsync = promisify(execFile);
+const DETACHED_HEAD_LEAVE_LOCAL_BRANCH = "HEAD";
 
 type GitResult = {
   stdout: string;
@@ -324,11 +325,15 @@ export class GitWorkspaceHandoffService {
       worktrees: context.worktrees,
     });
 
-    const leaveLocalBranch = sanitizeBranchName(params.leaveLocalBranch ?? "");
+    const rawLeaveLocalBranch = params.leaveLocalBranch?.trim() ?? "";
+    const leaveLocalDetached = rawLeaveLocalBranch === DETACHED_HEAD_LEAVE_LOCAL_BRANCH;
+    const leaveLocalBranch = leaveLocalDetached
+      ? DETACHED_HEAD_LEAVE_LOCAL_BRANCH
+      : sanitizeBranchName(rawLeaveLocalBranch);
     if (!leaveLocalBranch) {
       throw new Error("Choose a branch to leave in Local before handoff.");
     }
-    if (leaveLocalBranch && leaveLocalBranch === context.branch) {
+    if (!leaveLocalDetached && leaveLocalBranch === context.branch) {
       throw new Error("Local cannot be left on the same branch being moved.");
     }
 
@@ -342,11 +347,19 @@ export class GitWorkspaceHandoffService {
     });
 
     const warnings = ["Ignored files are not preserved by workspace handoff."];
+    if (leaveLocalDetached) {
+      warnings.push("Local was left on a detached HEAD at the moved branch commit.");
+    }
     const sourceStash = await createNamedStashIfDirty({
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
-    await runGit(context.sourcePath, ["switch", leaveLocalBranch]);
+    await runGit(
+      context.sourcePath,
+      leaveLocalDetached
+        ? ["switch", "--detach", context.headSha]
+        : ["switch", leaveLocalBranch],
+    );
 
     await mkdir(path.dirname(targetPath), { recursive: true });
     await runGit(context.repositoryPath, ["worktree", "add", targetPath, context.branch]);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -7696,6 +7696,15 @@ function validateHandoffRequest(
     if (request.strategy === "detached-changes") {
       return { valid: true };
     }
+    if (request.strategy === "new-branch") {
+      if (!request.newBranchName?.trim()) {
+        return {
+          valid: false,
+          reason: "Choose the new branch name before handoff.",
+        };
+      }
+      return { valid: true };
+    }
     if (!request.leaveLocalBranch) {
       return {
         valid: false,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -7630,13 +7630,14 @@ function handoffContextForBinding(
     []
   ).filter(
     (candidate, index, branches) =>
-      candidate !== branch && branches.indexOf(candidate) === index,
+      candidate !== "HEAD" && candidate !== branch && branches.indexOf(candidate) === index,
   );
+  const leaveLocalBranchChoices = ["HEAD", ...leaveLocalBranches];
 
   return {
     backend: binding.backend,
     branch,
-    leaveLocalBranches,
+    leaveLocalBranches: leaveLocalBranchChoices,
     projectLabel: localDirectory.label,
     repositoryPath: localDirectory.path,
     threadId: binding.threadId,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -793,7 +793,9 @@ export function handoffRequestFromValue(
     threadId: value.threadId,
     direction: value.direction,
     strategy:
-      value.strategy === "move-branch" || value.strategy === "detached-changes"
+      value.strategy === "move-branch" ||
+      value.strategy === "detached-changes" ||
+      value.strategy === "new-branch"
         ? value.strategy
         : undefined,
     repositoryPath: value.repositoryPath,
@@ -801,6 +803,8 @@ export function handoffRequestFromValue(
     sourceBranch: typeof value.sourceBranch === "string" ? value.sourceBranch : undefined,
     leaveLocalBranch:
       typeof value.leaveLocalBranch === "string" ? value.leaveLocalBranch : undefined,
+    newBranchName:
+      typeof value.newBranchName === "string" ? value.newBranchName : undefined,
   };
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -542,7 +542,7 @@ export function buildBranchPickerPage(params: {
     const branchNumber = pageStart + index + 1;
     return {
       id: params.branchActionId,
-      label: `${branchNumber}. ${branch}`,
+      label: `${branchNumber}. ${formatHandoffBranchChoiceLabel(branch)}`,
       fallbackText: String(branchNumber),
       style: "secondary" as const,
       priority: 100 + index,
@@ -583,6 +583,10 @@ export function buildBranchPickerPage(params: {
     pageSize,
     totalPages,
   };
+}
+
+function formatHandoffBranchChoiceLabel(branch: string): string {
+  return branch === "HEAD" ? "Detached HEAD" : branch;
 }
 
 export function buildHandoffBranchPickerIntent(params: {
@@ -706,7 +710,7 @@ export function buildHandoffConfirmationIntent(params: {
     `Working directory: ${params.context.workingDirectoryPath}`,
     `Branch: ${params.context.branch ?? unavailable()}`,
     params.leaveLocalBranch
-      ? `Leave Local on: ${params.leaveLocalBranch}`
+      ? `Leave Local on: ${formatHandoffBranchChoiceLabel(params.leaveLocalBranch)}`
       : undefined,
     params.strategy ? `Strategy: ${params.strategy}` : undefined,
   ]

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2738,7 +2738,6 @@ export function Composer(props: ComposerProps) {
     currentBranch: sourceBranch,
     directory: props.directory,
   });
-  const handoffBaseBranch = props.directory?.gitStatus?.defaultBranch;
   const canHandoffThreadWorkspace = Boolean(
     props.thread &&
       threadWorkspace &&
@@ -2764,11 +2763,7 @@ export function Composer(props: ComposerProps) {
     setHandoffDialog(direction);
     if (direction === "local-to-worktree") {
       setLocalHandoffStrategy("detached-changes");
-      setLeaveLocalBranch(
-        handoffBaseBranch && branchOptions.includes(handoffBaseBranch)
-          ? handoffBaseBranch
-          : branchOptions[0] ?? ""
-      );
+      setLeaveLocalBranch(branchOptions[0] ?? "");
       setNewLocalBranch(buildHandoffBranchSuggestion(sourceBranch));
     }
   };
@@ -3236,7 +3231,7 @@ export function Composer(props: ComposerProps) {
                       >
                         {branchOptions.map((branch) => (
                           <option key={branch} value={branch}>
-                            {branch}
+                            {formatLeaveLocalBranchOption(branch)}
                           </option>
                         ))}
                       </select>
@@ -4713,7 +4708,9 @@ function getLeaveLocalBranchOptions(params: {
   const currentBranch = params.currentBranch?.trim();
   const explicitHandoffBranches = params.directory?.gitStatus?.handoffBranches;
   const branches = explicitHandoffBranches ?? params.directory?.gitStatus?.branches ?? [];
-  const candidates = branches.filter((branch) => branch && branch !== currentBranch);
+  const candidates = branches.filter(
+    (branch) => branch && branch !== "HEAD" && branch !== currentBranch
+  );
   const defaultBranch = params.directory?.gitStatus?.defaultBranch;
   const preferred =
     defaultBranch && candidates.includes(defaultBranch)
@@ -4725,5 +4722,9 @@ function getLeaveLocalBranchOptions(params: {
     ? [preferred, ...candidates.filter((branch) => branch !== preferred)]
     : candidates;
 
-  return [...new Set(ordered)];
+  return ["HEAD", ...new Set(ordered)];
+}
+
+function formatLeaveLocalBranchOption(branch: string): string {
+  return branch === "HEAD" ? "Detached HEAD" : branch;
 }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3128,6 +3128,164 @@ export function Composer(props: ComposerProps) {
         document.body,
       )
     : null;
+  const workspaceHandoffDialog =
+    handoffDialog && threadWorkspace
+      ? createPortal(
+          <div className="workspace-handoff-modal">
+            <div
+              aria-label={
+                handoffDialog === "local-to-worktree"
+                  ? "Handoff to New Worktree"
+                  : "Handoff to Local"
+              }
+              aria-modal="true"
+              className="workspace-handoff-dialog"
+              role="dialog"
+            >
+              <h2>
+                {handoffDialog === "local-to-worktree"
+                  ? "Handoff to New Worktree"
+                  : "Handoff to Local"}
+              </h2>
+              <p>
+                {handoffDialog === "local-to-worktree"
+                  ? "Choose how this thread should move into a new worktree."
+                  : "Move this worktree branch back to Local. Dirty tracked and non-ignored files will be stashed and applied in Local, then the old worktree will be archived."}
+              </p>
+              <dl className="workspace-handoff-dialog__summary">
+                <div>
+                  <dt>
+                    {handoffDialog === "worktree-to-local" && sourceBranch === "HEAD"
+                      ? "Detached HEAD to move"
+                      : handoffDialog === "local-to-worktree" &&
+                          localHandoffStrategy === "detached-changes"
+                        ? "Current branch"
+                        : "Branch to move"}
+                  </dt>
+                  <dd>{sourceBranch ?? "Unknown branch"}</dd>
+                </div>
+              </dl>
+              {handoffDialog === "local-to-worktree" ? (
+                <>
+                  <div
+                    aria-label="Handoff strategy"
+                    className="workspace-handoff-dialog__strategy-list"
+                    role="radiogroup"
+                  >
+                    <button
+                      aria-checked={localHandoffStrategy === "detached-changes"}
+                      className="workspace-handoff-dialog__strategy"
+                      disabled={handoffSubmitting}
+                      role="radio"
+                      type="button"
+                      onClick={() => setLocalHandoffStrategy("detached-changes")}
+                    >
+                      <span className="workspace-handoff-dialog__strategy-title">
+                        Handoff to Detached HEAD
+                      </span>
+                      <span>
+                        Keep Local on the current branch. Create a detached worktree at
+                        the current branch tip and move dirty non-ignored changes on top.
+                      </span>
+                    </button>
+                    <button
+                      aria-checked={localHandoffStrategy === "suggested-branch"}
+                      className="workspace-handoff-dialog__strategy"
+                      disabled
+                      role="radio"
+                      type="button"
+                    >
+                      <span className="workspace-handoff-dialog__strategy-title">
+                        Handoff to New Branch
+                      </span>
+                      <span>
+                        Coming soon: keep Local on this branch and create a suggested
+                        branch in the new worktree.
+                      </span>
+                    </button>
+                    <button
+                      aria-checked={localHandoffStrategy === "move-branch"}
+                      className="workspace-handoff-dialog__strategy"
+                      disabled={handoffSubmitting || branchOptions.length === 0}
+                      role="radio"
+                      type="button"
+                      onClick={() => setLocalHandoffStrategy("move-branch")}
+                    >
+                      <span className="workspace-handoff-dialog__strategy-title">
+                        Handoff Current Branch
+                      </span>
+                      <span>
+                        Move this branch into the new worktree, then switch this checkout to
+                        a selected branch.
+                      </span>
+                    </button>
+                  </div>
+                  {localHandoffStrategy === "move-branch" ? (
+                    <label className="workspace-handoff-dialog__field">
+                      Leave current checkout on
+                      <select
+                        aria-label="Leave current checkout on"
+                        className="composer__select"
+                        disabled={handoffSubmitting || branchOptions.length === 0}
+                        value={leaveLocalBranch}
+                        onChange={(event) => setLeaveLocalBranch(event.target.value)}
+                      >
+                        {branchOptions.map((branch) => (
+                          <option key={branch} value={branch}>
+                            {branch}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null}
+                </>
+              ) : null}
+              {handoffDialog === "local-to-worktree" &&
+              localHandoffStrategy === "move-branch" &&
+              branchOptions.length === 0 ? (
+                <p className="workspace-handoff-dialog__note">
+                  No available local branch can be checked out before moving this branch.
+                </p>
+              ) : null}
+              {handoffDialog === "local-to-worktree" &&
+              localHandoffStrategy === "detached-changes" ? (
+                <p className="workspace-handoff-dialog__note">
+                  The new worktree starts at the current tip of{" "}
+                  {sourceBranch ?? "this branch"} and receives dirty non-ignored changes on
+                  top.
+                </p>
+              ) : null}
+              <p className="workspace-handoff-dialog__note">
+                Ignored files are not moved by handoff.
+              </p>
+              {handoffError ? (
+                <p className="workspace-handoff-dialog__error">{handoffError}</p>
+              ) : null}
+              <div className="workspace-handoff-dialog__actions">
+                <button
+                  className="button button--ghost"
+                  disabled={handoffSubmitting}
+                  type="button"
+                  onClick={() => setHandoffDialog(undefined)}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="button button--primary"
+                  disabled={handoffDisabled}
+                  type="button"
+                  onClick={() => {
+                    void submitHandoff();
+                  }}
+                >
+                  {handoffSubmitting ? "Handing off..." : "Handoff"}
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <>
@@ -3995,159 +4153,7 @@ export function Composer(props: ComposerProps) {
         </div>
       ) : null}
 
-      {handoffDialog && threadWorkspace ? (
-        <div className="workspace-handoff-modal">
-          <div
-            aria-label={
-              handoffDialog === "local-to-worktree"
-                ? "Handoff to New Worktree"
-                : "Handoff to Local"
-            }
-            className="workspace-handoff-dialog"
-            role="dialog"
-          >
-            <h2>
-              {handoffDialog === "local-to-worktree"
-                ? "Handoff to New Worktree"
-                : "Handoff to Local"}
-            </h2>
-            <p>
-              {handoffDialog === "local-to-worktree"
-                ? "Choose how this thread should move into a new worktree."
-                : "Move this worktree branch back to Local. Dirty tracked and non-ignored files will be stashed and applied in Local, then the old worktree will be archived."}
-            </p>
-            <dl className="workspace-handoff-dialog__summary">
-              <div>
-                <dt>
-                  {handoffDialog === "worktree-to-local" && sourceBranch === "HEAD"
-                    ? "Detached HEAD to move"
-                    : handoffDialog === "local-to-worktree" &&
-                        localHandoffStrategy === "detached-changes"
-                    ? "Current branch"
-                    : "Branch to move"}
-                </dt>
-                <dd>{sourceBranch ?? "Unknown branch"}</dd>
-              </div>
-            </dl>
-            {handoffDialog === "local-to-worktree" ? (
-              <>
-                <div
-                  aria-label="Handoff strategy"
-                  className="workspace-handoff-dialog__strategy-list"
-                  role="radiogroup"
-                >
-                  <button
-                    aria-checked={localHandoffStrategy === "detached-changes"}
-                    className="workspace-handoff-dialog__strategy"
-                    disabled={handoffSubmitting}
-                    role="radio"
-                    type="button"
-                    onClick={() => setLocalHandoffStrategy("detached-changes")}
-                  >
-                    <span className="workspace-handoff-dialog__strategy-title">
-                      Handoff to Detached HEAD
-                    </span>
-                    <span>
-                      Keep Local on the current branch. Create a detached worktree at
-                      the current branch tip and move dirty non-ignored changes on top.
-                    </span>
-                  </button>
-                  <button
-                    aria-checked={localHandoffStrategy === "suggested-branch"}
-                    className="workspace-handoff-dialog__strategy"
-                    disabled
-                    role="radio"
-                    type="button"
-                  >
-                    <span className="workspace-handoff-dialog__strategy-title">
-                      Handoff to New Branch
-                    </span>
-                    <span>
-                      Coming soon: keep Local on this branch and create a suggested
-                      branch in the new worktree.
-                    </span>
-                  </button>
-                  <button
-                    aria-checked={localHandoffStrategy === "move-branch"}
-                    className="workspace-handoff-dialog__strategy"
-                    disabled={handoffSubmitting || branchOptions.length === 0}
-                    role="radio"
-                    type="button"
-                    onClick={() => setLocalHandoffStrategy("move-branch")}
-                  >
-                    <span className="workspace-handoff-dialog__strategy-title">
-                      Handoff Current Branch
-                    </span>
-                    <span>
-                      Move this branch into the new worktree, then switch this checkout to
-                      a selected branch.
-                    </span>
-                  </button>
-                </div>
-                {localHandoffStrategy === "move-branch" ? (
-                  <label className="workspace-handoff-dialog__field">
-                    Leave current checkout on
-                    <select
-                      aria-label="Leave current checkout on"
-                      className="composer__select"
-                      disabled={handoffSubmitting || branchOptions.length === 0}
-                      value={leaveLocalBranch}
-                      onChange={(event) => setLeaveLocalBranch(event.target.value)}
-                    >
-                      {branchOptions.map((branch) => (
-                        <option key={branch} value={branch}>
-                          {branch}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : null}
-              </>
-            ) : null}
-            {handoffDialog === "local-to-worktree" &&
-            localHandoffStrategy === "move-branch" &&
-            branchOptions.length === 0 ? (
-              <p className="workspace-handoff-dialog__note">
-                No available local branch can be checked out before moving this branch.
-              </p>
-            ) : null}
-            {handoffDialog === "local-to-worktree" &&
-            localHandoffStrategy === "detached-changes" ? (
-              <p className="workspace-handoff-dialog__note">
-                The new worktree starts at the current tip of{" "}
-                {sourceBranch ?? "this branch"} and receives dirty non-ignored changes on
-                top.
-              </p>
-            ) : null}
-            <p className="workspace-handoff-dialog__note">
-              Ignored files are not moved by handoff.
-            </p>
-            {handoffError ? (
-              <p className="workspace-handoff-dialog__error">{handoffError}</p>
-            ) : null}
-            <div className="workspace-handoff-dialog__actions">
-              <button
-                className="button button--ghost"
-                disabled={handoffSubmitting}
-                type="button"
-                onClick={() => setHandoffDialog(undefined)}
-              >
-                Cancel
-              </button>
-              <button
-                className="button button--primary"
-                disabled={handoffDisabled}
-                type="button"
-                onClick={() => {
-                  void submitHandoff();
-                }}
-              >
-                {handoffSubmitting ? "Handing off…" : "Handoff"}
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      {workspaceHandoffDialog}
 
       {props.skillError ? <p className="composer__meta composer__meta--error">{props.skillError}</p> : null}
       {props.launchpadError ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -158,7 +158,7 @@ type ComposerProps = {
   threadModelSettingsError?: string;
 };
 
-type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy | "suggested-branch";
+type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy;
 
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
@@ -959,6 +959,7 @@ export function Composer(props: ComposerProps) {
   const [localHandoffStrategy, setLocalHandoffStrategy] =
     useState<LocalHandoffStrategy>("detached-changes");
   const [leaveLocalBranch, setLeaveLocalBranch] = useState("");
+  const [newLocalBranch, setNewLocalBranch] = useState("");
   const [handoffError, setHandoffError] = useState<string | undefined>();
   const [handoffSubmitting, setHandoffSubmitting] = useState(false);
   const [sending, setSendingState] = useState(false);
@@ -2768,6 +2769,7 @@ export function Composer(props: ComposerProps) {
           ? handoffBaseBranch
           : branchOptions[0] ?? ""
       );
+      setNewLocalBranch(buildHandoffBranchSuggestion(sourceBranch));
     }
   };
 
@@ -2781,9 +2783,7 @@ export function Composer(props: ComposerProps) {
     try {
       const handoffStrategy =
         handoffDialog === "local-to-worktree"
-          ? localHandoffStrategy === "suggested-branch"
-            ? undefined
-            : localHandoffStrategy
+          ? localHandoffStrategy
           : undefined;
       await props.onHandoffThreadWorkspace({
         direction: handoffDialog!,
@@ -2793,6 +2793,9 @@ export function Composer(props: ComposerProps) {
         sourceBranch,
         ...(handoffDialog === "local-to-worktree" && handoffStrategy === "move-branch"
           ? { leaveLocalBranch: leaveLocalBranch || undefined }
+          : {}),
+        ...(handoffDialog === "local-to-worktree" && handoffStrategy === "new-branch"
+          ? { newBranchName: newLocalBranch || undefined }
           : {}),
       });
       setHandoffDialog(undefined);
@@ -2832,7 +2835,7 @@ export function Composer(props: ComposerProps) {
     !sourceBranch ||
     (handoffDialog === "local-to-worktree" &&
       ((localHandoffStrategy === "move-branch" && !leaveLocalBranch) ||
-        localHandoffStrategy === "suggested-branch"));
+        (localHandoffStrategy === "new-branch" && !newLocalBranch.trim())));
 
   const commitActiveAutocomplete = (): void => {
     if (autocompleteKind === "skills") {
@@ -3189,18 +3192,19 @@ export function Composer(props: ComposerProps) {
                       </span>
                     </button>
                     <button
-                      aria-checked={localHandoffStrategy === "suggested-branch"}
+                      aria-checked={localHandoffStrategy === "new-branch"}
                       className="workspace-handoff-dialog__strategy"
-                      disabled
+                      disabled={handoffSubmitting}
                       role="radio"
                       type="button"
+                      onClick={() => setLocalHandoffStrategy("new-branch")}
                     >
                       <span className="workspace-handoff-dialog__strategy-title">
                         Handoff to New Branch
                       </span>
                       <span>
-                        Coming soon: keep Local on this branch and create a suggested
-                        branch in the new worktree.
+                        Keep Local on this branch. Create a named branch in the new
+                        worktree and move dirty non-ignored changes on top.
                       </span>
                     </button>
                     <button
@@ -3238,6 +3242,20 @@ export function Composer(props: ComposerProps) {
                       </select>
                     </label>
                   ) : null}
+                  {localHandoffStrategy === "new-branch" ? (
+                    <label className="workspace-handoff-dialog__field">
+                      New branch name
+                      <input
+                        aria-label="New branch name"
+                        className="workspace-handoff-dialog__text-input"
+                        disabled={handoffSubmitting}
+                        spellCheck={false}
+                        type="text"
+                        value={newLocalBranch}
+                        onChange={(event) => setNewLocalBranch(event.target.value)}
+                      />
+                    </label>
+                  ) : null}
                 </>
               ) : null}
               {handoffDialog === "local-to-worktree" &&
@@ -3253,6 +3271,19 @@ export function Composer(props: ComposerProps) {
                   The new worktree starts at the current tip of{" "}
                   {sourceBranch ?? "this branch"} and receives dirty non-ignored changes on
                   top.
+                </p>
+              ) : null}
+              {handoffDialog === "local-to-worktree" &&
+              localHandoffStrategy === "new-branch" ? (
+                <p className="workspace-handoff-dialog__note">
+                  The new worktree creates{" "}
+                  {newLocalBranch.trim() ? (
+                    <code>{newLocalBranch.trim()}</code>
+                  ) : (
+                    "a named branch"
+                  )}{" "}
+                  at the current tip of {sourceBranch ?? "this branch"} and receives
+                  dirty non-ignored changes on top.
                 </p>
               ) : null}
               <p className="workspace-handoff-dialog__note">
@@ -4661,6 +4692,18 @@ function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | 
   }
 
   return undefined;
+}
+
+function buildHandoffBranchSuggestion(sourceBranch: string | undefined): string {
+  const normalizedSource = sourceBranch
+    ?.replace(/^refs\/heads\//, "")
+    .trim()
+    .replace(/[^a-zA-Z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/^-+|-+$/g, "");
+  const branchSlug =
+    normalizedSource && normalizedSource !== "HEAD" ? normalizedSource : "detached";
+  return `pwragent/${branchSlug}-handoff`;
 }
 
 function getLeaveLocalBranchOptions(params: {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3090,7 +3090,7 @@ describe("Composer", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
     fireEvent.click(screen.getByRole("radio", { name: /Handoff Current Branch/ }));
 
-    expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("main");
+    expect(screen.getByLabelText("Leave current checkout on")).toHaveValue("HEAD");
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -3100,7 +3100,7 @@ describe("Composer", () => {
         repositoryPath: "/repo",
         sourcePath: "/repo",
         sourceBranch: "feature/handoff",
-        leaveLocalBranch: "main",
+        leaveLocalBranch: "HEAD",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2794,7 +2794,7 @@ describe("Composer", () => {
       screen.getByRole("radio", { name: /Handoff to Detached HEAD/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(screen.queryByLabelText("Leave current checkout on")).not.toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /Handoff to New Branch/ })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: /Handoff to New Branch/ })).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
 
     await waitFor(() => {
@@ -2811,6 +2811,73 @@ describe("Composer", () => {
 
     await waitFor(() => {
       expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
+  it("submits a local-to-worktree handoff on a new branch", async () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "main",
+            defaultBranch: "main",
+            branches: ["main", "release"],
+            handoffBranches: ["release"],
+            syncState: "untracked",
+          },
+        }}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          gitBranch: "main",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgent",
+              path: "/repo",
+              kind: "local",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Workspace mode"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Handoff to New Worktree" }));
+    fireEvent.click(screen.getByRole("radio", { name: /Handoff to New Branch/ }));
+
+    const newBranchInput = screen.getByLabelText("New branch name");
+    expect(newBranchInput).toHaveValue("pwragent/main-handoff");
+    fireEvent.change(newBranchInput, {
+      target: { value: "pwragent/main-wip" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Handoff" }));
+
+    await waitFor(() => {
+      expect(onHandoffThreadWorkspace).toHaveBeenCalledWith({
+        direction: "local-to-worktree",
+        strategy: "new-branch",
+        newBranchName: "pwragent/main-wip",
+        repositoryPath: "/repo",
+        sourcePath: "/repo",
+        sourceBranch: "main",
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7595,6 +7595,24 @@ textarea,
   font-weight: 600;
 }
 
+.workspace-handoff-dialog__text-input {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  line-height: 1.3;
+}
+
+.workspace-handoff-dialog__text-input:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  outline-offset: 1px;
+}
+
 .workspace-handoff-dialog__strategy-list {
   display: grid;
   gap: 8px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7477,6 +7477,32 @@ textarea,
   overflow-wrap: break-word;
 }
 
+.workspace-handoff-dialog__summary {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+
+.workspace-handoff-dialog__summary div {
+  min-width: 0;
+}
+
+.workspace-handoff-dialog__summary dt {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.workspace-handoff-dialog__summary dd {
+  margin: 4px 0 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
 .workspace-handoff-dialog__branch-path {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
@@ -7611,6 +7637,13 @@ textarea,
 
 .workspace-handoff-dialog__error {
   color: var(--danger-text);
+}
+
+.workspace-handoff-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .workspace-handoff-dialog__action {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -381,7 +381,8 @@ export type ThreadWorkspaceHandoffDirection =
 
 export type ThreadWorkspaceHandoffStrategy =
   | "move-branch"
-  | "detached-changes";
+  | "detached-changes"
+  | "new-branch";
 
 export type ThreadWorkspaceHandoffStashSummary = {
   ref?: string;
@@ -400,6 +401,7 @@ export type HandoffThreadWorkspaceRequest = {
   sourcePath?: string;
   sourceBranch?: string;
   leaveLocalBranch?: string;
+  newBranchName?: string;
 };
 
 export type HandoffThreadWorkspaceResponse = {


### PR DESCRIPTION
## Summary

- Center the workspace handoff modal by rendering the shared composer handoff dialog through a body portal.
- Add local-to-worktree strategy choices for detached HEAD, new branch, and moving the current branch.
- Allow moving the current branch while leaving Local on a detached HEAD, with matching backend, renderer, messaging, and E2E coverage.
- Block Worktree to Local handoff when Local has dirty tracked or untracked changes so the destination checkout is not silently stashed.
- Add UI-driven Electron E2E coverage for real temp git repo handoff round trips across Local to Worktree strategy combinations and Worktree back to Local cleanup.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/workspace-handoff-dialog.spec.ts e2e/workspace-handoff-flows.spec.ts --reporter=line`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- The manual inspector is available with `pnpm --filter @pwragent/desktop inspect:e2e:workspace-handoff` and opens the local-to-worktree dialog on the `Handoff Current Branch` path.
