### PR TITLE
fix(desktop): suppress branch drift dialog under settings

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -211,6 +211,7 @@ function DesktopAppShell(props: {
           selectedDirectory={navigation.selectedDirectory}
           selectedLaunchpad={navigation.selectedLaunchpad}
           selectedThread={navigation.selectedThread}
+          suppressBranchDriftDialog={mainView === "settings"}
           directories={navigation.directories}
           fullAccessRiskWarningDismissed={
             settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ??

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -878,15 +878,9 @@ export function ThreadView(props: ThreadViewProps) {
       if (selectedThreadKeyRef.current !== startedThreadKey) {
         return false;
       }
-      if (suppressBranchDriftDialogRef.current) {
-        return false;
-      }
       if (result.observedBranch !== thread.observedGitBranch) {
         await props.onRefreshNavigation?.();
         if (selectedThreadKeyRef.current !== startedThreadKey) {
-          return false;
-        }
-        if (suppressBranchDriftDialogRef.current) {
           return false;
         }
       }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -605,6 +605,7 @@ type ThreadViewProps = {
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
   selectedThread?: NavigationThreadSummary;
+  suppressBranchDriftDialog?: boolean;
   fullAccessRiskWarningDismissed?: boolean;
   /**
    * Project-directory picker (issue #223) — surfaced in the launchpad
@@ -769,6 +770,17 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? `${selectedThread.source}:${selectedThread.id}`
     : undefined;
+  const suppressBranchDriftDialogRef = useRef(
+    props.suppressBranchDriftDialog ?? false
+  );
+
+  useEffect(() => {
+    suppressBranchDriftDialogRef.current = props.suppressBranchDriftDialog ?? false;
+    if (props.suppressBranchDriftDialog) {
+      setBranchDriftDialog(undefined);
+      setBranchDriftError(undefined);
+    }
+  }, [props.suppressBranchDriftDialog]);
 
   useEffect(() => {
     if (!branchDriftDialog) return;
@@ -841,6 +853,9 @@ export function ThreadView(props: ThreadViewProps) {
     if (props.activeTurnId !== undefined) {
       return false;
     }
+    if (suppressBranchDriftDialogRef.current) {
+      return false;
+    }
     return showBranchDriftDialog(thread, expectedBranch, observedBranch, reason, checkedAt);
   };
 
@@ -863,9 +878,15 @@ export function ThreadView(props: ThreadViewProps) {
       if (selectedThreadKeyRef.current !== startedThreadKey) {
         return false;
       }
+      if (suppressBranchDriftDialogRef.current) {
+        return false;
+      }
       if (result.observedBranch !== thread.observedGitBranch) {
         await props.onRefreshNavigation?.();
         if (selectedThreadKeyRef.current !== startedThreadKey) {
+          return false;
+        }
+        if (suppressBranchDriftDialogRef.current) {
           return false;
         }
       }
@@ -923,7 +944,7 @@ export function ThreadView(props: ThreadViewProps) {
     }
 
     tryOpenBranchDriftDialog(thread, expectedBranch, observedBranch, "focus");
-  }, [selectedThread, props.activeTurnId]);
+  }, [selectedThread, props.activeTurnId, props.suppressBranchDriftDialog]);
 
   // End-of-turn falling-edge: re-run drift check when an active turn
   // settles on the focused thread. Combined ref guards against

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3175,6 +3175,76 @@ describe("ThreadView", () => {
     });
   });
 
+  it("refreshes branch drift state while the branch drift dialog is suppressed", async () => {
+    const checkThreadBranchDrift = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-branch",
+      checkedAt: Date.now(),
+      expectedBranch: "feature/old",
+      observedBranch: "main",
+      drifted: true,
+    }));
+    const refreshNavigation = vi.fn(async () => undefined);
+
+    const baseThread = {
+      id: "thread-branch",
+      title: "Branch drift",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      gitBranch: "feature/old",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    function Harness({
+      observedGitBranch,
+      suppress,
+    }: {
+      observedGitBranch: string;
+      suppress?: boolean;
+    }) {
+      return (
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{ checkThreadBranchDrift }}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={{ ...baseThread, observedGitBranch }}
+          suppressBranchDriftDialog={suppress}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          onRefreshNavigation={refreshNavigation}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    const { rerender } = render(
+      <Harness observedGitBranch="feature/old" suppress />
+    );
+
+    await waitFor(() => {
+      expect(refreshNavigation).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Thread branch changed" }),
+    ).not.toBeInTheDocument();
+
+    rerender(<Harness observedGitBranch="main" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Thread branch changed" }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("re-checks branch drift on end-of-turn falling edge", async () => {
     const checkThreadBranchDrift = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3116,6 +3116,65 @@ describe("ThreadView", () => {
     });
   });
 
+  it("suppresses the branch drift dialog when another top-level dialog is active", async () => {
+    const driftThread = {
+      id: "thread-branch",
+      title: "Branch drift",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      gitBranch: "feature/old",
+      observedGitBranch: "main",
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    function Harness({ suppress }: { suppress?: boolean }) {
+      return (
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{}}
+          loading={false}
+          loadingMore={false}
+          messageCount={1}
+          selectedThread={driftThread}
+          suppressBranchDriftDialog={suppress}
+          skills={[]}
+          transcriptEntries={[]}
+          clearPendingRequest={() => undefined}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Thread branch changed" }),
+      ).toBeInTheDocument();
+    });
+
+    rerender(<Harness suppress />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Thread branch changed" }),
+      ).not.toBeInTheDocument();
+    });
+
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Thread branch changed" }),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("re-checks branch drift on end-of-turn falling edge", async () => {
     const checkThreadBranchDrift = vi.fn(async () => ({
       backend: "codex" as const,


### PR DESCRIPTION
## Summary

- Suppress the branch drift warning modal while the Settings layer is active.
- Keep branch drift checks refreshing navigation state while the modal is suppressed, so closing Settings can surface a newly detected drift immediately.
- Add renderer regression coverage for both suppression and refresh-while-suppressed behavior.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx` and it passed with 28 tests.
- I ran `pnpm --filter @pwragent/desktop typecheck` and it passed.

## Notes

- I installed dependencies in this worktree with `pnpm install --frozen-lockfile --config.global-pnpmfile=` because the machine-level pnpmfile checksum blocked a frozen install.
