### PR TITLE
fix(desktop): handle unborn launchpad git repos

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -278,6 +278,173 @@ async function createDirectoryLaunchpadFixture(): Promise<{
   };
 }
 
+async function createUnbornHeadLaunchpadFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+  repoDir: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-launchpad-e2e-"));
+  const repoDir = path.join(rootDir, "PwrTester");
+  await mkdir(repoDir, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoDir, stdio: "ignore" });
+
+  const thread = {
+    id: "thread-unborn-existing",
+    title: "Existing unborn repo thread",
+    titleSource: "explicit",
+    summary: "Keeps PwrTester in the directory list",
+    source: "codex",
+    executionMode: "default",
+    linkedDirectories: [
+      {
+        id: "pwrtester",
+        label: "PwrTester",
+        path: repoDir,
+        kind: "local",
+      },
+    ],
+    updatedAt: 1760000000000,
+  };
+  const newThread = {
+    id: "thread-unborn-new",
+    title: "let's just make a dummy README.md file",
+    titleSource: "derived",
+    summary: "Started from an unborn HEAD repo",
+    source: "codex",
+    executionMode: "default",
+    linkedDirectories: [
+      {
+        id: repoDir,
+        label: "PwrTester",
+        path: repoDir,
+        kind: "local",
+      },
+    ],
+    updatedAt: 1760000001000,
+  };
+
+  const fixturePath = path.join(rootDir, "unborn-head-launchpad.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "directory-launchpad-unborn-head",
+          threadId: "thread-unborn-new",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [thread],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-unborn-existing-1",
+                  role: "user",
+                  text: "Keep this repo visible.",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-unborn-existing-1",
+                  role: "user",
+                  text: "Keep this repo visible.",
+                },
+              ],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-start-1",
+            kind: "response",
+            method: "thread/start",
+            result: {
+              threadId: "thread-unborn-new",
+            },
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-unborn-new",
+              turnId: "turn-unborn-new-1",
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [newThread, thread],
+          },
+          {
+            id: "thread-read-2",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "message-unborn-new-1",
+                  role: "user",
+                  text: "let's just make a dummy README.md file",
+                },
+              ],
+              messages: [
+                {
+                  id: "message-unborn-new-1",
+                  role: "user",
+                  text: "let's just make a dummy README.md file",
+                },
+              ],
+              lastUserMessage: "let's just make a dummy README.md file",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+    fixturePath,
+    repoDir,
+  };
+}
+
 async function createLocalHandoffSessionFixture(): Promise<{
   cleanup: () => Promise<void>;
   codexHome: string;
@@ -486,6 +653,57 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
 
     await expect(workspaceMode).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad starts a local thread from an unborn git HEAD", async () => {
+  const fixture = await createUnbornHeadLaunchpadFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for PwrTester" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "PwrTester" }),
+    ).toBeVisible();
+
+    const directoryKey = `directory:${fixture.repoDir}`;
+    await app.window.evaluate(async (key) => {
+      await (window as any).pwragent.updateDirectoryLaunchpad({
+        directoryKey: key,
+        patch: {
+          workMode: "worktree",
+        },
+        stickySettingsChanged: true,
+      });
+    }, directoryKey);
+
+    await expect(app.window.getByLabel("Workspace mode")).toHaveAttribute(
+      "data-value",
+      "local",
+    );
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("let's just make a dummy README.md file");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "let's just make a dummy README.md file",
+      }),
+    ).toBeVisible();
+    await expect(app.window.getByText("ambiguous argument 'HEAD'")).toHaveCount(0);
+    const startTurn = (await app.getLastStartTurn()) as { cwd?: string } | undefined;
+    expect(startTurn?.cwd).toBe(fixture.repoDir);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -105,6 +105,36 @@ describe("GitDirectoryService", () => {
     });
   });
 
+  it("creates a worktree from the default branch when the checked-out branch is unborn", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const mainRevision = runGit(repoDir, ["rev-parse", "main"]);
+    runGit(repoDir, ["checkout", "--orphan", "scratch"]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const status = await service.readDirectoryStatus({ path: repoDir });
+    expect(status).toMatchObject({
+      branches: expect.arrayContaining(["main"]),
+      defaultBranch: "main",
+      syncState: "untracked",
+    });
+    expect(status).not.toHaveProperty("currentBranch");
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    await expect(realpath(workspace.repositoryPath!)).resolves.toBe(await realpath(repoDir));
+    expect(workspace.cwd).toBeDefined();
+    expect(runGit(workspace.cwd!, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
+  });
+
   it("reports default and available handoff branches", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -135,6 +135,27 @@ describe("GitDirectoryService", () => {
     expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
   });
 
+  it("falls back to local mode when an explicit worktree base branch is stale", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "missing-base-branch",
+    });
+
+    expect(workspace).toEqual({
+      cwd: repoDir,
+      workMode: "local",
+    });
+  });
+
   it("reports default and available handoff branches", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -73,6 +73,38 @@ describe("GitDirectoryService", () => {
     });
   });
 
+  it("falls back to local mode when a worktree launchpad targets an unborn git HEAD", async () => {
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-git-directory-"));
+    cleanupPaths.push(repoDir);
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    const service = new GitDirectoryService();
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        workMode: "worktree",
+      }),
+    ).resolves.toEqual({
+      cwd: repoDir,
+      workMode: "local",
+    });
+  });
+
+  it("reports unborn git directories without surfacing raw HEAD errors", async () => {
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-status-"));
+    cleanupPaths.push(repoDir);
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    const service = new GitDirectoryService();
+
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      branches: [],
+      handoffBranches: [],
+      syncState: "untracked",
+    });
+  });
+
   it("reports default and available handoff branches", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -360,7 +360,7 @@ export class GitDirectoryService {
     }
 
     const [currentBranch, branchesOutput, remoteHead, worktreeList] = await Promise.all([
-      runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]),
+      runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
       runGit(repoRoot, [
         "for-each-ref",
         "refs/heads",
@@ -378,12 +378,17 @@ export class GitDirectoryService {
       "--symbolic-full-name",
       "@{upstream}",
     ]).catch(() => "");
-    if (!currentBranch) {
-      return undefined;
-    }
-
     const branches = parseGitLines(branchesOutput);
     const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
+    if (!currentBranch) {
+      return {
+        defaultBranch,
+        branches,
+        handoffBranches: branches,
+        syncState: "untracked",
+      };
+    }
+
     const handoffBranches = orderHandoffBranches({
       branches,
       currentBranch,
@@ -472,8 +477,28 @@ export class GitDirectoryService {
 
     const baseBranch =
       sanitizeBranchName(launchpad.branchName ?? "") ||
-      sanitizeBranchName(await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"])) ||
-      "main";
+      sanitizeBranchName(
+        await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
+      );
+    if (!baseBranch) {
+      return {
+        cwd: directoryPath,
+        workMode: "local",
+      };
+    }
+
+    const baseCommit = await runGit(repoRoot, [
+      "rev-parse",
+      "--verify",
+      `${baseBranch}^{commit}`,
+    ]).catch(() => "");
+    if (!baseCommit) {
+      return {
+        cwd: directoryPath,
+        workMode: "local",
+      };
+    }
+
     const storage = await this.resolveStorage();
     const worktreePath = await computeWorktreePath({
       backend: launchpad.backend,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -268,6 +268,16 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   repoRoot: string;
   requestedBranch?: string;
 }): Promise<string | undefined> {
+  const requestedBranch = sanitizeBranchName(params.requestedBranch ?? "");
+  if (requestedBranch) {
+    const commit = await runGit(params.repoRoot, [
+      "rev-parse",
+      "--verify",
+      `${requestedBranch}^{commit}`,
+    ]).catch(() => "");
+    return commit ? requestedBranch : undefined;
+  }
+
   const [currentBranch, branchesOutput, remoteHead] = await Promise.all([
     runGit(params.repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
     runGit(params.repoRoot, [
@@ -283,7 +293,6 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   const branches = parseGitLines(branchesOutput);
   const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
   const candidates = uniqueBranches([
-    params.requestedBranch,
     currentBranch,
     defaultBranch,
     ...branches,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -218,6 +218,20 @@ function resolveDefaultBranch(params: {
   );
 }
 
+function uniqueBranches(branches: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const branch of branches) {
+    const value = sanitizeBranchName(branch ?? "");
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
 function orderHandoffBranches(params: {
   branches: string[];
   currentBranch: string;
@@ -248,6 +262,45 @@ function orderHandoffBranches(params: {
 
 function isProtectedBranch(branch?: string): boolean {
   return !branch || ["main", "master", "develop", "trunk"].includes(branch);
+}
+
+async function resolveVerifiedWorktreeBaseBranch(params: {
+  repoRoot: string;
+  requestedBranch?: string;
+}): Promise<string | undefined> {
+  const [currentBranch, branchesOutput, remoteHead] = await Promise.all([
+    runGit(params.repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
+    runGit(params.repoRoot, [
+      "for-each-ref",
+      "refs/heads",
+      "--sort=-committerdate",
+      "--format=%(refname:short)",
+    ]).catch(() => ""),
+    runGit(params.repoRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
+      () => "",
+    ),
+  ]);
+  const branches = parseGitLines(branchesOutput);
+  const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
+  const candidates = uniqueBranches([
+    params.requestedBranch,
+    currentBranch,
+    defaultBranch,
+    ...branches,
+  ]);
+
+  for (const branch of candidates) {
+    const commit = await runGit(params.repoRoot, [
+      "rev-parse",
+      "--verify",
+      `${branch}^{commit}`,
+    ]).catch(() => "");
+    if (commit) {
+      return branch;
+    }
+  }
+
+  return undefined;
 }
 
 type CachedDirectoryStatus = {
@@ -475,24 +528,11 @@ export class GitDirectoryService {
       };
     }
 
-    const baseBranch =
-      sanitizeBranchName(launchpad.branchName ?? "") ||
-      sanitizeBranchName(
-        await runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
-      );
+    const baseBranch = await resolveVerifiedWorktreeBaseBranch({
+      repoRoot,
+      requestedBranch: launchpad.branchName,
+    });
     if (!baseBranch) {
-      return {
-        cwd: directoryPath,
-        workMode: "local",
-      };
-    }
-
-    const baseCommit = await runGit(repoRoot, [
-      "rev-parse",
-      "--verify",
-      `${baseBranch}^{commit}`,
-    ]).catch(() => "");
-    if (!baseCommit) {
       return {
         cwd: directoryPath,
         workMode: "local",


### PR DESCRIPTION
## Summary

- handle directory launchpad startup from freshly initialized Git repos with unborn `HEAD`
- fall back to local mode only when no branch resolves to a commit
- keep orphan-branch repos eligible for worktree creation by selecting a verified default/local base branch
- add focused Git service coverage and a replay-backed desktop E2E regression for the `PwrTester` flow

## Verification

- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "materializes"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e -- directory-launchpad-workspace.spec.ts -g "unborn git HEAD"`

## Notes

- I verified the empty-repo launchpad path no longer surfaces the raw `git rev-parse --abbrev-ref HEAD` error.
- I also verified the orphan-branch case still creates a detached worktree from `main` when `HEAD` is unborn but committed branches exist.
