### PR TITLE
feat(desktop): add image upload settings

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -20,6 +20,39 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
   });
 });
 
+describe("desktopSettingsPatchToEdits — messaging attachments", () => {
+  it("writes non-default image upload profiles", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        messaging: {
+          attachments: { imageProfile: "high" },
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["messaging", "attachments", "image_profile"],
+        value: "high",
+      },
+    ]);
+  });
+
+  it("removes the image upload profile when saving the default", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        messaging: {
+          attachments: { imageProfile: "medium" },
+        },
+      }),
+    ).toEqual([
+      {
+        op: "delete",
+        path: ["messaging", "attachments", "image_profile"],
+      },
+    ]);
+  });
+});
+
 describe("desktopSettingsPatchToEdits — Mattermost", () => {
   it("emits one set op per defined Mattermost field with the correct snake_case key", () => {
     const edits = desktopSettingsPatchToEdits({

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -20,6 +20,39 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
   });
 });
 
+describe("desktopSettingsPatchToEdits — image uploads", () => {
+  it("writes non-default pasted image patch budgets", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        imageUploads: {
+          pastedImageMaxPatches: 4096,
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["image_uploads", "pasted_image_max_patches"],
+        value: 4096,
+      },
+    ]);
+  });
+
+  it("removes the pasted image patch budget when saving the default", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        imageUploads: {
+          pastedImageMaxPatches: 1536,
+        },
+      }),
+    ).toEqual([
+      {
+        op: "delete",
+        path: ["image_uploads", "pasted_image_max_patches"],
+      },
+    ]);
+  });
+});
+
 describe("desktopSettingsPatchToEdits — messaging attachments", () => {
   it("writes non-default image upload profiles", () => {
     expect(

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -36,6 +36,9 @@ describe("DesktopSettingsService", () => {
         "input_debounce_ms = 750",
         'tool_update_mode = "show_more"',
         "",
+        "[messaging.attachments]",
+        'image_profile = "high"',
+        "",
         "[messaging.telegram]",
         "enabled = true",
         "streaming_responses = true",
@@ -97,6 +100,10 @@ describe("DesktopSettingsService", () => {
       value: "always",
       source: "config",
     });
+    expect(snapshot.messaging.attachments.imageProfile).toEqual({
+      value: "high",
+      source: "config",
+    });
     expect(snapshot.messaging.telegram.enabled).toEqual({
       value: true,
       source: "config",
@@ -150,6 +157,49 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.worktrees.effectivePath).toMatch(
       /\.pwragent\/worktrees$/,
     );
+  });
+
+  it("defaults the image upload profile and only persists non-default values", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.messaging.attachments.imageProfile).toEqual({
+      value: "medium",
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      messaging: {
+        attachments: { imageProfile: "actual" },
+      },
+    });
+
+    const afterActual = fs.readFileSync(configPath, "utf8");
+    expect(afterActual).toContain("[messaging.attachments]");
+    expect(afterActual).toContain('image_profile = "actual"');
+    expect((await service.readSettings()).messaging.attachments.imageProfile).toEqual({
+      value: "actual",
+      source: "config",
+    });
+
+    await service.writeConfigPatch({
+      messaging: {
+        attachments: { imageProfile: "medium" },
+      },
+    });
+
+    const afterDefault = fs.readFileSync(configPath, "utf8");
+    expect(afterDefault).not.toContain("image_profile");
+    expect((await service.readSettings()).messaging.attachments.imageProfile).toEqual({
+      value: "medium",
+      source: "default",
+    });
   });
 
   it("marks legacy chat reply composer config when another setting is saved", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -36,6 +36,9 @@ describe("DesktopSettingsService", () => {
         "input_debounce_ms = 750",
         'tool_update_mode = "show_more"',
         "",
+        "[image_uploads]",
+        "pasted_image_max_patches = 4096",
+        "",
         "[messaging.attachments]",
         'image_profile = "high"',
         "",
@@ -98,6 +101,10 @@ describe("DesktopSettingsService", () => {
     });
     expect(snapshot.messaging.fullAccessWarning).toEqual({
       value: "always",
+      source: "config",
+    });
+    expect(snapshot.imageUploads.pastedImageMaxPatches).toEqual({
+      value: 4096,
       source: "config",
     });
     expect(snapshot.messaging.attachments.imageProfile).toEqual({
@@ -198,6 +205,49 @@ describe("DesktopSettingsService", () => {
     expect(afterDefault).not.toContain("image_profile");
     expect((await service.readSettings()).messaging.attachments.imageProfile).toEqual({
       value: "medium",
+      source: "default",
+    });
+  });
+
+  it("defaults the pasted image patch budget and only persists non-default values", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.imageUploads.pastedImageMaxPatches).toEqual({
+      value: 1536,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      imageUploads: {
+        pastedImageMaxPatches: 1024,
+      },
+    });
+
+    const afterCompact = fs.readFileSync(configPath, "utf8");
+    expect(afterCompact).toContain("[image_uploads]");
+    expect(afterCompact).toContain("pasted_image_max_patches = 1024");
+    expect((await service.readSettings()).imageUploads.pastedImageMaxPatches).toEqual({
+      value: 1024,
+      source: "config",
+    });
+
+    await service.writeConfigPatch({
+      imageUploads: {
+        pastedImageMaxPatches: 1536,
+      },
+    });
+
+    const afterDefault = fs.readFileSync(configPath, "utf8");
+    expect(afterDefault).not.toContain("pasted_image_max_patches");
+    expect((await service.readSettings()).imageUploads.pastedImageMaxPatches).toEqual({
+      value: 1536,
       source: "default",
     });
   });

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -15,6 +15,7 @@ import {
   isDesktopWorktreeStorageLocation,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
+import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
 import { resolveActiveProfilePath } from "../profile";
 import {
   applyTomlEdits,
@@ -49,6 +50,9 @@ export type DesktopSettingsConfig = {
       enabled?: boolean;
       model?: string;
     };
+  };
+  imageUploads?: {
+    pastedImageMaxPatches?: number;
   };
   messaging?: {
     enabled?: boolean;
@@ -312,6 +316,21 @@ export function desktopSettingsPatchToEdits(
       ["experimental", "diff_condensation", "model"],
       patch.experimental.diffCondensation.model,
     );
+  }
+
+  if (patch.imageUploads?.pastedImageMaxPatches !== undefined) {
+    const pastedImageMaxPatches = patch.imageUploads.pastedImageMaxPatches;
+    if (pastedImageMaxPatches === DEFAULT_PASTED_IMAGE_MAX_PATCHES) {
+      edits.push({
+        op: "delete",
+        path: ["image_uploads", "pasted_image_max_patches"],
+      });
+    } else {
+      set(
+        ["image_uploads", "pasted_image_max_patches"],
+        pastedImageMaxPatches,
+      );
+    }
   }
 
   if (patch.messaging?.inputDebounceMs !== undefined) {
@@ -641,6 +660,7 @@ function normalizeDesktopConfig(
 ): DesktopSettingsConfig {
   const experimental = tables["experimental"];
   const diffCondensation = tables["experimental.diff_condensation"];
+  const imageUploads = tables["image_uploads"];
   const messaging = tables["messaging"];
   const attachments = tables["messaging.attachments"];
   const telegram = tables["messaging.telegram"];
@@ -665,6 +685,11 @@ function normalizeDesktopConfig(
         enabled: readBoolean(diffCondensation?.enabled),
         model: readString(diffCondensation?.model),
       },
+    },
+    imageUploads: {
+      pastedImageMaxPatches: readNumber(
+        imageUploads?.pasted_image_max_patches,
+      ),
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),
@@ -825,6 +850,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
 
   if (config.experimental && hasDefinedValue(config.experimental)) {
     pruned.experimental = config.experimental;
+  }
+
+  if (config.imageUploads && hasDefinedValue(config.imageUploads)) {
+    pruned.imageUploads = config.imageUploads;
   }
 
   const attachments = config.messaging?.attachments;

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -341,7 +341,14 @@ export function desktopSettingsPatchToEdits(
 
   const attachments = patch.messaging?.attachments;
   if (attachments?.imageProfile !== undefined) {
-    set(["messaging", "attachments", "image_profile"], attachments.imageProfile);
+    if (attachments.imageProfile === "medium") {
+      edits.push({
+        op: "delete",
+        path: ["messaging", "attachments", "image_profile"],
+      });
+    } else {
+      set(["messaging", "attachments", "image_profile"], attachments.imageProfile);
+    }
   }
   if (attachments?.maxAttachmentBytes !== undefined) {
     set(["messaging", "attachments", "max_attachment_bytes"], attachments.maxAttachmentBytes);

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -15,6 +15,7 @@ import {
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
 } from "@pwragent/shared";
+import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
 import {
   applyDesktopSettingsPatch,
   readDesktopSettingsConfig,
@@ -293,6 +294,11 @@ export class DesktopSettingsService {
             config.experimental?.diffCondensation?.model,
           ),
         },
+      },
+      imageUploads: {
+        pastedImageMaxPatches: this.resolvePastedImageMaxPatches(
+          config.imageUploads?.pastedImageMaxPatches,
+        ),
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
@@ -837,6 +843,19 @@ export class DesktopSettingsService {
       value: configValue ?? "medium",
       source: configValue === undefined ? "default" : "config",
       error: envValue.error,
+    };
+  }
+
+  private resolvePastedImageMaxPatches(
+    configValue: number | undefined,
+  ): DesktopSettingsValue<number> {
+    const normalized =
+      configValue !== undefined && Number.isFinite(configValue)
+        ? Math.max(0, Math.floor(configValue))
+        : undefined;
+    return {
+      value: normalized ?? DEFAULT_PASTED_IMAGE_MAX_PATCHES,
+      source: normalized === undefined ? "default" : "config",
     };
   }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -178,6 +178,8 @@ function DesktopAppShell(props: {
     pendingRequest: session.pendingRequest,
     pendingUserInput: session.pendingUserInput,
     pendingStatusText: session.pendingStatusText,
+    pastedImageMaxPatches:
+      settings.snapshot?.imageUploads.pastedImageMaxPatches.value,
     platform: desktopApi?.platform,
     selectedDirectory: navigation.selectedDirectory,
     selectedLaunchpad: navigation.selectedLaunchpad,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -166,6 +166,9 @@ describe("App", () => {
           model: { value: "auto", source: "default" },
         },
       },
+      imageUploads: {
+        pastedImageMaxPatches: { value: 1536, source: "default" },
+      },
       messaging: {
         enabled: { value: true, source: "default" },
         allowFullAccessEscalation: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -98,6 +98,7 @@ type ComposerProps = {
   onBeforeSendTurn?: () => void;
   onPendingStatusChange?: (status?: string) => void;
   onRefreshNavigation?: () => Promise<void>;
+  pastedImageMaxPatches?: number;
   onUpdateLaunchpad?: (
     directoryKey: string,
     patch: Partial<
@@ -2399,6 +2400,7 @@ export function Composer(props: ComposerProps) {
 
           const normalized = await normalizeImageFile(file, {
             fallback: props.desktopApi?.normalizeImageForUpload,
+            maxPatchCount: props.pastedImageMaxPatches,
           });
           void props.desktopApi?.recordImageUploadNormalization?.({
             fileName: file.name || fallbackName,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4562,6 +4562,7 @@ describe("Composer", () => {
           startTurn,
         }}
         disabled={false}
+        pastedImageMaxPatches={1024}
         skills={[]}
         thread={{
           id: "thread-1",
@@ -4590,6 +4591,10 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Describe this screenshot" } });
 
     expect(await screen.findByAltText("screenshot.jpeg")).toBeInTheDocument();
+    expect(normalizeImageFile).toHaveBeenCalledWith(
+      imageFile,
+      expect.objectContaining({ maxPatchCount: 1024 }),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,7 +1,4 @@
-import type {
-  DesktopMessagingImageProfile,
-  DesktopSettingsSnapshot,
-} from "@pwragent/shared";
+import type { DesktopSettingsSnapshot } from "@pwragent/shared";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -10,42 +7,45 @@ import {
 } from "./SettingsLayout";
 import { sourceBadge } from "./settings-fields";
 
-const IMAGE_PROFILE_OPTIONS: Array<{
+const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   description: string;
   label: string;
-  value: DesktopMessagingImageProfile;
+  value: number;
 }> = [
   {
-    description: "Lowest bandwidth. Images are downscaled aggressively.",
-    label: "Low",
-    value: "low",
+    description:
+      "Caps square images at about 1024 32px patches before model-specific multipliers.",
+    label: "1024 patches",
+    value: 1024,
   },
   {
-    description: "Default. Matches desktop paste behavior.",
-    label: "Medium",
-    value: "medium",
+    description:
+      "Default. Keeps current paste behavior and fits patch-based model budgets.",
+    label: "1536 patches",
+    value: 1536,
   },
   {
-    description: "Higher fidelity with larger uploads.",
-    label: "High",
-    value: "high",
+    description:
+      "Allows roughly a 2048 x 2048 square image before model-specific multipliers.",
+    label: "4096 patches",
+    value: 4096,
   },
   {
-    description: "Preserve the inbound image dimensions.",
-    label: "Actual",
-    value: "actual",
+    description: "Preserves pasted image dimensions before upload.",
+    label: "Actual size",
+    value: 0,
   },
 ];
 
 export function GeneralSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
-  onImageProfileChange: (value: DesktopMessagingImageProfile) => Promise<void>;
+  onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
 }) {
-  const imageProfile = props.snapshot.messaging.attachments.imageProfile;
-  const overridden = imageProfile.source === "env";
-  const activeOption = IMAGE_PROFILE_OPTIONS.find(
-    (option) => option.value === imageProfile.value,
+  const pastedImageMaxPatches =
+    props.snapshot.imageUploads.pastedImageMaxPatches;
+  const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
+    (option) => option.value === pastedImageMaxPatches.value,
   );
 
   return (
@@ -58,39 +58,44 @@ export function GeneralSettings(props: {
 
       <SettingsSection
         eyebrow="General"
-        title="Image uploads"
-        chip={sourceBadge(imageProfile)}
-        chipKind={overridden ? "warn" : "default"}
+        title="Pasted images"
+        chip={sourceBadge(pastedImageMaxPatches)}
       >
         <div className="settings-fields">
           <SettingsField
-            label="Image upload profile"
-            sub="Normalize inbound messaging images before forwarding them to the model."
+            label="Image patch budget"
+            sub="Resize pasted desktop images before upload to control image-token usage."
             help={
-              overridden
-                ? "Overridden by PWRAGENT_MESSAGING_ATTACHMENT_IMAGE_PROFILE; clear the environment variable to edit this from settings."
-                : activeOption?.description
+              <>
+                {activeOption?.description ??
+                  "Custom patch budget for pasted images."}{" "}
+                Patch-based models count 32 x 32 pixel blocks before
+                model-specific multipliers; tile-based models use their own
+                image resizing rules.
+              </>
             }
-            error={imageProfile.error}
-            source={sourceBadge(imageProfile)}
+            error={pastedImageMaxPatches.error}
+            source={sourceBadge(pastedImageMaxPatches)}
             control={
               <div
                 className="settings-segmented"
                 role="radiogroup"
-                aria-label="Image upload profile"
+                aria-label="Pasted image patch budget"
               >
-                {IMAGE_PROFILE_OPTIONS.map((option) => (
+                {PASTED_IMAGE_PATCH_OPTIONS.map((option) => (
                   <button
                     key={option.value}
-                    aria-checked={imageProfile.value === option.value}
+                    aria-checked={pastedImageMaxPatches.value === option.value}
                     className={`settings-segmented__button${
-                      imageProfile.value === option.value ? " is-active" : ""
+                      pastedImageMaxPatches.value === option.value
+                        ? " is-active"
+                        : ""
                     }`}
-                    disabled={props.saving || overridden}
+                    disabled={props.saving}
                     role="radio"
                     type="button"
                     onClick={() => {
-                      void props.onImageProfileChange(option.value);
+                      void props.onPastedImageMaxPatchesChange(option.value);
                     }}
                   >
                     {option.label}

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,0 +1,106 @@
+import type {
+  DesktopMessagingImageProfile,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import {
+  SettingsField,
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+import { sourceBadge } from "./settings-fields";
+
+const IMAGE_PROFILE_OPTIONS: Array<{
+  description: string;
+  label: string;
+  value: DesktopMessagingImageProfile;
+}> = [
+  {
+    description: "Lowest bandwidth. Images are downscaled aggressively.",
+    label: "Low",
+    value: "low",
+  },
+  {
+    description: "Default. Matches desktop paste behavior.",
+    label: "Medium",
+    value: "medium",
+  },
+  {
+    description: "Higher fidelity with larger uploads.",
+    label: "High",
+    value: "high",
+  },
+  {
+    description: "Preserve the inbound image dimensions.",
+    label: "Actual",
+    value: "actual",
+  },
+];
+
+export function GeneralSettings(props: {
+  saving: boolean;
+  snapshot: DesktopSettingsSnapshot;
+  onImageProfileChange: (value: DesktopMessagingImageProfile) => Promise<void>;
+}) {
+  const imageProfile = props.snapshot.messaging.attachments.imageProfile;
+  const overridden = imageProfile.source === "env";
+  const activeOption = IMAGE_PROFILE_OPTIONS.find(
+    (option) => option.value === imageProfile.value,
+  );
+
+  return (
+    <SettingsSectionStack paneId="general" aria-label="General settings">
+      <SettingsPanelHead
+        eyebrow="General"
+        title="General settings"
+        help="Defaults that apply across PwrAgent surfaces."
+      />
+
+      <SettingsSection
+        eyebrow="General"
+        title="Image uploads"
+        chip={sourceBadge(imageProfile)}
+        chipKind={overridden ? "warn" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Image upload profile"
+            sub="Normalize inbound messaging images before forwarding them to the model."
+            help={
+              overridden
+                ? "Overridden by PWRAGENT_MESSAGING_ATTACHMENT_IMAGE_PROFILE; clear the environment variable to edit this from settings."
+                : activeOption?.description
+            }
+            error={imageProfile.error}
+            source={sourceBadge(imageProfile)}
+            control={
+              <div
+                className="settings-segmented"
+                role="radiogroup"
+                aria-label="Image upload profile"
+              >
+                {IMAGE_PROFILE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    aria-checked={imageProfile.value === option.value}
+                    className={`settings-segmented__button${
+                      imageProfile.value === option.value ? " is-active" : ""
+                    }`}
+                    disabled={props.saving || overridden}
+                    role="radio"
+                    type="button"
+                    onClick={() => {
+                      void props.onImageProfileChange(option.value);
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            }
+          />
+        </div>
+      </SettingsSection>
+    </SettingsSectionStack>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -20,7 +20,7 @@ const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   },
   {
     description:
-      "Default. Keeps current paste behavior and fits patch-based model budgets.",
+      "Default. Limits large pasted images to roughly 1536 image patches before model-specific multipliers.",
     label: "1536 patches",
     value: 1536,
   },
@@ -70,8 +70,9 @@ export function GeneralSettings(props: {
                 {activeOption?.description ??
                   "Custom patch budget for pasted images."}{" "}
                 Patch-based models count 32 x 32 pixel blocks before
-                model-specific multipliers; tile-based models use their own
-                image resizing rules.
+                model-specific multipliers. Images within 20% of the selected
+                patch budget are left unchanged to avoid marginal re-encodes.
+                Tile-based models use their own image resizing rules.
               </>
             }
             error={pastedImageMaxPatches.error}

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -21,6 +21,7 @@ import {
   validateTelegramGroupChatId,
   validateTelegramPositiveId,
   type DesktopAuthorizedContact,
+  type DesktopMessagingImageProfile,
   type DesktopMessagingContactLookupKind,
   type DesktopMessagingContactLookupPlatform,
   type DesktopMessagingContactLookupResponse,
@@ -63,6 +64,7 @@ export function MessagingSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onToolUpdateModeChange: (mode: MessagingToolUpdateMode) => Promise<void>;
+  onImageProfileChange: (profile: DesktopMessagingImageProfile) => Promise<void>;
   onInputDebounceMsChange: (value: number) => Promise<void>;
   onMessagingEnabledChange: (enabled: boolean) => Promise<void>;
   onFullAccessEscalationChange: (enabled: boolean) => Promise<void>;
@@ -104,6 +106,7 @@ export function MessagingSettings(props: {
   const fullAccessWarning = props.snapshot.messaging.fullAccessWarning;
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
+  const imageProfile = props.snapshot.messaging.attachments.imageProfile;
   const runtimeMessaging = props.snapshot.runtime.messaging;
   const masterEnabled = runtimeMessaging.overrideActive
     ? !runtimeMessaging.disabled
@@ -226,6 +229,17 @@ export function MessagingSettings(props: {
             value={fullAccessWarning.value}
             onChange={(policy) => {
               void props.onFullAccessWarningPolicyChange(policy);
+            }}
+          />
+          <SegmentedField
+            disabled={props.saving || imageProfile.source === "env"}
+            label="Inbound image profile"
+            sub="Normalize images received from messaging platforms before forwarding them to the model."
+            options={IMAGE_PROFILE_OPTIONS}
+            source={sourceBadge(imageProfile)}
+            value={imageProfile.value}
+            onChange={(profile) => {
+              void props.onImageProfileChange(profile);
             }}
           />
         </div>
@@ -1348,6 +1362,16 @@ const TOOL_UPDATE_MODE_OPTIONS: Array<{
   { label: "Show Some", value: "show_some" },
   { label: "Show More", value: "show_more" },
   { label: "Show All", value: "show_all" },
+];
+
+const IMAGE_PROFILE_OPTIONS: Array<{
+  label: string;
+  value: DesktopMessagingImageProfile;
+}> = [
+  { label: "Low", value: "low" },
+  { label: "Medium", value: "medium" },
+  { label: "High", value: "high" },
+  { label: "Actual", value: "actual" },
 ];
 
 const FULL_ACCESS_WARNING_POLICY_OPTIONS: Array<{

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import type {
   DesktopSettingsSnapshot,
+  DesktopMessagingImageProfile,
   MessagingChannelKind,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -7,6 +8,7 @@ import type { PwrAgentProfilesState } from "../../lib/usePwrAgentProfiles";
 import type { DesktopSettingsState } from "./useDesktopSettings";
 import { AboutSettings } from "./AboutSettings";
 import { ExperimentalSettings } from "./ExperimentalSettings";
+import { GeneralSettings } from "./GeneralSettings";
 import { MessagingSettings } from "./MessagingSettings";
 import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
@@ -24,6 +26,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 
 export type SettingsSection =
+  | "general"
   | "experimental"
   | "messaging"
   | "models"
@@ -33,6 +36,7 @@ export type SettingsSection =
   | "about";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
+  { id: "general", label: "General" },
   { id: "applications", label: "Applications" },
   { id: "profiles", label: "Profiles" },
   { id: "worktrees", label: "Worktrees" },
@@ -55,7 +59,7 @@ export function SettingsScreen(props: {
   onOpenMessagingActivity?: () => void;
 }) {
   const [section, setSection] = useState<SettingsSection>(
-    props.initialSection ?? "applications",
+    props.initialSection ?? "general",
   );
   // When the parent re-mounts with a different initialSection (e.g.
   // a future deep-link), follow it.
@@ -212,6 +216,24 @@ function SettingsSectionBody(props: {
 }) {
   if (props.section === "about") {
     return <AboutSettings desktopApi={props.desktopApi} />;
+  }
+
+  if (props.section === "general") {
+    return (
+      <GeneralSettings
+        saving={props.settings.saving}
+        snapshot={props.snapshot}
+        onImageProfileChange={async (
+          imageProfile: DesktopMessagingImageProfile,
+        ) => {
+          await props.settings.writeConfig({
+            messaging: {
+              attachments: { imageProfile },
+            },
+          });
+        }}
+      />
+    );
   }
 
   if (props.section === "experimental") {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -223,12 +223,10 @@ function SettingsSectionBody(props: {
       <GeneralSettings
         saving={props.settings.saving}
         snapshot={props.snapshot}
-        onImageProfileChange={async (
-          imageProfile: DesktopMessagingImageProfile,
-        ) => {
+        onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {
           await props.settings.writeConfig({
-            messaging: {
-              attachments: { imageProfile },
+            imageUploads: {
+              pastedImageMaxPatches,
             },
           });
         }}
@@ -275,6 +273,15 @@ function SettingsSectionBody(props: {
           await props.settings.writeConfig({
             messaging: {
               inputDebounceMs,
+            },
+          });
+        }}
+        onImageProfileChange={async (
+          imageProfile: DesktopMessagingImageProfile,
+        ) => {
+          await props.settings.writeConfig({
+            messaging: {
+              attachments: { imageProfile },
             },
           });
         }}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -60,6 +60,9 @@ function createSnapshot(
         model: { value: "auto", source: "default" },
       },
     },
+    imageUploads: {
+      pastedImageMaxPatches: { value: 1536, source: "default" },
+    },
     messaging: {
       enabled: { value: true, source: "default" },
       allowFullAccessEscalation: { value: true, source: "default" },
@@ -287,18 +290,16 @@ describe("SettingsScreen", () => {
       "page",
     );
 
-    expect(screen.getByRole("heading", { name: "Image uploads" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "Medium" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { name: "Pasted images" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "1536 patches" })).toHaveAttribute(
       "aria-checked",
       "true",
     );
-    fireEvent.click(screen.getByRole("radio", { name: "High" }));
+    fireEvent.click(screen.getByRole("radio", { name: "4096 patches" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
-        messaging: {
-          attachments: {
-            imageProfile: "high",
-          },
+        imageUploads: {
+          pastedImageMaxPatches: 4096,
         },
       });
     });
@@ -335,6 +336,20 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Medium" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "High" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          attachments: {
+            imageProfile: "high",
+          },
+        },
+      });
+    });
     expect(screen.getByRole("radio", { name: "Show Some" })).toHaveAttribute(
       "aria-checked",
       "true",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -282,11 +282,28 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen settings={settings} onClose={() => undefined} />);
 
     const sections = screen.getByRole("navigation", { name: "Settings sections" });
-    expect(within(sections).getByRole("button", { name: "Applications" })).toHaveAttribute(
+    expect(within(sections).getByRole("button", { name: "General" })).toHaveAttribute(
       "aria-current",
       "page",
     );
 
+    expect(screen.getByRole("heading", { name: "Image uploads" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Medium" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "High" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          attachments: {
+            imageProfile: "high",
+          },
+        },
+      });
+    });
+
+    fireEvent.click(within(sections).getByRole("button", { name: "Applications" }));
     expect(screen.getByRole("heading", { name: "Editor" })).toBeInTheDocument();
     expect(screen.getByText("VS Code")).toBeInTheDocument();
     expect(screen.getByText("/Applications/Visual Studio Code.app")).toBeInTheDocument();
@@ -427,7 +444,7 @@ describe("SettingsScreen", () => {
       });
     });
 
-    fireEvent.click(within(sections).getByRole("button", { name: "Applications" }));
+    fireEvent.click(within(sections).getByRole("button", { name: "General" }));
     expect(within(sections).getByRole("button", { name: "Experimental" })).not.toHaveAttribute(
       "aria-current",
       "page",
@@ -588,6 +605,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         desktopApi={{ getGhStatus }}
+        initialSection="applications"
         settings={settings}
         onClose={() => undefined}
       />,
@@ -651,6 +669,7 @@ describe("SettingsScreen", () => {
     render(
       <SettingsScreen
         desktopApi={{ copyText: copyTextMock }}
+        initialSection="applications"
         settings={settings}
         onClose={() => undefined}
       />,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -793,6 +793,7 @@ export type ThreadViewProps = {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  pastedImageMaxPatches?: number;
   platform?: string;
   selectedDirectory?: NavigationDirectorySummary;
   selectedLaunchpad?: NavigationLaunchpadDraft;
@@ -1811,6 +1812,7 @@ export function ThreadView(props: ThreadViewProps) {
               disabled={!launchpadBackend?.available}
               launchpad={selectedLaunchpad}
               launchpadError={props.launchpadError}
+              pastedImageMaxPatches={props.pastedImageMaxPatches}
               fullAccessRiskWarningDismissed={
                 props.fullAccessRiskWarningDismissed
               }
@@ -1970,6 +1972,7 @@ export function ThreadView(props: ThreadViewProps) {
             pendingUserInputActive={Boolean(
               props.pendingUserInput || props.pendingMcpInteraction
             )}
+            pastedImageMaxPatches={props.pastedImageMaxPatches}
             removeOptimisticMessage={props.removeOptimisticMessage}
             setExecutionModeError={props.setExecutionModeError}
             threadModelSettingsError={props.setThreadModelSettingsError}

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   calculateBoundedImageDimensions,
+  calculatePatchBoundedImageDimensions,
   chooseNormalizedImageMimeType,
   normalizeImageFile,
   type ImageNormalizationDependencies,
@@ -8,6 +9,7 @@ import {
 
 function makeDependencies(params: {
   decode?: ImageNormalizationDependencies["decodeImage"];
+  encode?: ImageNormalizationDependencies["encodeCanvas"];
   hasAlpha?: boolean;
   outputBytes?: number[];
 }): ImageNormalizationDependencies {
@@ -26,9 +28,13 @@ function makeDependencies(params: {
         height: 1024,
         draw: vi.fn(),
       })),
-    encodeCanvas: vi.fn(async (_canvas, mimeType) =>
-      new Blob([new Uint8Array(params.outputBytes ?? [1, 2, 3])], { type: mimeType }),
-    ),
+    encodeCanvas:
+      params.encode ??
+      vi.fn(async (_canvas, mimeType) =>
+        new Blob([new Uint8Array(params.outputBytes ?? [1, 2, 3])], {
+          type: mimeType,
+        }),
+      ),
     hasAlpha: vi.fn(() => Boolean(params.hasAlpha)),
     readBlobAsDataUrl: vi.fn(async (blob) => `data:${blob.type};base64,AQID`),
   };
@@ -61,6 +67,23 @@ describe("image normalization", () => {
       width: 1024,
       height: 1536,
     });
+  });
+
+  it("caps images by a patch budget when provided", () => {
+    expect(
+      calculatePatchBoundedImageDimensions({
+        width: 2048,
+        height: 2048,
+        maxPatchCount: 1024,
+      }),
+    ).toEqual({ width: 1024, height: 1024 });
+    expect(
+      calculatePatchBoundedImageDimensions({
+        width: 2048,
+        height: 2048,
+        maxPatchCount: 0,
+      }),
+    ).toEqual({ width: 2048, height: 2048 });
   });
 
   it("does not upscale small images", () => {
@@ -119,6 +142,82 @@ describe("image normalization", () => {
       },
       size: 3,
       width: 1536,
+    });
+  });
+
+  it("passes the pasted image patch budget into normalization", async () => {
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 2048,
+        height: 2048,
+        draw: vi.fn(),
+      })),
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array([1])], "screenshot.png", { type: "image/png" }),
+      { dependencies, maxPatchCount: 1024 },
+    );
+
+    expect(normalized.width).toBe(1024);
+    expect(normalized.height).toBe(1024);
+  });
+
+  it("retries JPEG encoding when a resized output is larger than the source", async () => {
+    const encodeCanvas = vi.fn(async (_canvas, mimeType, quality) => {
+      const size = quality >= 0.85 ? 140 : 90;
+      return new Blob([new Uint8Array(size)], { type: mimeType });
+    });
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 2048,
+        height: 2048,
+        draw: vi.fn(),
+      })),
+      encode: encodeCanvas,
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array(100)], "photo.jpeg", { type: "image/jpeg" }),
+      { dependencies, maxPatchCount: 1024 },
+    );
+
+    expect(normalized.size).toBe(90);
+    expect(encodeCanvas).toHaveBeenCalledWith(
+      expect.anything(),
+      "image/jpeg",
+      expect.closeTo(0.85),
+    );
+    expect(encodeCanvas).toHaveBeenCalledWith(
+      expect.anything(),
+      "image/jpeg",
+      0.84,
+    );
+  });
+
+  it("preserves JPEG bytes when dimensions already fit", async () => {
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 640,
+        height: 480,
+        draw: vi.fn(),
+      })),
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array([1, 2, 3])], "screenshot.jpeg", {
+        type: "image/jpeg",
+      }),
+      { dependencies, maxPatchCount: 1536 },
+    );
+
+    expect(dependencies.encodeCanvas).not.toHaveBeenCalled();
+    expect(normalized).toMatchObject({
+      dataUrl: "data:image/jpeg;base64,AQID",
+      height: 480,
+      mimeType: "image/jpeg",
+      size: 3,
+      width: 640,
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -86,6 +86,38 @@ describe("image normalization", () => {
     ).toEqual({ width: 2048, height: 2048 });
   });
 
+  it("leaves images within 20 percent of the patch budget alone", () => {
+    expect(
+      calculatePatchBoundedImageDimensions({
+        width: 1120,
+        height: 1024,
+        maxPatchCount: 1024,
+      }),
+    ).toEqual({ width: 1120, height: 1024 });
+  });
+
+  it("only reduces dimensions and keeps the aspect ratio when patch capping", () => {
+    const dimensions = calculatePatchBoundedImageDimensions({
+      width: 2880,
+      height: 1920,
+      maxPatchCount: 1024,
+    });
+
+    expect(dimensions.width).toBeLessThan(2880);
+    expect(dimensions.height).toBeLessThan(1920);
+    expect(dimensions.width / dimensions.height).toBeCloseTo(2880 / 1920, 2);
+  });
+
+  it("does not upscale images below the selected patch budget", () => {
+    expect(
+      calculatePatchBoundedImageDimensions({
+        width: 800,
+        height: 533,
+        maxPatchCount: 4096,
+      }),
+    ).toEqual({ width: 800, height: 533 });
+  });
+
   it("does not upscale small images", () => {
     expect(calculateBoundedImageDimensions({ width: 640, height: 480 })).toEqual({
       width: 640,

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -155,12 +155,69 @@ describe("image normalization", () => {
     });
 
     const normalized = await normalizeImageFile(
-      new File([new Uint8Array([1])], "screenshot.png", { type: "image/png" }),
+      new File([new Uint8Array([1, 2, 3, 4])], "screenshot.png", {
+        type: "image/png",
+      }),
       { dependencies, maxPatchCount: 1024 },
     );
 
     expect(normalized.width).toBe(1024);
     expect(normalized.height).toBe(1024);
+  });
+
+  it("does not let resized PNG encoding grow beyond the source size", async () => {
+    const encodeCanvas = vi.fn(async (canvas, mimeType) => {
+      const size = canvas.width < 1024 ? 90 : 140;
+      return new Blob([new Uint8Array(size)], { type: mimeType });
+    });
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 2048,
+        height: 2048,
+        draw: vi.fn(),
+      })),
+      encode: encodeCanvas,
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array(100)], "screenshot.png", { type: "image/png" }),
+      { dependencies, maxPatchCount: 1024 },
+    );
+
+    expect(normalized).toMatchObject({
+      height: 972,
+      mimeType: "image/png",
+      size: 90,
+      width: 972,
+    });
+    expect(encodeCanvas).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves source PNG bytes when every resized encoding is larger", async () => {
+    const encodeCanvas = vi.fn(async (_canvas, mimeType) =>
+      new Blob([new Uint8Array(140)], { type: mimeType }),
+    );
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 2048,
+        height: 2048,
+        draw: vi.fn(),
+      })),
+      encode: encodeCanvas,
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array(100)], "screenshot.png", { type: "image/png" }),
+      { dependencies, maxPatchCount: 1024 },
+    );
+
+    expect(normalized).toMatchObject({
+      dataUrl: "data:image/png;base64,AQID",
+      height: 2048,
+      mimeType: "image/png",
+      size: 100,
+      width: 2048,
+    });
   });
 
   it("retries JPEG encoding when a resized output is larger than the source", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -252,6 +252,32 @@ describe("image normalization", () => {
     });
   });
 
+  it("preserves PNG bytes when actual size is selected", async () => {
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 2880,
+        height: 1920,
+        draw: vi.fn(),
+      })),
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array(329 * 1024)], "screenshot.png", {
+        type: "image/png",
+      }),
+      { dependencies, maxPatchCount: 0 },
+    );
+
+    expect(dependencies.encodeCanvas).not.toHaveBeenCalled();
+    expect(normalized).toMatchObject({
+      dataUrl: "data:image/png;base64,AQID",
+      height: 1920,
+      mimeType: "image/png",
+      size: 329 * 1024,
+      width: 2880,
+    });
+  });
+
   it("retries JPEG encoding when a resized output is larger than the source", async () => {
     const encodeCanvas = vi.fn(async (_canvas, mimeType, quality) => {
       const size = quality >= 0.85 ? 140 : 90;

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -221,6 +221,34 @@ describe("image normalization", () => {
     });
   });
 
+  it("normalizes extension-inferred JPEG files with empty blob MIME types", async () => {
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 640,
+        height: 480,
+        draw: vi.fn(),
+      })),
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array([1, 2, 3])], "screenshot.jpg"),
+      { dependencies, maxPatchCount: 1536 },
+    );
+
+    expect(dependencies.encodeCanvas).toHaveBeenCalledWith(
+      expect.anything(),
+      "image/jpeg",
+      expect.any(Number),
+    );
+    expect(normalized).toMatchObject({
+      dataUrl: "data:image/jpeg;base64,AQID",
+      height: 480,
+      mimeType: "image/jpeg",
+      size: 3,
+      width: 640,
+    });
+  });
+
   it("routes HEIC decode failures through the fallback and normalizes the result", async () => {
     const decode = vi
       .fn<ImageNormalizationDependencies["decodeImage"]>()

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -225,7 +225,7 @@ describe("image normalization", () => {
     expect(encodeCanvas).toHaveBeenCalledTimes(2);
   });
 
-  it("preserves source PNG bytes when every resized encoding is larger", async () => {
+  it("preserves the patch cap when every resized PNG encoding is larger", async () => {
     const encodeCanvas = vi.fn(async (_canvas, mimeType) =>
       new Blob([new Uint8Array(140)], { type: mimeType }),
     );
@@ -245,10 +245,10 @@ describe("image normalization", () => {
 
     expect(normalized).toMatchObject({
       dataUrl: "data:image/png;base64,AQID",
-      height: 2048,
+      height: 1024,
       mimeType: "image/png",
-      size: 100,
-      width: 2048,
+      size: 140,
+      width: 1024,
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -248,56 +248,62 @@ async function normalizeBlob(params: {
     });
     const sourceMimeType = normalizeSourceMimeType(params.originalMimeType);
     const blobMimeType = normalizeSourceMimeType(params.blob.type);
-    if (
-      dimensions.width === decoded.width &&
-      dimensions.height === decoded.height &&
-      (sourceMimeType === "image/jpeg" || sourceMimeType === "image/png") &&
-      blobMimeType === sourceMimeType
-    ) {
-      return {
-        conversionPath: params.conversionPath,
-        dataUrl: await params.dependencies.readBlobAsDataUrl(params.blob),
-        height: decoded.height,
-        mimeType: sourceMimeType,
-        original: {
-          height: decoded.height,
-          mimeType: params.originalMimeType,
-          name: params.fileName,
-          size: params.originalSize,
-          width: decoded.width,
-        },
-        size: params.blob.size,
-        width: decoded.width,
-      };
+    if (canPreserveSourceBlob(blobMimeType, sourceMimeType)) {
+      if (
+        dimensions.width === decoded.width &&
+        dimensions.height === decoded.height
+      ) {
+        return await preservedSourceImage({
+          blob: params.blob,
+          conversionPath: params.conversionPath,
+          decoded,
+          dependencies: params.dependencies,
+          fileName: params.fileName,
+          mimeType: sourceMimeType,
+          originalMimeType: params.originalMimeType,
+          originalSize: params.originalSize,
+        });
+      }
     }
 
-    const { canvas, context } = params.dependencies.createCanvas(
-      dimensions.width,
-      dimensions.height,
-    );
-    decoded.draw(context, dimensions.width, dimensions.height);
-    const hasAlpha = params.dependencies.hasAlpha(
-      context,
-      dimensions.width,
-      dimensions.height,
-    );
-    const mimeType = chooseNormalizedImageMimeType({
-      hasAlpha,
-      sourceMimeType: params.originalMimeType,
-    });
-    const outputBlob = await encodeNormalizedCanvas({
-      canvas,
+    let output = await encodeImageAtDimensions({
+      decoded,
       dependencies: params.dependencies,
+      dimensions,
       jpegQuality: params.jpegQuality,
-      mimeType,
-      originalSize: params.originalSize,
+      sourceMimeType: params.originalMimeType,
+      sourceSize: params.blob.size,
     });
+    if (output.blob.size > params.blob.size) {
+      const smallerOutput = await encodeSmallerImageWithinSourceSize({
+        decoded,
+        dependencies: params.dependencies,
+        dimensions,
+        jpegQuality: params.jpegQuality,
+        sourceMimeType: params.originalMimeType,
+        sourceSize: params.blob.size,
+      });
+      if (smallerOutput) {
+        output = smallerOutput;
+      } else if (canPreserveSourceBlob(blobMimeType, sourceMimeType)) {
+        return await preservedSourceImage({
+          blob: params.blob,
+          conversionPath: params.conversionPath,
+          decoded,
+          dependencies: params.dependencies,
+          fileName: params.fileName,
+          mimeType: sourceMimeType,
+          originalMimeType: params.originalMimeType,
+          originalSize: params.originalSize,
+        });
+      }
+    }
 
     return {
       conversionPath: params.conversionPath,
-      dataUrl: await params.dependencies.readBlobAsDataUrl(outputBlob),
-      height: dimensions.height,
-      mimeType,
+      dataUrl: await params.dependencies.readBlobAsDataUrl(output.blob),
+      height: output.height,
+      mimeType: output.mimeType,
       original: {
         height: decoded.height,
         mimeType: params.originalMimeType,
@@ -305,12 +311,133 @@ async function normalizeBlob(params: {
         size: params.originalSize,
         width: decoded.width,
       },
-      size: outputBlob.size,
-      width: dimensions.width,
+      size: output.blob.size,
+      width: output.width,
     };
   } finally {
     decoded.close?.();
   }
+}
+
+type EncodedImage = {
+  blob: Blob;
+  height: number;
+  mimeType: NormalizedImageMimeType;
+  width: number;
+};
+
+async function preservedSourceImage(params: {
+  blob: Blob;
+  conversionPath: NormalizedImage["conversionPath"];
+  decoded: DecodedImage;
+  dependencies: ImageNormalizationDependencies;
+  fileName: string;
+  mimeType: NormalizedImageMimeType;
+  originalMimeType: string;
+  originalSize: number;
+}): Promise<NormalizedImage> {
+  return {
+    conversionPath: params.conversionPath,
+    dataUrl: await params.dependencies.readBlobAsDataUrl(params.blob),
+    height: params.decoded.height,
+    mimeType: params.mimeType,
+    original: {
+      height: params.decoded.height,
+      mimeType: params.originalMimeType,
+      name: params.fileName,
+      size: params.originalSize,
+      width: params.decoded.width,
+    },
+    size: params.blob.size,
+    width: params.decoded.width,
+  };
+}
+
+async function encodeImageAtDimensions(params: {
+  decoded: DecodedImage;
+  dependencies: ImageNormalizationDependencies;
+  dimensions: { height: number; width: number };
+  jpegQuality: number;
+  sourceMimeType: string;
+  sourceSize: number;
+}): Promise<EncodedImage> {
+  const { canvas, context } = params.dependencies.createCanvas(
+    params.dimensions.width,
+    params.dimensions.height,
+  );
+  params.decoded.draw(
+    context,
+    params.dimensions.width,
+    params.dimensions.height,
+  );
+  const hasAlpha = params.dependencies.hasAlpha(
+    context,
+    params.dimensions.width,
+    params.dimensions.height,
+  );
+  const mimeType = chooseNormalizedImageMimeType({
+    hasAlpha,
+    sourceMimeType: params.sourceMimeType,
+  });
+  const blob = await encodeNormalizedCanvas({
+    canvas,
+    dependencies: params.dependencies,
+    jpegQuality: params.jpegQuality,
+    mimeType,
+    originalSize: params.sourceSize,
+  });
+
+  return {
+    blob,
+    height: params.dimensions.height,
+    mimeType,
+    width: params.dimensions.width,
+  };
+}
+
+async function encodeSmallerImageWithinSourceSize(params: {
+  decoded: DecodedImage;
+  dependencies: ImageNormalizationDependencies;
+  dimensions: { height: number; width: number };
+  jpegQuality: number;
+  sourceMimeType: string;
+  sourceSize: number;
+}): Promise<EncodedImage | undefined> {
+  for (const scale of [0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.5]) {
+    const dimensions = {
+      width: Math.max(1, Math.floor(params.dimensions.width * scale)),
+      height: Math.max(1, Math.floor(params.dimensions.height * scale)),
+    };
+    if (
+      dimensions.width === params.dimensions.width &&
+      dimensions.height === params.dimensions.height
+    ) {
+      continue;
+    }
+
+    const output = await encodeImageAtDimensions({
+      decoded: params.decoded,
+      dependencies: params.dependencies,
+      dimensions,
+      jpegQuality: params.jpegQuality,
+      sourceMimeType: params.sourceMimeType,
+      sourceSize: params.sourceSize,
+    });
+    if (output.blob.size <= params.sourceSize) {
+      return output;
+    }
+  }
+  return undefined;
+}
+
+function canPreserveSourceBlob(
+  blobMimeType: string,
+  sourceMimeType: string,
+): sourceMimeType is NormalizedImageMimeType {
+  return (
+    (sourceMimeType === "image/jpeg" || sourceMimeType === "image/png") &&
+    blobMimeType === sourceMimeType
+  );
 }
 
 async function encodeNormalizedCanvas(params: {

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -286,17 +286,6 @@ async function normalizeBlob(params: {
       });
       if (smallerOutput) {
         output = smallerOutput;
-      } else if (canPreserveSourceBlob(blobMimeType, sourceMimeType)) {
-        return await preservedSourceImage({
-          blob: params.blob,
-          conversionPath: params.conversionPath,
-          decoded,
-          dependencies: params.dependencies,
-          fileName: params.fileName,
-          mimeType: sourceMimeType,
-          originalMimeType: params.originalMimeType,
-          originalSize: params.originalSize,
-        });
       }
     }
 

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE,
+  DEFAULT_PASTED_IMAGE_MAX_PATCHES,
   IMAGE_UPLOAD_QUALITY_PROFILES,
   type ImageUploadQualityProfile,
 } from "../../../shared/image-normalization";
@@ -60,6 +61,7 @@ type CanvasHandle = {
 type NormalizeImageFileOptions = {
   fallback?: (request: ImageFallbackRequest) => Promise<ImageFallbackResponse>;
   jpegQuality?: number;
+  maxPatchCount?: number;
   maxLongEdge?: number;
   maxShortEdge?: number;
   qualityProfile?: ImageUploadQualityProfile;
@@ -85,11 +87,19 @@ export type ImageNormalizationDependencies = {
 export function calculateBoundedImageDimensions(params: {
   height: number;
   maxLongEdge?: number;
+  maxPatchCount?: number;
   maxShortEdge?: number;
   width: number;
 }): { height: number; width: number } {
   const width = Math.max(1, Math.round(params.width));
   const height = Math.max(1, Math.round(params.height));
+  if (params.maxPatchCount !== undefined) {
+    return calculatePatchBoundedImageDimensions({
+      width,
+      height,
+      maxPatchCount: params.maxPatchCount,
+    });
+  }
   const maxLongEdge = params.maxLongEdge ?? NORMALIZED_IMAGE_MAX_LONG_EDGE;
   const maxShortEdge = params.maxShortEdge ?? NORMALIZED_IMAGE_MAX_SHORT_EDGE;
   const longEdge = Math.max(width, height);
@@ -100,6 +110,43 @@ export function calculateBoundedImageDimensions(params: {
     width: Math.max(1, Math.round(width * scale)),
     height: Math.max(1, Math.round(height * scale)),
   };
+}
+
+export function calculatePatchBoundedImageDimensions(params: {
+  height: number;
+  maxPatchCount: number;
+  width: number;
+}): { height: number; width: number } {
+  const width = Math.max(1, Math.round(params.width));
+  const height = Math.max(1, Math.round(params.height));
+  const maxPatchCount = Math.floor(params.maxPatchCount);
+  if (maxPatchCount <= 0) {
+    return { width, height };
+  }
+
+  const patchCount = imagePatchCount(width, height);
+  if (patchCount <= maxPatchCount) {
+    return { width, height };
+  }
+
+  let scale = Math.sqrt((maxPatchCount * 32 * 32) / (width * height));
+  let nextWidth = Math.max(1, Math.floor(width * scale));
+  let nextHeight = Math.max(1, Math.floor(height * scale));
+
+  while (imagePatchCount(nextWidth, nextHeight) > maxPatchCount) {
+    scale *= 0.99;
+    nextWidth = Math.max(1, Math.floor(width * scale));
+    nextHeight = Math.max(1, Math.floor(height * scale));
+  }
+
+  return {
+    width: nextWidth,
+    height: nextHeight,
+  };
+}
+
+function imagePatchCount(width: number, height: number): number {
+  return Math.ceil(width / 32) * Math.ceil(height / 32);
 }
 
 export function chooseNormalizedImageMimeType(params: {
@@ -134,6 +181,9 @@ export async function normalizeImageFile(
     fileName: file.name || "pasted-image",
     jpegQuality: options.jpegQuality ?? profile.jpegQuality,
     maxLongEdge: options.maxLongEdge ?? profile.maxLongEdge,
+    maxPatchCount:
+      options.maxPatchCount ??
+      (options.qualityProfile ? undefined : DEFAULT_PASTED_IMAGE_MAX_PATCHES),
     maxShortEdge: options.maxShortEdge ?? profile.maxShortEdge,
     originalMimeType: inferImageMimeType(file),
     originalSize: file.size,
@@ -155,6 +205,7 @@ async function normalizeBlob(params: {
   fileName: string;
   jpegQuality: number;
   maxLongEdge: number;
+  maxPatchCount?: number;
   maxShortEdge: number;
   originalMimeType: string;
   originalSize: number;
@@ -192,8 +243,32 @@ async function normalizeBlob(params: {
       width: decoded.width,
       height: decoded.height,
       maxLongEdge: params.maxLongEdge,
+      maxPatchCount: params.maxPatchCount,
       maxShortEdge: params.maxShortEdge,
     });
+    const sourceMimeType = normalizeSourceMimeType(params.originalMimeType);
+    if (
+      dimensions.width === decoded.width &&
+      dimensions.height === decoded.height &&
+      (sourceMimeType === "image/jpeg" || sourceMimeType === "image/png")
+    ) {
+      return {
+        conversionPath: params.conversionPath,
+        dataUrl: await params.dependencies.readBlobAsDataUrl(params.blob),
+        height: decoded.height,
+        mimeType: sourceMimeType,
+        original: {
+          height: decoded.height,
+          mimeType: params.originalMimeType,
+          name: params.fileName,
+          size: params.originalSize,
+          width: decoded.width,
+        },
+        size: params.blob.size,
+        width: decoded.width,
+      };
+    }
+
     const { canvas, context } = params.dependencies.createCanvas(
       dimensions.width,
       dimensions.height,
@@ -208,11 +283,13 @@ async function normalizeBlob(params: {
       hasAlpha,
       sourceMimeType: params.originalMimeType,
     });
-    const outputBlob = await params.dependencies.encodeCanvas(
+    const outputBlob = await encodeNormalizedCanvas({
       canvas,
+      dependencies: params.dependencies,
+      jpegQuality: params.jpegQuality,
       mimeType,
-      params.jpegQuality,
-    );
+      originalSize: params.originalSize,
+    });
 
     return {
       conversionPath: params.conversionPath,
@@ -232,6 +309,43 @@ async function normalizeBlob(params: {
   } finally {
     decoded.close?.();
   }
+}
+
+async function encodeNormalizedCanvas(params: {
+  canvas: HTMLCanvasElement;
+  dependencies: ImageNormalizationDependencies;
+  jpegQuality: number;
+  mimeType: NormalizedImageMimeType;
+  originalSize: number;
+}): Promise<Blob> {
+  const initial = await params.dependencies.encodeCanvas(
+    params.canvas,
+    params.mimeType,
+    params.jpegQuality,
+  );
+  if (params.mimeType !== "image/jpeg" || initial.size <= params.originalSize) {
+    return initial;
+  }
+
+  let smallest = initial;
+  const retryQualities = [0.88, 0.84, 0.8, 0.76, 0.72, 0.66, 0.6].filter(
+    (quality) => quality < params.jpegQuality,
+  );
+  for (const quality of retryQualities) {
+    const candidate = await params.dependencies.encodeCanvas(
+      params.canvas,
+      params.mimeType,
+      quality,
+    );
+    if (candidate.size < smallest.size) {
+      smallest = candidate;
+    }
+    if (candidate.size <= params.originalSize) {
+      return candidate;
+    }
+  }
+
+  return smallest;
 }
 
 function normalizeSourceMimeType(mimeType: string): string {

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -11,6 +11,7 @@ export const NORMALIZED_IMAGE_MAX_SHORT_EDGE =
   IMAGE_UPLOAD_QUALITY_PROFILES.medium.maxShortEdge;
 export const NORMALIZED_IMAGE_JPEG_QUALITY =
   IMAGE_UPLOAD_QUALITY_PROFILES.medium.jpegQuality;
+const IMAGE_PATCH_BUDGET_SLOP_FACTOR = 1.2;
 
 export type NormalizedImageMimeType = "image/jpeg" | "image/png";
 
@@ -125,7 +126,7 @@ export function calculatePatchBoundedImageDimensions(params: {
   }
 
   const patchCount = imagePatchCount(width, height);
-  if (patchCount <= maxPatchCount) {
+  if (patchCount <= maxPatchCount * IMAGE_PATCH_BUDGET_SLOP_FACTOR) {
     return { width, height };
   }
 

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -247,10 +247,12 @@ async function normalizeBlob(params: {
       maxShortEdge: params.maxShortEdge,
     });
     const sourceMimeType = normalizeSourceMimeType(params.originalMimeType);
+    const blobMimeType = normalizeSourceMimeType(params.blob.type);
     if (
       dimensions.width === decoded.width &&
       dimensions.height === decoded.height &&
-      (sourceMimeType === "image/jpeg" || sourceMimeType === "image/png")
+      (sourceMimeType === "image/jpeg" || sourceMimeType === "image/png") &&
+      blobMimeType === sourceMimeType
     ) {
       return {
         conversionPath: params.conversionPath,

--- a/apps/desktop/src/shared/image-normalization.ts
+++ b/apps/desktop/src/shared/image-normalization.ts
@@ -9,6 +9,7 @@ export type ImageUploadQualityProfileSettings = {
 
 export const DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE: ImageUploadQualityProfile =
   "medium";
+export const DEFAULT_PASTED_IMAGE_MAX_PATCHES = 1536;
 
 export const IMAGE_UPLOAD_QUALITY_PROFILES: Record<
   ImageUploadQualityProfile,

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -334,8 +334,8 @@ The debounce setting can also be written as `input_debounce_ms` under
 `[messaging]` in the desktop config TOML. Use `0` to disable the pre-start wait
 while keeping active-turn queueing enabled.
 
-The image upload profile is available in Settings under General -> Image
-uploads. Its TOML equivalent is `image_profile` under
+The messaging image upload profile is available in Settings under Messaging ->
+General. Its TOML equivalent is `image_profile` under
 `[messaging.attachments]`; the default `medium` is omitted from the config file
 when saved from Settings.
 

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -325,14 +325,19 @@ LINE:
 
 Attachment policy:
 
-- `PWRAGNT_MESSAGING_INPUT_DEBOUNCE_MS`
-- `PWRAGNT_MESSAGING_ATTACHMENT_IMAGE_PROFILE` (`low`, `medium`, `high`, or `actual`)
-- `PWRAGNT_MESSAGING_ATTACHMENT_MAX_BYTES`
-- `PWRAGNT_MESSAGING_ATTACHMENT_MAX_COUNT`
+- `PWRAGENT_MESSAGING_INPUT_DEBOUNCE_MS`
+- `PWRAGENT_MESSAGING_ATTACHMENT_IMAGE_PROFILE` (`low`, `medium`, `high`, or `actual`)
+- `PWRAGENT_MESSAGING_ATTACHMENT_MAX_BYTES`
+- `PWRAGENT_MESSAGING_ATTACHMENT_MAX_COUNT`
 
 The debounce setting can also be written as `input_debounce_ms` under
 `[messaging]` in the desktop config TOML. Use `0` to disable the pre-start wait
 while keeping active-turn queueing enabled.
+
+The image upload profile is available in Settings under General -> Image
+uploads. Its TOML equivalent is `image_profile` under
+`[messaging.attachments]`; the default `medium` is omitted from the config file
+when saved from Settings.
 
 The authorized ID variables are comma-separated lists and may be empty during
 first-run discovery. Bot tokens are redacted from runtime logs. Telegram also

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -74,6 +74,15 @@ graph TD
 | `PWRAGENT_HOME` | Override the root directory (default: `~/.pwragent/`) |
 | `PWRAGENT_PROFILE` | Select a named profile (default: `default`) |
 
+## Desktop Config TOML
+
+Per-profile desktop settings live in `profiles/<name>/config.toml`. Settings
+saved at their defaults are omitted from the file.
+
+The General > Pasted images setting is stored as
+`pasted_image_max_patches` under `[image_uploads]`. The default is `1536`; use
+`0` to preserve pasted image dimensions before upload.
+
 ## sqlite Database (`state.db`)
 
 Single database containing all persistent state. Opened with WAL mode, `synchronous=NORMAL`, `busy_timeout=5000ms`, `auto_vacuum=INCREMENTAL`.

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -32,6 +32,9 @@ describe("desktop settings contracts", () => {
           model: { value: "auto", source: "default" },
         },
       },
+      imageUploads: {
+        pastedImageMaxPatches: { value: 1536, source: "default" },
+      },
       messaging: {
         enabled: {
           value: true,

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -132,6 +132,10 @@ export type DesktopMessagingAttachmentSettingsSnapshot = {
   maxAttachmentCount: DesktopSettingsValue<number>;
 };
 
+export type DesktopImageUploadSettingsSnapshot = {
+  pastedImageMaxPatches: DesktopSettingsValue<number>;
+};
+
 export type DesktopCodexCandidateSource =
   | "env"
   | "config"
@@ -300,6 +304,7 @@ export type DesktopSettingsSnapshot = {
       model: DesktopSettingsValue<string>;
     };
   };
+  imageUploads: DesktopImageUploadSettingsSnapshot;
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
     allowFullAccessEscalation: DesktopSettingsValue<boolean>;
@@ -405,6 +410,9 @@ export type DesktopSettingsConfigPatch = {
       /** "auto" or a specific model id. Empty string is coerced to "auto". */
       model?: string;
     };
+  };
+  imageUploads?: {
+    pastedImageMaxPatches?: number;
   };
   messaging?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

I moved the messaging-only inbound image profile control onto the Messaging settings tab and added a separate General setting for pasted desktop images.

The General setting now controls the maximum pasted-image patch budget, with `1536` as the default and `0` preserving original dimensions. It is stored as `pasted_image_max_patches` under `[image_uploads]` and omitted from config when saved at the default.

I also wired the setting through the desktop composer normalization path. Pasted PNGs remain PNGs, pasted JPEGs remain JPEGs, and resized JPEGs retry lower quality if recompression would otherwise make the output larger than the source.

## Validation

I verified the image token wording against the OpenAI image/vision docs: patch-based models count 32 x 32 pixel patches before model-specific multipliers, while other models can use tile-based rules.

I ran:

- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
