### PR TITLE
fix(desktop): avoid default-branch PR false positives

### DIFF
--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -12,11 +12,13 @@ const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
 
 afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
 });
 
 describe("detectPullRequestsForThread", () => {
-  it("uses local branches pointing at HEAD when the thread is detached", async () => {
+  it("uses local feature branches pointing at detached HEAD", async () => {
     const repo = await createDetachedRepoWithFeatureBranchAtHead(
       "fix/messaging-nonblocking-startup",
     );
@@ -51,27 +53,10 @@ describe("detectPullRequestsForThread", () => {
     expect(prs).toHaveLength(1);
   });
 
-  it("does not inherit stale PR branches when a detached thread is at the default branch tip", async () => {
-    const repo = await createDetachedRepoWithDefaultAndStaleBranchAtHead(
-      "fix/sidebar-tooltips",
-    );
-    const fetchedBranches: string[] = [];
+  it("does not use detached HEAD at the default branch tip for PR lookup", async () => {
+    const repo = await createDetachedRepoAtDefaultBranchTip("main");
     const fetcher = {
-      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
-        fetchedBranches.push(branch);
-        if (branch !== "fix/sidebar-tooltips") {
-          return [];
-        }
-        return [
-          {
-            number: 317,
-            org: "pwrdrvr",
-            repo: "PwrAgent",
-            state: "merged",
-            url: "https://github.com/pwrdrvr/PwrAgent/pull/317",
-          },
-        ];
-      }),
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
     } as unknown as GithubPrFetcher;
 
     const prs = await detectPullRequestsForThread({
@@ -80,8 +65,87 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(fetchedBranches).toEqual(["main"]);
     expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
+  it("does not inherit stale PR branches at the default branch tip", async () => {
+    const repo = await createDetachedRepoWithDefaultAndStaleBranchAtHead(
+      "fix/sidebar-tooltips",
+    );
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => [
+        {
+          number: 317,
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          state: "merged",
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/317",
+        },
+      ]),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "HEAD",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
+  it("does not use an attached default branch for PR lookup", async () => {
+    const repo = await createRepoWithDefaultBranch("main");
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "main",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
+  it("lets named-branch lookups degrade through the fetcher for invalid directories", async () => {
+    const staleDirectory = await createNonGitDirectory();
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => {
+        throw new Error("not a git repository");
+      }),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix/pr-chip",
+      directoryPaths: [staleDirectory],
+    });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: staleDirectory,
+      branch: "fix/pr-chip",
+    });
+  });
+
+  it("does not reject detached HEAD lookups for invalid directories", async () => {
+    const staleDirectory = await createNonGitDirectory();
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "HEAD",
+      directoryPaths: [staleDirectory],
+    });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
   it("preserves feature branch lookup when fallback default candidates are not at HEAD", async () => {
@@ -124,37 +188,59 @@ describe("detectPullRequestsForThread", () => {
 async function createDetachedRepoWithFeatureBranchAtHead(
   branch: string,
 ): Promise<string> {
-  const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
-  tempDirs.push(repo);
-  await git(repo, "init", "-b", "main");
-  await git(repo, "config", "user.email", "test@example.com");
-  await git(repo, "config", "user.name", "PwrAgent Test");
-  await git(repo, "commit", "--allow-empty", "-m", "initial");
-  const sha = (await git(repo, "rev-parse", "HEAD")).trim();
-  await git(repo, "branch", branch, sha);
+  const repo = await createRepoWithBranch(branch);
   await git(repo, "commit", "--allow-empty", "-m", "move main forward");
-  await git(repo, "checkout", "--detach", sha);
+  await git(repo, "checkout", "--detach", branch);
+  return repo;
+}
+
+async function createDetachedRepoAtDefaultBranchTip(
+  branch: string,
+): Promise<string> {
+  const repo = await createRepoWithDefaultBranch(branch);
+  await git(repo, "checkout", "--detach", "HEAD");
   return repo;
 }
 
 async function createDetachedRepoWithDefaultAndStaleBranchAtHead(
   branch: string,
 ): Promise<string> {
-  const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
-  tempDirs.push(repo);
-  await git(repo, "init", "-b", "main");
-  await git(repo, "config", "user.email", "test@example.com");
-  await git(repo, "config", "user.name", "PwrAgent Test");
-  await git(repo, "commit", "--allow-empty", "-m", "initial");
-  const sha = (await git(repo, "rev-parse", "HEAD")).trim();
-  await git(repo, "branch", branch, sha);
-  await git(repo, "checkout", "--detach", sha);
+  const repo = await createRepoWithDefaultBranch("main");
+  await git(repo, "branch", branch, "HEAD");
+  await git(repo, "checkout", "--detach", "HEAD");
   return repo;
 }
 
 async function createDetachedRepoWithDevelopAndFeatureAtHead(
   branch: string,
 ): Promise<string> {
+  const repo = await createRepoWithBranch(branch);
+  await git(repo, "branch", "develop", branch);
+  await git(repo, "commit", "--allow-empty", "-m", "move main forward");
+  await git(repo, "checkout", "--detach", branch);
+  return repo;
+}
+
+async function createRepoWithDefaultBranch(branch: string): Promise<string> {
+  const repo = await createRepoWithBranch(branch);
+  const remote = await mkdtemp(
+    path.join(tmpdir(), "pwragent-pr-detection-remote-"),
+  );
+  tempDirs.push(remote);
+  await git(remote, "init", "--bare");
+  await git(repo, "remote", "add", "origin", remote);
+  await git(repo, "update-ref", `refs/remotes/origin/${branch}`, "HEAD");
+  await git(
+    repo,
+    "symbolic-ref",
+    "refs/remotes/origin/HEAD",
+    `refs/remotes/origin/${branch}`,
+  );
+  await git(repo, "branch", "--set-upstream-to", `origin/${branch}`, branch);
+  return repo;
+}
+
+async function createRepoWithBranch(branch: string): Promise<string> {
   const repo = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
   tempDirs.push(repo);
   await git(repo, "init", "-b", "main");
@@ -162,14 +248,29 @@ async function createDetachedRepoWithDevelopAndFeatureAtHead(
   await git(repo, "config", "user.name", "PwrAgent Test");
   await git(repo, "commit", "--allow-empty", "-m", "initial");
   const sha = (await git(repo, "rev-parse", "HEAD")).trim();
-  await git(repo, "branch", "develop", sha);
-  await git(repo, "branch", branch, sha);
-  await git(repo, "commit", "--allow-empty", "-m", "move main forward");
-  await git(repo, "checkout", "--detach", sha);
+  if (!(await branchExists(repo, branch))) {
+    await git(repo, "branch", branch, sha);
+  }
   return repo;
+}
+
+async function createNonGitDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "pwragent-pr-detection-"));
+  tempDirs.push(directory);
+  await mkdir(path.join(directory, "nested"));
+  return directory;
 }
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args, { cwd });
   return stdout;
+}
+
+async function branchExists(cwd: string, branch: string): Promise<boolean> {
+  try {
+    await git(cwd, "rev-parse", "--verify", branch);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -130,6 +130,7 @@ function getThreadPullRequestsRequestKey(
   request: RefreshThreadPullRequestsRequest,
 ): string {
   return JSON.stringify({
+    lookupVersion: 2,
     backend,
     threadId: request.threadId,
     branch: request.branch.trim(),

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -1,9 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import type {
-  LinkedDirectorySummary,
-  PrSummary,
-} from "@pwragent/shared";
+import type { LinkedDirectorySummary, PrSummary } from "@pwragent/shared";
 import type { GithubPrFetcher } from "./github-pr-fetcher";
 
 const execFileAsync = promisify(execFile);
@@ -14,6 +11,16 @@ const FALLBACK_DEFAULT_BRANCHES = [
   "develop",
   "trunk",
 ] as const;
+
+type LocalBranchAtHead = {
+  name: string;
+  upstream?: string;
+};
+
+type DefaultBranchInfo = {
+  names: Set<string>;
+  upstreams: Set<string>;
+};
 
 /**
  * Detect PRs for a single thread by walking the resolved directory paths
@@ -70,57 +77,124 @@ async function resolvePrLookupBranches(params: {
   branch: string;
   cwd: string;
 }): Promise<string[]> {
+  const defaultBranchInfo = await readDefaultBranchInfo(params.cwd);
+
   if (params.branch !== "HEAD") {
-    return [params.branch];
+    return defaultBranchInfo.names.has(params.branch) ? [] : [params.branch];
   }
 
   const branchesAtHead = await readLocalBranchesPointingAtHead(params.cwd);
-  const defaultBranch = await readDefaultBranch(params.cwd);
-  if (defaultBranch && branchesAtHead.includes(defaultBranch)) {
-    return [defaultBranch];
+  if (branchesAtHead.some((branch) => isDefaultBranch(branch, defaultBranchInfo))) {
+    return [];
   }
-  return branchesAtHead.length > 0 ? branchesAtHead : ["HEAD"];
+
+  return uniqueNonEmpty(
+    branchesAtHead
+      .filter((branch) => branch.name !== "HEAD")
+      .map((branch) => branch.name),
+  );
 }
 
-async function readLocalBranchesPointingAtHead(cwd: string): Promise<string[]> {
+function isDefaultBranch(
+  branch: LocalBranchAtHead,
+  defaultBranchInfo: DefaultBranchInfo,
+): boolean {
+  return (
+    defaultBranchInfo.names.has(branch.name) ||
+    Boolean(branch.upstream && defaultBranchInfo.upstreams.has(branch.upstream))
+  );
+}
+
+async function readLocalBranchesPointingAtHead(
+  cwd: string,
+): Promise<LocalBranchAtHead[]> {
   try {
-    const { stdout } = await execFileAsync(
-      "git",
-      [
-        "for-each-ref",
-        "--points-at",
-        "HEAD",
-        "--format=%(refname:short)",
-        "refs/heads",
-      ],
-      {
-        cwd,
-        maxBuffer: 64 * 1024,
-        timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
-      },
-    );
-    return uniqueNonEmpty(
-      stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter((line) => line && line !== "HEAD"),
-    );
+    return await readBranchesPointingAtHead(cwd);
   } catch {
     return [];
   }
 }
 
-async function readDefaultBranch(cwd: string): Promise<string | undefined> {
-  const remoteHead = await readGitLine(cwd, [
-    "symbolic-ref",
-    "refs/remotes/origin/HEAD",
-    "--short",
-  ]);
-  const normalizedRemoteHead = remoteHead?.replace(/^origin\//, "").trim();
-  if (normalizedRemoteHead) {
-    return normalizedRemoteHead;
-  }
+async function readBranchesPointingAtHead(
+  cwd: string,
+): Promise<LocalBranchAtHead[]> {
+  const { stdout } = await execFileAsync(
+    "git",
+    [
+      "for-each-ref",
+      "--points-at",
+      "HEAD",
+      "--format=%(refname:short)%09%(upstream:short)",
+      "refs/heads",
+    ],
+    {
+      cwd,
+      maxBuffer: 64 * 1024,
+      timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
+    },
+  );
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [name = "", upstream = ""] = line.split("\t");
+      return {
+        name: name.trim(),
+        upstream: upstream.trim() || undefined,
+      };
+    })
+    .filter((branch) => branch.name);
+}
 
+async function readDefaultBranchInfo(cwd: string): Promise<DefaultBranchInfo> {
+  try {
+    const upstreams = await readRemoteDefaultUpstreams(cwd);
+    const names = remoteDefaultBranchNames(upstreams);
+
+    if (names.size === 0) {
+      const fallbackDefaultBranch = await readFallbackDefaultBranchName(cwd);
+      if (fallbackDefaultBranch) {
+        names.add(fallbackDefaultBranch);
+      }
+    }
+
+    return { names, upstreams };
+  } catch {
+    return { names: new Set(), upstreams: new Set() };
+  }
+}
+
+async function readRemoteDefaultUpstreams(cwd: string): Promise<Set<string>> {
+  const { stdout } = await execFileAsync("git", ["remote"], {
+    cwd,
+    maxBuffer: 64 * 1024,
+    timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
+  });
+  const remotes = uniqueNonEmpty(stdout.split(/\r?\n/));
+  const upstreams = await Promise.all(
+    remotes.map(async (remote) => {
+      const remoteHead = await readGitLine(cwd, [
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        `refs/remotes/${remote}/HEAD`,
+      ]);
+      return remoteHead ?? "";
+    }),
+  );
+  return new Set(uniqueNonEmpty(upstreams));
+}
+
+function remoteDefaultBranchNames(defaultUpstreams: Set<string>): Set<string> {
+  return new Set(
+    [...defaultUpstreams].map((upstream) => upstream.replace(/^[^/]+\//, "")),
+  );
+}
+
+async function readFallbackDefaultBranchName(
+  cwd: string,
+): Promise<string | undefined> {
   for (const branch of FALLBACK_DEFAULT_BRANCHES) {
     const localBranch = await readGitLine(cwd, [
       "for-each-ref",


### PR DESCRIPTION
## Summary
- Stop PR detection from querying repository default branches such as `main` as PR head branches.
- Preserve detached `HEAD` lookups for real non-default feature branches at the checked-out commit.
- Keep stale or invalid linked directories best-effort so Git metadata failures do not break PR refresh.
- Version the persisted PR refresh key so previously stored false-positive chip snapshots are invalidated.

## Root Cause
`gh pr list --head main --state all` matches fork PRs whose head branch is also named `main`. For open-source repos, a detached checkout at the default branch tip could therefore show unrelated fork PRs as thread chips.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts`
- `pnpm exec tsc --noEmit --pretty false --project apps/desktop/tsconfig.json`
- `git diff --check`
