### PR TITLE
fix(desktop): avoid settings flash on startup

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,7 +24,11 @@ export function App() {
   const desktopApi = useDesktopApi();
   const settings = useDesktopSettings(desktopApi);
 
-  if (desktopApi?.readSettings && !settings.snapshot) {
+  if (desktopApi?.readSettings && !settings.snapshot && !settings.error) {
+    return <AppStartupScreen />;
+  }
+
+  if (desktopApi?.readSettings && !settings.snapshot && settings.error) {
     return (
       <div className="app-shell app-shell--fatal-settings">
         <main className="app-main">
@@ -45,6 +49,21 @@ export function App() {
   }
 
   return <DesktopAppShell desktopApi={desktopApi} settings={settings} />;
+}
+
+function AppStartupScreen() {
+  return (
+    <div className="app-shell app-shell--startup">
+      <main className="app-startup" aria-label="Starting PwrAgent">
+        <div className="app-startup__brand" aria-hidden="true">
+          Pwr<span>Agent</span>
+        </div>
+        <p className="app-startup__status" role="status">
+          Loading PwrAgent...
+        </p>
+      </main>
+    </div>
+  );
 }
 
 function DesktopAppShell(props: {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -61,6 +61,56 @@ describe("App", () => {
     cleanup();
   });
 
+  it("does not show Settings while the startup settings read is pending", async () => {
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: Date.now(),
+      backends: [],
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const readSettings = vi.fn(
+      async () =>
+        await new Promise<never>(() => {
+          // Keep startup in the pending settings-read state.
+        }),
+    );
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings,
+        listBackends,
+        getNavigationSnapshot,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      screen.getByRole("main", { name: "Starting PwrAgent" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading PwrAgent...");
+    expect(screen.queryByText("Exit Settings")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("complementary", { name: "Threads" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(readSettings).toHaveBeenCalledTimes(1);
+    });
+    expect(listBackends).not.toHaveBeenCalled();
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
   it("blocks the app shell when desktop settings config is malformed", async () => {
     const listBackends = vi.fn(async () => ({
       fetchedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -101,6 +101,39 @@ textarea,
   grid-template-columns: minmax(0, 1fr);
 }
 
+.app-shell--startup {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.app-startup {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--bg-app);
+}
+
+.app-startup__brand {
+  color: var(--text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.app-startup__brand span {
+  color: var(--accent);
+}
+
+.app-startup__status {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .sidebar {
   display: flex;
   position: relative;


### PR DESCRIPTION
## Summary

- I replaced the startup-time Settings render with a neutral PwrAgent loading surface while settings are still being read
- I preserved the existing fatal Settings/config error path so malformed config still blocks the shell and shows the Settings error UI
- I added a renderer shell regression test that keeps Settings and navigation IPC out of the pending-settings startup state

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- I ran `pnpm --filter @pwragent/desktop typecheck`

## Notes

- This PR intentionally excludes the later draggable-startup experiments; the startup drag/hang behavior is being handled separately.
