### PR TITLE
fix(desktop): steady context rail hover

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -38,6 +39,7 @@ type ThreadContextPanelProps = {
 };
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
+  const railRef = useRef<HTMLElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [revealed, setRevealed] = useState(false);
   const [railWidth, setRailWidth] = useState(380);
@@ -53,19 +55,63 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const pinned = props.pinned;
   const open = pinned || revealed;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
+
+  const rememberMousePosition = useCallback((event: MouseEvent<HTMLElement>) => {
+    lastMousePositionRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+    };
+  }, []);
+
+  const isMouseInsideRail = useCallback((point: { x: number; y: number }) => {
+    const rail = railRef.current;
+    if (!rail) {
+      return false;
+    }
+
+    const rect = rail.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return false;
+    }
+
+    return (
+      point.x >= rect.left - 1 &&
+      point.x <= rect.right + 1 &&
+      point.y >= rect.top - 1 &&
+      point.y <= rect.bottom + 1
+    );
+  }, []);
 
   // Debounced reveal/hide prevents flicker from CSS transform transitions
-  // causing spurious mouseenter→mouseleave sequences.
+  // causing spurious mouseenter→mouseleave sequences. The final hit test
+  // keeps the rail open when an inactive window reports a transient leave
+  // during the collapsed-spine → open-panel swap while the cursor is still
+  // inside the opened rail.
   const revealRail = useCallback(() => {
     clearTimeout(hideTimerRef.current);
     setRevealed(true);
   }, []);
 
-  const hideRail = useCallback(() => {
-    clearTimeout(hideTimerRef.current);
-    hideTimerRef.current = setTimeout(() => {
-      setRevealed(false);
-    }, 200);
+  const hideRail = useCallback(
+    (point?: { x: number; y: number }) => {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = setTimeout(() => {
+        const latestPoint = lastMousePositionRef.current ?? point;
+        if (latestPoint && isMouseInsideRail(latestPoint)) {
+          return;
+        }
+
+        setRevealed(false);
+      }, 300);
+    },
+    [isMouseInsideRail]
+  );
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(hideTimerRef.current);
+    };
   }, []);
 
   useLayoutEffect(() => {
@@ -135,19 +181,26 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
   return (
     <aside
+      ref={railRef}
       aria-label="Thread context"
       className={`context-rail${open ? " is-open" : " is-collapsed"}${
         pinned ? " is-pinned" : ""
       }${resizing ? " is-resizing" : ""}`}
       style={{ "--context-rail-width": `${railWidth}px` } as CSSProperties}
-      onMouseEnter={() => {
+      onMouseEnter={(event) => {
+        rememberMousePosition(event);
         if (!pinned) {
           revealRail();
         }
       }}
-      onMouseLeave={() => {
+      onMouseMove={rememberMousePosition}
+      onMouseLeave={(event) => {
+        rememberMousePosition(event);
         if (!pinned) {
-          hideRail();
+          hideRail({
+            x: event.clientX,
+            y: event.clientY,
+          });
         }
       }}
       onFocusCapture={() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1,11 +1,13 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 const baseThread: NavigationThreadSummary = {
@@ -79,6 +81,66 @@ const baseBackend: BackendSummary = {
 };
 
 describe("ThreadContextPanel", () => {
+  it("keeps the hover rail open when a transient leave is still inside the opened rail", () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(rail, { clientX: 980, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+  });
+
+  it("hides the hover rail after the mouse leaves the opened rail", () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(rail, { clientX: 600, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+
+    expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+  });
+
   it("shows path tooltips on linked directory labels and kind badges", () => {
     render(
       <ThreadContextPanel

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6130,7 +6130,7 @@ textarea,
   background: var(--bg-panel);
   transform: translateX(calc(100% - 48px));
   transition:
-    transform 160ms ease,
+    transform 260ms cubic-bezier(0.2, 0, 0.2, 1),
     border-color 140ms ease,
     background 140ms ease;
   -webkit-app-region: no-drag;
@@ -6292,8 +6292,8 @@ textarea,
   pointer-events: none;
   transform: translateX(12px);
   transition:
-    opacity 140ms ease,
-    transform 160ms ease;
+    opacity 200ms ease,
+    transform 240ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 
 .context-rail.is-open .context-panel {


### PR DESCRIPTION
## Summary

I fixed the right context rail hover behavior so it no longer collapses immediately after expanding when the PwrAgent window is inactive and the cursor is still over the rail.

I also slowed the rail slide-out animation so the menu opens with a calmer, less abrupt motion.

## Changes

- Added a ref-backed final hit test before the hover rail is allowed to auto-hide.
- Tracked the latest mouse position across rail mouse events so transient leave events during the collapsed-spine to open-panel transition do not collapse the panel.
- Increased the context rail and context panel transition durations and switched the slide motion to a softer easing curve.
- Added regression tests for transient inside-leave behavior and normal outside-leave behavior.

## Verification

I verified the focused behavior with:

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

Before rebasing onto current `origin/main`, I also ran:

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e e2e/context-rail-linked-directory-tooltips.spec.ts`
