### PR TITLE
fix(desktop): keep sticky directory focus ring inside chip

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -250,6 +250,17 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps focused sticky directory summaries from painting outside the scrollport", () => {
+    const headerRule = extractRuleBody(css, ".directory-row__header");
+
+    expect(headerRule).toContain("position: sticky;");
+    expect(headerRule).toContain("top: 0;");
+    expect(headerRule).toContain("background: var(--bg-sidebar);");
+    expect(css).toMatch(
+      /\.directory-row__summary:focus,\s*\.directory-row__summary:focus-visible\s*\{[\s\S]*?outline-offset:\s*-2px;[\s\S]*?\}/
+    );
+  });
+
   it("keeps thread context menu hover states visible", () => {
     expect(css).toMatch(
       /\.thread-context-menu button:hover,\s*\.thread-context-menu button:focus-visible\s*\{[\s\S]*?background:\s*var\(--accent-soft\);[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2109,6 +2109,11 @@ textarea,
   padding: 10px 12px;
 }
 
+.directory-row__summary:focus,
+.directory-row__summary:focus-visible {
+  outline-offset: -2px;
+}
+
 .directory-row__summary-main,
 .directory-row__summary-meta,
 .directory-row__title-wrap {


### PR DESCRIPTION
Fixes the selected directory chip when it sticks under the thread-lens tabs after being clicked. The directory summary now keeps its focus outline inside the chip, so the sticky row no longer paints outside the scrollport where the outline can clip or expose content moving underneath it.

I added a CSS contract test that locks the sticky directory header background and the inner focus-outline offset so this regression is covered without needing a brittle pixel test.

Verification:
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via Codex
