### PR TITLE
fix(desktop): align directory new thread buttons

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -11,7 +11,12 @@ import {
   isPinnedThread,
   moveThreadKey,
 } from "@pwragent/shared";
-import { FolderIcon, UnlinkedDotIcon, WorkspaceIcon } from "../../icons";
+import {
+  FolderIcon,
+  NewThreadIcon,
+  UnlinkedDotIcon,
+  WorkspaceIcon,
+} from "../../icons";
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
@@ -314,7 +319,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   void props.onOpenLaunchpad(directory, directory.launchpad?.backend);
                 }}
               >
-                +
+                <NewThreadIcon size={16} />
               </button>
             </div>
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2159,25 +2159,34 @@ textarea,
 }
 
 .directory-row__launchpad-button {
-  width: 32px;
-  height: 32px;
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  cursor: pointer;
   padding: 0;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: 20px;
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  font-size: 16px;
   line-height: 1;
 }
 
-.directory-row__launchpad-button:hover {
+.directory-row__launchpad-button:hover,
+.directory-row__launchpad-button:focus-visible {
+  border-color: var(--accent-border);
   background: var(--bg-panel-hover);
+  color: var(--text-primary);
+  outline: none;
 }
 
 .directory-row__launchpad-button.has-draft {
   border-color: var(--accent-border);
-  background: var(--bg-row-active);
-  color: var(--accent);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
 }
 
 .directory-row__details {


### PR DESCRIPTION
## Summary

- I aligned the Directories-row new-thread button with the title-bar new-thread button by using the shared document-plus glyph instead of a literal plus sign.
- I updated the row button styling to match the title-bar icon button's sizing, panel background, border, radius, hover, and focus treatment.

## Verification

- I verified `pnpm --filter @pwragent/desktop typecheck`.
- I verified `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx`.
- I verified `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I verified `git diff --check`.

## Notes

- I installed the locked pnpm dependency set in this worktree before verification because `node_modules` was present but empty.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
