### PR TITLE
perf(desktop): reduce default profile startup latency

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -56,6 +56,7 @@ MIT
 - @floating-ui/core@1.7.5 | https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.7.6 | https://github.com/floating-ui/floating-ui
 - @floating-ui/utils@0.2.11 | https://github.com/floating-ui/floating-ui
+- @shutterstock/p-map-iterable@1.1.2 | https://github.com/shutterstock/p-map-iterable
 - @tiptap/core@3.22.5 | https://github.com/ueberdosis/tiptap
 - @tiptap/extension-blockquote@3.22.5 | https://github.com/ueberdosis/tiptap
 - @tiptap/extension-bold@3.22.5 | https://github.com/ueberdosis/tiptap
@@ -98,6 +99,7 @@ MIT
 - @types/unist@3.0.3 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/use-sync-external-store@0.0.6 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - abort-controller@3.0.0 | https://github.com/mysticatea/abort-controller
+- aggregate-error@3.1.0 | sindresorhus/aggregate-error
 - bail@2.0.2 | wooorm/bail
 - base64-js@1.5.1 | https://github.com/beatgammit/base64-js
 - better-sqlite3@12.9.0 | https://github.com/WiseLibs/better-sqlite3
@@ -110,6 +112,7 @@ MIT
 - character-entities-html4@2.1.0 | wooorm/character-entities-html4
 - character-entities-legacy@3.0.0 | wooorm/character-entities-legacy
 - character-reference-invalid@2.0.1 | wooorm/character-reference-invalid
+- clean-stack@2.2.0 | sindresorhus/clean-stack
 - comma-separated-tokens@2.0.3 | wooorm/comma-separated-tokens
 - csstype@3.2.3 | https://github.com/frenic/csstype
 - debug@4.4.3 | https://github.com/debug-js/debug
@@ -134,6 +137,7 @@ MIT
 - hast-util-to-jsx-runtime@2.3.6 | syntax-tree/hast-util-to-jsx-runtime
 - hast-util-whitespace@3.0.0 | syntax-tree/hast-util-whitespace
 - html-url-attributes@3.0.1 | https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
+- indent-string@4.0.0 | sindresorhus/indent-string
 - inline-style-parser@0.2.7 | https://github.com/remarkablemark/inline-style-parser
 - is-alphabetical@2.0.1 | wooorm/is-alphabetical
 - is-alphanumerical@2.0.1 | wooorm/is-alphanumerical
@@ -295,6 +299,36 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+@shutterstock/p-map-iterable@1.1.2 (MIT)
+----------------------------------------
+
+Applies to:
+- @shutterstock/p-map-iterable@1.1.2 (MIT)
+
+Representative file: @shutterstock/p-map-iterable@1.1.2/LICENSE.md
+
+The MIT License (MIT)
+=====================
+Copyright (c) `2022` `Shutterstock, Inc.`
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 @tiptap/core@3.22.5 (MIT)
 -------------------------
 
@@ -447,6 +481,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+aggregate-error@3.1.0 (MIT)
+---------------------------
+
+Applies to:
+- aggregate-error@3.1.0 (MIT)
+- clean-stack@2.2.0 (MIT)
+- indent-string@4.0.0 (MIT)
+
+Representative file: aggregate-error@3.1.0/license
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 argparse@2.0.1 (Python-2.0)
 ---------------------------

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -75,6 +75,11 @@ export default defineConfig(({ command }) => {
     },
     renderer: {
       plugins: [react()],
+      optimizeDeps: {
+        esbuildOptions: {
+          minify: true,
+        },
+      },
       resolve: {
         alias: {
           "@renderer": resolve(__dirname, "src/renderer/src")

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "dev": "node scripts/rebuild-native-for-electron.mjs && electron-vite dev --",
     "dev:dev": "node scripts/rebuild-native-for-electron.mjs && electron-vite dev -- --profile dev",
     "dev:no-messaging": "node scripts/rebuild-native-for-electron.mjs && PWRAGENT_DISABLE_MESSAGING=1 electron-vite dev -- --disable-messaging",
+    "profile:startup": "node scripts/rebuild-native-for-electron.mjs && PWRAGENT_STARTUP_CPU_PROFILING=1 PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE=1 PWRAGENT_DISABLE_MESSAGING=1 electron-vite dev -- --disable-messaging",
     "derive:replay-fixture": "tsx ./scripts/derive-replay-fixture.ts",
     "export:session-capture": "tsx ./scripts/export-session-capture.ts",
     "generate:dmg-background": "swift ./scripts/generate-dmg-background.swift ./build/dmg-background.png",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -46,6 +46,7 @@
     "@pwragent/messaging-provider-slack": "workspace:*",
     "@pwragent/messaging-provider-telegram": "workspace:*",
     "@pwragent/shared": "workspace:*",
+    "@shutterstock/p-map-iterable": "^1.1.2",
     "@tiptap/extension-mention": "^3.22.5",
     "@tiptap/react": "^3.22.5",
     "@tiptap/starter-kit": "^3.22.5",

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -175,6 +175,8 @@ const readDirectoryStatusEntries = vi.fn((directories: Array<{ key: string }>) =
     }
   })(),
 );
+const readDirectoryGitStatusCache = vi.fn(async () => ({}));
+const writeDirectoryGitStatusCacheEntry = vi.fn(async () => undefined);
 const publishLocalEvent = vi.fn(async () => undefined);
 const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   backend: request.backend ?? "codex",
@@ -201,6 +203,8 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({
     reconcileNavigationSnapshot,
     markThreadSeen,
+    readDirectoryGitStatusCache,
+    writeDirectoryGitStatusCacheEntry,
   }),
 }));
 
@@ -236,6 +240,9 @@ describe("app server ipc", () => {
     reconcileNavigationSnapshot.mockClear();
     readDirectoryStatuses.mockClear();
     readDirectoryStatusEntries.mockClear();
+    readDirectoryGitStatusCache.mockClear();
+    readDirectoryGitStatusCache.mockResolvedValue({});
+    writeDirectoryGitStatusCacheEntry.mockClear();
     publishLocalEvent.mockClear();
     markThreadSeen.mockClear();
   });
@@ -654,5 +661,129 @@ describe("app server ipc", () => {
         executionMode: "default",
       },
     });
+  });
+
+  it("uses cached directory git status without refreshing unchanged directories", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    readDirectoryGitStatusCache.mockResolvedValueOnce({
+      "directory:/repo/app": {
+        directoryKey: "directory:/repo/app",
+        directoryPath: "/repo/app",
+        directoryUpdatedAt: 2000,
+        fetchedAt: 1000,
+        gitStatus: directoryGitStatus,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(readDirectoryStatusEntries).not.toHaveBeenCalled();
+    expect(response).toEqual(
+      expect.objectContaining({
+        directories: [
+          expect.objectContaining({
+            key: "directory:/repo/app",
+            gitStatus: directoryGitStatus,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("refreshes cached directory git status when explicitly requested", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const {
+      NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+      NAVIGATION_SNAPSHOT_CHANNEL,
+    } = await import("../../shared/ipc");
+
+    readDirectoryGitStatusCache.mockResolvedValueOnce({
+      "directory:/repo/app": {
+        directoryKey: "directory:/repo/app",
+        directoryPath: "/repo/app",
+        directoryUpdatedAt: 2000,
+        fetchedAt: 1000,
+        gitStatus: directoryGitStatus,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    expect(readDirectoryStatusEntries).not.toHaveBeenCalled();
+
+    await expect(
+      handlers.get(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL)?.(
+        {},
+        {
+          directoryKeys: ["directory:/repo/app"],
+        },
+      ),
+    ).resolves.toEqual({ scheduledCount: 1 });
+
+    await vi.waitFor(() => {
+      expect(readDirectoryStatusEntries).toHaveBeenCalled();
+    });
+    expect(readDirectoryStatusEntries.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({ key: "directory:/repo/app" }),
+    ]);
+  });
+
+  it("caps automatic startup directory git status refreshes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    const directories = Array.from({ length: 6 }, (_, index) => ({
+      key: `directory:/repo/app-${index}`,
+      kind: "directory" as const,
+      label: `app-${index}`,
+      path: `/repo/app-${index}`,
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      latestUpdatedAt: 1000 + index,
+    }));
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "all",
+      fetchedAt: 1234,
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Thread one",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+      inboxThreadKeys: [],
+      directories,
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(readDirectoryStatusEntries).toHaveBeenCalled();
+    });
+
+    expect(readDirectoryStatusEntries.mock.calls[0]?.[0]).toHaveLength(4);
+    expect(
+      (readDirectoryStatusEntries.mock.calls[0]?.[0] as Array<{ key: string }>)
+        .map((directory) => directory.key),
+    ).toEqual([
+      "directory:/repo/app-5",
+      "directory:/repo/app-4",
+      "directory:/repo/app-3",
+      "directory:/repo/app-2",
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ArchiveWorktreeRequest,
   ArchiveThreadRequest,
@@ -157,6 +157,25 @@ const readDirectoryStatuses = vi.fn(async () => ({
     branches: ["main"],
   },
 }));
+const directoryGitStatus = {
+  currentBranch: "main",
+  upstreamBranch: "origin/main",
+  ahead: 0,
+  behind: 0,
+  syncState: "in-sync" as const,
+  branches: ["main"],
+};
+const readDirectoryStatusEntries = vi.fn((directories: Array<{ key: string }>) =>
+  (async function* () {
+    for (const directory of directories) {
+      yield {
+        directoryKey: directory.key,
+        gitStatus: directoryGitStatus,
+      };
+    }
+  })(),
+);
+const publishLocalEvent = vi.fn(async () => undefined);
 const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   backend: request.backend ?? "codex",
   threadId: request.threadId,
@@ -197,6 +216,8 @@ vi.mock("../app-server/backend-registry", () => ({
     listThreads,
     readThread,
     readDirectoryStatuses,
+    readDirectoryStatusEntries,
+    publishLocalEvent,
     getQueuedExecutionModesSnapshot: () => ({}),
   }),
 }));
@@ -214,7 +235,14 @@ describe("app server ipc", () => {
     readThread.mockClear();
     reconcileNavigationSnapshot.mockClear();
     readDirectoryStatuses.mockClear();
+    readDirectoryStatusEntries.mockClear();
+    publishLocalEvent.mockClear();
     markThreadSeen.mockClear();
+  });
+
+  afterEach(async () => {
+    const { disposeAppServerIpcHandlers } = await import("../ipc/app-server");
+    await disposeAppServerIpcHandlers();
   });
 
   it("aggregates navigation snapshots across backends by default", async () => {
@@ -260,14 +288,6 @@ describe("app server ipc", () => {
           threadKeys: ["codex:thread-1"],
           needsAttentionCount: 1,
           latestUpdatedAt: 2000,
-          gitStatus: {
-            currentBranch: "main",
-            upstreamBranch: "origin/main",
-            ahead: 0,
-            behind: 0,
-            syncState: "in-sync",
-            branches: ["main"],
-          },
         },
       ],
       launchpadDefaults: {
@@ -560,17 +580,58 @@ describe("app server ipc", () => {
           backend: "codex" as const,
           executionMode: "default" as const,
         },
+      })
+      .mockResolvedValueOnce({
+        backend: "all",
+        fetchedAt: 9012,
+        unchanged: true,
+        threads: [
+          {
+            id: "thread-1",
+            title: "Thread one",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            updatedAt: 2000,
+          },
+        ],
+        inboxThreadKeys: ["codex:thread-1"],
+        directories: [
+          {
+            key: "directory:/repo/app",
+            kind: "directory" as const,
+            label: "app",
+            path: "/repo/app",
+            threadKeys: ["codex:thread-1"],
+            needsAttentionCount: 1,
+            latestUpdatedAt: 2000,
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
       });
 
     registerAppServerIpcHandlers();
 
     await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(publishLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notification: expect.objectContaining({
+            method: "navigation/directoryGitStatus/updated",
+          }),
+        }),
+      );
+    });
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
     const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
 
-    expect(readDirectoryStatuses).toHaveBeenCalledTimes(2);
+    expect(readDirectoryStatuses).not.toHaveBeenCalled();
     expect(response).toEqual({
       backend: "all",
-      fetchedAt: 5678,
+      fetchedAt: 9012,
       unchanged: true,
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
@@ -585,14 +646,7 @@ describe("app server ipc", () => {
           threadKeys: ["codex:thread-1"],
           needsAttentionCount: 1,
           latestUpdatedAt: 2000,
-          gitStatus: {
-            currentBranch: "main",
-            upstreamBranch: "origin/main",
-            ahead: 0,
-            behind: 0,
-            syncState: "in-sync",
-            branches: ["main"],
-          },
+          gitStatus: directoryGitStatus,
         },
       ],
       launchpadDefaults: {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -178,6 +178,30 @@ const readDirectoryStatusEntries = vi.fn((directories: Array<{ key: string }>) =
 const readDirectoryGitStatusCache = vi.fn(async () => ({}));
 const writeDirectoryGitStatusCacheEntry = vi.fn(async () => undefined);
 const publishLocalEvent = vi.fn(async () => undefined);
+const ensureDirectoryLaunchpad = vi.fn(async (request: {
+  directoryKey: string;
+  directoryKind: string;
+  directoryLabel: string;
+  directoryPath?: string;
+  currentBranch?: string;
+}) => ({
+  launchpad: {
+    directoryKey: request.directoryKey,
+    directoryKind: request.directoryKind,
+    directoryLabel: request.directoryLabel,
+    directoryPath: request.directoryPath,
+    backend: "codex",
+    executionMode: "default",
+    prompt: "",
+    branchName: request.currentBranch,
+    createdAt: 1000,
+    updatedAt: 1000,
+  },
+  defaults: {
+    backend: "codex",
+    executionMode: "default",
+  },
+}));
 const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   backend: request.backend ?? "codex",
   threadId: request.threadId,
@@ -222,6 +246,7 @@ vi.mock("../app-server/backend-registry", () => ({
     readDirectoryStatuses,
     readDirectoryStatusEntries,
     publishLocalEvent,
+    ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
   }),
 }));
@@ -244,6 +269,7 @@ describe("app server ipc", () => {
     readDirectoryGitStatusCache.mockResolvedValue({});
     writeDirectoryGitStatusCacheEntry.mockClear();
     publishLocalEvent.mockClear();
+    ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
   });
 
@@ -672,7 +698,7 @@ describe("app server ipc", () => {
         directoryKey: "directory:/repo/app",
         directoryPath: "/repo/app",
         directoryUpdatedAt: 2000,
-        fetchedAt: 1000,
+        fetchedAt: Date.now(),
         gitStatus: directoryGitStatus,
       },
     });
@@ -694,6 +720,32 @@ describe("app server ipc", () => {
     );
   });
 
+  it("refreshes stale cached directory git status in the background", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    readDirectoryGitStatusCache.mockResolvedValueOnce({
+      "directory:/repo/app": {
+        directoryKey: "directory:/repo/app",
+        directoryPath: "/repo/app",
+        directoryUpdatedAt: 2000,
+        fetchedAt: Date.now() - 60 * 60 * 1000,
+        gitStatus: directoryGitStatus,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    await vi.waitFor(() => {
+      expect(readDirectoryStatusEntries).toHaveBeenCalled();
+    });
+    expect(readDirectoryStatusEntries.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({ key: "directory:/repo/app" }),
+    ]);
+  });
+
   it("refreshes cached directory git status when explicitly requested", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const {
@@ -706,7 +758,7 @@ describe("app server ipc", () => {
         directoryKey: "directory:/repo/app",
         directoryPath: "/repo/app",
         directoryUpdatedAt: 2000,
-        fetchedAt: 1000,
+        fetchedAt: Date.now(),
         gitStatus: directoryGitStatus,
       },
     });
@@ -785,5 +837,45 @@ describe("app server ipc", () => {
       "directory:/repo/app-3",
       "directory:/repo/app-2",
     ]);
+  });
+
+  it("refreshes launchpad directory git status before selecting the default branch", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL } = await import("../../shared/ipc");
+
+    readDirectoryStatusEntries.mockImplementationOnce((directories: Array<{ key: string }>) =>
+      (async function* () {
+        yield {
+          directoryKey: directories[0]!.key,
+          gitStatus: {
+            ...directoryGitStatus,
+            currentBranch: "fresh-branch",
+          },
+        };
+      })(),
+    );
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL)?.({}, {
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      currentBranch: "stale-branch",
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: "directory:/repo/app",
+        currentBranch: "fresh-branch",
+      }),
+    );
+    expect(writeDirectoryGitStatusCacheEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: "directory:/repo/app",
+        gitStatus: expect.objectContaining({ currentBranch: "fresh-branch" }),
+      }),
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -511,6 +511,8 @@ class MockBackendClient {
     ownerId?: string;
   };
   lastListThreadsParams?: {
+    archived?: boolean;
+    enrichDirectories?: boolean;
     filter?: string;
   };
 
@@ -560,6 +562,7 @@ class MockBackendClient {
 
   async listThreads(params?: {
     archived?: boolean;
+    enrichDirectories?: boolean;
     filter?: string;
   }, diagnostics?: { callerReason?: string; ownerId?: string }): Promise<AppServerThreadSummary[]> {
     this.listThreadsCallCount += 1;
@@ -1232,6 +1235,9 @@ describe("DesktopBackendRegistry", () => {
     });
 
     expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+    });
     expect(grokClient.listThreadsCallCount).toBe(1);
     expect(grokClient.lastListThreadsDiagnostics).toMatchObject({
       callerReason: "navigation-snapshot",
@@ -1239,6 +1245,76 @@ describe("DesktopBackendRegistry", () => {
     expect(grokClient.lastListThreadsDiagnostics?.ownerId).toMatch(
       /^backend-thread-list-cache-/,
     );
+
+    await registry.close();
+  });
+
+  it("keeps cheap navigation lists separate from directory-enriched thread lists", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "workspace-handoff",
+    });
+
+    expect(codexClient.listThreadsCallCount).toBe(2);
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: true,
+    });
+
+    await registry.close();
+  });
+
+  it("uses cheap thread summaries for selected-thread branch drift checks", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          projectKey: "/repo/app",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "branch-drift",
+    });
+
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+    });
 
     await registry.close();
   });
@@ -3612,7 +3688,10 @@ command = "pnpm dev"
       }),
     ]);
     expect(codexClient.listThreadsCallCount).toBe(1);
-    expect(codexClient.lastListThreadsParams).toEqual({ filter: "thread" });
+    expect(codexClient.lastListThreadsParams).toEqual({
+      enrichDirectories: true,
+      filter: "thread",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -988,6 +988,38 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("can list cheap thread summaries without directory enrichment", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async () => ({
+      linkedDirectories: [
+        {
+          id: "/Users/huntharo/pwrdrvr/PwrAgent",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "local" as const,
+        },
+      ],
+    }));
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+
+    const threads = await client.listThreads({ enrichDirectories: false });
+    const primaryThread = threads.find((thread) => thread.id === "thread-2");
+
+    expect(threadDirectoryEnricher).not.toHaveBeenCalled();
+    expect(primaryThread).toMatchObject({
+      id: "thread-2",
+      projectKey: "/Users/huntharo/pwrdrvr/PwrAgent",
+      linkedDirectories: [],
+      source: "codex",
+    });
+
+    await client.close();
+  });
+
   it("derives a title from preview when Codex returns the placeholder name", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1013,7 +1013,14 @@ describe("CodexAppServerClient", () => {
     expect(primaryThread).toMatchObject({
       id: "thread-2",
       projectKey: "/Users/huntharo/pwrdrvr/PwrAgent",
-      linkedDirectories: [],
+      linkedDirectories: [
+        {
+          id: "/Users/huntharo/pwrdrvr/PwrAgent",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "local",
+        },
+      ],
       source: "codex",
     });
 

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GitDirectoryService,
   computeWorktreePath,
@@ -185,6 +185,63 @@ describe("GitDirectoryService", () => {
       expect.arrayContaining(["main", "release", "older"]),
     );
     expect(status?.handoffBranches).toEqual(["recent", "older"]);
+  });
+
+  it("streams directory status lookups with bounded concurrency", async () => {
+    const service = new GitDirectoryService({
+      statusConcurrency: 2,
+      statusMaxUnread: 2,
+    });
+    let active = 0;
+    let maxActive = 0;
+    vi.spyOn(service, "readDirectoryStatus").mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return {
+        currentBranch: "main",
+        syncState: "in-sync",
+      };
+    });
+
+    const results = [];
+    for await (const entry of service.readDirectoryStatusEntries([
+      {
+        key: "directory:/repo/one",
+        kind: "directory",
+        label: "one",
+        path: "/repo/one",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      },
+      {
+        key: "directory:/repo/two",
+        kind: "directory",
+        label: "two",
+        path: "/repo/two",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      },
+      {
+        key: "directory:/repo/three",
+        kind: "directory",
+        label: "three",
+        path: "/repo/three",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      },
+    ])) {
+      results.push(entry);
+    }
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(results).toHaveLength(3);
+    expect(results.map((entry) => entry.directoryKey).sort()).toEqual([
+      "directory:/repo/one",
+      "directory:/repo/three",
+      "directory:/repo/two",
+    ]);
   });
 
   it("creates a detached in-repo worktree at <hash>/<project-folder> from the selected base branch", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -41,6 +41,7 @@ const getRuntimeMessagingLeaseCoordinatorMock = vi.fn();
 const getExistingRuntimeMessagingLeaseCoordinatorMock = vi.fn();
 const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
+const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
 const disposeMessagingStatusIpcHandlersMock = vi.fn();
@@ -202,6 +203,7 @@ const runtimeMessagingLeaseCoordinatorMock = {
 
 vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
+    listThreads: listThreadsMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -274,6 +276,8 @@ describe("bootstrapApp", () => {
     );
     requestBindingRevokeAllForThreadMock.mockReset();
     setMessagingArchiveCleanerMock.mockReset();
+    listThreadsMock.mockReset();
+    listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();
     registerMessagingStatusIpcHandlersMock.mockReset();
     disposeMessagingStatusIpcHandlersMock.mockReset();
@@ -364,6 +368,39 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
     });
+  });
+
+  it("prewarms the initial thread list after starting the first window", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    listThreadsMock.mockReturnValue(new Promise(() => {}));
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(createMainWindowMock).toHaveBeenCalledWith({
+      startupCpuProfiler: startupProfilerInstance,
+    });
+    expect(listThreadsMock).toHaveBeenCalledWith({
+      callerReason: "startup-prewarm",
+    });
+  });
+
+  it("logs startup thread list prewarm failures without blocking startup", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    listThreadsMock.mockRejectedValue(new Error("codex unavailable"));
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(createMainWindowMock).toHaveBeenCalledWith({
+      startupCpuProfiler: startupProfilerInstance,
+    });
+    expect(mainLogWarnMock).toHaveBeenCalledWith(
+      "startup thread list prewarm failed",
+      expect.objectContaining({
+        error: "codex unavailable",
+      }),
+    );
   });
 
   it("logs unexpected background messaging startup failures", async () => {

--- a/apps/desktop/src/main/__tests__/startup-cpu-analysis.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-cpu-analysis.test.ts
@@ -114,6 +114,63 @@ describe("startup CPU analysis", () => {
     });
   });
 
+  it("aggregates duplicate function frames from repeated optimized nodes", () => {
+    const analysis = analyzeCpuProfile({
+      process: "renderer",
+      profile: {
+        startTime: 0,
+        endTime: 3000,
+        samples: [2, 3, 3],
+        timeDeltas: [1000, 750, 1250],
+        nodes: [
+          {
+            id: 1,
+            callFrame: {
+              functionName: "(root)",
+              scriptId: "0",
+              url: "",
+            },
+            children: [2, 3],
+          },
+          {
+            id: 2,
+            callFrame: {
+              functionName: "formatRelativeTime",
+              scriptId: "1",
+              url: "http://127.0.0.1:5173/src/features/navigation/ThreadRow.tsx",
+              lineNumber: 10,
+              columnNumber: 2,
+            },
+          },
+          {
+            id: 3,
+            callFrame: {
+              functionName: "formatRelativeTime",
+              scriptId: "2",
+              url: "http://127.0.0.1:5173/src/features/navigation/ThreadRow.tsx",
+              lineNumber: 10,
+              columnNumber: 2,
+            },
+          },
+        ],
+      },
+      repoRoot: "/repo",
+      desktopRoot: "/repo/apps/desktop",
+    });
+
+    expect(analysis.topFunctionsBySelf[0]).toMatchObject({
+      functionName: "formatRelativeTime",
+      selfMicros: 3000,
+      totalMicros: 3000,
+      lineNumber: 10,
+    });
+    expect(
+      analysis.topFunctionsBySelf.filter(
+        (entry) => entry.functionName === "formatRelativeTime"
+      )
+    ).toHaveLength(1);
+  });
+
   it("renders a human-readable summary for both processes", () => {
     const main = analyzeCpuProfile({
       process: "main",

--- a/apps/desktop/src/main/__tests__/startup-cpu-profile-session.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-cpu-profile-session.test.ts
@@ -90,6 +90,7 @@ describe("startup CPU profiling session", () => {
       config: {
         postLoadDurationMs: 5000,
         hardTimeoutMs: 15000,
+        quitOnComplete: false,
       },
       versions: {
         appVersion: "0.1.0",
@@ -217,6 +218,7 @@ describe("startup CPU profiling session", () => {
         PWRAGENT_STARTUP_CPU_PROFILING: "1",
         PWRAGENT_STARTUP_CPU_PROFILE_POST_LOAD_MS: "8000",
         PWRAGENT_STARTUP_CPU_PROFILE_HARD_TIMEOUT_MS: "25000",
+        PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE: "1",
       },
       repoRoot: workspace.path,
     });
@@ -225,6 +227,7 @@ describe("startup CPU profiling session", () => {
       enabled: true,
       postLoadDurationMs: 8000,
       hardTimeoutMs: 25000,
+      quitOnComplete: true,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/startup-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-cpu-profiler.test.ts
@@ -5,6 +5,7 @@ vi.mock("electron", () => ({
   app: {
     getAppPath: vi.fn(() => "/repo/apps/desktop"),
     getVersion: vi.fn(() => "0.1.0"),
+    quit: vi.fn(),
   },
 }));
 
@@ -17,6 +18,7 @@ function createEnabledConfig() {
     outputRoot: "/repo/.local",
     postLoadDurationMs: 5000,
     hardTimeoutMs: 15000,
+    quitOnComplete: false,
   };
 }
 
@@ -155,6 +157,41 @@ describe("StartupCpuProfiler", () => {
         status: "completed",
       },
     });
+  });
+
+  it("quits the app after capture when requested by profiling config", async () => {
+    const { app } = await import("electron");
+    const session = createSession();
+    const { window, emitWebContents } = createWindowTarget();
+
+    const { StartupCpuProfiler } = await import("../diagnostics/startup-cpu-profiler");
+    const profiler = new StartupCpuProfiler({
+      config: {
+        ...createEnabledConfig(),
+        quitOnComplete: true,
+      },
+      now: () => new Date("2026-04-19T13:30:00.000Z"),
+      createSession: vi.fn(async () => ({
+        ok: true as const,
+        session,
+      })),
+      createMainProfiler: vi.fn(() => ({
+        start: vi.fn(async () => true),
+        stop: vi.fn(async () => true),
+      })),
+      createRendererProfiler: vi.fn(() => ({
+        start: vi.fn(async () => true),
+        stop: vi.fn(async () => true),
+      })),
+      analyzeSession: vi.fn(async () => ({ ok: true })),
+    });
+
+    await profiler.start();
+    profiler.attachWindow(window as never);
+    emitWebContents("did-finish-load");
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(app.quit).toHaveBeenCalledTimes(1);
   });
 
   it("stops on the hard timeout and skips analysis when no profiles were captured", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -195,7 +195,7 @@ type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
   listThreads(
-    params?: { archived?: boolean; filter?: string },
+    params?: { archived?: boolean; enrichDirectories?: boolean; filter?: string },
     diagnostics?: { callerReason?: string; ownerId?: string },
   ): Promise<AppServerThreadSummary[]>;
   archiveThread?(params: { threadId: string }): Promise<{ threadId: string }>;
@@ -868,6 +868,7 @@ type ThreadListCallerReason =
   | "ipc-list-threads"
   | "messaging-navigation-snapshot"
   | "navigation-snapshot"
+  | "startup-prewarm"
   | "title-generation"
   | "workspace-handoff"
   | (string & {});
@@ -879,6 +880,23 @@ type ThreadListCacheState = {
 };
 
 let threadListCacheSequence = 0;
+
+function shouldEnrichThreadDirectories(
+  callerReason?: ThreadListCallerReason,
+): boolean {
+  switch (callerReason) {
+    case "active-turn-branch-adoption":
+    case "branch-drift":
+    case "messaging-navigation-snapshot":
+    case "navigation-snapshot":
+    case "startup-prewarm":
+    case "title-generation":
+    case "turn-cwd":
+      return false;
+    default:
+      return true;
+  }
+}
 
 type MessagingArchiveCleanupStore = Pick<
   MessagingStoreLike,
@@ -1502,9 +1520,15 @@ export class DesktopBackendRegistry {
     archived?: boolean;
     backend?: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
+    enrichDirectories?: boolean;
     filter?: string;
   } = {}): Promise<AppServerThreadSummary[]> {
-    const cacheKey = this.buildThreadListCacheKey(params);
+    const normalizedParams = {
+      ...params,
+      enrichDirectories:
+        params.enrichDirectories ?? shouldEnrichThreadDirectories(params.callerReason),
+    };
+    const cacheKey = this.buildThreadListCacheKey(normalizedParams);
     const cached = this.threadListCache.get(cacheKey);
     const now = Date.now();
     if (cached?.threads && (cached.expiresAt ?? 0) > now) {
@@ -1524,7 +1548,7 @@ export class DesktopBackendRegistry {
       return await cached.promise;
     }
 
-    const promise = this.readThreadList(params)
+    const promise = this.readThreadList(normalizedParams)
       .then((threads) => {
         this.threadListCache.set(cacheKey, {
           expiresAt: Date.now() + THREAD_LIST_REUSE_WINDOW_MS,
@@ -1544,6 +1568,7 @@ export class DesktopBackendRegistry {
     archived?: boolean;
     backend?: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
+    enrichDirectories: boolean;
     filter?: string;
   }): Promise<AppServerThreadSummary[]> {
     const diagnostics = {
@@ -1553,6 +1578,7 @@ export class DesktopBackendRegistry {
     if (params.backend === "codex") {
       const threads = await this.listCodexThreads({
         archived: params.archived,
+        enrichDirectories: params.enrichDirectories,
         filter: params.filter,
       }, diagnostics);
       this.scheduleThreadListArchiveStateCleanup({
@@ -1587,12 +1613,14 @@ export class DesktopBackendRegistry {
         backend: "codex",
         archived: params.archived,
         callerReason: params.callerReason,
+        enrichDirectories: params.enrichDirectories,
         filter: params.filter,
       }),
       this.listThreads({
         backend: "grok",
         archived: params.archived,
         callerReason: params.callerReason,
+        enrichDirectories: params.enrichDirectories,
         filter: params.filter,
       }).catch(() => []),
     ]);
@@ -3779,11 +3807,14 @@ export class DesktopBackendRegistry {
   private buildThreadListCacheKey(params: {
     archived?: boolean;
     backend?: AppServerBackendKind;
+    enrichDirectories?: boolean;
     filter?: string;
   }): string {
     return JSON.stringify({
       archived: params.archived === true,
       backend: params.backend ?? "all",
+      enrichDirectories:
+        params.backend === "grok" ? undefined : params.enrichDirectories === true,
       filter: params.filter?.trim() ?? "",
     });
   }
@@ -4138,6 +4169,7 @@ export class DesktopBackendRegistry {
 
   private async listCodexThreads(params: {
     archived?: boolean;
+    enrichDirectories?: boolean;
     filter?: string;
   } = {}, diagnostics?: {
     callerReason?: string;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -134,7 +134,9 @@ type InitializeResult = {
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
-const THREAD_LIST_REUSE_WINDOW_MS = 750;
+// Keep startup prewarm useful through renderer parse/effect scheduling. Thread
+// lifecycle notifications still invalidate this cache when the list changes.
+const THREAD_LIST_REUSE_WINDOW_MS = 5_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 /**

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -95,6 +95,7 @@ import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
 import { GitDirectoryService } from "./git-directory-service";
+import type { DirectoryGitStatusEntry } from "./git-directory-service";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
@@ -1854,6 +1855,12 @@ export class DesktopBackendRegistry {
     Record<string, NavigationDirectoryGitStatus | undefined>
   > {
     return await this.gitDirectoryService.readDirectoryStatuses(directories);
+  }
+
+  readDirectoryStatusEntries(
+    directories: NavigationDirectorySummary[],
+  ): AsyncIterable<DirectoryGitStatusEntry> {
+    return this.gitDirectoryService.readDirectoryStatusEntries(directories);
   }
 
   async readThread(

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,6 +1,7 @@
 import { access, mkdir, rmdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { IterableMapper } from "@shutterstock/p-map-iterable";
 import type {
   AppServerThreadSummary,
   AppServerBackendKind,
@@ -318,8 +319,15 @@ type CachedDirectoryStatus = {
   status?: NavigationDirectoryGitStatus;
 };
 
+export type DirectoryGitStatusEntry = {
+  directoryKey: string;
+  gitStatus?: NavigationDirectoryGitStatus;
+};
+
 type GitDirectoryServiceOptions = {
   cacheTtlMs?: number;
+  statusConcurrency?: number;
+  statusMaxUnread?: number;
   codexHome?: string;
   resolveWorktreeStorage?: () =>
     | DesktopWorktreeStorageLocation
@@ -330,6 +338,8 @@ type GitDirectoryServiceOptions = {
 export class GitDirectoryService {
   private readonly statusCache = new Map<string, CachedDirectoryStatus>();
   private readonly cacheTtlMs: number;
+  private readonly statusConcurrency: number;
+  private readonly statusMaxUnread: number;
   private readonly codexHome?: string;
   private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
   private readonly homeDir: string;
@@ -338,6 +348,11 @@ export class GitDirectoryService {
     const normalized: GitDirectoryServiceOptions =
       typeof options === "number" ? { cacheTtlMs: options } : options;
     this.cacheTtlMs = normalized.cacheTtlMs ?? 3_000;
+    this.statusConcurrency = normalized.statusConcurrency ?? 4;
+    this.statusMaxUnread = Math.max(
+      normalized.statusMaxUnread ?? 8,
+      this.statusConcurrency,
+    );
     this.codexHome = normalized.codexHome;
     this.homeDir = normalized.homeDir ?? os.homedir();
     const resolveStorage = normalized.resolveWorktreeStorage;
@@ -348,13 +363,27 @@ export class GitDirectoryService {
   async readDirectoryStatuses(
     directories: NavigationDirectorySummary[],
   ): Promise<Record<string, NavigationDirectoryGitStatus | undefined>> {
-    const statuses = await Promise.all(
-      directories.map(async (directory) => [
-        directory.key,
-        await this.readDirectoryStatus(directory),
-      ] as const),
+    const statuses: Record<string, NavigationDirectoryGitStatus | undefined> = {};
+    for await (const entry of this.readDirectoryStatusEntries(directories)) {
+      statuses[entry.directoryKey] = entry.gitStatus;
+    }
+    return statuses;
+  }
+
+  readDirectoryStatusEntries(
+    directories: NavigationDirectorySummary[],
+  ): AsyncIterable<DirectoryGitStatusEntry> {
+    return new IterableMapper(
+      directories,
+      async (directory): Promise<DirectoryGitStatusEntry> => ({
+        directoryKey: directory.key,
+        gitStatus: await this.readDirectoryStatus(directory),
+      }),
+      {
+        concurrency: this.statusConcurrency,
+        maxUnread: this.statusMaxUnread,
+      },
     );
-    return Object.fromEntries(statuses);
   }
 
   async readDirectoryStatus(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -935,6 +935,28 @@ async function resolveThreadProjectKey(
   return projectKey || undefined;
 }
 
+function buildProjectKeyLinkedDirectories(
+  projectKey: string | undefined
+): LinkedDirectorySummary[] {
+  const directoryPath = projectKey?.trim();
+  if (!directoryPath) {
+    return [];
+  }
+
+  const resolvedPath = path.isAbsolute(directoryPath)
+    ? directoryPath
+    : path.resolve(directoryPath);
+
+  return [
+    {
+      id: resolvedPath,
+      label: path.basename(resolvedPath) || resolvedPath,
+      path: resolvedPath,
+      kind: "local",
+    },
+  ];
+}
+
 function normalizeConversationRole(
   value: string | undefined
 ): "user" | "assistant" | undefined {
@@ -4024,7 +4046,7 @@ export class CodexAppServerClient {
           ...thread,
           projectKey,
           gitBranch: thread.gitBranch,
-          linkedDirectories: [],
+          linkedDirectories: buildProjectKeyLinkedDirectories(projectKey),
           source: "codex" as const,
         };
       });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3907,6 +3907,7 @@ export class CodexAppServerClient {
 
   async listThreads(params?: {
     archived?: boolean;
+    enrichDirectories?: boolean;
     filter?: string;
   }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
@@ -3925,7 +3926,9 @@ export class CodexAppServerClient {
         filter: params?.filter,
         requestTimeoutMs: requestParams.timeoutMs,
       });
-      return await this.enrichThreads(archivedThreads);
+      return await this.enrichThreads(archivedThreads, {
+        enrichDirectories: params?.enrichDirectories ?? true,
+      });
     }
 
     const activeThreads = await requestThreadListPages({
@@ -3941,7 +3944,9 @@ export class CodexAppServerClient {
     });
     this.scheduleArchivedThreadMetadataRefresh(params?.filter, diagnostics);
 
-    return await this.enrichThreads(threads);
+    return await this.enrichThreads(threads, {
+      enrichDirectories: params?.enrichDirectories ?? true,
+    });
   }
 
   private getCachedArchivedThreadMetadata(filter?: string): RawCodexThreadSummary[] {
@@ -4010,7 +4015,21 @@ export class CodexAppServerClient {
 
   private async enrichThreads(
     threads: RawCodexThreadSummary[],
+    options: { enrichDirectories: boolean },
   ): Promise<AppServerThreadSummary[]> {
+    if (!options.enrichDirectories) {
+      return threads.map((thread) => {
+        const projectKey = thread.projectKey?.trim() || undefined;
+        return {
+          ...thread,
+          projectKey,
+          gitBranch: thread.gitBranch,
+          linkedDirectories: [],
+          source: "codex" as const,
+        };
+      });
+    }
+
     const enrichedThreads = await Promise.all(
       threads.map(async (thread) => {
         const projectKey = await resolveThreadProjectKey(thread);

--- a/apps/desktop/src/main/diagnostics/startup-cpu-analysis.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-analysis.ts
@@ -22,7 +22,9 @@ export type CpuProfile = {
 type CpuProfileProcess = "main" | "renderer";
 
 type RankedFunction = {
+  columnNumber?: number;
   functionName: string;
+  lineNumber?: number;
   sourceBucket: string;
   selfMicros: number;
   totalMicros: number;
@@ -89,7 +91,7 @@ export function analyzeCpuProfile(params: {
     }
   }
 
-  const functionRankings: RankedFunction[] = [];
+  const functionRankings = new Map<string, RankedFunction>();
   const sourceRankings = new Map<string, RankedSource>();
 
   for (const [nodeId, node] of nodeById.entries()) {
@@ -106,12 +108,25 @@ export function analyzeCpuProfile(params: {
     });
 
     const functionName = node.callFrame.functionName?.trim() || "(anonymous)";
-    functionRankings.push({
+    const lineNumber = normalizeLocationNumber(node.callFrame.lineNumber);
+    const columnNumber = normalizeLocationNumber(node.callFrame.columnNumber);
+    const functionKey = [
       functionName,
       sourceBucket,
-      selfMicros,
-      totalMicros,
-    });
+      lineNumber ?? "",
+      columnNumber ?? "",
+    ].join("\u0000");
+    const existingFunction = functionRankings.get(functionKey) ?? {
+      functionName,
+      sourceBucket,
+      ...(lineNumber !== undefined ? { lineNumber } : {}),
+      ...(columnNumber !== undefined ? { columnNumber } : {}),
+      selfMicros: 0,
+      totalMicros: 0,
+    };
+    existingFunction.selfMicros += selfMicros;
+    existingFunction.totalMicros += totalMicros;
+    functionRankings.set(functionKey, existingFunction);
 
     const existingSource = sourceRankings.get(sourceBucket) ?? {
       sourceBucket,
@@ -126,10 +141,10 @@ export function analyzeCpuProfile(params: {
   return {
     process: params.process,
     durationMicros,
-    topFunctionsBySelf: [...functionRankings]
+    topFunctionsBySelf: [...functionRankings.values()]
       .sort((left, right) => right.selfMicros - left.selfMicros)
       .slice(0, 10),
-    topFunctionsByTotal: [...functionRankings]
+    topFunctionsByTotal: [...functionRankings.values()]
       .sort((left, right) => right.totalMicros - left.totalMicros)
       .slice(0, 10),
     topSourcesBySelf: [...sourceRankings.values()]
@@ -139,6 +154,10 @@ export function analyzeCpuProfile(params: {
       .sort((left, right) => right.totalMicros - left.totalMicros)
       .slice(0, 10),
   };
+}
+
+function normalizeLocationNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && value >= 0 ? value : undefined;
 }
 
 export function renderStartupCpuAnalysisSummary(params: {
@@ -159,8 +178,10 @@ export function renderStartupCpuAnalysisSummary(params: {
     lines.push("");
     lines.push("Top functions by self time:");
     for (const entry of result.topFunctionsBySelf.slice(0, 5)) {
+      const location =
+        entry.lineNumber !== undefined ? `:${entry.lineNumber + 1}` : "";
       lines.push(
-        `- \`${entry.functionName}\` in \`${entry.sourceBucket}\` — self ${formatMicros(
+        `- \`${entry.functionName}\` in \`${entry.sourceBucket}${location}\` — self ${formatMicros(
           entry.selfMicros,
         )}, total ${formatMicros(entry.totalMicros)}`,
       );

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profile-config.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profile-config.ts
@@ -11,6 +11,7 @@ export type StartupCpuProfileConfig =
       outputRoot: string;
       postLoadDurationMs: number;
       hardTimeoutMs: number;
+      quitOnComplete: boolean;
     };
 
 function isEnabled(value: string | undefined): boolean {
@@ -59,5 +60,6 @@ export function resolveStartupCpuProfileConfig(options?: {
       env.PWRAGENT_STARTUP_CPU_PROFILE_HARD_TIMEOUT_MS,
       DEFAULT_HARD_TIMEOUT_MS,
     ),
+    quitOnComplete: isEnabled(env.PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE),
   };
 }

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profile-session.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profile-session.ts
@@ -40,6 +40,7 @@ type StartupCpuProfileManifest = {
   config: {
     postLoadDurationMs: number;
     hardTimeoutMs: number;
+    quitOnComplete: boolean;
   };
   versions: StartupCpuProfileVersions;
 };
@@ -134,6 +135,7 @@ export async function createStartupCpuProfileSession(options: {
     config: {
       postLoadDurationMs: options.config.postLoadDurationMs,
       hardTimeoutMs: options.config.hardTimeoutMs,
+      quitOnComplete: options.config.quitOnComplete,
     },
     versions: options.versions,
   };

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profiler.ts
@@ -265,6 +265,10 @@ export class StartupCpuProfiler {
         status,
       },
     });
+
+    if (this.config.quitOnComplete) {
+      app.quit();
+    }
   }
 
   private clearPostLoadTimer(): void {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,6 +71,32 @@ const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
 let mainProcessResourcesDisposed = false;
 
+function prewarmInitialThreadList(): void {
+  const startedAt = Date.now();
+  void getDesktopBackendRegistry()
+    .listThreads({
+      callerReason: "startup-prewarm",
+    })
+    .then((threads) => {
+      if (!isDevelopment) {
+        return;
+      }
+      mainLog.info("startup thread list prewarm completed", {
+        count: threads.length,
+        durationMs: Date.now() - startedAt,
+      });
+    })
+    .catch((error) => {
+      if (!isDevelopment) {
+        return;
+      }
+      mainLog.warn("startup thread list prewarm failed", {
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
 function disposeMainProcessResourcesSync(): void {
   if (mainProcessResourcesDisposed) {
     return;
@@ -248,6 +274,7 @@ export function bootstrapApp(): void {
     createMainWindow({
       startupCpuProfiler,
     });
+    prewarmInitialThreadList();
 
     // Wire up auto-update *after* the window is created so a slow update
     // check does not delay first paint. Skips automatically in dev.

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -97,6 +97,7 @@ import { getDesktopSettingsService } from "../settings/desktop-settings-singleto
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
+const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
 
 type AppServerOverlayStoreLike = OverlayStoreLike &
   Pick<
@@ -566,6 +567,9 @@ class DesktopAppServerService {
       if (!cached) {
         return true;
       }
+      if (!isFreshDirectoryGitStatusCacheEntry(cached)) {
+        return true;
+      }
       return (directory.latestUpdatedAt ?? 0) > (cached.directoryUpdatedAt ?? 0);
     });
 
@@ -585,6 +589,55 @@ class DesktopAppServerService {
       .slice(0, remaining);
   }
 
+  private async refreshLaunchpadDirectoryGitStatus(
+    request: EnsureDirectoryLaunchpadRequest,
+  ): Promise<EnsureDirectoryLaunchpadRequest> {
+    const directoryPath = request.directoryPath?.trim();
+    if (!directoryPath) {
+      return request;
+    }
+
+    const cachedDirectory = this.lastDirectoriesByKey.get(request.directoryKey);
+    const directory: NavigationSnapshot["directories"][number] = {
+      key: request.directoryKey,
+      kind: request.directoryKind,
+      label: request.directoryLabel,
+      path: directoryPath,
+      threadKeys: [],
+      needsAttentionCount: 0,
+      ...(cachedDirectory?.latestUpdatedAt !== undefined
+        ? { latestUpdatedAt: cachedDirectory.latestUpdatedAt }
+        : {}),
+    };
+
+    try {
+      const registry = getDesktopBackendRegistry();
+      for await (const entry of registry.readDirectoryStatusEntries([directory])) {
+        const fetchedAt = Date.now();
+        await this.writeDirectoryGitStatusEntry({
+          directory,
+          directoryKey: entry.directoryKey,
+          fetchedAt,
+          gitStatus: entry.gitStatus,
+        });
+        if (!entry.gitStatus?.currentBranch) {
+          return request;
+        }
+        return {
+          ...request,
+          currentBranch: entry.gitStatus.currentBranch,
+        };
+      }
+    } catch (error) {
+      logDebug("directoryGitStatusRefresh:launchpadRefreshFailed", {
+        directoryKey: request.directoryKey,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return request;
+  }
+
   private async refreshDirectoryGitStatuses(
     directories: NavigationSnapshot["directories"],
   ): Promise<void> {
@@ -600,30 +653,46 @@ class DesktopAppServerService {
     for await (const entry of registry.readDirectoryStatusEntries(refreshableDirectories)) {
       const directory = directoryByKey.get(entry.directoryKey);
       const fetchedAt = Date.now();
-      const cacheEntry: DirectoryGitStatusCacheEntry = {
+      await this.writeDirectoryGitStatusEntry({
+        directory,
         directoryKey: entry.directoryKey,
-        ...(directory?.path ? { directoryPath: directory.path } : {}),
-        ...(directory?.latestUpdatedAt !== undefined
-          ? { directoryUpdatedAt: directory.latestUpdatedAt }
-          : {}),
         fetchedAt,
-        ...(entry.gitStatus ? { gitStatus: entry.gitStatus } : {}),
-      };
-      this.directoryGitStatusByKey.set(entry.directoryKey, cacheEntry);
-      await this.getOverlayStore().writeDirectoryGitStatusCacheEntry(cacheEntry);
-      const notification: NavigationDirectoryGitStatusUpdatedNotification = {
-        method: "navigation/directoryGitStatus/updated",
-        params: {
-          directoryKey: entry.directoryKey,
-          gitStatus: entry.gitStatus ?? null,
-          fetchedAt,
-        },
-      };
-      await registry.publishLocalEvent({
-        backend: "codex",
-        notification,
-      } as unknown as AgentEvent);
+        gitStatus: entry.gitStatus,
+      });
     }
+  }
+
+  private async writeDirectoryGitStatusEntry(params: {
+    directory?: NavigationSnapshot["directories"][number];
+    directoryKey: string;
+    fetchedAt: number;
+    gitStatus?: NavigationDirectoryGitStatus;
+  }): Promise<void> {
+    const current = this.directoryGitStatusByKey.get(params.directoryKey);
+    const directoryPath = params.directory?.path ?? current?.directoryPath;
+    const directoryUpdatedAt =
+      params.directory?.latestUpdatedAt ?? current?.directoryUpdatedAt;
+    const cacheEntry: DirectoryGitStatusCacheEntry = {
+      directoryKey: params.directoryKey,
+      ...(directoryPath ? { directoryPath } : {}),
+      ...(directoryUpdatedAt !== undefined ? { directoryUpdatedAt } : {}),
+      fetchedAt: params.fetchedAt,
+      ...(params.gitStatus ? { gitStatus: params.gitStatus } : {}),
+    };
+    this.directoryGitStatusByKey.set(params.directoryKey, cacheEntry);
+    await this.getOverlayStore().writeDirectoryGitStatusCacheEntry(cacheEntry);
+    const notification: NavigationDirectoryGitStatusUpdatedNotification = {
+      method: "navigation/directoryGitStatus/updated",
+      params: {
+        directoryKey: params.directoryKey,
+        gitStatus: params.gitStatus ?? null,
+        fetchedAt: params.fetchedAt,
+      },
+    };
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend: "codex",
+      notification,
+    } as unknown as AgentEvent);
   }
 
   async markThreadSeen(
@@ -880,7 +949,8 @@ class DesktopAppServerService {
   async ensureDirectoryLaunchpad(
     request: EnsureDirectoryLaunchpadRequest,
   ): Promise<EnsureDirectoryLaunchpadResponse> {
-    return await getDesktopBackendRegistry().ensureDirectoryLaunchpad(request);
+    const refreshedRequest = await this.refreshLaunchpadDirectoryGitStatus(request);
+    return await getDesktopBackendRegistry().ensureDirectoryLaunchpad(refreshedRequest);
   }
 
   async updateDirectoryLaunchpad(
@@ -1033,6 +1103,12 @@ class DesktopAppServerService {
     this.focusedDiffServiceModel = modelOverride;
     return this.focusedDiffService;
   }
+}
+
+function isFreshDirectoryGitStatusCacheEntry(
+  entry: DirectoryGitStatusCacheEntry,
+): boolean {
+  return Date.now() - entry.fetchedAt < DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS;
 }
 
 const appServerService = new DesktopAppServerService();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,5 +1,9 @@
 import { BrowserWindow, dialog, ipcMain } from "electron";
-import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
+import type {
+  DirectoryGitStatusCacheEntry,
+  OverlayStoreLike,
+  SqliteOverlayStore,
+} from "../state/overlay-store-sqlite";
 import type {
   AgentEvent,
   AppServerBackendKind,
@@ -24,6 +28,8 @@ import type {
   GetGhStatusRequest,
   GhStatus,
   PickDirectoryFromDiskResponse,
+  RefreshDirectoryGitStatusesRequest,
+  RefreshDirectoryGitStatusesResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
   RegisterDirectoryFromDiskRequest,
@@ -68,6 +74,7 @@ import {
   APP_SERVER_READ_THREAD_CHANNEL,
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
+  NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -89,6 +96,13 @@ import { getDesktopSettingsService } from "../settings/desktop-settings-singleto
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
+const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
+
+type AppServerOverlayStoreLike = OverlayStoreLike &
+  Pick<
+    SqliteOverlayStore,
+    "readDirectoryGitStatusCache" | "writeDirectoryGitStatusCacheEntry"
+  >;
 const appServerLog = getMainLogger("pwragent:app-server");
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -173,9 +187,16 @@ class DesktopAppServerService {
   >();
   private readonly directoryGitStatusByKey = new Map<
     string,
-    NavigationDirectoryGitStatus | undefined
+    DirectoryGitStatusCacheEntry
+  >();
+  private directoryGitStatusCacheLoaded = false;
+  private automaticDirectoryGitStatusRefreshesStarted = 0;
+  private readonly lastDirectoriesByKey = new Map<
+    string,
+    NavigationSnapshot["directories"][number]
   >();
   private readonly pendingDirectoryGitStatusRefreshes = new Map<string, Promise<void>>();
+  private readonly pendingDirectoryGitStatusKeys = new Set<string>();
 
   async listThreads(
     request: AppServerListThreadsRequest = {}
@@ -398,14 +419,16 @@ class DesktopAppServerService {
     });
     const overlayDurationMs = Date.now() - overlayStartedAt;
     const directoryStartedAt = Date.now();
+    await this.loadDirectoryGitStatusCache();
+    for (const directory of snapshot.directories) {
+      this.lastDirectoriesByKey.set(directory.key, directory);
+    }
     const directories = snapshot.directories.map((directory) => {
-      if (!this.directoryGitStatusByKey.has(directory.key)) {
+      const cached = this.directoryGitStatusByKey.get(directory.key);
+      if (!cached) {
         return directory;
       }
-      return applyDirectoryGitStatus(
-        directory,
-        this.directoryGitStatusByKey.get(directory.key),
-      );
+      return applyDirectoryGitStatus(directory, cached.gitStatus);
     });
     const directoryDurationMs = Date.now() - directoryStartedAt;
     const previousDirectories = this.previousDirectoriesByBackend.get(backend);
@@ -413,7 +436,11 @@ class DesktopAppServerService {
       ? directoryStatusesEqual(previousDirectories, directories)
       : false;
     this.previousDirectoriesByBackend.set(backend, directories);
-    this.startDirectoryGitStatusRefresh(request, snapshot.directories);
+    this.startDirectoryGitStatusRefresh({
+      automatic: true,
+      directories: snapshot.directories,
+      requestKey: getNavigationSnapshotRequestKey(request),
+    });
 
     logDebug("getNavigationSnapshot", {
       backend,
@@ -435,21 +462,75 @@ class DesktopAppServerService {
     };
   }
 
-  private startDirectoryGitStatusRefresh(
-    request: GetNavigationSnapshotRequest,
-    directories: NavigationSnapshot["directories"],
-  ): void {
-    if (directories.length === 0) {
+  async refreshDirectoryGitStatusesForKeys(
+    request: RefreshDirectoryGitStatusesRequest,
+  ): Promise<RefreshDirectoryGitStatusesResponse> {
+    await this.loadDirectoryGitStatusCache();
+    const directoryKeys = [
+      ...new Set(request.directoryKeys.map((key) => key.trim()).filter(Boolean)),
+    ];
+    const directories = directoryKeys
+      .map((key) => this.lastDirectoriesByKey.get(key))
+      .filter((directory): directory is NavigationSnapshot["directories"][number] =>
+        Boolean(directory?.path?.trim()),
+      );
+    const scheduledCount = this.startDirectoryGitStatusRefresh({
+      automatic: false,
+      directories,
+      force: request.force ?? true,
+      requestKey: "explicit",
+    });
+
+    return { scheduledCount };
+  }
+
+  private async loadDirectoryGitStatusCache(): Promise<void> {
+    if (this.directoryGitStatusCacheLoaded) {
       return;
+    }
+    this.directoryGitStatusCacheLoaded = true;
+
+    const entries = await this.getOverlayStore().readDirectoryGitStatusCache();
+    for (const entry of Object.values(entries)) {
+      this.directoryGitStatusByKey.set(entry.directoryKey, entry);
+    }
+  }
+
+  private startDirectoryGitStatusRefresh(params: {
+    automatic: boolean;
+    directories: NavigationSnapshot["directories"];
+    force?: boolean;
+    requestKey: string;
+  }): number {
+    const directories = this.selectDirectoryGitStatusRefreshCandidates(params).filter(
+      (directory) => !this.pendingDirectoryGitStatusKeys.has(directory.key),
+    );
+    if (directories.length === 0) {
+      return 0;
     }
 
     const refreshKey = JSON.stringify({
-      request: getNavigationSnapshotRequestKey(request),
+      request: params.requestKey,
       directoryKeys: directories.map((directory) => directory.key),
+      force: params.force === true,
     });
     if (this.pendingDirectoryGitStatusRefreshes.has(refreshKey)) {
-      return;
+      return 0;
     }
+
+    if (params.automatic) {
+      this.automaticDirectoryGitStatusRefreshesStarted += directories.length;
+    }
+    for (const directory of directories) {
+      this.pendingDirectoryGitStatusKeys.add(directory.key);
+    }
+
+    logDebug("directoryGitStatusRefresh:scheduled", {
+      mode: params.automatic ? "automatic" : "explicit",
+      count: directories.length,
+      automaticStarted: this.automaticDirectoryGitStatusRefreshesStarted,
+      automaticLimit: STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT,
+    });
 
     const promise = this.refreshDirectoryGitStatuses(directories)
       .catch((error) => {
@@ -458,25 +539,84 @@ class DesktopAppServerService {
         });
       })
       .finally(() => {
+        for (const directory of directories) {
+          this.pendingDirectoryGitStatusKeys.delete(directory.key);
+        }
         if (this.pendingDirectoryGitStatusRefreshes.get(refreshKey) === promise) {
           this.pendingDirectoryGitStatusRefreshes.delete(refreshKey);
         }
       });
     this.pendingDirectoryGitStatusRefreshes.set(refreshKey, promise);
+    return directories.length;
+  }
+
+  private selectDirectoryGitStatusRefreshCandidates(params: {
+    automatic: boolean;
+    directories: NavigationSnapshot["directories"];
+    force?: boolean;
+  }): NavigationSnapshot["directories"] {
+    const candidates = params.directories.filter((directory) => {
+      if (!directory.path?.trim()) {
+        return false;
+      }
+      if (params.force) {
+        return true;
+      }
+      const cached = this.directoryGitStatusByKey.get(directory.key);
+      if (!cached) {
+        return true;
+      }
+      return (directory.latestUpdatedAt ?? 0) > (cached.directoryUpdatedAt ?? 0);
+    });
+
+    if (!params.automatic) {
+      return candidates;
+    }
+
+    const remaining =
+      STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT -
+      this.automaticDirectoryGitStatusRefreshesStarted;
+    if (remaining <= 0) {
+      return [];
+    }
+
+    return [...candidates]
+      .sort((left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0))
+      .slice(0, remaining);
   }
 
   private async refreshDirectoryGitStatuses(
     directories: NavigationSnapshot["directories"],
   ): Promise<void> {
+    const refreshableDirectories = directories.filter((directory) => directory.path?.trim());
+    if (refreshableDirectories.length === 0) {
+      return;
+    }
+
     const registry = getDesktopBackendRegistry();
-    for await (const entry of registry.readDirectoryStatusEntries(directories)) {
-      this.directoryGitStatusByKey.set(entry.directoryKey, entry.gitStatus);
+    const directoryByKey = new Map(
+      refreshableDirectories.map((directory) => [directory.key, directory]),
+    );
+    for await (const entry of registry.readDirectoryStatusEntries(refreshableDirectories)) {
+      const directory = directoryByKey.get(entry.directoryKey);
+      const fetchedAt = Date.now();
+      const cacheEntry: DirectoryGitStatusCacheEntry = {
+        directoryKey: entry.directoryKey,
+        ...(directory?.path ? { directoryPath: directory.path } : {}),
+        ...(directory?.latestUpdatedAt !== undefined
+          ? { directoryUpdatedAt: directory.latestUpdatedAt }
+          : {}),
+        fetchedAt,
+        ...(entry.gitStatus ? { gitStatus: entry.gitStatus } : {}),
+      };
+      this.directoryGitStatusByKey.set(entry.directoryKey, cacheEntry);
+      await this.getOverlayStore().writeDirectoryGitStatusCacheEntry(cacheEntry);
       const notification: NavigationDirectoryGitStatusUpdatedNotification = {
         method: "navigation/directoryGitStatus/updated",
         params: {
           directoryKey: entry.directoryKey,
           gitStatus: entry.gitStatus ?? null,
-          fetchedAt: Date.now(),
+          fetchedAt,
         },
       };
       await registry.publishLocalEvent({
@@ -855,8 +995,12 @@ class DesktopAppServerService {
     this.prFetcher = undefined;
     this.pendingNavigationSnapshots.clear();
     this.pendingDirectoryGitStatusRefreshes.clear();
+    this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();
     this.directoryGitStatusByKey.clear();
+    this.directoryGitStatusCacheLoaded = false;
+    this.automaticDirectoryGitStatusRefreshesStarted = 0;
+    this.lastDirectoriesByKey.clear();
     await disposeDesktopBackendRegistry();
   }
 
@@ -867,7 +1011,7 @@ class DesktopAppServerService {
     return this.prFetcher;
   }
 
-  private getOverlayStore(): OverlayStoreLike {
+  private getOverlayStore(): AppServerOverlayStoreLike {
     return getDesktopOverlayStore();
   }
 
@@ -1054,6 +1198,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.refreshThreadPullRequests(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+    async (
+      _event,
+      request: RefreshDirectoryGitStatusesRequest,
+    ): Promise<RefreshDirectoryGitStatusesResponse> => {
+      return await appServerService.refreshDirectoryGitStatusesForKeys(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.handle(
     NAVIGATION_GET_GH_STATUS_CHANNEL,
@@ -1131,6 +1285,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_REACTION_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -353,15 +353,21 @@ class DesktopAppServerService {
   private async readNavigationSnapshot(
     request: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> {
+    const startedAt = Date.now();
     const backend: AppServerBackendScope = request.backend ?? "all";
+    const listStartedAt = Date.now();
     const threads = await getDesktopBackendRegistry().listThreads({
       backend: backend === "all" ? undefined : backend,
       callerReason: "navigation-snapshot",
       filter: request.filter,
     });
+    const listDurationMs = Date.now() - listStartedAt;
+    const bindingsStartedAt = Date.now();
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
+    const bindingsDurationMs = Date.now() - bindingsStartedAt;
     const queuedExecutionModesByThreadId = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
+    const overlayStartedAt = Date.now();
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
@@ -369,8 +375,11 @@ class DesktopAppServerService {
       queuedExecutionModesByThreadId,
       threads,
     });
+    const overlayDurationMs = Date.now() - overlayStartedAt;
+    const directoryStartedAt = Date.now();
     const directoryStatuses =
       await getDesktopBackendRegistry().readDirectoryStatuses(snapshot.directories);
+    const directoryDurationMs = Date.now() - directoryStartedAt;
     const directories = snapshot.directories.map((directory) => ({
       ...directory,
       gitStatus: directoryStatuses[directory.key],
@@ -386,6 +395,11 @@ class DesktopAppServerService {
       count: snapshot.threads.length,
       inboxCount: snapshot.inboxThreadKeys.length,
       unchanged: snapshot.unchanged && directoriesUnchanged,
+      durationMs: Date.now() - startedAt,
+      listDurationMs,
+      bindingsDurationMs,
+      overlayDurationMs,
+      directoryDurationMs,
     });
 
     return {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, dialog, ipcMain } from "electron";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import type {
+  AgentEvent,
   AppServerBackendKind,
   AppServerBackendScope,
   ArchiveWorktreeRequest,
@@ -29,6 +30,8 @@ import type {
   RegisterDirectoryFromDiskResponse,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
+  NavigationDirectoryGitStatus,
+  NavigationDirectoryGitStatusUpdatedNotification,
   NavigationSnapshot,
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
@@ -116,6 +119,19 @@ function directoryStatusesEqual(
   });
 }
 
+function applyDirectoryGitStatus(
+  directory: NavigationSnapshot["directories"][number],
+  gitStatus: NavigationDirectoryGitStatus | undefined,
+): NavigationSnapshot["directories"][number] {
+  const next = { ...directory };
+  if (gitStatus) {
+    next.gitStatus = gitStatus;
+  } else {
+    delete next.gitStatus;
+  }
+  return next;
+}
+
 function getNavigationSnapshotRequestKey(
   request: GetNavigationSnapshotRequest,
 ): string {
@@ -155,6 +171,11 @@ class DesktopAppServerService {
     AppServerBackendScope,
     NavigationSnapshot["directories"]
   >();
+  private readonly directoryGitStatusByKey = new Map<
+    string,
+    NavigationDirectoryGitStatus | undefined
+  >();
+  private readonly pendingDirectoryGitStatusRefreshes = new Map<string, Promise<void>>();
 
   async listThreads(
     request: AppServerListThreadsRequest = {}
@@ -377,18 +398,22 @@ class DesktopAppServerService {
     });
     const overlayDurationMs = Date.now() - overlayStartedAt;
     const directoryStartedAt = Date.now();
-    const directoryStatuses =
-      await getDesktopBackendRegistry().readDirectoryStatuses(snapshot.directories);
+    const directories = snapshot.directories.map((directory) => {
+      if (!this.directoryGitStatusByKey.has(directory.key)) {
+        return directory;
+      }
+      return applyDirectoryGitStatus(
+        directory,
+        this.directoryGitStatusByKey.get(directory.key),
+      );
+    });
     const directoryDurationMs = Date.now() - directoryStartedAt;
-    const directories = snapshot.directories.map((directory) => ({
-      ...directory,
-      gitStatus: directoryStatuses[directory.key],
-    }));
     const previousDirectories = this.previousDirectoriesByBackend.get(backend);
     const directoriesUnchanged = previousDirectories
       ? directoryStatusesEqual(previousDirectories, directories)
       : false;
     this.previousDirectoriesByBackend.set(backend, directories);
+    this.startDirectoryGitStatusRefresh(request, snapshot.directories);
 
     logDebug("getNavigationSnapshot", {
       backend,
@@ -400,6 +425,7 @@ class DesktopAppServerService {
       bindingsDurationMs,
       overlayDurationMs,
       directoryDurationMs,
+      directoryStatusMode: "background",
     });
 
     return {
@@ -407,6 +433,57 @@ class DesktopAppServerService {
       directories,
       unchanged: snapshot.unchanged && directoriesUnchanged,
     };
+  }
+
+  private startDirectoryGitStatusRefresh(
+    request: GetNavigationSnapshotRequest,
+    directories: NavigationSnapshot["directories"],
+  ): void {
+    if (directories.length === 0) {
+      return;
+    }
+
+    const refreshKey = JSON.stringify({
+      request: getNavigationSnapshotRequestKey(request),
+      directoryKeys: directories.map((directory) => directory.key),
+    });
+    if (this.pendingDirectoryGitStatusRefreshes.has(refreshKey)) {
+      return;
+    }
+
+    const promise = this.refreshDirectoryGitStatuses(directories)
+      .catch((error) => {
+        logDebug("directoryGitStatusRefresh:failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        if (this.pendingDirectoryGitStatusRefreshes.get(refreshKey) === promise) {
+          this.pendingDirectoryGitStatusRefreshes.delete(refreshKey);
+        }
+      });
+    this.pendingDirectoryGitStatusRefreshes.set(refreshKey, promise);
+  }
+
+  private async refreshDirectoryGitStatuses(
+    directories: NavigationSnapshot["directories"],
+  ): Promise<void> {
+    const registry = getDesktopBackendRegistry();
+    for await (const entry of registry.readDirectoryStatusEntries(directories)) {
+      this.directoryGitStatusByKey.set(entry.directoryKey, entry.gitStatus);
+      const notification: NavigationDirectoryGitStatusUpdatedNotification = {
+        method: "navigation/directoryGitStatus/updated",
+        params: {
+          directoryKey: entry.directoryKey,
+          gitStatus: entry.gitStatus ?? null,
+          fetchedAt: Date.now(),
+        },
+      };
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification,
+      } as unknown as AgentEvent);
+    }
   }
 
   async markThreadSeen(
@@ -776,6 +853,10 @@ class DesktopAppServerService {
     this.focusedDiffServiceApiKey = undefined;
     this.focusedDiffServiceModel = undefined;
     this.prFetcher = undefined;
+    this.pendingNavigationSnapshots.clear();
+    this.pendingDirectoryGitStatusRefreshes.clear();
+    this.previousDirectoriesByBackend.clear();
+    this.directoryGitStatusByKey.clear();
     await disposeDesktopBackendRegistry();
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -26,6 +26,28 @@ import {
 } from "@pwragent/agent-core";
 import type { StateDb } from "./state-db.js";
 
+export type DirectoryGitStatusCacheEntry = {
+  directoryKey: string;
+  directoryPath?: string;
+  directoryUpdatedAt?: number;
+  fetchedAt: number;
+  gitStatus?: NavigationDirectoryGitStatus;
+};
+
+function parseDirectoryGitStatusCachePayload(
+  payload: string | null,
+): NavigationDirectoryGitStatus | undefined {
+  if (!payload) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(payload) as NavigationDirectoryGitStatus;
+  } catch {
+    return undefined;
+  }
+}
+
 export class SqliteOverlayStore {
   constructor(private readonly stateDb: StateDb) {}
 
@@ -663,6 +685,61 @@ export class SqliteOverlayStore {
     this.stateDb.raw
       .prepare("DELETE FROM directory_launchpads WHERE directory_path = ?")
       .run(params.directoryKey);
+  }
+
+  async readDirectoryGitStatusCache(): Promise<
+    Record<string, DirectoryGitStatusCacheEntry>
+  > {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT directory_key, directory_path, directory_updated_at, fetched_at, payload
+         FROM directory_git_status`,
+      )
+      .all() as Array<{
+        directory_key: string;
+        directory_path: string | null;
+        directory_updated_at: number | null;
+        fetched_at: number;
+        payload: string | null;
+      }>;
+
+    return Object.fromEntries(
+      rows.map((row) => {
+        const gitStatus = parseDirectoryGitStatusCachePayload(row.payload);
+        const entry: DirectoryGitStatusCacheEntry = {
+          directoryKey: row.directory_key,
+          ...(row.directory_path ? { directoryPath: row.directory_path } : {}),
+          ...(row.directory_updated_at !== null
+            ? { directoryUpdatedAt: row.directory_updated_at }
+            : {}),
+          fetchedAt: row.fetched_at,
+          ...(gitStatus ? { gitStatus } : {}),
+        };
+        return [entry.directoryKey, entry];
+      }),
+    );
+  }
+
+  async writeDirectoryGitStatusCacheEntry(
+    entry: DirectoryGitStatusCacheEntry,
+  ): Promise<void> {
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO directory_git_status(
+           directory_key,
+           directory_path,
+           directory_updated_at,
+           fetched_at,
+           payload
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        entry.directoryKey,
+        entry.directoryPath ?? null,
+        entry.directoryUpdatedAt ?? null,
+        entry.fetchedAt,
+        entry.gitStatus ? JSON.stringify(entry.gitStatus) : null,
+      );
   }
 
   private getThread(threadKey: string): ThreadOverlayState | undefined {

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -185,6 +185,18 @@ CREATE INDEX IF NOT EXISTS idx_messaging_runtime_lease_status_expires
   ON messaging_runtime_lease(status, expires_at);
 `;
 
+const DIRECTORY_GIT_STATUS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS directory_git_status (
+  directory_key        TEXT PRIMARY KEY,
+  directory_path       TEXT,
+  directory_updated_at INTEGER,
+  fetched_at           INTEGER NOT NULL,
+  payload              TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_directory_git_status_fetched
+  ON directory_git_status(fetched_at DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -380,6 +392,7 @@ export class StateDb {
 function ensureCurrentSchema(db: BetterSqlite3.Database): void {
   db.transaction(() => {
     db.exec(SCHEMA_V4);
+    db.exec(DIRECTORY_GIT_STATUS_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -71,6 +71,8 @@ import type {
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
+  RefreshDirectoryGitStatusesRequest,
+  RefreshDirectoryGitStatusesResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -193,6 +195,7 @@ import {
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
+  NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -517,6 +520,13 @@ const desktopApi = Object.freeze({
     request: RefreshThreadPullRequestsRequest,
   ): Promise<RefreshThreadPullRequestsResponse> =>
     await ipcRenderer.invoke(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL, request),
+  refreshDirectoryGitStatuses: async (
+    request: RefreshDirectoryGitStatusesRequest,
+  ): Promise<RefreshDirectoryGitStatusesResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+      request,
+    ),
   getGhStatus: async (request?: GetGhStatusRequest): Promise<GhStatus> =>
     await ipcRenderer.invoke(NAVIGATION_GET_GH_STATUS_CHANNEL, request),
   ensureDirectoryLaunchpad: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useState, type CSSProperties, type PointerEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type ComponentType,
+  type CSSProperties,
+  type PointerEvent,
+} from "react";
 import { Sidebar } from "./features/navigation/Sidebar";
 import {
   SettingsScreen,
@@ -8,7 +15,7 @@ import {
   useDesktopSettings,
   type DesktopSettingsState,
 } from "./features/settings/useDesktopSettings";
-import { ThreadView } from "./features/thread-detail/ThreadView";
+import type { ThreadViewProps } from "./features/thread-detail/ThreadView";
 import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
@@ -80,6 +87,9 @@ function DesktopAppShell(props: {
   const [settingsInitialSection, setSettingsInitialSection] = useState<
     SettingsSection | undefined
   >(undefined);
+  const [threadViewReady, setThreadViewReady] = useState(false);
+  const [ThreadViewComponent, setThreadViewComponent] =
+    useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
   // Spawning / focusing the Messaging Activity window is fire-and-forget
   // — see `apps/desktop/src/main/messaging-activity-window.ts`. The
@@ -106,15 +116,149 @@ function DesktopAppShell(props: {
     selectedThread: navigation.selectedThread,
     threads: navigation.threads,
   });
+  useEffect(() => {
+    if (threadViewReady || mainView !== "thread" || navigation.loading) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      setThreadViewReady(true);
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [mainView, navigation.loading, threadViewReady]);
+  useEffect(() => {
+    if (!threadViewReady || ThreadViewComponent) {
+      return;
+    }
+
+    let cancelled = false;
+    void import("./features/thread-detail/ThreadView").then((module) => {
+      if (!cancelled) {
+        setThreadViewComponent(() => module.ThreadView);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ThreadViewComponent, threadViewReady]);
+  const loadThreadDetail = threadViewReady && mainView === "thread";
   const session = useThreadSessionState({
     desktopApi,
-    thread: navigation.selectedThread,
+    thread: loadThreadDetail ? navigation.selectedThread : undefined,
   });
   const skills = useThreadSkills({
     desktopApi,
     launchpad: navigation.selectedLaunchpad,
-    thread: navigation.selectedThread,
+    thread: loadThreadDetail ? navigation.selectedThread : undefined,
   });
+  const threadViewProps = {
+    activeTurnId: session.activeTurnId,
+    activeTurnStartedAt: session.activeTurnStartedAt,
+    addOptimisticReviewEntry: session.addOptimisticReviewEntry,
+    addOptimisticUserMessage: session.addOptimisticUserMessage,
+    backendError: backendSummaries.error,
+    backends: backendSummaries.backends,
+    applications: settings.snapshot?.applications,
+    archiveThreadError: navigation.archiveThreadError,
+    clearPendingRequest: session.clearPendingRequest,
+    composerDisabled:
+      !navigation.selectedThread ||
+      !backendSummaries.backends.some(
+        (backend) =>
+          backend.kind === navigation.selectedThread?.source &&
+          backend.available
+      ),
+    composerImplementation: settings.composerImplementation,
+    composerDraftStore,
+    desktopApi,
+    launchpadError: navigation.launchpadError,
+    loading: session.loading,
+    loadingMore: session.loadingMore,
+    messageCount: session.messages.length,
+    contextWindow: session.contextWindow,
+    pendingAssistantMessage: session.pendingAssistantMessage,
+    pendingMcpInteraction: session.pendingMcpInteraction,
+    pendingRequest: session.pendingRequest,
+    pendingUserInput: session.pendingUserInput,
+    pendingStatusText: session.pendingStatusText,
+    platform: desktopApi?.platform,
+    selectedDirectory: navigation.selectedDirectory,
+    selectedLaunchpad: navigation.selectedLaunchpad,
+    selectedThread: navigation.selectedThread,
+    suppressBranchDriftDialog: mainView === "settings",
+    directories: navigation.directories,
+    fullAccessRiskWarningDismissed:
+      settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ?? false,
+    pickDirectoryError: navigation.pickDirectoryError,
+    pickingDirectory: navigation.pickingDirectory,
+    onSelectDirectoryFromPicker: (directory) => {
+      void navigation.openDirectoryLaunchpad(directory);
+    },
+    onPickAndRegisterDirectory: () => {
+      void navigation.pickAndRegisterDirectory();
+    },
+    onClearPickDirectoryError: navigation.clearPickDirectoryError,
+    setExecutionModeError: navigation.setThreadExecutionModeError,
+    setThreadModelSettingsError: navigation.setThreadModelSettingsError,
+    skillError: skills.error,
+    skillLoading: skills.loading,
+    skills: skills.skills,
+    transcriptEntries: session.entries,
+    transcriptError: session.error,
+    transcriptPagination: session.response?.replay.pagination,
+    updatingExecutionMode: navigation.updatingThreadExecutionMode,
+    worktreeArchiveError: navigation.worktreeArchiveError,
+    onActiveTurnIdChange: session.setActiveTurnId,
+    onArchiveThread: navigation.archiveThread,
+    onArchiveWorktree: navigation.archiveWorktree,
+    onEnsureSkillsLoaded: skills.ensureLoaded,
+    onDismissFullAccessRiskWarning: async () => {
+      const saved = await settings.writeConfig({
+        experimental: {
+          fullAccessRiskWarningDismissed: true,
+        },
+      });
+      if (!saved) {
+        throw new Error("Could not save the Full Access warning preference.");
+      }
+    },
+    onOpenMessagingActivity: openMessagingActivityWindow,
+    onHandoffThreadWorkspace: navigation.selectedThread
+      ? async (request) =>
+          await navigation.handoffThreadWorkspace(
+            navigation.selectedThread!,
+            request
+          )
+      : undefined,
+    onLoadOlder: session.loadOlder,
+    onLiveTranscriptEntry: session.upsertLiveTranscriptEntry,
+    onMaterializeLaunchpad: navigation.materializeDirectoryLaunchpad,
+    onPendingStatusChange: session.setPendingStatusText,
+    onRefreshNavigation: navigation.refresh,
+    onSetExecutionMode: navigation.selectedThread
+      ? async (executionMode) =>
+          await navigation.setThreadExecutionMode(
+            navigation.selectedThread!,
+            executionMode
+          )
+      : undefined,
+    onCancelExecutionModeQueue: navigation.selectedThread
+      ? async () =>
+          await navigation.cancelThreadExecutionModeQueue(navigation.selectedThread!)
+      : undefined,
+    onSetThreadModelSettings: navigation.selectedThread
+      ? async (patch) =>
+          await navigation.setThreadModelSettings(navigation.selectedThread!, patch)
+      : undefined,
+    onRestoreWorktree: navigation.restoreWorktree,
+    onTranscriptViewportChange: session.setViewport,
+    onUpdateLaunchpad: navigation.updateDirectoryLaunchpad,
+    onUpdatePendingMcpInteraction: session.updatePendingMcpInteraction,
+    onUpdatePendingUserInput: session.updatePendingUserInput,
+    removeOptimisticMessage: session.removeOptimisticMessage,
+    transcriptViewport: session.viewport,
+  } satisfies ThreadViewProps;
 
   const resizeSidebar = (nextWidth: number): void => {
     setSidebarWidth(Math.min(560, Math.max(280, nextWidth)));
@@ -196,129 +340,7 @@ function DesktopAppShell(props: {
       />
 
       <main className="app-main">
-        <ThreadView
-          activeTurnId={session.activeTurnId}
-          activeTurnStartedAt={session.activeTurnStartedAt}
-          addOptimisticReviewEntry={session.addOptimisticReviewEntry}
-          addOptimisticUserMessage={session.addOptimisticUserMessage}
-          backendError={backendSummaries.error}
-          backends={backendSummaries.backends}
-          applications={settings.snapshot?.applications}
-          clearPendingRequest={session.clearPendingRequest}
-          composerDisabled={
-            !navigation.selectedThread ||
-            !backendSummaries.backends.some(
-              (backend) =>
-                backend.kind === navigation.selectedThread?.source &&
-                backend.available
-            )
-          }
-          composerImplementation={settings.composerImplementation}
-          composerDraftStore={composerDraftStore}
-          desktopApi={desktopApi}
-          launchpadError={navigation.launchpadError}
-          loading={session.loading}
-          loadingMore={session.loadingMore}
-          messageCount={session.messages.length}
-          contextWindow={session.contextWindow}
-          pendingAssistantMessage={session.pendingAssistantMessage}
-          pendingMcpInteraction={session.pendingMcpInteraction}
-          pendingRequest={session.pendingRequest}
-          pendingUserInput={session.pendingUserInput}
-          pendingStatusText={session.pendingStatusText}
-          platform={desktopApi?.platform}
-          selectedDirectory={navigation.selectedDirectory}
-          selectedLaunchpad={navigation.selectedLaunchpad}
-          selectedThread={navigation.selectedThread}
-          archiveThreadError={navigation.archiveThreadError}
-          suppressBranchDriftDialog={mainView === "settings"}
-          directories={navigation.directories}
-          fullAccessRiskWarningDismissed={
-            settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ??
-            false
-          }
-          pickDirectoryError={navigation.pickDirectoryError}
-          pickingDirectory={navigation.pickingDirectory}
-          onSelectDirectoryFromPicker={(directory) => {
-            void navigation.openDirectoryLaunchpad(directory);
-          }}
-          onPickAndRegisterDirectory={() => {
-            void navigation.pickAndRegisterDirectory();
-          }}
-          onClearPickDirectoryError={navigation.clearPickDirectoryError}
-          setExecutionModeError={navigation.setThreadExecutionModeError}
-          setThreadModelSettingsError={navigation.setThreadModelSettingsError}
-          skillError={skills.error}
-          skillLoading={skills.loading}
-          skills={skills.skills}
-          transcriptEntries={session.entries}
-          transcriptError={session.error}
-          transcriptPagination={session.response?.replay.pagination}
-          updatingExecutionMode={navigation.updatingThreadExecutionMode}
-          worktreeArchiveError={navigation.worktreeArchiveError}
-          onActiveTurnIdChange={session.setActiveTurnId}
-          onArchiveThread={navigation.archiveThread}
-          onArchiveWorktree={navigation.archiveWorktree}
-          onEnsureSkillsLoaded={skills.ensureLoaded}
-          onDismissFullAccessRiskWarning={async () => {
-            const saved = await settings.writeConfig({
-              experimental: {
-                fullAccessRiskWarningDismissed: true,
-              },
-            });
-            if (!saved) {
-              throw new Error("Could not save the Full Access warning preference.");
-            }
-          }}
-          onOpenMessagingActivity={openMessagingActivityWindow}
-          onHandoffThreadWorkspace={
-            navigation.selectedThread
-              ? async (request) =>
-                  await navigation.handoffThreadWorkspace(
-                    navigation.selectedThread!,
-                    request
-                  )
-              : undefined
-          }
-          onLoadOlder={session.loadOlder}
-          onLiveTranscriptEntry={session.upsertLiveTranscriptEntry}
-          onMaterializeLaunchpad={navigation.materializeDirectoryLaunchpad}
-          onPendingStatusChange={session.setPendingStatusText}
-          onRefreshNavigation={navigation.refresh}
-          onSetExecutionMode={
-            navigation.selectedThread
-              ? async (executionMode) =>
-                  await navigation.setThreadExecutionMode(
-                    navigation.selectedThread!,
-                    executionMode
-                  )
-              : undefined
-          }
-          onCancelExecutionModeQueue={
-            navigation.selectedThread
-              ? async () =>
-                  await navigation.cancelThreadExecutionModeQueue(
-                    navigation.selectedThread!
-                  )
-              : undefined
-          }
-          onSetThreadModelSettings={
-            navigation.selectedThread
-              ? async (patch) =>
-                  await navigation.setThreadModelSettings(
-                    navigation.selectedThread!,
-                    patch
-                  )
-              : undefined
-          }
-          onRestoreWorktree={navigation.restoreWorktree}
-          onTranscriptViewportChange={session.setViewport}
-          onUpdateLaunchpad={navigation.updateDirectoryLaunchpad}
-          onUpdatePendingMcpInteraction={session.updatePendingMcpInteraction}
-          onUpdatePendingUserInput={session.updatePendingUserInput}
-          removeOptimisticMessage={session.removeOptimisticMessage}
-          transcriptViewport={session.viewport}
-        />
+        {ThreadViewComponent ? <ThreadViewComponent {...threadViewProps} /> : null}
       </main>
 
       {mainView === "settings" ? (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -121,10 +121,25 @@ function DesktopAppShell(props: {
       return;
     }
 
-    const frameId = window.requestAnimationFrame(() => {
-      setThreadViewReady(true);
+    let timeoutId: number | undefined;
+    let secondFrameId: number | undefined;
+    const firstFrameId = window.requestAnimationFrame(() => {
+      secondFrameId = window.requestAnimationFrame(() => {
+        timeoutId = window.setTimeout(() => {
+          setThreadViewReady(true);
+        }, 0);
+      });
     });
-    return () => window.cancelAnimationFrame(frameId);
+
+    return () => {
+      window.cancelAnimationFrame(firstFrameId);
+      if (secondFrameId !== undefined) {
+        window.cancelAnimationFrame(secondFrameId);
+      }
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
   }, [mainView, navigation.loading, threadViewReady]);
   useEffect(() => {
     if (!threadViewReady || ThreadViewComponent) {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -91,8 +91,8 @@ function DesktopAppShell(props: {
   const settings = props.settings;
   const profiles = usePwrAgentProfiles(desktopApi);
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
-  const backendSummaries = useBackendSummaries(desktopApi);
   const navigation = useThreadNavigation(desktopApi);
+  const backendSummaries = useBackendSummaries(desktopApi);
   const pullRequests = usePullRequestRefresh({
     desktopApi,
     onRefreshNavigation: navigation.refresh,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -31,10 +31,6 @@ export function App() {
   const desktopApi = useDesktopApi();
   const settings = useDesktopSettings(desktopApi);
 
-  if (desktopApi?.readSettings && !settings.snapshot && !settings.error) {
-    return <AppStartupScreen />;
-  }
-
   if (desktopApi?.readSettings && !settings.snapshot && settings.error) {
     return (
       <div className="app-shell app-shell--fatal-settings">
@@ -56,21 +52,6 @@ export function App() {
   }
 
   return <DesktopAppShell desktopApi={desktopApi} settings={settings} />;
-}
-
-function AppStartupScreen() {
-  return (
-    <div className="app-shell app-shell--startup">
-      <main className="app-startup" aria-label="Starting PwrAgent">
-        <div className="app-startup__brand" aria-hidden="true">
-          Pwr<span>Agent</span>
-        </div>
-        <p className="app-startup__status" role="status">
-          Loading PwrAgent...
-        </p>
-      </main>
-    </div>
-  );
 }
 
 function DesktopAppShell(props: {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -75,7 +75,7 @@ describe("App", () => {
     cleanup();
   });
 
-  it("does not show Settings while the startup settings read is pending", async () => {
+  it("shows the thread shell while the startup settings read is pending", async () => {
     const listBackends = vi.fn(async () => ({
       fetchedAt: Date.now(),
       backends: [],
@@ -110,19 +110,15 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(
-      screen.getByRole("main", { name: "Starting PwrAgent" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Loading PwrAgent...");
     expect(screen.queryByText("Exit Settings")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("complementary", { name: "Threads" }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
     await waitFor(() => {
       expect(readSettings).toHaveBeenCalledTimes(1);
     });
-    expect(listBackends).not.toHaveBeenCalled();
-    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(1);
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("blocks the app shell when desktop settings config is malformed", async () => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -56,6 +56,20 @@ function getComposerValueHost(textbox: HTMLElement): HTMLElement {
   );
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("App", () => {
   afterEach(() => {
     cleanup();
@@ -292,8 +306,42 @@ describe("App", () => {
     );
     expect(screen.getByRole("alert")).toHaveTextContent("line 3: expected a key");
     expect(screen.queryByRole("complementary", { name: "Threads" })).not.toBeInTheDocument();
-    expect(listBackends).not.toHaveBeenCalled();
-    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("starts loading navigation before settings discovery completes", async () => {
+    const settings = createDeferred<{ snapshot: DesktopSettingsSnapshot }>();
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: () => settings.promise,
+        listBackends: vi.fn(async () => ({
+          fetchedAt: Date.now(),
+          backends: [],
+        })),
+        getNavigationSnapshot,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
   });
 
   it("renders the live thread shell with transcript history", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -25,6 +25,10 @@ import { ThreadMetaChips } from "./ThreadMetaChips";
 import { getThreadRowStatus, ThreadRowStatus } from "./ThreadRowStatus";
 
 const HOVER_PREFETCH_DELAY_MS = 750;
+const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
 
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -693,8 +697,5 @@ function formatRelativeTime(timestamp?: number): string {
     return `${deltaDays}d`;
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-  }).format(timestamp);
+  return absoluteDateFormatter.format(timestamp);
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -766,7 +766,7 @@ function activityContainsDiff(
   });
 }
 
-type ThreadViewProps = {
+export type ThreadViewProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   addOptimisticReviewEntry?: (displayText: string) => string;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -107,6 +107,68 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("refreshes selected thread directory git status on demand", async () => {
+    const refreshDirectoryGitStatuses = vi.fn(async () => ({ scheduledCount: 1 }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      refreshDirectoryGitStatuses,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(1);
+    });
+
+    expect(refreshDirectoryGitStatuses).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(refreshDirectoryGitStatuses).toHaveBeenCalledWith({
+        directoryKeys: ["directory:/repo/app"],
+        force: true,
+      });
+    });
+  });
+
   it("keeps a selected unread marker until another item is selected", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -323,6 +323,90 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("applies streamed directory git status updates without refreshing the snapshot", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 1,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.key).toBe("directory:/repo/app");
+    });
+    expect(result.current.directories[0]?.gitStatus).toBeUndefined();
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "navigation/directoryGitStatus/updated",
+            params: {
+              directoryKey: "directory:/repo/app",
+              gitStatus: {
+                currentBranch: "main",
+                upstreamBranch: "origin/main",
+                ahead: 0,
+                behind: 0,
+                syncState: "in-sync",
+              },
+              fetchedAt: Date.now(),
+            },
+          },
+        });
+      }
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    expect(result.current.directories[0]?.gitStatus).toMatchObject({
+      currentBranch: "main",
+      syncState: "in-sync",
+    });
+  });
+
   it("does not move selection to another thread when refresh temporarily drops the selected thread", async () => {
     const listeners = new Set<(event: any) => void>();
     let includeSelectedThread = true;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -65,6 +65,8 @@ import type {
   UnbindMessagingThreadResponse,
   RefreshThreadPullRequestsRequest,
   RefreshThreadPullRequestsResponse,
+  RefreshDirectoryGitStatusesRequest,
+  RefreshDirectoryGitStatusesResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -308,6 +310,9 @@ export type DesktopApi = {
   refreshThreadPullRequests?: (
     request: RefreshThreadPullRequestsRequest
   ) => Promise<RefreshThreadPullRequestsResponse>;
+  refreshDirectoryGitStatuses?: (
+    request: RefreshDirectoryGitStatusesRequest
+  ) => Promise<RefreshDirectoryGitStatusesResponse>;
   getGhStatus?: (request?: GetGhStatusRequest) => Promise<GhStatus>;
   ensureDirectoryLaunchpad?: (
     request: EnsureDirectoryLaunchpadRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -8,6 +8,7 @@ import type {
   ArchiveThreadCleanupResult,
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
+  NavigationDirectoryGitStatusUpdatedNotification,
   NavigationDirectorySummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -345,8 +346,20 @@ function reconcileNavigationSnapshot(
       thread,
     ])
   );
+  const previousByDirectoryKey = new Map(
+    previous.directories.map((directory) => [directory.key, directory])
+  );
   return {
     ...next,
+    directories: next.directories.map((directory) => {
+      if (Object.prototype.hasOwnProperty.call(directory, "gitStatus")) {
+        return directory;
+      }
+      const previousDirectory = previousByDirectoryKey.get(directory.key);
+      return previousDirectory?.gitStatus
+        ? { ...directory, gitStatus: previousDirectory.gitStatus }
+        : directory;
+    }),
     threads: next.threads.map((thread) => {
       const previousThread = previousByThreadKey.get(
         buildThreadIdentityKey(thread.source, thread.id)
@@ -356,6 +369,36 @@ function reconcileNavigationSnapshot(
         : thread;
     }),
   };
+}
+
+function applyDirectoryGitStatusUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: NavigationDirectoryGitStatusUpdatedNotification["params"],
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const directories = snapshot.directories.map((directory) => {
+    if (directory.key !== params.directoryKey) {
+      return directory;
+    }
+    if (JSON.stringify(directory.gitStatus ?? null) === JSON.stringify(params.gitStatus)) {
+      return directory;
+    }
+
+    changed = true;
+    const next = { ...directory };
+    if (params.gitStatus) {
+      next.gitStatus = params.gitStatus;
+    } else {
+      delete next.gitStatus;
+    }
+    return next;
+  });
+
+  return changed ? { ...snapshot, directories } : snapshot;
 }
 
 function updateThreadReactionsInSnapshot(
@@ -1498,7 +1541,17 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     }
 
     return desktopApi.onAgentEvent((event) => {
-      const method = event.notification.method;
+      const method = event.notification.method as string;
+      if (method === "navigation/directoryGitStatus/updated") {
+        const params = event.notification
+          .params as NavigationDirectoryGitStatusUpdatedNotification["params"];
+        setState((current) => ({
+          ...current,
+          response: applyDirectoryGitStatusUpdate(current.response, params),
+        }));
+        return;
+      }
+
       if (method === "thread/name/updated") {
         const { threadId, threadName } = event.notification.params as {
           threadId: string;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -65,6 +65,19 @@ function sortNavigationDirectories(
   return [...directories].sort(compareNavigationDirectoriesByLabel);
 }
 
+function directoryKeysForThread(
+  directories: NavigationSnapshot["directories"],
+  threadKey?: string,
+): string[] {
+  if (!threadKey) {
+    return [];
+  }
+
+  return directories
+    .filter((directory) => directory.path && directory.threadKeys.includes(threadKey))
+    .map((directory) => directory.key);
+}
+
 function formatArchiveCleanupFailure(
   cleanup: ArchiveThreadCleanupResult[]
 ): string | undefined {
@@ -1907,7 +1920,6 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       directory.threadKeys.includes(selectedThreadKey)
     );
   }, [directories, selectedItemKey, selectedThreadKey]);
-
   const selectedLaunchpad = useMemo(() => {
     const launchpadDirectoryKey = getDirectoryKeyFromLaunchpadSelection(selectedItemKey);
     if (!launchpadDirectoryKey) {
@@ -1980,9 +1992,29 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     };
   }, [markThreadSeen, pendingSeenThreadKey, retainedUnreadThread, selectedThread]);
 
+  const refreshThreadDirectoryGitStatuses = useCallback(
+    (threadKey: string): void => {
+      if (!desktopApi?.refreshDirectoryGitStatuses) {
+        return;
+      }
+
+      const directoryKeys = directoryKeysForThread(directories, threadKey);
+      if (directoryKeys.length === 0) {
+        return;
+      }
+
+      void desktopApi.refreshDirectoryGitStatuses({
+        directoryKeys,
+        force: true,
+      });
+    },
+    [desktopApi?.refreshDirectoryGitStatuses, directories]
+  );
+
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
     releaseRetainedUnreadThread(threadKey);
+    refreshThreadDirectoryGitStatuses(threadKey);
     setCreateThreadError(undefined);
     setLaunchpadError(undefined);
     setArchiveThreadError(undefined);
@@ -1993,7 +2025,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     if (thread.inbox.inInbox && thread.inbox.reason === "updated-since-seen") {
       setRetainedUnreadThread(thread);
     }
-  }, [releaseRetainedUnreadThread]);
+  }, [refreshThreadDirectoryGitStatuses, releaseRetainedUnreadThread]);
 
   const createThread = useCallback(
     async (

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,14 +1,22 @@
-import React, { type ReactElement } from "react";
+import React, { Suspense, lazy, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
-import { ChangelogWindow } from "./features/changelog/ChangelogWindow";
-import { LogsWindow } from "./features/logs/LogsWindow";
-import { MessagingActivityWindow } from "./features/messaging-activity/MessagingActivityWindow";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
 import "./styles/app.css";
 
 installGlobalRendererErrorHandlers();
+
+const ChangelogWindow = lazy(async () => ({
+  default: (await import("./features/changelog/ChangelogWindow")).ChangelogWindow,
+}));
+const LogsWindow = lazy(async () => ({
+  default: (await import("./features/logs/LogsWindow")).LogsWindow,
+}));
+const MessagingActivityWindow = lazy(async () => ({
+  default: (await import("./features/messaging-activity/MessagingActivityWindow"))
+    .MessagingActivityWindow,
+}));
 
 /**
  * Routes recognized by `chooseRoot` below. The Messaging Activity
@@ -47,6 +55,8 @@ function chooseRoot(): ReactElement {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RendererErrorBoundary>{chooseRoot()}</RendererErrorBoundary>
+    <RendererErrorBoundary>
+      <Suspense fallback={null}>{chooseRoot()}</Suspense>
+    </RendererErrorBoundary>
   </React.StrictMode>,
 );

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -48,6 +48,8 @@ export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
 export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
+export const NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL =
+  "navigation:refresh-directory-git-statuses";
 export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -234,6 +234,15 @@ export type NavigationDirectoryGitStatusUpdatedNotification = {
   };
 };
 
+export type RefreshDirectoryGitStatusesRequest = {
+  directoryKeys: string[];
+  force?: boolean;
+};
+
+export type RefreshDirectoryGitStatusesResponse = {
+  scheduledCount: number;
+};
+
 export function buildThreadIdentityKey(
   backend: AppServerBackendKind,
   threadId: ThreadIdentifier,

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -225,6 +225,15 @@ export type NavigationDirectorySummary = {
   launchpad?: NavigationLaunchpadDraft;
 };
 
+export type NavigationDirectoryGitStatusUpdatedNotification = {
+  method: "navigation/directoryGitStatus/updated";
+  params: {
+    directoryKey: string;
+    gitStatus: NavigationDirectoryGitStatus | null;
+    fetchedAt: number;
+  };
+};
+
 export function buildThreadIdentityKey(
   backend: AppServerBackendKind,
   threadId: ThreadIdentifier,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@pwragent/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@shutterstock/p-map-iterable':
+        specifier: ^1.1.2
+        version: 1.1.2(aggregate-error@3.1.0)
       '@tiptap/extension-mention':
         specifier: ^3.22.5
         version: 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
@@ -1204,6 +1207,11 @@ packages:
     resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@shutterstock/p-map-iterable@1.1.2':
+    resolution: {integrity: sha512-zNPPB2cro7fr+gPsNPoEir6pzYfJngkik7EnsSD5uMqwzGB8qtMmausS5XO10KM5c1Hfw/hpe1oXf/UoHNZFlg==}
+    peerDependencies:
+      aggregate-error: ^3.0.0
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1601,6 +1609,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
   ai@6.0.168:
     resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
     engines: {node: '>=18'}
@@ -1808,6 +1820,10 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
@@ -4572,6 +4588,10 @@ snapshots:
 
   '@sapphire/snowflake@3.5.5': {}
 
+  '@shutterstock/p-map-iterable@1.1.2(aggregate-error@3.1.0)':
+    dependencies:
+      aggregate-error: 3.1.0
+
   '@sindresorhus/is@4.6.0': {}
 
   '@slack/logger@4.0.1':
@@ -5038,6 +5058,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
   ai@6.0.168(zod@4.3.6):
     dependencies:
       '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
@@ -5292,6 +5317,8 @@ snapshots:
   ci-info@4.3.1: {}
 
   ci-info@4.4.0: {}
+
+  clean-stack@2.2.0: {}
 
   cli-truncate@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- I reduced default-profile startup latency by keeping navigation thread lists cheap: startup prewarm, navigation snapshots, branch drift, title generation, and turn-cwd lookups no longer force Codex directory/git enrichment for every thread.
- I moved directory git-status refreshes and directory status cache hydration behind bounded background work, using `@shutterstock/p-map-iterable` so git status work can fill in asynchronously instead of blocking the thread list.
- I added startup CPU profiling tooling and used it to find the renderer-side gap: the main shell was importing the changelog route, which imported `ThreadMarkdown`, which imported `react-markdown`. Secondary renderer windows are now lazy-loaded so the main window does not pay that module-evaluation cost before the list can render.
- I delayed thread-detail loading until after the sidebar has had a chance to paint, and removed per-row `Intl.DateTimeFormat` construction from the thread list render path.
- I kept the thread shell mounted while the startup settings read is pending, so settings discovery cannot prevent navigation from starting.
- I minified Vite's renderer optimized dependency cache in dev mode. On the measured default-profile startup profile this reduced `react-markdown.js` from about 217 KB / 7,247 lines to about 90 KB / 14 lines.

| Check | Before | After |
| --- | --- | --- |
| Startup thread prewarm | Around 1.2s on the default profile, plus directory/git enrichment risk | Cheap-summary path; no per-thread directory enrichment on startup |
| Navigation snapshot list step | Blocked behind startup renderer work; first snapshot observed after the `react-markdown` load gap | Cached/coalesced list path, with observed `listDurationMs` down to 0-5ms after prewarm |
| Renderer CPU profile | `react-markdown` module load started near renderer startup and consumed about 2.47s before navigation could move | Secondary-window import no longer pulls markdown into main-shell startup; markdown cost happens later when thread detail actually loads |
| Thread-detail markdown dependency | Unminified Vite dep profile: about 217 KB and roughly 1.0s self time / 4.6s total in `react-markdown.js` | Minified Vite dep profile: about 90 KB and roughly 0.84s self time / 3.7s total in `react-markdown.js` |
| Directory git status | Could fan out across startup directories | Persisted cache plus bounded async refresh, capped for automatic startup work |

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I captured default-profile startup CPU profiles, including `.local/startup-cpu-2026-05-14-0004-042fde` and `.local/startup-cpu-2026-05-14-0030-7deb3a`, and verified the main-window navigation path is no longer blocked by the changelog/markdown import.

## Notes

- Codex `thread/list` itself still takes real time on the default profile; this PR keeps that result to cheap summaries for navigation and prevents the expensive directory/git enrichment from being part of the startup path.
- Thread detail can still load `react-markdown`, but that work is now separated from the first useful thread-list paint.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (Codex context, medium reasoning) via [Codex](https://openai.com/codex)
