### PR TITLE
fix(desktop): stabilize context rail tooltip e2e

### DIFF
--- a/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
+++ b/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
@@ -11,6 +11,10 @@ test("shows linked directory path tooltips in the context rail", async () => {
       specDir,
       "fixtures/context-rail-linked-directory-tooltips/replay.fixture.json"
     ),
+    windowSize: {
+      width: 1280,
+      height: 820,
+    },
   });
 
   try {
@@ -18,10 +22,22 @@ test("shows linked directory path tooltips in the context rail", async () => {
       .getByRole("button", { name: /Linked directory tooltip thread/i })
       .first()
       .click();
-    await app.window.getByRole("button", { name: "Open context rail" }).click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Linked directory tooltip thread",
+      })
+    ).toBeVisible();
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",
     });
+    const openRailButton = app.window.getByRole("button", { name: "Open context rail" });
+    if (await openRailButton.count()) {
+      await openRailButton.click();
+    }
+    await expect(
+      contextRail.getByLabel("Path for PwrAgent", { exact: true })
+    ).toBeVisible();
 
     await contextRail.getByLabel("Path for PwrAgent", { exact: true }).focus();
     await expectVisibleTooltip(app.window, "/repo/PwrAgent");


### PR DESCRIPTION
## Summary

- Stabilize the context rail linked-directory tooltip E2E by fixing its window size.
- Wait for the selected thread detail before interacting with the rail.
- Only click the manual rail opener when that control is present, so the test also tolerates auto-pinned rail layouts.

## Verification

- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/context-rail-linked-directory-tooltips.spec.ts --repeat-each=10 --reporter=line`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/approval-pending.spec.ts e2e/codex-environment-setup.spec.ts e2e/composer-draft-persistence-regression.spec.ts e2e/composer-draft-settings.spec.ts e2e/composer-height-growth.spec.ts e2e/composer-image-normalization.spec.ts e2e/composer-image-thread-switch.spec.ts e2e/context-rail-linked-directory-tooltips.spec.ts --reporter=line`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/plan-autocomplete-order.spec.ts --reporter=line`

## Notes

- I inspected failing CI run `25840938949`; the trace showed the timeout while clicking `Open context rail`.
- I also ran the full desktop E2E suite locally. The patched context rail test passed in sequence; a later unrelated local `plan-autocomplete-order.spec.ts` assertion failed once, then passed when rerun directly.
